### PR TITLE
fix(core): prevent account enumeration via forgot-password verification codes

### DIFF
--- a/.changeset/early-buses-laugh.md
+++ b/.changeset/early-buses-laugh.md
@@ -2,6 +2,7 @@
 "@logto/core": patch
 ---
 
-avoid delivering forgot-password verification codes to unknown accounts when dev features are enabled
+return a unified verification_code.code_mismatch error in forgot-password flows to prevent account enumeration
 
-This keeps connector and template validation while skipping message delivery for unknown email or phone identifiers in forgot-password flows.
+Forgot-password verification no longer exposes whether an email or phone exists through differing
+error responses.

--- a/.changeset/early-buses-laugh.md
+++ b/.changeset/early-buses-laugh.md
@@ -4,5 +4,4 @@
 
 return a unified verification_code.code_mismatch error in forgot-password flows to prevent account enumeration
 
-Forgot-password verification no longer exposes whether an email or phone exists through differing
-error responses.
+Forgot-password verification no longer exposes whether an email or phone exists through differing error responses.

--- a/.changeset/early-buses-laugh.md
+++ b/.changeset/early-buses-laugh.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+avoid delivering forgot-password verification codes to unknown accounts when dev features are enabled
+
+This keeps connector and template validation while skipping message delivery for unknown email or phone identifiers in forgot-password flows.

--- a/packages/core/src/libraries/passcode.send.test.ts
+++ b/packages/core/src/libraries/passcode.send.test.ts
@@ -113,4 +113,47 @@ describe('sendPasscode validateOnly', () => {
       'Template not found for type: ForgotPassword'
     );
   });
+
+  it('should not pre-validate templates on the normal send path', async () => {
+    const sendMessage = jest.fn();
+    getMessageConnector.mockResolvedValueOnce({
+      ...defaultConnectorMethods,
+      configGuard: any(),
+      dbEntry: {
+        ...mockConnector,
+        id: 'id0',
+        config: {},
+      },
+      metadata: {
+        ...mockMetadata,
+        platform: null,
+      },
+      type: ConnectorType.Email,
+      sendMessage,
+    });
+    const passcode: Passcode = {
+      tenantId: 'fake_tenant',
+      id: 'passcode_id',
+      interactionJti: 'jti',
+      phone: null,
+      email: 'foo@example.com',
+      type: TemplateType.ForgotPassword,
+      code: '1234',
+      consumed: false,
+      tryCount: 0,
+      createdAt: Date.now(),
+    };
+
+    await sendPasscode(passcode, { locale: 'en' });
+
+    expect(getI18nEmailTemplate).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledWith({
+      to: 'foo@example.com',
+      type: TemplateType.ForgotPassword,
+      payload: {
+        code: '1234',
+        locale: 'en',
+      },
+    });
+  });
 });

--- a/packages/core/src/libraries/passcode.send.test.ts
+++ b/packages/core/src/libraries/passcode.send.test.ts
@@ -1,0 +1,116 @@
+import { defaultConnectorMethods } from '@logto/cli/lib/connector/index.js';
+import { ConnectorType, TemplateType } from '@logto/connector-kit';
+import { type Passcode } from '@logto/schemas';
+import { any } from 'zod';
+
+import { mockConnector, mockMetadata } from '#src/__mocks__/index.js';
+import { MockQueries } from '#src/test-utils/tenant.js';
+
+import { createPasscodeLibrary } from './passcode.js';
+
+const { jest } = import.meta;
+
+const getMessageConnector = jest.fn();
+const getI18nEmailTemplate = jest.fn();
+
+const unusedPasscodeQueries = {
+  consumePasscode: jest.fn(),
+  deletePasscodesByIds: jest.fn(),
+  findUnconsumedPasscodeByIdentifierAndType: jest.fn(),
+  findUnconsumedPasscodeByJtiAndType: jest.fn(),
+  findUnconsumedPasscodesByIdentifierAndType: jest.fn(),
+  findUnconsumedPasscodesByJtiAndType: jest.fn(),
+  increasePasscodeTryCount: jest.fn(),
+  insertPasscode: jest.fn(),
+};
+
+const { sendPasscode } = createPasscodeLibrary(
+  new MockQueries({ passcodes: unusedPasscodeQueries }),
+  // @ts-expect-error Only connector lookups are required in these tests.
+  { getI18nEmailTemplate, getMessageConnector }
+);
+
+describe('sendPasscode validateOnly', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should validate connector/template without sending when validateOnly is true', async () => {
+    const sendMessage = jest.fn();
+    getMessageConnector.mockResolvedValueOnce({
+      ...defaultConnectorMethods,
+      configGuard: any(),
+      dbEntry: {
+        ...mockConnector,
+        id: 'id0',
+        config: {
+          templates: [
+            { usageType: TemplateType.ForgotPassword, subject: 'subject', content: 'code' },
+          ],
+        },
+      },
+      metadata: {
+        ...mockMetadata,
+        platform: null,
+      },
+      type: ConnectorType.Email,
+      sendMessage,
+    });
+    getI18nEmailTemplate.mockResolvedValueOnce(null);
+    const passcode: Passcode = {
+      tenantId: 'fake_tenant',
+      id: 'passcode_id',
+      interactionJti: 'jti',
+      phone: null,
+      email: 'foo@example.com',
+      type: TemplateType.ForgotPassword,
+      code: '1234',
+      consumed: false,
+      tryCount: 0,
+      createdAt: Date.now(),
+    };
+
+    await sendPasscode(passcode, { locale: 'en' }, { validateOnly: true });
+
+    expect(getMessageConnector).toHaveBeenCalledWith(ConnectorType.Email);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('should still fail fast when validateOnly is true but the template is unavailable', async () => {
+    const sendMessage = jest.fn();
+    getMessageConnector.mockResolvedValueOnce({
+      ...defaultConnectorMethods,
+      configGuard: any(),
+      dbEntry: {
+        ...mockConnector,
+        id: 'id0',
+        config: {
+          templates: [],
+        },
+      },
+      metadata: {
+        ...mockMetadata,
+        platform: null,
+      },
+      type: ConnectorType.Email,
+      sendMessage,
+    });
+    getI18nEmailTemplate.mockResolvedValueOnce(null);
+    const passcode: Passcode = {
+      tenantId: 'fake_tenant',
+      id: 'passcode_id',
+      interactionJti: 'jti',
+      phone: null,
+      email: 'foo@example.com',
+      type: TemplateType.ForgotPassword,
+      code: '1234',
+      consumed: false,
+      tryCount: 0,
+      createdAt: Date.now(),
+    };
+
+    await expect(sendPasscode(passcode, { locale: 'en' }, { validateOnly: true })).rejects.toThrow(
+      'Template not found for type: ForgotPassword'
+    );
+  });
+});

--- a/packages/core/src/libraries/passcode.test.ts
+++ b/packages/core/src/libraries/passcode.test.ts
@@ -40,11 +40,12 @@ const {
 } = passcodeQueries;
 
 const getMessageConnector = jest.fn();
+const getI18nEmailTemplate = jest.fn();
 
 const { createPasscode, sendPasscode, verifyPasscode } = createPasscodeLibrary(
   new MockQueries({ passcodes: passcodeQueries }),
   // @ts-expect-error
-  { getMessageConnector }
+  { getI18nEmailTemplate, getMessageConnector }
 );
 
 beforeAll(() => {
@@ -174,6 +175,9 @@ describe('sendPasscode', () => {
       dbEntry: {
         ...mockConnector,
         id: 'id0',
+        config: {
+          templates: [{ usageType: TemplateType.SignIn, content: 'code {{code}}' }],
+        },
       },
       metadata: {
         ...mockMetadata,
@@ -213,6 +217,9 @@ describe('sendPasscode', () => {
       dbEntry: {
         ...mockConnector,
         id: 'id0',
+        config: {
+          templates: [{ usageType: TemplateType.SignIn, content: 'code {{code}}' }],
+        },
       },
       metadata: {
         ...mockMetadata,

--- a/packages/core/src/libraries/passcode.ts
+++ b/packages/core/src/libraries/passcode.ts
@@ -1,14 +1,20 @@
 import { appInsights } from '@logto/app-insights/node';
 import type { SendMessagePayload, TemplateType } from '@logto/connector-kit';
-import { templateTypeGuard, ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
+import {
+  templateTypeGuard,
+  ConnectorError,
+  ConnectorErrorCodes,
+  getConfigTemplateByType,
+} from '@logto/connector-kit';
 import {
   buildBuiltInApplicationDataForTenant,
   isBuiltInApplicationId,
   type Passcode,
   type User,
 } from '@logto/schemas';
-import { conditional } from '@silverhand/essentials';
+import { conditional, trySafe } from '@silverhand/essentials';
 import { customAlphabet, nanoid } from 'nanoid';
+import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import type { ConnectorLibrary } from '#src/libraries/connector.js';
@@ -36,6 +42,24 @@ export type SendPasscodeContextPayload = Pick<SendMessagePayload, 'locale' | 'ui
     ip?: string;
   };
 
+type SendPasscodeOptions = {
+  validateOnly?: boolean;
+};
+
+const templateTypeConfigGuard = z.object({
+  templates: z.array(z.object({ usageType: z.string() })).optional(),
+});
+
+const resolveTemplateType = (type: string) => {
+  const messageTypeResult = templateTypeGuard.safeParse(type);
+
+  if (!messageTypeResult.success) {
+    throw new ConnectorError(ConnectorErrorCodes.InvalidConfig);
+  }
+
+  return messageTypeResult.data;
+};
+
 export const createPasscodeLibrary = (queries: Queries, connectorLibrary: ConnectorLibrary) => {
   const {
     consumePasscode,
@@ -47,7 +71,7 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
     increasePasscodeTryCount,
     insertPasscode,
   } = queries.passcodes;
-  const { getMessageConnector } = connectorLibrary;
+  const { getI18nEmailTemplate, getMessageConnector } = connectorLibrary;
 
   const createPasscode = async (
     jti: string | undefined,
@@ -79,28 +103,53 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
    * @param {Passcode} passcode The passcode object being sent.
    * @param {SendPasscodeContextPayload} contextPayload The extra context information for the verification code email template.
    */
-  const sendPasscode = async (passcode: Passcode, contextPayload?: SendPasscodeContextPayload) => {
+  const validateMessageTemplate = async (
+    type: TemplateType,
+    config: unknown,
+    contextPayload?: SendPasscodeContextPayload
+  ) => {
+    const customTemplate = await trySafe(async () =>
+      getI18nEmailTemplate(type, contextPayload?.locale)
+    );
+    const templateConfig = templateTypeConfigGuard.safeParse(config);
+    const template =
+      customTemplate ??
+      getConfigTemplateByType(type, templateConfig.success ? templateConfig.data : {});
+
+    if (!template) {
+      throw new ConnectorError(
+        ConnectorErrorCodes.TemplateNotFound,
+        `Template not found for type: ${type}`
+      );
+    }
+  };
+
+  const sendPasscode = async (
+    passcode: Passcode,
+    contextPayload?: SendPasscodeContextPayload,
+    options?: SendPasscodeOptions
+  ) => {
     const emailOrPhone = passcode.email ?? passcode.phone;
 
     if (!emailOrPhone) {
       throw new RequestError('verification_code.phone_email_empty');
     }
 
+    const templateType = resolveTemplateType(passcode.type);
     const expectType = passcode.phone ? ConnectorType.Sms : ConnectorType.Email;
     const connector = await getMessageConnector(expectType);
     const { dbEntry, metadata, sendMessage } = connector;
-
-    const messageTypeResult = templateTypeGuard.safeParse(passcode.type);
-
-    if (!messageTypeResult.success) {
-      throw new ConnectorError(ConnectorErrorCodes.InvalidConfig);
-    }
+    await validateMessageTemplate(templateType, dbEntry.config, contextPayload);
 
     const { ip, ...payloadContext } = contextPayload ?? {};
 
+    if (options?.validateOnly) {
+      return { dbEntry, metadata, response: undefined };
+    }
+
     const response = await sendMessage({
       to: emailOrPhone,
-      type: messageTypeResult.data,
+      type: templateType,
       payload: {
         code: passcode.code,
         ...payloadContext,

--- a/packages/core/src/libraries/passcode.ts
+++ b/packages/core/src/libraries/passcode.ts
@@ -139,11 +139,11 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
     const expectType = passcode.phone ? ConnectorType.Sms : ConnectorType.Email;
     const connector = await getMessageConnector(expectType);
     const { dbEntry, metadata, sendMessage } = connector;
-    await validateMessageTemplate(templateType, dbEntry.config, contextPayload);
 
     const { ip, ...payloadContext } = contextPayload ?? {};
 
     if (options?.validateOnly) {
+      await validateMessageTemplate(templateType, dbEntry.config, contextPayload);
       return { dbEntry, metadata, response: undefined };
     }
 

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -101,7 +101,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
    */
   async sendVerificationCode(
     payload?: SendPasscodeContextPayload,
-    options?: { skipDelivery?: boolean }
+    options?: { validateOnly?: boolean }
   ) {
     const { createPasscode, sendPasscode } = this.libraries.passcodes;
 
@@ -111,9 +111,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
       getPasscodeIdentifierPayload(this.identifier)
     );
 
-    if (!options?.skipDelivery) {
-      await sendPasscode(verificationCode, payload);
-    }
+    await sendPasscode(verificationCode, payload, options);
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -99,7 +99,10 @@ abstract class CodeVerification<T extends CodeVerificationType>
    * the verification id is used as `interaction_jti` to uniquely identify the passcode record in DB
    * for the current interaction.
    */
-  async sendVerificationCode(payload?: SendPasscodeContextPayload) {
+  async sendVerificationCode(
+    payload?: SendPasscodeContextPayload,
+    options?: { skipDelivery?: boolean }
+  ) {
     const { createPasscode, sendPasscode } = this.libraries.passcodes;
 
     const verificationCode = await createPasscode(
@@ -108,7 +111,9 @@ abstract class CodeVerification<T extends CodeVerificationType>
       getPasscodeIdentifierPayload(this.identifier)
     );
 
-    await sendPasscode(verificationCode, payload);
+    if (!options?.skipDelivery) {
+      await sendPasscode(verificationCode, payload);
+    }
   }
 
   /**

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,6 +1,7 @@
 import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
 
 import type Libraries from '#src/tenants/Libraries.js';
+import type Queries from '#src/tenants/Queries.js';
 
 import type { EmailCodeVerification } from '../classes/verifications/code-verification.js';
 import type { ExperienceInteractionRouterContext } from '../types.js';
@@ -45,6 +46,13 @@ describe('sendCode parameter passing', () => {
     buildVerificationCodeContext: mockBuildVerificationCodeContext,
   };
 
+  const mockQueries = {
+    users: {
+      hasUserWithEmail: jest.fn().mockResolvedValue(true),
+      hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(true),
+    },
+  } as unknown as Queries;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockSendVerificationCode.mockImplementation(resolveVoid);
@@ -68,13 +76,123 @@ describe('sendCode parameter passing', () => {
       identifier: { type: SignInIdentifier.Phone, value: '+8613123456789' },
       createVerificationRecord: () => mockCodeVerification,
       libraries: libraries as unknown as Libraries,
+      queries: mockQueries,
       ctx: ctx as unknown as ExperienceInteractionRouterContext,
     });
 
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.objectContaining({
         ip: SAMPLE_IP,
+      }),
+      expect.objectContaining({
+        skipDelivery: false,
       })
+    );
+  });
+
+  it('should skip delivery for forgot-password with non-existing email user', async () => {
+    const mockQueriesNoUser = {
+      users: {
+        hasUserWithEmail: jest.fn().mockResolvedValue(false),
+        hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
+      },
+    } as unknown as Queries;
+
+    const ctx = {
+      request: { ip: '127.0.0.1' },
+      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+      experienceInteraction: {
+        ...mockExperienceInteraction,
+        interactionEvent: InteractionEvent.ForgotPassword,
+      },
+      emailI18n: {},
+    };
+
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
+    await sendCode({
+      identifier: { type: SignInIdentifier.Email, value: 'nonexistent@example.com' },
+      interactionEvent: InteractionEvent.ForgotPassword,
+      createVerificationRecord: () => mockCodeVerification,
+      libraries: libraries as unknown as Libraries,
+      queries: mockQueriesNoUser,
+      ctx: ctx as unknown as ExperienceInteractionRouterContext,
+    });
+
+    expect(mockQueriesNoUser.users.hasUserWithEmail).toHaveBeenCalledWith(
+      'nonexistent@example.com'
+    );
+    expect(mockSendVerificationCode).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ skipDelivery: true })
+    );
+  });
+
+  it('should not skip delivery for forgot-password with existing user', async () => {
+    const mockQueriesWithUser = {
+      users: {
+        hasUserWithEmail: jest.fn().mockResolvedValue(true),
+        hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(true),
+      },
+    } as unknown as Queries;
+
+    const ctx = {
+      request: { ip: '127.0.0.1' },
+      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+      experienceInteraction: {
+        ...mockExperienceInteraction,
+        interactionEvent: InteractionEvent.ForgotPassword,
+      },
+      emailI18n: {},
+    };
+
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
+    await sendCode({
+      identifier: { type: SignInIdentifier.Phone, value: '+8613123456789' },
+      interactionEvent: InteractionEvent.ForgotPassword,
+      createVerificationRecord: () => mockCodeVerification,
+      libraries: libraries as unknown as Libraries,
+      queries: mockQueriesWithUser,
+      ctx: ctx as unknown as ExperienceInteractionRouterContext,
+    });
+
+    expect(mockQueriesWithUser.users.hasUserWithNormalizedPhone).toHaveBeenCalledWith(
+      '+8613123456789'
+    );
+    expect(mockSendVerificationCode).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ skipDelivery: false })
+    );
+  });
+
+  it('should not check user existence for non-ForgotPassword events', async () => {
+    const mockQueriesTracking = {
+      users: {
+        hasUserWithEmail: jest.fn().mockResolvedValue(false),
+        hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
+      },
+    } as unknown as Queries;
+
+    const ctx = {
+      request: { ip: '127.0.0.1' },
+      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+      experienceInteraction: mockExperienceInteraction,
+      emailI18n: {},
+    };
+
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
+    await sendCode({
+      identifier: { type: SignInIdentifier.Email, value: 'test@example.com' },
+      interactionEvent: InteractionEvent.SignIn,
+      createVerificationRecord: () => mockCodeVerification,
+      libraries: libraries as unknown as Libraries,
+      queries: mockQueriesTracking,
+      ctx: ctx as unknown as ExperienceInteractionRouterContext,
+    });
+
+    expect(mockQueriesTracking.users.hasUserWithEmail).not.toHaveBeenCalled();
+    expect(mockSendVerificationCode).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ skipDelivery: false })
     );
   });
 });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -92,7 +92,7 @@ describe('sendCode parameter passing', () => {
         ip: SAMPLE_IP,
       }),
       expect.objectContaining({
-        skipDelivery: false,
+        validateOnly: false,
       })
     );
   });
@@ -130,7 +130,7 @@ describe('sendCode parameter passing', () => {
     );
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ skipDelivery: true })
+      expect.objectContaining({ validateOnly: true })
     );
   });
 
@@ -167,7 +167,7 @@ describe('sendCode parameter passing', () => {
     );
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ skipDelivery: false })
+      expect.objectContaining({ validateOnly: false })
     );
   });
 
@@ -204,7 +204,7 @@ describe('sendCode parameter passing', () => {
     expect(mockQueriesTracking.users.hasUserWithEmail).not.toHaveBeenCalled();
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ skipDelivery: false })
+      expect.objectContaining({ validateOnly: false })
     );
   });
 
@@ -236,7 +236,7 @@ describe('sendCode parameter passing', () => {
     expect(mockQueriesTracking.users.hasUserWithEmail).not.toHaveBeenCalled();
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ skipDelivery: false })
+      expect.objectContaining({ validateOnly: false })
     );
   });
 });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,5 +1,6 @@
 import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
 
+import { EnvSet } from '#src/env-set/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -24,6 +25,7 @@ async function resolveVoid(): Promise<void> {
 const { sendCode } = await import('./verification-code-helpers.js');
 
 describe('sendCode parameter passing', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
   // To make a void callable function/method
   const mockSendVerificationCode = jest.fn().mockImplementation(resolveVoid);
 
@@ -55,9 +57,14 @@ describe('sendCode parameter passing', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
     mockSendVerificationCode.mockImplementation(resolveVoid);
     mockExperienceInteraction.save.mockImplementation(resolveVoid);
     mockBuildVerificationCodeContext.mockResolvedValue({});
+  });
+
+  afterAll(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('should pass ctx.request.ip to sendVerificationCode', async () => {
@@ -158,6 +165,43 @@ describe('sendCode parameter passing', () => {
     expect(mockQueriesWithUser.users.hasUserWithNormalizedPhone).toHaveBeenCalledWith(
       '+8613123456789'
     );
+    expect(mockSendVerificationCode).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ skipDelivery: false })
+    );
+  });
+
+  it('should keep the old forgot-password delivery behavior when dev features are disabled', async () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+
+    const mockQueriesTracking = {
+      users: {
+        hasUserWithEmail: jest.fn().mockResolvedValue(false),
+        hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
+      },
+    } as unknown as Queries;
+
+    const ctx = {
+      request: { ip: '127.0.0.1' },
+      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+      experienceInteraction: {
+        ...mockExperienceInteraction,
+        interactionEvent: InteractionEvent.ForgotPassword,
+      },
+      emailI18n: {},
+    };
+
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
+    await sendCode({
+      identifier: { type: SignInIdentifier.Email, value: 'nonexistent@example.com' },
+      interactionEvent: InteractionEvent.ForgotPassword,
+      createVerificationRecord: () => mockCodeVerification,
+      libraries: libraries as unknown as Libraries,
+      queries: mockQueriesTracking,
+      ctx: ctx as unknown as ExperienceInteractionRouterContext,
+    });
+
+    expect(mockQueriesTracking.users.hasUserWithEmail).not.toHaveBeenCalled();
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({ skipDelivery: false })

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -69,7 +69,26 @@ type SendCodeParams = {
   interactionEvent?: InteractionEvent;
   createVerificationRecord: () => CodeVerificationRecord;
   libraries: Libraries;
+  queries: Queries;
   ctx: ExperienceInteractionRouterContext;
+};
+
+/**
+ * Check if a user exists with the given identifier (email or phone).
+ * Used to determine whether to actually deliver verification codes
+ * in the forgot-password flow, preventing account enumeration and spam.
+ */
+const hasUserWithIdentifier = async (
+  queries: Queries,
+  identifier: VerificationCodeIdentifier
+): Promise<boolean> => {
+  const { type, value } = identifier;
+
+  if (type === SignInIdentifier.Email) {
+    return queries.users.hasUserWithEmail(value);
+  }
+
+  return queries.users.hasUserWithNormalizedPhone(value);
 };
 
 /**
@@ -81,6 +100,7 @@ export const sendCode = async ({
   interactionEvent,
   createVerificationRecord,
   libraries,
+  queries,
   ctx,
 }: SendCodeParams): Promise<{ verificationId: string }> => {
   const { experienceInteraction } = ctx;
@@ -104,6 +124,14 @@ export const sendCode = async ({
     await experienceInteraction.signInExperienceValidator.guardEmailBlocklist(codeVerification);
   }
 
+  // For forgot-password flows, check if the user actually exists.
+  // If not, we still create the passcode record in the database (so the verify step
+  // returns a consistent `code_mismatch` error instead of `not_found`, preventing
+  // account enumeration), but skip the actual message delivery to avoid spam.
+  const skipDelivery =
+    interactionEvent === InteractionEvent.ForgotPassword &&
+    !(await hasUserWithIdentifier(queries, identifier));
+
   // Build template context
   const templateContext = await buildVerificationCodeTemplateContext(
     libraries.passcodes,
@@ -112,12 +140,15 @@ export const sendCode = async ({
   );
 
   // Send verification code
-  await codeVerification.sendVerificationCode({
-    ...ctx.emailI18n,
-    ...templateContext,
-    /** The client IP address for rate limiting and fraud detection. */
-    ...(ctx.request.ip && { ip: ctx.request.ip }),
-  });
+  await codeVerification.sendVerificationCode(
+    {
+      ...ctx.emailI18n,
+      ...templateContext,
+      /** The client IP address for rate limiting and fraud detection. */
+      ...(ctx.request.ip && { ip: ctx.request.ip }),
+    },
+    { skipDelivery }
+  );
 
   // Save state
   experienceInteraction.setVerificationRecord(codeVerification);

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -127,9 +127,9 @@ export const sendCode = async ({
 
   // When dev features are enabled, forgot-password requests check whether the user
   // actually exists. For unknown identifiers we still create the passcode record
-  // (so verification returns `code_mismatch` instead of `not_found`), but skip
-  // the actual message delivery to avoid account enumeration and spam abuse.
-  const skipDelivery =
+  // (so verification returns `code_mismatch` instead of `not_found`) and keep
+  // connector/template validation, but avoid the actual message delivery.
+  const validateOnly =
     EnvSet.values.isDevFeaturesEnabled &&
     interactionEvent === InteractionEvent.ForgotPassword &&
     !(await hasUserWithIdentifier(queries, identifier));
@@ -149,7 +149,7 @@ export const sendCode = async ({
       /** The client IP address for rate limiting and fraud detection. */
       ...(ctx.request.ip && { ip: ctx.request.ip }),
     },
-    { skipDelivery }
+    { validateOnly }
   );
 
   // Save state

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -8,6 +8,7 @@ import {
 } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { type LogContext } from '#src/middleware/koa-audit-log.js';
@@ -124,11 +125,12 @@ export const sendCode = async ({
     await experienceInteraction.signInExperienceValidator.guardEmailBlocklist(codeVerification);
   }
 
-  // For forgot-password flows, check if the user actually exists.
-  // If not, we still create the passcode record in the database (so the verify step
-  // returns a consistent `code_mismatch` error instead of `not_found`, preventing
-  // account enumeration), but skip the actual message delivery to avoid spam.
+  // When dev features are enabled, forgot-password requests check whether the user
+  // actually exists. For unknown identifiers we still create the passcode record
+  // (so verification returns `code_mismatch` instead of `not_found`), but skip
+  // the actual message delivery to avoid account enumeration and spam abuse.
   const skipDelivery =
+    EnvSet.values.isDevFeaturesEnabled &&
     interactionEvent === InteractionEvent.ForgotPassword &&
     !(await hasUserWithIdentifier(queries, identifier));
 

--- a/packages/core/src/routes/experience/verification-routes/verification-code.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.ts
@@ -76,6 +76,7 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
             isBindingEmailForMfa ? TemplateType.BindMfa : getTemplateTypeByEvent(interactionEvent)
           ),
         libraries,
+        queries,
         ctx,
       });
 
@@ -139,6 +140,7 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
         createVerificationRecord: () =>
           createNewMfaCodeVerificationRecord(libraries, queries, identifier),
         libraries,
+        queries,
         ctx,
       });
 

--- a/packages/integration-tests/src/tests/api/email-templates/experience-api.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/experience-api.test.ts
@@ -9,6 +9,10 @@ import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
 import { successfullySendVerificationCode } from '#src/helpers/experience/verification-code.js';
 import { readConnectorMessage } from '#src/helpers/index.js';
 import { OrganizationApiTest } from '#src/helpers/organization.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+} from '#src/helpers/profile.js';
 import { generateEmail } from '#src/utils.js';
 
 const mockSignInTemplate: MockEmailTemplatePayload = {
@@ -79,30 +83,37 @@ describe('experience API with i18n email templates', () => {
     const defaultForgotPasswordTemplate = mockEmailConnectorConfig.templates.find(
       ({ usageType }) => usageType === 'ForgotPassword'
     )!;
-
-    const client = await initExperienceClient({
-      interactionEvent: InteractionEvent.ForgotPassword,
-    });
-    const { code } = await successfullySendVerificationCode(client, {
-      interactionEvent: InteractionEvent.ForgotPassword,
-      identifier: {
-        type: SignInIdentifier.Email,
-        value: mockEmail,
-      },
+    const { user } = await createDefaultTenantUserWithPassword({
+      primaryEmail: mockEmail,
     });
 
-    expect(await readConnectorMessage('Email')).toMatchObject({
-      type: TemplateType.ForgotPassword,
-      payload: {
-        code,
-        application: {
-          id: demoAppApplicationId,
-          name: 'Live Preview',
+    try {
+      const client = await initExperienceClient({
+        interactionEvent: InteractionEvent.ForgotPassword,
+      });
+      const { code } = await successfullySendVerificationCode(client, {
+        interactionEvent: InteractionEvent.ForgotPassword,
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: mockEmail,
         },
-      },
-      template: defaultForgotPasswordTemplate,
-      content: defaultForgotPasswordTemplate.content.replace('{{code}}', code),
-      subject: defaultForgotPasswordTemplate.subject,
-    });
+      });
+
+      expect(await readConnectorMessage('Email')).toMatchObject({
+        type: TemplateType.ForgotPassword,
+        payload: {
+          code,
+          application: {
+            id: demoAppApplicationId,
+            name: 'Live Preview',
+          },
+        },
+        template: defaultForgotPasswordTemplate,
+        content: defaultForgotPasswordTemplate.content.replace('{{code}}', code),
+        subject: defaultForgotPasswordTemplate.subject,
+      });
+    } finally {
+      await deleteDefaultTenantUser(user.id);
+    }
   });
 });

--- a/packages/integration-tests/src/tests/api/email-templates/experience-api.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/experience-api.test.ts
@@ -3,17 +3,18 @@ import { demoAppApplicationId, InteractionEvent, SignInIdentifier } from '@logto
 
 import { mockEmailConnectorConfig } from '#src/__mocks__/connectors-mock.js';
 import { type MockEmailTemplatePayload } from '#src/__mocks__/email-templates.js';
+import { isDevFeaturesEnabled } from '#src/constants.js';
 import { initExperienceClient } from '#src/helpers/client.js';
 import { setEmailConnector } from '#src/helpers/connector.js';
 import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
 import { successfullySendVerificationCode } from '#src/helpers/experience/verification-code.js';
-import { readConnectorMessage } from '#src/helpers/index.js';
+import { expectRejects, readConnectorMessage, removeConnectorMessage } from '#src/helpers/index.js';
 import { OrganizationApiTest } from '#src/helpers/organization.js';
 import {
   createDefaultTenantUserWithPassword,
   deleteDefaultTenantUser,
 } from '#src/helpers/profile.js';
-import { generateEmail } from '#src/utils.js';
+import { devFeatureDisabledTest, devFeatureTest, generateEmail } from '#src/utils.js';
 
 const mockSignInTemplate: MockEmailTemplatePayload = {
   languageTag: 'en',
@@ -36,6 +37,10 @@ describe('experience API with i18n email templates', () => {
 
   afterAll(async () => {
     await Promise.all([emailTemplatesApi.cleanUp(), organizationApi.cleanUp()]);
+  });
+
+  afterEach(async () => {
+    await removeConnectorMessage('Email');
   });
 
   it('should send verification code using custom i18n template', async () => {
@@ -83,8 +88,9 @@ describe('experience API with i18n email templates', () => {
     const defaultForgotPasswordTemplate = mockEmailConnectorConfig.templates.find(
       ({ usageType }) => usageType === 'ForgotPassword'
     )!;
+    const existingEmail = generateEmail();
     const { user } = await createDefaultTenantUserWithPassword({
-      primaryEmail: mockEmail,
+      primaryEmail: existingEmail,
     });
 
     try {
@@ -95,7 +101,7 @@ describe('experience API with i18n email templates', () => {
         interactionEvent: InteractionEvent.ForgotPassword,
         identifier: {
           type: SignInIdentifier.Email,
-          value: mockEmail,
+          value: existingEmail,
         },
       });
 
@@ -116,4 +122,72 @@ describe('experience API with i18n email templates', () => {
       await deleteDefaultTenantUser(user.id);
     }
   });
+
+  devFeatureTest.it(
+    'should not deliver forgot-password verification code for a non-existing user when dev features are enabled',
+    async () => {
+      const nonExistingEmail = generateEmail();
+      const client = await initExperienceClient({
+        interactionEvent: InteractionEvent.ForgotPassword,
+      });
+
+      const { verificationId } = await client.sendVerificationCode({
+        interactionEvent: InteractionEvent.ForgotPassword,
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: nonExistingEmail,
+        },
+      });
+
+      expect(verificationId).toBeTruthy();
+      await expect(readConnectorMessage('Email')).rejects.toThrow();
+      await expectRejects(
+        client.verifyVerificationCode({
+          identifier: {
+            type: SignInIdentifier.Email,
+            value: nonExistingEmail,
+          },
+          verificationId,
+          code: '111111',
+        }),
+        {
+          code: 'verification_code.code_mismatch',
+          status: 400,
+        }
+      );
+    }
+  );
+
+  devFeatureDisabledTest.it(
+    'should keep delivering forgot-password verification code for a non-existing user when dev features are disabled',
+    async () => {
+      const defaultForgotPasswordTemplate = mockEmailConnectorConfig.templates.find(
+        ({ usageType }) => usageType === 'ForgotPassword'
+      )!;
+      const nonExistingEmail = generateEmail();
+      const client = await initExperienceClient({
+        interactionEvent: InteractionEvent.ForgotPassword,
+      });
+
+      const { verificationId } = await client.sendVerificationCode({
+        interactionEvent: InteractionEvent.ForgotPassword,
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: nonExistingEmail,
+        },
+      });
+
+      const { code, address, type, template, content, subject } =
+        await readConnectorMessage('Email');
+
+      expect(isDevFeaturesEnabled).toBe(false);
+      expect(verificationId).toBeTruthy();
+      expect(code).toBeTruthy();
+      expect(address).toBe(nonExistingEmail);
+      expect(type).toBe(TemplateType.ForgotPassword);
+      expect(template).toMatchObject(defaultForgotPasswordTemplate);
+      expect(content).toBe(defaultForgotPasswordTemplate.content.replace('{{code}}', code));
+      expect(subject).toBe(defaultForgotPasswordTemplate.subject);
+    }
+  );
 });


### PR DESCRIPTION
## Summary

- Updates the Experience forgot-password verification-code flow so that, when `isDevFeaturesEnabled` is enabled, unknown email addresses or phone numbers still get a passcode record and still validate connector/template availability in dry-run mode, but do not trigger real delivery, keeping verification on the `verification_code.code_mismatch` path instead of exposing a `not_found` branch.
- Preserves the previous forgot-password delivery behavior when `isDevFeaturesEnabled` is disabled, so the rollout stays guarded behind the dev-features flag.
- Adds unit coverage for the guarded validate-only delivery path and integration coverage for both enabled and disabled flag states, while keeping the forgot-password callback-template email path covered with an existing user.

## Testing

Unit tests, Integration tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments

Closes #8485
Related: #8375
