### PR TITLE
feat(core): add custom tenant CSP connect-src allowlist

### DIFF
--- a/packages/core/src/middleware/koa-security-headers.test.ts
+++ b/packages/core/src/middleware/koa-security-headers.test.ts
@@ -1,0 +1,58 @@
+import { GlobalValues } from '@logto/shared';
+import { createMockUtils } from '@logto/shared/esm';
+import { noop } from '@silverhand/essentials';
+import type Koa from 'koa';
+
+import createMockContext from '#src/test-utils/jest-koa-mocks/create-mock-context.js';
+
+const { jest } = import.meta;
+const { mockEsmWithActual } = createMockUtils(jest);
+
+await mockEsmWithActual('#src/env-set/index.js', () => ({
+  EnvSet: {
+    get values() {
+      return new GlobalValues();
+    },
+  },
+  AdminApps: { Console: 'console', Welcome: 'welcome' },
+  UserApps: { AccountCenter: 'account-center' },
+  getTenantEndpoint: () => new URL('https://tenant.example.com'),
+}));
+
+const { default: koaSecurityHeaders } = await import('./koa-security-headers.js');
+
+const koaNoop = noop as unknown as Koa.Next;
+
+const getCsp = (ctx: Koa.Context): string => {
+  const value = ctx.res.getHeader('Content-Security-Policy');
+  return typeof value === 'string' ? value : '';
+};
+
+describe('koaSecurityHeaders() middleware — experience CSP', () => {
+  it('includes the hardcoded custom tenant allowlist (e.g. LaunchDarkly) in connect-src', async () => {
+    const run = koaSecurityHeaders([], 'default');
+    // Any path that isn't an admin app / user app / mounted app falls through
+    // to the experience CSP settings.
+    const ctx = createMockContext({ method: 'GET', url: '/sign-in' });
+
+    await run(ctx, koaNoop);
+
+    const csp = getCsp(ctx);
+    const connectSource = csp
+      .split(';')
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith('connect-src '));
+
+    expect(connectSource).toBeDefined();
+    expect(connectSource).toContain('https://*.launchdarkly.com');
+  });
+
+  it('does not leak the custom allowlist into the admin console CSP', async () => {
+    const run = koaSecurityHeaders([], 'default');
+    const ctx = createMockContext({ method: 'GET', url: '/console' });
+
+    await run(ctx, koaNoop);
+
+    expect(getCsp(ctx)).not.toContain('launchdarkly');
+  });
+});

--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -54,6 +54,15 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
   /** Google Sign-In (GSI) origin for Google One Tap. */
   const gsiOrigin = 'https://accounts.google.com/gsi/';
 
+  /**
+   * Temporary hardcoded tenant-level `connect-src` allowlist for BYO-UI customers.
+   * TODO: migrate to DB so tenants can self-manage. Review each entry for trust.
+   */
+  const customTenantConnectSourceAllowlist = [
+    // LaunchDarkly — A/B testing SDK (flag eval, streaming, events).
+    'https://*.launchdarkly.com',
+  ];
+
   // We have the following use cases:
   //
   // - We use `react-monaco-editor` for code editing in the admin console. It loads the monaco
@@ -135,6 +144,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
           'https://recaptcha.net/recaptcha/',
           'https://www.gstatic.com/recaptcha/',
           'https://www.gstatic.cn/recaptcha/',
+          ...customTenantConnectSourceAllowlist,
           ...developmentOrigins,
         ],
         // WARNING (high risk): Need to allow self-hosted terms of use page loaded in an iframe


### PR DESCRIPTION
## Summary

Introduces a small, clearly-commented hardcoded allowlist (`customTenantConnectSourceAllowlist`) that is spread into the experience app's CSP `connect-src` directive. This unblocks a BYO-UI customer who is running LaunchDarkly A/B testing inside the sign-in experience — their SDK calls to `app.launchdarkly.com/sdk/evalx/...` were being blocked by our strict CSP.

### What changed
- `packages/core/src/middleware/koa-security-headers.ts`: added `customTenantConnectSourceAllowlist` with a single entry (`https://*.launchdarkly.com`, wildcard chosen to cover LD's multiple subdomains — flag eval / streaming / events / regional endpoints — and be consistent with the existing `https://*.logto.io` wildcard style). List is spread into the experience `connectSrc` only; admin console and account center CSPs are untouched.
- `packages/core/src/middleware/koa-security-headers.test.ts` (new): two tests — one confirms the LaunchDarkly wildcard appears in the experience `connect-src`; one confirms it does **not** leak into the admin console CSP.

### Reviewer notes
- LaunchDarkly is an established SaaS (SOC 2 Type II); the blocked URL is their standard client-side SDK flag-eval endpoint.
- Scoped to the **experience** CSP only — this is intentional; admin / account center don't need it.

## Testing

Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments