### PR TITLE
chore: release account center security page

### DIFF
--- a/.changeset/release-account-center-security-page.md
+++ b/.changeset/release-account-center-security-page.md
@@ -1,0 +1,11 @@
+---
+"@logto/account": minor
+"@logto/console": minor
+---
+
+add the account center security page
+
+End users can now manage their account security from the account center:
+
+- `@logto/account` ships the `/account/security` route with social account linking and unlinking, MFA 2-step verification, and account deletion.
+- `@logto/console` exposes the delete-account URL field on the sign-in experience account center settings, and surfaces the account center and social prebuilt UI entries.

--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -166,8 +166,7 @@ const Main = () => {
     return <GlobalLoading />;
   }
 
-  const showsSecurityPage =
-    isDevFeaturesEnabled && hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
+  const showsSecurityPage = hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
 
   return (
     <Routes>
@@ -197,9 +196,7 @@ const Main = () => {
         element={<UpdateSuccess identifierType="backup_code" />}
       />
       <Route path={passkeySuccessRoute} element={<UpdateSuccess identifierType="passkey" />} />
-      {isDevFeaturesEnabled && (
-        <Route path={socialSuccessRoute} element={<UpdateSuccess identifierType="social" />} />
-      )}
+      <Route path={socialSuccessRoute} element={<UpdateSuccess identifierType="social" />} />
       <Route path={emailRoute} element={<Email />} />
       <Route path={phoneRoute} element={<Phone />} />
       <Route path={passwordRoute} element={<Password />} />
@@ -211,17 +208,13 @@ const Main = () => {
       <Route path={backupCodesManageRoute} element={<BackupCodeView />} />
       <Route path={passkeyAddRoute} element={<PasskeyBinding />} />
       <Route path={passkeyManageRoute} element={<PasskeyView />} />
-      {isDevFeaturesEnabled && <Route path={verifiedActionRoute} element={<VerifiedAction />} />}
-      {isDevFeaturesEnabled && (
-        <>
-          <Route path={`${socialCallbackRoutePrefix}/:connectorId`} element={<SocialCallback />} />
-          <Route path={`${socialRoutePrefix}/:connectorId`} element={<SocialFlow mode="add" />} />
-          <Route
-            path={`${socialRoutePrefix}/:connectorId/remove`}
-            element={<SocialFlow mode="remove" />}
-          />
-        </>
-      )}
+      <Route path={verifiedActionRoute} element={<VerifiedAction />} />
+      <Route path={`${socialCallbackRoutePrefix}/:connectorId`} element={<SocialCallback />} />
+      <Route path={`${socialRoutePrefix}/:connectorId`} element={<SocialFlow mode="add" />} />
+      <Route
+        path={`${socialRoutePrefix}/:connectorId/remove`}
+        element={<SocialFlow mode="remove" />}
+      />
       {showsSecurityPage && <Route path={securityRoute} element={<Security />} />}
       {isDevFeaturesEnabled && <Route path={profileRoute} element={<Profile />} />}
       <Route index element={<Home />} />
@@ -234,8 +227,7 @@ const Layout = () => {
   const { accountCenterSettings, experienceSettings, theme } = useContext(PageContext);
   const hideLogtoBranding = experienceSettings?.hideLogtoBranding === true;
   const { pathname } = useLocation();
-  const showsSecurityPage =
-    isDevFeaturesEnabled && hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
+  const showsSecurityPage = hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
   const isSecurityFullPage = pathname === securityRoute && showsSecurityPage;
   const isProfileFullPage = pathname === profileRoute && isDevFeaturesEnabled;
   const isFullPage = isSecurityFullPage || isProfileFullPage;

--- a/packages/account/src/pages/Security/MfaSection/index.tsx
+++ b/packages/account/src/pages/Security/MfaSection/index.tsx
@@ -12,7 +12,6 @@ import { useNavigate } from 'react-router-dom';
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import ConfirmModal from '@ac/components/ConfirmModal';
 import ToggleSwitch from '@ac/components/ToggleSwitch';
-import { isDevFeaturesEnabled } from '@ac/constants/env';
 import { layoutClassNames } from '@ac/constants/layout';
 import { verifiedActionRoute } from '@ac/constants/routes';
 import { getPendingReturn, setPendingReturn } from '@ac/utils/account-center-route';
@@ -52,7 +51,6 @@ const MfaSection = () => {
   const isMfaSectionVisible = hasVisibleMfaSection(mfaControl, experienceSettings);
 
   const showToggle =
-    isDevFeaturesEnabled &&
     isEditable &&
     mfaPolicy !== undefined &&
     !mandatoryMfaPolicies.has(mfaPolicy) &&

--- a/packages/account/src/pages/Security/index.tsx
+++ b/packages/account/src/pages/Security/index.tsx
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import PageFooter from '@ac/components/PageFooter';
-import { isDevFeaturesEnabled } from '@ac/constants/env';
 import { layoutClassNames } from '@ac/constants/layout';
 
 import styles from '../Home/index.module.scss';
@@ -33,7 +32,7 @@ const Security = () => {
         <PasswordSection />
         <SocialSection />
         <MfaSection />
-        {isDevFeaturesEnabled && <DeleteAccountSection />}
+        <DeleteAccountSection />
       </div>
       <PageFooter />
     </div>

--- a/packages/account/src/utils/security-page.test.ts
+++ b/packages/account/src/utils/security-page.test.ts
@@ -16,6 +16,7 @@ void test('hasVisibleSecuritySection returns false when account center is disabl
   assert.equal(
     hasVisibleSecuritySection({
       enabled: false,
+      deleteAccountUrl: null,
       fields: {
         username: AccountCenterControlValue.Edit,
         email: AccountCenterControlValue.Off,
@@ -32,6 +33,7 @@ void test('hasVisibleSecuritySection returns true when any supported field is vi
   assert.equal(
     hasVisibleSecuritySection({
       enabled: true,
+      deleteAccountUrl: null,
       fields: {
         username: AccountCenterControlValue.ReadOnly,
         email: AccountCenterControlValue.Off,
@@ -49,6 +51,7 @@ void test('hasVisibleSecuritySection returns true when social field is visible',
     hasVisibleSecuritySection(
       {
         enabled: true,
+        deleteAccountUrl: null,
         fields: {
           username: AccountCenterControlValue.Off,
           email: AccountCenterControlValue.Off,
@@ -71,6 +74,24 @@ void test('hasVisibleSecuritySection returns true when social field is visible',
         mfa: { factors: [], policy: MfaPolicy.UserControlled },
       }
     ),
+    true
+  );
+});
+
+void test('hasVisibleSecuritySection returns true when delete account URL is configured', () => {
+  assert.equal(
+    hasVisibleSecuritySection({
+      enabled: true,
+      deleteAccountUrl: 'https://example.com/delete-account',
+      fields: {
+        username: AccountCenterControlValue.Off,
+        email: AccountCenterControlValue.Off,
+        phone: AccountCenterControlValue.Off,
+        password: AccountCenterControlValue.Off,
+        social: AccountCenterControlValue.Off,
+        mfa: AccountCenterControlValue.Off,
+      },
+    }),
     true
   );
 });

--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -4,7 +4,7 @@ import { AccountCenterControlValue } from '@logto/schemas';
 
 import { getAvailableSocialConnectors } from './social-connector.js';
 
-type SecurityPageSettings = Pick<AccountCenter, 'enabled' | 'fields'>;
+type SecurityPageSettings = Pick<AccountCenter, 'enabled' | 'fields' | 'deleteAccountUrl'>;
 type SecurityPageExperienceSettings = Pick<SignInExperienceResponse, 'socialConnectors' | 'mfa'>;
 
 const isVisibleField = (value?: AccountCenterControlValue): boolean =>
@@ -34,12 +34,14 @@ export const hasVisibleSecuritySection = (
   }
 
   const { username, email, phone, password, social, mfa } = accountCenterSettings.fields;
+  const hasDeleteAccountUrl = Boolean(accountCenterSettings.deleteAccountUrl?.trim());
 
   return (
     isVisibleField(username) ||
     isVisibleField(email) ||
     isVisibleField(phone) ||
     isVisibleField(password) ||
+    hasDeleteAccountUrl ||
     hasVisibleSocialSection(social, experienceSettings) ||
     hasVisibleMfaSection(mfa, experienceSettings)
   );

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
@@ -2,7 +2,6 @@ import { useContext } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import DynamicT from '@/ds-components/DynamicT';
 import FormField from '@/ds-components/FormField';
@@ -13,6 +12,12 @@ import useUserPreferences from '@/hooks/use-user-preferences';
 
 import PrebuiltUiUrlItem from './PrebuiltUiUrlItem';
 import styles from './index.module.scss';
+
+type PrebuiltRoute = {
+  path: string;
+  tooltipKey: string;
+  isPreviewHidden?: boolean;
+};
 
 const prebuiltRoutes = [
   { path: '/account/email', tooltipKey: 'sign_in_exp.account_center.prebuilt_ui.tooltips.email' },
@@ -49,18 +54,17 @@ const prebuiltRoutes = [
     path: '/account/backup-codes/manage',
     tooltipKey: 'sign_in_exp.account_center.prebuilt_ui.tooltips.backup_codes_manage',
   },
-] as const;
-
-const devPrebuiltRoutes = [
   {
     path: '/account/social/:connectorId',
     tooltipKey: 'sign_in_exp.account_center.prebuilt_ui.tooltips.social',
+    isPreviewHidden: true,
   },
   {
     path: '/account/social/:connectorId/remove',
     tooltipKey: 'sign_in_exp.account_center.prebuilt_ui.tooltips.social_remove',
+    isPreviewHidden: true,
   },
-] as const;
+] as const satisfies readonly PrebuiltRoute[];
 
 const accountCenterRoute = {
   path: '/account/security',
@@ -83,7 +87,7 @@ function IntegratePrebuiltUi() {
       learnMoreLink={{ href: 'end-user-flows/account-settings/by-account-center-ui' }}
     >
       <div className={styles.cardContent}>
-        {isDevFeaturesEnabled && !prebuiltUiPermissionNoticeAcknowledged && (
+        {!prebuiltUiPermissionNoticeAcknowledged && (
           <InlineNotification
             className={styles.notice}
             action="general.got_it"
@@ -100,78 +104,40 @@ function IntegratePrebuiltUi() {
             </Trans>
           </InlineNotification>
         )}
-        {isDevFeaturesEnabled && (
-          <FormField
-            className={styles.firstFormField}
-            title="sign_in_exp.account_center.prebuilt_ui.account_center_title"
-            headlineSpacing="large"
-          >
-            <div className={styles.description}>
-              <DynamicT forKey="sign_in_exp.account_center.prebuilt_ui.account_center_description" />
-            </div>
-            <div className={styles.urlGrid}>
-              <PrebuiltUiUrlItem
-                path={accountCenterRoute.path}
-                tooltip={t(accountCenterRoute.tooltipKey)}
-                tenantEndpoint={tenantEndpoint}
-              />
-            </div>
-          </FormField>
-        )}
         <FormField
-          className={isDevFeaturesEnabled ? styles.secondFormField : undefined}
-          title={
-            isDevFeaturesEnabled
-              ? 'sign_in_exp.account_center.prebuilt_ui.single_task_flows_title'
-              : 'sign_in_exp.account_center.prebuilt_ui.flows_title'
-          }
+          className={styles.firstFormField}
+          title="sign_in_exp.account_center.prebuilt_ui.account_center_title"
           headlineSpacing="large"
         >
           <div className={styles.description}>
-            <DynamicT
-              forKey={
-                isDevFeaturesEnabled
-                  ? 'sign_in_exp.account_center.prebuilt_ui.single_task_flows_description'
-                  : 'sign_in_exp.account_center.prebuilt_ui.flows_description'
-              }
+            <DynamicT forKey="sign_in_exp.account_center.prebuilt_ui.account_center_description" />
+          </div>
+          <div className={styles.urlGrid}>
+            <PrebuiltUiUrlItem
+              path={accountCenterRoute.path}
+              tooltip={t(accountCenterRoute.tooltipKey)}
+              tenantEndpoint={tenantEndpoint}
             />
           </div>
-          {!isDevFeaturesEnabled && !prebuiltUiPermissionNoticeAcknowledged && (
-            <InlineNotification
-              className={styles.notice}
-              action="general.got_it"
-              onClick={() => {
-                void update({ prebuiltUiPermissionNoticeAcknowledged: true });
-              }}
-            >
-              <Trans
-                components={{
-                  strong: <strong />,
-                }}
-              >
-                {t('sign_in_exp.account_center.prebuilt_ui.permission_notice')}
-              </Trans>
-            </InlineNotification>
-          )}
+        </FormField>
+        <FormField
+          className={styles.secondFormField}
+          title="sign_in_exp.account_center.prebuilt_ui.single_task_flows_title"
+          headlineSpacing="large"
+        >
+          <div className={styles.description}>
+            <DynamicT forKey="sign_in_exp.account_center.prebuilt_ui.single_task_flows_description" />
+          </div>
           <div className={styles.urlGrid}>
-            {prebuiltRoutes.map(({ path, tooltipKey }) => (
+            {prebuiltRoutes.map((route) => (
               <PrebuiltUiUrlItem
-                key={path}
-                path={path}
-                tooltip={t(tooltipKey)}
+                key={route.path}
+                isPreviewHidden={'isPreviewHidden' in route ? route.isPreviewHidden : false}
+                path={route.path}
+                tooltip={t(route.tooltipKey)}
                 tenantEndpoint={tenantEndpoint}
               />
             ))}
-            {isDevFeaturesEnabled &&
-              devPrebuiltRoutes.map(({ path, tooltipKey }) => (
-                <PrebuiltUiUrlItem
-                  key={path}
-                  isPreviewHidden
-                  path={path}
-                  tooltip={t(tooltipKey)}
-                  tenantEndpoint={tenantEndpoint}
-                />
-              ))}
           </div>
         </FormField>
         <div className={styles.customizeNote}>

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -5,7 +5,6 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
 import PageMeta from '@/components/PageMeta';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import CodeEditor from '@/ds-components/CodeEditor';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
@@ -154,9 +153,7 @@ function AccountCenter({ isActive, data }: Props) {
             {section.key === 'accountSecurity' && (
               <>
                 <WebauthnRelatedOriginsField isAccountApiEnabled={isAccountApiEnabled} />
-                {isDevFeaturesEnabled && (
-                  <DeleteAccountUrlField isAccountApiEnabled={isAccountApiEnabled} />
-                )}
+                <DeleteAccountUrlField isAccountApiEnabled={isAccountApiEnabled} />
               </>
             )}
           </div>


### PR DESCRIPTION
## Summary
Remove `isDevFeaturesEnabled` guards around the account center security page and its supporting code so the feature ships by default.

- `@logto/account`: unconditionally mount the `/account/security` route, the social add/remove and verified-action routes, the social success page, the MFA 2-step verification toggle, and the delete-account section on the security page. Drop the now-unused `isDevFeaturesEnabled` constant and its Vite `define` entry.
- `@logto/console`: surface the delete-account URL field on the sign-in experience account center page, and expose the account center and social prebuilt UI entries without the dev feature flag.

## Testing
Tested locally

## Checklist

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
