### PR TITLE
feat(console): configure sign-up profile fields

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/SignUpProfileFieldItem.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/SignUpProfileFieldItem.module.scss
@@ -1,0 +1,26 @@
+@use '@/scss/underscore' as _;
+
+.profileFieldItem {
+  display: flex;
+  align-items: center;
+  margin: _.unit(2) 0;
+  gap: _.unit(2);
+}
+
+.profileField {
+  display: flex;
+  align-items: center;
+  height: 44px;
+  width: 100%;
+  padding: _.unit(3) _.unit(2);
+  background-color: var(--color-layer-2);
+  border-radius: 8px;
+  cursor: move;
+  gap: _.unit(1);
+  color: var(--color-text);
+  font: var(--font-label-2);
+
+  .draggableIcon {
+    color: var(--color-text-secondary);
+  }
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/SignUpProfileFieldItem.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/SignUpProfileFieldItem.tsx
@@ -1,0 +1,26 @@
+import Draggable from '@/assets/icons/draggable.svg?react';
+import Minus from '@/assets/icons/minus.svg?react';
+import IconButton from '@/ds-components/IconButton';
+
+import styles from './SignUpProfileFieldItem.module.scss';
+
+type Props = {
+  readonly label: string;
+  readonly onDelete: () => void;
+};
+
+function SignUpProfileFieldItem({ label, onDelete }: Props) {
+  return (
+    <div className={styles.profileFieldItem}>
+      <div className={styles.profileField}>
+        <Draggable className={styles.draggableIcon} />
+        {label}
+      </div>
+      <IconButton onClick={onDelete}>
+        <Minus />
+      </IconButton>
+    </div>
+  );
+}
+
+export default SignUpProfileFieldItem;

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/index.module.scss
@@ -1,0 +1,19 @@
+@use '@/scss/underscore' as _;
+
+.draggleItemContainer {
+  transform: translate(0, 0);
+}
+
+.addProfileFieldsDropdown {
+  min-width: 208px;
+}
+
+.setUpHint {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+  margin-top: _.unit(2);
+
+  .setup {
+    margin: 0 _.unit(1);
+  }
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/index.tsx
@@ -1,0 +1,126 @@
+import { type CustomProfileField } from '@logto/schemas';
+import { useMemo } from 'react';
+import { Controller, useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import useSWR from 'swr';
+
+import CirclePlus from '@/assets/icons/circle-plus.svg?react';
+import Plus from '@/assets/icons/plus.svg?react';
+import ActionMenu from '@/ds-components/ActionMenu';
+import type { Props as ButtonProps } from '@/ds-components/Button';
+import { DragDropProvider, DraggableItem } from '@/ds-components/DragDrop';
+import { DropdownItem } from '@/ds-components/Dropdown';
+import TextLink from '@/ds-components/TextLink';
+import { type RequestError } from '@/hooks/use-api';
+
+import { type SignInExperienceForm } from '../../../../types';
+import { collectUserProfilePathname } from '../../../CollectUserProfile/consts';
+import useI18nFieldLabel from '../../../CollectUserProfile/use-i18n-field-label';
+
+import SignUpProfileFieldItem from './SignUpProfileFieldItem';
+import styles from './index.module.scss';
+
+function SignUpProfileFieldsEditBox() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { control } = useFormContext<SignInExperienceForm>();
+  const getI18nLabel = useI18nFieldLabel();
+
+  const { data: catalog } = useSWR<CustomProfileField[], RequestError>('api/custom-profile-fields');
+
+  const signUpProfileFields = useWatch({ control, name: 'signUpProfileFields' });
+
+  const { fields, swap, remove, append } = useFieldArray({
+    control,
+    name: 'signUpProfileFields',
+  });
+
+  const availableFields = useMemo(() => {
+    if (!catalog) {
+      return [];
+    }
+    const selectedNames = new Set(signUpProfileFields.map(({ name }) => name));
+    return catalog.filter(({ name }) => !selectedNames.has(name));
+  }, [catalog, signUpProfileFields]);
+
+  const fieldLabelByName = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const field of catalog ?? []) {
+      map.set(field.name, field.label || getI18nLabel(field.name));
+    }
+    return map;
+  }, [catalog, getI18nLabel]);
+
+  const hasSelectedFields = fields.length > 0;
+
+  const addProfileFieldsButtonProps: ButtonProps = {
+    type: 'default',
+    size: 'medium',
+    title: 'sign_in_exp.sign_up_and_sign_in.sign_up.add_profile_fields',
+    icon: <Plus />,
+  };
+
+  const addAnotherButtonProps: ButtonProps = {
+    type: 'text',
+    size: 'small',
+    title: 'general.add_another',
+    icon: <CirclePlus />,
+  };
+
+  return (
+    <div>
+      <DragDropProvider>
+        {fields.map(({ id }, index) => {
+          return (
+            <DraggableItem
+              key={id}
+              id={id}
+              sortIndex={index}
+              moveItem={swap}
+              className={styles.draggleItemContainer}
+            >
+              <Controller
+                control={control}
+                name={`signUpProfileFields.${index}`}
+                render={({ field: { value } }) => (
+                  <SignUpProfileFieldItem
+                    label={fieldLabelByName.get(value.name) ?? value.name}
+                    onDelete={() => {
+                      remove(index);
+                    }}
+                  />
+                )}
+              />
+            </DraggableItem>
+          );
+        })}
+      </DragDropProvider>
+      {availableFields.length > 0 && (
+        <ActionMenu
+          buttonProps={hasSelectedFields ? addAnotherButtonProps : addProfileFieldsButtonProps}
+          dropdownHorizontalAlign="start"
+          dropdownClassName={styles.addProfileFieldsDropdown}
+        >
+          {availableFields.map(({ name, label }) => (
+            <DropdownItem
+              key={name}
+              onClick={() => {
+                append({ name });
+              }}
+            >
+              {label || getI18nLabel(name)}
+            </DropdownItem>
+          ))}
+        </ActionMenu>
+      )}
+      <div className={styles.setUpHint}>
+        {t('sign_in_exp.sign_up_and_sign_in.sign_up.profile_fields_hint.not_in_list')}
+        <TextLink to={collectUserProfilePathname} className={styles.setup}>
+          {t('sign_in_exp.sign_up_and_sign_in.sign_up.profile_fields_hint.set_up')}
+        </TextLink>
+        {t('sign_in_exp.sign_up_and_sign_in.sign_up.profile_fields_hint.go_to')}
+      </div>
+    </div>
+  );
+}
+
+export default SignUpProfileFieldsEditBox;

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import Card from '@/ds-components/Card';
 import Checkbox from '@/ds-components/Checkbox';
 import FormField from '@/ds-components/FormField';
@@ -12,6 +13,7 @@ import FormFieldDescription from '../../components/FormFieldDescription';
 import FormSectionTitle from '../../components/FormSectionTitle';
 
 import SignUpIdentifiersEditBox from './SignUpIdentifiersEditBox';
+import SignUpProfileFieldsEditBox from './SignUpProfileFieldsEditBox';
 import styles from './index.module.scss';
 import useSignUpPasswordListeners from './use-sign-up-password-listeners';
 
@@ -106,6 +108,11 @@ function SignUpForm({ signInExperience }: Props) {
               />
             )}
           </div>
+        </FormField>
+      )}
+      {isDevFeaturesEnabled && (
+        <FormField title="sign_in_exp.sign_up_and_sign_in.sign_up.collect_user_profile">
+          <SignUpProfileFieldsEditBox />
         </FormField>
       )}
     </Card>

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
@@ -132,6 +132,10 @@ export const sieFormDataParser = {
     return {
       ...rest,
       signUp: signUpFormDataParser.fromSignUp(signUp),
+      // `useFieldArray` cannot handle `null`, so normalize to an empty array. Legacy tenants
+      // with `null` will see the same empty UI as new tenants; the dev-feature guard keeps the
+      // section hidden in production.
+      signUpProfileFields: rest.signUpProfileFields ?? [],
       createAccountEnabled: rest.signInMode !== SignInMode.SignIn,
       customCss: customCss ?? undefined,
       socialSignIn: {
@@ -188,6 +192,8 @@ export const sieFormDataParser = {
  * Affected fields:
  * - `signUp.secondaryIdentifiers`: This field is optional in the data schema,
  *  but through the form, we always fill it with an empty array.
+ * - `signUpProfileFields`: nullable in the data schema, normalized to an empty array
+ *  to match the form state (see `SignInExperienceForm`).
  * - `mfa`
  * - `adaptiveMfa`
  * - `passwordPolicy`
@@ -219,6 +225,7 @@ export const signInExperienceToUpdatedDataParser = (
       ...signUp,
       secondaryIdentifiers: signUp.secondaryIdentifiers ?? [],
     },
+    signUpProfileFields: rest.signUpProfileFields ?? [],
     ...conditional(isCloud && { hideLogtoBranding }),
   };
 };

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -5,6 +5,7 @@ import {
   type SignInExperience,
   type SignInIdentifier,
   type SignUpIdentifier as SignUpIdentifierMethod,
+  type SignUpProfileFields,
   type AccountCenterFieldControl,
 } from '@logto/schemas';
 /**
@@ -109,10 +110,15 @@ export type SignUpForm = Omit<SignUp, 'identifiers' | 'secondaryIdentifiers'> & 
 
 export type SignInExperienceForm = Omit<
   SignInExperience,
-  'signUp' | 'customCss' | OmittedSignInExperienceKeys
+  'signUp' | 'customCss' | 'signUpProfileFields' | OmittedSignInExperienceKeys
 > & {
   customCss?: string; // Code editor components can not properly handle null value, manually transform null to undefined instead.
   signUp: SignUpForm;
+  /**
+   * `useFieldArray` requires an array, so null from the API is normalized to an empty array when
+   * the form is initialized (see `sieFormDataParser.fromSignInExperience`).
+   */
+  signUpProfileFields: SignUpProfileFields;
   createAccountEnabled: boolean;
 };
 

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -19,6 +19,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'Create your password',
     verify_at_sign_up_option: 'Verify at sign-up',
     social_only_creation_description: '(This apply to social only account creation)',
+    collect_user_profile: 'Collect user profile',
+    add_profile_fields: 'Add profile fields',
+    profile_fields_hint: {
+      not_in_list: 'Not in the list?',
+      set_up: 'Set up',
+      go_to: 'other profile fields now.',
+    },
   },
   sign_in: {
     title: 'SIGN IN',


### PR DESCRIPTION
## Summary

- Add a new "Collect user profile" section to the sign-up form where admins can pick which custom profile fields are collected during sign-up and drag to reorder them.
- Fetches the field catalog from `GET /api/custom-profile-fields`; the picker only lists fields that haven't been selected yet and includes a link to the "Collect user profile" tab for setting up new fields.
- Wires the selection into the sign-in experience form as `signUpProfileFields`, normalized from `null` to `[]` so `useFieldArray` and the diff-compare parser behave consistently.
- Guarded by `isDevFeaturesEnabled`; no changeset (will be added with the flag-removal PR).

## Test plan

- [ ] Type-check passes (`pnpm tsc --noEmit` in `packages/console`).
- [ ] Existing parser unit tests still pass.
- [ ] With dev features on, verify empty/dropdown/added states render, items drag-reorder, remove works, and the form saves the expected payload.
- [ ] With dev features off, confirm the section is hidden.