### PR TITLE
fix(account): restore security page desktop value alignment

### DIFF
--- a/.changeset/security-page-value-alignment.md
+++ b/.changeset/security-page-value-alignment.md
@@ -1,0 +1,7 @@
+---
+"@logto/account": patch
+---
+
+fix(account): restore security page desktop value alignment
+
+The mobile layout refactor split each row's icon into a dedicated grid column, which pushed the title column — and therefore every value cell — further right. Icon and title now share a single grid cell (with padding-left on the title) so the name slot stays within the original 200px budget and values align with the pre-refactor layout.

--- a/.changeset/security-page-value-alignment.md
+++ b/.changeset/security-page-value-alignment.md
@@ -1,7 +1,0 @@
----
-"@logto/account": patch
----
-
-fix(account): restore security page desktop value alignment
-
-The mobile layout refactor split each row's icon into a dedicated grid column, which pushed the title column — and therefore every value cell — further right. Icon and title now share a single grid cell (with padding-left on the title) so the name slot stays within the original 200px budget and values align with the pre-refactor layout.

--- a/packages/account/src/pages/Security/EmailPhoneSection/index.module.scss
+++ b/packages/account/src/pages/Security/EmailPhoneSection/index.module.scss
@@ -20,7 +20,8 @@
 
 .row {
   display: grid;
-  grid-template-columns: auto minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-auto-flow: dense;
   column-gap: _.unit(6);
   align-items: center;
   padding: _.unit(5) _.unit(6);
@@ -35,11 +36,14 @@
   display: contents;
 }
 
+// Icon and title share the same grid cell so the name slot stays within 200px,
+// matching the original non-grid layout. Title offsets via padding to sit after the icon.
 .iconWrap {
+  grid-column: 1;
+  grid-row: 1;
   display: flex;
   align-items: center;
-  justify-content: center;
-  grid-column: 1;
+  justify-self: start;
   flex-shrink: 0;
 }
 
@@ -50,14 +54,16 @@
 }
 
 .title {
-  grid-column: 2;
+  grid-column: 1;
+  grid-row: 1;
   min-width: 0;
+  padding-left: calc(20px + #{_.unit(4)});
   font: var(--font-label-2);
   color: var(--color-type-primary);
 }
 
 .value {
-  grid-column: 3;
+  grid-column: 2;
   min-width: 0;
   font: var(--font-body-2);
   color: var(--color-type-primary);
@@ -68,7 +74,7 @@
 }
 
 .actions {
-  grid-column: 4;
+  grid-column: 3;
   display: flex;
   align-items: center;
   gap: _.unit(6);
@@ -137,6 +143,10 @@
     width: 100%;
     overflow-wrap: anywhere;
     word-break: break-word;
+  }
+
+  .title {
+    padding-left: 0;
   }
 
   .changeButton,

--- a/packages/account/src/pages/Security/MfaSection/index.module.scss
+++ b/packages/account/src/pages/Security/MfaSection/index.module.scss
@@ -20,7 +20,8 @@
 
 .row {
   display: grid;
-  grid-template-columns: auto minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-auto-flow: dense;
   column-gap: _.unit(6);
   align-items: center;
   padding: _.unit(5) _.unit(6);
@@ -35,11 +36,14 @@
   display: contents;
 }
 
+// Icon and title share the same grid cell so the name slot stays within 200px,
+// matching the original non-grid layout. Title offsets via padding to sit after the icon.
 .iconWrap {
+  grid-column: 1;
+  grid-row: 1;
   display: flex;
   align-items: center;
-  justify-content: center;
-  grid-column: 1;
+  justify-self: start;
   flex-shrink: 0;
 }
 
@@ -51,14 +55,16 @@
 }
 
 .title {
-  grid-column: 2;
+  grid-column: 1;
+  grid-row: 1;
   min-width: 0;
+  padding-left: calc(20px + #{_.unit(4)});
   font: var(--font-label-2);
   color: var(--color-type-primary);
 }
 
 .value {
-  grid-column: 3;
+  grid-column: 2;
   min-width: 0;
   display: flex;
   align-items: center;
@@ -93,7 +99,7 @@
 }
 
 .actions {
-  grid-column: 4;
+  grid-column: 3;
   display: flex;
   align-items: center;
   gap: _.unit(4);
@@ -188,6 +194,11 @@
     align-items: center;
     justify-content: space-between;
     gap: _.unit(3);
+    width: 100%;
+  }
+
+  .title {
+    padding-left: 0;
     width: 100%;
   }
 

--- a/packages/account/src/pages/Security/PasswordSection/index.module.scss
+++ b/packages/account/src/pages/Security/PasswordSection/index.module.scss
@@ -20,7 +20,8 @@
 
 .row {
   display: grid;
-  grid-template-columns: auto minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-auto-flow: dense;
   column-gap: _.unit(6);
   align-items: center;
   padding: _.unit(5) _.unit(6);
@@ -31,11 +32,14 @@
   display: contents;
 }
 
+// Icon and title share the same grid cell so the name slot stays within 200px,
+// matching the original non-grid layout. Title offsets via padding to sit after the icon.
 .iconWrap {
+  grid-column: 1;
+  grid-row: 1;
   display: flex;
   align-items: center;
-  justify-content: center;
-  grid-column: 1;
+  justify-self: start;
   flex-shrink: 0;
 }
 
@@ -46,14 +50,16 @@
 }
 
 .title {
-  grid-column: 2;
+  grid-column: 1;
+  grid-row: 1;
   min-width: 0;
+  padding-left: calc(20px + #{_.unit(4)});
   font: var(--font-label-2);
   color: var(--color-type-primary);
 }
 
 .value {
-  grid-column: 3;
+  grid-column: 2;
   min-width: 0;
   display: flex;
   align-items: center;
@@ -83,7 +89,7 @@
 }
 
 .changeButton {
-  grid-column: 4;
+  grid-column: 3;
   font: var(--font-label-2);
   color: var(--color-type-link);
   cursor: pointer;
@@ -122,6 +128,10 @@
   .title,
   .value {
     width: 100%;
+  }
+
+  .title {
+    padding-left: 0;
   }
 
   .value {

--- a/packages/account/src/pages/Security/SocialSection/index.module.scss
+++ b/packages/account/src/pages/Security/SocialSection/index.module.scss
@@ -20,7 +20,8 @@
 
 .row {
   display: grid;
-  grid-template-columns: auto minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-auto-flow: dense;
   column-gap: _.unit(4);
   align-items: center;
   padding: _.unit(4.5) _.unit(6);
@@ -35,11 +36,14 @@
   display: contents;
 }
 
+// Icon and name share the same grid cell so the name slot stays within 200px,
+// matching the original non-grid layout. Name offsets via padding to sit after the icon.
 .iconWrap {
+  grid-column: 1;
+  grid-row: 1;
   display: flex;
   align-items: center;
-  justify-content: center;
-  grid-column: 1;
+  justify-self: start;
   flex-shrink: 0;
 }
 
@@ -51,14 +55,16 @@
 }
 
 .connectorName {
-  grid-column: 2;
+  grid-column: 1;
+  grid-row: 1;
   min-width: 0;
+  padding-left: calc(20px + #{_.unit(4)});
   font: var(--font-label-2);
   color: var(--color-type-primary);
 }
 
 .identityInfo {
-  grid-column: 3;
+  grid-column: 2;
   display: flex;
   align-items: center;
   gap: _.unit(3);
@@ -90,14 +96,14 @@
 }
 
 .notLinked {
-  grid-column: 3;
+  grid-column: 2;
   min-width: 0;
   font: var(--font-body-2);
   color: var(--color-type-secondary);
 }
 
 .actions {
-  grid-column: 4;
+  grid-column: 3;
   display: flex;
   align-items: center;
   gap: _.unit(4);
@@ -157,6 +163,10 @@
     width: 100%;
     overflow-wrap: anywhere;
     word-break: break-word;
+  }
+
+  .connectorName {
+    padding-left: 0;
   }
 
   .identityInfo {

--- a/packages/account/src/pages/Security/UsernameSection/index.module.scss
+++ b/packages/account/src/pages/Security/UsernameSection/index.module.scss
@@ -21,6 +21,7 @@
 .row {
   display: grid;
   grid-template-columns: minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-auto-flow: dense;
   column-gap: _.unit(6);
   align-items: center;
   padding: _.unit(5) _.unit(6);


### PR DESCRIPTION
## Summary

The mobile layout refactor in #8647 split each row's icon into a dedicated grid column, which pushed the title column — and every value cell — to the right (Email/Phone/Password/MFA/Social all shifted ~44px, and Username wrapped the value to a new row on desktop due to source-order auto-placement).

Fix:
- Icon and title share a single grid cell (col 1, row 1); title uses `padding-left` to sit after the icon, so the "name" slot stays within the original 200px budget.
- Grid template drops the separate icon column (4 cols → 3 cols) across EmailPhone / Password / MFA / Social.
- UsernameSection adds `grid-auto-flow: dense` so the value cell (col 2) doesn't wrap below the change button (col 3).
- Mobile layout unchanged (title padding reset to 0 inside `body.mobile`).

## Testing

Tested locally

## Checklist

- [x] \`.changeset\`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments