### PR TITLE
fix(console): make OSS company onboarding fields optional

### DIFF
--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -26,7 +26,7 @@ import styles from './index.module.scss';
 import { submitOssOnboarding } from './submit-oss-onboarding';
 import {
   getOssOnboardingDefaultValues,
-  shouldRequireCompanyFields,
+  shouldIncludeCompanyFields,
   type OssOnboardingFormData,
 } from './utils';
 
@@ -47,7 +47,7 @@ function OssOnboarding() {
     shouldUnregister: true,
   });
   const project = watch('project');
-  const isCompanyProject = shouldRequireCompanyFields(project);
+  const isCompanyProject = shouldIncludeCompanyFields(project);
 
   useEffect(() => {
     setThemeOverride(Theme.Light);

--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -162,25 +162,18 @@ function OssOnboarding() {
             </FormField>
             {isCompanyProject && (
               <>
-                <FormField isRequired title="oss_onboarding.company_name.label">
+                <FormField title="oss_onboarding.company_name.label">
                   <TextInput
                     placeholder={t('oss_onboarding.company_name.placeholder')}
                     disabled={isSubmitting}
                     error={errors.companyName?.message}
-                    {...register('companyName', {
-                      validate: (value) =>
-                        Boolean(value.trim()) || t('oss_onboarding.errors.company_name_required'),
-                    })}
+                    {...register('companyName')}
                   />
                 </FormField>
-                <FormField isRequired title="oss_onboarding.company_size.label">
+                <FormField title="oss_onboarding.company_size.label">
                   <Controller
                     name="companySize"
                     control={control}
-                    rules={{
-                      validate: (value) =>
-                        Boolean(value) || t('oss_onboarding.errors.company_size_required'),
-                    }}
                     render={({ field: { onChange, value, name } }) => (
                       <>
                         <RadioGroup

--- a/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
+++ b/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
@@ -138,6 +138,46 @@ describe('submitOssOnboarding', () => {
     expect(navigate).toHaveBeenCalledWith('/get-started', { replace: true });
   });
 
+  it('omits empty company fields in persisted and reported payload', async () => {
+    const submitOssOnboarding = await getSubmitOssOnboarding();
+    const update = jest.fn<Promise<void>, [Partial<OssUserOnboardingData>]>();
+    const navigate = jest.fn<void, [string, { replace: boolean }]>();
+    const formData: OssOnboardingFormData = {
+      ...mockFormData,
+      companyName: '   ',
+      companySize: undefined,
+    };
+
+    update.mockResolvedValue();
+
+    await submitOssOnboarding({
+      formData,
+      navigate,
+      update,
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      questionnaire: {
+        emailAddress: 'dev@example.com',
+        newsletter: true,
+        project: Project.Company,
+      },
+      isOnboardingDone: true,
+    });
+    expect(mockKyPost).toHaveBeenCalledWith(
+      new URL('https://survey.example.com/api/surveys'),
+      expect.objectContaining({
+        json: {
+          emailAddress: 'dev@example.com',
+          newsletter: true,
+          project: Project.Company,
+        },
+        keepalive: true,
+      })
+    );
+    expect(navigate).toHaveBeenCalledWith('/get-started', { replace: true });
+  });
+
   it('constructs the reporting URL when endpoint has trailing slash', async () => {
     const submitOssOnboarding = await getSubmitOssOnboarding();
     const update = jest.fn<Promise<void>, [Partial<OssUserOnboardingData>]>();

--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -3,7 +3,7 @@ import { CompanySize, Project, type OssSurveyReportPayload } from '@logto/schema
 import {
   getOssOnboardingDefaultValues,
   getOssOnboardingSubmitPayload,
-  shouldRequireCompanyFields,
+  shouldIncludeCompanyFields,
 } from './utils';
 
 describe('OSS onboarding form utils', () => {
@@ -17,9 +17,9 @@ describe('OSS onboarding form utils', () => {
     });
   });
 
-  test('requires company-only fields only for company projects', () => {
-    expect(shouldRequireCompanyFields(Project.Company)).toBe(true);
-    expect(shouldRequireCompanyFields(Project.Personal)).toBe(false);
+  test('identifies company projects for optional company fields', () => {
+    expect(shouldIncludeCompanyFields(Project.Company)).toBe(true);
+    expect(shouldIncludeCompanyFields(Project.Personal)).toBe(false);
   });
 
   test('drops company-only values from the submit payload for personal projects', () => {

--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -4,7 +4,6 @@ import {
   getOssOnboardingDefaultValues,
   getOssOnboardingSubmitPayload,
   shouldRequireCompanyFields,
-  type OssOnboardingFormData,
 } from './utils';
 
 describe('OSS onboarding form utils', () => {
@@ -44,7 +43,7 @@ describe('OSS onboarding form utils', () => {
       emailAddress: 'Dev@Example.COM',
       newsletter: false,
       project: Project.Company,
-      companyName: 'Acme',
+      companyName: ' Acme ',
       companySize: CompanySize.Scale3,
     });
 
@@ -54,6 +53,22 @@ describe('OSS onboarding form utils', () => {
       project: Project.Company,
       companyName: 'Acme',
       companySize: CompanySize.Scale3,
-    } satisfies OssOnboardingFormData);
+    } satisfies OssSurveyReportPayload);
+  });
+
+  test('omits empty company fields in the submit payload for company projects', () => {
+    const payload = getOssOnboardingSubmitPayload({
+      emailAddress: 'Dev@Example.COM',
+      newsletter: false,
+      project: Project.Company,
+      companyName: '   ',
+      companySize: undefined,
+    });
+
+    expect(payload).toEqual({
+      emailAddress: 'dev@example.com',
+      newsletter: false,
+      project: Project.Company,
+    } satisfies OssSurveyReportPayload);
   });
 });

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -22,23 +22,21 @@ export const getOssOnboardingSubmitPayload = (
   data: OssOnboardingFormData
 ): OssSurveyReportPayload => {
   const normalizedEmailAddress = data.emailAddress.toLowerCase();
+  const { companyName, companySize, ...rest } = data;
 
   if (!shouldRequireCompanyFields(data.project)) {
-    const {
-      companyName: _companyName,
-      companySize: _companySize,
-      emailAddress: _emailAddress,
-      ...rest
-    } = data;
-
     return {
       ...rest,
       emailAddress: normalizedEmailAddress,
     };
   }
 
+  const normalizedCompanyName = companyName.trim();
+
   return {
-    ...data,
+    ...rest,
     emailAddress: normalizedEmailAddress,
+    ...(normalizedCompanyName ? { companyName: normalizedCompanyName } : {}),
+    ...(companySize ? { companySize } : {}),
   };
 };

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -16,7 +16,7 @@ export const getOssOnboardingDefaultValues = (): OssOnboardingFormData => ({
   companySize: undefined,
 });
 
-export const shouldRequireCompanyFields = (project: Project) => project === Project.Company;
+export const shouldIncludeCompanyFields = (project: Project) => project === Project.Company;
 
 export const getOssOnboardingSubmitPayload = (
   data: OssOnboardingFormData
@@ -24,7 +24,7 @@ export const getOssOnboardingSubmitPayload = (
   const normalizedEmailAddress = data.emailAddress.toLowerCase();
   const { companyName, companySize, ...rest } = data;
 
-  if (!shouldRequireCompanyFields(data.project)) {
+  if (!shouldIncludeCompanyFields(data.project)) {
     return {
       ...rest,
       emailAddress: normalizedEmailAddress,

--- a/packages/phrases/src/locales/ar/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/oss-onboarding.ts
@@ -23,8 +23,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'البريد الإلكتروني مطلوب',
     email_invalid: 'أدخل بريدًا إلكترونيًا صالحًا',
-    company_name_required: 'اسم الشركة مطلوب',
-    company_size_required: 'حجم الشركة مطلوب',
   },
 };
 

--- a/packages/phrases/src/locales/de/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/oss-onboarding.ts
@@ -25,8 +25,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'E-Mail-Adresse ist erforderlich',
     email_invalid: 'Gib eine gültige E-Mail-Adresse ein',
-    company_name_required: 'Firmenname ist erforderlich',
-    company_size_required: 'Unternehmensgröße ist erforderlich',
   },
 };
 

--- a/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
@@ -24,8 +24,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'Email address is required',
     email_invalid: 'Enter a valid email address',
-    company_name_required: 'Company name is required',
-    company_size_required: 'Company size is required',
   },
 };
 

--- a/packages/phrases/src/locales/es/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/oss-onboarding.ts
@@ -25,8 +25,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'El correo electrónico es obligatorio',
     email_invalid: 'Introduce un correo electrónico válido',
-    company_name_required: 'El nombre de la empresa es obligatorio',
-    company_size_required: 'El tamaño de la empresa es obligatorio',
   },
 };
 

--- a/packages/phrases/src/locales/fr/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/oss-onboarding.ts
@@ -26,8 +26,6 @@ const oss_onboarding = {
   errors: {
     email_required: "L'adresse e-mail est requise",
     email_invalid: 'Saisissez une adresse e-mail valide',
-    company_name_required: "Le nom de l'entreprise est requis",
-    company_size_required: "La taille de l'entreprise est requise",
   },
 };
 

--- a/packages/phrases/src/locales/it/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/oss-onboarding.ts
@@ -26,8 +26,6 @@ const oss_onboarding = {
   errors: {
     email_required: "L'indirizzo email e obbligatorio",
     email_invalid: 'Inserisci un indirizzo email valido',
-    company_name_required: "Il nome dell'azienda e obbligatorio",
-    company_size_required: "La dimensione dell'azienda e obbligatoria",
   },
 };
 

--- a/packages/phrases/src/locales/ja/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/oss-onboarding.ts
@@ -24,8 +24,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'メールアドレスは必須です',
     email_invalid: '有効なメールアドレスを入力してください',
-    company_name_required: '会社名は必須です',
-    company_size_required: '会社規模は必須です',
   },
 };
 

--- a/packages/phrases/src/locales/ko/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/oss-onboarding.ts
@@ -23,8 +23,6 @@ const oss_onboarding = {
   errors: {
     email_required: '이메일 주소는 필수입니다',
     email_invalid: '유효한 이메일 주소를 입력하세요',
-    company_name_required: '회사명은 필수입니다',
-    company_size_required: '회사 규모는 필수입니다',
   },
 };
 

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/oss-onboarding.ts
@@ -26,8 +26,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'Adres e-mail jest wymagany',
     email_invalid: 'Wprowadz prawidlowy adres e-mail',
-    company_name_required: 'Nazwa firmy jest wymagana',
-    company_size_required: 'Wielkosc firmy jest wymagana',
   },
 };
 

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/oss-onboarding.ts
@@ -25,8 +25,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'O endereco de e-mail e obrigatorio',
     email_invalid: 'Digite um endereco de e-mail valido',
-    company_name_required: 'O nome da empresa e obrigatorio',
-    company_size_required: 'O tamanho da empresa e obrigatorio',
   },
 };
 

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/oss-onboarding.ts
@@ -26,8 +26,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'O endereco de email e obrigatorio',
     email_invalid: 'Introduza um endereco de email valido',
-    company_name_required: 'O nome da empresa e obrigatorio',
-    company_size_required: 'A dimensao da empresa e obrigatoria',
   },
 };
 

--- a/packages/phrases/src/locales/ru/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/oss-onboarding.ts
@@ -26,8 +26,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'Электронная почта обязательна',
     email_invalid: 'Введите корректный адрес электронной почты',
-    company_name_required: 'Название компании обязательно',
-    company_size_required: 'Размер компании обязателен',
   },
 };
 

--- a/packages/phrases/src/locales/th/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/oss-onboarding.ts
@@ -24,8 +24,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'จำเป็นต้องกรอกอีเมล',
     email_invalid: 'กรุณากรอกอีเมลที่ถูกต้อง',
-    company_name_required: 'จำเป็นต้องกรอกชื่อบริษัท',
-    company_size_required: 'จำเป็นต้องเลือกขนาดบริษัท',
   },
 };
 

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/oss-onboarding.ts
@@ -25,8 +25,6 @@ const oss_onboarding = {
   errors: {
     email_required: 'E-posta adresi gerekli',
     email_invalid: 'Gecerli bir e-posta adresi girin',
-    company_name_required: 'Sirket adi gerekli',
-    company_size_required: 'Sirket buyuklugu gerekli',
   },
 };
 

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
@@ -23,8 +23,6 @@ const oss_onboarding = {
   errors: {
     email_required: '邮箱地址为必填项',
     email_invalid: '请输入有效的邮箱地址',
-    company_name_required: '公司名称为必填项',
-    company_size_required: '公司规模为必填项',
   },
 };
 

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
@@ -23,8 +23,6 @@ const oss_onboarding = {
   errors: {
     email_required: '電郵地址為必填項',
     email_invalid: '請輸入有效的電郵地址',
-    company_name_required: '公司名稱為必填項',
-    company_size_required: '公司規模為必填項',
   },
 };
 

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
@@ -23,8 +23,6 @@ const oss_onboarding = {
   errors: {
     email_required: '電子郵件地址為必填項',
     email_invalid: '請輸入有效的電子郵件地址',
-    company_name_required: '公司名稱為必填項',
-    company_size_required: '公司規模為必填項',
   },
 };
 


### PR DESCRIPTION
## Summary
- Made `companyName` and `companySize` optional for OSS onboarding company projects by removing required validation and required field indicators in the form UI.
- Updated OSS onboarding submit payload normalization to omit empty company fields (`companyName` blank/whitespace and unset `companySize`) while keeping company fields removed for personal projects.
- Added unit test coverage for the optional company-field behavior in payload generation and submit flow, and removed unused `company_name_required` / `company_size_required` OSS onboarding error keys across locales.

## Testing
Unit tests

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
