### PR TITLE
feat(console): add optional project name to OSS onboarding

### DIFF
--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -26,7 +26,7 @@ import styles from './index.module.scss';
 import { submitOssOnboarding } from './submit-oss-onboarding';
 import {
   getOssOnboardingDefaultValues,
-  shouldIncludeCompanyFields,
+  shouldRequireCompanyFields,
   type OssOnboardingFormData,
 } from './utils';
 
@@ -47,7 +47,7 @@ function OssOnboarding() {
     shouldUnregister: true,
   });
   const project = watch('project');
-  const isCompanyProject = shouldIncludeCompanyFields(project);
+  const isCompanyProject = shouldRequireCompanyFields(project);
 
   useEffect(() => {
     setThemeOverride(Theme.Light);
@@ -162,9 +162,16 @@ function OssOnboarding() {
             </FormField>
             <FormField title="oss_onboarding.project_name.label">
               <TextInput
+                maxLength={200}
                 placeholder={t('oss_onboarding.project_name.placeholder')}
                 disabled={isSubmitting}
-                {...register('projectName')}
+                error={errors.projectName?.message}
+                {...register('projectName', {
+                  maxLength: {
+                    value: 200,
+                    message: t('oss_onboarding.errors.project_name_too_long'),
+                  },
+                })}
               />
             </FormField>
             {isCompanyProject && (

--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -160,6 +160,13 @@ function OssOnboarding() {
                 )}
               />
             </FormField>
+            <FormField title="oss_onboarding.project_name.label">
+              <TextInput
+                placeholder={t('oss_onboarding.project_name.placeholder')}
+                disabled={isSubmitting}
+                {...register('projectName')}
+              />
+            </FormField>
             {isCompanyProject && (
               <>
                 <FormField title="oss_onboarding.company_name.label">

--- a/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
+++ b/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
@@ -164,6 +164,7 @@ describe('submitOssOnboarding', () => {
         emailAddress: 'dev@example.com',
         newsletter: true,
         project: Project.Company,
+        projectName: 'OSS Starter',
       },
       isOnboardingDone: true,
     });
@@ -174,6 +175,7 @@ describe('submitOssOnboarding', () => {
           emailAddress: 'dev@example.com',
           newsletter: true,
           project: Project.Company,
+          projectName: 'OSS Starter',
         },
         keepalive: true,
       })

--- a/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
+++ b/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
@@ -57,6 +57,7 @@ const mockFormData: OssOnboardingFormData = {
   emailAddress: 'Dev@Example.COM',
   newsletter: true,
   project: Project.Company,
+  projectName: ' OSS Starter ',
   companyName: 'Acme',
   companySize: CompanySize.Scale3,
 };
@@ -117,6 +118,7 @@ describe('submitOssOnboarding', () => {
         emailAddress: 'dev@example.com',
         newsletter: true,
         project: Project.Company,
+        projectName: 'OSS Starter',
         companyName: 'Acme',
         companySize: CompanySize.Scale3,
       },
@@ -129,6 +131,7 @@ describe('submitOssOnboarding', () => {
           emailAddress: 'dev@example.com',
           newsletter: true,
           project: Project.Company,
+          projectName: 'OSS Starter',
           companyName: 'Acme',
           companySize: CompanySize.Scale3,
         },
@@ -322,6 +325,48 @@ describe('submitOssOnboarding', () => {
     });
 
     expect(mockKyPost).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('/get-started', { replace: true });
+  });
+
+  it('omits whitespace-only project name before update and report', async () => {
+    const submitOssOnboarding = await getSubmitOssOnboarding();
+    const update = jest.fn<Promise<void>, [Partial<OssUserOnboardingData>]>();
+    const navigate = jest.fn<void, [string, { replace: boolean }]>();
+
+    update.mockResolvedValue();
+
+    await submitOssOnboarding({
+      formData: {
+        ...mockFormData,
+        projectName: '   ',
+      },
+      navigate,
+      update,
+    });
+
+    expect(update).toHaveBeenCalledWith({
+      questionnaire: {
+        emailAddress: 'dev@example.com',
+        newsletter: true,
+        project: Project.Company,
+        companyName: 'Acme',
+        companySize: CompanySize.Scale3,
+      },
+      isOnboardingDone: true,
+    });
+    expect(mockKyPost).toHaveBeenCalledWith(
+      new URL('https://survey.example.com/api/surveys'),
+      expect.objectContaining({
+        json: {
+          emailAddress: 'dev@example.com',
+          newsletter: true,
+          project: Project.Company,
+          companyName: 'Acme',
+          companySize: CompanySize.Scale3,
+        },
+        keepalive: true,
+      })
+    );
     expect(navigate).toHaveBeenCalledWith('/get-started', { replace: true });
   });
 });

--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -3,7 +3,8 @@ import { CompanySize, Project, type OssSurveyReportPayload } from '@logto/schema
 import {
   getOssOnboardingDefaultValues,
   getOssOnboardingSubmitPayload,
-  shouldIncludeCompanyFields,
+  shouldRequireCompanyFields,
+  type OssOnboardingFormData,
 } from './utils';
 
 describe('OSS onboarding form utils', () => {
@@ -12,14 +13,15 @@ describe('OSS onboarding form utils', () => {
       emailAddress: '',
       newsletter: false,
       project: Project.Company,
+      projectName: '',
       companyName: '',
-      companySize: CompanySize.Scale3,
+      companySize: undefined,
     });
   });
 
-  test('identifies company projects for optional company fields', () => {
-    expect(shouldIncludeCompanyFields(Project.Company)).toBe(true);
-    expect(shouldIncludeCompanyFields(Project.Personal)).toBe(false);
+  test('requires company-only fields only for company projects', () => {
+    expect(shouldRequireCompanyFields(Project.Company)).toBe(true);
+    expect(shouldRequireCompanyFields(Project.Personal)).toBe(false);
   });
 
   test('drops company-only values from the submit payload for personal projects', () => {
@@ -27,6 +29,7 @@ describe('OSS onboarding form utils', () => {
       emailAddress: 'Dev@Example.COM',
       newsletter: true,
       project: Project.Personal,
+      projectName: '  My starter app  ',
       companyName: 'Should be ignored',
       companySize: CompanySize.Scale3,
     });
@@ -35,6 +38,7 @@ describe('OSS onboarding form utils', () => {
       emailAddress: 'dev@example.com',
       newsletter: true,
       project: Project.Personal,
+      projectName: 'My starter app',
     } satisfies OssSurveyReportPayload);
   });
 
@@ -43,7 +47,8 @@ describe('OSS onboarding form utils', () => {
       emailAddress: 'Dev@Example.COM',
       newsletter: false,
       project: Project.Company,
-      companyName: ' Acme ',
+      projectName: '  OSS Portal ',
+      companyName: 'Acme',
       companySize: CompanySize.Scale3,
     });
 
@@ -51,24 +56,26 @@ describe('OSS onboarding form utils', () => {
       emailAddress: 'dev@example.com',
       newsletter: false,
       project: Project.Company,
+      projectName: 'OSS Portal',
       companyName: 'Acme',
       companySize: CompanySize.Scale3,
-    } satisfies OssSurveyReportPayload);
+    } satisfies OssOnboardingFormData);
   });
 
-  test('omits empty company fields in the submit payload for company projects', () => {
+  test('omits project name when input contains only whitespace', () => {
     const payload = getOssOnboardingSubmitPayload({
       emailAddress: 'Dev@Example.COM',
       newsletter: false,
-      project: Project.Company,
-      companyName: '   ',
+      project: Project.Personal,
+      projectName: '   ',
+      companyName: '',
       companySize: undefined,
     });
 
     expect(payload).toEqual({
       emailAddress: 'dev@example.com',
       newsletter: false,
-      project: Project.Company,
+      project: Project.Personal,
     } satisfies OssSurveyReportPayload);
   });
 });

--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -4,7 +4,6 @@ import {
   getOssOnboardingDefaultValues,
   getOssOnboardingSubmitPayload,
   shouldRequireCompanyFields,
-  type OssOnboardingFormData,
 } from './utils';
 
 describe('OSS onboarding form utils', () => {
@@ -59,7 +58,7 @@ describe('OSS onboarding form utils', () => {
       projectName: 'OSS Portal',
       companyName: 'Acme',
       companySize: CompanySize.Scale3,
-    } satisfies OssOnboardingFormData);
+    } satisfies OssSurveyReportPayload);
   });
 
   test('omits project name when input contains only whitespace', () => {

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -25,29 +25,22 @@ export const getOssOnboardingSubmitPayload = (
 ): OssSurveyReportPayload => {
   const normalizedEmailAddress = data.emailAddress.toLowerCase();
   const normalizedProjectName = data.projectName.trim();
+  const normalizedCompanyName = data.companyName.trim();
   const projectNamePayload = normalizedProjectName ? { projectName: normalizedProjectName } : {};
+  const basePayload = {
+    emailAddress: normalizedEmailAddress,
+    newsletter: data.newsletter,
+    project: data.project,
+    ...projectNamePayload,
+  };
 
   if (!shouldRequireCompanyFields(data.project)) {
-    const {
-      projectName: _projectName,
-      companyName: _companyName,
-      companySize: _companySize,
-      emailAddress: _emailAddress,
-      ...rest
-    } = data;
-
-    return {
-      ...rest,
-      emailAddress: normalizedEmailAddress,
-      ...projectNamePayload,
-    };
+    return basePayload;
   }
 
-  const { projectName: _projectName, ...rest } = data;
-
   return {
-    ...rest,
-    emailAddress: normalizedEmailAddress,
-    ...projectNamePayload,
+    ...basePayload,
+    ...(normalizedCompanyName ? { companyName: normalizedCompanyName } : {}),
+    ...(data.companySize ? { companySize: data.companySize } : {}),
   };
 };

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -1,9 +1,10 @@
-import { CompanySize, type OssSurveyReportPayload, Project } from '@logto/schemas';
+import { type CompanySize, type OssSurveyReportPayload, Project } from '@logto/schemas';
 
 export type OssOnboardingFormData = {
   emailAddress: string;
   newsletter: boolean;
   project: Project;
+  projectName: string;
   companyName: string;
   companySize?: CompanySize;
 };
@@ -12,31 +13,41 @@ export const getOssOnboardingDefaultValues = (): OssOnboardingFormData => ({
   emailAddress: '',
   newsletter: false,
   project: Project.Company,
+  projectName: '',
   companyName: '',
-  companySize: CompanySize.Scale3,
+  companySize: undefined,
 });
 
-export const shouldIncludeCompanyFields = (project: Project) => project === Project.Company;
+export const shouldRequireCompanyFields = (project: Project) => project === Project.Company;
 
 export const getOssOnboardingSubmitPayload = (
   data: OssOnboardingFormData
 ): OssSurveyReportPayload => {
   const normalizedEmailAddress = data.emailAddress.toLowerCase();
-  const { companyName, companySize, ...rest } = data;
+  const normalizedProjectName = data.projectName.trim();
+  const projectNamePayload = normalizedProjectName ? { projectName: normalizedProjectName } : {};
 
-  if (!shouldIncludeCompanyFields(data.project)) {
+  if (!shouldRequireCompanyFields(data.project)) {
+    const {
+      projectName: _projectName,
+      companyName: _companyName,
+      companySize: _companySize,
+      emailAddress: _emailAddress,
+      ...rest
+    } = data;
+
     return {
       ...rest,
       emailAddress: normalizedEmailAddress,
+      ...projectNamePayload,
     };
   }
 
-  const normalizedCompanyName = companyName.trim();
+  const { projectName: _projectName, ...rest } = data;
 
   return {
     ...rest,
     emailAddress: normalizedEmailAddress,
-    ...(normalizedCompanyName ? { companyName: normalizedCompanyName } : {}),
-    ...(companySize ? { companySize } : {}),
+    ...projectNamePayload,
   };
 };

--- a/packages/phrases/src/locales/ar/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/oss-onboarding.ts
@@ -27,6 +27,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'البريد الإلكتروني مطلوب',
     email_invalid: 'أدخل بريدًا إلكترونيًا صالحًا',
+    project_name_too_long: 'يجب ألا يتجاوز اسم المشروع 200 حرف',
   },
 };
 

--- a/packages/phrases/src/locales/ar/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/oss-onboarding.ts
@@ -13,6 +13,10 @@ const oss_onboarding = {
     personal: 'مشروع شخصي',
     company: 'مشروع شركة',
   },
+  project_name: {
+    label: 'اسم المشروع',
+    placeholder: 'مشروعي',
+  },
   company_name: {
     label: 'اسم الشركة',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/de/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/oss-onboarding.ts
@@ -15,6 +15,10 @@ const oss_onboarding = {
     personal: 'Persönliches Projekt',
     company: 'Unternehmensprojekt',
   },
+  project_name: {
+    label: 'Projektname',
+    placeholder: 'Mein Projekt',
+  },
   company_name: {
     label: 'Firmenname',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/de/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/oss-onboarding.ts
@@ -29,6 +29,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'E-Mail-Adresse ist erforderlich',
     email_invalid: 'Gib eine gültige E-Mail-Adresse ein',
+    project_name_too_long: 'Der Projektname darf maximal 200 Zeichen lang sein',
   },
 };
 

--- a/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
@@ -28,6 +28,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'Email address is required',
     email_invalid: 'Enter a valid email address',
+    project_name_too_long: 'Project name must be 200 characters or fewer',
   },
 };
 

--- a/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/oss-onboarding.ts
@@ -14,6 +14,10 @@ const oss_onboarding = {
     personal: 'Personal project',
     company: 'Company project',
   },
+  project_name: {
+    label: 'Project name',
+    placeholder: 'My project',
+  },
   company_name: {
     label: 'Company name',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/es/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/oss-onboarding.ts
@@ -15,6 +15,10 @@ const oss_onboarding = {
     personal: 'Proyecto personal',
     company: 'Proyecto de empresa',
   },
+  project_name: {
+    label: 'Nombre del proyecto',
+    placeholder: 'Mi proyecto',
+  },
   company_name: {
     label: 'Nombre de la empresa',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/es/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/oss-onboarding.ts
@@ -29,6 +29,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'El correo electrónico es obligatorio',
     email_invalid: 'Introduce un correo electrónico válido',
+    project_name_too_long: 'El nombre del proyecto debe tener como maximo 200 caracteres',
   },
 };
 

--- a/packages/phrases/src/locales/fr/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/oss-onboarding.ts
@@ -16,6 +16,10 @@ const oss_onboarding = {
     personal: 'Projet personnel',
     company: "Projet d'entreprise",
   },
+  project_name: {
+    label: 'Nom du projet',
+    placeholder: 'Mon projet',
+  },
   company_name: {
     label: "Nom de l'entreprise",
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/fr/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/oss-onboarding.ts
@@ -30,6 +30,7 @@ const oss_onboarding = {
   errors: {
     email_required: "L'adresse e-mail est requise",
     email_invalid: 'Saisissez une adresse e-mail valide',
+    project_name_too_long: 'Le nom du projet doit comporter 200 caracteres maximum',
   },
 };
 

--- a/packages/phrases/src/locales/it/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/oss-onboarding.ts
@@ -16,6 +16,10 @@ const oss_onboarding = {
     personal: 'Progetto personale',
     company: 'Progetto aziendale',
   },
+  project_name: {
+    label: 'Nome del progetto',
+    placeholder: 'Il mio progetto',
+  },
   company_name: {
     label: "Nome dell'azienda",
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/it/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/oss-onboarding.ts
@@ -30,6 +30,7 @@ const oss_onboarding = {
   errors: {
     email_required: "L'indirizzo email e obbligatorio",
     email_invalid: 'Inserisci un indirizzo email valido',
+    project_name_too_long: 'Il nome del progetto deve contenere al massimo 200 caratteri',
   },
 };
 

--- a/packages/phrases/src/locales/ja/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/oss-onboarding.ts
@@ -14,6 +14,10 @@ const oss_onboarding = {
     personal: '個人プロジェクト',
     company: '会社のプロジェクト',
   },
+  project_name: {
+    label: 'プロジェクト名',
+    placeholder: '私のプロジェクト',
+  },
   company_name: {
     label: '会社名',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/ja/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/oss-onboarding.ts
@@ -28,6 +28,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'メールアドレスは必須です',
     email_invalid: '有効なメールアドレスを入力してください',
+    project_name_too_long: 'プロジェクト名は200文字以内で入力してください',
   },
 };
 

--- a/packages/phrases/src/locales/ko/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/oss-onboarding.ts
@@ -27,6 +27,7 @@ const oss_onboarding = {
   errors: {
     email_required: '이메일 주소는 필수입니다',
     email_invalid: '유효한 이메일 주소를 입력하세요',
+    project_name_too_long: '프로젝트 이름은 200자 이하여야 합니다',
   },
 };
 

--- a/packages/phrases/src/locales/ko/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/oss-onboarding.ts
@@ -13,6 +13,10 @@ const oss_onboarding = {
     personal: '개인 프로젝트',
     company: '회사 프로젝트',
   },
+  project_name: {
+    label: '프로젝트 이름',
+    placeholder: '내 프로젝트',
+  },
   company_name: {
     label: '회사명',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/oss-onboarding.ts
@@ -16,6 +16,10 @@ const oss_onboarding = {
     personal: 'Projektu osobistego',
     company: 'Projektu firmowego',
   },
+  project_name: {
+    label: 'Nazwa projektu',
+    placeholder: 'Moj projekt',
+  },
   company_name: {
     label: 'Nazwa firmy',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/oss-onboarding.ts
@@ -30,6 +30,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'Adres e-mail jest wymagany',
     email_invalid: 'Wprowadz prawidlowy adres e-mail',
+    project_name_too_long: 'Nazwa projektu musi miec maksymalnie 200 znakow',
   },
 };
 

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/oss-onboarding.ts
@@ -15,6 +15,10 @@ const oss_onboarding = {
     personal: 'Projeto pessoal',
     company: 'Projeto da empresa',
   },
+  project_name: {
+    label: 'Nome do projeto',
+    placeholder: 'Meu projeto',
+  },
   company_name: {
     label: 'Nome da empresa',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/oss-onboarding.ts
@@ -29,6 +29,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'O endereco de e-mail e obrigatorio',
     email_invalid: 'Digite um endereco de e-mail valido',
+    project_name_too_long: 'O nome do projeto deve ter no maximo 200 caracteres',
   },
 };
 

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/oss-onboarding.ts
@@ -16,6 +16,10 @@ const oss_onboarding = {
     personal: 'Projeto pessoal',
     company: 'Projeto empresarial',
   },
+  project_name: {
+    label: 'Nome do projeto',
+    placeholder: 'O meu projeto',
+  },
   company_name: {
     label: 'Nome da empresa',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/oss-onboarding.ts
@@ -30,6 +30,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'O endereco de email e obrigatorio',
     email_invalid: 'Introduza um endereco de email valido',
+    project_name_too_long: 'O nome do projeto deve ter no maximo 200 caracteres',
   },
 };
 

--- a/packages/phrases/src/locales/ru/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/oss-onboarding.ts
@@ -30,6 +30,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'Электронная почта обязательна',
     email_invalid: 'Введите корректный адрес электронной почты',
+    project_name_too_long: 'Название проекта должно содержать не более 200 символов',
   },
 };
 

--- a/packages/phrases/src/locales/ru/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/oss-onboarding.ts
@@ -16,6 +16,10 @@ const oss_onboarding = {
     personal: 'Личного проекта',
     company: 'Проекта компании',
   },
+  project_name: {
+    label: 'Название проекта',
+    placeholder: 'Мой проект',
+  },
   company_name: {
     label: 'Название компании',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/th/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/oss-onboarding.ts
@@ -14,6 +14,10 @@ const oss_onboarding = {
     personal: 'โปรเจกต์ส่วนตัว',
     company: 'โปรเจกต์ของบริษัท',
   },
+  project_name: {
+    label: 'ชื่อโปรเจกต์',
+    placeholder: 'โปรเจกต์ของฉัน',
+  },
   company_name: {
     label: 'ชื่อบริษัท',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/th/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/oss-onboarding.ts
@@ -28,6 +28,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'จำเป็นต้องกรอกอีเมล',
     email_invalid: 'กรุณากรอกอีเมลที่ถูกต้อง',
+    project_name_too_long: 'ชื่อโปรเจกต์ต้องมีไม่เกิน 200 ตัวอักษร',
   },
 };
 

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/oss-onboarding.ts
@@ -29,6 +29,7 @@ const oss_onboarding = {
   errors: {
     email_required: 'E-posta adresi gerekli',
     email_invalid: 'Gecerli bir e-posta adresi girin',
+    project_name_too_long: 'Proje adi en fazla 200 karakter olabilir',
   },
 };
 

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/oss-onboarding.ts
@@ -15,6 +15,10 @@ const oss_onboarding = {
     personal: 'Kisisel proje',
     company: 'Sirket projesi',
   },
+  project_name: {
+    label: 'Proje adi',
+    placeholder: 'Projem',
+  },
   company_name: {
     label: 'Sirket adi',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
@@ -27,6 +27,7 @@ const oss_onboarding = {
   errors: {
     email_required: '邮箱地址为必填项',
     email_invalid: '请输入有效的邮箱地址',
+    project_name_too_long: '项目名称不能超过 200 个字符',
   },
 };
 

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/oss-onboarding.ts
@@ -13,6 +13,10 @@ const oss_onboarding = {
     personal: '个人项目',
     company: '公司项目',
   },
+  project_name: {
+    label: '项目名称',
+    placeholder: '我的项目',
+  },
   company_name: {
     label: '公司名称',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
@@ -27,6 +27,7 @@ const oss_onboarding = {
   errors: {
     email_required: '電郵地址為必填項',
     email_invalid: '請輸入有效的電郵地址',
+    project_name_too_long: '項目名稱不能超過 200 個字元',
   },
 };
 

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/oss-onboarding.ts
@@ -13,6 +13,10 @@ const oss_onboarding = {
     personal: '個人項目',
     company: '公司項目',
   },
+  project_name: {
+    label: '項目名稱',
+    placeholder: '我的項目',
+  },
   company_name: {
     label: '公司名稱',
     placeholder: 'Acme.co',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
@@ -27,6 +27,7 @@ const oss_onboarding = {
   errors: {
     email_required: '電子郵件地址為必填項',
     email_invalid: '請輸入有效的電子郵件地址',
+    project_name_too_long: '專案名稱不能超過 200 個字元',
   },
 };
 

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/oss-onboarding.ts
@@ -13,6 +13,10 @@ const oss_onboarding = {
     personal: '個人專案',
     company: '公司專案',
   },
+  project_name: {
+    label: '專案名稱',
+    placeholder: '我的專案',
+  },
   company_name: {
     label: '公司名稱',
     placeholder: 'Acme.co',

--- a/packages/schemas/src/types/onboarding.ts
+++ b/packages/schemas/src/types/onboarding.ts
@@ -79,6 +79,7 @@ const ossQuestionnaireGuard = z.object({
   emailAddress: z.string().optional(),
   newsletter: z.boolean().optional(),
   project: z.nativeEnum(Project).optional(),
+  projectName: z.string().max(200).optional(),
   companyName: z.string().optional(),
   companySize: z.nativeEnum(CompanySize).optional(),
 });
@@ -89,6 +90,7 @@ export const ossSurveyReportPayloadGuard = z.object({
   emailAddress: z.string().email().max(320),
   newsletter: z.boolean().optional(),
   project: z.nativeEnum(Project),
+  projectName: z.string().max(200).optional(),
   companyName: z.string().max(200).optional(),
   companySize: z.nativeEnum(CompanySize).optional(),
 });


### PR DESCRIPTION
## Summary
<!-- Describe the current net changes in this branch relative to the base branch. -->
<!-- Treat this as a snapshot, not a changelog of how the branch evolved. -->

- Add an optional `Project name` field to OSS onboarding under "I’m using Logto for", available for both personal and company projects.
- Extend OSS onboarding schema and survey payload typing to include optional `projectName` with a `max(200)` limit.
- Normalize submit payload to trim `projectName` and omit it when input is whitespace-only, while keeping existing company-only field behavior unchanged.
- Add/adjust OSS onboarding unit tests and submit-flow tests for the new field behavior, and add `project_name` locale entries in all `oss-onboarding` translation files.

## Testing
<!-- How did you test this PR? -->

Unit tests

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
