### PR TITLE
fix(console): default OSS onboarding company size to 50-199

### DIFF
--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -14,7 +14,7 @@ describe('OSS onboarding form utils', () => {
       newsletter: false,
       project: Project.Company,
       companyName: '',
-      companySize: undefined,
+      companySize: CompanySize.Scale3,
     });
   });
 

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -1,4 +1,4 @@
-import { type CompanySize, type OssSurveyReportPayload, Project } from '@logto/schemas';
+import { CompanySize, type OssSurveyReportPayload, Project } from '@logto/schemas';
 
 export type OssOnboardingFormData = {
   emailAddress: string;
@@ -13,7 +13,7 @@ export const getOssOnboardingDefaultValues = (): OssOnboardingFormData => ({
   newsletter: false,
   project: Project.Company,
   companyName: '',
-  companySize: undefined,
+  companySize: CompanySize.Scale3,
 });
 
 export const shouldRequireCompanyFields = (project: Project) => project === Project.Company;


### PR DESCRIPTION
## Summary

- Default the OSS onboarding `companySize` selection to `50-199` in the shared default-values helper so company projects no longer start with an empty required company-size field.
- Update the OSS onboarding utils unit test to cover the new default selection.


## Testing

Unit tests


## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
