### PR TITLE
fix(console): reorder OSS onboarding project type options

### DIFF
--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -146,15 +146,15 @@ function OssOnboarding() {
                   >
                     <Radio
                       className={styles.projectRadio}
-                      title="oss_onboarding.project.personal"
-                      value={Project.Personal}
-                      icon={<PizzaIcon className={styles.projectOptionIcon} />}
-                    />
-                    <Radio
-                      className={styles.projectRadio}
                       title="oss_onboarding.project.company"
                       value={Project.Company}
                       icon={<BuildingIcon className={styles.projectOptionIcon} />}
+                    />
+                    <Radio
+                      className={styles.projectRadio}
+                      title="oss_onboarding.project.personal"
+                      value={Project.Personal}
+                      icon={<PizzaIcon className={styles.projectOptionIcon} />}
                     />
                   </RadioGroup>
                 )}


### PR DESCRIPTION
## Summary

- Reorder the OSS onboarding project type options so Company appears on the left and Personal on the right.
- Keep the existing Company default selection, which now aligns with the first option in the form.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
