### PR TITLE
fix(console): remove top radius from saml upsell footer

### DIFF
--- a/packages/console/src/components/SamlAppLimitBanner/index.module.scss
+++ b/packages/console/src/components/SamlAppLimitBanner/index.module.scss
@@ -40,6 +40,8 @@
   margin: 0 _.unit(-6) _.unit(-6);
   gap: _.unit(6);
   flex: 1;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .footerAction {


### PR DESCRIPTION
## Summary

- Remove the top-left and top-right border radius from the SAML app limit banner when it is
  rendered as the application creation modal footer.
- Keep the existing full-width footer layout and bottom edge presentation unchanged.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
