### PR TITLE
fix(console): align OSS upsell top banner with design

### DIFF
--- a/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
+++ b/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
@@ -73,6 +73,7 @@ function OssCloudUpsell({ isBannerVisible, onDismissBanner }: Props) {
             size="small"
             aria-label={t('general.close')}
             className={styles.dismissButton}
+            iconClassName={styles.dismissButtonIcon}
             onClick={onDismissBanner}
           >
             <CloseIcon className={styles.dismissIcon} />

--- a/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
+++ b/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
@@ -61,7 +61,6 @@ function OssCloudUpsell({ isBannerVisible, onDismissBanner }: Props) {
                 type="primary"
                 size="large"
                 title="get_started.oss_cloud.try.action"
-                className={styles.bannerActionButton}
                 trailingIcon={<ExternalLinkIcon className={styles.bannerActionIcon} />}
                 onClick={() => {
                   window.open(logtoCloudConsoleLink, '_blank', 'noopener,noreferrer');

--- a/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
+++ b/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
@@ -51,13 +51,17 @@ function OssCloudUpsell({ isBannerVisible, onDismissBanner }: Props) {
                     {t('get_started.oss_cloud.try.badge')}
                   </Tag>
                 </div>
-                <div className={styles.bodyText}>{t('get_started.oss_cloud.try.description')}</div>
+                <div className={styles.ossCloudBannerDescription}>
+                  {t('get_started.oss_cloud.try.description')}
+                </div>
               </div>
             </div>
             <div className={styles.ossCloudBannerActions}>
               <Button
                 type="primary"
+                size="large"
                 title="get_started.oss_cloud.try.action"
+                className={styles.bannerActionButton}
                 trailingIcon={<ExternalLinkIcon className={styles.bannerActionIcon} />}
                 onClick={() => {
                   window.open(logtoCloudConsoleLink, '_blank', 'noopener,noreferrer');

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -131,7 +131,7 @@
   display: inline-flex;
   align-items: center;
   min-height: 22px;
-  padding: 2px _.unit(2);
+  padding: _.unit(0.5) _.unit(2);
   border-radius: 999px;
   color: var(--color-text-link);
   background: var(--color-function-n-overlay-primary-focused);
@@ -160,10 +160,6 @@
   margin-left: auto;
   margin-right: _.unit(3);
   flex-shrink: 0;
-}
-
-.bannerActionButton {
-  border-radius: _.unit(2);
 }
 
 .bannerActionIcon {

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -73,14 +73,14 @@
   position: relative;
   border: 1px solid rgba(93, 52, 242, 20%);
   border-radius: 12px;
-  background-color: var(--color-layer-1);
-  background-image:
+  background:
     linear-gradient(
       173.3deg,
       rgba(93, 52, 242, 6%) 0%,
       rgba(250, 171, 255, 8%) 50%,
       rgba(93, 52, 242, 4%) 100%
-    );
+    ),
+    var(--color-overlay-primary-hover);
 }
 
 .ossCloudBannerContent {
@@ -179,12 +179,17 @@
   flex-shrink: 0;
 }
 
+.dismissButtonIcon {
+  &.dismissButtonIcon > svg {
+    color: var(--color-text);
+    opacity: 35%;
+  }
+}
+
 .dismissIcon {
   display: block;
   width: 16px;
   height: 16px;
-  color: var(--color-text);
-  opacity: 35%;
 }
 
 .card {

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -73,14 +73,7 @@
   position: relative;
   border: 1px solid rgba(93, 52, 242, 20%);
   border-radius: 12px;
-  background:
-    linear-gradient(
-      173.3deg,
-      rgba(93, 52, 242, 6%) 0%,
-      rgba(250, 171, 255, 8%) 50%,
-      rgba(93, 52, 242, 4%) 100%
-    ),
-    var(--color-overlay-primary-hover);
+  background: linear-gradient(180deg, rgba(93, 52, 242, 6%) 0%, rgba(250, 171, 255, 8%) 100%);
 }
 
 .ossCloudBannerContent {

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -72,15 +72,22 @@
 .ossCloudBanner {
   position: relative;
   border: 1px solid rgba(93, 52, 242, 20%);
-  background:
-    linear-gradient(173deg, rgba(93, 52, 242, 6%) 0%, rgba(250, 171, 255, 8%) 52%, rgba(93, 52, 242, 4%) 100%),
-    var(--color-layer-1);
+  border-radius: 12px;
+  background-color: var(--color-layer-1);
+  background-image:
+    linear-gradient(
+      173.3deg,
+      rgba(93, 52, 242, 6%) 0%,
+      rgba(250, 171, 255, 8%) 50%,
+      rgba(93, 52, 242, 4%) 100%
+    );
 }
 
 .ossCloudBannerContent {
   display: flex;
   align-items: center;
   gap: _.unit(6);
+  min-height: 88px;
 }
 
 .ossCloudBannerMain {
@@ -121,28 +128,48 @@
 }
 
 .recommendedTag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px _.unit(2);
   border-radius: 999px;
   color: var(--color-text-link);
   background: var(--color-function-n-overlay-primary-focused);
   gap: _.unit(1);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 18px;
 }
 
 .recommendedTagIcon {
-  width: 10px;
-  height: 10px;
-  color: inherit;
+  width: 12px;
+  height: 12px;
   flex-shrink: 0;
+}
+
+.ossCloudBannerDescription {
+  max-width: 852px;
+  font: var(--font-body-2);
+  color: var(--color-text);
+  opacity: 35%;
 }
 
 .ossCloudBannerActions {
   display: flex;
   align-items: center;
   margin-left: auto;
+  margin-right: _.unit(3);
+  flex-shrink: 0;
+}
+
+.bannerActionButton {
+  border-radius: _.unit(2);
 }
 
 .bannerActionIcon {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
+  opacity: 70%;
 }
 
 .dismissButton {
@@ -156,7 +183,8 @@
   display: block;
   width: 16px;
   height: 16px;
-  color: var(--color-text-secondary);
+  color: var(--color-text);
+  opacity: 35%;
 }
 
 .card {

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -129,9 +129,7 @@
   color: var(--color-text-link);
   background: var(--color-function-n-overlay-primary-focused);
   gap: _.unit(1);
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 18px;
+  font: var(--font-label-3);
 }
 
 .recommendedTagIcon {


### PR DESCRIPTION
## Summary

- Updated the Get Started OSS cloud upsell banner to better match the approved design by using a dedicated banner description style and the large CTA button size.
- Refined the banner-specific styling for the gradient background, border radius, Recommended tag padding/icon sizing, CTA icon sizing, description tone, and the CTA/dismiss-button alignment on desktop.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
