### PR TITLE
fix(console): point OSS branding cloud links to cloud.logto.io

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/Branding/BrandingForm/HideLogtoBrandingField.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/Branding/BrandingForm/HideLogtoBrandingField.tsx
@@ -2,7 +2,7 @@ import { useFormContext } from 'react-hook-form';
 import { Trans } from 'react-i18next';
 
 import { CloudTag } from '@/components/FeatureTag';
-import { officialWebsiteLink } from '@/consts/external-links';
+import { logtoCloudConsoleLink } from '@/consts/external-links';
 import { latestProPlanId } from '@/consts/subscriptions';
 import DynamicT from '@/ds-components/DynamicT';
 import FormField from '@/ds-components/FormField';
@@ -62,7 +62,7 @@ function HideLogtoBrandingField({ variant, isEnabledInCloud }: Props) {
           components={{
             a: (
               <TextLink
-                href={officialWebsiteLink}
+                href={logtoCloudConsoleLink}
                 targetBlank="noopener"
                 className={styles.highlight}
               />

--- a/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.tsx
@@ -6,7 +6,7 @@ import CloudUploadIcon from '@/assets/icons/cloud-upload.svg?react';
 import CustomCssEditorField from '@/components/CustomCssEditorField';
 import { CloudTag } from '@/components/FeatureTag';
 import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
-import { officialWebsiteLink } from '@/consts/external-links';
+import { logtoCloudConsoleLink } from '@/consts/external-links';
 import { latestProPlanId } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import Card from '@/ds-components/Card';
@@ -48,7 +48,7 @@ function OssBringYourUiCard() {
               components={{
                 a: (
                   <TextLink
-                    href={officialWebsiteLink}
+                    href={logtoCloudConsoleLink}
                     targetBlank="noopener"
                     className={styles.highlight}
                   />


### PR DESCRIPTION
## Summary
- Updated the OSS "Hide Logto branding" upsell link in Sign-in Experience Branding to open `https://cloud.logto.io` instead of `https://logto.io`.
- Updated the OSS "Bring your own UI" upsell card link in Sign-in Experience Branding to open `https://cloud.logto.io` instead of `https://logto.io`.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
