### PR TITLE
fix(console): align bring your ui card background in dark mode

### DIFF
--- a/.changeset/fair-ants-grin.md
+++ b/.changeset/fair-ants-grin.md
@@ -1,5 +1,0 @@
----
-"@logto/console": patch
----
-
-align bring your ui card background with the custom css editor in dark mode

--- a/.changeset/fair-ants-grin.md
+++ b/.changeset/fair-ants-grin.md
@@ -1,0 +1,5 @@
+---
+"@logto/console": patch
+---
+
+align bring your ui card background with the custom css editor in dark mode

--- a/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.module.scss
@@ -12,9 +12,9 @@
   align-items: center;
   gap: _.unit(4);
   padding: _.unit(4);
-  border: 1px solid rgba(93, 52, 242, 12%);
+  border: 1px solid var(--color-overlay-primary-pressed);
   border-radius: _.unit(3);
-  background: var(--color-layer-2);
+  background: var(--color-overlay-primary-subtle);
 
   .ossCardContent {
     display: flex;
@@ -31,7 +31,7 @@
     height: 40px;
     flex-shrink: 0;
     border-radius: _.unit(2);
-    background: rgba(93, 52, 242, 8%);
+    background: var(--color-overlay-primary-hover);
 
     > img {
       width: 20px;

--- a/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.module.scss
@@ -14,7 +14,7 @@
   padding: _.unit(4);
   border: 1px solid rgba(93, 52, 242, 12%);
   border-radius: _.unit(3);
-  background: rgba(93, 52, 242, 4%);
+  background: var(--color-layer-2);
 
   .ossCardContent {
     display: flex;

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -89,7 +89,12 @@ describe('smoke testing for console admin account creation and sign-in', () => {
       await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
       await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');
       await expect(page).toClick('div[role=radio]', { text: '50-199' });
-      await expectNavigation(expect(page).toClick('button', { text: 'Next' }));
+      await expect(page).toClick('button', { text: 'Next' });
+      await page.waitForFunction(
+        (expectedUrl) => window.location.href === expectedUrl,
+        {},
+        new URL('console/get-started', logtoConsoleUrl).href
+      );
 
       expect(page.url()).toBe(new URL('console/get-started', logtoConsoleUrl).href);
     }

--- a/packages/toolkit/core-kit/scss/_console-themes.scss
+++ b/packages/toolkit/core-kit/scss/_console-themes.scss
@@ -166,6 +166,7 @@
   --color-specific-focused-inside: var(--color-primary-30);
   --color-specific-focused-outside: var(--color-primary-40);
   --color-specific-button-icon: rgba(255, 255, 255, 70%); // 70% static white
+  --color-overlay-primary-subtle: rgba(93, 52, 242, 4%); // 4% Primary-40
   --color-overlay-primary-hover: rgba(93, 52, 242, 8%); // 8% Primary-40
   --color-overlay-primary-pressed: rgba(93, 52, 242, 12%); // 12% Primary-40
   --color-function-n-overlay-primary-focused: rgba(93, 52, 242, 16%); // 16% Primary-40
@@ -390,6 +391,7 @@
   --color-specific-focused-inside: var(--color-primary-40);
   --color-specific-focused-outside: rgba(#cabeff, 32%); // 32% Primary-40
   --color-specific-button-icon: rgba(255, 255, 255, 60%); // 60% static white
+  --color-overlay-primary-subtle: rgba(202, 190, 255, 4%); // 4% Primary-40
   --color-overlay-primary-hover: rgba(202, 190, 255, 8%); // 8% Primary-40
   --color-overlay-primary-pressed: rgba(202, 190, 255, 12%); // 12% Primary-40
   --color-function-n-overlay-primary-focused: rgba(202, 190, 255, 16%); // 16% Primary-40


### PR DESCRIPTION
## Summary

- align the OSS `Bring your UI` card in `CustomUiForm` with the design by replacing hardcoded background and border colors with theme overlay tokens
- add `--color-overlay-primary-subtle` to both light and dark console theme variable sets and consume it in the card icon background style
- stabilize the console bootstrap integration test for OSS onboarding by waiting for the final `/console/get-started` route before asserting URL

## Testing

Integration tests

## Checklist

- [ ] `.changeset` (only when explicitly required)
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
