### PR TITLE
chore: add changeset for domain cleanup endpoint

### DIFF
--- a/.changeset/noisy-pugs-smile.md
+++ b/.changeset/noisy-pugs-smile.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": minor
+---
+
+add `POST /api/domains/cleanup` endpoint to clean up custom domains that have been inactive (not verified) for a configurable number of days. The endpoint uses Cloudflare as the source of truth to determine domain activity and returns a summary of scanned, deleted, skipped and failed domains.


### PR DESCRIPTION
Follow-up for #8556, which added `POST /api/domains/cleanup` but missed a changeset entry. This PR adds one so the new endpoint shows up in the `@logto/core` (and fixed-group `@logto/api`) changelog on the next release.