### PR TITLE
fix(core): force direct SSO sign-in during consent

### DIFF
--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -35,6 +35,7 @@ import {
   buildLoginPromptUrl,
   isOriginAllowed,
   readOptionalQueryString,
+  shouldForceLoginPrompt,
   validateCustomClientMetadata,
 } from '#src/oidc/utils.js';
 import type Libraries from '#src/tenants/Libraries.js';
@@ -245,6 +246,10 @@ export default function initOidc(
               maxAge: 10 * 1000, // 10s
             }
           );
+        }
+
+        if (shouldForceLoginPrompt(params, prompt.name)) {
+          return '/' + buildLoginPromptUrl(params, sharedParams);
         }
 
         switch (prompt.name) {

--- a/packages/core/src/oidc/utils.test.ts
+++ b/packages/core/src/oidc/utils.test.ts
@@ -16,6 +16,7 @@ import {
   validateCustomClientMetadata,
   buildLoginPromptUrl,
   parseSharedExperienceParams,
+  shouldForceLoginPrompt,
 } from './utils.js';
 
 describe('getConstantClientMetadata()', () => {
@@ -403,6 +404,20 @@ describe('buildLoginPromptUrl', () => {
         { appId: 'app_123', organizationId: 'org_123', uiLocales: 'fr-CA fr' }
       )
     ).toBe('sign-in?app_id=app_123&organization_id=org_123&ui_locales=fr-CA+fr');
+  });
+});
+
+describe('shouldForceLoginPrompt', () => {
+  it('should force login when direct SSO sign-in is requested during consent', () => {
+    expect(shouldForceLoginPrompt({ direct_sign_in: 'sso:connector-id' }, 'consent')).toBe(true);
+  });
+
+  it('should not force login for social direct sign-in during consent', () => {
+    expect(shouldForceLoginPrompt({ direct_sign_in: 'social:google' }, 'consent')).toBe(false);
+  });
+
+  it('should not force login when the current prompt is already login', () => {
+    expect(shouldForceLoginPrompt({ direct_sign_in: 'sso:connector-id' }, 'login')).toBe(false);
   });
 });
 

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -330,6 +330,15 @@ export const buildSharedExperienceCookie = ({
     uiLocales,
   });
 
+/**
+ * A `direct_sign_in=sso:...` request is an explicit request to authenticate with the target
+ * enterprise SSO connector. If the current OIDC prompt is already `consent`, it means an earlier
+ * login session is being reused. In that case, keep routing through the login experience so the
+ * requested SSO flow actually runs instead of silently reusing the previous authentication method.
+ */
+export const shouldForceLoginPrompt = (params: ExtraParamsObject, promptName: string): boolean =>
+  promptName === 'consent' && Boolean(params[ExtraParamsKey.DirectSignIn]?.startsWith('sso:'));
+
 // eslint-disable-next-line complexity
 export const buildLoginPromptUrl = (
   params: ExtraParamsObject,


### PR DESCRIPTION
## Summary

  This PR makes `direct_sign_in=sso:<connector-id>` take precedence over an existing reusable session.

  Today, if a user already has a Logto session and a new authorization request comes in with `direct_sign_in=sso:...`, the OIDC interaction can land directly on the `consent` prompt. In that case, the requested enterprise SSO flow is skipped and the existing authentication context is reused instead.

  This change fixes that behavior by forcing the request back through the login prompt when:
  - the current OIDC prompt is `consent`; and
  - the request explicitly asks for `direct_sign_in=sso:...`.

  Concretely:
  - a new `shouldForceLoginPrompt()` helper was added in `packages/core/src/oidc/utils.ts`;
  - `packages/core/src/oidc/init.ts` now uses that helper before routing `consent` interactions;
  - unit tests were added for the new routing decision.

  This keeps the fix scoped to enterprise SSO direct sign-in requests and avoids changing the behavior for social direct sign-in.

  ## Testing

  Manual/code-level verification:
  - reviewed the OIDC interaction routing path in `packages/core/src/oidc/init.ts`;
  - verified that `direct_sign_in` is normally only applied on the login prompt path;
  - added unit tests covering:
    - forcing login for `direct_sign_in=sso:...` during `consent`;
    - not forcing login for `direct_sign_in=social:...` during `consent`;
    - not forcing login when the prompt is already `login`.

  Environment limitation:
  - I could not complete the full local `@logto/core` test run in this shell because the workspace `pnpm` toolchain is not fully usable in the current sandboxed environment.

  ## Checklist

  - [ ] `.changeset`
  - [x] unit tests
  - [ ] integration tests
  - [x] necessary TSDoc comments