### PR TITLE
feat(console): configure sign-up profile fields

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/SignUpProfileFieldItem.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/SignUpProfileFieldItem.module.scss
@@ -1,0 +1,26 @@
+@use '@/scss/underscore' as _;
+
+.profileFieldItem {
+  display: flex;
+  align-items: center;
+  margin: _.unit(2) 0;
+  gap: _.unit(2);
+}
+
+.profileField {
+  display: flex;
+  align-items: center;
+  height: 44px;
+  width: 100%;
+  padding: _.unit(3) _.unit(2);
+  background-color: var(--color-layer-2);
+  border-radius: 8px;
+  cursor: move;
+  gap: _.unit(1);
+  color: var(--color-text);
+  font: var(--font-label-2);
+
+  .draggableIcon {
+    color: var(--color-text-secondary);
+  }
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/SignUpProfileFieldItem.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/SignUpProfileFieldItem.tsx
@@ -1,0 +1,26 @@
+import Draggable from '@/assets/icons/draggable.svg?react';
+import Minus from '@/assets/icons/minus.svg?react';
+import IconButton from '@/ds-components/IconButton';
+
+import styles from './SignUpProfileFieldItem.module.scss';
+
+type Props = {
+  readonly label: string;
+  readonly onDelete: () => void;
+};
+
+function SignUpProfileFieldItem({ label, onDelete }: Props) {
+  return (
+    <div className={styles.profileFieldItem}>
+      <div className={styles.profileField}>
+        <Draggable className={styles.draggableIcon} />
+        {label}
+      </div>
+      <IconButton onClick={onDelete}>
+        <Minus />
+      </IconButton>
+    </div>
+  );
+}
+
+export default SignUpProfileFieldItem;

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/index.module.scss
@@ -1,0 +1,19 @@
+@use '@/scss/underscore' as _;
+
+.draggleItemContainer {
+  transform: translate(0, 0);
+}
+
+.addProfileFieldsDropdown {
+  min-width: 208px;
+}
+
+.setUpHint {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+  margin-top: _.unit(2);
+
+  .setup {
+    margin: 0 _.unit(1);
+  }
+}

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/SignUpProfileFieldsEditBox/index.tsx
@@ -1,0 +1,135 @@
+import { type CustomProfileField } from '@logto/schemas';
+import { useMemo } from 'react';
+import { Controller, useFieldArray, useFormContext, useWatch } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import useSWR from 'swr';
+
+import CirclePlus from '@/assets/icons/circle-plus.svg?react';
+import Plus from '@/assets/icons/plus.svg?react';
+import ActionMenu from '@/ds-components/ActionMenu';
+import type { Props as ButtonProps } from '@/ds-components/Button';
+import { DragDropProvider, DraggableItem } from '@/ds-components/DragDrop';
+import { DropdownItem } from '@/ds-components/Dropdown';
+import TextLink from '@/ds-components/TextLink';
+import { type RequestError } from '@/hooks/use-api';
+
+import { type SignInExperienceForm } from '../../../../types';
+import { collectUserProfilePathname } from '../../../CollectUserProfile/consts';
+import useI18nFieldLabel from '../../../CollectUserProfile/use-i18n-field-label';
+
+import SignUpProfileFieldItem from './SignUpProfileFieldItem';
+import styles from './index.module.scss';
+
+function SignUpProfileFieldsEditBox() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { control, setValue } = useFormContext<SignInExperienceForm>();
+  const getI18nLabel = useI18nFieldLabel();
+
+  const { data: catalog } = useSWR<CustomProfileField[], RequestError>('api/custom-profile-fields');
+
+  const signUpProfileFields = useWatch({ control, name: 'signUpProfileFields' });
+
+  const { fields, swap, remove, append } = useFieldArray({
+    control,
+    name: 'signUpProfileFields',
+  });
+
+  const markSignUpProfileFieldsAsConfigured = () => {
+    setValue('hasConfiguredSignUpProfileFields', true, { shouldDirty: true });
+  };
+
+  const availableFields = useMemo(() => {
+    if (!catalog) {
+      return [];
+    }
+    const selectedNames = new Set(signUpProfileFields.map(({ name }) => name));
+    return catalog.filter(({ name }) => !selectedNames.has(name));
+  }, [catalog, signUpProfileFields]);
+
+  const fieldLabelByName = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const field of catalog ?? []) {
+      map.set(field.name, field.label || getI18nLabel(field.name));
+    }
+    return map;
+  }, [catalog, getI18nLabel]);
+
+  const hasSelectedFields = fields.length > 0;
+
+  const addProfileFieldsButtonProps: ButtonProps = {
+    type: 'default',
+    size: 'medium',
+    title: 'sign_in_exp.sign_up_and_sign_in.sign_up.add_profile_fields',
+    icon: <Plus />,
+  };
+
+  const addAnotherButtonProps: ButtonProps = {
+    type: 'text',
+    size: 'small',
+    title: 'general.add_another',
+    icon: <CirclePlus />,
+  };
+
+  return (
+    <div>
+      <DragDropProvider>
+        {fields.map(({ id }, index) => {
+          return (
+            <DraggableItem
+              key={id}
+              id={id}
+              sortIndex={index}
+              moveItem={(from, to) => {
+                markSignUpProfileFieldsAsConfigured();
+                swap(from, to);
+              }}
+              className={styles.draggleItemContainer}
+            >
+              <Controller
+                control={control}
+                name={`signUpProfileFields.${index}`}
+                render={({ field: { value } }) => (
+                  <SignUpProfileFieldItem
+                    label={fieldLabelByName.get(value.name) ?? value.name}
+                    onDelete={() => {
+                      markSignUpProfileFieldsAsConfigured();
+                      remove(index);
+                    }}
+                  />
+                )}
+              />
+            </DraggableItem>
+          );
+        })}
+      </DragDropProvider>
+      {availableFields.length > 0 && (
+        <ActionMenu
+          buttonProps={hasSelectedFields ? addAnotherButtonProps : addProfileFieldsButtonProps}
+          dropdownHorizontalAlign="start"
+          dropdownClassName={styles.addProfileFieldsDropdown}
+        >
+          {availableFields.map(({ name, label }) => (
+            <DropdownItem
+              key={name}
+              onClick={() => {
+                markSignUpProfileFieldsAsConfigured();
+                append({ name });
+              }}
+            >
+              {label || getI18nLabel(name)}
+            </DropdownItem>
+          ))}
+        </ActionMenu>
+      )}
+      <div className={styles.setUpHint}>
+        {t('sign_in_exp.sign_up_and_sign_in.sign_up.profile_fields_hint.not_in_list')}
+        <TextLink to={collectUserProfilePathname} className={styles.setup}>
+          {t('sign_in_exp.sign_up_and_sign_in.sign_up.profile_fields_hint.set_up')}
+        </TextLink>
+        {t('sign_in_exp.sign_up_and_sign_in.sign_up.profile_fields_hint.go_to')}
+      </div>
+    </div>
+  );
+}
+
+export default SignUpProfileFieldsEditBox;

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/SignUpForm/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from 'react';
 import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import Card from '@/ds-components/Card';
 import Checkbox from '@/ds-components/Checkbox';
 import FormField from '@/ds-components/FormField';
@@ -12,6 +13,7 @@ import FormFieldDescription from '../../components/FormFieldDescription';
 import FormSectionTitle from '../../components/FormSectionTitle';
 
 import SignUpIdentifiersEditBox from './SignUpIdentifiersEditBox';
+import SignUpProfileFieldsEditBox from './SignUpProfileFieldsEditBox';
 import styles from './index.module.scss';
 import useSignUpPasswordListeners from './use-sign-up-password-listeners';
 
@@ -106,6 +108,11 @@ function SignUpForm({ signInExperience }: Props) {
               />
             )}
           </div>
+        </FormField>
+      )}
+      {isDevFeaturesEnabled && (
+        <FormField title="sign_in_exp.sign_up_and_sign_in.sign_up.collect_user_profile">
+          <SignUpProfileFieldsEditBox />
         </FormField>
       )}
     </Card>

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.test.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.test.ts
@@ -112,6 +112,31 @@ describe('sign-in experience parser', () => {
     expect(registerPayload.customCss).toBe('body { color: red; }');
   });
 
+  it('should preserve legacy null sign-up profile fields until explicitly configured', () => {
+    const formData = sieFormDataParser.fromSignInExperience(mockSignInExperience);
+
+    expect(formData.signUpProfileFields).toEqual([]);
+    expect(formData.hasConfiguredSignUpProfileFields).toBe(false);
+    expect(sieFormDataParser.toSignInExperience(formData).signUpProfileFields).toBeNull();
+
+    expect(
+      sieFormDataParser.toSignInExperience({
+        ...formData,
+        hasConfiguredSignUpProfileFields: true,
+      }).signUpProfileFields
+    ).toEqual([]);
+  });
+
+  it('should keep explicitly configured empty sign-up profile fields as an empty array', () => {
+    const formData = sieFormDataParser.fromSignInExperience({
+      ...mockSignInExperience,
+      signUpProfileFields: [],
+    });
+
+    expect(formData.hasConfiguredSignUpProfileFields).toBe(true);
+    expect(sieFormDataParser.toSignInExperience(formData).signUpProfileFields).toEqual([]);
+  });
+
   it('should omit hideLogtoBranding from OSS payloads', () => {
     const formData = sieFormDataParser.fromSignInExperience(mockSignInExperience);
 
@@ -153,6 +178,18 @@ describe('sign-in experience parser', () => {
     });
 
     expect(comparePayload.signUp.secondaryIdentifiers).toEqual([]);
+  });
+
+  it('should keep null and empty sign-up profile fields distinct in compare payloads', () => {
+    expect(
+      signInExperienceToUpdatedDataParser(mockSignInExperience).signUpProfileFields
+    ).toBeNull();
+    expect(
+      signInExperienceToUpdatedDataParser({
+        ...mockSignInExperience,
+        signUpProfileFields: [],
+      }).signUpProfileFields
+    ).toEqual([]);
   });
 
   it('should omit hideLogtoBranding from OSS compare payloads', () => {

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.ts
@@ -111,6 +111,10 @@ export const signUpFormDataParser = {
   },
 };
 
+const normalizeSignUpProfileFields = (
+  signUpProfileFields: SignInExperience['signUpProfileFields']
+): NonNullable<SignInExperience['signUpProfileFields']> => signUpProfileFields ?? [];
+
 export const sieFormDataParser = {
   fromSignInExperience: (data: SignInExperience): SignInExperienceForm => {
     const {
@@ -132,6 +136,8 @@ export const sieFormDataParser = {
     return {
       ...rest,
       signUp: signUpFormDataParser.fromSignUp(signUp),
+      signUpProfileFields: normalizeSignUpProfileFields(rest.signUpProfileFields),
+      hasConfiguredSignUpProfileFields: rest.signUpProfileFields !== null,
       createAccountEnabled: rest.signInMode !== SignInMode.SignIn,
       customCss: customCss ?? undefined,
       socialSignIn: {
@@ -160,6 +166,7 @@ export const sieFormDataParser = {
       createAccountEnabled,
       signUp,
       customCss,
+      hasConfiguredSignUpProfileFields,
       socialSignIn,
       hideLogtoBranding,
       ...rest
@@ -169,6 +176,10 @@ export const sieFormDataParser = {
       ...rest,
       branding: removeFalsyValues(branding),
       signUp: signUpFormDataParser.toSignUp(signUp),
+      signUpProfileFields:
+        hasConfiguredSignUpProfileFields || rest.signUpProfileFields.length > 0
+          ? rest.signUpProfileFields
+          : null,
       socialSignIn,
       signInMode: createAccountEnabled ? SignInMode.SignInAndRegister : SignInMode.SignIn,
       customCss: customCss?.length ? customCss : null,
@@ -188,6 +199,8 @@ export const sieFormDataParser = {
  * Affected fields:
  * - `signUp.secondaryIdentifiers`: This field is optional in the data schema,
  *  but through the form, we always fill it with an empty array.
+ * - `signUpProfileFields`: nullable in the data schema, but `null` and `[]` carry different
+ *  runtime semantics and must stay distinct in compare payloads.
  * - `mfa`
  * - `adaptiveMfa`
  * - `passwordPolicy`
@@ -219,6 +232,7 @@ export const signInExperienceToUpdatedDataParser = (
       ...signUp,
       secondaryIdentifiers: signUp.secondaryIdentifiers ?? [],
     },
+    signUpProfileFields: rest.signUpProfileFields,
     ...conditional(isCloud && { hideLogtoBranding }),
   };
 };

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -5,6 +5,7 @@ import {
   type SignInExperience,
   type SignInIdentifier,
   type SignUpIdentifier as SignUpIdentifierMethod,
+  type SignUpProfileFields,
   type AccountCenterFieldControl,
 } from '@logto/schemas';
 /**
@@ -109,10 +110,20 @@ export type SignUpForm = Omit<SignUp, 'identifiers' | 'secondaryIdentifiers'> & 
 
 export type SignInExperienceForm = Omit<
   SignInExperience,
-  'signUp' | 'customCss' | OmittedSignInExperienceKeys
+  'signUp' | 'customCss' | 'signUpProfileFields' | OmittedSignInExperienceKeys
 > & {
   customCss?: string; // Code editor components can not properly handle null value, manually transform null to undefined instead.
   signUp: SignUpForm;
+  /**
+   * `useFieldArray` requires an array, so the form always stores this as an array.
+   */
+  signUpProfileFields: SignUpProfileFields;
+  /**
+   * Legacy tenants may still store `null`, which means "use the default catalog behavior".
+   * Keep tracking whether the original value was already explicitly configured so saving unrelated
+   * settings does not silently change `null` into `[]`.
+   */
+  hasConfiguredSignUpProfileFields: boolean;
   createAccountEnabled: boolean;
 };
 

--- a/packages/phrases/src/locales/ar/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -17,6 +17,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'إنشاء كلمة المرور الخاصة بك',
     verify_at_sign_up_option: 'التحقق عند التسجيل',
     social_only_creation_description: '(ينطبق هذا على إنشاء الحساب الاجتماعي فقط)',
+    collect_user_profile: 'جمع ملف تعريف المستخدم',
+    add_profile_fields: 'إضافة حقول الملف الشخصي',
+    profile_fields_hint: {
+      not_in_list: 'غير موجود في القائمة؟',
+      set_up: 'إعداد',
+      go_to: 'حقول الملف الشخصي الأخرى الآن.',
+    },
   },
   sign_in: {
     title: 'تسجيل الدخول',

--- a/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -19,6 +19,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'Erstellen Sie Ihr Passwort',
     verify_at_sign_up_option: 'Bei Anmeldung überprüfen',
     social_only_creation_description: '(Dies gilt nur für die Erstellung von Social-Accounts)',
+    collect_user_profile: 'Benutzerprofil sammeln',
+    add_profile_fields: 'Profilfelder hinzufügen',
+    profile_fields_hint: {
+      not_in_list: 'Nicht in der Liste?',
+      set_up: 'Einrichten',
+      go_to: 'weitere Profilfelder jetzt.',
+    },
   },
   sign_in: {
     title: 'ANMELDEN',

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -19,6 +19,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'Create your password',
     verify_at_sign_up_option: 'Verify at sign-up',
     social_only_creation_description: '(This apply to social only account creation)',
+    collect_user_profile: 'Collect user profile',
+    add_profile_fields: 'Add profile fields',
+    profile_fields_hint: {
+      not_in_list: 'Not in the list?',
+      set_up: 'Set up',
+      go_to: 'other profile fields now.',
+    },
   },
   sign_in: {
     title: 'SIGN IN',

--- a/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -20,6 +20,13 @@ const sign_up_and_sign_in = {
     verify_at_sign_up_option: 'Verificar al registrarse',
     social_only_creation_description:
       '(Esto se aplica solo a la creación de cuentas mediante redes sociales)',
+    collect_user_profile: 'Recopilar perfil de usuario',
+    add_profile_fields: 'Agregar campos de perfil',
+    profile_fields_hint: {
+      not_in_list: '¿No está en la lista?',
+      set_up: 'Configura',
+      go_to: 'otros campos de perfil ahora.',
+    },
   },
   sign_in: {
     title: 'INICIAR SESIÓN',

--- a/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -20,6 +20,13 @@ const sign_up_and_sign_in = {
     verify_at_sign_up_option: "Vérifier lors de l'inscription",
     social_only_creation_description:
       "(Ceci s'applique à la création de compte uniquement via un réseau social)",
+    collect_user_profile: 'Collecter le profil utilisateur',
+    add_profile_fields: 'Ajouter des champs de profil',
+    profile_fields_hint: {
+      not_in_list: 'Pas dans la liste ?',
+      set_up: 'Configurer',
+      go_to: "d'autres champs de profil maintenant.",
+    },
   },
   sign_in: {
     title: 'CONNEXION',

--- a/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -20,6 +20,13 @@ const sign_up_and_sign_in = {
     verify_at_sign_up_option: "Verifica all'atto della registrazione",
     social_only_creation_description:
       '(Questo si applica solo alla creazione di account con i social)',
+    collect_user_profile: 'Raccogli profilo utente',
+    add_profile_fields: 'Aggiungi campi profilo',
+    profile_fields_hint: {
+      not_in_list: "Non è nell'elenco?",
+      set_up: 'Configura',
+      go_to: 'altri campi profilo ora.',
+    },
   },
   sign_in: {
     title: 'ACCEDI',

--- a/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -19,6 +19,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'パスワードの設定',
     verify_at_sign_up_option: 'サインアップ時に確認する',
     social_only_creation_description: '（これはソーシャルアカウント作成に適用されます）',
+    collect_user_profile: 'ユーザープロフィールを収集',
+    add_profile_fields: 'プロフィールフィールドを追加',
+    profile_fields_hint: {
+      not_in_list: '一覧にない場合は?',
+      set_up: '設定',
+      go_to: '他のプロフィールフィールドに移動します。',
+    },
   },
   sign_in: {
     title: 'サインイン',

--- a/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -17,6 +17,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: '비밀번호 생성',
     verify_at_sign_up_option: '회원가입 인증',
     social_only_creation_description: '(이것은 소셜 전용 계정 생성에 적용돼요.)',
+    collect_user_profile: '사용자 프로필 수집',
+    add_profile_fields: '프로필 필드 추가',
+    profile_fields_hint: {
+      not_in_list: '목록에 없나요?',
+      set_up: '설정',
+      go_to: '다른 프로필 필드로 이동하세요.',
+    },
   },
   sign_in: {
     title: '로그인',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -19,6 +19,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'Utwórz hasło',
     verify_at_sign_up_option: 'Weryfikuj podczas rejestracji',
     social_only_creation_description: '(Stosuje się tylko do tworzenia kont społecznościowych)',
+    collect_user_profile: 'Zbieraj profil użytkownika',
+    add_profile_fields: 'Dodaj pola profilu',
+    profile_fields_hint: {
+      not_in_list: 'Nie ma na liście?',
+      set_up: 'Skonfiguruj',
+      go_to: 'inne pola profilu teraz.',
+    },
   },
   sign_in: {
     title: 'LOGOWANIE',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -19,6 +19,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'Crie sua senha',
     verify_at_sign_up_option: 'Visualize na inscrição',
     social_only_creation_description: '(Isso se aplica apenas à criação de contas sociais)',
+    collect_user_profile: 'Coletar perfil do usuário',
+    add_profile_fields: 'Adicionar campos de perfil',
+    profile_fields_hint: {
+      not_in_list: 'Não está na lista?',
+      set_up: 'Configure',
+      go_to: 'outros campos de perfil agora.',
+    },
   },
   sign_in: {
     title: 'ENTRAR',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -19,6 +19,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'Criar uma senha',
     verify_at_sign_up_option: 'Verificar durante o registo',
     social_only_creation_description: '(Aplica-se apenas à criação de contas sociais)',
+    collect_user_profile: 'Recolher perfil do utilizador',
+    add_profile_fields: 'Adicionar campos de perfil',
+    profile_fields_hint: {
+      not_in_list: 'Não está na lista?',
+      set_up: 'Configure',
+      go_to: 'outros campos de perfil agora.',
+    },
   },
   sign_in: {
     title: 'INICIAR SESSÃO',

--- a/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -20,6 +20,13 @@ const sign_up_and_sign_in = {
     verify_at_sign_up_option: 'Подтвердить при регистрации',
     social_only_creation_description:
       '(Применяется только к созданию учетной записи в социальных сетях)',
+    collect_user_profile: 'Сбор профиля пользователя',
+    add_profile_fields: 'Добавить поля профиля',
+    profile_fields_hint: {
+      not_in_list: 'Нет в списке?',
+      set_up: 'Настройте',
+      go_to: 'другие поля профиля сейчас.',
+    },
   },
   sign_in: {
     title: 'ВХОД',

--- a/packages/phrases/src/locales/th/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -18,6 +18,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'สร้างรหัสผ่านของคุณ',
     verify_at_sign_up_option: 'ยืนยันตัวตนในขั้นตอนสมัครสมาชิก',
     social_only_creation_description: '(ใช้สำหรับการสร้างบัญชีด้วยโซเชียลเท่านั้น)',
+    collect_user_profile: 'เก็บข้อมูลโปรไฟล์ผู้ใช้',
+    add_profile_fields: 'เพิ่มฟิลด์โปรไฟล์',
+    profile_fields_hint: {
+      not_in_list: 'ไม่มีในรายการ?',
+      set_up: 'ตั้งค่า',
+      go_to: 'ฟิลด์โปรไฟล์อื่นตอนนี้',
+    },
   },
   sign_in: {
     title: 'เข้าสู่ระบบ',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -19,6 +19,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: 'Şifrenizi oluşturun',
     verify_at_sign_up_option: 'Kaydolduğunuzda doğrulayın',
     social_only_creation_description: '(Bu sadece sosyal hesap yaratımı için geçerlidir)',
+    collect_user_profile: 'Kullanıcı profili topla',
+    add_profile_fields: 'Profil alanları ekle',
+    profile_fields_hint: {
+      not_in_list: 'Listede yok mu?',
+      set_up: 'Ayarla',
+      go_to: 'diğer profil alanlarını şimdi.',
+    },
   },
   sign_in: {
     title: 'OTURUM AÇIN',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -16,6 +16,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: '创建密码',
     verify_at_sign_up_option: '注册时验证身份',
     social_only_creation_description: '（仅对社交注册用户适用）',
+    collect_user_profile: '收集用户资料',
+    add_profile_fields: '添加资料字段',
+    profile_fields_hint: {
+      not_in_list: '没有你想要的字段？',
+      set_up: '立即设置',
+      go_to: '其他资料字段。',
+    },
   },
   sign_in: {
     title: '登录',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -16,6 +16,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: '創建密碼',
     verify_at_sign_up_option: '註冊時驗證身份',
     social_only_creation_description: '（僅對社交註冊用戶適用）',
+    collect_user_profile: '收集用戶資料',
+    add_profile_fields: '添加個人資料欄位',
+    profile_fields_hint: {
+      not_in_list: '沒有你想要的欄位？',
+      set_up: '立即設置',
+      go_to: '其他個人資料欄位。',
+    },
   },
   sign_in: {
     title: '登錄',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/sign-up-and-sign-in.ts
@@ -16,6 +16,13 @@ const sign_up_and_sign_in = {
     set_a_password_option: '建立密碼',
     verify_at_sign_up_option: '驗證身分',
     social_only_creation_description: '（僅適用於社交註冊使用者）',
+    collect_user_profile: '收集用戶資料',
+    add_profile_fields: '新增個人資料欄位',
+    profile_fields_hint: {
+      not_in_list: '沒有你想要的欄位？',
+      set_up: '立即設定',
+      go_to: '其他個人資料欄位。',
+    },
   },
   sign_in: {
     title: '登入',


### PR DESCRIPTION
## Summary

- Add a new "Collect user profile" section to the sign-up form where admins can pick which custom profile fields are collected during sign-up and drag to reorder them.
- Fetches the field catalog from `GET /api/custom-profile-fields`; the picker only lists fields that haven't been selected yet and includes a link to the "Collect user profile" tab for setting up new fields.
- Wires the selection into the sign-in experience form as `signUpProfileFields`, normalized from `null` to `[]` so `useFieldArray` and the diff-compare parser behave consistently.
- Guarded by `isDevFeaturesEnabled`; no changeset (will be added with the flag-removal PR).

Stacked on top of #8695.

## Test plan

- [x] Type-check passes (`pnpm tsc --noEmit` in `packages/console`).
- [x] Existing parser unit tests still pass.
- [ ] With dev features on, verify empty / dropdown / added states render, items drag-reorder, remove works, and the form saves the expected payload.
- [ ] With dev features off, confirm the section is hidden.
