### PR TITLE
feat(console): show signing key statuses

### DIFF
--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
@@ -2,6 +2,7 @@ import {
   SupportedSigningKeyAlgorithm,
   type OidcConfigKeysResponse,
   LogtoOidcConfigKeyType,
+  OidcSigningKeyStatus,
 } from '@logto/schemas';
 import { condArray } from '@silverhand/essentials';
 import { useMemo, useState } from 'react';
@@ -20,6 +21,7 @@ import IconButton from '@/ds-components/IconButton';
 import Select from '@/ds-components/Select';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import Table from '@/ds-components/Table';
+import type { Column } from '@/ds-components/Table/types';
 import Tag from '@/ds-components/Tag';
 import useApi, { type RequestError } from '@/hooks/use-api';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
@@ -38,6 +40,27 @@ const keyTypeTabs = [
     keyTypePhrase: 'cookie',
   },
 ] as const;
+
+const privateKeyStatusTagMap = {
+  [OidcSigningKeyStatus.Next]: {
+    tagStatus: 'info' as const,
+    translationKey: 'status.next' as const,
+  },
+  [OidcSigningKeyStatus.Current]: {
+    tagStatus: 'success' as const,
+    translationKey: 'status.current' as const,
+  },
+  [OidcSigningKeyStatus.Previous]: {
+    tagStatus: 'alert' as const,
+    translationKey: 'status.previous' as const,
+  },
+} satisfies Record<
+  OidcSigningKeyStatus,
+  { tagStatus: 'info' | 'success' | 'alert'; translationKey: `status.${string}` }
+>;
+
+const getPrivateKeyStatusTag = (status?: OidcSigningKeyStatus) =>
+  privateKeyStatusTagMap[status ?? OidcSigningKeyStatus.Current];
 
 function SigningKeysFormCard() {
   const api = useApi();
@@ -61,28 +84,38 @@ function SigningKeysFormCard() {
 
   const isLoadingKeys = !data && !error;
 
-  const tableColumns = useMemo(
+  const tableColumns = useMemo<Array<Column<OidcConfigKeysResponse>>>(
     () => [
       {
-        title: t('table_column.id'),
+        title: String(t('table_column.id')),
         dataIndex: 'id',
         colSpan: 8,
         render: ({ id }: OidcConfigKeysResponse) => <span className={styles.idWrapper}>{id}</span>,
       },
       {
-        title: t('table_column.status'),
+        title: String(t('table_column.status')),
         dataIndex: 'status',
         colSpan: 4,
-        render: (_: OidcConfigKeysResponse, rowIndex: number) => (
-          <Tag type="state" variant="plain" status={rowIndex === 0 ? 'success' : 'alert'}>
-            {t(rowIndex === 0 ? 'status.current' : 'status.previous')}
-          </Tag>
-        ),
+        render: ({ status }: OidcConfigKeysResponse, rowIndex: number) => {
+          const { tagStatus, translationKey } = isPrivateKey
+            ? getPrivateKeyStatusTag(status)
+            : {
+                tagStatus: rowIndex === 0 ? ('success' as const) : ('alert' as const),
+                translationKey:
+                  rowIndex === 0 ? ('status.current' as const) : ('status.previous' as const),
+              };
+
+          return (
+            <Tag type="state" variant="plain" status={tagStatus}>
+              {t(translationKey)}
+            </Tag>
+          );
+        },
       },
       ...condArray(
         isPrivateKey && [
           {
-            title: t('table_column.algorithm'),
+            title: String(t('table_column.algorithm')),
             dataIndex: 'signingKeyAlgorithm',
             colSpan: 7,
             render: ({ signingKeyAlgorithm }: OidcConfigKeysResponse) => (
@@ -95,8 +128,9 @@ function SigningKeysFormCard() {
         title: '',
         dataIndex: 'action',
         colSpan: 2,
-        render: ({ id }: OidcConfigKeysResponse, rowIndex: number) =>
-          rowIndex !== 0 && (
+        render: ({ id, status }: OidcConfigKeysResponse, rowIndex: number) =>
+          ((isPrivateKey && status === OidcSigningKeyStatus.Previous) ||
+            (!isPrivateKey && rowIndex !== 0)) && (
             <div className={styles.deleteIcon}>
               <IconButton
                 onClick={() => {
@@ -170,7 +204,7 @@ function SigningKeysFormCard() {
               })
               .json<OidcConfigKeysResponse[]>();
             void mutate(keys);
-            toast.success(t('messages.rotate_key_success'));
+            toast.success(String(t('messages.rotate_key_success')));
           } finally {
             setIsRotating(false);
           }
@@ -211,7 +245,7 @@ function SigningKeysFormCard() {
           try {
             await api.delete(`api/configs/oidc/${activeTab}/${deletingKeyId}`);
             void mutate(data?.filter((key) => key.id !== deletingKeyId));
-            toast.success(t('messages.delete_key_success'));
+            toast.success(String(t('messages.delete_key_success')));
           } finally {
             setDeletingKeyId(undefined);
           }

--- a/packages/phrases/src/locales/ar/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: 'خوارزمية مفتاح التوقيع',
   },
   status: {
+    next: 'التالي',
     current: 'الحالي',
     previous: 'السابق',
   },

--- a/packages/phrases/src/locales/de/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/signing-keys.ts
@@ -22,6 +22,7 @@ const signing_keys = {
     algorithm: 'Signierungsschlüssel Algorithmus',
   },
   status: {
+    next: 'Nächster',
     current: 'Aktuell',
     previous: 'Vorherige',
   },

--- a/packages/phrases/src/locales/es/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: 'Algoritmo de clave de firma',
   },
   status: {
+    next: 'Siguiente',
     current: 'Actual',
     previous: 'Anterior',
   },

--- a/packages/phrases/src/locales/fr/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/signing-keys.ts
@@ -22,6 +22,7 @@ const signing_keys = {
     algorithm: 'Algorithme de clé de signature',
   },
   status: {
+    next: 'Suivant',
     current: 'Actuel',
     previous: 'Précédent',
   },

--- a/packages/phrases/src/locales/it/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: 'Algoritmo di firma della chiave',
   },
   status: {
+    next: 'Successivo',
     current: 'Attuale',
     previous: 'Precedente',
   },

--- a/packages/phrases/src/locales/ja/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: '署名キーアルゴリズム',
   },
   status: {
+    next: '次の',
     current: '現在の',
     previous: '以前の',
   },

--- a/packages/phrases/src/locales/ko/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: '서명 키 알고리즘',
   },
   status: {
+    next: '다음',
     current: '현재',
     previous: '이전',
   },

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: 'Algorytm podpisywania klucza',
   },
   status: {
+    next: 'Następny',
     current: 'Bieżący',
     previous: 'Poprzedni',
   },

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: 'Algoritmo de assinatura',
   },
   status: {
+    next: 'Próximo',
     current: 'Atual',
     previous: 'Anterior',
   },

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: 'Algoritmo de assinatura da chave',
   },
   status: {
+    next: 'Próximo',
     current: 'Atual',
     previous: 'Anterior',
   },

--- a/packages/phrases/src/locales/ru/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: 'Алгоритм подписи ключа',
   },
   status: {
+    next: 'Следующий',
     current: 'Текущий',
     previous: 'Предыдущий',
   },

--- a/packages/phrases/src/locales/th/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/signing-keys.ts
@@ -21,6 +21,7 @@ const signing_keys = {
     algorithm: 'อัลกอริทึมของคีย์ลงนาม',
   },
   status: {
+    next: 'ถัดไป',
     current: 'ปัจจุบัน',
     previous: 'ก่อนหน้า',
   },

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/signing-keys.ts
@@ -22,6 +22,7 @@ const signing_keys = {
     algorithm: 'İmzalama anahtar algoritması',
   },
   status: {
+    next: 'Sonraki',
     current: 'Geçerli',
     previous: 'Önceki',
   },

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/signing-keys.ts
@@ -21,8 +21,9 @@ const signing_keys = {
     algorithm: '签名密钥算法',
   },
   status: {
+    next: '待切换',
     current: '当前',
-    previous: '之前',
+    previous: '旧密钥',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/signing-keys.ts
@@ -21,8 +21,9 @@ const signing_keys = {
     algorithm: '簽署金鑰算法',
   },
   status: {
+    next: '待切換',
     current: '當前',
-    previous: '之前',
+    previous: '舊金鑰',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/signing-keys.ts
@@ -21,8 +21,9 @@ const signing_keys = {
     algorithm: '簽名演算法',
   },
   status: {
+    next: '待切換',
     current: '當前的',
-    previous: '之前的',
+    previous: '舊密鑰',
   },
   reminder: {
     rotate_private_key:


### PR DESCRIPTION
## Summary
- render private signing key rows in the Console from the API-provided `status` field instead of inferring lifecycle from row index
- only show the delete action for `Previous` private keys while keeping cookie-key behavior unchanged
- add the missing `status.next` locale copy for signing keys and refine the Chinese translations for staged and previous key labels

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
