### PR TITLE
fix(core): qualify tenant rotation state updates

### DIFF
--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -38,6 +38,7 @@ const {
 
 describe('connector queries', () => {
   const { table, fields } = convertToIdentifiers(LogtoConfigs);
+  const qualifiedValueField = sql.identifier([LogtoConfigs.table, LogtoConfigs.fields.value]);
 
   test('getAdminConsoleConfig', async () => {
     const rowData = { key: 'adminConsole', value: `{"signInExperienceCustomized": false}` };
@@ -210,7 +211,7 @@ describe('connector queries', () => {
           ${sql.jsonb({ tenantCacheExpiresAt: timestamp })}
         )
         on conflict (${fields.tenantId}, ${fields.key}) do update
-        set ${fields.value} = coalesce(${fields.value}, '{}'::jsonb) || ${sql.jsonb({
+        set ${fields.value} = coalesce(${qualifiedValueField}, '{}'::jsonb) || ${sql.jsonb({
           tenantCacheExpiresAt: timestamp,
         })}
         returning ${fields.value}
@@ -240,7 +241,7 @@ describe('connector queries', () => {
           ${sql.jsonb({ signingKeyRotationAt: timestamp })}
         )
         on conflict (${fields.tenantId}, ${fields.key}) do update
-        set ${fields.value} = coalesce(${fields.value}, '{}'::jsonb) || ${sql.jsonb({
+        set ${fields.value} = coalesce(${qualifiedValueField}, '{}'::jsonb) || ${sql.jsonb({
           signingKeyRotationAt: timestamp,
         })}
         returning ${fields.value}

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -24,6 +24,7 @@ import { DeletionError } from '#src/errors/SlonikError/index.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 
 const { table, fields } = convertToIdentifiers(LogtoConfigs);
+const qualifiedValueField = sql.identifier([LogtoConfigs.table, LogtoConfigs.fields.value]);
 
 export const createLogtoConfigQueries = (
   pool: CommonQueryMethods,
@@ -170,7 +171,7 @@ export const createLogtoConfigQueries = (
           ${sql.jsonb({ tenantCacheExpiresAt })}
         )
         on conflict (${fields.tenantId}, ${fields.key}) do update
-        set ${fields.value} = coalesce(${fields.value}, '{}'::jsonb) || ${sql.jsonb({
+        set ${fields.value} = coalesce(${qualifiedValueField}, '{}'::jsonb) || ${sql.jsonb({
           tenantCacheExpiresAt,
         })}
         returning ${fields.value}
@@ -189,7 +190,7 @@ export const createLogtoConfigQueries = (
           ${sql.jsonb({ signingKeyRotationAt })}
         )
         on conflict (${fields.tenantId}, ${fields.key}) do update
-        set ${fields.value} = coalesce(${fields.value}, '{}'::jsonb) || ${sql.jsonb({
+        set ${fields.value} = coalesce(${qualifiedValueField}, '{}'::jsonb) || ${sql.jsonb({
           signingKeyRotationAt,
         })}
         returning ${fields.value}

--- a/packages/core/src/tenants/Tenant.test.ts
+++ b/packages/core/src/tenants/Tenant.test.ts
@@ -4,7 +4,9 @@ import Sinon from 'sinon';
 
 import { RedisCache } from '#src/caches/index.js';
 import { WellKnownCache } from '#src/caches/well-known.js';
+import { createLogtoConfigQueries } from '#src/queries/logto-config.js';
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
+import { createMockCommonQueryMethods, expectSqlString } from '#src/test-utils/query.js';
 import { MockWellKnownCache } from '#src/test-utils/tenant.js';
 import { emptyMiddleware } from '#src/utils/test-utils.js';
 
@@ -87,6 +89,33 @@ describe('Tenant `.run()`', () => {
 });
 
 describe('Tenant cache health check', () => {
+  it('uses the qualified rotation-state update query when invalidating cache', async () => {
+    const redisCache = new RedisCache();
+    const tenant = await Tenant.create({ id: defaultTenantId, redisCache });
+    const methods = createMockCommonQueryMethods();
+    const logtoConfigQueries = createLogtoConfigQueries(methods as never, tenant.wellKnownCache);
+
+    methods.one.mockResolvedValueOnce({
+      value: {
+        tenantCacheExpiresAt: 1_234_567_890,
+        signingKeyRotationAt: 2_222_222_222,
+      },
+    } as never);
+
+    Sinon.stub(tenant.queries.logtoConfigs, 'setTenantCacheExpiresAt').value(
+      logtoConfigQueries.setTenantCacheExpiresAt
+    );
+    Sinon.stub(tenant.wellKnownCache, 'set').value(jest.fn());
+    Sinon.stub(tenant.wellKnownCache, 'delete').value(jest.fn());
+
+    await tenant.invalidateCache();
+
+    expect(methods.one).toHaveBeenCalledTimes(1);
+    expect(methods.one).toHaveBeenCalledWith(
+      expectSqlString('coalesce("logto_configs"."value", \'{}\'::jsonb)')
+    );
+  });
+
   it('should persist tenant invalidation state and mirror it to cache', async () => {
     const redisCache = new RedisCache();
     const tenant = await Tenant.create({ id: defaultTenantId, redisCache });


### PR DESCRIPTION
## Summary
- fix the ambiguous `value` reference in tenant rotation-state upserts used by signing key rotation invalidation
- qualify the JSONB merge against `logto_configs.value` so local rotate flows can persist `tenantCacheExpiresAt` and `signingKeyRotationAt` without SQL errors
- add a `Tenant.invalidateCache()` regression test that exercises the real rotation-state query path and asserts the qualified SQL is used

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
