### PR TITLE
feat(core): support PRIVATE_KEY_ROTATION_GRACE_PERIOD default for key rotation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,10 @@ RUN rm -rf .scripts pnpm-*.yaml packages/cloud
 FROM node:22-alpine AS app
 WORKDIR /etc/logto
 ARG logto_oss_survey_endpoint=
+ARG private_key_rotation_grace_period=0
 # Default to empty so external survey relaying stays opt-in for controlled builds/environments.
 ENV LOGTO_OSS_SURVEY_ENDPOINT=${logto_oss_survey_endpoint}
+ENV PRIVATE_KEY_ROTATION_GRACE_PERIOD=${private_key_rotation_grace_period}
 COPY --from=builder /etc/logto .
 RUN mkdir -p /etc/logto/packages/cli/alteration-scripts && chmod g+w /etc/logto/packages/cli/alteration-scripts
 EXPOSE 3001

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
     environment:
       - TRUST_PROXY_HEADER=1
       - DB_URL=postgres://postgres:p0stgr3s@postgres:5432/logto
+      # Optional default grace period, in seconds, for OIDC private key rotation when the API
+      # request omits `rotationGracePeriod`.
+      - PRIVATE_KEY_ROTATION_GRACE_PERIOD
       # Mandatory for GitPod to map host env to the container, thus GitPod can dynamically configure the public URL of Logto;
       # Or, you can leverage it for local testing.
       - ENDPOINT

--- a/packages/core/src/routes/logto-config/index.test.ts
+++ b/packages/core/src/routes/logto-config/index.test.ts
@@ -4,6 +4,7 @@ import { createMockUtils, pickDefault } from '@logto/shared/esm';
 import Sinon from 'sinon';
 
 import { mockAdminConsoleData, mockCookieKeys, mockPrivateKeys } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
@@ -77,6 +78,7 @@ const oidcPrivateKeyLibraries = {
 const settingRoutes = await pickDefault(import('./index.js'));
 
 describe('configs routes', () => {
+  const originalPrivateKeyRotationGracePeriod = EnvSet.values.privateKeyRotationGracePeriod;
   const tenantContext = new MockTenant(undefined, { logtoConfigs: logtoConfigQueries }, undefined, {
     oidcPrivateKeys: oidcPrivateKeyLibraries,
   });
@@ -90,6 +92,11 @@ describe('configs routes', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    Reflect.set(
+      EnvSet.values,
+      'privateKeyRotationGracePeriod',
+      originalPrivateKeyRotationGracePeriod
+    );
   });
 
   it('GET /configs/admin-console', async () => {
@@ -233,10 +240,7 @@ describe('configs routes', () => {
 
     const response = await routeRequester.post('/configs/oidc/private-keys/rotate');
     expect(response.status).toEqual(200);
-    expect(oidcPrivateKeyLibraries.rotatePrivateSigningKeys).toHaveBeenCalledWith(
-      newPrivateKey,
-      undefined
-    );
+    expect(oidcPrivateKeyLibraries.rotatePrivateSigningKeys).toHaveBeenCalledWith(newPrivateKey, 0);
     expect(response.body[0]).toEqual({
       id: newPrivateKey.id,
       createdAt: newPrivateKey.createdAt,
@@ -272,7 +276,7 @@ describe('configs routes', () => {
 
     expect(oidcPrivateKeyLibraries.rotatePrivateSigningKeys).toHaveBeenCalledWith(
       newPrivateKey2,
-      undefined
+      0
     );
   });
 
@@ -286,9 +290,20 @@ describe('configs routes', () => {
       422
     );
 
+    expect(oidcPrivateKeyLibraries.rotatePrivateSigningKeys).toHaveBeenCalledWith(newPrivateKey, 0);
+  });
+
+  it('uses PRIVATE_KEY_ROTATION_GRACE_PERIOD as the default private-key rotation grace period', async () => {
+    Reflect.set(EnvSet.values, 'privateKeyRotationGracePeriod', 14_400);
+
+    await expect(routeRequester.post('/configs/oidc/private-keys/rotate')).resolves.toHaveProperty(
+      'status',
+      200
+    );
+
     expect(oidcPrivateKeyLibraries.rotatePrivateSigningKeys).toHaveBeenCalledWith(
       newPrivateKey,
-      undefined
+      14_400
     );
   });
 

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -17,6 +17,7 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import defaults from '#src/oidc/defaults.js';
@@ -227,6 +228,8 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
       const { keyType } = ctx.guard.params;
       const { signingKeyAlgorithm, rotationGracePeriod } = ctx.guard.body;
       const configKey = getOidcConfigKeyDatabaseColumnName(keyType);
+      const effectiveRotationGracePeriod =
+        rotationGracePeriod ?? EnvSet.values.privateKeyRotationGracePeriod;
 
       if (configKey !== LogtoOidcConfigKey.PrivateKeys && rotationGracePeriod !== undefined) {
         throw new RequestError({ code: 'oidc.invalid_request', status: 422 });
@@ -239,7 +242,10 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
 
       const updatedKeys =
         configKey === LogtoOidcConfigKey.PrivateKeys
-          ? await oidcPrivateKeys.rotatePrivateSigningKeys(newPrivateKey, rotationGracePeriod)
+          ? await oidcPrivateKeys.rotatePrivateSigningKeys(
+              newPrivateKey,
+              effectiveRotationGracePeriod
+            )
           : await (async () => {
               const configs = await getOidcConfigs(getConsoleLogFromContext(ctx));
               const existingKeys = configs[configKey];

--- a/packages/shared/src/node/env/GlobalValues.test.ts
+++ b/packages/shared/src/node/env/GlobalValues.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseTimeoutEnv } from './GlobalValues.js';
+import { parseNonNegativeIntegerEnv, parseTimeoutEnv } from './GlobalValues.js';
 
 describe('parseTimeoutEnv', () => {
   it('returns undefined for missing, blank, or invalid values', () => {
@@ -25,5 +25,23 @@ describe('parseTimeoutEnv', () => {
   it('accepts negative and decimal values as numbers', () => {
     expect(parseTimeoutEnv('-1')).toBe(-1);
     expect(parseTimeoutEnv('1.5')).toBe(1.5);
+  });
+});
+
+describe('parseNonNegativeIntegerEnv', () => {
+  it('returns the fallback for missing, blank, negative, decimal, or invalid values', () => {
+    expect(parseNonNegativeIntegerEnv()).toBe(0);
+    expect(parseNonNegativeIntegerEnv('')).toBe(0);
+    expect(parseNonNegativeIntegerEnv('   ')).toBe(0);
+    expect(parseNonNegativeIntegerEnv('-1')).toBe(0);
+    expect(parseNonNegativeIntegerEnv('1.5')).toBe(0);
+    expect(parseNonNegativeIntegerEnv('abc')).toBe(0);
+    expect(parseNonNegativeIntegerEnv('abc', 30)).toBe(30);
+  });
+
+  it('parses non-negative integer values', () => {
+    expect(parseNonNegativeIntegerEnv('0')).toBe(0);
+    expect(parseNonNegativeIntegerEnv('60')).toBe(60);
+    expect(parseNonNegativeIntegerEnv(' 14400 ')).toBe(14_400);
   });
 });

--- a/packages/shared/src/node/env/GlobalValues.test.ts
+++ b/packages/shared/src/node/env/GlobalValues.test.ts
@@ -29,13 +29,14 @@ describe('parseTimeoutEnv', () => {
 });
 
 describe('parseNonNegativeIntegerEnv', () => {
-  it('returns the fallback for missing, blank, negative, decimal, or invalid values', () => {
+  it('returns the fallback for missing, blank, negative, decimal, invalid, or unsafe integer values', () => {
     expect(parseNonNegativeIntegerEnv()).toBe(0);
     expect(parseNonNegativeIntegerEnv('')).toBe(0);
     expect(parseNonNegativeIntegerEnv('   ')).toBe(0);
     expect(parseNonNegativeIntegerEnv('-1')).toBe(0);
     expect(parseNonNegativeIntegerEnv('1.5')).toBe(0);
     expect(parseNonNegativeIntegerEnv('abc')).toBe(0);
+    expect(parseNonNegativeIntegerEnv('9007199254740992')).toBe(0);
     expect(parseNonNegativeIntegerEnv('abc', 30)).toBe(30);
   });
 

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -51,19 +51,15 @@ export const parseTimeoutEnv = (value?: string): Optional<number | 'DISABLE_TIME
 };
 
 export const parseNonNegativeIntegerEnv = (value?: string, fallback = 0): number => {
-  if (value === undefined) {
-    return fallback;
-  }
+  const normalized = value?.trim();
 
-  const normalized = value.trim();
-
-  if (normalized === '') {
+  if (!normalized) {
     return fallback;
   }
 
   const parsed = Number(normalized);
 
-  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
 };
 
 export default class GlobalValues {

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -50,6 +50,22 @@ export const parseTimeoutEnv = (value?: string): Optional<number | 'DISABLE_TIME
   return Number.isFinite(parsed) ? parsed : undefined;
 };
 
+export const parseNonNegativeIntegerEnv = (value?: string, fallback = 0): number => {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  const normalized = value.trim();
+
+  if (normalized === '') {
+    return fallback;
+  }
+
+  const parsed = Number(normalized);
+
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
 export default class GlobalValues {
   public readonly isProduction = getEnv('NODE_ENV') === 'production';
   public readonly isIntegrationTest = yes(getEnv('INTEGRATION_TEST'));
@@ -196,6 +212,15 @@ export default class GlobalValues {
    * You can set it to a truthy value like `true` or `1` to enable cache with the default Redis URL.
    */
   public readonly redisUrl = getEnv('REDIS_URL');
+
+  /**
+   * Default grace period for private signing key rotation, in seconds.
+   * Cloud can configure a safe platform-wide default, while OSS/self-host deployments
+   * may opt in through environment configuration.
+   */
+  public readonly privateKeyRotationGracePeriod = parseNonNegativeIntegerEnv(
+    getEnv('PRIVATE_KEY_ROTATION_GRACE_PERIOD', '0')
+  );
 
   public get dbUrl(): string {
     return this.databaseUrl;


### PR DESCRIPTION
## Summary
Add support for `PRIVATE_KEY_ROTATION_GRACE_PERIOD` as the default grace period for OIDC private-key rotation.

When the env is unset or invalid, the default remains `0` so the current immediate-rotation behavior is preserved. When the rotate API request omits `rotationGracePeriod`, the route now falls back to the env-configured value. Explicit request values still take precedence.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments