### PR TITLE
fix(console): move sidebar cloud card into scroll container

### DIFF
--- a/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
@@ -13,6 +13,12 @@
   min-height: 0;
 }
 
+.menuContent {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .skeleton {
   width: 248px;
   height: 100%;

--- a/packages/console/src/containers/ConsoleContent/Sidebar/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/index.tsx
@@ -24,26 +24,28 @@ function Sidebar() {
   return (
     <div className={styles.sidebar}>
       <OverlayScrollbar className={styles.menu}>
-        {sections.map(({ title, items }) => (
-          <Section key={title} title={t(title)}>
-            {items.map(
-              ({ title, Icon, isHidden, modal, externalLink, path }) =>
-                !isHidden && (
-                  <Item
-                    key={title}
-                    titleKey={title}
-                    icon={<Icon />}
-                    isActive={match('/' + (path ?? getPath(title)))}
-                    modal={modal}
-                    externalLink={externalLink}
-                    path={path}
-                  />
-                )
-            )}
-          </Section>
-        ))}
+        <div className={styles.menuContent}>
+          {sections.map(({ title, items }) => (
+            <Section key={title} title={t(title)}>
+              {items.map(
+                ({ title, Icon, isHidden, modal, externalLink, path }) =>
+                  !isHidden && (
+                    <Item
+                      key={title}
+                      titleKey={title}
+                      icon={<Icon />}
+                      isActive={match('/' + (path ?? getPath(title)))}
+                      modal={modal}
+                      externalLink={externalLink}
+                      path={path}
+                    />
+                  )
+              )}
+            </Section>
+          ))}
+          <OssCloudCard />
+        </div>
       </OverlayScrollbar>
-      <OssCloudCard />
     </div>
   );
 }

--- a/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
@@ -2,6 +2,11 @@
 
 .wrapper {
   padding: _.unit(4) _.unit(4) 0;
+  margin-top: auto;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
+  background: linear-gradient(180deg, transparent 0, var(--color-layer-1) _.unit(4));
 }
 
 .withDevStatusOffset {


### PR DESCRIPTION
## Summary
<!-- Describe the current net changes in this branch relative to the base branch. -->
<!-- Treat this as a snapshot, not a changelog of how the branch evolved. -->

- Move the OSS Cloud upsell card into the sidebar overlay scrollbar content so it lives inside the same scroll container as the navigation items.
- Add a full-height sidebar content wrapper and sticky card wrapper styles so the card stays attached to the bottom of the visible sidebar area instead of rendering below the scrollbar.

## Testing
<!-- How did you test this PR? -->

Tested locally

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset` (only when explicitly required)
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
