### PR TITLE
fix(console): resolve sidebar visual issues and onboarding submit crash

### DIFF
--- a/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
@@ -1,4 +1,5 @@
 @use '@/scss/underscore' as _;
+@use '../dev-status-spacing' as devStatusSpacing;
 
 .sidebar {
   width: 248px;
@@ -21,8 +22,7 @@
 
 .devStatusSpacer {
   // Keep the last sidebar item clear of the floating "Dev features enabled" status badge.
-  // 3 = badge bottom offset, 3 = gap, 5 = badge height.
-  height: _.unit(3 + 3 + 5);
+  height: devStatusSpacing.$dev-status-reserved-space;
   pointer-events: none;
 }
 

--- a/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
@@ -19,6 +19,13 @@
   flex-direction: column;
 }
 
+.devStatusSpacer {
+  // Keep the last sidebar item clear of the floating "Dev features enabled" status badge.
+  // 3 = badge bottom offset, 3 = gap, 5 = badge height.
+  height: _.unit(3 + 3 + 5);
+  pointer-events: none;
+}
+
 .skeleton {
   width: 248px;
   height: 100%;

--- a/packages/console/src/containers/ConsoleContent/Sidebar/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
 import useMatchTenantPath from '@/hooks/use-tenant-pathname';
 
@@ -43,6 +44,7 @@ function Sidebar() {
               )}
             </Section>
           ))}
+          {isDevFeaturesEnabled && <div aria-hidden className={styles.devStatusSpacer} />}
           <OssCloudCard />
         </div>
       </OverlayScrollbar>

--- a/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
@@ -6,7 +6,8 @@
   position: sticky;
   bottom: 0;
   z-index: 1;
-  background: linear-gradient(180deg, transparent 0, var(--color-layer-1) _.unit(4));
+  // Keep the fade aligned with the sidebar background instead of forcing card-like layer color.
+  background: linear-gradient(180deg, transparent 0, var(--color-base) _.unit(4));
 }
 
 .withDevStatusOffset {

--- a/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
@@ -1,4 +1,5 @@
 @use '@/scss/underscore' as _;
+@use '../dev-status-spacing' as devStatusSpacing;
 
 .wrapper {
   padding: _.unit(4) _.unit(4) 0;
@@ -11,9 +12,7 @@
 }
 
 .withDevStatusOffset {
-  // 3 is the bottom margin of the dev status badge, so we need to include this margin when considering the spacing between the card and the status badge.
-  // 5 is the height of the status badge.
-  padding-bottom: _.unit(3 + 3 + 5);
+  padding-bottom: devStatusSpacing.$dev-status-reserved-space;
 }
 
 .card {

--- a/packages/console/src/containers/ConsoleContent/_dev-status-spacing.scss
+++ b/packages/console/src/containers/ConsoleContent/_dev-status-spacing.scss
@@ -1,0 +1,10 @@
+@use '@/scss/underscore' as _;
+
+$dev-status-bottom-offset-factor: 3;
+$dev-status-gap-factor: 3;
+$dev-status-height-factor: 5;
+
+$dev-status-bottom-offset: _.unit($dev-status-bottom-offset-factor);
+$dev-status-reserved-space: _.unit(
+  $dev-status-bottom-offset-factor + $dev-status-gap-factor + $dev-status-height-factor
+);

--- a/packages/console/src/containers/ConsoleContent/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/index.module.scss
@@ -1,4 +1,5 @@
 @use '@/scss/underscore' as _;
+@use './dev-status-spacing' as devStatusSpacing;
 
 .content {
   flex-grow: 1;
@@ -29,7 +30,7 @@
 .devStatus {
   color: var(--color-text-secondary);
   position: absolute;
-  bottom: _.unit(3);
+  bottom: devStatusSpacing.$dev-status-bottom-offset;
   inset-inline-start: _.unit(4);
 }
 

--- a/packages/console/src/pages/OssOnboarding/index.tsx
+++ b/packages/console/src/pages/OssOnboarding/index.tsx
@@ -143,6 +143,20 @@ function OssOnboarding() {
                 />
               )}
             </div>
+            <FormField title="oss_onboarding.project_name.label">
+              <TextInput
+                maxLength={200}
+                placeholder={t('oss_onboarding.project_name.placeholder')}
+                disabled={isSubmitting}
+                error={errors.projectName?.message}
+                {...register('projectName', {
+                  maxLength: {
+                    value: 200,
+                    message: t('oss_onboarding.errors.project_name_too_long'),
+                  },
+                })}
+              />
+            </FormField>
             <FormField title="oss_onboarding.project.label">
               <Controller
                 name="project"
@@ -170,20 +184,6 @@ function OssOnboarding() {
                     />
                   </RadioGroup>
                 )}
-              />
-            </FormField>
-            <FormField title="oss_onboarding.project_name.label">
-              <TextInput
-                maxLength={200}
-                placeholder={t('oss_onboarding.project_name.placeholder')}
-                disabled={isSubmitting}
-                error={errors.projectName?.message}
-                {...register('projectName', {
-                  maxLength: {
-                    value: 200,
-                    message: t('oss_onboarding.errors.project_name_too_long'),
-                  },
-                })}
               />
             </FormField>
             {isCompanyProject && (

--- a/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
+++ b/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
@@ -71,6 +71,13 @@ const mockFormDataWithoutEmail: OssOnboardingFormData = {
   companySize: CompanySize.Scale3,
 };
 
+const mockPersonalFormDataWithoutCompanyFields: OssOnboardingFormData = {
+  emailAddress: 'Dev@Example.COM',
+  newsletter: true,
+  project: Project.Personal,
+  projectName: ' OSS Starter ',
+};
+
 const getSubmitOssOnboarding = async () => {
   const module = await import('./submit-oss-onboarding');
   return module.submitOssOnboarding;
@@ -173,6 +180,45 @@ describe('submitOssOnboarding', () => {
       isOnboardingDone: true,
     });
     expect(mockKyPost).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith('/get-started', { replace: true });
+  });
+
+  it('handles personal project submit when company fields are missing', async () => {
+    const submitOssOnboarding = await getSubmitOssOnboarding();
+    const update = jest.fn<Promise<void>, [Partial<OssUserOnboardingData>]>();
+    const navigate = jest.fn<void, [string, { replace: boolean }]>();
+
+    update.mockResolvedValue();
+
+    await expect(
+      submitOssOnboarding({
+        formData: mockPersonalFormDataWithoutCompanyFields,
+        navigate,
+        update,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(update).toHaveBeenCalledWith({
+      questionnaire: {
+        emailAddress: 'dev@example.com',
+        newsletter: true,
+        project: Project.Personal,
+        projectName: 'OSS Starter',
+      },
+      isOnboardingDone: true,
+    });
+    expect(mockKyPost).toHaveBeenCalledWith(
+      new URL('https://survey.example.com/api/surveys'),
+      expect.objectContaining({
+        json: {
+          emailAddress: 'dev@example.com',
+          newsletter: true,
+          project: Project.Personal,
+          projectName: 'OSS Starter',
+        },
+        keepalive: true,
+      })
+    );
     expect(navigate).toHaveBeenCalledWith('/get-started', { replace: true });
   });
 

--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -54,6 +54,23 @@ describe('OSS onboarding form utils', () => {
     });
   });
 
+  test('handles missing company fields for personal project payloads', () => {
+    const payload = getBaseOssOnboardingPayload({
+      emailAddress: 'Dev@Example.COM',
+      newsletter: true,
+      project: Project.Personal,
+      projectName: '  My starter app  ',
+      companySize: CompanySize.Scale3,
+    });
+
+    expect(payload).toEqual({
+      emailAddress: 'dev@example.com',
+      newsletter: true,
+      project: Project.Personal,
+      projectName: 'My starter app',
+    });
+  });
+
   test('omits email-related fields from the questionnaire payload when email is missing', () => {
     const payload = getBaseOssOnboardingPayload({
       emailAddress: '',
@@ -114,6 +131,23 @@ describe('OSS onboarding form utils', () => {
         companySize: CompanySize.Scale3,
       })
     ).toEqual({
+      emailAddress: 'dev@example.com',
+      newsletter: false,
+      project: Project.Personal,
+      projectName: 'My starter app',
+    } satisfies OssSurveyReportPayload);
+  });
+
+  test('handles missing company fields for personal survey payloads', () => {
+    const payload = getOssOnboardingSurveyPayload({
+      emailAddress: 'Dev@Example.COM',
+      newsletter: false,
+      project: Project.Personal,
+      projectName: '  My starter app  ',
+      companySize: CompanySize.Scale3,
+    });
+
+    expect(payload).toEqual({
       emailAddress: 'dev@example.com',
       newsletter: false,
       project: Project.Personal,

--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -71,6 +71,22 @@ describe('OSS onboarding form utils', () => {
     });
   });
 
+  test('handles missing project name in the questionnaire payload', () => {
+    const payload = getBaseOssOnboardingPayload({
+      emailAddress: 'Dev@Example.COM',
+      newsletter: true,
+      project: Project.Personal,
+      companyName: 'Should be ignored',
+      companySize: CompanySize.Scale3,
+    });
+
+    expect(payload).toEqual({
+      emailAddress: 'dev@example.com',
+      newsletter: true,
+      project: Project.Personal,
+    });
+  });
+
   test('omits email-related fields from the questionnaire payload when email is missing', () => {
     const payload = getBaseOssOnboardingPayload({
       emailAddress: '',
@@ -152,6 +168,22 @@ describe('OSS onboarding form utils', () => {
       newsletter: false,
       project: Project.Personal,
       projectName: 'My starter app',
+    } satisfies OssSurveyReportPayload);
+  });
+
+  test('handles missing project name in survey payloads', () => {
+    const payload = getOssOnboardingSurveyPayload({
+      emailAddress: 'Dev@Example.COM',
+      newsletter: false,
+      project: Project.Personal,
+      companyName: 'Should be ignored',
+      companySize: CompanySize.Scale3,
+    });
+
+    expect(payload).toEqual({
+      emailAddress: 'dev@example.com',
+      newsletter: false,
+      project: Project.Personal,
     } satisfies OssSurveyReportPayload);
   });
 

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -7,7 +7,7 @@ export type OssOnboardingFormData = {
   newsletter: boolean;
   project: Project;
   projectName: string;
-  companyName: string;
+  companyName?: string;
   companySize?: CompanySize;
 };
 
@@ -38,7 +38,7 @@ export const isValidOssOnboardingEmailAddress = (emailAddress: string) =>
 export const getBaseOssOnboardingPayload = (data: OssOnboardingFormData) => {
   const normalizedEmailAddress = normalizeOssOnboardingEmailAddress(data.emailAddress);
   const normalizedProjectName = data.projectName.trim();
-  const normalizedCompanyName = data.companyName.trim();
+  const normalizedCompanyName = (data.companyName ?? '').trim();
   const projectNameFields = normalizedProjectName ? { projectName: normalizedProjectName } : {};
   const companyNameFields = normalizedCompanyName ? { companyName: normalizedCompanyName } : {};
   const emailFields = normalizedEmailAddress
@@ -70,7 +70,7 @@ export const getOssOnboardingSurveyPayload = (
 ): Optional<OssSurveyReportPayload> => {
   const normalizedEmailAddress = normalizeOssOnboardingEmailAddress(data.emailAddress);
   const normalizedProjectName = data.projectName.trim();
-  const normalizedCompanyName = data.companyName.trim();
+  const normalizedCompanyName = (data.companyName ?? '').trim();
   const projectNameFields = normalizedProjectName ? { projectName: normalizedProjectName } : {};
   const companyNameFields = normalizedCompanyName ? { companyName: normalizedCompanyName } : {};
 

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -6,7 +6,7 @@ export type OssOnboardingFormData = {
   emailAddress: string;
   newsletter: boolean;
   project: Project;
-  projectName: string;
+  projectName?: string;
   companyName?: string;
   companySize?: CompanySize;
 };
@@ -37,7 +37,7 @@ export const isValidOssOnboardingEmailAddress = (emailAddress: string) =>
 
 export const getBaseOssOnboardingPayload = (data: OssOnboardingFormData) => {
   const normalizedEmailAddress = normalizeOssOnboardingEmailAddress(data.emailAddress);
-  const normalizedProjectName = data.projectName.trim();
+  const normalizedProjectName = (data.projectName ?? '').trim();
   const normalizedCompanyName = (data.companyName ?? '').trim();
   const projectNameFields = normalizedProjectName ? { projectName: normalizedProjectName } : {};
   const companyNameFields = normalizedCompanyName ? { companyName: normalizedCompanyName } : {};
@@ -69,7 +69,7 @@ export const getOssOnboardingSurveyPayload = (
   data: OssOnboardingFormData
 ): Optional<OssSurveyReportPayload> => {
   const normalizedEmailAddress = normalizeOssOnboardingEmailAddress(data.emailAddress);
-  const normalizedProjectName = data.projectName.trim();
+  const normalizedProjectName = (data.projectName ?? '').trim();
   const normalizedCompanyName = (data.companyName ?? '').trim();
   const projectNameFields = normalizedProjectName ? { projectName: normalizedProjectName } : {};
   const companyNameFields = normalizedCompanyName ? { companyName: normalizedCompanyName } : {};


### PR DESCRIPTION
## Summary
<!-- Describe the current net changes in this branch relative to the base branch. -->
<!-- Treat this as a snapshot, not a changelog of how the branch evolved. -->

- Add a dev-mode-only spacer before `OssCloudCard` in the console sidebar so the floating "Dev features enabled" status badge does not visually overlap the last sidebar item.
- Keep the "Focus on building" card fade aligned with the sidebar background by using `--color-base`, so showing the card does not shift the sidebar bottom background color in light/dark mode.
- Reorder OSS onboarding fields to place `Project Name` before `I'm using Logto for` in the form flow.
- Make OSS onboarding payload normalization tolerant of missing company fields by treating `companyName` as optional and safely normalizing empty values.
- Add unit tests for OSS onboarding payload builders and submit flow to cover personal-project submissions where company fields are absent.


## Testing
<!-- How did you test this PR? -->

Unit tests


## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset` (only when explicitly required)
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
