### PR TITLE
fix(account): align 2-step verification toggle on mobile

### DIFF
--- a/packages/account/src/pages/Security/MfaSection/index.module.scss
+++ b/packages/account/src/pages/Security/MfaSection/index.module.scss
@@ -160,14 +160,11 @@
   }
 
   .toggleRow {
-    flex-direction: column;
-    align-items: flex-start;
     gap: _.unit(3);
     padding: _.unit(4);
   }
 
   .toggleInfo {
-    width: 100%;
     gap: _.unit(1.5);
   }
 


### PR DESCRIPTION
## Summary
Fix the mobile layout for the Account Center 2-step verification section so the copy and toggle stay horizontally aligned, matching the design.

## Testing
Tested locally

<img width="339" height="316" alt="Screenshot 2026-04-27 at 11 00 54 AM" src="https://github.com/user-attachments/assets/b9f59faa-97e2-4c33-a65e-d11e1e69a5c0" />


## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments