### PR TITLE
fix: align account center language detection

### DIFF
--- a/packages/account/src/i18n/init.ts
+++ b/packages/account/src/i18n/init.ts
@@ -1,12 +1,11 @@
 import type { LanguageTag } from '@logto/language-kit';
 import resources from '@logto/phrases-experience';
 import i18next from 'i18next';
-import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
-import { resolveLanguage, storageKey } from '@ac/i18n/utils';
+import { resolveLanguage } from '@ac/i18n/utils';
 
-i18next.use(initReactI18next).use(LanguageDetector);
+i18next.use(initReactI18next);
 
 const initI18n = async (initialLanguage?: LanguageTag) => {
   const normalizedLanguage =
@@ -16,10 +15,6 @@ const initI18n = async (initialLanguage?: LanguageTag) => {
     resources: {},
     fallbackLng: 'en',
     lng: normalizedLanguage,
-    detection: {
-      lookupLocalStorage: storageKey,
-      lookupSessionStorage: storageKey,
-    },
     interpolation: {
       escapeValue: false,
     },

--- a/packages/account/src/i18n/utils.test.ts
+++ b/packages/account/src/i18n/utils.test.ts
@@ -49,8 +49,8 @@ void test('getPreferredLanguage uses the shared SIE language source when auto de
     },
   };
   const navigator = {
-    languages: ['en-US'],
-    language: 'en-US',
+    languages: ['fr'],
+    language: 'fr',
   };
 
   Reflect.defineProperty(globalThis, 'navigator', {

--- a/packages/account/src/i18n/utils.test.ts
+++ b/packages/account/src/i18n/utils.test.ts
@@ -31,3 +31,66 @@ void test('getPreferredLanguage respects ui_locales fallback before language set
     'pl-PL'
   );
 });
+
+void test('getPreferredLanguage uses the shared SIE language source when auto detecting', () => {
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+  const storage = new Map([
+    ['i18nextAccountCenterLng', 'zh-CN'],
+    ['i18nextLogtoUiLng', 'en-US'],
+  ]);
+  const localStorage = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+  };
+  const navigator = {
+    languages: ['en-US'],
+    language: 'en-US',
+  };
+
+  Reflect.defineProperty(globalThis, 'navigator', {
+    value: navigator,
+    configurable: true,
+  });
+  Reflect.defineProperty(globalThis, 'window', {
+    value: {
+      location: {
+        hash: '',
+        search: '',
+      },
+      localStorage,
+      sessionStorage: localStorage,
+      navigator,
+    },
+    configurable: true,
+  });
+
+  try {
+    assert.equal(
+      getPreferredLanguage({
+        languageSettings: {
+          autoDetect: true,
+          fallbackLanguage: 'fr',
+        },
+      }),
+      'en'
+    );
+  } finally {
+    if (navigatorDescriptor) {
+      Reflect.defineProperty(globalThis, 'navigator', navigatorDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, 'navigator');
+    }
+
+    if (windowDescriptor) {
+      Reflect.defineProperty(globalThis, 'window', windowDescriptor);
+    } else {
+      Reflect.deleteProperty(globalThis, 'window');
+    }
+  }
+});

--- a/packages/account/src/i18n/utils.ts
+++ b/packages/account/src/i18n/utils.ts
@@ -4,8 +4,7 @@ import type { LanguageInfo } from '@logto/schemas';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-const storageKey = 'i18nextAccountCenterLng';
-export { storageKey };
+const storageKey = 'i18nextLogtoUiLng';
 
 export const resolveLanguage = (language?: string): BuiltInLanguageTag | undefined =>
   language
@@ -27,11 +26,7 @@ export const resolveUiLocalesLanguage = (uiLocales?: string) => {
     .find(Boolean);
 };
 
-export const detectLanguage = (languageSettings?: LanguageInfo) => {
-  if (languageSettings?.autoDetect === false) {
-    return resolveLanguage(languageSettings.fallbackLanguage) ?? 'en';
-  }
-
+const detectLanguages = () => {
   const languageDetector = new LanguageDetector();
   languageDetector.init(
     { languageUtils: {} },
@@ -44,10 +39,18 @@ export const detectLanguage = (languageSettings?: LanguageInfo) => {
   const detected = languageDetector.detect();
 
   if (Array.isArray(detected)) {
-    return matchSupportedLanguageTag(detected, builtInLanguages).match ?? 'en';
+    return detected;
   }
 
-  return resolveLanguage(detected) ?? 'en';
+  return detected ? [detected] : [];
+};
+
+export const detectLanguage = (languageSettings?: LanguageInfo) => {
+  if (languageSettings?.autoDetect === false) {
+    return resolveLanguage(languageSettings.fallbackLanguage) ?? 'en';
+  }
+
+  return matchSupportedLanguageTag(detectLanguages(), builtInLanguages).match ?? 'en';
 };
 
 export const getPreferredLanguage = ({


### PR DESCRIPTION
## Summary
Fix Account Center language detection so it aligns with the sign-in experience language source instead of persisting and reusing its own language cache.

The root cause was that Account Center registered the browser language detector in i18next initialization, so a `ui_locales` override could be cached under `i18nextAccountCenterLng` and reused on later launches. Account Center now mirrors the sign-in experience pattern: use the detector only for detection, share the SIE cache key, and avoid i18next detector-side language caching.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments