### PR TITLE
fix(console): prevent account center route list overflow

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.module.scss
@@ -24,7 +24,7 @@
 
 .urlGrid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: _.unit(3);
 }
 
@@ -38,6 +38,7 @@
   padding: 0 _.unit(3);
   height: 36px;
   gap: _.unit(2);
+  min-width: 0;
 }
 
 .urlPath {


### PR DESCRIPTION
## Summary
Fix LOG-13273 by allowing the Account Center prebuilt UI route grid to shrink within the Console form card. Long route paths now ellipsize inside their grid cells instead of pushing the second column outside the page content.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments