### PR TITLE
fix(console): align OSS onboarding field spacing

### DIFF
--- a/packages/console/src/pages/OssOnboarding/index.module.scss
+++ b/packages/console/src/pages/OssOnboarding/index.module.scss
@@ -57,7 +57,6 @@
   margin-top: _.unit(6);
   display: flex;
   flex-direction: column;
-  gap: _.unit(6);
 }
 
 .emailSection {


### PR DESCRIPTION
## Summary
<!-- Describe the current net changes in this branch relative to the base branch. -->
<!-- Treat this as a snapshot, not a changelog of how the branch evolved. -->

- Removed the extra `gap` on the OSS onboarding form container so spacing between sections is no longer applied twice.
- Kept field spacing driven by `FormField` margins, aligning the project/company section vertical rhythm with the Figma spec for LOG-13294.

## Testing
<!-- How did you test this PR? -->
Tested locally
<img width="1756" height="1490" alt="image" src="https://github.com/user-attachments/assets/3925e068-c07f-4fe9-9661-9f052968e8f4" />

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset` (only when explicitly required)
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
