### PR TITLE
fix(console): update OSS cloud upsell banner padding and action alignment

### DIFF
--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -76,6 +76,10 @@
   background: linear-gradient(180deg, rgba(93, 52, 242, 6%) 0%, rgba(250, 171, 255, 8%) 100%);
 }
 
+.card.ossCloudBanner {
+  padding: _.unit(4.5);
+}
+
 .ossCloudBannerContent {
   display: flex;
   align-items: center;
@@ -149,7 +153,7 @@
   display: flex;
   align-items: center;
   margin-left: auto;
-  margin-right: _.unit(3);
+  margin-right: _.unit(4.5);
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
## Summary
- Update the OSS Cloud upsell banner container to use 18px padding by overriding the shared `Card` padding with `.card.ossCloudBanner`.
- Adjust `ossCloudBannerActions` right margin from 12px to 18px so the primary action area aligns better with the close button area in the banner header.

## Testing
Tested locally

## Checklist
- [ ] `.changeset` (only when explicitly required)
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
