### PR TITLE
fix(console): remove company size default in OSS onboarding

### DIFF
--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -10,14 +10,13 @@ import {
 } from './utils';
 
 describe('OSS onboarding form utils', () => {
-  test('uses company project as the default selection and leaves email blank', () => {
+  test('uses company project as the default selection with no company size preselected', () => {
     expect(getOssOnboardingDefaultValues()).toEqual({
       emailAddress: '',
       newsletter: false,
       project: Project.Company,
       projectName: '',
       companyName: '',
-      companySize: CompanySize.Scale3,
     });
   });
 

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -1,5 +1,5 @@
 import { emailRegEx } from '@logto/core-kit';
-import { CompanySize, type OssSurveyReportPayload, Project } from '@logto/schemas';
+import { type CompanySize, type OssSurveyReportPayload, Project } from '@logto/schemas';
 import { type Optional } from '@silverhand/essentials';
 
 export type OssOnboardingFormData = {
@@ -17,7 +17,6 @@ export const getOssOnboardingDefaultValues = (): OssOnboardingFormData => ({
   project: Project.Company,
   projectName: '',
   companyName: '',
-  companySize: CompanySize.Scale3,
 });
 
 export const shouldRequireCompanyFields = (project: Project) => project === Project.Company;


### PR DESCRIPTION
## Summary
- Remove the default `companySize` value from OSS onboarding form defaults, so the company size radio group starts with no preselected option.
- Update OSS onboarding utility test expectations to match the new default behavior.

## Testing
Unit tests
<img width="1786" height="1708" alt="image" src="https://github.com/user-attachments/assets/82819132-9ae7-47b9-8a1b-d10b170d031f" />

## Checklist
- [ ] `.changeset` (only when explicitly required)
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
