### PR TITLE
fix(console): guard undefined email in OSS onboarding

### DIFF
--- a/packages/console/src/pages/OssOnboarding/utils.test.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.test.ts
@@ -30,10 +30,12 @@ describe('OSS onboarding form utils', () => {
     expect(normalizeOssOnboardingEmailAddress(' Dev@Example.COM ')).toBe('dev@example.com');
     expect(normalizeOssOnboardingEmailAddress('not-an-email')).toBeUndefined();
     expect(normalizeOssOnboardingEmailAddress('')).toBeUndefined();
+    expect(normalizeOssOnboardingEmailAddress()).toBeUndefined();
 
     expect(isValidOssOnboardingEmailAddress('Dev@Example.COM')).toBe(true);
     expect(isValidOssOnboardingEmailAddress('not-an-email')).toBe(false);
     expect(isValidOssOnboardingEmailAddress('')).toBe(false);
+    expect(isValidOssOnboardingEmailAddress()).toBe(false);
   });
 
   test('drops company-only values from the questionnaire payload for personal projects', () => {

--- a/packages/console/src/pages/OssOnboarding/utils.ts
+++ b/packages/console/src/pages/OssOnboarding/utils.ts
@@ -3,7 +3,7 @@ import { CompanySize, type OssSurveyReportPayload, Project } from '@logto/schema
 import { type Optional } from '@silverhand/essentials';
 
 export type OssOnboardingFormData = {
-  emailAddress: string;
+  emailAddress?: string;
   newsletter: boolean;
   project: Project;
   projectName?: string;
@@ -22,8 +22,8 @@ export const getOssOnboardingDefaultValues = (): OssOnboardingFormData => ({
 
 export const shouldRequireCompanyFields = (project: Project) => project === Project.Company;
 
-export const normalizeOssOnboardingEmailAddress = (emailAddress: string): Optional<string> => {
-  const normalizedEmailAddress = emailAddress.trim().toLowerCase();
+export const normalizeOssOnboardingEmailAddress = (emailAddress?: string): Optional<string> => {
+  const normalizedEmailAddress = (emailAddress ?? '').trim().toLowerCase();
 
   if (!normalizedEmailAddress || !emailRegEx.test(normalizedEmailAddress)) {
     return;
@@ -32,7 +32,7 @@ export const normalizeOssOnboardingEmailAddress = (emailAddress: string): Option
   return normalizedEmailAddress;
 };
 
-export const isValidOssOnboardingEmailAddress = (emailAddress: string) =>
+export const isValidOssOnboardingEmailAddress = (emailAddress?: string) =>
   Boolean(normalizeOssOnboardingEmailAddress(emailAddress));
 
 export const getBaseOssOnboardingPayload = (data: OssOnboardingFormData) => {


### PR DESCRIPTION
## Summary
<!-- Describe the current net changes in this branch relative to the base branch. -->
<!-- Treat this as a snapshot, not a changelog of how the branch evolved. -->

- Hardened OSS onboarding email normalization and validation to safely handle missing `emailAddress` values, preventing runtime errors when calling `trim()`.
- Updated `OssOnboardingFormData` so `emailAddress` is optional and aligned the email helper signatures with that type.
- Added unit test assertions covering missing email inputs for both normalization and validation helpers.

## Testing
<!-- How did you test this PR? -->

Unit tests

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset` (only when explicitly required)
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
