### PR TITLE
feat(core): expose oidc session uid on ctx.auth

### DIFF
--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
@@ -81,6 +81,29 @@ describe('koaOidcAuth middleware', () => {
       scopes: new Set(['openid']),
       identityVerified: false,
       clientId: mockAccessToken.clientId,
+      sessionUid: undefined,
+    });
+  });
+
+  it('should propagate sessionUid from the access token to ctx.auth', async () => {
+    ctx.request = {
+      ...ctx.request,
+      headers: {
+        authorization: 'Bearer access_token',
+      },
+    };
+    Sinon.stub(provider.AccessToken, 'find').resolves({
+      ...mockAccessToken,
+      sessionUid: 'fooSessionUid',
+    });
+    await koaOidcAuth(tenantContext)(ctx, next);
+    expect(ctx.auth).toEqual({
+      type: 'user',
+      id: 'fooUser',
+      scopes: new Set(['openid']),
+      identityVerified: false,
+      clientId: mockAccessToken.clientId,
+      sessionUid: 'fooSessionUid',
     });
   });
 

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
@@ -64,7 +64,7 @@ export default function koaOidcAuth<StateT, ContextT extends IRouterParamContext
 
     assertThat(accessToken, new RequestError({ code: 'auth.unauthorized', status: 401 }));
 
-    const { accountId, scopes, clientId } = accessToken;
+    const { accountId, scopes, clientId, sessionUid } = accessToken;
     assertThat(accountId, new RequestError({ code: 'auth.unauthorized', status: 401 }));
     assertThat(scopes.has('openid'), new RequestError({ code: 'auth.forbidden', status: 403 }));
 
@@ -85,6 +85,7 @@ export default function koaOidcAuth<StateT, ContextT extends IRouterParamContext
       scopes,
       clientId,
       identityVerified,
+      sessionUid,
     };
 
     return next();

--- a/packages/core/src/middleware/koa-auth/types.ts
+++ b/packages/core/src/middleware/koa-auth/types.ts
@@ -8,6 +8,11 @@ type Auth = {
   identityVerified?: boolean;
   /** Client ID of the OIDC access token */
   clientId?: string;
+  /**
+   * OIDC session uid that backs the current access token, when the token was minted from an
+   * interactive (session-backed) flow. Absent for client-credentials tokens.
+   */
+  sessionUid?: string;
 };
 
 export type WithAuthContext<ContextT extends IRouterParamContext = IRouterParamContext> =


### PR DESCRIPTION
## Summary

Plumb the access token's `sessionUid` (already persisted on every session-backed `AccessToken` model by node-oidc-provider) through `koaOidcAuth` so route handlers can identify the current OIDC session. Adds an optional `sessionUid?: string` to the user `Auth` type and forwards the value verbatim from the verified access token.

This is groundwork for the upcoming `isCurrent` flag on the `GET /api/my-account/sessions` response — see GitHub [#8681](https://github.com/logto-io/logto/issues/8681). No consumer reads `ctx.auth.sessionUid` yet; that lands in the next PR (P1.2).

## Testing

Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments