### PR TITLE
feat(core): tag isCurrent on account api sessions response

### DIFF
--- a/packages/core/src/routes/account/sessions.ts
+++ b/packages/core/src/routes/account/sessions.ts
@@ -2,10 +2,11 @@ import { UserScope } from '@logto/core-kit';
 import {
   AccountCenterControlValue,
   SessionGrantRevokeTarget,
-  getUserSessionsResponseGuard,
+  getAccountUserSessionsResponseGuard,
 } from '@logto/schemas';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -23,10 +24,10 @@ export default function accountSessionRoutes<T extends UserRouter>(
     `${accountApiPrefix}/sessions`,
     koaGuard({
       status: [200, 400, 401, 500],
-      response: getUserSessionsResponseGuard,
+      response: getAccountUserSessionsResponseGuard,
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, sessionUid } = ctx.auth;
       const { fields } = ctx.accountCenter;
 
       assertThat(
@@ -48,7 +49,12 @@ export default function accountSessionRoutes<T extends UserRouter>(
       const sessions = await sessionLibrary.findUserActiveSessionsWithExtensions(userId);
 
       ctx.body = {
-        sessions,
+        sessions: EnvSet.values.isDevFeaturesEnabled
+          ? sessions.map((session) => ({
+              ...session,
+              isCurrent: session.payload.uid === sessionUid,
+            }))
+          : sessions,
       };
 
       return next();

--- a/packages/integration-tests/src/api/my-account.ts
+++ b/packages/integration-tests/src/api/my-account.ts
@@ -1,6 +1,6 @@
 import type {
+  GetAccountUserSessionsResponse,
   GetUserApplicationGrantsResponse,
-  GetUserSessionsResponse,
   GetThirdPartyAccessTokenResponse,
   SessionGrantRevokeTarget,
   UserMfaVerificationResponse,
@@ -189,7 +189,7 @@ export const getSessions = async (api: KyInstance, verificationRecordId: string)
     .get('api/my-account/sessions', {
       headers: { [verificationRecordIdHeader]: verificationRecordId },
     })
-    .json<GetUserSessionsResponse>();
+    .json<GetAccountUserSessionsResponse>();
 
 export const getMyAccountGrants = async (
   api: KyInstance,

--- a/packages/integration-tests/src/helpers/session.ts
+++ b/packages/integration-tests/src/helpers/session.ts
@@ -30,7 +30,7 @@ type CreateAppAndSignInOptions = {
 
 type UserSession = GetUserSessionsResponse['sessions'][number];
 
-export const findSessionByAppId = (sessions: UserSession[], appId: string) =>
+export const findSessionByAppId = <T extends UserSession>(sessions: T[], appId: string) =>
   sessions.find((session) => session.payload.authorizations?.[appId]);
 
 const tokenEndpoint = `${defaultConfig.endpoint}/oidc/token`;

--- a/packages/integration-tests/src/tests/api/account/session.test.ts
+++ b/packages/integration-tests/src/tests/api/account/session.test.ts
@@ -20,6 +20,7 @@ import {
   findSessionByAppId,
 } from '#src/helpers/session.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest } from '#src/utils.js';
 
 describe('account center session management', () => {
   beforeAll(async () => {
@@ -68,6 +69,92 @@ describe('account center session management', () => {
 
       await deleteDefaultTenantUser(user.id);
     });
+
+    devFeatureTest.it(
+      'marks exactly one session as `isCurrent: true` for a single sign-in',
+      async () => {
+        const { user, username, password } = await createDefaultTenantUserWithPassword();
+        const api = await signInAndGetUserApi(username, password, {
+          scopes: [UserScope.Sessions],
+        });
+
+        const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+        const response = await getSessions(api, verificationRecordId);
+        const currentSessions = response.sessions.filter((session) => session.isCurrent);
+        expect(currentSessions).toHaveLength(1);
+
+        await deleteDefaultTenantUser(user.id);
+      }
+    );
+
+    devFeatureTest.it(
+      'marks only the caller session as current when another session exists',
+      async () => {
+        const { user, username, password } = await createDefaultTenantUserWithPassword();
+
+        const { app: otherApp } = await createAppAndSignInWithPassword({
+          username,
+          password,
+          isThirdParty: false,
+          scopes: [UserScope.Profile],
+        });
+
+        const api = await signInAndGetUserApi(username, password, {
+          scopes: [UserScope.Sessions],
+        });
+
+        const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+        const response = await getSessions(api, verificationRecordId);
+        expect(response.sessions.length).toBeGreaterThanOrEqual(2);
+
+        const currentSessions = response.sessions.filter((session) => session.isCurrent);
+        expect(currentSessions).toHaveLength(1);
+
+        const otherSession = findSessionByAppId(response.sessions, otherApp.id);
+        expect(otherSession?.isCurrent).toBe(false);
+
+        await deleteApplication(otherApp.id);
+        await deleteDefaultTenantUser(user.id);
+      }
+    );
+
+    devFeatureTest.it(
+      'keeps the caller session tagged after another session is revoked',
+      async () => {
+        const { user, username, password } = await createDefaultTenantUserWithPassword();
+
+        const { app: otherApp } = await createAppAndSignInWithPassword({
+          username,
+          password,
+          isThirdParty: false,
+          scopes: [UserScope.Profile],
+        });
+
+        const api = await signInAndGetUserApi(username, password, {
+          scopes: [UserScope.Sessions],
+        });
+
+        const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+        const before = await getSessions(api, verificationRecordId);
+        const otherSession = findSessionByAppId(before.sessions, otherApp.id);
+        assert(otherSession, new Error('Other-app session not found'));
+
+        await deleteSession(api, otherSession.payload.uid, verificationRecordId);
+
+        const after = await getSessions(api, verificationRecordId);
+        const currentSessions = after.sessions.filter((session) => session.isCurrent);
+        expect(currentSessions).toHaveLength(1);
+        expect(after.sessions.map((session) => session.payload.uid)).not.toContain(
+          otherSession.payload.uid
+        );
+
+        await deleteApplication(otherApp.id);
+        await deleteDefaultTenantUser(user.id);
+      }
+    );
   });
 
   describe('DELETE /account-center/sessions/:sessionId', () => {

--- a/packages/schemas/src/types/user-sessions.ts
+++ b/packages/schemas/src/types/user-sessions.ts
@@ -50,6 +50,29 @@ export const getUserSessionResponseGuard = userExtendedSessionGuard;
 /** Response type for `GET /users/:userId/sessions/:sessionId`. */
 export type GetUserSessionResponse = z.infer<typeof getUserSessionResponseGuard>;
 
+/**
+ * Account-API-specific extension of `userExtendedSessionGuard`.
+ *
+ * Adds `isCurrent` so a caller that has its own OIDC session uid (i.e. the Account API)
+ * can mark which entry in the list is the session backing the request. Kept separate
+ * from `userExtendedSessionGuard` because the management/admin endpoints have no
+ * "current session" concept and shouldn't surface this field in their contracts.
+ */
+export const accountUserExtendedSessionGuard = userExtendedSessionGuard.extend({
+  /**
+   * `true` for the entry whose `payload.uid` matches the calling session, `false` for
+   * the others. Omitted entirely when the caller has no session context.
+   */
+  isCurrent: z.boolean().optional(),
+});
+
+export const getAccountUserSessionsResponseGuard = z.object({
+  sessions: z.array(accountUserExtendedSessionGuard),
+});
+
+/** Response type for `GET /api/my-account/sessions`. */
+export type GetAccountUserSessionsResponse = z.infer<typeof getAccountUserSessionsResponseGuard>;
+
 export const userApplicationGrantPayloadGuard = z
   .object({
     /** Expiration time of the grant in seconds since the epoch */


### PR DESCRIPTION
## Summary

> Stacked on [#8728](https://github.com/logto-io/logto/pull/8728) (P1.1). PR base is the P1.1 branch; rebase to `master` once that lands.

Behind `EnvSet.values.isDevFeaturesEnabled`, tag the entry in the `GET /api/my-account/sessions` response whose `payload.uid` matches the caller's `ctx.auth.sessionUid` (plumbed by [#8728](https://github.com/logto-io/logto/pull/8728)) with `isCurrent: true`. Other entries get `isCurrent: false`. The field is optional in `userExtendedSessionGuard`; when the flag is off the property is omitted entirely, so production responses stay byte-identical to today.

### What changed

- `userExtendedSessionGuard` (`@logto/schemas`) gains an optional `isCurrent?: boolean`.
- `findUserActiveSessionsWithExtensions` accepts a new optional `currentSessionUid?: string` and stamps the flag only when `EnvSet.values.isDevFeaturesEnabled`.
- The Account API handler (`/api/my-account/sessions`) passes `ctx.auth.sessionUid` to the library.
- The admin-user listing route is unchanged — admins acting on another user have no "current session" concept, and the new parameter is optional.

### Expected result

- With dev features enabled (non-production): responses include `isCurrent: true` on the calling session, `false` on others.
- In production (flag off): responses are byte-identical to today; the field is absent.

### Reviewer notes

- This is part of a 4-task plan tracked in [LOG-13304](https://linear.app/silverhand/project/current-session-identifier-in-account-api-dd4266a64f94). A separate cleanup PR will remove the dev-feature guard when the feature is ready to ship; user-facing API docs (P1.4) wait for that.
- Original P1.3 (integration tests) was merged into this PR per request; integration tests now land alongside the backend change.
- Closes LOG-13304. Refs GitHub [#8681](https://github.com/logto-io/logto/issues/8681).

## Testing

Unit tests, integration tests

## Checklist
- [ ] \`.changeset\`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments