### PR TITLE
fix(test): stabilize OIDC config setup

### DIFF
--- a/packages/integration-tests/src/api/logto-config.ts
+++ b/packages/integration-tests/src/api/logto-config.ts
@@ -12,7 +12,18 @@ import {
   type OidcSessionConfig,
 } from '@logto/schemas';
 
+import { waitFor } from '#src/utils.js';
+
 import { authedAdminApi } from './api.js';
+
+// OIDC config mutation APIs invalidate tenant cache asynchronously. These integration helpers wait
+// before returning so follow-up test requests do not race the cache refresh while the production API
+// behavior stays non-blocking.
+const tenantCacheInvalidationDelay = 2000;
+
+const waitForTenantCacheInvalidation = async () => {
+  await waitFor(tenantCacheInvalidationDelay);
+};
 
 export const getAdminConsoleConfig = async () =>
   authedAdminApi.get('configs/admin-console').json<AdminConsoleData>();
@@ -27,15 +38,18 @@ export const updateAdminConsoleConfig = async (payload: Partial<AdminConsoleData
 export const getOidcKeys = async (keyType: LogtoOidcConfigKeyType) =>
   authedAdminApi.get(`configs/oidc/${keyType}`).json<OidcConfigKeysResponse[]>();
 
-export const deleteOidcKey = async (keyType: LogtoOidcConfigKeyType, id: string) =>
-  authedAdminApi.delete(`configs/oidc/${keyType}/${id}`);
+export const deleteOidcKey = async (keyType: LogtoOidcConfigKeyType, id: string) => {
+  const response = await authedAdminApi.delete(`configs/oidc/${keyType}/${id}`);
+  await waitForTenantCacheInvalidation();
+  return response;
+};
 
 export const rotateOidcKeys = async (
   keyType: LogtoOidcConfigKeyType,
   signingKeyAlgorithm: SupportedSigningKeyAlgorithm = SupportedSigningKeyAlgorithm.EC,
   rotationGracePeriod?: number
-) =>
-  authedAdminApi
+) => {
+  const oidcKeys = await authedAdminApi
     .post(`configs/oidc/${keyType}/rotate`, {
       json: {
         signingKeyAlgorithm,
@@ -43,6 +57,9 @@ export const rotateOidcKeys = async (
       },
     })
     .json<OidcConfigKeysResponse[]>();
+  await waitForTenantCacheInvalidation();
+  return oidcKeys;
+};
 
 export const upsertJwtCustomizer = async (
   keyTypePath: 'access-token' | 'client-credentials',
@@ -91,7 +108,10 @@ export const getSessionConfig = async () =>
     }
   >();
 
-export const updateSessionConfig = async (payload: Partial<OidcSessionConfig>) =>
-  authedAdminApi
+export const updateSessionConfig = async (payload: Partial<OidcSessionConfig>) => {
+  const sessionConfig = await authedAdminApi
     .patch('configs/oidc/session', { json: payload })
     .json<OidcSessionConfig & { ttl: number }>();
+  await waitForTenantCacheInvalidation();
+  return sessionConfig;
+};


### PR DESCRIPTION
## Summary

- Add a documented 2-second tenant cache invalidation wait in the integration-test OIDC config API helpers.
- Apply the wait after deleting OIDC keys, rotating OIDC keys, and updating OIDC session config so follow-up requests read the settled tenant state.

## Testing

Integration tests

## Checklist

- [ ] `.changeset` (only when explicitly required)
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
