### PR TITLE
feat(core): ship isCurrent on account api sessions response

### DIFF
--- a/.changeset/quiet-rivers-tag.md
+++ b/.changeset/quiet-rivers-tag.md
@@ -1,0 +1,12 @@
+---
+"@logto/schemas": patch
+"@logto/core": patch
+---
+
+expose `isCurrent` on the Account API sessions response
+
+`GET /api/my-account/sessions` now returns `isCurrent: boolean` on every entry. The session whose OIDC uid backs the calling access token is `true`; the others are `false`. Use this to mark the "This device" entry in session-management UIs and to avoid revoking the caller's own session.
+
+The admin user-sessions endpoints (`GET /users/:userId/sessions` and `GET /users/:userId/sessions/:sessionId`) are unchanged — they have no caller-session concept and continue to use the original response shape.
+
+Closes [#8681](https://github.com/logto-io/logto/issues/8681).

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -636,10 +636,10 @@
       "get": {
         "operationId": "GetSessions",
         "summary": "Get all active sessions",
-        "description": "Retrieve all non-expired sessions for the user, including session metadata and interaction details when available. A logto-verification-id in header is required for checking sensitive session details.",
+        "description": "Retrieve all non-expired sessions for the user, including session metadata and interaction details when available. A logto-verification-id in header is required for checking sensitive session details. Each entry includes an `isCurrent` boolean: `true` for the entry whose OIDC session backs the calling access token, `false` for the others. Use this to mark the \"This device\" entry in session-management UIs and to avoid revoking the caller's own session. At most one entry is `true` per response. Zero entries are tagged when the calling access token has no matching session uid — for example, the caller has revoked its own session but the token has not yet expired, or the token was issued from a non-session-backed grant.",
         "responses": {
           "200": {
-            "description": "Return a list of non-expired sessions of the user."
+            "description": "Return a list of non-expired sessions of the user. At most one entry has `isCurrent: true` per request."
           },
           "401": {
             "description": "Permission denied, the verification record is invalid or the session does not have the required scope to access session details."

--- a/packages/core/src/routes/account/sessions.ts
+++ b/packages/core/src/routes/account/sessions.ts
@@ -6,7 +6,6 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -49,12 +48,10 @@ export default function accountSessionRoutes<T extends UserRouter>(
       const sessions = await sessionLibrary.findUserActiveSessionsWithExtensions(userId);
 
       ctx.body = {
-        sessions: EnvSet.values.isDevFeaturesEnabled
-          ? sessions.map((session) => ({
-              ...session,
-              isCurrent: session.payload.uid === sessionUid,
-            }))
-          : sessions,
+        sessions: sessions.map((session) => ({
+          ...session,
+          isCurrent: session.payload.uid === sessionUid,
+        })),
       };
 
       return next();

--- a/packages/integration-tests/src/tests/api/account/session.test.ts
+++ b/packages/integration-tests/src/tests/api/account/session.test.ts
@@ -20,7 +20,6 @@ import {
   findSessionByAppId,
 } from '#src/helpers/session.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest } from '#src/utils.js';
 
 describe('account center session management', () => {
   beforeAll(async () => {
@@ -70,150 +69,135 @@ describe('account center session management', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    devFeatureTest.it(
-      'marks exactly one session as `isCurrent: true` for a single sign-in',
-      async () => {
-        const { user, username, password } = await createDefaultTenantUserWithPassword();
-        const api = await signInAndGetUserApi(username, password, {
-          scopes: [UserScope.Sessions],
-        });
+    it('marks exactly one session as `isCurrent: true` for a single sign-in', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Sessions],
+      });
 
-        const verificationRecordId = await createVerificationRecordByPassword(api, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
-        const response = await getSessions(api, verificationRecordId);
-        const currentSessions = response.sessions.filter((session) => session.isCurrent);
-        expect(currentSessions).toHaveLength(1);
+      const response = await getSessions(api, verificationRecordId);
+      const currentSessions = response.sessions.filter((session) => session.isCurrent);
+      expect(currentSessions).toHaveLength(1);
 
-        await deleteDefaultTenantUser(user.id);
-      }
-    );
+      await deleteDefaultTenantUser(user.id);
+    });
 
-    devFeatureTest.it(
-      'marks only the caller session as current when another session exists',
-      async () => {
-        const { user, username, password } = await createDefaultTenantUserWithPassword();
+    it('marks only the caller session as current when another session exists', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
 
-        const { app: otherApp } = await createAppAndSignInWithPassword({
-          username,
-          password,
-          isThirdParty: false,
-          scopes: [UserScope.Profile],
-        });
+      const { app: otherApp } = await createAppAndSignInWithPassword({
+        username,
+        password,
+        isThirdParty: false,
+        scopes: [UserScope.Profile],
+      });
 
-        const api = await signInAndGetUserApi(username, password, {
-          scopes: [UserScope.Sessions],
-        });
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Sessions],
+      });
 
-        const verificationRecordId = await createVerificationRecordByPassword(api, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
-        const response = await getSessions(api, verificationRecordId);
-        expect(response.sessions.length).toBeGreaterThanOrEqual(2);
+      const response = await getSessions(api, verificationRecordId);
+      expect(response.sessions.length).toBeGreaterThanOrEqual(2);
 
-        const currentSessions = response.sessions.filter((session) => session.isCurrent);
-        expect(currentSessions).toHaveLength(1);
+      const currentSessions = response.sessions.filter((session) => session.isCurrent);
+      expect(currentSessions).toHaveLength(1);
 
-        const otherSession = findSessionByAppId(response.sessions, otherApp.id);
-        expect(otherSession?.isCurrent).toBe(false);
+      const otherSession = findSessionByAppId(response.sessions, otherApp.id);
+      expect(otherSession?.isCurrent).toBe(false);
 
-        await deleteApplication(otherApp.id);
-        await deleteDefaultTenantUser(user.id);
-      }
-    );
+      await deleteApplication(otherApp.id);
+      await deleteDefaultTenantUser(user.id);
+    });
 
-    devFeatureTest.it(
-      'keeps the caller session tagged after another session is revoked',
-      async () => {
-        const { user, username, password } = await createDefaultTenantUserWithPassword();
+    it('keeps the caller session tagged after another session is revoked', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
 
-        const { app: otherApp } = await createAppAndSignInWithPassword({
-          username,
-          password,
-          isThirdParty: false,
-          scopes: [UserScope.Profile],
-        });
+      const { app: otherApp } = await createAppAndSignInWithPassword({
+        username,
+        password,
+        isThirdParty: false,
+        scopes: [UserScope.Profile],
+      });
 
-        const api = await signInAndGetUserApi(username, password, {
-          scopes: [UserScope.Sessions],
-        });
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Sessions],
+      });
 
-        const verificationRecordId = await createVerificationRecordByPassword(api, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
-        const before = await getSessions(api, verificationRecordId);
-        const otherSession = findSessionByAppId(before.sessions, otherApp.id);
-        assert(otherSession, new Error('Other-app session not found'));
+      const before = await getSessions(api, verificationRecordId);
+      const otherSession = findSessionByAppId(before.sessions, otherApp.id);
+      assert(otherSession, new Error('Other-app session not found'));
 
-        await deleteSession(api, otherSession.payload.uid, verificationRecordId);
+      await deleteSession(api, otherSession.payload.uid, verificationRecordId);
 
-        const after = await getSessions(api, verificationRecordId);
-        const currentSessions = after.sessions.filter((session) => session.isCurrent);
-        expect(currentSessions).toHaveLength(1);
-        expect(after.sessions.map((session) => session.payload.uid)).not.toContain(
-          otherSession.payload.uid
-        );
+      const after = await getSessions(api, verificationRecordId);
+      const currentSessions = after.sessions.filter((session) => session.isCurrent);
+      expect(currentSessions).toHaveLength(1);
+      expect(after.sessions.map((session) => session.payload.uid)).not.toContain(
+        otherSession.payload.uid
+      );
 
-        await deleteApplication(otherApp.id);
-        await deleteDefaultTenantUser(user.id);
-      }
-    );
+      await deleteApplication(otherApp.id);
+      await deleteDefaultTenantUser(user.id);
+    });
 
-    devFeatureTest.it(
-      'returns zero `isCurrent: true` entries after the caller revokes its own session',
-      async () => {
-        const { user, username, password } = await createDefaultTenantUserWithPassword();
-        const api = await signInAndGetUserApi(username, password, {
-          scopes: [UserScope.Sessions],
-        });
+    it('returns zero `isCurrent: true` entries after the caller revokes its own session', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Sessions],
+      });
 
-        const verificationRecordId = await createVerificationRecordByPassword(api, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
-        const before = await getSessions(api, verificationRecordId);
-        const ownSession = before.sessions.find((session) => session.isCurrent);
-        assert(ownSession, new Error('Caller session not tagged before revoke'));
+      const before = await getSessions(api, verificationRecordId);
+      const ownSession = before.sessions.find((session) => session.isCurrent);
+      assert(ownSession, new Error('Caller session not tagged before revoke'));
 
-        await deleteSession(api, ownSession.payload.uid, verificationRecordId);
+      await deleteSession(api, ownSession.payload.uid, verificationRecordId);
 
-        const after = await getSessions(api, verificationRecordId);
-        const currentSessions = after.sessions.filter((session) => session.isCurrent);
-        expect(currentSessions).toHaveLength(0);
-        expect(after.sessions.map((session) => session.payload.uid)).not.toContain(
-          ownSession.payload.uid
-        );
+      const after = await getSessions(api, verificationRecordId);
+      const currentSessions = after.sessions.filter((session) => session.isCurrent);
+      expect(currentSessions).toHaveLength(0);
+      expect(after.sessions.map((session) => session.payload.uid)).not.toContain(
+        ownSession.payload.uid
+      );
 
-        await deleteDefaultTenantUser(user.id);
-      }
-    );
+      await deleteDefaultTenantUser(user.id);
+    });
 
-    devFeatureTest.it(
-      'tags the calling session from each caller perspective when two sessions exist',
-      async () => {
-        const { user, username, password } = await createDefaultTenantUserWithPassword();
+    it('tags the calling session from each caller perspective when two sessions exist', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
 
-        const apiA = await signInAndGetUserApi(username, password, {
-          scopes: [UserScope.Sessions],
-        });
-        const apiB = await signInAndGetUserApi(username, password, {
-          scopes: [UserScope.Sessions],
-        });
+      const apiA = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Sessions],
+      });
+      const apiB = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Sessions],
+      });
 
-        const verificationRecordIdA = await createVerificationRecordByPassword(apiA, password);
-        const verificationRecordIdB = await createVerificationRecordByPassword(apiB, password);
+      const verificationRecordIdA = await createVerificationRecordByPassword(apiA, password);
+      const verificationRecordIdB = await createVerificationRecordByPassword(apiB, password);
 
-        const responseA = await getSessions(apiA, verificationRecordIdA);
-        const responseB = await getSessions(apiB, verificationRecordIdB);
+      const responseA = await getSessions(apiA, verificationRecordIdA);
+      const responseB = await getSessions(apiB, verificationRecordIdB);
 
-        const currentA = responseA.sessions.find((session) => session.isCurrent);
-        const currentB = responseB.sessions.find((session) => session.isCurrent);
+      const currentA = responseA.sessions.find((session) => session.isCurrent);
+      const currentB = responseB.sessions.find((session) => session.isCurrent);
 
-        assert(currentA, new Error('A session not tagged from A perspective'));
-        assert(currentB, new Error('B session not tagged from B perspective'));
+      assert(currentA, new Error('A session not tagged from A perspective'));
+      assert(currentB, new Error('B session not tagged from B perspective'));
 
-        expect(responseA.sessions.filter((session) => session.isCurrent)).toHaveLength(1);
-        expect(responseB.sessions.filter((session) => session.isCurrent)).toHaveLength(1);
-        expect(currentA.payload.uid).not.toBe(currentB.payload.uid);
+      expect(responseA.sessions.filter((session) => session.isCurrent)).toHaveLength(1);
+      expect(responseB.sessions.filter((session) => session.isCurrent)).toHaveLength(1);
+      expect(currentA.payload.uid).not.toBe(currentB.payload.uid);
 
-        await deleteDefaultTenantUser(user.id);
-      }
-    );
+      await deleteDefaultTenantUser(user.id);
+    });
   });
 
   describe('DELETE /account-center/sessions/:sessionId', () => {

--- a/packages/integration-tests/src/tests/api/sessions/index.test.ts
+++ b/packages/integration-tests/src/tests/api/sessions/index.test.ts
@@ -20,7 +20,6 @@ import {
 } from '#src/helpers/session.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
-import { devFeatureTest } from '#src/utils.js';
 
 describe('Sessions API', () => {
   const userApi = new UserApiTest();
@@ -77,29 +76,26 @@ describe('Sessions API', () => {
     expect(sessionsAfterRevoke[0]!.payload.uid).toBe(sessions[1]!.payload.uid);
   });
 
-  devFeatureTest.it(
-    'admin sessions response does not include the account-only `isCurrent` field',
-    async () => {
-      await enableAllPasswordSignInMethods();
+  it('admin sessions response does not include the account-only `isCurrent` field', async () => {
+    await enableAllPasswordSignInMethods();
 
-      const { username, password } = generateNewUserProfile({ username: true, password: true });
-      const user = await userApi.create({ username, password });
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({ username, password });
 
-      await signInWithPassword({
-        identifier: {
-          type: SignInIdentifier.Username,
-          value: username,
-        },
-        password,
-      });
+    await signInWithPassword({
+      identifier: {
+        type: SignInIdentifier.Username,
+        value: username,
+      },
+      password,
+    });
 
-      const { sessions } = await getUserSessions(user.id);
-      expect(sessions.length).toBeGreaterThan(0);
-      for (const session of sessions) {
-        expect(session).not.toHaveProperty('isCurrent');
-      }
+    const { sessions } = await getUserSessions(user.id);
+    expect(sessions.length).toBeGreaterThan(0);
+    for (const session of sessions) {
+      expect(session).not.toHaveProperty('isCurrent');
     }
-  );
+  });
 
   it('should get a single user session by session id', async () => {
     await enableAllPasswordSignInMethods();

--- a/packages/schemas/src/types/user-sessions.ts
+++ b/packages/schemas/src/types/user-sessions.ts
@@ -61,9 +61,12 @@ export type GetUserSessionResponse = z.infer<typeof getUserSessionResponseGuard>
 export const accountUserExtendedSessionGuard = userExtendedSessionGuard.extend({
   /**
    * `true` for the entry whose `payload.uid` matches the calling session, `false` for
-   * the others. Omitted entirely when the caller has no session context.
+   * the others. At most one entry is `true` per response. Zero entries are tagged when
+   * the calling access token has no matching session uid — for example, the caller has
+   * revoked its own session but the token has not yet expired, or the token was issued
+   * from a non-session-backed grant.
    */
-  isCurrent: z.boolean().optional(),
+  isCurrent: z.boolean(),
 });
 
 export const getAccountUserSessionsResponseGuard = z.object({


### PR DESCRIPTION
## Summary

> Stacked on [#8729](https://github.com/logto-io/logto/pull/8729) (P1.2). PR base is the P1.2 branch; rebase to \`master\` once that lands.

Remove the \`EnvSet.values.isDevFeaturesEnabled\` guard added in [#8729](https://github.com/logto-io/logto/pull/8729) and ship \`isCurrent\` on \`GET /api/my-account/sessions\` to production. Each entry in the response is now unconditionally tagged: \`true\` for the session whose OIDC uid backs the calling access token, \`false\` for the others.

### What changed

- \`packages/core/src/routes/account/sessions.ts\` — drop the dev-feature ternary; the \`isCurrent\` mapping is unconditional.
- \`packages/core/src/routes/account/index.openapi.json\` — extend the \`GetSessions\` description to document \`isCurrent\` for SDK / spec consumers.
- \`packages/integration-tests/src/tests/api/account/session.test.ts\` — drop the \`devFeatureTest.it\` wrappers added in [#8729](https://github.com/logto-io/logto/pull/8729). The three \`isCurrent\` tests now run in every CI configuration.
- \`.changeset/quiet-rivers-tag.md\` — patch entry for \`@logto/core\` and \`@logto/schemas\` referencing GitHub [#8681](https://github.com/logto-io/logto/issues/8681).

### Expected result

- Production responses include \`isCurrent\` on every entry. Existing clients that ignore unknown fields are unaffected.
- Admin user-sessions endpoints (\`/users/:userId/sessions\`, \`/users/:userId/sessions/:sessionId\`) are untouched and continue to use \`getUserSessionsResponseGuard\` without \`isCurrent\` (cleanly separated in [#8729](https://github.com/logto-io/logto/pull/8729) by the \`accountUserExtendedSessionGuard\` split).

### Reviewer notes

- Closes LOG-13306. Closes [#8681](https://github.com/logto-io/logto/issues/8681).
- The original 4-task plan listed P1.4 as docs-only with a separate cleanup PR for the gate. Per agreement, these were collapsed into one PR — see updated LOG-13306 description.

## Testing

Integration tests

## Checklist
- [x] \`.changeset\`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments