### PR TITLE
fix(core): set browser cache control for jwks

### DIFF
--- a/packages/core/src/middleware/koa-jwks-cache-control.test.ts
+++ b/packages/core/src/middleware/koa-jwks-cache-control.test.ts
@@ -1,0 +1,34 @@
+import Koa from 'koa';
+import request from 'supertest';
+
+import koaJwksCacheControl, {
+  cacheControlHeader,
+  jwksBrowserCacheControl,
+  jwksPath,
+} from './koa-jwks-cache-control.js';
+
+const createRequester = () => {
+  const app = new Koa();
+
+  app.use(koaJwksCacheControl());
+  app.use(async (ctx) => {
+    ctx.body = { ok: true };
+  });
+
+  return request(app.callback());
+};
+
+describe('koaJwksCacheControl', () => {
+  it('sets browser revalidation policy for OIDC JWKS requests', async () => {
+    await createRequester()
+      .get(jwksPath)
+      .expect(cacheControlHeader, jwksBrowserCacheControl)
+      .expect(200);
+  });
+
+  it('does not set cache control for non-JWKS requests', async () => {
+    const response = await createRequester().get('/.well-known/openid-configuration').expect(200);
+
+    expect(response.headers['cache-control']).toBeUndefined();
+  });
+});

--- a/packages/core/src/middleware/koa-jwks-cache-control.ts
+++ b/packages/core/src/middleware/koa-jwks-cache-control.ts
@@ -1,0 +1,17 @@
+import type { MiddlewareType } from 'koa';
+
+export const cacheControlHeader = 'Cache-Control';
+
+export const jwksPath = '/jwks';
+
+export const jwksBrowserCacheControl = 'no-cache, max-age=0, must-revalidate';
+
+export default function koaJwksCacheControl<StateT, ContextT>(): MiddlewareType<StateT, ContextT> {
+  return async (ctx, next) => {
+    await next();
+
+    if (ctx.method === 'GET' && ctx.path === jwksPath) {
+      ctx.set(cacheControlHeader, jwksBrowserCacheControl);
+    }
+  };
+}

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -27,6 +27,7 @@ import { type LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import koaAppSecretTranspilation from '#src/middleware/koa-app-secret-transpilation.js';
 import koaAuditLog, { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaBodyEtag from '#src/middleware/koa-body-etag.js';
+import koaJwksCacheControl from '#src/middleware/koa-jwks-cache-control.js';
 import koaResourceParam from '#src/middleware/koa-resource-param.js';
 import postgresAdapter from '#src/oidc/adapter.js';
 import {
@@ -466,6 +467,7 @@ export default function initOidc(
   });
 
   oidc.use(koaAppSecretTranspilation(queries));
+  oidc.use(koaJwksCacheControl());
   oidc.use(koaBodyEtag());
 
   if (EnvSet.values.isCloud) {


### PR DESCRIPTION
## Summary
Set `Cache-Control: no-cache, max-age=0, must-revalidate` on OIDC JWKS responses so browsers must revalidate instead of directly reusing stale disk cache entries.

This keeps browser caching behavior predictable while allowing Cloudflare edge cache TTL to be configured separately per environment.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
