### PR TITLE
ci: validate OSS survey Docker injection

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,48 +120,6 @@ jobs:
           build-args: | # Test cloud build
             additional_connector_args=--cloud
 
-  main-dockerize-oss-validation:
-    runs-on: ubuntu-latest
-    env:
-      LOGTO_OSS_SURVEY_ENDPOINT: ${{ vars.LOGTO_OSS_SURVEY_ENDPOINT_VALIDATION }}
-      OSS_VALIDATION_IMAGE: logto:oss-ci-validation
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Validate OSS survey endpoint config
-        run: : "${LOGTO_OSS_SURVEY_ENDPOINT:?LOGTO_OSS_SURVEY_ENDPOINT_VALIDATION GitHub Actions variable must be set and non-empty}"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build OSS validation image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: ${{ env.OSS_VALIDATION_IMAGE }}
-          build-args: |
-            logto_oss_survey_endpoint=${{ env.LOGTO_OSS_SURVEY_ENDPOINT }}
-
-      - name: Verify injected OSS survey endpoint
-        run: |
-          set -euo pipefail
-
-          docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$OSS_VALIDATION_IMAGE" \
-            | grep -Fx "LOGTO_OSS_SURVEY_ENDPOINT=$LOGTO_OSS_SURVEY_ENDPOINT"
-
-          docker run --rm --entrypoint sh \
-            -e EXPECTED_LOGTO_OSS_SURVEY_ENDPOINT="$LOGTO_OSS_SURVEY_ENDPOINT" \
-            "$OSS_VALIDATION_IMAGE" \
-            -lc '
-              set -e
-              test "$LOGTO_OSS_SURVEY_ENDPOINT" = "$EXPECTED_LOGTO_OSS_SURVEY_ENDPOINT"
-              grep -R -F -- "$LOGTO_OSS_SURVEY_ENDPOINT" /etc/logto/packages/console/dist >/dev/null
-            '
-
   main-alteration:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,47 @@ jobs:
           build-args: | # Test cloud build
             additional_connector_args=--cloud
 
+  main-dockerize-oss-validation:
+    runs-on: ubuntu-latest
+    env:
+      LOGTO_OSS_SURVEY_ENDPOINT: ${{ vars.LOGTO_OSS_SURVEY_ENDPOINT_VALIDATION }}
+      OSS_VALIDATION_IMAGE: logto:oss-ci-validation
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate OSS survey endpoint config
+        run: test -n "$LOGTO_OSS_SURVEY_ENDPOINT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build OSS validation image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ env.OSS_VALIDATION_IMAGE }}
+          build-args: |
+            logto_oss_survey_endpoint=${{ env.LOGTO_OSS_SURVEY_ENDPOINT }}
+
+      - name: Verify injected OSS survey endpoint
+        run: |
+          set -euo pipefail
+
+          docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$OSS_VALIDATION_IMAGE" \
+            | grep -Fx "LOGTO_OSS_SURVEY_ENDPOINT=$LOGTO_OSS_SURVEY_ENDPOINT"
+
+          docker run --rm --entrypoint sh \
+            -e EXPECTED_LOGTO_OSS_SURVEY_ENDPOINT="$LOGTO_OSS_SURVEY_ENDPOINT" \
+            "$OSS_VALIDATION_IMAGE" \
+            -lc '
+              test "$LOGTO_OSS_SURVEY_ENDPOINT" = "$EXPECTED_LOGTO_OSS_SURVEY_ENDPOINT"
+              grep -R -F -- "$LOGTO_OSS_SURVEY_ENDPOINT" /etc/logto/packages/console/dist >/dev/null
+            '
+
   main-alteration:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -157,6 +157,7 @@ jobs:
             -e EXPECTED_LOGTO_OSS_SURVEY_ENDPOINT="$LOGTO_OSS_SURVEY_ENDPOINT" \
             "$OSS_VALIDATION_IMAGE" \
             -lc '
+              set -e
               test "$LOGTO_OSS_SURVEY_ENDPOINT" = "$EXPECTED_LOGTO_OSS_SURVEY_ENDPOINT"
               grep -R -F -- "$LOGTO_OSS_SURVEY_ENDPOINT" /etc/logto/packages/console/dist >/dev/null
             '

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
           fetch-depth: 0
 
       - name: Validate OSS survey endpoint config
-        run: test -n "$LOGTO_OSS_SURVEY_ENDPOINT"
+        run: : "${LOGTO_OSS_SURVEY_ENDPOINT:?LOGTO_OSS_SURVEY_ENDPOINT_VALIDATION GitHub Actions variable must be set and non-empty}"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       LOGTO_OSS_SURVEY_ENDPOINT: ${{ vars.LOGTO_OSS_SURVEY_ENDPOINT }}
+      OSS_VALIDATION_IMAGE: logto:oss-release-validation
     permissions:
       contents: read
       id-token: write
@@ -39,6 +40,38 @@ jobs:
             type=semver,pattern={{major}}
             type=edge
 
+      - name: Validate OSS survey endpoint config
+        run: |
+          : "${LOGTO_OSS_SURVEY_ENDPOINT:?LOGTO_OSS_SURVEY_ENDPOINT is required for release builds}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build OSS validation image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ env.OSS_VALIDATION_IMAGE }}
+          build-args: |
+            logto_oss_survey_endpoint=${{ env.LOGTO_OSS_SURVEY_ENDPOINT }}
+
+      - name: Verify injected OSS survey endpoint
+        run: |
+          set -euo pipefail
+
+          docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$OSS_VALIDATION_IMAGE" \
+            | grep -Fx "LOGTO_OSS_SURVEY_ENDPOINT=$LOGTO_OSS_SURVEY_ENDPOINT"
+
+          docker run --rm --entrypoint sh \
+            -e EXPECTED_LOGTO_OSS_SURVEY_ENDPOINT="$LOGTO_OSS_SURVEY_ENDPOINT" \
+            "$OSS_VALIDATION_IMAGE" \
+            -lc '
+              set -e
+              test "$LOGTO_OSS_SURVEY_ENDPOINT" = "$EXPECTED_LOGTO_OSS_SURVEY_ENDPOINT"
+              grep -R -F -- "$LOGTO_OSS_SURVEY_ENDPOINT" /etc/logto/packages/console/dist >/dev/null
+            '
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -54,9 +87,6 @@ jobs:
 
       - name: Setup Depot
         uses: depot/setup-action@v1
-
-      - name: Validate OSS survey endpoint config
-        run: : "${LOGTO_OSS_SURVEY_ENDPOINT:?LOGTO_OSS_SURVEY_ENDPOINT is required for release builds}"
 
       - name: Build and push
         uses: depot/build-push-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: depot/setup-action@v1
 
       - name: Validate OSS survey endpoint config
-        run: test -n "$LOGTO_OSS_SURVEY_ENDPOINT"
+        run: : "${LOGTO_OSS_SURVEY_ENDPOINT:?LOGTO_OSS_SURVEY_ENDPOINT is required for release builds}"
 
       - name: Build and push
         uses: depot/build-push-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     environment: release
     runs-on: ubuntu-latest
+    env:
+      LOGTO_OSS_SURVEY_ENDPOINT: ${{ vars.LOGTO_OSS_SURVEY_ENDPOINT }}
     permissions:
       contents: read
       id-token: write
@@ -53,6 +55,9 @@ jobs:
       - name: Setup Depot
         uses: depot/setup-action@v1
 
+      - name: Validate OSS survey endpoint config
+        run: test -n "$LOGTO_OSS_SURVEY_ENDPOINT"
+
       - name: Build and push
         uses: depot/build-push-action@v1
         with:
@@ -60,6 +65,8 @@ jobs:
           project: g902cp6dvv
           context: .
           push: true
+          build-args: |
+            logto_oss_survey_endpoint=${{ env.LOGTO_OSS_SURVEY_ENDPOINT }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
## Summary
- pass `LOGTO_OSS_SURVEY_ENDPOINT` from the release environment vars into the OSS release Docker build
- validate the release Docker image before pushing by building a local validation image and checking the injected env value
- fail release early when the endpoint is missing from the image config or built console bundle

## Testing
Tested locally

## Checklist
- [ ] `.changeset` (only when explicitly required)
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
