### PR TITLE
fix(core): unify account identifier deletion guard

### DIFF
--- a/packages/core/src/routes/account/email-and-phone.ts
+++ b/packages/core/src/routes/account/email-and-phone.ts
@@ -1,8 +1,9 @@
 import { emailRegEx, phoneRegEx, UserScope } from '@logto/core-kit';
-import { VerificationType, AccountCenterControlValue, SignInIdentifier } from '@logto/schemas';
+import { VerificationType, AccountCenterControlValue } from '@logto/schemas';
 import { z } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
+import { assertUserHasRemainingIdentifier } from '#src/utils/user.js';
 
 import RequestError from '../../errors/RequestError/index.js';
 import { validateEmailAgainstBlocklistPolicy } from '../../libraries/sign-in-experience/email-blocklist-policy.js';
@@ -17,6 +18,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
   const {
     users: { updateUserById, findUserById },
     signInExperiences: { findDefaultSignInExperience },
+    userSsoIdentities,
   } = queries;
 
   const {
@@ -92,15 +94,11 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
 
       assertThat(scopes.has(UserScope.Email), 'auth.unauthorized');
 
-      const { signUp } = await findDefaultSignInExperience();
-
-      if (signUp.identifiers.includes(SignInIdentifier.Email)) {
-        // If email is the only sign-up identifier, we need to keep the email
-        assertThat(signUp.identifiers.includes(SignInIdentifier.Phone), 'user.email_required');
-        // If phone is also a sign-up identifier, check if phone is set
-        const user = await findUserById(userId);
-        assertThat(user.primaryPhone, 'user.email_or_phone_required');
-      }
+      const [user, ssoIdentities] = await Promise.all([
+        findUserById(userId),
+        userSsoIdentities.findUserSsoIdentitiesByUserId(userId),
+      ]);
+      assertUserHasRemainingIdentifier(user, { primaryEmail: null }, ssoIdentities.length);
 
       const updatedUser = await updateUserById(userId, { primaryEmail: null });
 
@@ -177,15 +175,11 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
 
       assertThat(scopes.has(UserScope.Phone), 'auth.unauthorized');
 
-      const { signUp } = await findDefaultSignInExperience();
-
-      if (signUp.identifiers.includes(SignInIdentifier.Phone)) {
-        // If phone is the only sign-up identifier, we need to keep the phone
-        assertThat(signUp.identifiers.includes(SignInIdentifier.Email), 'user.phone_required');
-        // If email is also a sign-up identifier, check if email is set
-        const user = await findUserById(userId);
-        assertThat(user.primaryEmail, 'user.email_or_phone_required');
-      }
+      const [user, ssoIdentities] = await Promise.all([
+        findUserById(userId),
+        userSsoIdentities.findUserSsoIdentitiesByUserId(userId),
+      ]);
+      assertUserHasRemainingIdentifier(user, { primaryPhone: null }, ssoIdentities.length);
 
       const updatedUser = await updateUserById(userId, { primaryPhone: null });
 

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -20,7 +20,7 @@
       "patch": {
         "operationId": "UpdateProfile",
         "summary": "Update profile",
-        "description": "Update profile for the user, only the fields that are passed in will be updated.",
+        "description": "Update profile for the user, only the fields that are passed in will be updated. Updating or deleting username requires a logto-verification-id header for checking sensitive permissions. Deleting username is rejected if it would remove the user's last identifier.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -50,6 +50,9 @@
           },
           "400": {
             "description": "The request body is invalid."
+          },
+          "401": {
+            "description": "Permission denied, the verification record is invalid."
           },
           "422": {
             "description": "The username is already in use."
@@ -274,10 +277,16 @@
       "delete": {
         "operationId": "DeletePrimaryEmail",
         "summary": "Delete primary email",
-        "description": "Delete primary email for the user, a verification-record-id in header is required for checking sensitive permissions.",
+        "description": "Delete primary email for the user, a logto-verification-id header is required for checking sensitive permissions. The request is rejected if it would remove the user's last identifier.",
         "responses": {
           "204": {
             "description": "The primary email was deleted successfully."
+          },
+          "400": {
+            "description": "The request would remove the user's last identifier."
+          },
+          "401": {
+            "description": "Permission denied, the verification record is invalid."
           }
         }
       }
@@ -318,10 +327,16 @@
       "delete": {
         "operationId": "DeletePrimaryPhone",
         "summary": "Delete primary phone",
-        "description": "Delete primary phone for the user, a verification-record-id in header is required for checking sensitive permissions.",
+        "description": "Delete primary phone for the user, a logto-verification-id header is required for checking sensitive permissions. The request is rejected if it would remove the user's last identifier.",
         "responses": {
           "204": {
             "description": "The primary phone was deleted successfully."
+          },
+          "400": {
+            "description": "The request would remove the user's last identifier."
+          },
+          "401": {
+            "description": "Permission denied, the verification record is invalid."
           }
         }
       }
@@ -355,13 +370,16 @@
       "delete": {
         "operationId": "DeleteIdentity",
         "summary": "Delete a user identity",
-        "description": "Delete an identity (social identity) from the user, a logto-verification-id in header is required for checking sensitive permissions.",
+        "description": "Delete an identity (social identity) from the user, a logto-verification-id in header is required for checking sensitive permissions. The request is rejected if it would remove the user's last identifier.",
         "responses": {
           "204": {
             "description": "The identity was deleted successfully."
           },
           "400": {
-            "description": "The verification record is invalid."
+            "description": "The request would remove the user's last identifier."
+          },
+          "401": {
+            "description": "Permission denied, the verification record is invalid."
           },
           "404": {
             "description": "The identity does not exist."

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -20,7 +20,7 @@
       "patch": {
         "operationId": "UpdateProfile",
         "summary": "Update profile",
-        "description": "Update profile for the user, only the fields that are passed in will be updated. Updating or deleting username requires a logto-verification-id header for checking sensitive permissions. Deleting username is rejected if it would remove the user's last identifier.",
+        "description": "Update profile for the user, only the fields that are passed in will be updated. Updating or deleting username requires a logto-verification-id header for checking sensitive permissions. Removing any sign-in identifier, including username, is rejected if it would remove the user's last identifier.",
         "requestBody": {
           "content": {
             "application/json": {

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -3,7 +3,6 @@ import {
   userProfileResponseGuard,
   userProfileGuard,
   AccountCenterControlValue,
-  SignInIdentifier,
   userMfaDataGuard,
   userMfaDataKey,
   userMfaSettingsResponseGuard,
@@ -16,6 +15,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import { encryptUserPassword } from '#src/libraries/user.utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
+import { assertUserHasRemainingIdentifier } from '#src/utils/user.js';
 
 import { PasswordValidator } from '../experience/classes/libraries/password-validator.js';
 import type { UserRouter, RouterInitArgs } from '../types.js';
@@ -36,6 +36,7 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
   const {
     users: { updateUserById, findUserById },
     signInExperiences: { findDefaultSignInExperience },
+    userSsoIdentities,
   } = queries;
 
   const {
@@ -68,10 +69,10 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
         customData: jsonObjectGuard.optional(),
       }),
       response: userProfileResponseGuard.partial(),
-      status: [200, 400, 422],
+      status: [200, 400, 401, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes } = ctx.auth;
+      const { id: userId, scopes, identityVerified } = ctx.auth;
       const { body } = ctx.guard;
       const { name, avatar, username, customData } = body;
       const { fields } = ctx.accountCenter;
@@ -98,12 +99,17 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
       }
 
       if (username !== undefined) {
+        assertThat(
+          identityVerified,
+          new RequestError({ code: 'verification_record.permission_denied', status: 401 })
+        );
+
         if (username === null) {
-          const { signUp } = await findDefaultSignInExperience();
-          assertThat(
-            !signUp.identifiers.includes(SignInIdentifier.Username),
-            'user.username_required'
-          );
+          const [user, ssoIdentities] = await Promise.all([
+            findUserById(userId),
+            userSsoIdentities.findUserSsoIdentitiesByUserId(userId),
+          ]);
+          assertUserHasRemainingIdentifier(user, { username: null }, ssoIdentities.length);
         } else {
           await checkIdentifierCollision({ username }, userId);
         }

--- a/packages/core/src/utils/user.ts
+++ b/packages/core/src/utils/user.ts
@@ -113,13 +113,27 @@ export const getUserIdentifierCount = (user: User, ssoIdentityCount = 0): number
   );
 };
 
+type UserIdentifierUpdate = Partial<
+  Pick<User, 'username' | 'primaryEmail' | 'primaryPhone' | 'identities'>
+>;
+
+export const assertUserHasRemainingIdentifier = (
+  user: User,
+  identifierUpdate: UserIdentifierUpdate,
+  ssoIdentityCount = 0
+) => {
+  assertThat(
+    getUserIdentifierCount({ ...user, ...identifierUpdate }, ssoIdentityCount) > 0,
+    new RequestError('user.last_sign_in_method_required')
+  );
+};
+
 export const assertCanDeleteSocialIdentity = (user: User, target: string, ssoIdentityCount = 0) => {
   assertThat(
     user.identities[target],
     new RequestError({ code: 'user.identity_not_exist', status: 404 })
   );
-  assertThat(
-    getUserIdentifierCount(user, ssoIdentityCount) > 1,
-    new RequestError('user.last_sign_in_method_required')
-  );
+
+  const { [target]: _deletedIdentity, ...identities } = user.identities;
+  assertUserHasRemainingIdentifier(user, { identities }, ssoIdentityCount);
 };

--- a/packages/integration-tests/src/api/my-account.ts
+++ b/packages/integration-tests/src/api/my-account.ts
@@ -72,8 +72,19 @@ export const deleteIdentity = async (
     headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
-export const updateUser = async (api: KyInstance, body: Record<string, unknown>) =>
-  api.patch('api/my-account', { json: body }).json<Partial<UserProfileResponse>>();
+export const updateUser = async (
+  api: KyInstance,
+  body: Record<string, unknown>,
+  verificationRecordId?: string
+) =>
+  api
+    .patch('api/my-account', {
+      json: body,
+      ...conditional(
+        verificationRecordId && { headers: { [verificationRecordIdHeader]: verificationRecordId } }
+      ),
+    })
+    .json<Partial<UserProfileResponse>>();
 
 export const updateOtherProfile = async (api: KyInstance, body: Record<string, unknown>) =>
   api

--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -11,6 +11,7 @@ import {
   getUserInfo,
   updatePrimaryEmail,
   updatePrimaryPhone,
+  updateUser,
 } from '#src/api/my-account.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import {
@@ -200,45 +201,78 @@ describe('account (email and phone)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    it('should fail if email is the only sign-up identifier', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
+    it('should reject deleting the last identifier', async () => {
+      const primaryEmail = generateEmail();
+      const { user, username, password } = await createDefaultTenantUserWithPassword({
+        primaryEmail,
+      });
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Email],
       });
       const verificationRecordId = await createVerificationRecordByPassword(api, password);
-      await enableAllPasswordSignInMethods({
-        identifiers: [SignInIdentifier.Email],
-        password: true,
-        verify: true,
-      });
+      await updateUser(api, { username: null }, verificationRecordId);
 
       await expectRejects(deletePrimaryEmail(api, verificationRecordId), {
-        code: 'user.email_required',
+        code: 'user.last_sign_in_method_required',
         status: 400,
       });
 
-      await enableAllPasswordSignInMethods();
       await deleteDefaultTenantUser(user.id);
     });
 
-    it('should fail if email or phone is the sign-up identifier', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
+    it('should be able to delete primary email if email is the sign-up identifier and another identifier remains', async () => {
+      const primaryEmail = generateEmail();
+      const { user, username, password } = await createDefaultTenantUserWithPassword({
+        primaryEmail,
+      });
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Email],
       });
       const verificationRecordId = await createVerificationRecordByPassword(api, password);
-      await enableAllPasswordSignInMethods({
-        identifiers: [SignInIdentifier.Email, SignInIdentifier.Phone],
-        password: true,
-        verify: true,
-      });
 
-      await expectRejects(deletePrimaryEmail(api, verificationRecordId), {
-        code: 'user.email_or_phone_required',
-        status: 400,
-      });
+      try {
+        await enableAllPasswordSignInMethods({
+          identifiers: [SignInIdentifier.Email],
+          password: true,
+          verify: true,
+        });
 
-      await enableAllPasswordSignInMethods();
+        await deletePrimaryEmail(api, verificationRecordId);
+
+        const userInfo = await getUserInfo(api);
+        expect(userInfo).toHaveProperty('primaryEmail', null);
+      } finally {
+        await enableAllPasswordSignInMethods();
+      }
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should be able to delete primary email if email or phone is the sign-up identifier and another identifier remains', async () => {
+      const primaryEmail = generateEmail();
+      const { user, username, password } = await createDefaultTenantUserWithPassword({
+        primaryEmail,
+      });
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Email],
+      });
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      try {
+        await enableAllPasswordSignInMethods({
+          identifiers: [SignInIdentifier.Email, SignInIdentifier.Phone],
+          password: true,
+          verify: true,
+        });
+
+        await deletePrimaryEmail(api, verificationRecordId);
+
+        const userInfo = await getUserInfo(api);
+        expect(userInfo).toHaveProperty('primaryEmail', null);
+      } finally {
+        await enableAllPasswordSignInMethods();
+      }
+
       await deleteDefaultTenantUser(user.id);
     });
 
@@ -439,45 +473,78 @@ describe('account (email and phone)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    it('should fail if phone is the only sign-up identifier', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
+    it('should reject deleting the last identifier', async () => {
+      const primaryPhone = generatePhone();
+      const { user, username, password } = await createDefaultTenantUserWithPassword({
+        primaryPhone,
+      });
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Phone],
       });
       const verificationRecordId = await createVerificationRecordByPassword(api, password);
-      await enableAllPasswordSignInMethods({
-        identifiers: [SignInIdentifier.Phone],
-        password: true,
-        verify: true,
-      });
+      await updateUser(api, { username: null }, verificationRecordId);
 
       await expectRejects(deletePrimaryPhone(api, verificationRecordId), {
-        code: 'user.phone_required',
+        code: 'user.last_sign_in_method_required',
         status: 400,
       });
 
-      await enableAllPasswordSignInMethods();
       await deleteDefaultTenantUser(user.id);
     });
 
-    it('should fail if email or phone is the sign-up identifier', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
+    it('should be able to delete primary phone if phone is the sign-up identifier and another identifier remains', async () => {
+      const primaryPhone = generatePhone();
+      const { user, username, password } = await createDefaultTenantUserWithPassword({
+        primaryPhone,
+      });
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile, UserScope.Phone],
       });
       const verificationRecordId = await createVerificationRecordByPassword(api, password);
-      await enableAllPasswordSignInMethods({
-        identifiers: [SignInIdentifier.Email, SignInIdentifier.Phone],
-        password: true,
-        verify: true,
-      });
 
-      await expectRejects(deletePrimaryPhone(api, verificationRecordId), {
-        code: 'user.email_or_phone_required',
-        status: 400,
-      });
+      try {
+        await enableAllPasswordSignInMethods({
+          identifiers: [SignInIdentifier.Phone],
+          password: true,
+          verify: true,
+        });
 
-      await enableAllPasswordSignInMethods();
+        await deletePrimaryPhone(api, verificationRecordId);
+
+        const userInfo = await getUserInfo(api);
+        expect(userInfo).toHaveProperty('primaryPhone', null);
+      } finally {
+        await enableAllPasswordSignInMethods();
+      }
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should be able to delete primary phone if email or phone is the sign-up identifier and another identifier remains', async () => {
+      const primaryPhone = generatePhone();
+      const { user, username, password } = await createDefaultTenantUserWithPassword({
+        primaryPhone,
+      });
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Phone],
+      });
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      try {
+        await enableAllPasswordSignInMethods({
+          identifiers: [SignInIdentifier.Email, SignInIdentifier.Phone],
+          password: true,
+          verify: true,
+        });
+
+        await deletePrimaryPhone(api, verificationRecordId);
+
+        const userInfo = await getUserInfo(api);
+        expect(userInfo).toHaveProperty('primaryPhone', null);
+      } finally {
+        await enableAllPasswordSignInMethods();
+      }
+
       await deleteDefaultTenantUser(user.id);
     });
 

--- a/packages/integration-tests/src/tests/api/account/index.test.ts
+++ b/packages/integration-tests/src/tests/api/account/index.test.ts
@@ -1,5 +1,5 @@
 import { UserScope } from '@logto/core-kit';
-import { hookEvents, SignInIdentifier } from '@logto/schemas';
+import { hookEvents } from '@logto/schemas';
 
 import { enableAllAccountCenterFields } from '#src/api/account-center.js';
 import { authedAdminApi } from '#src/api/api.js';
@@ -21,7 +21,7 @@ import {
   signInAndGetUserApi,
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { generatePassword, generateUsername } from '#src/utils.js';
+import { generateEmail, generatePassword, generateUsername } from '#src/utils.js';
 
 import WebhookMockServer from '../hook/WebhookMockServer.js';
 import { assertHookLogResult } from '../hook/utils.js';
@@ -171,8 +171,9 @@ describe('account', () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);
       const newUsername = generateUsername();
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
-      const response = await updateUser(api, { username: newUsername });
+      const response = await updateUser(api, { username: newUsername }, verificationRecordId);
       expect(response).toMatchObject({ username: newUsername });
 
       // Sign in with new username
@@ -181,23 +182,44 @@ describe('account', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
-    it('should be able to update username to null', async () => {
+    it('should fail to update username without identity verification', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);
 
-      await updateSignInExperience({
-        signUp: {
-          identifiers: [SignInIdentifier.Email],
-          password: true,
-          verify: true,
-        },
+      await expectRejects(updateUser(api, { username: generateUsername() }), {
+        code: 'verification_record.permission_denied',
+        status: 401,
       });
-      const response = await updateUser(api, { username: null });
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should be able to update username to null when another identifier remains', async () => {
+      const primaryEmail = generateEmail();
+      const { user, username, password } = await createDefaultTenantUserWithPassword({
+        primaryEmail,
+      });
+      const api = await signInAndGetUserApi(username, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      const response = await updateUser(api, { username: null }, verificationRecordId);
       expect(response).toMatchObject({ username: null });
-      await enableAllPasswordSignInMethods();
 
       const userInfo = await getUserInfo(api);
       expect(userInfo).toHaveProperty('username', null);
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should reject deleting the last identifier', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      await expectRejects(updateUser(api, { username: null }, verificationRecordId), {
+        code: 'user.last_sign_in_method_required',
+        status: 400,
+      });
 
       await deleteDefaultTenantUser(user.id);
     });
@@ -206,8 +228,9 @@ describe('account', () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const { user: user2, username: username2 } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
 
-      await expectRejects(updateUser(api, { username: username2 }), {
+      await expectRejects(updateUser(api, { username: username2 }, verificationRecordId), {
         code: 'user.username_already_in_use',
         status: 422,
       });

--- a/packages/integration-tests/src/tests/api/account/social.delete-identity.test.ts
+++ b/packages/integration-tests/src/tests/api/account/social.delete-identity.test.ts
@@ -10,7 +10,7 @@ import {
 import { enableAllAccountCenterFields } from '#src/api/account-center.js';
 import { putUserIdentity } from '#src/api/admin-user.js';
 import { updateConnectorConfig } from '#src/api/connector.js';
-import { deleteIdentity, getUserInfo } from '#src/api/my-account.js';
+import { deleteIdentity, getUserInfo, updateUser } from '#src/api/my-account.js';
 import { createVerificationRecordByPassword } from '#src/api/verification-record.js';
 import {
   clearConnectorsByTypes,
@@ -143,11 +143,7 @@ describe('my-account (social delete identity)', () => {
           isPasswordPrimary: true,
           socialConnectorTarget: mockSocialConnectorTarget,
         });
-        await api.patch('api/my-account', {
-          json: {
-            username: null,
-          },
-        });
+        await updateUser(api, { username: null }, verificationRecordId);
 
         await expectRejects(deleteIdentity(api, mockSocialConnectorTarget, verificationRecordId), {
           code: 'user.last_sign_in_method_required',
@@ -230,11 +226,7 @@ describe('my-account (social delete identity)', () => {
           isPasswordPrimary: true,
           socialConnectorTarget: mockSocialConnectorTarget,
         });
-        await api.patch('api/my-account', {
-          json: {
-            username: null,
-          },
-        });
+        await updateUser(api, { username: null }, verificationRecordId);
 
         await expectRejects(deleteIdentity(api, mockSocialConnectorTarget, verificationRecordId), {
           code: 'user.last_sign_in_method_required',


### PR DESCRIPTION
## Summary
Unify Account API identifier deletion protection so username, primary email, primary phone, and social identity deletion are rejected only when they would remove the last identifier.

Require `logto-verification-id` when updating or deleting username, matching other sensitive account identifier mutations.

Update OpenAPI descriptions and account API integration test coverage for the new behavior.

## Testing
Integration tests

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments