### PR TITLE
feat(core,console): show OIDC private key effective time

### DIFF
--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.module.scss
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.module.scss
@@ -13,6 +13,10 @@
   padding: 0 _.unit(2);
   border-radius: 6px;
   background-color: var(--color-bg-info-tag);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .deleteIcon {

--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.module.scss
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.module.scss
@@ -25,6 +25,18 @@
   justify-content: flex-end;
 }
 
+.status {
+  display: flex;
+  align-items: center;
+  gap: _.unit(2);
+  white-space: nowrap;
+}
+
+.effectiveIn {
+  font: var(--font-body-2);
+  color: var(--color-text-secondary);
+}
+
 .rotateKey {
   display: flex;
   align-items: center;

--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
@@ -14,7 +14,6 @@ import useSWR from 'swr';
 import Delete from '@/assets/icons/delete.svg?react';
 import FormCard from '@/components/FormCard';
 import { signingKeysLink } from '@/consts';
-import { privateKeyRotationGracePeriod } from '@/consts/env';
 import Button from '@/ds-components/Button';
 import DangerConfirmModal from '@/ds-components/DeleteConfirmModal';
 import DynamicT from '@/ds-components/DynamicT';
@@ -63,8 +62,6 @@ const privateKeyStatusTagMap = {
 
 const getPrivateKeyStatusTag = (status?: OidcSigningKeyStatus) =>
   privateKeyStatusTagMap[status ?? OidcSigningKeyStatus.Current];
-
-const privateKeyRotationGracePeriodInMilliseconds = privateKeyRotationGracePeriod * 1000;
 
 function SigningKeysFormCard() {
   const api = useApi();
@@ -130,8 +127,8 @@ function SigningKeysFormCard() {
             title: String(t('table_column.effective_at')),
             dataIndex: 'effectiveAt',
             colSpan: 5,
-            render: ({ createdAt }: OidcConfigKeysResponse) => (
-              <span>{format(createdAt + privateKeyRotationGracePeriodInMilliseconds, 'Pp')}</span>
+            render: ({ effectiveAt }: OidcConfigKeysResponse) => (
+              <span>{effectiveAt ? format(effectiveAt, 'Ppp') : '-'}</span>
             ),
           },
         ]

--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
@@ -128,7 +128,7 @@ function SigningKeysFormCard() {
             dataIndex: 'effectiveAt',
             colSpan: 5,
             render: ({ effectiveAt }: OidcConfigKeysResponse) => (
-              <span>{effectiveAt ? format(effectiveAt, 'Ppp') : '-'}</span>
+              <span>{effectiveAt ? format(effectiveAt, 'P HH:mm:ss') : '-'}</span>
             ),
           },
         ]

--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
@@ -5,8 +5,7 @@ import {
   OidcSigningKeyStatus,
 } from '@logto/schemas';
 import { condArray } from '@silverhand/essentials';
-import { format } from 'date-fns';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
 import useSWR from 'swr';
@@ -63,6 +62,15 @@ const privateKeyStatusTagMap = {
 const getPrivateKeyStatusTag = (status?: OidcSigningKeyStatus) =>
   privateKeyStatusTagMap[status ?? OidcSigningKeyStatus.Current];
 
+const formatRemainingTime = (remainingMilliseconds: number) => {
+  const totalSeconds = Math.max(0, Math.ceil(remainingMilliseconds / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return [hours, minutes, seconds].map((value) => String(value).padStart(2, '0')).join(':');
+};
+
 function SigningKeysFormCard() {
   const api = useApi();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.signing_keys' });
@@ -82,8 +90,27 @@ function SigningKeysFormCard() {
   const [rotateKeyAlgorithm, setRotateKeyAlgorithm] = useState<SupportedSigningKeyAlgorithm>(
     SupportedSigningKeyAlgorithm.EC
   );
+  const nextKeyEffectiveAt = data?.find(
+    ({ status }) => status === OidcSigningKeyStatus.Next
+  )?.effectiveAt;
+  const [now, setNow] = useState(Date.now());
 
   const isLoadingKeys = !data && !error;
+
+  useEffect(() => {
+    if (!nextKeyEffectiveAt || nextKeyEffectiveAt <= Date.now()) {
+      return;
+    }
+
+    setNow(Date.now());
+    const interval = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [nextKeyEffectiveAt]);
 
   const tableColumns = useMemo<Array<Column<OidcConfigKeysResponse>>>(
     () => [
@@ -92,26 +119,6 @@ function SigningKeysFormCard() {
         dataIndex: 'id',
         colSpan: 8,
         render: ({ id }: OidcConfigKeysResponse) => <div className={styles.idWrapper}>{id}</div>,
-      },
-      {
-        title: String(t('table_column.status')),
-        dataIndex: 'status',
-        colSpan: 4,
-        render: ({ status }: OidcConfigKeysResponse, rowIndex: number) => {
-          const { tagStatus, translationKey } = isPrivateKey
-            ? getPrivateKeyStatusTag(status)
-            : {
-                tagStatus: rowIndex === 0 ? ('success' as const) : ('alert' as const),
-                translationKey:
-                  rowIndex === 0 ? ('status.current' as const) : ('status.previous' as const),
-              };
-
-          return (
-            <Tag type="state" variant="plain" status={tagStatus}>
-              {t(translationKey)}
-            </Tag>
-          );
-        },
       },
       ...condArray(
         isPrivateKey && [
@@ -123,16 +130,37 @@ function SigningKeysFormCard() {
               <span>{signingKeyAlgorithm}</span>
             ),
           },
-          {
-            title: String(t('table_column.effective_at')),
-            dataIndex: 'effectiveAt',
-            colSpan: 5,
-            render: ({ effectiveAt }: OidcConfigKeysResponse) => (
-              <span>{effectiveAt ? format(effectiveAt, 'P HH:mm:ss') : '-'}</span>
-            ),
-          },
         ]
       ),
+      {
+        title: String(t('table_column.status')),
+        dataIndex: 'status',
+        colSpan: isPrivateKey ? 9 : 4,
+        render: ({ status, effectiveAt }: OidcConfigKeysResponse, rowIndex: number) => {
+          const { tagStatus, translationKey } = isPrivateKey
+            ? getPrivateKeyStatusTag(status)
+            : {
+                tagStatus: rowIndex === 0 ? ('success' as const) : ('alert' as const),
+                translationKey:
+                  rowIndex === 0 ? ('status.current' as const) : ('status.previous' as const),
+              };
+
+          return (
+            <div className={styles.status}>
+              <Tag type="state" variant="plain" status={tagStatus}>
+                {t(translationKey)}
+              </Tag>
+              {status === OidcSigningKeyStatus.Next && effectiveAt && (
+                <span className={styles.effectiveIn}>
+                  {t('status.effective_in', {
+                    time: formatRemainingTime(effectiveAt - now),
+                  })}
+                </span>
+              )}
+            </div>
+          );
+        },
+      },
       {
         title: '',
         dataIndex: 'action',
@@ -152,7 +180,7 @@ function SigningKeysFormCard() {
           ),
       },
     ],
-    [isPrivateKey, t]
+    [isPrivateKey, now, t]
   );
 
   return (

--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
@@ -91,7 +91,7 @@ function SigningKeysFormCard() {
         title: String(t('table_column.id')),
         dataIndex: 'id',
         colSpan: 8,
-        render: ({ id }: OidcConfigKeysResponse) => <span className={styles.idWrapper}>{id}</span>,
+        render: ({ id }: OidcConfigKeysResponse) => <div className={styles.idWrapper}>{id}</div>,
       },
       {
         title: String(t('table_column.status')),

--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
@@ -5,6 +5,7 @@ import {
   OidcSigningKeyStatus,
 } from '@logto/schemas';
 import { condArray } from '@silverhand/essentials';
+import { format } from 'date-fns';
 import { useMemo, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
@@ -117,9 +118,17 @@ function SigningKeysFormCard() {
           {
             title: String(t('table_column.algorithm')),
             dataIndex: 'signingKeyAlgorithm',
-            colSpan: 7,
+            colSpan: 5,
             render: ({ signingKeyAlgorithm }: OidcConfigKeysResponse) => (
               <span>{signingKeyAlgorithm}</span>
+            ),
+          },
+          {
+            title: String(t('table_column.created_at')),
+            dataIndex: 'createdAt',
+            colSpan: 5,
+            render: ({ createdAt }: OidcConfigKeysResponse) => (
+              <span>{format(createdAt, 'Pp')}</span>
             ),
           },
         ]

--- a/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
+++ b/packages/console/src/components/OidcConfigs/SigningKeysFormCard.tsx
@@ -14,6 +14,7 @@ import useSWR from 'swr';
 import Delete from '@/assets/icons/delete.svg?react';
 import FormCard from '@/components/FormCard';
 import { signingKeysLink } from '@/consts';
+import { privateKeyRotationGracePeriod } from '@/consts/env';
 import Button from '@/ds-components/Button';
 import DangerConfirmModal from '@/ds-components/DeleteConfirmModal';
 import DynamicT from '@/ds-components/DynamicT';
@@ -62,6 +63,8 @@ const privateKeyStatusTagMap = {
 
 const getPrivateKeyStatusTag = (status?: OidcSigningKeyStatus) =>
   privateKeyStatusTagMap[status ?? OidcSigningKeyStatus.Current];
+
+const privateKeyRotationGracePeriodInMilliseconds = privateKeyRotationGracePeriod * 1000;
 
 function SigningKeysFormCard() {
   const api = useApi();
@@ -124,11 +127,11 @@ function SigningKeysFormCard() {
             ),
           },
           {
-            title: String(t('table_column.created_at')),
-            dataIndex: 'createdAt',
+            title: String(t('table_column.effective_at')),
+            dataIndex: 'effectiveAt',
             colSpan: 5,
             render: ({ createdAt }: OidcConfigKeysResponse) => (
-              <span>{format(createdAt, 'Pp')}</span>
+              <span>{format(createdAt + privateKeyRotationGracePeriodInMilliseconds, 'Pp')}</span>
             ),
           },
         ]

--- a/packages/console/src/consts/env.ts
+++ b/packages/console/src/consts/env.ts
@@ -5,28 +5,9 @@ import { storageKeys } from './storage';
 const normalizeEnv = (value: unknown) =>
   value === null || value === undefined ? undefined : String(value);
 
-const parseNonNegativeIntegerEnv = (value: unknown) => {
-  const normalizedValue = normalizeEnv(value);
-
-  if (!normalizedValue) {
-    return 0;
-  }
-
-  const parsedValue = Number(normalizedValue);
-
-  if (!Number.isSafeInteger(parsedValue) || parsedValue < 0) {
-    throw new TypeError('Invalid PRIVATE_KEY_ROTATION_GRACE_PERIOD env value');
-  }
-
-  return parsedValue;
-};
-
 const isProduction = import.meta.env.PROD;
 export const isCloud = yes(normalizeEnv(import.meta.env.IS_CLOUD));
 export const adminEndpoint = normalizeEnv(import.meta.env.ADMIN_ENDPOINT);
-export const privateKeyRotationGracePeriod = parseNonNegativeIntegerEnv(
-  import.meta.env.PRIVATE_KEY_ROTATION_GRACE_PERIOD
-);
 
 export const isDevFeaturesEnabled =
   !isProduction ||

--- a/packages/console/src/consts/env.ts
+++ b/packages/console/src/consts/env.ts
@@ -5,9 +5,28 @@ import { storageKeys } from './storage';
 const normalizeEnv = (value: unknown) =>
   value === null || value === undefined ? undefined : String(value);
 
+const parseNonNegativeIntegerEnv = (value: unknown) => {
+  const normalizedValue = normalizeEnv(value);
+
+  if (!normalizedValue) {
+    return 0;
+  }
+
+  const parsedValue = Number(normalizedValue);
+
+  if (!Number.isSafeInteger(parsedValue) || parsedValue < 0) {
+    throw new TypeError('Invalid PRIVATE_KEY_ROTATION_GRACE_PERIOD env value');
+  }
+
+  return parsedValue;
+};
+
 const isProduction = import.meta.env.PROD;
 export const isCloud = yes(normalizeEnv(import.meta.env.IS_CLOUD));
 export const adminEndpoint = normalizeEnv(import.meta.env.ADMIN_ENDPOINT);
+export const privateKeyRotationGracePeriod = parseNonNegativeIntegerEnv(
+  import.meta.env.PRIVATE_KEY_ROTATION_GRACE_PERIOD
+);
 
 export const isDevFeaturesEnabled =
   !isProduction ||

--- a/packages/console/vite.config.ts
+++ b/packages/console/vite.config.ts
@@ -48,9 +48,6 @@ const buildConfig = (mode: string): UserConfig => ({
     'import.meta.env.ADMIN_ENDPOINT': JSON.stringify(process.env.ADMIN_ENDPOINT),
     'import.meta.env.DEV_FEATURES_ENABLED': JSON.stringify(process.env.DEV_FEATURES_ENABLED),
     'import.meta.env.INTEGRATION_TEST': JSON.stringify(process.env.INTEGRATION_TEST),
-    'import.meta.env.PRIVATE_KEY_ROTATION_GRACE_PERIOD': JSON.stringify(
-      process.env.PRIVATE_KEY_ROTATION_GRACE_PERIOD
-    ),
     'import.meta.env.CONSOLE_EMBEDDED_PRICING_URL': JSON.stringify(
       process.env.CONSOLE_EMBEDDED_PRICING_URL
     ),

--- a/packages/console/vite.config.ts
+++ b/packages/console/vite.config.ts
@@ -48,6 +48,9 @@ const buildConfig = (mode: string): UserConfig => ({
     'import.meta.env.ADMIN_ENDPOINT': JSON.stringify(process.env.ADMIN_ENDPOINT),
     'import.meta.env.DEV_FEATURES_ENABLED': JSON.stringify(process.env.DEV_FEATURES_ENABLED),
     'import.meta.env.INTEGRATION_TEST': JSON.stringify(process.env.INTEGRATION_TEST),
+    'import.meta.env.PRIVATE_KEY_ROTATION_GRACE_PERIOD': JSON.stringify(
+      process.env.PRIVATE_KEY_ROTATION_GRACE_PERIOD
+    ),
     'import.meta.env.CONSOLE_EMBEDDED_PRICING_URL': JSON.stringify(
       process.env.CONSOLE_EMBEDDED_PRICING_URL
     ),

--- a/packages/core/src/libraries/logto-config.ts
+++ b/packages/core/src/libraries/logto-config.ts
@@ -1,16 +1,23 @@
+import crypto from 'node:crypto';
+
 import type {
   CloudConnectionData,
   IdTokenConfig,
   JwtCustomizerType,
   LogtoOidcConfigType,
+  OidcConfigKey,
+  OidcConfigKeysResponse,
+  OidcPrivateKey,
 } from '@logto/schemas';
 import {
   LogtoConfigs,
   LogtoJwtTokenKey,
   LogtoOidcConfigKey,
+  OidcSigningKeyStatus,
   cloudApiIndicator,
   cloudConnectionDataGuard,
   normalizeOidcPrivateKeys,
+  oidcConfigKeysResponseGuard,
   rotateOidcPrivateKeyStatuses,
   idTokenConfigGuard,
   jwtCustomizerConfigGuard,
@@ -23,6 +30,7 @@ import { ZodError, z } from 'zod';
 import RequestError from '#src/errors/RequestError/index.js';
 import { createLogtoConfigQueries } from '#src/queries/logto-config.js';
 import type Queries from '#src/tenants/Queries.js';
+import { exportJWK } from '#src/utils/jwks.js';
 
 export type LogtoConfigLibrary = ReturnType<typeof createLogtoConfigLibrary>;
 
@@ -32,6 +40,7 @@ export const createLogtoConfigLibrary = ({
     getCloudConnectionData: queryCloudConnectionData,
     upsertJwtCustomizer: queryUpsertJwtCustomizer,
     upsertIdTokenConfig: queryUpsertIdTokenConfig,
+    getSigningKeyRotationState,
   },
   pool,
   wellKnownCache,
@@ -153,6 +162,46 @@ export const createLogtoConfigLibrary = ({
   };
 
   /**
+   * Remove key material before returning OIDC keys through the management API.
+   * For private signing keys, also attach the scheduled effective time from the
+   * persisted rotation state to the staged Next key.
+   */
+  const getRedactedOidcKeyResponse = async (
+    type: LogtoOidcConfigKey,
+    keys: Array<OidcConfigKey | OidcPrivateKey>
+  ): Promise<OidcConfigKeysResponse[]> => {
+    const signingKeyRotationState =
+      type === LogtoOidcConfigKey.PrivateKeys ? await getSigningKeyRotationState() : undefined;
+
+    return Promise.all(
+      keys.map(async ({ id, value, createdAt, ...rest }) => {
+        if (type === LogtoOidcConfigKey.PrivateKeys) {
+          const jwk = await exportJWK(crypto.createPrivateKey(value));
+          const status = 'status' in rest ? rest.status : undefined;
+          const parseResult = oidcConfigKeysResponseGuard.safeParse({
+            id,
+            createdAt,
+            effectiveAt:
+              status === OidcSigningKeyStatus.Next
+                ? signingKeyRotationState?.signingKeyRotationAt
+                : undefined,
+            signingKeyAlgorithm: jwk.kty,
+            status,
+          });
+
+          if (!parseResult.success) {
+            throw new RequestError({ code: 'request.general', status: 422 });
+          }
+
+          return parseResult.data;
+        }
+
+        return { id, createdAt };
+      })
+    );
+  };
+
+  /**
    * Rotate OIDC private signing key statuses if the scheduled rotation time has come.
    * This function is intended to be called before accessing OIDC configs to ensure the key statuses are up-to-date.
    */
@@ -187,6 +236,7 @@ export const createLogtoConfigLibrary = ({
     getJwtCustomizers,
     updateJwtCustomizer,
     upsertIdTokenConfig,
+    getRedactedOidcKeyResponse,
     promoteScheduledSigningKeyRotation,
   };
 };

--- a/packages/core/src/routes/logto-config/index.rotation.test.ts
+++ b/packages/core/src/routes/logto-config/index.rotation.test.ts
@@ -21,8 +21,9 @@ const previousPrivateKey = {
   value: '-----BEGIN PRIVATE KEY-----\nlegacy\nprevious\nkey\n-----END PRIVATE KEY-----\n',
   createdAt: Math.floor(Date.now() / 1000) - 10,
 };
+const signingKeyRotationAt = 1_777_777_777_000;
 
-await mockEsmWithActual('#src/utils/jwks.js', () => ({
+const { exportJWK } = await mockEsmWithActual('#src/utils/jwks.js', () => ({
   exportJWK: jest.fn(async () => ({ kty: 'EC' })),
 }));
 
@@ -40,6 +41,7 @@ const logtoConfigQueries = {
   updateAdminConsoleConfig: async () => ({ value: mockAdminConsoleData }),
   updatePrivateSigningKeysWithLock: jest.fn(),
   updateOidcConfigsByKey: jest.fn(),
+  getSigningKeyRotationState: jest.fn(),
 };
 
 const logtoConfigLibraries = {
@@ -48,14 +50,53 @@ const logtoConfigLibraries = {
       { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
     ],
     [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
+    [LogtoOidcConfigKey.Session]: {},
   })),
+  getRedactedOidcKeyResponse: jest.fn(
+    async (
+      type: LogtoOidcConfigKey,
+      keys: Array<{ id: string; value: string; createdAt: number }>
+    ) => {
+      const signingKeyRotationState = (await (type === LogtoOidcConfigKey.PrivateKeys
+        ? logtoConfigQueries.getSigningKeyRotationState()
+        : undefined)) as { signingKeyRotationAt?: number } | undefined;
+
+      return Promise.all(
+        keys.map(async ({ id, value, createdAt, ...rest }) => {
+          if (type === LogtoOidcConfigKey.PrivateKeys) {
+            const jwk = await (exportJWK as (key: unknown) => Promise<{ kty: string }>)(value);
+            const status = ('status' in rest ? rest.status : undefined) as
+              | OidcSigningKeyStatus
+              | undefined;
+
+            return {
+              id,
+              createdAt,
+              effectiveAt:
+                status === OidcSigningKeyStatus.Next
+                  ? signingKeyRotationState?.signingKeyRotationAt
+                  : undefined,
+              signingKeyAlgorithm: jwk.kty,
+              status,
+            };
+          }
+
+          return { id, createdAt };
+        })
+      );
+    }
+  ),
 };
 
 const logtoConfigRoutes = await pickDefault(import('./index.js'));
 
 describe('configs routes staged rotation', () => {
   const tenantContext = new MockTenant(undefined, { logtoConfigs: logtoConfigQueries });
-  Sinon.stub(tenantContext, 'logtoConfigs').value(logtoConfigLibraries);
+  Sinon.stub(tenantContext, 'logtoConfigs').value({
+    ...tenantContext.logtoConfigs,
+    getOidcConfigs: logtoConfigLibraries.getOidcConfigs,
+    getRedactedOidcKeyResponse: logtoConfigLibraries.getRedactedOidcKeyResponse,
+  });
   const invalidateCache = Sinon.stub(tenantContext, 'invalidateCache').resolves();
   const rotatePrivateSigningKeys = jest.fn();
   Sinon.stub(tenantContext.libraries, 'oidcPrivateKeys').value({
@@ -79,6 +120,9 @@ describe('configs routes staged rotation', () => {
       { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
       { ...previousPrivateKey, status: OidcSigningKeyStatus.Previous },
     ]);
+    logtoConfigQueries.getSigningKeyRotationState.mockResolvedValueOnce({
+      signingKeyRotationAt,
+    });
 
     const response = await routeRequester.post('/configs/oidc/private-keys/rotate').send({
       rotationGracePeriod: 14_400,
@@ -92,21 +136,19 @@ describe('configs routes staged rotation', () => {
       {
         id: newPrivateKey.id,
         createdAt: newPrivateKey.createdAt,
-        effectiveAt: (newPrivateKey.createdAt + 14_400) * 1000,
+        effectiveAt: signingKeyRotationAt,
         signingKeyAlgorithm: 'EC',
         status: OidcSigningKeyStatus.Next,
       },
       {
         id: mockPrivateKeys[0]!.id,
         createdAt: mockPrivateKeys[0]!.createdAt,
-        effectiveAt: (mockPrivateKeys[0]!.createdAt + 14_400) * 1000,
         signingKeyAlgorithm: 'EC',
         status: OidcSigningKeyStatus.Current,
       },
       {
         id: previousPrivateKey.id,
         createdAt: previousPrivateKey.createdAt,
-        effectiveAt: (previousPrivateKey.createdAt + 14_400) * 1000,
         signingKeyAlgorithm: 'EC',
         status: OidcSigningKeyStatus.Previous,
       },

--- a/packages/core/src/routes/logto-config/index.rotation.test.ts
+++ b/packages/core/src/routes/logto-config/index.rotation.test.ts
@@ -92,18 +92,21 @@ describe('configs routes staged rotation', () => {
       {
         id: newPrivateKey.id,
         createdAt: newPrivateKey.createdAt,
+        effectiveAt: (newPrivateKey.createdAt + 14_400) * 1000,
         signingKeyAlgorithm: 'EC',
         status: OidcSigningKeyStatus.Next,
       },
       {
         id: mockPrivateKeys[0]!.id,
         createdAt: mockPrivateKeys[0]!.createdAt,
+        effectiveAt: (mockPrivateKeys[0]!.createdAt + 14_400) * 1000,
         signingKeyAlgorithm: 'EC',
         status: OidcSigningKeyStatus.Current,
       },
       {
         id: previousPrivateKey.id,
         createdAt: previousPrivateKey.createdAt,
+        effectiveAt: (previousPrivateKey.createdAt + 14_400) * 1000,
         signingKeyAlgorithm: 'EC',
         status: OidcSigningKeyStatus.Previous,
       },

--- a/packages/core/src/routes/logto-config/index.test.ts
+++ b/packages/core/src/routes/logto-config/index.test.ts
@@ -126,6 +126,7 @@ describe('configs routes', () => {
         ({ id, createdAt, status }) => ({
           id,
           createdAt,
+          effectiveAt: createdAt * 1000,
           signingKeyAlgorithm: 'EC',
           status,
         })
@@ -244,6 +245,7 @@ describe('configs routes', () => {
     expect(response.body[0]).toEqual({
       id: newPrivateKey.id,
       createdAt: newPrivateKey.createdAt,
+      effectiveAt: newPrivateKey.createdAt * 1000,
       signingKeyAlgorithm: 'RSA',
       status: OidcSigningKeyStatus.Current,
     });
@@ -326,6 +328,7 @@ describe('configs routes', () => {
     expect(response.body[0]).toEqual({
       id: newPrivateKey.id,
       createdAt: newPrivateKey.createdAt,
+      effectiveAt: (newPrivateKey.createdAt + 60) * 1000,
       signingKeyAlgorithm: 'RSA',
       status: OidcSigningKeyStatus.Next,
     });

--- a/packages/core/src/routes/logto-config/index.test.ts
+++ b/packages/core/src/routes/logto-config/index.test.ts
@@ -28,6 +28,7 @@ const previousPrivateKey = {
   value: '-----BEGIN PRIVATE KEY-----\nlegacy\nprevious\nkey\n-----END PRIVATE KEY-----\n',
   createdAt: Math.floor(Date.now() / 1000) - 10,
 };
+const signingKeyRotationAt = 1_777_777_777_000;
 
 const { exportJWK } = await mockEsmWithActual('#src/utils/jwks.js', () => ({
   exportJWK: jest.fn(async () => ({ kty: 'EC' })),
@@ -54,6 +55,7 @@ const logtoConfigQueries = {
     },
   }),
   updateOidcConfigsByKey: jest.fn(),
+  getSigningKeyRotationState: jest.fn(),
 };
 
 const logtoConfigLibraries = {
@@ -62,7 +64,42 @@ const logtoConfigLibraries = {
       { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
     ],
     [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
+    [LogtoOidcConfigKey.Session]: {},
   })),
+  getRedactedOidcKeyResponse: jest.fn(
+    async (
+      type: LogtoOidcConfigKey,
+      keys: Array<{ id: string; value: string; createdAt: number }>
+    ) => {
+      const signingKeyRotationState = (await (type === LogtoOidcConfigKey.PrivateKeys
+        ? logtoConfigQueries.getSigningKeyRotationState()
+        : undefined)) as { signingKeyRotationAt?: number } | undefined;
+
+      return Promise.all(
+        keys.map(async ({ id, value, createdAt, ...rest }) => {
+          if (type === LogtoOidcConfigKey.PrivateKeys) {
+            const jwk = await (exportJWK as (key: unknown) => Promise<{ kty: string }>)(value);
+            const status = ('status' in rest ? rest.status : undefined) as
+              | OidcSigningKeyStatus
+              | undefined;
+
+            return {
+              id,
+              createdAt,
+              effectiveAt:
+                status === OidcSigningKeyStatus.Next
+                  ? signingKeyRotationState?.signingKeyRotationAt
+                  : undefined,
+              signingKeyAlgorithm: jwk.kty,
+              status,
+            };
+          }
+
+          return { id, createdAt };
+        })
+      );
+    }
+  ),
 };
 
 const oidcPrivateKeyLibraries = {
@@ -82,7 +119,11 @@ describe('configs routes', () => {
   const tenantContext = new MockTenant(undefined, { logtoConfigs: logtoConfigQueries }, undefined, {
     oidcPrivateKeys: oidcPrivateKeyLibraries,
   });
-  Sinon.stub(tenantContext, 'logtoConfigs').value(logtoConfigLibraries);
+  Sinon.stub(tenantContext, 'logtoConfigs').value({
+    ...tenantContext.logtoConfigs,
+    getOidcConfigs: logtoConfigLibraries.getOidcConfigs,
+    getRedactedOidcKeyResponse: logtoConfigLibraries.getRedactedOidcKeyResponse,
+  });
   Sinon.stub(tenantContext.libraries, 'oidcPrivateKeys').value(oidcPrivateKeyLibraries);
 
   const routeRequester = createRequester({
@@ -119,19 +160,35 @@ describe('configs routes', () => {
   });
 
   it('GET /configs/oidc/:keyType', async () => {
+    logtoConfigLibraries.getOidcConfigs.mockResolvedValueOnce({
+      [LogtoOidcConfigKey.PrivateKeys]: [
+        { ...newPrivateKey, status: OidcSigningKeyStatus.Next },
+        { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
+      ],
+      [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
+      [LogtoOidcConfigKey.Session]: {},
+    });
+    logtoConfigQueries.getSigningKeyRotationState.mockResolvedValueOnce({
+      signingKeyRotationAt,
+    });
+
     const response = await routeRequester.get('/configs/oidc/private-keys');
     expect(response.status).toEqual(200);
-    expect(response.body).toEqual(
-      [{ ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current }].map(
-        ({ id, createdAt, status }) => ({
-          id,
-          createdAt,
-          effectiveAt: createdAt * 1000,
-          signingKeyAlgorithm: 'EC',
-          status,
-        })
-      )
-    );
+    expect(response.body).toEqual([
+      {
+        id: newPrivateKey.id,
+        createdAt: newPrivateKey.createdAt,
+        effectiveAt: signingKeyRotationAt,
+        signingKeyAlgorithm: 'EC',
+        status: OidcSigningKeyStatus.Next,
+      },
+      {
+        id: mockPrivateKeys[0]!.id,
+        createdAt: mockPrivateKeys[0]!.createdAt,
+        signingKeyAlgorithm: 'EC',
+        status: OidcSigningKeyStatus.Current,
+      },
+    ]);
 
     const response2 = await routeRequester.get('/configs/oidc/cookie-keys');
     expect(response2.status).toEqual(200);
@@ -141,6 +198,7 @@ describe('configs routes', () => {
         createdAt,
       }))
     );
+    expect(logtoConfigQueries.getSigningKeyRotationState).toHaveBeenCalledTimes(1);
   });
 
   it('DELETE /configs/oidc/:keyType/:keyId will fail if there is only one key', async () => {
@@ -165,6 +223,7 @@ describe('configs routes', () => {
         { ...newPrivateKey, status: OidcSigningKeyStatus.Current },
       ],
       [LogtoOidcConfigKey.CookieKeys]: [newCookieKey, ...mockCookieKeys],
+      [LogtoOidcConfigKey.Session]: {},
     });
 
     await expect(
@@ -236,6 +295,7 @@ describe('configs routes', () => {
         { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
       ],
       [LogtoOidcConfigKey.CookieKeys]: mockCookieKeys,
+      [LogtoOidcConfigKey.Session]: {},
     });
     exportJWK.mockResolvedValueOnce({ kty: 'RSA' });
 
@@ -245,7 +305,6 @@ describe('configs routes', () => {
     expect(response.body[0]).toEqual({
       id: newPrivateKey.id,
       createdAt: newPrivateKey.createdAt,
-      effectiveAt: newPrivateKey.createdAt * 1000,
       signingKeyAlgorithm: 'RSA',
       status: OidcSigningKeyStatus.Current,
     });
@@ -315,6 +374,9 @@ describe('configs routes', () => {
       { ...mockPrivateKeys[0]!, status: OidcSigningKeyStatus.Current },
     ]);
     exportJWK.mockResolvedValueOnce({ kty: 'RSA' });
+    logtoConfigQueries.getSigningKeyRotationState.mockResolvedValueOnce({
+      signingKeyRotationAt,
+    });
 
     const response = await routeRequester
       .post('/configs/oidc/private-keys/rotate')
@@ -328,7 +390,7 @@ describe('configs routes', () => {
     expect(response.body[0]).toEqual({
       id: newPrivateKey.id,
       createdAt: newPrivateKey.createdAt,
-      effectiveAt: (newPrivateKey.createdAt + 60) * 1000,
+      effectiveAt: signingKeyRotationAt,
       signingKeyAlgorithm: 'RSA',
       status: OidcSigningKeyStatus.Next,
     });

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -50,7 +50,8 @@ const oidcSessionConfigResponseGuard = oidcSessionConfigGuard.required({ ttl: tr
  */
 const getRedactedOidcKeyResponse = async (
   type: LogtoOidcConfigKey,
-  keys: Array<OidcConfigKey | OidcPrivateKey>
+  keys: Array<OidcConfigKey | OidcPrivateKey>,
+  privateKeyRotationGracePeriod = EnvSet.values.privateKeyRotationGracePeriod
 ): Promise<OidcConfigKeysResponse[]> =>
   Promise.all(
     keys.map(async ({ id, value, createdAt, ...rest }) => {
@@ -59,6 +60,7 @@ const getRedactedOidcKeyResponse = async (
         const parseResult = oidcConfigKeysResponseGuard.safeParse({
           id,
           createdAt,
+          effectiveAt: (createdAt + privateKeyRotationGracePeriod) * 1000,
           signingKeyAlgorithm: jwk.kty,
           status: 'status' in rest ? rest.status : undefined,
         });
@@ -256,7 +258,11 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
       void tenant.invalidateCache();
 
       // Remove actual values of the private keys from response
-      ctx.body = await getRedactedOidcKeyResponse(configKey, updatedKeys);
+      ctx.body = await getRedactedOidcKeyResponse(
+        configKey,
+        updatedKeys,
+        effectiveRotationGracePeriod
+      );
 
       return next();
     }

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -1,5 +1,3 @@
-import crypto from 'node:crypto';
-
 import {
   generateOidcCookieKey,
   generateOidcPrivateKey,
@@ -9,9 +7,6 @@ import {
   adminConsoleDataGuard,
   oidcConfigKeysResponseGuard,
   SupportedSigningKeyAlgorithm,
-  type OidcConfigKeysResponse,
-  type OidcConfigKey,
-  type OidcPrivateKey,
   LogtoOidcConfigKeyType,
   oidcSessionConfigGuard,
 } from '@logto/schemas';
@@ -22,7 +17,6 @@ import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import defaults from '#src/oidc/defaults.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
-import { exportJWK } from '#src/utils/jwks.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
@@ -42,43 +36,12 @@ const getOidcConfigKeyDatabaseColumnName = (
 // Keep `ttl` constraints from `oidcSessionConfigGuard` while requiring this field in API responses.
 const oidcSessionConfigResponseGuard = oidcSessionConfigGuard.required({ ttl: true });
 
-/**
- * Remove actual values of the private keys from response.
- * @param type Logto config key DB column name. Values are either `oidc.privateKeys` or `oidc.cookieKeys`.
- * @param keys Logto OIDC private keys.
- * @returns Redacted Logto OIDC private keys without actual private key value.
- */
-const getRedactedOidcKeyResponse = async (
-  type: LogtoOidcConfigKey,
-  keys: Array<OidcConfigKey | OidcPrivateKey>,
-  privateKeyRotationGracePeriod = EnvSet.values.privateKeyRotationGracePeriod
-): Promise<OidcConfigKeysResponse[]> =>
-  Promise.all(
-    keys.map(async ({ id, value, createdAt, ...rest }) => {
-      if (type === LogtoOidcConfigKey.PrivateKeys) {
-        const jwk = await exportJWK(crypto.createPrivateKey(value));
-        const parseResult = oidcConfigKeysResponseGuard.safeParse({
-          id,
-          createdAt,
-          effectiveAt: (createdAt + privateKeyRotationGracePeriod) * 1000,
-          signingKeyAlgorithm: jwk.kty,
-          status: 'status' in rest ? rest.status : undefined,
-        });
-        if (!parseResult.success) {
-          throw new RequestError({ code: 'request.general', status: 422 });
-        }
-        return parseResult.data;
-      }
-      return { id, createdAt };
-    })
-  );
-
 export default function logtoConfigRoutes<T extends ManagementApiRouter>(
   ...[router, tenant]: RouterInitArgs<T>
 ) {
   const { getAdminConsoleConfig, updateAdminConsoleConfig, updateOidcConfigsByKey } =
     tenant.queries.logtoConfigs;
-  const { getOidcConfigs } = tenant.logtoConfigs;
+  const { getOidcConfigs, getRedactedOidcKeyResponse } = tenant.logtoConfigs;
   const { oidcPrivateKeys } = tenant.libraries;
 
   router.get(
@@ -258,11 +221,7 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
       void tenant.invalidateCache();
 
       // Remove actual values of the private keys from response
-      ctx.body = await getRedactedOidcKeyResponse(
-        configKey,
-        updatedKeys,
-        effectiveRotationGracePeriod
-      );
+      ctx.body = await getRedactedOidcKeyResponse(configKey, updatedKeys);
 
       return next();
     }

--- a/packages/core/src/test-utils/mock-libraries.ts
+++ b/packages/core/src/test-utils/mock-libraries.ts
@@ -10,6 +10,7 @@ const { jest } = import.meta;
 export const mockLogtoConfigsLibrary: jest.Mocked<LogtoConfigLibrary> = {
   getCloudConnectionData: jest.fn(),
   getOidcConfigs: jest.fn(),
+  getRedactedOidcKeyResponse: jest.fn(),
   promoteScheduledSigningKeyRotation: jest.fn(),
   upsertJwtCustomizer: jest.fn(),
   getJwtCustomizer: jest.fn(),

--- a/packages/phrases/src/locales/ar/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'المعرف',
     status: 'الحالة',
     algorithm: 'خوارزمية مفتاح التوقيع',
-    created_at: 'تاريخ الإنشاء',
+    effective_at: 'يسري في',
   },
   status: {
     next: 'التالي',

--- a/packages/phrases/src/locales/ar/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'المعرف',
     status: 'الحالة',
     algorithm: 'خوارزمية مفتاح التوقيع',
+    created_at: 'تاريخ الإنشاء',
   },
   status: {
     next: 'التالي',

--- a/packages/phrases/src/locales/ar/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: 'التالي',
     current: 'الحالي',
     previous: 'السابق',
+    effective_in: 'يسري خلال {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/de/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/signing-keys.ts
@@ -20,6 +20,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Status',
     algorithm: 'Signierungsschlüssel Algorithmus',
+    created_at: 'Erstellt am',
   },
   status: {
     next: 'Nächster',

--- a/packages/phrases/src/locales/de/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/signing-keys.ts
@@ -20,7 +20,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Status',
     algorithm: 'Signierungsschlüssel Algorithmus',
-    created_at: 'Erstellt am',
+    effective_at: 'Wirksam ab',
   },
   status: {
     next: 'Nächster',

--- a/packages/phrases/src/locales/de/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/signing-keys.ts
@@ -26,6 +26,7 @@ const signing_keys = {
     next: 'Nächster',
     current: 'Aktuell',
     previous: 'Vorherige',
+    effective_in: 'Wirksam in {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/en/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Status',
     algorithm: 'Signing key algorithm',
-    created_at: 'Created at',
+    effective_at: 'Effective at',
   },
   status: {
     next: 'Next',

--- a/packages/phrases/src/locales/en/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Status',
     algorithm: 'Signing key algorithm',
+    created_at: 'Created at',
   },
   status: {
     next: 'Next',

--- a/packages/phrases/src/locales/en/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: 'Next',
     current: 'Current',
     previous: 'Previous',
+    effective_in: 'Effective in {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/es/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: 'Siguiente',
     current: 'Actual',
     previous: 'Anterior',
+    effective_in: 'Vigente en {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/es/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Estado',
     algorithm: 'Algoritmo de clave de firma',
+    created_at: 'Creado el',
   },
   status: {
     next: 'Siguiente',

--- a/packages/phrases/src/locales/es/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Estado',
     algorithm: 'Algoritmo de clave de firma',
-    created_at: 'Creado el',
+    effective_at: 'Vigente desde',
   },
   status: {
     next: 'Siguiente',

--- a/packages/phrases/src/locales/fr/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/signing-keys.ts
@@ -20,7 +20,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Statut',
     algorithm: 'Algorithme de clé de signature',
-    created_at: 'Créé le',
+    effective_at: 'Effectif le',
   },
   status: {
     next: 'Suivant',

--- a/packages/phrases/src/locales/fr/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/signing-keys.ts
@@ -20,6 +20,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Statut',
     algorithm: 'Algorithme de clé de signature',
+    created_at: 'Créé le',
   },
   status: {
     next: 'Suivant',

--- a/packages/phrases/src/locales/fr/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/signing-keys.ts
@@ -26,6 +26,7 @@ const signing_keys = {
     next: 'Suivant',
     current: 'Actuel',
     previous: 'Précédent',
+    effective_in: 'Effectif dans {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/it/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Stato',
     algorithm: 'Algoritmo di firma della chiave',
-    created_at: 'Creato il',
+    effective_at: 'Effettivo dal',
   },
   status: {
     next: 'Successivo',

--- a/packages/phrases/src/locales/it/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: 'Successivo',
     current: 'Attuale',
     previous: 'Precedente',
+    effective_in: 'Effettivo tra {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/it/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Stato',
     algorithm: 'Algoritmo di firma della chiave',
+    created_at: 'Creato il',
   },
   status: {
     next: 'Successivo',

--- a/packages/phrases/src/locales/ja/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'ステータス',
     algorithm: '署名キーアルゴリズム',
+    created_at: '作成日時',
   },
   status: {
     next: '次の',

--- a/packages/phrases/src/locales/ja/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'ステータス',
     algorithm: '署名キーアルゴリズム',
-    created_at: '作成日時',
+    effective_at: '有効日時',
   },
   status: {
     next: '次の',

--- a/packages/phrases/src/locales/ja/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: '次の',
     current: '現在の',
     previous: '以前の',
+    effective_in: '{{time}} 後に有効',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/ko/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: '상태',
     algorithm: '서명 키 알고리즘',
-    created_at: '생성일',
+    effective_at: '적용 시간',
   },
   status: {
     next: '다음',

--- a/packages/phrases/src/locales/ko/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: '상태',
     algorithm: '서명 키 알고리즘',
+    created_at: '생성일',
   },
   status: {
     next: '다음',

--- a/packages/phrases/src/locales/ko/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: '다음',
     current: '현재',
     previous: '이전',
+    effective_in: '{{time}} 후 적용',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Status',
     algorithm: 'Algorytm podpisywania klucza',
+    created_at: 'Utworzono',
   },
   status: {
     next: 'Następny',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Status',
     algorithm: 'Algorytm podpisywania klucza',
-    created_at: 'Utworzono',
+    effective_at: 'Obowiązuje od',
   },
   status: {
     next: 'Następny',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: 'Następny',
     current: 'Bieżący',
     previous: 'Poprzedni',
+    effective_in: 'Obowiązuje za {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Status',
     algorithm: 'Algoritmo de assinatura',
+    created_at: 'Criado em',
   },
   status: {
     next: 'Próximo',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Status',
     algorithm: 'Algoritmo de assinatura',
-    created_at: 'Criado em',
+    effective_at: 'Efetivo em',
   },
   status: {
     next: 'Próximo',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: 'Próximo',
     current: 'Atual',
     previous: 'Anterior',
+    effective_in: 'Efetivo em {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Estado',
     algorithm: 'Algoritmo de assinatura da chave',
-    created_at: 'Criado em',
+    effective_at: 'Efetivo em',
   },
   status: {
     next: 'Próximo',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: 'Próximo',
     current: 'Atual',
     previous: 'Anterior',
+    effective_in: 'Efetivo em {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Estado',
     algorithm: 'Algoritmo de assinatura da chave',
+    created_at: 'Criado em',
   },
   status: {
     next: 'Próximo',

--- a/packages/phrases/src/locales/ru/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Статус',
     algorithm: 'Алгоритм подписи ключа',
-    created_at: 'Создано',
+    effective_at: 'Вступает в силу',
   },
   status: {
     next: 'Следующий',

--- a/packages/phrases/src/locales/ru/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: 'Следующий',
     current: 'Текущий',
     previous: 'Предыдущий',
+    effective_in: 'Вступит в силу через {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/ru/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'Статус',
     algorithm: 'Алгоритм подписи ключа',
+    created_at: 'Создано',
   },
   status: {
     next: 'Следующий',

--- a/packages/phrases/src/locales/th/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'สถานะ',
     algorithm: 'อัลกอริทึมของคีย์ลงนาม',
+    created_at: 'สร้างเมื่อ',
   },
   status: {
     next: 'ถัดไป',

--- a/packages/phrases/src/locales/th/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: 'ถัดไป',
     current: 'ปัจจุบัน',
     previous: 'ก่อนหน้า',
+    effective_in: 'มีผลใน {{time}}',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/th/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: 'สถานะ',
     algorithm: 'อัลกอริทึมของคีย์ลงนาม',
-    created_at: 'สร้างเมื่อ',
+    effective_at: 'มีผลเมื่อ',
   },
   status: {
     next: 'ถัดไป',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/signing-keys.ts
@@ -20,7 +20,7 @@ const signing_keys = {
     id: 'Kimlik',
     status: 'Durum',
     algorithm: 'İmzalama anahtar algoritması',
-    created_at: 'Oluşturulma zamanı',
+    effective_at: 'Geçerlilik zamanı',
   },
   status: {
     next: 'Sonraki',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/signing-keys.ts
@@ -26,6 +26,7 @@ const signing_keys = {
     next: 'Sonraki',
     current: 'Geçerli',
     previous: 'Önceki',
+    effective_in: '{{time}} içinde geçerli',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/signing-keys.ts
@@ -20,6 +20,7 @@ const signing_keys = {
     id: 'Kimlik',
     status: 'Durum',
     algorithm: 'İmzalama anahtar algoritması',
+    created_at: 'Oluşturulma zamanı',
   },
   status: {
     next: 'Sonraki',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: '状态',
     algorithm: '签名密钥算法',
+    created_at: '创建时间',
   },
   status: {
     next: '待切换',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: '状态',
     algorithm: '签名密钥算法',
-    created_at: '创建时间',
+    effective_at: '生效时间',
   },
   status: {
     next: '待切换',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: '待切换',
     current: '当前',
     previous: '旧密钥',
+    effective_in: '{{time}} 后生效',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: '狀態',
     algorithm: '簽署金鑰算法',
-    created_at: '建立時間',
+    effective_at: '生效時間',
   },
   status: {
     next: '待切換',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: '待切換',
     current: '當前',
     previous: '舊金鑰',
+    effective_in: '將於 {{time}} 後生效',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: '狀態',
     algorithm: '簽署金鑰算法',
+    created_at: '建立時間',
   },
   status: {
     next: '待切換',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/signing-keys.ts
@@ -25,6 +25,7 @@ const signing_keys = {
     next: '待切換',
     current: '當前的',
     previous: '舊密鑰',
+    effective_in: '將於 {{time}} 後生效',
   },
   reminder: {
     rotate_private_key:

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/signing-keys.ts
@@ -19,6 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: '狀態',
     algorithm: '簽名演算法',
+    created_at: '建立時間',
   },
   status: {
     next: '待切換',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/signing-keys.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/signing-keys.ts
@@ -19,7 +19,7 @@ const signing_keys = {
     id: 'ID',
     status: '狀態',
     algorithm: '簽名演算法',
-    created_at: '建立時間',
+    effective_at: '生效時間',
   },
   status: {
     next: '待切換',

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -213,6 +213,7 @@ export const oidcConfigKeysResponseGuard = oidcConfigKeyGuard.omit({ value: true
   z.object({
     signingKeyAlgorithm: z.nativeEnum(SupportedSigningKeyAlgorithm).optional(),
     status: z.nativeEnum(OidcSigningKeyStatus).optional(),
+    effectiveAt: z.number().optional(),
   })
 );
 


### PR DESCRIPTION
## Summary
- Return `effectiveAt` from the persisted signing key rotation state (`signingKeyRotationAt`) for the staged `Next` private key.
- Update the OIDC private keys table to show the signing key algorithm before status, and keep status as the last business column.
- Remove the standalone `Effective at` column. For `Next` keys, show an inline countdown next to the status tag: `Effective in hh:mm:ss`.
- Add localized copy for the inline effective countdown.

## Testing
- `pnpm -C packages/core exec eslint src/libraries/logto-config.ts src/routes/logto-config/index.ts src/routes/logto-config/index.test.ts src/routes/logto-config/index.rotation.test.ts src/test-utils/mock-libraries.ts`
- `pnpm -C packages/core build:test`
- `pnpm -C packages/core test:only build/routes/logto-config/index.test.js build/routes/logto-config/index.rotation.test.js`
- `pnpm -C packages/console check`
- `pnpm -C packages/phrases build`

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
