### PR TITLE
refactor(console): remove OSS upsell dev guards

### DIFF
--- a/packages/console/src/components/CreateConnectorForm/index.tsx
+++ b/packages/console/src/components/CreateConnectorForm/index.tsx
@@ -12,7 +12,7 @@ import ExternalLink from '@/assets/icons/external-link.svg?react';
 import LogtoEmailLogoDark from '@/assets/icons/logto-email-service-dark.svg?url';
 import LogtoEmailLogo from '@/assets/icons/logto-email-service.svg?url';
 import ConnectorLogo from '@/components/ConnectorLogo';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { pricingLink } from '@/consts/external-links';
 import Button from '@/ds-components/Button';
 import DangerousRaw from '@/ds-components/DangerousRaw';
@@ -125,7 +125,6 @@ function CreateConnectorForm({ onClose, isOpen: isFormOpen, type }: Props) {
   const shouldShowEmailConnectorUpsellBannerValue = shouldShowEmailConnectorUpsellBanner({
     type,
     isCloud,
-    isDevFeaturesEnabled,
   });
 
   const activeGroup = useMemo(

--- a/packages/console/src/components/CreateConnectorForm/utils.test.ts
+++ b/packages/console/src/components/CreateConnectorForm/utils.test.ts
@@ -4,36 +4,26 @@ import type { TFuncKey } from 'i18next';
 import { getEmailConnectorUpsellCopyKeys, shouldShowEmailConnectorUpsellBanner } from './utils';
 
 describe('shouldShowEmailConnectorUpsellBanner', () => {
-  test('returns true only for OSS email connectors with dev features enabled', () => {
+  test('returns true for OSS email connectors', () => {
     expect(
       shouldShowEmailConnectorUpsellBanner({
         type: ConnectorType.Email,
         isCloud: false,
-        isDevFeaturesEnabled: true,
       })
     ).toBe(true);
   });
 
-  test('returns false for cloud, non-email, or disabled dev-features cases', () => {
+  test('returns false for cloud or non-email cases', () => {
     expect(
       shouldShowEmailConnectorUpsellBanner({
         type: ConnectorType.Email,
         isCloud: true,
-        isDevFeaturesEnabled: true,
-      })
-    ).toBe(false);
-    expect(
-      shouldShowEmailConnectorUpsellBanner({
-        type: ConnectorType.Email,
-        isCloud: false,
-        isDevFeaturesEnabled: false,
       })
     ).toBe(false);
     expect(
       shouldShowEmailConnectorUpsellBanner({
         type: ConnectorType.Sms,
         isCloud: false,
-        isDevFeaturesEnabled: true,
       })
     ).toBe(false);
   });

--- a/packages/console/src/components/CreateConnectorForm/utils.ts
+++ b/packages/console/src/components/CreateConnectorForm/utils.ts
@@ -69,13 +69,12 @@ export const getEmailConnectorUpsellCopyKeys = () => ({
 type ConnectorSelectionStateOptions = {
   readonly type?: ConnectorType;
   readonly isCloud: boolean;
-  readonly isDevFeaturesEnabled: boolean;
 };
 
 export const shouldShowEmailConnectorUpsellBanner = (
   options: ConnectorSelectionStateOptions
 ): boolean => {
-  const { type, isCloud, isDevFeaturesEnabled } = options;
+  const { type, isCloud } = options;
 
-  return type === ConnectorType.Email && !isCloud && isDevFeaturesEnabled;
+  return type === ConnectorType.Email && !isCloud;
 };

--- a/packages/console/src/containers/ConsoleContent/Sidebar/OssCloudCard.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/OssCloudCard.tsx
@@ -44,7 +44,6 @@ function OssCloudCard() {
   if (
     !shouldShowOssCloudSidebarCard({
       isCloud,
-      isDevFeaturesEnabled,
       dismissedUntil,
       now,
     })

--- a/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.test.ts
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.test.ts
@@ -3,11 +3,10 @@ import { shouldShowOssCloudSidebarCard } from './oss-cloud-card';
 describe('shouldShowOssCloudSidebarCard', () => {
   const now = 1_000_000;
 
-  it('returns true for OSS consoles with dev features enabled when the card has not been dismissed', () => {
+  it('returns true for OSS consoles when the card has not been dismissed', () => {
     expect(
       shouldShowOssCloudSidebarCard({
         isCloud: false,
-        isDevFeaturesEnabled: true,
         dismissedUntil: undefined,
         now,
       })
@@ -18,18 +17,6 @@ describe('shouldShowOssCloudSidebarCard', () => {
     expect(
       shouldShowOssCloudSidebarCard({
         isCloud: true,
-        isDevFeaturesEnabled: true,
-        dismissedUntil: undefined,
-        now,
-      })
-    ).toBe(false);
-  });
-
-  it('returns false when dev features are disabled', () => {
-    expect(
-      shouldShowOssCloudSidebarCard({
-        isCloud: false,
-        isDevFeaturesEnabled: false,
         dismissedUntil: undefined,
         now,
       })
@@ -40,7 +27,6 @@ describe('shouldShowOssCloudSidebarCard', () => {
     expect(
       shouldShowOssCloudSidebarCard({
         isCloud: false,
-        isDevFeaturesEnabled: true,
         dismissedUntil: now + 1,
         now,
       })
@@ -51,7 +37,6 @@ describe('shouldShowOssCloudSidebarCard', () => {
     expect(
       shouldShowOssCloudSidebarCard({
         isCloud: false,
-        isDevFeaturesEnabled: true,
         dismissedUntil: now - 1,
         now,
       })
@@ -62,7 +47,6 @@ describe('shouldShowOssCloudSidebarCard', () => {
     expect(
       shouldShowOssCloudSidebarCard({
         isCloud: false,
-        isDevFeaturesEnabled: true,
         dismissedUntil: now,
         now,
       })

--- a/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.ts
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.ts
@@ -2,7 +2,6 @@ import { conditional, type Nullable, type Optional } from '@silverhand/essential
 
 type ShouldShowOssCloudSidebarCardOptions = {
   readonly isCloud: boolean;
-  readonly isDevFeaturesEnabled: boolean;
   readonly dismissedUntil?: number;
   readonly now: number;
 };
@@ -19,8 +18,7 @@ export const parseOssCloudSidebarCardDismissedUntil = (
 
 export const shouldShowOssCloudSidebarCard = ({
   isCloud,
-  isDevFeaturesEnabled,
   dismissedUntil,
   now,
 }: ShouldShowOssCloudSidebarCardOptions): boolean =>
-  !isCloud && isDevFeaturesEnabled && (dismissedUntil === undefined || dismissedUntil <= now);
+  !isCloud && (dismissedUntil === undefined || dismissedUntil <= now);

--- a/packages/console/src/hooks/use-console-routes/routes/tenant-settings.tsx
+++ b/packages/console/src/hooks/use-console-routes/routes/tenant-settings.tsx
@@ -4,7 +4,7 @@ import { Navigate, type RouteObject } from 'react-router-dom';
 import { safeLazy } from 'react-safe-lazy';
 
 import { TenantSettingsTabs } from '@/consts';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import useCurrentTenantScopes from '@/hooks/use-current-tenant-scopes';
@@ -84,10 +84,7 @@ const useCloudTenantSettings = () => {
 
 const useOssTenantSettings = (): RouteObject =>
   useMemo(() => {
-    const shouldShowMembersTab = shouldShowOssTenantMembersTab({
-      isCloud: false,
-      isDevFeaturesEnabled,
-    });
+    const shouldShowMembersTab = shouldShowOssTenantMembersTab({ isCloud: false });
 
     return {
       path: 'tenant-settings',

--- a/packages/console/src/pages/Applications/components/SamlAppLimitNotice/index.tsx
+++ b/packages/console/src/pages/Applications/components/SamlAppLimitNotice/index.tsx
@@ -1,6 +1,6 @@
 import SamlAppLimitBanner from '@/components/SamlAppLimitBanner';
 import { ossSamlApplicationsLimit } from '@/consts/application-limits';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 
 import styles from '../../index.module.scss';
 import { shouldShowSamlAppLimitNotice } from '../../utils';
@@ -13,7 +13,6 @@ type Props = {
 function SamlAppLimitNotice({ isThirdPartyTab, samlAppTotalCount }: Props) {
   const isVisible = shouldShowSamlAppLimitNotice({
     isCloud,
-    isDevFeaturesEnabled,
     isThirdPartyTab,
     samlAppTotalCount,
   });

--- a/packages/console/src/pages/Applications/index.tsx
+++ b/packages/console/src/pages/Applications/index.tsx
@@ -14,7 +14,7 @@ import ApplicationPreview from '@/components/ItemPreview/ApplicationPreview';
 import LearnMore from '@/components/LearnMore';
 import PageMeta from '@/components/PageMeta';
 import { integrateLogto } from '@/consts';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import Button from '@/ds-components/Button';
 import CardTitle from '@/ds-components/CardTitle';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
@@ -79,7 +79,7 @@ function Applications({ tab }: Props) {
   const [selectedGuide, setSelectedGuide] = useState<Nullable<SelectedGuide>>();
 
   const isThirdPartyTab = tab === 'thirdPartyApplications';
-  const shouldFetchSamlApplicationsCount = !isCloud && isDevFeaturesEnabled && !isThirdPartyTab;
+  const shouldFetchSamlApplicationsCount = !isCloud && !isThirdPartyTab;
 
   const { data, error, mutate, pagination, updatePagination, paginationRecords } =
     useApplicationsData(isThirdPartyTab);

--- a/packages/console/src/pages/Applications/utils.test.ts
+++ b/packages/console/src/pages/Applications/utils.test.ts
@@ -5,33 +5,20 @@ import { shouldShowSamlAppLimitNotice } from './utils';
 const belowSamlLimit = ossSamlApplicationsLimit - 1;
 
 describe('shouldShowSamlAppLimitNotice', () => {
-  it('returns true for OSS my apps when the SAML app limit is reached and dev features are enabled', () => {
+  it('returns true for OSS my apps when the SAML app limit is reached', () => {
     expect(
       shouldShowSamlAppLimitNotice({
         isCloud: false,
-        isDevFeaturesEnabled: true,
         isThirdPartyTab: false,
         samlAppTotalCount: ossSamlApplicationsLimit,
       })
     ).toBe(true);
   });
 
-  it('returns false when dev features are disabled', () => {
-    expect(
-      shouldShowSamlAppLimitNotice({
-        isCloud: false,
-        isDevFeaturesEnabled: false,
-        isThirdPartyTab: false,
-        samlAppTotalCount: ossSamlApplicationsLimit,
-      })
-    ).toBe(false);
-  });
-
   it('returns false when the SAML app count is below the OSS limit', () => {
     expect(
       shouldShowSamlAppLimitNotice({
         isCloud: false,
-        isDevFeaturesEnabled: true,
         isThirdPartyTab: false,
         samlAppTotalCount: belowSamlLimit,
       })
@@ -42,7 +29,6 @@ describe('shouldShowSamlAppLimitNotice', () => {
     expect(
       shouldShowSamlAppLimitNotice({
         isCloud: false,
-        isDevFeaturesEnabled: true,
         isThirdPartyTab: true,
         samlAppTotalCount: ossSamlApplicationsLimit,
       })

--- a/packages/console/src/pages/Applications/utils.ts
+++ b/packages/console/src/pages/Applications/utils.ts
@@ -2,19 +2,16 @@ import { ossSamlApplicationsLimit } from '@/consts/application-limits';
 
 type ShouldShowSamlAppLimitNoticeOptions = {
   readonly isCloud: boolean;
-  readonly isDevFeaturesEnabled: boolean;
   readonly isThirdPartyTab: boolean;
   readonly samlAppTotalCount?: number;
 };
 
 export const shouldShowSamlAppLimitNotice = ({
   isCloud,
-  isDevFeaturesEnabled,
   isThirdPartyTab,
   samlAppTotalCount,
 }: ShouldShowSamlAppLimitNoticeOptions) =>
   !isCloud &&
-  isDevFeaturesEnabled &&
   !isThirdPartyTab &&
   typeof samlAppTotalCount === 'number' &&
   samlAppTotalCount >= ossSamlApplicationsLimit;

--- a/packages/console/src/pages/GetStarted/index.tsx
+++ b/packages/console/src/pages/GetStarted/index.tsx
@@ -17,7 +17,7 @@ import GuideCardGroup from '@/components/Guide/GuideCardGroup';
 import { useApiGuideMetadata, useAppGuideMetadata } from '@/components/Guide/hooks';
 import PageMeta from '@/components/PageMeta';
 import { ConnectorsTabs, convertToProductionThresholdDays } from '@/consts';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import { LinkButton } from '@/ds-components/Button';
@@ -126,7 +126,7 @@ function GetStarted() {
     return daysSinceCreation >= convertToProductionThresholdDays;
   }, [isDevTenant, currentTenant]);
 
-  const shouldShowOssCloudUpsell = !isCloud && isDevFeaturesEnabled;
+  const shouldShowOssCloudUpsell = !isCloud;
   const shouldShowOssCloudBanner =
     shouldShowOssCloudUpsell &&
     isUserPreferencesLoaded &&

--- a/packages/console/src/pages/OssTenantSettings/index.tsx
+++ b/packages/console/src/pages/OssTenantSettings/index.tsx
@@ -1,7 +1,6 @@
 import { Outlet } from 'react-router-dom';
 
 import { TenantSettingsTabs } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import CardTitle from '@/ds-components/CardTitle';
 import DynamicT from '@/ds-components/DynamicT';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
@@ -10,10 +9,7 @@ import styles from './index.module.scss';
 import { shouldShowOssTenantMembersTab } from './utils';
 
 function OssTenantSettings() {
-  const shouldShowMembersTab = shouldShowOssTenantMembersTab({
-    isCloud: false,
-    isDevFeaturesEnabled,
-  });
+  const shouldShowMembersTab = shouldShowOssTenantMembersTab({ isCloud: false });
 
   return (
     <div className={styles.container}>

--- a/packages/console/src/pages/OssTenantSettings/utils.test.ts
+++ b/packages/console/src/pages/OssTenantSettings/utils.test.ts
@@ -3,29 +3,12 @@ import type { TFuncKey } from 'i18next';
 import { getOssTenantMembersUpsellCopyKeys, shouldShowOssTenantMembersTab } from './utils';
 
 describe('shouldShowOssTenantMembersTab', () => {
-  it('returns true only for OSS with dev features enabled', () => {
-    expect(
-      shouldShowOssTenantMembersTab({
-        isCloud: false,
-        isDevFeaturesEnabled: true,
-      })
-    ).toBe(true);
+  it('returns true for OSS', () => {
+    expect(shouldShowOssTenantMembersTab({ isCloud: false })).toBe(true);
   });
 
-  it('returns false for cloud or when dev features are disabled', () => {
-    expect(
-      shouldShowOssTenantMembersTab({
-        isCloud: true,
-        isDevFeaturesEnabled: true,
-      })
-    ).toBe(false);
-
-    expect(
-      shouldShowOssTenantMembersTab({
-        isCloud: false,
-        isDevFeaturesEnabled: false,
-      })
-    ).toBe(false);
+  it('returns false for cloud', () => {
+    expect(shouldShowOssTenantMembersTab({ isCloud: true })).toBe(false);
   });
 });
 

--- a/packages/console/src/pages/OssTenantSettings/utils.ts
+++ b/packages/console/src/pages/OssTenantSettings/utils.ts
@@ -1,12 +1,9 @@
 type OssTenantMembersAvailabilityOptions = {
   readonly isCloud: boolean;
-  readonly isDevFeaturesEnabled: boolean;
 };
 
-export const shouldShowOssTenantMembersTab = ({
-  isCloud,
-  isDevFeaturesEnabled,
-}: OssTenantMembersAvailabilityOptions) => !isCloud && isDevFeaturesEnabled;
+export const shouldShowOssTenantMembersTab = ({ isCloud }: OssTenantMembersAvailabilityOptions) =>
+  !isCloud;
 
 export const getOssTenantMembersUpsellCopyKeys = () => ({
   title: 'tenants.members.card_title' as const,

--- a/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.tsx
@@ -5,7 +5,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import CloudUploadIcon from '@/assets/icons/cloud-upload.svg?react';
 import CustomCssEditorField from '@/components/CustomCssEditorField';
 import { CloudTag } from '@/components/FeatureTag';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { latestProPlanId } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import Card from '@/ds-components/Card';
@@ -70,7 +70,7 @@ function CustomUiForm() {
   const { control } = useFormContext<SignInExperienceForm>();
   const { currentSubscriptionQuota } = useContext(SubscriptionDataContext);
   const isBringYourUiEnabled = currentSubscriptionQuota.bringYourUiEnabled;
-  const shouldShowOssBringYourUi = !isCloud && isDevFeaturesEnabled;
+  const shouldShowOssBringYourUi = !isCloud;
 
   return (
     <Card>


### PR DESCRIPTION
## Summary
- remove OSS upsell-specific `isDevFeaturesEnabled` guards from console entry points and visibility helpers
- keep unrelated dev-only guards unchanged
- update focused helper tests to match the new OSS visibility rules

## Testing
- `pnpm --filter @logto/console check`
- `pnpm --filter @logto/console lint`
- `pnpm --filter @logto/console exec jest --runInBand`

## Notes
- OSS onboarding, internal routes, and other non-upsell dev-only features were intentionally left unchanged
- dev-status layout offsets remain in place, but they no longer control OSS upsell visibility