### PR TITLE
fix(core): launch forgot-password anti-enumeration

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,6 +1,5 @@
 import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
 
-import { EnvSet } from '#src/env-set/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -25,7 +24,6 @@ async function resolveVoid(): Promise<void> {
 const { sendCode } = await import('./verification-code-helpers.js');
 
 describe('sendCode parameter passing', () => {
-  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
   // To make a void callable function/method
   const mockSendVerificationCode = jest.fn().mockImplementation(resolveVoid);
 
@@ -57,14 +55,9 @@ describe('sendCode parameter passing', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
     mockSendVerificationCode.mockImplementation(resolveVoid);
     mockExperienceInteraction.save.mockImplementation(resolveVoid);
     mockBuildVerificationCodeContext.mockResolvedValue({});
-  });
-
-  afterAll(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('should pass ctx.request.ip to sendVerificationCode', async () => {
@@ -165,43 +158,6 @@ describe('sendCode parameter passing', () => {
     expect(mockQueriesWithUser.users.hasUserWithNormalizedPhone).toHaveBeenCalledWith(
       '+8613123456789'
     );
-    expect(mockSendVerificationCode).toHaveBeenCalledWith(
-      expect.any(Object),
-      expect.objectContaining({ validateOnly: false })
-    );
-  });
-
-  it('should keep the old forgot-password delivery behavior when dev features are disabled', async () => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
-
-    const mockQueriesTracking = {
-      users: {
-        hasUserWithEmail: jest.fn().mockResolvedValue(false),
-        hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
-      },
-    } as unknown as Queries;
-
-    const ctx = {
-      request: { ip: '127.0.0.1' },
-      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
-      experienceInteraction: {
-        ...mockExperienceInteraction,
-        interactionEvent: InteractionEvent.ForgotPassword,
-      },
-      emailI18n: {},
-    };
-
-    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
-    await sendCode({
-      identifier: { type: SignInIdentifier.Email, value: 'nonexistent@example.com' },
-      interactionEvent: InteractionEvent.ForgotPassword,
-      createVerificationRecord: () => mockCodeVerification,
-      libraries: libraries as unknown as Libraries,
-      queries: mockQueriesTracking,
-      ctx: ctx as unknown as ExperienceInteractionRouterContext,
-    });
-
-    expect(mockQueriesTracking.users.hasUserWithEmail).not.toHaveBeenCalled();
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.any(Object),
       expect.objectContaining({ validateOnly: false })

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -8,7 +8,6 @@ import {
 } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { type LogContext } from '#src/middleware/koa-audit-log.js';
@@ -125,12 +124,10 @@ export const sendCode = async ({
     await experienceInteraction.signInExperienceValidator.guardEmailBlocklist(codeVerification);
   }
 
-  // When dev features are enabled, forgot-password requests check whether the user
-  // actually exists. For unknown identifiers we still create the passcode record
+  // For forgot-password requests, unknown identifiers still create the passcode record
   // (so verification returns `code_mismatch` instead of `not_found`) and keep
   // connector/template validation, but avoid the actual message delivery.
   const validateOnly =
-    EnvSet.values.isDevFeaturesEnabled &&
     interactionEvent === InteractionEvent.ForgotPassword &&
     !(await hasUserWithIdentifier(queries, identifier));
 

--- a/packages/integration-tests/src/tests/api/email-templates/experience-api.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/experience-api.test.ts
@@ -3,7 +3,6 @@ import { demoAppApplicationId, InteractionEvent, SignInIdentifier } from '@logto
 
 import { mockEmailConnectorConfig } from '#src/__mocks__/connectors-mock.js';
 import { type MockEmailTemplatePayload } from '#src/__mocks__/email-templates.js';
-import { isDevFeaturesEnabled } from '#src/constants.js';
 import { initExperienceClient } from '#src/helpers/client.js';
 import { setEmailConnector } from '#src/helpers/connector.js';
 import { EmailTemplatesApiTest } from '#src/helpers/email-templates.js';
@@ -14,7 +13,7 @@ import {
   createDefaultTenantUserWithPassword,
   deleteDefaultTenantUser,
 } from '#src/helpers/profile.js';
-import { devFeatureDisabledTest, devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateEmail } from '#src/utils.js';
 
 const mockSignInTemplate: MockEmailTemplatePayload = {
   languageTag: 'en',
@@ -123,71 +122,35 @@ describe('experience API with i18n email templates', () => {
     }
   });
 
-  devFeatureTest.it(
-    'should not deliver forgot-password verification code for a non-existing user when dev features are enabled',
-    async () => {
-      const nonExistingEmail = generateEmail();
-      const client = await initExperienceClient({
-        interactionEvent: InteractionEvent.ForgotPassword,
-      });
+  it('should not deliver forgot-password verification code for a non-existing user', async () => {
+    const nonExistingEmail = generateEmail();
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.ForgotPassword,
+    });
 
-      const { verificationId } = await client.sendVerificationCode({
-        interactionEvent: InteractionEvent.ForgotPassword,
+    const { verificationId } = await client.sendVerificationCode({
+      interactionEvent: InteractionEvent.ForgotPassword,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: nonExistingEmail,
+      },
+    });
+
+    expect(verificationId).toBeTruthy();
+    await expect(readConnectorMessage('Email')).rejects.toThrow();
+    await expectRejects(
+      client.verifyVerificationCode({
         identifier: {
           type: SignInIdentifier.Email,
           value: nonExistingEmail,
         },
-      });
-
-      expect(verificationId).toBeTruthy();
-      await expect(readConnectorMessage('Email')).rejects.toThrow();
-      await expectRejects(
-        client.verifyVerificationCode({
-          identifier: {
-            type: SignInIdentifier.Email,
-            value: nonExistingEmail,
-          },
-          verificationId,
-          code: '111111',
-        }),
-        {
-          code: 'verification_code.code_mismatch',
-          status: 400,
-        }
-      );
-    }
-  );
-
-  devFeatureDisabledTest.it(
-    'should keep delivering forgot-password verification code for a non-existing user when dev features are disabled',
-    async () => {
-      const defaultForgotPasswordTemplate = mockEmailConnectorConfig.templates.find(
-        ({ usageType }) => usageType === 'ForgotPassword'
-      )!;
-      const nonExistingEmail = generateEmail();
-      const client = await initExperienceClient({
-        interactionEvent: InteractionEvent.ForgotPassword,
-      });
-
-      const { verificationId } = await client.sendVerificationCode({
-        interactionEvent: InteractionEvent.ForgotPassword,
-        identifier: {
-          type: SignInIdentifier.Email,
-          value: nonExistingEmail,
-        },
-      });
-
-      const { code, address, type, template, content, subject } =
-        await readConnectorMessage('Email');
-
-      expect(isDevFeaturesEnabled).toBe(false);
-      expect(verificationId).toBeTruthy();
-      expect(code).toBeTruthy();
-      expect(address).toBe(nonExistingEmail);
-      expect(type).toBe(TemplateType.ForgotPassword);
-      expect(template).toMatchObject(defaultForgotPasswordTemplate);
-      expect(content).toBe(defaultForgotPasswordTemplate.content.replace('{{code}}', code));
-      expect(subject).toBe(defaultForgotPasswordTemplate.subject);
-    }
-  );
+        verificationId,
+        code: '111111',
+      }),
+      {
+        code: 'verification_code.code_mismatch',
+        status: 400,
+      }
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Remove the dev feature guard from forgot-password verification code delivery protection, so unknown email/phone identifiers always use validate-only delivery while preserving the verification record.
- Keep the existing forgot-password anti-enumeration integration coverage as a regular test and remove obsolete dev-feature-disabled expectations.

## Testing

Unit tests, Integration tests

## Checklist

<!-- The palest ink is better than the best memory -->

- [ ] `.changeset` (only when explicitly required)
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
