### PR TITLE
chore(toolkit): add missing changeset for core-kit theme token

### DIFF
--- a/.changeset/new-oranges-design.md
+++ b/.changeset/new-oranges-design.md
@@ -1,5 +1,5 @@
 ---
-"@logto/core-kit": patch
+"@logto/core-kit": minor
 ---
 
 add subtle primary overlay color token for console themes

--- a/.changeset/new-oranges-design.md
+++ b/.changeset/new-oranges-design.md
@@ -1,0 +1,7 @@
+---
+"@logto/core-kit": patch
+---
+
+add subtle primary overlay color token for console themes
+
+This adds the missing `--color-overlay-primary-subtle` token for both light and dark console themes.


### PR DESCRIPTION
## Summary
Add the missing `@logto/core-kit` changeset for the console theme token update that is already on `master`.

The underlying theme token change landed in [#8692](https://github.com/logto-io/logto/pull/8692). This follow-up PR only adds the missing changeset.

The changeset records a minor release and documents the added `--color-overlay-primary-subtle` token for both light and dark console themes.

## Testing
Tested locally

## Checklist
- [x] `.changeset` (only when explicitly required)
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
