### PR TITLE
fix(core): skip template validation for unknown reset email

### DIFF
--- a/packages/core/src/libraries/passcode.send.test.ts
+++ b/packages/core/src/libraries/passcode.send.test.ts
@@ -11,7 +11,6 @@ import { createPasscodeLibrary } from './passcode.js';
 const { jest } = import.meta;
 
 const getMessageConnector = jest.fn();
-const getI18nEmailTemplate = jest.fn();
 
 const unusedPasscodeQueries = {
   consumePasscode: jest.fn(),
@@ -27,94 +26,15 @@ const unusedPasscodeQueries = {
 const { sendPasscode } = createPasscodeLibrary(
   new MockQueries({ passcodes: unusedPasscodeQueries }),
   // @ts-expect-error Only connector lookups are required in these tests.
-  { getI18nEmailTemplate, getMessageConnector }
+  { getMessageConnector }
 );
 
-describe('sendPasscode validateOnly', () => {
+describe('sendPasscode', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should validate connector/template without sending when validateOnly is true', async () => {
-    const sendMessage = jest.fn();
-    getMessageConnector.mockResolvedValueOnce({
-      ...defaultConnectorMethods,
-      configGuard: any(),
-      dbEntry: {
-        ...mockConnector,
-        id: 'id0',
-        config: {
-          templates: [
-            { usageType: TemplateType.ForgotPassword, subject: 'subject', content: 'code' },
-          ],
-        },
-      },
-      metadata: {
-        ...mockMetadata,
-        platform: null,
-      },
-      type: ConnectorType.Email,
-      sendMessage,
-    });
-    getI18nEmailTemplate.mockResolvedValueOnce(null);
-    const passcode: Passcode = {
-      tenantId: 'fake_tenant',
-      id: 'passcode_id',
-      interactionJti: 'jti',
-      phone: null,
-      email: 'foo@example.com',
-      type: TemplateType.ForgotPassword,
-      code: '1234',
-      consumed: false,
-      tryCount: 0,
-      createdAt: Date.now(),
-    };
-
-    await sendPasscode(passcode, { locale: 'en' }, { validateOnly: true });
-
-    expect(getMessageConnector).toHaveBeenCalledWith(ConnectorType.Email);
-    expect(sendMessage).not.toHaveBeenCalled();
-  });
-
-  it('should still fail fast when validateOnly is true but the template is unavailable', async () => {
-    const sendMessage = jest.fn();
-    getMessageConnector.mockResolvedValueOnce({
-      ...defaultConnectorMethods,
-      configGuard: any(),
-      dbEntry: {
-        ...mockConnector,
-        id: 'id0',
-        config: {
-          templates: [],
-        },
-      },
-      metadata: {
-        ...mockMetadata,
-        platform: null,
-      },
-      type: ConnectorType.Email,
-      sendMessage,
-    });
-    getI18nEmailTemplate.mockResolvedValueOnce(null);
-    const passcode: Passcode = {
-      tenantId: 'fake_tenant',
-      id: 'passcode_id',
-      interactionJti: 'jti',
-      phone: null,
-      email: 'foo@example.com',
-      type: TemplateType.ForgotPassword,
-      code: '1234',
-      consumed: false,
-      tryCount: 0,
-      createdAt: Date.now(),
-    };
-
-    await expect(sendPasscode(passcode, { locale: 'en' }, { validateOnly: true })).rejects.toThrow(
-      'Template not found for type: ForgotPassword'
-    );
-  });
-
-  it('should not pre-validate templates on the normal send path', async () => {
+  it('should let the connector handle template selection on the send path', async () => {
     const sendMessage = jest.fn();
     getMessageConnector.mockResolvedValueOnce({
       ...defaultConnectorMethods,
@@ -146,7 +66,6 @@ describe('sendPasscode validateOnly', () => {
 
     await sendPasscode(passcode, { locale: 'en' });
 
-    expect(getI18nEmailTemplate).not.toHaveBeenCalled();
     expect(sendMessage).toHaveBeenCalledWith({
       to: 'foo@example.com',
       type: TemplateType.ForgotPassword,

--- a/packages/core/src/libraries/passcode.ts
+++ b/packages/core/src/libraries/passcode.ts
@@ -1,20 +1,14 @@
 import { appInsights } from '@logto/app-insights/node';
 import type { SendMessagePayload, TemplateType } from '@logto/connector-kit';
-import {
-  templateTypeGuard,
-  ConnectorError,
-  ConnectorErrorCodes,
-  getConfigTemplateByType,
-} from '@logto/connector-kit';
+import { templateTypeGuard, ConnectorError, ConnectorErrorCodes } from '@logto/connector-kit';
 import {
   buildBuiltInApplicationDataForTenant,
   isBuiltInApplicationId,
   type Passcode,
   type User,
 } from '@logto/schemas';
-import { conditional, trySafe } from '@silverhand/essentials';
+import { conditional } from '@silverhand/essentials';
 import { customAlphabet, nanoid } from 'nanoid';
-import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import type { ConnectorLibrary } from '#src/libraries/connector.js';
@@ -42,14 +36,6 @@ export type SendPasscodeContextPayload = Pick<SendMessagePayload, 'locale' | 'ui
     ip?: string;
   };
 
-type SendPasscodeOptions = {
-  validateOnly?: boolean;
-};
-
-const templateTypeConfigGuard = z.object({
-  templates: z.array(z.object({ usageType: z.string() })).optional(),
-});
-
 const resolveTemplateType = (type: string) => {
   const messageTypeResult = templateTypeGuard.safeParse(type);
 
@@ -71,7 +57,7 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
     increasePasscodeTryCount,
     insertPasscode,
   } = queries.passcodes;
-  const { getI18nEmailTemplate, getMessageConnector } = connectorLibrary;
+  const { getMessageConnector } = connectorLibrary;
 
   const createPasscode = async (
     jti: string | undefined,
@@ -103,32 +89,7 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
    * @param {Passcode} passcode The passcode object being sent.
    * @param {SendPasscodeContextPayload} contextPayload The extra context information for the verification code email template.
    */
-  const validateMessageTemplate = async (
-    type: TemplateType,
-    config: unknown,
-    contextPayload?: SendPasscodeContextPayload
-  ) => {
-    const customTemplate = await trySafe(async () =>
-      getI18nEmailTemplate(type, contextPayload?.locale)
-    );
-    const templateConfig = templateTypeConfigGuard.safeParse(config);
-    const template =
-      customTemplate ??
-      getConfigTemplateByType(type, templateConfig.success ? templateConfig.data : {});
-
-    if (!template) {
-      throw new ConnectorError(
-        ConnectorErrorCodes.TemplateNotFound,
-        `Template not found for type: ${type}`
-      );
-    }
-  };
-
-  const sendPasscode = async (
-    passcode: Passcode,
-    contextPayload?: SendPasscodeContextPayload,
-    options?: SendPasscodeOptions
-  ) => {
+  const sendPasscode = async (passcode: Passcode, contextPayload?: SendPasscodeContextPayload) => {
     const emailOrPhone = passcode.email ?? passcode.phone;
 
     if (!emailOrPhone) {
@@ -141,11 +102,6 @@ export const createPasscodeLibrary = (queries: Queries, connectorLibrary: Connec
     const { dbEntry, metadata, sendMessage } = connector;
 
     const { ip, ...payloadContext } = contextPayload ?? {};
-
-    if (options?.validateOnly) {
-      await validateMessageTemplate(templateType, dbEntry.config, contextPayload);
-      return { dbEntry, metadata, response: undefined };
-    }
 
     const response = await sendMessage({
       to: emailOrPhone,

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.test.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.test.ts
@@ -1,0 +1,52 @@
+import { TemplateType } from '@logto/connector-kit';
+import { SignInIdentifier, VerificationType } from '@logto/schemas';
+
+import { type PasscodeLibrary } from '#src/libraries/passcode.js';
+import type Libraries from '#src/tenants/Libraries.js';
+import type Queries from '#src/tenants/Queries.js';
+
+import { EmailCodeVerification } from './code-verification.js';
+
+const { jest } = import.meta;
+
+describe('EmailCodeVerification', () => {
+  it('should create passcode without sending when delivery is skipped', async () => {
+    const createPasscode = jest.fn().mockResolvedValue({
+      tenantId: 'fake_tenant',
+      id: 'passcode_id',
+      interactionJti: 'verification_id',
+      phone: null,
+      email: 'foo@example.com',
+      type: TemplateType.ForgotPassword,
+      code: '123456',
+      consumed: false,
+      tryCount: 0,
+      createdAt: Date.now(),
+    });
+    const sendPasscode = jest.fn();
+    const libraries = {
+      passcodes: {
+        createPasscode,
+        sendPasscode,
+      } as unknown as PasscodeLibrary,
+    } as unknown as Libraries;
+
+    const verification = new EmailCodeVerification(libraries, {} as unknown as Queries, {
+      id: 'verification_id',
+      type: VerificationType.EmailVerificationCode,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: 'foo@example.com',
+      },
+      templateType: TemplateType.ForgotPassword,
+      verified: false,
+    });
+
+    await verification.sendVerificationCode({ locale: 'en' }, { skipDelivery: true });
+
+    expect(createPasscode).toHaveBeenCalledWith('verification_id', TemplateType.ForgotPassword, {
+      email: 'foo@example.com',
+    });
+    expect(sendPasscode).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -101,7 +101,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
    */
   async sendVerificationCode(
     payload?: SendPasscodeContextPayload,
-    options?: { validateOnly?: boolean }
+    options?: { skipDelivery?: boolean; validateOnly?: boolean }
   ) {
     const { createPasscode, sendPasscode } = this.libraries.passcodes;
 
@@ -110,6 +110,10 @@ abstract class CodeVerification<T extends CodeVerificationType>
       this.templateType,
       getPasscodeIdentifierPayload(this.identifier)
     );
+
+    if (options?.skipDelivery) {
+      return;
+    }
 
     await sendPasscode(verificationCode, payload, options);
   }

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -101,7 +101,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
    */
   async sendVerificationCode(
     payload?: SendPasscodeContextPayload,
-    options?: { skipDelivery?: boolean; validateOnly?: boolean }
+    options?: { skipDelivery?: boolean }
   ) {
     const { createPasscode, sendPasscode } = this.libraries.passcodes;
 
@@ -115,7 +115,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
       return;
     }
 
-    await sendPasscode(verificationCode, payload, options);
+    await sendPasscode(verificationCode, payload);
   }
 
   /**

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -121,8 +121,9 @@ describe('sendCode parameter passing', () => {
     expect(mockQueriesNoUser.users.hasUserWithEmail).toHaveBeenCalledWith(
       'nonexistent@example.com'
     );
+    expect(mockBuildVerificationCodeContext).not.toHaveBeenCalled();
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
-      expect.any(Object),
+      undefined,
       expect.objectContaining({ skipDelivery: true })
     );
   });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -85,7 +85,7 @@ describe('sendCode parameter passing', () => {
         ip: SAMPLE_IP,
       }),
       expect.objectContaining({
-        validateOnly: false,
+        skipDelivery: false,
       })
     );
   });
@@ -123,7 +123,7 @@ describe('sendCode parameter passing', () => {
     );
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ validateOnly: true })
+      expect.objectContaining({ skipDelivery: true })
     );
   });
 
@@ -160,7 +160,7 @@ describe('sendCode parameter passing', () => {
     );
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ validateOnly: false })
+      expect.objectContaining({ skipDelivery: false })
     );
   });
 
@@ -192,7 +192,7 @@ describe('sendCode parameter passing', () => {
     expect(mockQueriesTracking.users.hasUserWithEmail).not.toHaveBeenCalled();
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ validateOnly: false })
+      expect.objectContaining({ skipDelivery: false })
     );
   });
 });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -125,9 +125,9 @@ export const sendCode = async ({
   }
 
   // For forgot-password requests, unknown identifiers still create the passcode record
-  // (so verification returns `code_mismatch` instead of `not_found`) and keep
-  // connector/template validation, but avoid the actual message delivery.
-  const validateOnly =
+  // (so verification returns `code_mismatch` instead of `not_found`), but skip
+  // delivery and connector/template validation to avoid leaking configuration errors.
+  const skipDelivery =
     interactionEvent === InteractionEvent.ForgotPassword &&
     !(await hasUserWithIdentifier(queries, identifier));
 
@@ -146,7 +146,7 @@ export const sendCode = async ({
       /** The client IP address for rate limiting and fraud detection. */
       ...(ctx.request.ip && { ip: ctx.request.ip }),
     },
-    { validateOnly }
+    { skipDelivery }
   );
 
   // Save state

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -131,23 +131,17 @@ export const sendCode = async ({
     interactionEvent === InteractionEvent.ForgotPassword &&
     !(await hasUserWithIdentifier(queries, identifier));
 
-  // Build template context
-  const templateContext = await buildVerificationCodeTemplateContext(
-    libraries.passcodes,
-    ctx,
-    identifier
-  );
+  const payload = skipDelivery
+    ? undefined
+    : {
+        ...ctx.emailI18n,
+        ...(await buildVerificationCodeTemplateContext(libraries.passcodes, ctx, identifier)),
+        /** The client IP address for rate limiting and fraud detection. */
+        ...(ctx.request.ip && { ip: ctx.request.ip }),
+      };
 
   // Send verification code
-  await codeVerification.sendVerificationCode(
-    {
-      ...ctx.emailI18n,
-      ...templateContext,
-      /** The client IP address for rate limiting and fraud detection. */
-      ...(ctx.request.ip && { ip: ctx.request.ip }),
-    },
-    { skipDelivery }
-  );
+  await codeVerification.sendVerificationCode(payload, { skipDelivery });
 
   // Save state
   experienceInteraction.setVerificationRecord(codeVerification);


### PR DESCRIPTION
## Summary

Handle forgot-password verification codes for unknown email addresses by creating the verification record while skipping message delivery before connector lookup.

This keeps the send-code response consistent with existing users and removes the unused passcode dry-run template validation path so template selection is handled only by real connector sends.

## Testing

Unit tests

## Checklist

- [ ] `.changeset` (only when explicitly required)
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
