### PR TITLE
fix(console): reset date picker to today when cleared to prevent 400 error

### DIFF
--- a/packages/console/src/pages/Dashboard/index.tsx
+++ b/packages/console/src/pages/Dashboard/index.tsx
@@ -69,7 +69,7 @@ function Dashboard() {
   const isLoading = (!totalData || !newData || !activeData) && !error;
 
   const handleDateChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    setDate(event.target.value);
+    setDate(event.target.value || format(Date.now(), 'yyyy-MM-dd'));
   };
 
   return (


### PR DESCRIPTION
## Problem

Closes #8491.

When the user clicks the **Clear** button on the native \`<input type="date">\` in the Dashboard's "Daily Active Users" section, \`event.target.value\` becomes \`""\`. That empty string is passed directly into the SWR key:

\`\`\`
api/dashboard/users/active?date=
\`\`\`

The backend \`koaGuard\` validates \`date\` with \`string().regex(dateRegEx).optional()\`. \`.optional()\` allows \`undefined\` but **not** an empty string, so it returns a \`400 guard.invalid_input\` error and the Dashboard crashes. Additionally, clicking the **Retry** button re-triggers the broken request and forces a session logout.

## Root cause

\`\`\`ts
// packages/console/src/pages/Dashboard/index.tsx
const handleDateChange: ChangeEventHandler<HTMLInputElement> = (event) => {
  setDate(event.target.value); // "" when cleared → invalid API param
};
\`\`\`

## Fix

Fall back to today's date when the input value is empty:

\`\`\`ts
const handleDateChange: ChangeEventHandler<HTMLInputElement> = (event) => {
  setDate(event.target.value || format(Date.now(), 'yyyy-MM-dd'));
};
\`\`\`

\`format\` is already imported from \`date-fns\` and used in the \`useState\` initializer on the same line above, so no new dependencies are introduced.

## Behaviour after fix

| Action | Before | After |
|--------|--------|-------|
| Clear date picker | 400 error, page crash | Resets to today's data |
| Retry on error screen | Session logout | N/A — error no longer occurs |
| Set a specific date | Works | Works (unchanged) |