### PR TITLE
fix: tighten URL detection in email connector to avoid false positives

### DIFF
--- a/.changeset/nervous-bats-bow.md
+++ b/.changeset/nervous-bats-bow.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-kit": patch
+---
+
+fix email branding URL detection for dotted abbreviations

--- a/packages/toolkit/connector-kit/src/types/passwordless.test.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, it } from 'vitest';
 import { emailServiceBrandingGuard, urlRegEx } from './passwordless.js';
 
 describe('urlRegEx', () => {
-  it('does not treat dotted abbreviations like p.s.a. as URLs', () => {
+  it('does not treat dotted abbreviations or legal suffixes as URLs', () => {
     const sample = 'SomeCompany p.s.a. | os. Some Street 12/34 60-123 Poznań, PL | KRS 0001221212';
     expect(urlRegEx.test(sample)).toBe(false);
     expect(urlRegEx.test('Company p.s.a.')).toBe(false);
     expect(urlRegEx.test('Company P.S.A.')).toBe(false);
+    expect(urlRegEx.test('Company S.A.')).toBe(false);
+    expect(urlRegEx.test('Company P.C.')).toBe(false);
   });
 
   it('still detects http(s) URLs', () => {
@@ -44,5 +46,14 @@ describe('emailServiceBrandingGuard companyInformation', () => {
       companyInformation: 'SomeCompany example.com',
     });
     expect(parsed.success).toBe(false);
+  });
+});
+
+describe('emailServiceBrandingGuard senderName', () => {
+  it('accepts dotted legal suffixes', () => {
+    const parsed = emailServiceBrandingGuard.safeParse({
+      senderName: 'SomeCompany S.A.',
+    });
+    expect(parsed.success).toBe(true);
   });
 });

--- a/packages/toolkit/connector-kit/src/types/passwordless.test.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { emailServiceBrandingGuard, urlRegEx } from './passwordless.js';
+
+describe('urlRegEx', () => {
+  it('does not treat dotted abbreviations like p.s.a. as URLs', () => {
+    const sample = 'SomeCompany p.s.a. | os. Some Street 12/34 60-123 Poznań, PL | KRS 0001221212';
+    expect(urlRegEx.test(sample)).toBe(false);
+    expect(urlRegEx.test('Company p.s.a.')).toBe(false);
+    expect(urlRegEx.test('Company P.S.A.')).toBe(false);
+  });
+
+  it('still detects http(s) URLs', () => {
+    expect(urlRegEx.test('https://example.com')).toBe(true);
+    expect(urlRegEx.test('prefix https://example.com/phish suffix')).toBe(true);
+    expect(urlRegEx.test('HTTPS://Example.COM/path')).toBe(true);
+  });
+
+  it('still detects www.-prefixed hostnames', () => {
+    expect(urlRegEx.test('www.example.com')).toBe(true);
+    expect(urlRegEx.test('See WWW.EXAMPLE.COM for details')).toBe(true);
+  });
+
+  it('still detects bare domains without scheme or www', () => {
+    expect(urlRegEx.test('example.com')).toBe(true);
+    expect(urlRegEx.test('contact example.com only')).toBe(true);
+    expect(urlRegEx.test('foo.bar/path')).toBe(true);
+    expect(urlRegEx.test('x.y')).toBe(true);
+    expect(urlRegEx.test('a.b.c.com')).toBe(true);
+  });
+});
+
+describe('emailServiceBrandingGuard companyInformation', () => {
+  it('accepts Polish company info containing p.s.a.', () => {
+    const parsed = emailServiceBrandingGuard.safeParse({
+      companyInformation:
+        'SomeCompany p.s.a. | os. Some Street 12/34 60-123 Poznań, PL | KRS 0001221212',
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects company info containing a bare domain', () => {
+    const parsed = emailServiceBrandingGuard.safeParse({
+      companyInformation: 'SomeCompany example.com',
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/toolkit/connector-kit/src/types/passwordless.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.ts
@@ -93,7 +93,7 @@ export const sendMessagePayloadGuard = z
 
 /** Matches URLs while ignoring standalone dotted abbreviations (e.g. p.s.a.). */
 export const urlRegEx =
-  /(?<![\w.])(?![A-Za-z](?:\.[A-Za-z]){2,}\.?(?=$|[^\w#%&()+./:=?@~-]))(https?:\/\/)?(?:www\.)?[\w#%+.:=@~-]{1,256}\.[\d()A-Za-z]{1,6}\b[\w#%&()+./:=?@~-]*/;
+  /(?<![\w.])(?![A-Za-z]\.[A-Za-z]\.(?=$|[^\w#%&()+./:=?@~-]))(?![A-Za-z](?:\.[A-Za-z]){2,}\.?(?=$|[^\w#%&()+./:=?@~-]))(https?:\/\/)?(?:www\.)?[\w#%+.:=@~-]{1,256}\.[\d()A-Za-z]{1,6}\b[\w#%&()+./:=?@~-]*/;
 
 export const emailServiceBrandingGuard = z
   .object({

--- a/packages/toolkit/connector-kit/src/types/passwordless.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.ts
@@ -91,8 +91,9 @@ export const sendMessagePayloadGuard = z
   })
   .catchall(z.unknown()) satisfies z.ZodType<SendMessagePayload>;
 
+/** Matches URLs while ignoring standalone dotted abbreviations (e.g. p.s.a.). */
 export const urlRegEx =
-  /(https?:\/\/)?(?:www\.)?[\w#%+.:=@~-]{1,256}\.[\d()A-Za-z]{1,6}\b[\w#%&()+./:=?@~-]*/;
+  /(?<![\w.])(?![A-Za-z](?:\.[A-Za-z]){2,}\.?(?=$|[^\w#%&()+./:=?@~-]))(https?:\/\/)?(?:www\.)?[\w#%+.:=@~-]{1,256}\.[\d()A-Za-z]{1,6}\b[\w#%&()+./:=?@~-]*/;
 
 export const emailServiceBrandingGuard = z
   .object({


### PR DESCRIPTION
## Problem
Email connector settings validation incorrectly rejects company information like "Company p.s.a." as a URL, preventing valid configuration.

## Change
Tighten the URL detection pattern to require explicit URL schemes or sufficient structural evidence, avoiding false positives on dotted abbreviations.

Fixes #8589.

Made with [Cursor](https://cursor.com)