### PR TITLE
fix(account): preserve social callback connector id

### DIFF
--- a/.changeset/fix-account-social-callback-connector-id.md
+++ b/.changeset/fix-account-social-callback-connector-id.md
@@ -1,0 +1,5 @@
+---
+"@logto/account": patch
+---
+
+Fix social linking callback in Account Center incorrectly showing "social sign-in method is not enabled". The callback is now rendered through React Router so `useParams()` can correctly read the `connectorId` from the URL.

--- a/.changeset/fix-account-social-callback-connector-id.md
+++ b/.changeset/fix-account-social-callback-connector-id.md
@@ -2,4 +2,6 @@
 "@logto/account": patch
 ---
 
-Fix social linking callback in Account Center incorrectly showing "social sign-in method is not enabled". The callback is now rendered through React Router so `useParams()` can correctly read the `connectorId` from the URL.
+fix social linking callback in Account Center to preserve connector id
+
+Render the callback through React Router so `useParams()` can correctly read the `connectorId` from the URL and avoid incorrectly showing "social sign-in method is not enabled"

--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -142,7 +142,11 @@ const Main = () => {
     userInfoError,
   ]);
   if (isSocialCallback) {
-    return <SocialCallback />;
+    return (
+      <Routes>
+        <Route path={`${socialCallbackRoutePrefix}/:connectorId`} element={<SocialCallback />} />
+      </Routes>
+    );
   }
 
   if (isAuthCallback) {
@@ -209,7 +213,6 @@ const Main = () => {
       <Route path={passkeyAddRoute} element={<PasskeyBinding />} />
       <Route path={passkeyManageRoute} element={<PasskeyView />} />
       <Route path={verifiedActionRoute} element={<VerifiedAction />} />
-      <Route path={`${socialCallbackRoutePrefix}/:connectorId`} element={<SocialCallback />} />
       <Route path={`${socialRoutePrefix}/:connectorId`} element={<SocialFlow mode="add" />} />
       <Route
         path={`${socialRoutePrefix}/:connectorId/remove`}


### PR DESCRIPTION
## Summary
Fix Account Center social linking callbacks rendering outside React Router route matching, which caused `useParams()` to lose `connectorId` and incorrectly show the social method as not enabled.

Fixes #8756

## Testing
Tested locally

## Checklist
- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments