### PR TITLE
test(test): cover isCurrent edge cases

### DIFF
--- a/packages/integration-tests/src/tests/api/account/session.test.ts
+++ b/packages/integration-tests/src/tests/api/account/session.test.ts
@@ -155,6 +155,65 @@ describe('account center session management', () => {
         await deleteDefaultTenantUser(user.id);
       }
     );
+
+    devFeatureTest.it(
+      'returns zero `isCurrent: true` entries after the caller revokes its own session',
+      async () => {
+        const { user, username, password } = await createDefaultTenantUserWithPassword();
+        const api = await signInAndGetUserApi(username, password, {
+          scopes: [UserScope.Sessions],
+        });
+
+        const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+        const before = await getSessions(api, verificationRecordId);
+        const ownSession = before.sessions.find((session) => session.isCurrent);
+        assert(ownSession, new Error('Caller session not tagged before revoke'));
+
+        await deleteSession(api, ownSession.payload.uid, verificationRecordId);
+
+        const after = await getSessions(api, verificationRecordId);
+        const currentSessions = after.sessions.filter((session) => session.isCurrent);
+        expect(currentSessions).toHaveLength(0);
+        expect(after.sessions.map((session) => session.payload.uid)).not.toContain(
+          ownSession.payload.uid
+        );
+
+        await deleteDefaultTenantUser(user.id);
+      }
+    );
+
+    devFeatureTest.it(
+      'tags the calling session from each caller perspective when two sessions exist',
+      async () => {
+        const { user, username, password } = await createDefaultTenantUserWithPassword();
+
+        const apiA = await signInAndGetUserApi(username, password, {
+          scopes: [UserScope.Sessions],
+        });
+        const apiB = await signInAndGetUserApi(username, password, {
+          scopes: [UserScope.Sessions],
+        });
+
+        const verificationRecordIdA = await createVerificationRecordByPassword(apiA, password);
+        const verificationRecordIdB = await createVerificationRecordByPassword(apiB, password);
+
+        const responseA = await getSessions(apiA, verificationRecordIdA);
+        const responseB = await getSessions(apiB, verificationRecordIdB);
+
+        const currentA = responseA.sessions.find((session) => session.isCurrent);
+        const currentB = responseB.sessions.find((session) => session.isCurrent);
+
+        assert(currentA, new Error('A session not tagged from A perspective'));
+        assert(currentB, new Error('B session not tagged from B perspective'));
+
+        expect(responseA.sessions.filter((session) => session.isCurrent)).toHaveLength(1);
+        expect(responseB.sessions.filter((session) => session.isCurrent)).toHaveLength(1);
+        expect(currentA.payload.uid).not.toBe(currentB.payload.uid);
+
+        await deleteDefaultTenantUser(user.id);
+      }
+    );
   });
 
   describe('DELETE /account-center/sessions/:sessionId', () => {

--- a/packages/integration-tests/src/tests/api/sessions/index.test.ts
+++ b/packages/integration-tests/src/tests/api/sessions/index.test.ts
@@ -20,6 +20,7 @@ import {
 } from '#src/helpers/session.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest } from '#src/utils.js';
 
 describe('Sessions API', () => {
   const userApi = new UserApiTest();
@@ -75,6 +76,30 @@ describe('Sessions API', () => {
     expect(sessionsAfterRevoke).toHaveLength(1);
     expect(sessionsAfterRevoke[0]!.payload.uid).toBe(sessions[1]!.payload.uid);
   });
+
+  devFeatureTest.it(
+    'admin sessions response does not include the account-only `isCurrent` field',
+    async () => {
+      await enableAllPasswordSignInMethods();
+
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
+      const user = await userApi.create({ username, password });
+
+      await signInWithPassword({
+        identifier: {
+          type: SignInIdentifier.Username,
+          value: username,
+        },
+        password,
+      });
+
+      const { sessions } = await getUserSessions(user.id);
+      expect(sessions.length).toBeGreaterThan(0);
+      for (const session of sessions) {
+        expect(session).not.toHaveProperty('isCurrent');
+      }
+    }
+  );
 
   it('should get a single user session by session id', async () => {
     await enableAllPasswordSignInMethods();


### PR DESCRIPTION
## Summary

Three additional integration tests for the \`isCurrent\` flag on the Account API sessions response — fills gaps surfaced by the bug-bash review of #8728 / #8729.

All three are wrapped in \`devFeatureTest.it\` because \`isCurrent\` is still gated by \`isDevFeaturesEnabled\` on \`master\`. The wrappers are dropped in #8731 (P1.4) when the gate goes away.

### What changed

- \`packages/integration-tests/src/tests/api/account/session.test.ts\` — two new cases under \`describe('GET /account-center/sessions')\`:
  - \`returns zero \`\`isCurrent: true\`\` entries after the caller revokes its own session\` — token still valid, OIDC session row gone, no entry tagged.
  - \`tags the calling session from each caller perspective when two sessions exist\` — two account-API sign-ins for the same user; each call tags the right session; the tagged uids differ.
- \`packages/integration-tests/src/tests/api/sessions/index.test.ts\` — one new case under \`describe('Sessions API')\`:
  - \`admin sessions response does not include the account-only \`\`isCurrent\`\` field\` — protects the schema split between \`userExtendedSessionGuard\` and \`accountUserExtendedSessionGuard\` introduced in #8729.

### Out of scope

- Refresh-token round-trip preserving the tag — deferred. The harness doesn't expose a clean refresh on the account-API Ky client; adding that helper is its own task.
- Cross-user negative — sessions library SQL filters by \`accountId\`, structurally covered.

## Testing

Integration tests

Each new case passes in isolation against a local Logto with \`DEV_FEATURES_ENABLED=true\`.

Refs LOG-13305. Closes LOG-13305.

## Checklist
- [ ] \`.changeset\`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments