### PR TITLE
chore(console): update android SDK version to 2.0.2

### DIFF
--- a/packages/console/src/assets/docs/fragments/_redirect-uris-native.mdx
+++ b/packages/console/src/assets/docs/fragments/_redirect-uris-native.mdx
@@ -7,6 +7,6 @@ export const defaultRedirectUri = 'io.logto://callback';
 
 <ExperienceOverview />
 
-Now, let's configure your redirect URI. E.g. {`${props.defaultUri ?? defaultRedirectUri}`}.
+Now, let's configure your redirect URI. E.g. <code>{`${props.defaultUri ?? defaultRedirectUri}`}</code>.
 
 <UriInputField name="redirectUris" />

--- a/packages/console/src/assets/docs/guides/native-android/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-android/README.mdx
@@ -29,7 +29,7 @@ Add Logto Android SDK to your dependencies:
 
 ```kotlin title="build.gradle.kts"
 dependencies {
-    implementation("io.logto.sdk:android:1.1.3")
+    implementation("io.logto.sdk:android:2.0.2")
 }
 ```
 


### PR DESCRIPTION
## Summary

- Bumps Android SDK version reference in the getting-started guide to `2.0.2` (just released).
- Wraps the redirect URI example in backticks so it renders as inline code.

## Testing

tested locally