### PR TITLE
fix: report forwarded headers in app insights requests

### DIFF
--- a/packages/app-insights/src/node.test.ts
+++ b/packages/app-insights/src/node.test.ts
@@ -77,6 +77,7 @@ describe('appInsights', () => {
         headers: {
           'x-forwarded-for': '192.0.2.1',
           'x-forwarded-host': 'tenant.logto.app',
+          'x-forwarded-proto': 'https',
         },
       },
     });
@@ -87,6 +88,7 @@ describe('appInsights', () => {
         existing: 'value',
         xForwardedFor: '192.0.2.1',
         xForwardedHost: 'tenant.logto.app',
+        xForwardedProto: 'https',
       },
     });
   });
@@ -100,6 +102,7 @@ describe('appInsights', () => {
         headers: {
           'x-forwarded-for': '192.0.2.1, 198.51.100.1',
           'x-forwarded-host': 'tenant.logto.app, azure-service.local',
+          'x-forwarded-proto': 'https, http',
         },
       },
     });
@@ -108,10 +111,11 @@ describe('appInsights', () => {
       existing: 'value',
       xForwardedFor: '192.0.2.1',
       xForwardedHost: 'tenant.logto.app',
+      xForwardedProto: 'https',
     });
   });
 
-  it('should add forwarded for without forwarded host', async () => {
+  it('should add partial forwarded headers', async () => {
     const processor = await setupAppInsights();
     const envelope = createRequestEnvelope();
 
@@ -119,6 +123,7 @@ describe('appInsights', () => {
       'http.ServerRequest': {
         headers: {
           'x-forwarded-for': '192.0.2.1',
+          'x-forwarded-proto': 'https',
         },
       },
     });
@@ -126,6 +131,7 @@ describe('appInsights', () => {
     expect(envelope.data.baseData.properties).toStrictEqual({
       existing: 'value',
       xForwardedFor: '192.0.2.1',
+      xForwardedProto: 'https',
     });
   });
 });

--- a/packages/app-insights/src/node.test.ts
+++ b/packages/app-insights/src/node.test.ts
@@ -68,13 +68,14 @@ describe('appInsights', () => {
     vi.unstubAllEnvs();
   });
 
-  it('should add forwarded host to auto-collected request telemetry properties', async () => {
+  it('should add forwarded headers to auto-collected request telemetry properties', async () => {
     const processor = await setupAppInsights();
     const envelope = createRequestEnvelope();
 
     processor(envelope, {
       'http.ServerRequest': {
         headers: {
+          'x-forwarded-for': '192.0.2.1',
           'x-forwarded-host': 'tenant.logto.app',
         },
       },
@@ -84,18 +85,20 @@ describe('appInsights', () => {
       url: 'http://azure-service.local/api/callback?foo=bar',
       properties: {
         existing: 'value',
+        xForwardedFor: '192.0.2.1',
         xForwardedHost: 'tenant.logto.app',
       },
     });
   });
 
-  it('should use the first forwarded host value', async () => {
+  it('should use the first forwarded header value', async () => {
     const processor = await setupAppInsights();
     const envelope = createRequestEnvelope();
 
     processor(envelope, {
       'http.ServerRequest': {
         headers: {
+          'x-forwarded-for': '192.0.2.1, 198.51.100.1',
           'x-forwarded-host': 'tenant.logto.app, azure-service.local',
         },
       },
@@ -103,7 +106,26 @@ describe('appInsights', () => {
 
     expect(envelope.data.baseData.properties).toStrictEqual({
       existing: 'value',
+      xForwardedFor: '192.0.2.1',
       xForwardedHost: 'tenant.logto.app',
+    });
+  });
+
+  it('should add forwarded for without forwarded host', async () => {
+    const processor = await setupAppInsights();
+    const envelope = createRequestEnvelope();
+
+    processor(envelope, {
+      'http.ServerRequest': {
+        headers: {
+          'x-forwarded-for': '192.0.2.1',
+        },
+      },
+    });
+
+    expect(envelope.data.baseData.properties).toStrictEqual({
+      existing: 'value',
+      xForwardedFor: '192.0.2.1',
     });
   });
 });

--- a/packages/app-insights/src/node.test.ts
+++ b/packages/app-insights/src/node.test.ts
@@ -1,0 +1,109 @@
+import type { TelemetryClient } from 'applicationinsights';
+import { type EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts/index.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type TelemetryProcessor = Parameters<TelemetryClient['addTelemetryProcessor']>[0];
+type RequestTelemetryEnvelope = EnvelopeTelemetry & {
+  data: {
+    baseType: string;
+    baseData: {
+      url: string;
+      properties?: Record<string, string | undefined>;
+    };
+  };
+};
+
+const mockAppInsights = vi.hoisted(() => {
+  const addTelemetryProcessor = vi.fn();
+
+  return {
+    addTelemetryProcessor,
+    applicationinsights: {
+      defaultClient: {
+        context: {
+          keys: { cloudRole: 'ai.cloud.role' },
+          tags: {},
+        },
+        addTelemetryProcessor,
+        trackException: vi.fn(),
+      },
+      setup: vi.fn(() => true),
+      start: vi.fn(),
+    },
+  };
+});
+
+vi.mock('applicationinsights', () => ({
+  default: mockAppInsights.applicationinsights,
+}));
+
+const createRequestEnvelope = (): RequestTelemetryEnvelope =>
+  ({
+    data: {
+      baseType: 'RequestData',
+      baseData: {
+        url: 'http://azure-service.local/api/callback?foo=bar',
+        properties: {
+          existing: 'value',
+        },
+      },
+    },
+  }) as unknown as RequestTelemetryEnvelope;
+
+const setupAppInsights = async () => {
+  vi.stubEnv(
+    'APPLICATIONINSIGHTS_CONNECTION_STRING',
+    'InstrumentationKey=00000000-0000-0000-0000-000000000000'
+  );
+  const { appInsights } = await import('./node.js');
+  await appInsights.setup('core');
+
+  return mockAppInsights.addTelemetryProcessor.mock.calls[0]?.[0] as TelemetryProcessor;
+};
+
+describe('appInsights', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  it('should add forwarded host to auto-collected request telemetry properties', async () => {
+    const processor = await setupAppInsights();
+    const envelope = createRequestEnvelope();
+
+    processor(envelope, {
+      'http.ServerRequest': {
+        headers: {
+          'x-forwarded-host': 'tenant.logto.app',
+        },
+      },
+    });
+
+    expect(envelope.data.baseData).toStrictEqual({
+      url: 'http://azure-service.local/api/callback?foo=bar',
+      properties: {
+        existing: 'value',
+        xForwardedHost: 'tenant.logto.app',
+      },
+    });
+  });
+
+  it('should use the first forwarded host value', async () => {
+    const processor = await setupAppInsights();
+    const envelope = createRequestEnvelope();
+
+    processor(envelope, {
+      'http.ServerRequest': {
+        headers: {
+          'x-forwarded-host': 'tenant.logto.app, azure-service.local',
+        },
+      },
+    });
+
+    expect(envelope.data.baseData.properties).toStrictEqual({
+      existing: 'value',
+      xForwardedHost: 'tenant.logto.app',
+    });
+  });
+});

--- a/packages/app-insights/src/node.ts
+++ b/packages/app-insights/src/node.ts
@@ -17,6 +17,7 @@ type ServerRequestContext = {
   headers?: {
     'x-forwarded-for'?: string | string[];
     'x-forwarded-host'?: string | string[];
+    'x-forwarded-proto'?: string | string[];
   };
 };
 
@@ -31,9 +32,11 @@ const appendForwardedHeadersToRequestTelemetry = (
 ) => {
   const xForwardedFor = getFirstForwardedHeaderValue(request?.headers?.['x-forwarded-for']);
   const xForwardedHost = getFirstForwardedHeaderValue(request?.headers?.['x-forwarded-host']);
+  const xForwardedProto = getFirstForwardedHeaderValue(request?.headers?.['x-forwarded-proto']);
   const forwardedProperties = {
     ...(xForwardedFor && { xForwardedFor }),
     ...(xForwardedHost && { xForwardedHost }),
+    ...(xForwardedProto && { xForwardedProto }),
   };
 
   if (

--- a/packages/app-insights/src/node.ts
+++ b/packages/app-insights/src/node.ts
@@ -15,6 +15,7 @@ type RequestTelemetryEnvelope = EnvelopeTelemetry & {
 
 type ServerRequestContext = {
   headers?: {
+    'x-forwarded-for'?: string | string[];
     'x-forwarded-host'?: string | string[];
   };
 };
@@ -24,20 +25,29 @@ type RequestContext = Record<string, ServerRequestContext>;
 const getFirstForwardedHeaderValue = (value?: string | string[]) =>
   (Array.isArray(value) ? value[0] : value)?.split(',')[0]?.trim();
 
-const appendForwardedHostToRequestTelemetry = (
+const appendForwardedHeadersToRequestTelemetry = (
   envelope: RequestTelemetryEnvelope,
   { 'http.ServerRequest': request }: RequestContext = {}
 ) => {
+  const xForwardedFor = getFirstForwardedHeaderValue(request?.headers?.['x-forwarded-for']);
   const xForwardedHost = getFirstForwardedHeaderValue(request?.headers?.['x-forwarded-host']);
+  const forwardedProperties = {
+    ...(xForwardedFor && { xForwardedFor }),
+    ...(xForwardedHost && { xForwardedHost }),
+  };
 
-  if (envelope.data.baseType !== 'RequestData' || !envelope.data.baseData || !xForwardedHost) {
+  if (
+    envelope.data.baseType !== 'RequestData' ||
+    !envelope.data.baseData ||
+    Object.keys(forwardedProperties).length === 0
+  ) {
     return true;
   }
 
   // eslint-disable-next-line @silverhand/fp/no-mutation
   envelope.data.baseData.properties = {
     ...envelope.data.baseData.properties,
-    xForwardedHost,
+    ...forwardedProperties,
   };
 
   return true;
@@ -64,7 +74,7 @@ class AppInsights {
 
     this.client = applicationinsights.defaultClient;
     this.client.context.tags[this.client.context.keys.cloudRole] = cloudRole;
-    this.client.addTelemetryProcessor(appendForwardedHostToRequestTelemetry);
+    this.client.addTelemetryProcessor(appendForwardedHeadersToRequestTelemetry);
     applicationinsights.start();
 
     return true;

--- a/packages/app-insights/src/node.ts
+++ b/packages/app-insights/src/node.ts
@@ -1,10 +1,47 @@
 import { trySafe } from '@silverhand/essentials';
 import type { TelemetryClient } from 'applicationinsights';
-import { type ExceptionTelemetry } from 'applicationinsights/out/Declarations/Contracts/index.js';
+import {
+  type EnvelopeTelemetry,
+  type ExceptionTelemetry,
+} from 'applicationinsights/out/Declarations/Contracts/index.js';
 
 import { normalizeError } from './normalize-error.js';
 
 export { type ExceptionTelemetry } from 'applicationinsights/out/Declarations/Contracts/index.js';
+
+type RequestTelemetryEnvelope = EnvelopeTelemetry & {
+  data: { baseData?: { properties?: Record<string, string | undefined> } };
+};
+
+type ServerRequestContext = {
+  headers?: {
+    'x-forwarded-host'?: string | string[];
+  };
+};
+
+type RequestContext = Record<string, ServerRequestContext>;
+
+const getFirstForwardedHeaderValue = (value?: string | string[]) =>
+  (Array.isArray(value) ? value[0] : value)?.split(',')[0]?.trim();
+
+const appendForwardedHostToRequestTelemetry = (
+  envelope: RequestTelemetryEnvelope,
+  { 'http.ServerRequest': request }: RequestContext = {}
+) => {
+  const xForwardedHost = getFirstForwardedHeaderValue(request?.headers?.['x-forwarded-host']);
+
+  if (envelope.data.baseType !== 'RequestData' || !envelope.data.baseData || !xForwardedHost) {
+    return true;
+  }
+
+  // eslint-disable-next-line @silverhand/fp/no-mutation
+  envelope.data.baseData.properties = {
+    ...envelope.data.baseData.properties,
+    xForwardedHost,
+  };
+
+  return true;
+};
 
 class AppInsights {
   client?: TelemetryClient;
@@ -27,6 +64,7 @@ class AppInsights {
 
     this.client = applicationinsights.defaultClient;
     this.client.context.tags[this.client.context.keys.cloudRole] = cloudRole;
+    this.client.addTelemetryProcessor(appendForwardedHostToRequestTelemetry);
     applicationinsights.start();
 
     return true;


### PR DESCRIPTION
## Summary
<!-- Provide detailed PR description below -->

Add x-forwarded related headers to auto-collected Application Insights request telemetry as custom dimensions:

- `x-forwarded-host` -> `customDimensions.xForwardedHost`
- `x-forwarded-for` -> `customDimensions.xForwardedFor`
- `x-forwarded-proto` -> `customDimensions.xForwardedProto`

Application Insights request URLs can show the Azure service/internal host in Azure deployments, while the original public host is carried by `x-forwarded-host`. Related proxy context, including the client/proxy chain and original protocol, is carried by `x-forwarded-for` and `x-forwarded-proto`. This change makes the forwarded request context available on auto-collected request telemetry without changing the recorded request URL.

## Testing
<!-- How did you test this PR? -->

- `pnpm --filter @logto/app-insights build`
- `pnpm --filter @logto/app-insights lint`
- `pnpm --filter @logto/app-insights test`
- `git diff --check`

## Checklist
<!-- The palest ink is better than the best memory -->
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
