### PR TITLE
fix(account): include redirect uri for social callback

### DIFF
--- a/packages/account/src/pages/SocialCallback/index.tsx
+++ b/packages/account/src/pages/SocialCallback/index.tsx
@@ -7,9 +7,10 @@ import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import { linkSocialIdentity, verifySocialVerification } from '@ac/apis/social';
 import ErrorPage from '@ac/components/ErrorPage';
 import GlobalLoading from '@ac/components/GlobalLoading';
-import { getSocialAddRoute } from '@ac/constants/routes';
+import { getSocialAddRoute, getSocialCallbackRoute } from '@ac/constants/routes';
 import useApi from '@ac/hooks/use-api';
 import useErrorHandler from '@ac/hooks/use-error-handler';
+import { accountCenterBasePath } from '@ac/utils/account-center-route';
 import { accountStorage } from '@ac/utils/session-storage';
 import { getLocalizedConnectorName } from '@ac/utils/social-connector';
 import { finalizeSocialFlowFailure, finalizeSocialFlowSuccess } from '@ac/utils/social-flow';
@@ -125,9 +126,15 @@ const SocialCallback = () => {
     };
 
     const completeCallback = async () => {
+      const redirectUri = `${window.location.origin}${accountCenterBasePath}${getSocialCallbackRoute(
+        connectorId
+      )}`;
       const [verifyError] = await verifySocialVerificationRequest({
         verificationRecordId: storedSocialFlow.verificationRecordId,
-        connectorData: Object.fromEntries(searchParameters.entries()),
+        connectorData: {
+          ...Object.fromEntries(searchParameters.entries()),
+          redirectUri,
+        },
       });
 
       if (verifyError) {


### PR DESCRIPTION
## Summary
Fix Account Center social callback verification by passing the callback redirect URI to connectors. This matches the sign-in experience flow and allows Google OAuth callbacks to pass connector validation.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments