### PR TITLE
fix(account): show loading mask for mfa section

### DIFF
--- a/packages/account/src/pages/Security/MfaSection/index.module.scss
+++ b/packages/account/src/pages/Security/MfaSection/index.module.scss
@@ -154,6 +154,30 @@
   background: var(--color-line-divider);
 }
 
+.loadingMask {
+  min-height: 152px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-type-primary);
+}
+
+.loadingIcon {
+  width: 20px;
+  height: 20px;
+  animation: rotating 1s steps(12, end) infinite;
+}
+
+@keyframes rotating {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 :global(body.mobile) {
   .sectionTitle {
     padding-left: 0;
@@ -213,6 +237,10 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
+  }
+
+  .loadingMask {
+    min-height: 96px;
   }
 
   .actionButton {

--- a/packages/account/src/pages/Security/MfaSection/index.tsx
+++ b/packages/account/src/pages/Security/MfaSection/index.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
+import LoadingIcon from '@ac/assets/icons/loading-icon.svg?react';
 import ConfirmModal from '@ac/components/ConfirmModal';
 import ToggleSwitch from '@ac/components/ToggleSwitch';
 import { layoutClassNames } from '@ac/constants/layout';
@@ -32,6 +33,103 @@ const mandatoryMfaPolicies = new Set<MfaPolicy>([
   MfaPolicy.PromptOnlyAtSignInMandatory,
 ]);
 
+type MfaRowsProps = {
+  readonly rows: ReturnType<typeof useMfaRows>;
+};
+
+const MfaRows = ({ rows }: MfaRowsProps) => {
+  const { t } = useTranslation();
+
+  return rows.map(({ key, icon: Icon, label, value, isPlainValue, isConfigured, action }) => (
+    <div key={key} className={classNames(styles.row, layoutClassNames.row)}>
+      <div className={styles.topLine}>
+        <div className={styles.iconWrap}>
+          <Icon className={styles.icon} />
+        </div>
+        {action && (
+          <div className={styles.actions}>
+            <button type="button" className={styles.actionButton} onClick={action.handler}>
+              {action.label}
+            </button>
+          </div>
+        )}
+      </div>
+      <div className={styles.title}>{label}</div>
+      <div className={styles.value}>
+        {isConfigured ? (
+          isPlainValue ? (
+            <span className={styles.plainValue}>{value}</span>
+          ) : (
+            <span className={styles.statusTag}>
+              <span className={styles.statusDot} />
+              {value}
+            </span>
+          )
+        ) : (
+          <span className={styles.notConfigured}>
+            {t('account_center.security.not_configured')}
+          </span>
+        )}
+      </div>
+    </div>
+  ));
+};
+
+type MfaContentProps = {
+  readonly isLoading: boolean;
+  readonly hasToggle: boolean;
+  readonly isTwoStepEnabled: boolean;
+  readonly rows: ReturnType<typeof useMfaRows>;
+  readonly onToggleChange: (checked: boolean) => Promise<void>;
+};
+
+const MfaContent = ({
+  isLoading,
+  hasToggle,
+  isTwoStepEnabled,
+  rows,
+  onToggleChange,
+}: MfaContentProps) => {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div className={styles.loadingMask} aria-busy="true">
+        <LoadingIcon className={styles.loadingIcon} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {hasToggle && (
+        <div className={styles.toggleRow}>
+          <div className={styles.toggleInfo}>
+            <div className={styles.toggleTitle}>
+              {t(
+                isTwoStepEnabled
+                  ? 'account_center.security.turn_off_2_step_verification'
+                  : 'account_center.security.turn_on_2_step_verification'
+              )}
+            </div>
+            <div className={styles.toggleDescription}>
+              {t('account_center.security.turn_on_2_step_verification_description')}
+            </div>
+          </div>
+          <ToggleSwitch
+            isChecked={isTwoStepEnabled}
+            onChange={(checked) => {
+              void onToggleChange(checked);
+            }}
+          />
+        </div>
+      )}
+      {hasToggle && rows.length > 0 && <div className={styles.divider} />}
+      <MfaRows rows={rows} />
+    </>
+  );
+};
+
 const MfaSection = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -39,6 +137,10 @@ const MfaSection = () => {
     useContext(PageContext);
   const [mfaVerifications, setMfaVerifications] = useState<UserMfaVerificationResponse>();
   const [skipMfaOnSignIn, setSkipMfaOnSignIn] = useState<boolean>();
+  const [hasLoadedMfaVerifications, setHasLoadedMfaVerifications] = useState(false);
+  const [isLoadingMfaVerifications, setIsLoadingMfaVerifications] = useState(false);
+  const [hasLoadedMfaSettings, setHasLoadedMfaSettings] = useState(false);
+  const [isLoadingMfaSettings, setIsLoadingMfaSettings] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const handleError = useErrorHandler();
 
@@ -58,22 +160,31 @@ const MfaSection = () => {
 
   const isTwoStepEnabled = skipMfaOnSignIn === false;
   const hasConfiguredMfa = (mfaVerifications?.length ?? 0) > 0;
+  const isMfaSectionLoading =
+    (isMfaSectionVisible && (!hasLoadedMfaVerifications || isLoadingMfaVerifications)) ||
+    (showToggle && (!hasLoadedMfaSettings || isLoadingMfaSettings));
 
   const getMfaRequest = useApi(getMfaVerifications, { silent: true });
   const getMfaSettingsRequest = useApi(getMfaSettings, { silent: true });
 
   const fetchMfaVerifications = useCallback(async () => {
+    setIsLoadingMfaVerifications(true);
     const [error, result] = await getMfaRequest();
     if (!error && result) {
       setMfaVerifications(result);
     }
+    setHasLoadedMfaVerifications(true);
+    setIsLoadingMfaVerifications(false);
   }, [getMfaRequest]);
 
   const fetchMfaSettings = useCallback(async () => {
+    setIsLoadingMfaSettings(true);
     const [error, result] = await getMfaSettingsRequest();
     if (!error && result) {
       setSkipMfaOnSignIn(result.skipMfaOnSignIn);
     }
+    setHasLoadedMfaSettings(true);
+    setIsLoadingMfaSettings(false);
   }, [getMfaSettingsRequest]);
 
   useEffect(() => {
@@ -164,7 +275,7 @@ const MfaSection = () => {
     void updateSkipMfaOnSignIn(verificationId, pendingAction === 'disable-mfa');
   }, [updateSkipMfaOnSignIn, verificationId]);
 
-  if (rows.length === 0 && !showToggle) {
+  if (!isMfaSectionLoading && rows.length === 0 && !showToggle) {
     return null;
   }
 
@@ -174,74 +285,21 @@ const MfaSection = () => {
         <div className={classNames(styles.sectionTitle, layoutClassNames.sectionTitle)}>
           {t('account_center.security.two_step_verification')}
         </div>
-        {showToggle && isTwoStepEnabled && !hasConfiguredMfa && (
+        {!isMfaSectionLoading && showToggle && isTwoStepEnabled && !hasConfiguredMfa && (
           <InlineNotification
             message="account_center.security.no_verification_method_warning"
             className={styles.notification}
           />
         )}
-        {(showToggle || rows.length > 0) && (
+        {(isMfaSectionLoading || showToggle || rows.length > 0) && (
           <div className={classNames(styles.card, layoutClassNames.card)}>
-            {showToggle && (
-              <div className={styles.toggleRow}>
-                <div className={styles.toggleInfo}>
-                  <div className={styles.toggleTitle}>
-                    {t(
-                      isTwoStepEnabled
-                        ? 'account_center.security.turn_off_2_step_verification'
-                        : 'account_center.security.turn_on_2_step_verification'
-                    )}
-                  </div>
-                  <div className={styles.toggleDescription}>
-                    {t('account_center.security.turn_on_2_step_verification_description')}
-                  </div>
-                </div>
-                <ToggleSwitch
-                  isChecked={isTwoStepEnabled}
-                  onChange={(checked) => {
-                    void handleToggleChange(checked);
-                  }}
-                />
-              </div>
-            )}
-            {showToggle && rows.length > 0 && <div className={styles.divider} />}
-            {rows.map(({ key, icon: Icon, label, value, isPlainValue, isConfigured, action }) => (
-              <div key={key} className={classNames(styles.row, layoutClassNames.row)}>
-                <div className={styles.topLine}>
-                  <div className={styles.iconWrap}>
-                    <Icon className={styles.icon} />
-                  </div>
-                  {action && (
-                    <div className={styles.actions}>
-                      <button
-                        type="button"
-                        className={styles.actionButton}
-                        onClick={action.handler}
-                      >
-                        {action.label}
-                      </button>
-                    </div>
-                  )}
-                </div>
-                <div className={styles.title}>{label}</div>
-                <div className={styles.value}>
-                  {isConfigured ? (
-                    isPlainValue ? (
-                      <span className={styles.plainValue}>{value}</span>
-                    ) : (
-                      <span className={styles.statusTag}>
-                        <span className={styles.statusDot} />
-                        {value}
-                      </span>
-                    )
-                  ) : (
-                    <span className={styles.notConfigured}>
-                      {t('account_center.security.not_configured')}
-                    </span>
-                  )}
-                </div>
-              </div>
-            ))}
+            <MfaContent
+              isLoading={isMfaSectionLoading}
+              hasToggle={showToggle}
+              isTwoStepEnabled={isTwoStepEnabled}
+              rows={rows}
+              onToggleChange={handleToggleChange}
+            />
           </div>
         )}
       </div>

--- a/packages/account/src/pages/Security/MfaSection/index.tsx
+++ b/packages/account/src/pages/Security/MfaSection/index.tsx
@@ -94,8 +94,14 @@ const MfaContent = ({
 
   if (isLoading) {
     return (
-      <div className={styles.loadingMask} aria-busy="true">
-        <LoadingIcon className={styles.loadingIcon} />
+      <div
+        className={styles.loadingMask}
+        role="status"
+        aria-live="polite"
+        aria-busy="true"
+        aria-label={t('account_center.security.two_step_verification')}
+      >
+        <LoadingIcon className={styles.loadingIcon} aria-hidden="true" focusable="false" />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
Fix the account center security page MFA section flicker by showing an inline loading mask while MFA verifications and settings are being loaded.

This prevents the empty MFA state and the no-verification-method warning from flashing before the user's configured factors are available.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments