### PR TITLE
fix(account): wait for settings in social callback

### DIFF
--- a/.changeset/fix-account-social-callback-settings-loading.md
+++ b/.changeset/fix-account-social-callback-settings-loading.md
@@ -1,0 +1,5 @@
+---
+"@logto/account": patch
+---
+
+Fix Account Center social callback to wait for settings before checking permissions

--- a/.changeset/fix-account-social-callback-settings-loading.md
+++ b/.changeset/fix-account-social-callback-settings-loading.md
@@ -1,5 +1,0 @@
----
-"@logto/account": patch
----
-
-Fix Account Center social callback to wait for settings before checking permissions

--- a/packages/account/src/pages/SocialCallback/index.tsx
+++ b/packages/account/src/pages/SocialCallback/index.tsx
@@ -25,6 +25,7 @@ const SocialCallback = () => {
   const {
     accountCenterSettings,
     experienceSettings,
+    isLoadingExperience,
     refreshUserInfo,
     setToast,
     verificationId,
@@ -170,17 +171,17 @@ const SocialCallback = () => {
     t,
   ]);
 
+  if (isLoadingExperience || !accountCenterSettings || !experienceSettings) {
+    return <GlobalLoading />;
+  }
+
   if (
-    !accountCenterSettings?.enabled ||
+    !accountCenterSettings.enabled ||
     accountCenterSettings.fields.social !== AccountCenterControlValue.Edit
   ) {
     return (
       <ErrorPage titleKey="error.something_went_wrong" messageKey="error.feature_not_enabled" />
     );
-  }
-
-  if (!experienceSettings) {
-    return <GlobalLoading />;
   }
 
   if (!connectorId || !connector) {

--- a/packages/account/src/pages/SocialCallback/index.tsx
+++ b/packages/account/src/pages/SocialCallback/index.tsx
@@ -171,8 +171,12 @@ const SocialCallback = () => {
     t,
   ]);
 
-  if (isLoadingExperience || !accountCenterSettings || !experienceSettings) {
+  if (isLoadingExperience) {
     return <GlobalLoading />;
+  }
+
+  if (!accountCenterSettings || !experienceSettings) {
+    return <ErrorPage titleKey="error.something_went_wrong" />;
   }
 
   if (


### PR DESCRIPTION
## Summary
Fix Account Center social callback to wait until account center and sign-in experience settings are loaded before checking social field permissions. This avoids incorrectly showing the feature permission error while returning from GitHub OAuth.

## Testing
Tested locally

## Checklist
- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments