### PR TITLE
fix(console): skip OSS onboarding in development

### DIFF
--- a/packages/console/src/consts/env.ts
+++ b/packages/console/src/consts/env.ts
@@ -5,7 +5,7 @@ import { storageKeys } from './storage';
 const normalizeEnv = (value: unknown) =>
   value === null || value === undefined ? undefined : String(value);
 
-const isProduction = import.meta.env.PROD;
+export const isProduction = import.meta.env.PROD;
 export const isCloud = yes(normalizeEnv(import.meta.env.IS_CLOUD));
 export const adminEndpoint = normalizeEnv(import.meta.env.ADMIN_ENDPOINT);
 

--- a/packages/console/src/containers/ConsoleRoutes/index.tsx
+++ b/packages/console/src/containers/ConsoleRoutes/index.tsx
@@ -55,9 +55,7 @@ export function ConsoleRoutes() {
           <Route element={<ProtectedRoutes />}>
             <Route path={dropLeadingSlash(GlobalRoute.Profile) + '/*'} element={<Profile />} />
             <Route element={<TenantAccess />}>
-              {!isCloud && isProduction && (
-                <Route path="onboarding" element={<OssOnboarding />} />
-              )}
+              {!isCloud && isProduction && <Route path="onboarding" element={<OssOnboarding />} />}
               {isCloud && (
                 <Route
                   path={dropLeadingSlash(GlobalRoute.CheckoutSuccessCallback)}

--- a/packages/console/src/containers/ConsoleRoutes/index.tsx
+++ b/packages/console/src/containers/ConsoleRoutes/index.tsx
@@ -55,7 +55,7 @@ export function ConsoleRoutes() {
           <Route element={<ProtectedRoutes />}>
             <Route path={dropLeadingSlash(GlobalRoute.Profile) + '/*'} element={<Profile />} />
             <Route element={<TenantAccess />}>
-              {!isCloud && (isProduction || isDevFeaturesEnabled) && (
+              {!isCloud && isProduction && (
                 <Route path="onboarding" element={<OssOnboarding />} />
               )}
               {isCloud && (

--- a/packages/console/src/containers/ConsoleRoutes/index.tsx
+++ b/packages/console/src/containers/ConsoleRoutes/index.tsx
@@ -5,7 +5,7 @@ import { safeLazy } from 'react-safe-lazy';
 import { SWRConfig } from 'swr';
 
 import AppLoading from '@/components/AppLoading';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled, isProduction } from '@/consts/env';
 import AppBoundary from '@/containers/AppBoundary';
 import AppContent, { RedirectToFirstItem } from '@/containers/AppContent';
 import ConsoleContent from '@/containers/ConsoleContent';
@@ -55,7 +55,7 @@ export function ConsoleRoutes() {
           <Route element={<ProtectedRoutes />}>
             <Route path={dropLeadingSlash(GlobalRoute.Profile) + '/*'} element={<Profile />} />
             <Route element={<TenantAccess />}>
-              {!isCloud && isDevFeaturesEnabled && (
+              {!isCloud && (isProduction || isDevFeaturesEnabled) && (
                 <Route path="onboarding" element={<OssOnboarding />} />
               )}
               {isCloud && (

--- a/packages/console/src/containers/ConsoleRoutes/index.tsx
+++ b/packages/console/src/containers/ConsoleRoutes/index.tsx
@@ -55,7 +55,9 @@ export function ConsoleRoutes() {
           <Route element={<ProtectedRoutes />}>
             <Route path={dropLeadingSlash(GlobalRoute.Profile) + '/*'} element={<Profile />} />
             <Route element={<TenantAccess />}>
-              {!isCloud && isProduction && <Route path="onboarding" element={<OssOnboarding />} />}
+              {!isCloud && isProduction && isDevFeaturesEnabled && (
+                <Route path="onboarding" element={<OssOnboarding />} />
+              )}
               {isCloud && (
                 <Route
                   path={dropLeadingSlash(GlobalRoute.CheckoutSuccessCallback)}

--- a/packages/console/src/containers/OssOnboardingGuard/index.tsx
+++ b/packages/console/src/containers/OssOnboardingGuard/index.tsx
@@ -1,7 +1,7 @@
 import { useParams, Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import AppLoading from '@/components/AppLoading';
-import { isCloud, isProduction } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled, isProduction } from '@/consts/env';
 import useOssOnboardingData from '@/hooks/use-oss-onboarding-data';
 
 import { getOssOnboardingRedirectPath } from './utils';
@@ -18,6 +18,7 @@ function OssOnboardingGuard() {
   const redirectPath = tenantId
     ? getOssOnboardingRedirectPath({
         isCloud,
+        isDevFeaturesEnabled,
         isProduction,
         hasError: Boolean(error),
         isLoading,

--- a/packages/console/src/containers/OssOnboardingGuard/index.tsx
+++ b/packages/console/src/containers/OssOnboardingGuard/index.tsx
@@ -1,7 +1,7 @@
 import { useParams, Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import AppLoading from '@/components/AppLoading';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud, isProduction } from '@/consts/env';
 import useOssOnboardingData from '@/hooks/use-oss-onboarding-data';
 
 import { getOssOnboardingRedirectPath } from './utils';
@@ -18,7 +18,7 @@ function OssOnboardingGuard() {
   const redirectPath = tenantId
     ? getOssOnboardingRedirectPath({
         isCloud,
-        isDevFeaturesEnabled,
+        isProduction,
         hasError: Boolean(error),
         isLoading,
         isOnboardingDone,

--- a/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
@@ -5,7 +5,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
-        isDevFeaturesEnabled: true,
+        isProduction: true,
         hasError: false,
         isLoading: false,
         isOnboardingDone: false,
@@ -19,7 +19,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
-        isDevFeaturesEnabled: true,
+        isProduction: true,
         hasError: false,
         isLoading: false,
         isOnboardingDone: true,
@@ -31,7 +31,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
-        isDevFeaturesEnabled: true,
+        isProduction: true,
         hasError: false,
         isLoading: false,
         isOnboardingDone: false,
@@ -45,7 +45,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: true,
-        isDevFeaturesEnabled: true,
+        isProduction: true,
         hasError: false,
         isLoading: false,
         isOnboardingDone: false,
@@ -55,11 +55,11 @@ describe('OSS onboarding guard utils', () => {
     ).toBeUndefined();
   });
 
-  test('does not redirect when the OSS onboarding feature is disabled', () => {
+  test('does not redirect in non-production environments', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
-        isDevFeaturesEnabled: false,
+        isProduction: false,
         hasError: false,
         isLoading: false,
         isOnboardingDone: false,
@@ -73,7 +73,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
-        isDevFeaturesEnabled: true,
+        isProduction: true,
         hasError: true,
         isLoading: false,
         isOnboardingDone: false,

--- a/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
@@ -5,6 +5,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: false,
         isLoading: false,
@@ -19,6 +20,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: false,
         isLoading: false,
@@ -31,6 +33,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: false,
         isLoading: false,
@@ -45,6 +48,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: true,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: false,
         isLoading: false,
@@ -59,7 +63,23 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: false,
+        hasError: false,
+        isLoading: false,
+        isOnboardingDone: false,
+        tenantId: 'console',
+        pathname: '/console/get-started',
+      })
+    ).toBeUndefined();
+  });
+
+  test('does not redirect when dev features are disabled', () => {
+    expect(
+      getOssOnboardingRedirectPath({
+        isCloud: false,
+        isDevFeaturesEnabled: false,
+        isProduction: true,
         hasError: false,
         isLoading: false,
         isOnboardingDone: false,
@@ -73,6 +93,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: true,
         isLoading: false,

--- a/packages/console/src/containers/OssOnboardingGuard/utils.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.ts
@@ -1,6 +1,6 @@
 type GetOssOnboardingRedirectPathOptions = {
   isCloud: boolean;
-  isDevFeaturesEnabled: boolean;
+  isProduction: boolean;
   hasError: boolean;
   isLoading: boolean;
   isOnboardingDone: boolean;
@@ -12,7 +12,7 @@ const onboardingPath = 'onboarding';
 
 export const getOssOnboardingRedirectPath = ({
   isCloud,
-  isDevFeaturesEnabled,
+  isProduction,
   hasError,
   isLoading,
   isOnboardingDone,
@@ -21,7 +21,7 @@ export const getOssOnboardingRedirectPath = ({
 }: GetOssOnboardingRedirectPathOptions): string | undefined => {
   if (
     isCloud ||
-    !isDevFeaturesEnabled ||
+    !isProduction ||
     hasError ||
     isLoading ||
     isOnboardingDone ||

--- a/packages/console/src/containers/OssOnboardingGuard/utils.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.ts
@@ -1,5 +1,6 @@
 type GetOssOnboardingRedirectPathOptions = {
   isCloud: boolean;
+  isDevFeaturesEnabled: boolean;
   isProduction: boolean;
   hasError: boolean;
   isLoading: boolean;
@@ -12,6 +13,7 @@ const onboardingPath = 'onboarding';
 
 export const getOssOnboardingRedirectPath = ({
   isCloud,
+  isDevFeaturesEnabled,
   isProduction,
   hasError,
   isLoading,
@@ -21,6 +23,7 @@ export const getOssOnboardingRedirectPath = ({
 }: GetOssOnboardingRedirectPathOptions): string | undefined => {
   if (
     isCloud ||
+    !isDevFeaturesEnabled ||
     !isProduction ||
     hasError ||
     isLoading ||

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -84,16 +84,16 @@ describe('smoke testing for console admin account creation and sign-in', () => {
 
     const getStartedUrl = new URL('console/get-started', logtoConsoleUrl).href;
     const onboardingUrl = new URL('console/onboarding', logtoConsoleUrl).href;
-    const expectedUrl = isDevFeaturesEnabled ? onboardingUrl : getStartedUrl;
+    const expectedUrls = isDevFeaturesEnabled ? [onboardingUrl, getStartedUrl] : [getStartedUrl];
     await page.waitForFunction(
-      (expectedUrl) => window.location.href === expectedUrl,
+      (expectedUrls) => expectedUrls.includes(window.location.href),
       {},
-      expectedUrl
+      expectedUrls
     );
 
-    expect(page.url()).toBe(expectedUrl);
+    expect(expectedUrls).toContain(page.url());
 
-    if (isDevFeaturesEnabled) {
+    if (page.url() === onboardingUrl) {
       await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
       await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');
       await expect(page).toClick('div[role=radio]', { text: '50-199' });

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -82,22 +82,19 @@ describe('smoke testing for console admin account creation and sign-in', () => {
 
     await expectNavigation(expect(page).toClick('button[name=submit]'));
 
-    const expectedPathname = isDevFeaturesEnabled ? 'console/onboarding' : 'console/get-started';
-    expect(page.url()).toBe(new URL(expectedPathname, logtoConsoleUrl).href);
+    expect(page.url()).toBe(new URL('console/onboarding', logtoConsoleUrl).href);
 
-    if (isDevFeaturesEnabled) {
-      await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
-      await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');
-      await expect(page).toClick('div[role=radio]', { text: '50-199' });
-      await expect(page).toClick('button', { text: 'Next' });
-      await page.waitForFunction(
-        (expectedUrl) => window.location.href === expectedUrl,
-        {},
-        new URL('console/get-started', logtoConsoleUrl).href
-      );
+    await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
+    await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');
+    await expect(page).toClick('div[role=radio]', { text: '50-199' });
+    await expect(page).toClick('button', { text: 'Next' });
+    await page.waitForFunction(
+      (expectedUrl) => window.location.href === expectedUrl,
+      {},
+      new URL('console/get-started', logtoConsoleUrl).href
+    );
 
-      expect(page.url()).toBe(new URL('console/get-started', logtoConsoleUrl).href);
-    }
+    expect(page.url()).toBe(new URL('console/get-started', logtoConsoleUrl).href);
   });
 
   it('should have html attributes "lang=en" and "dir=ltr" by default', async () => {

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -82,7 +82,14 @@ describe('smoke testing for console admin account creation and sign-in', () => {
 
     await expectNavigation(expect(page).toClick('button[name=submit]'));
 
-    expect(page.url()).toBe(new URL('console/onboarding', logtoConsoleUrl).href);
+    const onboardingUrl = new URL('console/onboarding', logtoConsoleUrl).href;
+    await page.waitForFunction(
+      (expectedUrl) => window.location.href === expectedUrl,
+      {},
+      onboardingUrl
+    );
+
+    expect(page.url()).toBe(onboardingUrl);
 
     await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
     await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -82,26 +82,30 @@ describe('smoke testing for console admin account creation and sign-in', () => {
 
     await expectNavigation(expect(page).toClick('button[name=submit]'));
 
+    const getStartedUrl = new URL('console/get-started', logtoConsoleUrl).href;
     const onboardingUrl = new URL('console/onboarding', logtoConsoleUrl).href;
+    const expectedUrl = isDevFeaturesEnabled ? onboardingUrl : getStartedUrl;
     await page.waitForFunction(
       (expectedUrl) => window.location.href === expectedUrl,
       {},
-      onboardingUrl
+      expectedUrl
     );
 
-    expect(page.url()).toBe(onboardingUrl);
+    expect(page.url()).toBe(expectedUrl);
 
-    await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
-    await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');
-    await expect(page).toClick('div[role=radio]', { text: '50-199' });
-    await expect(page).toClick('button', { text: 'Next' });
-    await page.waitForFunction(
-      (expectedUrl) => window.location.href === expectedUrl,
-      {},
-      new URL('console/get-started', logtoConsoleUrl).href
-    );
+    if (isDevFeaturesEnabled) {
+      await expect(page).toFill('input[type=email]', 'oss-admin@example.com');
+      await expect(page).toFill('input[placeholder="Acme.co"]', 'Acme');
+      await expect(page).toClick('div[role=radio]', { text: '50-199' });
+      await expect(page).toClick('button', { text: 'Next' });
+      await page.waitForFunction(
+        (expectedUrl) => window.location.href === expectedUrl,
+        {},
+        getStartedUrl
+      );
 
-    expect(page.url()).toBe(new URL('console/get-started', logtoConsoleUrl).href);
+      expect(page.url()).toBe(getStartedUrl);
+    }
   });
 
   it('should have html attributes "lang=en" and "dir=ltr" by default', async () => {


### PR DESCRIPTION
## Summary
Make the OSS onboarding guard require onboarding only in production builds, so local `pnpm dev` sessions skip the `/console/onboarding` redirect.

Keep the onboarding route available in production OSS builds and update the console bootstrap integration expectation accordingly.

## Testing
Unit tests
Integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments