### PR TITLE
fix(account): show skeleton for mfa loading

### DIFF
--- a/packages/account/src/pages/Security/MfaSection/MfaSkeleton.tsx
+++ b/packages/account/src/pages/Security/MfaSection/MfaSkeleton.tsx
@@ -1,0 +1,50 @@
+import classNames from 'classnames';
+
+import { layoutClassNames } from '@ac/constants/layout';
+
+import styles from './index.module.scss';
+
+type Props = {
+  readonly hasToggle: boolean;
+  readonly rows: ReadonlyArray<{
+    readonly key: string;
+    readonly action?: unknown;
+  }>;
+};
+
+const MfaSkeleton = ({ hasToggle, rows }: Props) => (
+  <>
+    {hasToggle && (
+      <div className={styles.toggleRow}>
+        <div className={styles.toggleInfo}>
+          <div className={classNames(styles.skeletonBlock, styles.skeletonToggleTitle)} />
+          <div className={classNames(styles.skeletonBlock, styles.skeletonToggleDescription)} />
+        </div>
+        <div className={classNames(styles.skeletonBlock, styles.skeletonSwitch)} />
+      </div>
+    )}
+    {hasToggle && rows.length > 0 && <div className={styles.divider} />}
+    {rows.map(({ key, action }) => (
+      <div key={key} className={classNames(styles.row, layoutClassNames.row)}>
+        <div className={styles.topLine}>
+          <div className={styles.iconWrap}>
+            <div className={classNames(styles.skeletonBlock, styles.skeletonIcon)} />
+          </div>
+          {Boolean(action) && (
+            <div className={styles.actions}>
+              <div className={classNames(styles.skeletonBlock, styles.skeletonAction)} />
+            </div>
+          )}
+        </div>
+        <div className={styles.skeletonTitleWrap}>
+          <div className={classNames(styles.skeletonBlock, styles.skeletonTitle)} />
+        </div>
+        <div className={styles.value}>
+          <div className={classNames(styles.skeletonBlock, styles.skeletonValue)} />
+        </div>
+      </div>
+    ))}
+  </>
+);
+
+export default MfaSkeleton;

--- a/packages/account/src/pages/Security/MfaSection/index.module.scss
+++ b/packages/account/src/pages/Security/MfaSection/index.module.scss
@@ -1,5 +1,28 @@
 @use '@experience/shared/scss/underscore' as _;
 
+@mixin skeleton-block($radius: 8px) {
+  position: relative;
+  overflow: hidden;
+  border-radius: $radius;
+  background: var(--color-bg-state-disabled);
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    transform: translateX(-100%);
+    background-image:
+      linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0%),
+        rgba(255, 255, 255, 20%),
+        rgba(255, 255, 255, 45%),
+        rgba(255, 255, 255, 0%)
+      );
+    animation: shimmer 2s infinite;
+  }
+}
+
 .section {
   display: flex;
   flex-direction: column;
@@ -154,27 +177,67 @@
   background: var(--color-line-divider);
 }
 
-.loadingMask {
-  min-height: 152px;
+.skeletonContent {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-type-primary);
+  flex-direction: column;
 }
 
-.loadingIcon {
+.skeletonBlock {
+  @include skeleton-block;
+}
+
+.skeletonIcon {
   width: 20px;
   height: 20px;
-  animation: rotating 1s steps(12, end) infinite;
+  border-radius: 50%;
 }
 
-@keyframes rotating {
-  from {
-    transform: rotate(0deg);
-  }
+.skeletonTitleWrap {
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+  padding-left: calc(20px + #{_.unit(4)});
+}
 
-  to {
-    transform: rotate(360deg);
+.skeletonTitle {
+  width: 120px;
+  max-width: 100%;
+  height: 16px;
+}
+
+.skeletonValue {
+  width: 160px;
+  max-width: 70%;
+  height: 24px;
+}
+
+.skeletonAction {
+  width: 56px;
+  height: 16px;
+}
+
+.skeletonToggleTitle {
+  width: 200px;
+  max-width: 60%;
+  height: 16px;
+}
+
+.skeletonToggleDescription {
+  width: 360px;
+  max-width: 100%;
+  height: 14px;
+}
+
+.skeletonSwitch {
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
+  border-radius: 12px;
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
   }
 }
 
@@ -239,13 +302,28 @@
     justify-content: flex-end;
   }
 
-  .loadingMask {
-    min-height: 96px;
-  }
-
   .actionButton {
     padding: 0;
     white-space: normal;
     text-align: left;
+  }
+
+  .skeletonTitleWrap {
+    padding-left: 0;
+    width: 100%;
+  }
+
+  .skeletonTitle {
+    width: 140px;
+  }
+
+  .skeletonValue {
+    width: 180px;
+    max-width: 100%;
+  }
+
+  .skeletonToggleTitle,
+  .skeletonToggleDescription {
+    max-width: 100%;
   }
 }

--- a/packages/account/src/pages/Security/MfaSection/index.tsx
+++ b/packages/account/src/pages/Security/MfaSection/index.tsx
@@ -10,7 +10,6 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
-import LoadingIcon from '@ac/assets/icons/loading-icon.svg?react';
 import ConfirmModal from '@ac/components/ConfirmModal';
 import ToggleSwitch from '@ac/components/ToggleSwitch';
 import { layoutClassNames } from '@ac/constants/layout';
@@ -23,6 +22,7 @@ import { getMfaSettings, getMfaVerifications, updateMfaSettings } from '../../..
 import useApi from '../../../hooks/use-api';
 import useErrorHandler from '../../../hooks/use-error-handler';
 
+import MfaSkeleton from './MfaSkeleton';
 import styles from './index.module.scss';
 import useMfaRows from './use-mfa-rows';
 
@@ -95,13 +95,13 @@ const MfaContent = ({
   if (isLoading) {
     return (
       <div
-        className={styles.loadingMask}
+        className={styles.skeletonContent}
         role="status"
         aria-live="polite"
         aria-busy="true"
         aria-label={t('account_center.security.two_step_verification')}
       >
-        <LoadingIcon className={styles.loadingIcon} aria-hidden="true" focusable="false" />
+        <MfaSkeleton hasToggle={hasToggle} rows={rows} />
       </div>
     );
   }
@@ -214,6 +214,7 @@ const MfaSection = () => {
   );
 
   const rows = useMfaRows(mfaVerifications, navigateTo);
+  const shouldShowMfaCard = showToggle || rows.length > 0;
 
   const updateSkipMfaOnSignIn = useCallback(
     async (verifiedId: string, skipMfaOnSignIn: boolean) => {
@@ -281,7 +282,7 @@ const MfaSection = () => {
     void updateSkipMfaOnSignIn(verificationId, pendingAction === 'disable-mfa');
   }, [updateSkipMfaOnSignIn, verificationId]);
 
-  if (!isMfaSectionLoading && rows.length === 0 && !showToggle) {
+  if (!shouldShowMfaCard) {
     return null;
   }
 
@@ -297,17 +298,15 @@ const MfaSection = () => {
             className={styles.notification}
           />
         )}
-        {(isMfaSectionLoading || showToggle || rows.length > 0) && (
-          <div className={classNames(styles.card, layoutClassNames.card)}>
-            <MfaContent
-              isLoading={isMfaSectionLoading}
-              hasToggle={showToggle}
-              isTwoStepEnabled={isTwoStepEnabled}
-              rows={rows}
-              onToggleChange={handleToggleChange}
-            />
-          </div>
-        )}
+        <div className={classNames(styles.card, layoutClassNames.card)}>
+          <MfaContent
+            isLoading={isMfaSectionLoading}
+            hasToggle={showToggle}
+            isTwoStepEnabled={isTwoStepEnabled}
+            rows={rows}
+            onToggleChange={handleToggleChange}
+          />
+        </div>
       </div>
       <ConfirmModal
         isOpen={isConfirmModalOpen}


### PR DESCRIPTION
## Summary
Replace the 2-step verification loading spinner with a skeleton that matches the resolved MFA card layout. The skeleton renders only after account security configuration has determined which MFA rows and toggle should be shown.

## Testing
Tested locally

<img width="899" height="650" alt="Screenshot 2026-05-08 at 4 01 47 PM" src="https://github.com/user-attachments/assets/8b7572c2-fe03-477d-ad88-458e3ad74fbf" />


## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments