### PR TITLE
feat(core,schemas): add custom CSP config column to sign-in-exp table

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.test.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.test.ts
@@ -50,6 +50,7 @@ const mockSignInExperience: SignInExperience = {
   customContent: {},
   agreeToTermsPolicy: AgreeToTermsPolicy.Automatic,
   customUiAssets: null,
+  customUiCsp: {},
   passwordPolicy: {},
   mfa: {
     policy: MfaPolicy.Mandatory,

--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -94,6 +94,7 @@ export const mockSignInExperience: SignInExperience = {
   customContent: {},
   agreeToTermsPolicy: AgreeToTermsPolicy.Automatic,
   customUiAssets: null,
+  customUiCsp: {},
   passwordPolicy: {},
   mfa: {
     policy: MfaPolicy.PromptAtSignInAndSignUp,

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -33,6 +33,7 @@ describe('sign-in-experience query', () => {
     socialSignInConnectorTargets: JSON.stringify(mockSignInExperience.socialSignInConnectorTargets),
     customContent: JSON.stringify(mockSignInExperience.customContent),
     customUiAssets: JSON.stringify(mockSignInExperience.customUiAssets),
+    customUiCsp: JSON.stringify(mockSignInExperience.customUiCsp),
     passwordPolicy: JSON.stringify(mockSignInExperience.passwordPolicy),
     mfa: JSON.stringify(mockSignInExperience.mfa),
     adaptiveMfa: JSON.stringify(mockSignInExperience.adaptiveMfa),
@@ -48,7 +49,7 @@ describe('sign-in-experience query', () => {
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "tenant_id", "id", "color", "branding", "hide_logto_branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "password_policy", "mfa", "adaptive_mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy", "email_blocklist_policy", "forgot_password_methods", "passkey_sign_in", "sign_up_profile_fields"
+      select "tenant_id", "id", "color", "branding", "hide_logto_branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "custom_ui_csp", "password_policy", "mfa", "adaptive_mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy", "email_blocklist_policy", "forgot_password_methods", "passkey_sign_in", "sign_up_profile_fields"
       from "sign_in_experiences"
       where "id"=$1
     `;

--- a/packages/experience/src/__mocks__/logto.tsx
+++ b/packages/experience/src/__mocks__/logto.tsx
@@ -107,6 +107,7 @@ export const mockSignInExperience: SignInExperience = {
   customContent: {},
   agreeToTermsPolicy: AgreeToTermsPolicy.ManualRegistrationOnly,
   customUiAssets: null,
+  customUiCsp: {},
   passwordPolicy: {},
   mfa: {
     policy: MfaPolicy.PromptAtSignInAndSignUp,
@@ -153,6 +154,7 @@ export const mockSignInExperienceSettings: SignInExperienceResponse = {
   customContent: {},
   agreeToTermsPolicy: mockSignInExperience.agreeToTermsPolicy,
   customUiAssets: null,
+  customUiCsp: {},
   passwordPolicy: {},
   mfa: {
     policy: MfaPolicy.PromptAtSignInAndSignUp,

--- a/packages/schemas/alterations/next-1778318116-add-custom-ui-csp-to-sie.ts
+++ b/packages/schemas/alterations/next-1778318116-add-custom-ui-csp-to-sie.ts
@@ -1,0 +1,20 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        add column custom_ui_csp jsonb not null default '{}'::jsonb;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        drop column custom_ui_csp;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.test.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { customUiCspGuard } from './sign-in-experience.js';
+
+describe('customUiCspGuard', () => {
+  it.each([
+    {},
+    { scriptSrc: ['https://example.com'] },
+    { connectSrc: ['https://api.example.com'] },
+    {
+      scriptSrc: ['https://example.com'],
+      connectSrc: ['https://api.example.com'],
+    },
+  ])('accepts %p', (value) => {
+    expect(customUiCspGuard.safeParse(value).success).toBe(true);
+  });
+
+  it('rejects unsupported directives', () => {
+    expect(customUiCspGuard.safeParse({ imgSrc: ['https://example.com'] }).success).toBe(false);
+  });
+});

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
@@ -273,6 +273,18 @@ export const customUiAssetsGuard = z.object({
 
 export type CustomUiAssets = z.infer<typeof customUiAssetsGuard>;
 
+export type CustomUiCsp = {
+  scriptSrc?: string[];
+  connectSrc?: string[];
+};
+
+export const customUiCspGuard = z
+  .object({
+    scriptSrc: z.string().array().optional(),
+    connectSrc: z.string().array().optional(),
+  })
+  .strict() satisfies ToZodObject<CustomUiCsp>;
+
 export const captchaPolicyGuard = z.object({
   enabled: z.boolean().optional(),
 });

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -21,6 +21,7 @@ create table sign_in_experiences (
   custom_css text,
   custom_content jsonb /* @use CustomContent */ not null default '{}'::jsonb,
   custom_ui_assets jsonb /* @use CustomUiAssets */,
+  custom_ui_csp jsonb /* @use CustomUiCsp */ not null default '{}'::jsonb,
   password_policy jsonb /* @use PartialPasswordPolicy */ not null default '{}'::jsonb,
   mfa jsonb /* @use Mfa */ not null default '{}'::jsonb,
   adaptive_mfa jsonb /* @use AdaptiveMfa */ not null default '{}'::jsonb,


### PR DESCRIPTION
## Summary
Add tenant-level storage for Custom UI CSP source allowlists in the default sign-in experience row.

- Add `custom_ui_csp` JSONB column with `{}` default to `sign_in_experiences`.
- Add `CustomUiCsp` schema guard for the first supported directives: `scriptSrc` and `connectSrc`.
- Add a database alteration script with up/down migration.
- Update typed Sign-in Experience mocks and query expectations for the new field.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
