### PR TITLE
feat(core): support custom UI CSP updates in sign-in-exp API

### DIFF
--- a/packages/core/src/routes/sign-in-experience/custom-ui-csp.test.ts
+++ b/packages/core/src/routes/sign-in-experience/custom-ui-csp.test.ts
@@ -1,0 +1,72 @@
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+
+import { hasCustomUiCspSources, normalizeCustomUiCsp } from './custom-ui-csp.js';
+
+const originalIsProduction = EnvSet.values.isProduction;
+
+describe('normalizeCustomUiCsp()', () => {
+  afterEach(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after production-gate tests.
+    (EnvSet.values as { isProduction: boolean }).isProduction = originalIsProduction;
+  });
+
+  it('should normalize, deduplicate, and drop empty directive arrays', () => {
+    expect(
+      normalizeCustomUiCsp({
+        scriptSrc: [' https://EXAMPLE.com ', 'https://example.com', 'https://*.example.com/path/'],
+        connectSrc: [],
+      })
+    ).toEqual({
+      scriptSrc: ['https://example.com', 'https://*.example.com/path/'],
+    });
+  });
+
+  it('should allow wss only for connectSrc', () => {
+    expect(
+      normalizeCustomUiCsp({
+        connectSrc: ['wss://events.example.com'],
+      })
+    ).toEqual({
+      connectSrc: ['wss://events.example.com'],
+    });
+
+    expect(() => normalizeCustomUiCsp({ scriptSrc: ['wss://events.example.com'] })).toThrow(
+      RequestError
+    );
+  });
+
+  it('should allow localhost HTTP sources only outside production', () => {
+    expect(normalizeCustomUiCsp({ scriptSrc: ['http://localhost:3000'] })).toEqual({
+      scriptSrc: ['http://localhost:3000'],
+    });
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for production validation.
+    (EnvSet.values as { isProduction: boolean }).isProduction = true;
+
+    expect(() => normalizeCustomUiCsp({ scriptSrc: ['http://localhost:3000'] })).toThrow(
+      RequestError
+    );
+  });
+
+  it.each([
+    { title: 'empty source', customUiCsp: { scriptSrc: [' '] } },
+    { title: 'semicolon', customUiCsp: { scriptSrc: ['https://example.com; report-uri /csp'] } },
+    { title: 'CSP keyword', customUiCsp: { scriptSrc: ["'unsafe-inline'"] } },
+    { title: 'URL credentials', customUiCsp: { scriptSrc: ['https://user@example.com'] } },
+    { title: 'URL query', customUiCsp: { scriptSrc: ['https://example.com?foo=bar'] } },
+    { title: 'malformed wildcard host', customUiCsp: { connectSrc: ['https://*.*.example.com'] } },
+    { title: 'single-label host', customUiCsp: { connectSrc: ['https://example'] } },
+  ])('should reject invalid sources: $title', ({ customUiCsp }) => {
+    expect(() => normalizeCustomUiCsp(customUiCsp)).toThrow(RequestError);
+  });
+});
+
+describe('hasCustomUiCspSources()', () => {
+  it('should return whether any supported directive has configured sources', () => {
+    expect(hasCustomUiCspSources()).toBe(false);
+    expect(hasCustomUiCspSources({})).toBe(false);
+    expect(hasCustomUiCspSources({ scriptSrc: [] })).toBe(false);
+    expect(hasCustomUiCspSources({ connectSrc: ['https://example.com'] })).toBe(true);
+  });
+});

--- a/packages/core/src/routes/sign-in-experience/custom-ui-csp.ts
+++ b/packages/core/src/routes/sign-in-experience/custom-ui-csp.ts
@@ -1,0 +1,130 @@
+import { type CustomUiCsp } from '@logto/schemas';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+
+const customUiCspDirectives = Object.freeze(['scriptSrc', 'connectSrc'] as const);
+
+type CustomUiCspDirective = (typeof customUiCspDirectives)[number];
+
+const validHostLabelRegEx = /^[\da-z](?:[\da-z-]{0,61}[\da-z])?$/;
+
+const createInvalidSourceError = (
+  directive: CustomUiCspDirective,
+  source: string,
+  reason: string
+) =>
+  new RequestError(
+    {
+      code: 'request.invalid_input',
+      details: `Invalid customUiCsp.${directive} source "${source}": ${reason}`,
+    },
+    { directive, source, reason }
+  );
+
+const isValidHostLabel = (label: string) => validHostLabelRegEx.test(label);
+
+const validateHostname = (directive: CustomUiCspDirective, source: string, hostname: string) => {
+  if (hostname === 'localhost') {
+    return;
+  }
+
+  const labels = hostname.split('.');
+  const wildcardCount = labels.filter((label) => label === '*').length;
+
+  if (wildcardCount > 0) {
+    if (labels[0] !== '*' || wildcardCount !== 1 || labels.length < 3) {
+      throw createInvalidSourceError(directive, source, 'Malformed wildcard host');
+    }
+
+    for (const label of labels.slice(1)) {
+      if (!isValidHostLabel(label)) {
+        throw createInvalidSourceError(directive, source, 'Malformed wildcard host');
+      }
+    }
+
+    return;
+  }
+
+  if (labels.length < 2 || labels.some((label) => !isValidHostLabel(label))) {
+    throw createInvalidSourceError(directive, source, 'Malformed host');
+  }
+};
+
+const validateScheme = (directive: CustomUiCspDirective, source: string, url: URL) => {
+  const isLocalhostHttpSource =
+    !EnvSet.values.isProduction &&
+    url.protocol === 'http:' &&
+    url.hostname === 'localhost' &&
+    url.port;
+
+  if (isLocalhostHttpSource) {
+    return;
+  }
+
+  const allowedSchemes = directive === 'connectSrc' ? ['https:', 'wss:'] : ['https:'];
+
+  if (!allowedSchemes.includes(url.protocol)) {
+    throw createInvalidSourceError(directive, source, 'Unsupported scheme');
+  }
+};
+
+const normalizeSourceExpression = (directive: CustomUiCspDirective, rawSource: string) => {
+  const source = rawSource.trim();
+
+  if (!source) {
+    throw createInvalidSourceError(directive, rawSource, 'Empty source');
+  }
+
+  if (source.includes(';')) {
+    throw createInvalidSourceError(directive, rawSource, 'Semicolons are not allowed');
+  }
+
+  if (source.includes("'")) {
+    throw createInvalidSourceError(directive, rawSource, 'CSP keywords are not supported');
+  }
+
+  try {
+    const url = new URL(source);
+
+    if (url.username || url.password || url.search || url.hash) {
+      throw createInvalidSourceError(
+        directive,
+        rawSource,
+        'Credentials, query strings, and fragments are not allowed'
+      );
+    }
+
+    validateScheme(directive, rawSource, url);
+    validateHostname(directive, rawSource, url.hostname);
+
+    return `${url.protocol}//${url.host}${url.pathname === '/' ? '' : url.pathname}`;
+  } catch (error: unknown) {
+    if (error instanceof RequestError) {
+      throw error;
+    }
+
+    throw createInvalidSourceError(directive, rawSource, 'Malformed URL');
+  }
+};
+
+export const normalizeCustomUiCsp = (customUiCsp: CustomUiCsp): CustomUiCsp =>
+  customUiCspDirectives.reduce<CustomUiCsp>((normalizedCustomUiCsp, directive) => {
+    const sources = customUiCsp[directive];
+
+    if (!sources?.length) {
+      return normalizedCustomUiCsp;
+    }
+
+    const normalizedSources = [
+      ...new Set(sources.map((source) => normalizeSourceExpression(directive, source))),
+    ];
+
+    return {
+      ...normalizedCustomUiCsp,
+      [directive]: normalizedSources,
+    };
+  }, {});
+
+export const hasCustomUiCspSources = (customUiCsp?: CustomUiCsp): boolean =>
+  Boolean(customUiCsp && customUiCspDirectives.some((directive) => customUiCsp[directive]?.length));

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -24,6 +24,7 @@ import {
   mockPrivacyPolicyUrl,
   mockDemoSocialConnector,
 } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
@@ -86,6 +87,9 @@ const signInExperienceRequester = createRequester({
   authedRoutes: signInExperiencesRoutes,
   tenantContext,
 });
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+const originalIsCloud = EnvSet.values.isCloud;
+const originalIsProduction = EnvSet.values.isProduction;
 
 const createDevFeaturesDisabledRequester = async () => {
   jest.resetModules();
@@ -165,6 +169,52 @@ const createSignUpProfileFieldsRequester = (
   });
 
   return { requester, updateDefaultSignInExperience, normalizeProfileFields };
+};
+
+const createCustomUiCspRequester = async ({
+  isDevFeaturesEnabled = true,
+  isCloud = true,
+  isProduction = false,
+} = {}) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet in this route test without reloading mocked modules.
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet in this route test without reloading mocked modules.
+  (EnvSet.values as { isCloud: boolean }).isCloud = isCloud;
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet in this route test without reloading mocked modules.
+  (EnvSet.values as { isProduction: boolean }).isProduction = isProduction;
+
+  const updateDefaultSignInExperience = jest.fn(
+    async (data: Partial<CreateSignInExperience>): Promise<SignInExperience> => ({
+      ...mockSignInExperience,
+      ...data,
+    })
+  );
+  const guardTenantUsageByKey = jest.fn(async () => {
+    await Promise.resolve();
+  });
+  const reportSubscriptionUpdatesUsage = jest.fn(async () => {
+    await Promise.resolve();
+  });
+  const requester = createRequester({
+    authedRoutes: signInExperiencesRoutes,
+    tenantContext: new MockTenant(
+      undefined,
+      {
+        signInExperiences: {
+          updateDefaultSignInExperience,
+          findDefaultSignInExperience: jest.fn().mockResolvedValue(mockSignInExperience),
+        },
+        customPhrases: { findAllCustomLanguageTags: async () => [] },
+      },
+      { getLogtoConnectors: jest.fn().mockResolvedValue([]) },
+      {
+        signInExperiences: { validateLanguageInfo: jest.fn() },
+        quota: { guardTenantUsageByKey, reportSubscriptionUpdatesUsage },
+      }
+    ),
+  });
+
+  return { requester, updateDefaultSignInExperience, guardTenantUsageByKey };
 };
 
 describe('GET /sign-in-exp', () => {
@@ -577,6 +627,155 @@ describe('PATCH /sign-in-exp signUpProfileFields', () => {
 
     expect(response.status).toEqual(200);
     expect(updateDefaultSignInExperience).toHaveBeenCalledWith({ signUpProfileFields: null });
+  });
+});
+
+describe('PATCH /sign-in-exp customUiCsp', () => {
+  afterEach(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+      originalIsDevFeaturesEnabled;
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
+    (EnvSet.values as { isCloud: boolean }).isCloud = originalIsCloud;
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
+    (EnvSet.values as { isProduction: boolean }).isProduction = originalIsProduction;
+  });
+
+  it('should normalize and persist valid Custom UI CSP config', async () => {
+    const { requester, updateDefaultSignInExperience, guardTenantUsageByKey } =
+      await createCustomUiCspRequester();
+
+    const response = await requester.patch('/sign-in-exp').send({
+      customUiCsp: {
+        scriptSrc: [' https://EXAMPLE.com ', 'https://example.com', 'https://*.example.com/path/'],
+        connectSrc: ['wss://api.example.com', 'https://api.example.com'],
+      },
+    });
+
+    const customUiCsp = {
+      scriptSrc: ['https://example.com', 'https://*.example.com/path/'],
+      connectSrc: ['wss://api.example.com', 'https://api.example.com'],
+    };
+
+    expect(response.status).toEqual(200);
+    expect(updateDefaultSignInExperience).toHaveBeenCalledWith({ customUiCsp });
+    expect(response.body).toMatchObject({ customUiCsp });
+    expect(guardTenantUsageByKey).toHaveBeenCalledWith('bringYourUiEnabled');
+  });
+
+  it('should guard Bring Your Own UI quota once when updating branding and Custom UI CSP', async () => {
+    const { requester, guardTenantUsageByKey } = await createCustomUiCspRequester();
+
+    const response = await requester.patch('/sign-in-exp').send({
+      hideLogtoBranding: true,
+      customUiCsp: {
+        scriptSrc: ['https://example.com'],
+      },
+    });
+
+    expect(response.status).toEqual(200);
+    expect(guardTenantUsageByKey).toHaveBeenCalledTimes(1);
+    expect(guardTenantUsageByKey).toHaveBeenCalledWith('bringYourUiEnabled');
+  });
+
+  it.each([
+    {
+      customUiCsp: { scriptSrc: ["'unsafe-inline'"] },
+      title: 'CSP keyword',
+    },
+    {
+      customUiCsp: { scriptSrc: ['https://example.com; report-uri https://evil.test'] },
+      title: 'semicolon',
+    },
+    {
+      customUiCsp: { scriptSrc: ['http://example.com'] },
+      title: 'unsupported scheme',
+    },
+    {
+      customUiCsp: { connectSrc: ['https://*.*.example.com'] },
+      title: 'malformed wildcard host',
+    },
+    {
+      customUiCsp: { imgSrc: ['https://example.com'] },
+      title: 'unsupported directive',
+    },
+  ])('should reject invalid Custom UI CSP config: $title', async ({ customUiCsp }) => {
+    const { requester, updateDefaultSignInExperience, guardTenantUsageByKey } =
+      await createCustomUiCspRequester();
+
+    const response = await requester.patch('/sign-in-exp').send({ customUiCsp });
+
+    expect(response.status).toEqual(400);
+    expect(updateDefaultSignInExperience).not.toHaveBeenCalled();
+    expect(guardTenantUsageByKey).not.toHaveBeenCalled();
+  });
+
+  it('should reject non-empty Custom UI CSP updates when dev features are disabled', async () => {
+    const { requester, updateDefaultSignInExperience, guardTenantUsageByKey } =
+      await createCustomUiCspRequester({ isDevFeaturesEnabled: false });
+
+    const response = await requester.patch('/sign-in-exp').send({
+      customUiCsp: {
+        scriptSrc: ['https://example.com'],
+      },
+    });
+
+    expect(response.status).toEqual(400);
+    expect(updateDefaultSignInExperience).not.toHaveBeenCalled();
+    expect(guardTenantUsageByKey).not.toHaveBeenCalled();
+  });
+
+  it('should reject non-empty Custom UI CSP updates outside Cloud', async () => {
+    const { requester, updateDefaultSignInExperience, guardTenantUsageByKey } =
+      await createCustomUiCspRequester({ isCloud: false });
+
+    const response = await requester.patch('/sign-in-exp').send({
+      customUiCsp: {
+        scriptSrc: ['https://example.com'],
+      },
+    });
+
+    expect(response.status).toEqual(400);
+    expect(updateDefaultSignInExperience).not.toHaveBeenCalled();
+    expect(guardTenantUsageByKey).not.toHaveBeenCalled();
+  });
+
+  it('should allow clearing Custom UI CSP config without checking quota', async () => {
+    const { requester, updateDefaultSignInExperience, guardTenantUsageByKey } =
+      await createCustomUiCspRequester({ isDevFeaturesEnabled: false });
+
+    const response = await requester.patch('/sign-in-exp').send({
+      customUiCsp: {
+        scriptSrc: [],
+        connectSrc: [],
+      },
+    });
+
+    expect(response.status).toEqual(200);
+    expect(updateDefaultSignInExperience).toHaveBeenCalledWith({ customUiCsp: {} });
+    expect(guardTenantUsageByKey).not.toHaveBeenCalled();
+  });
+
+  it('should allow localhost HTTP source only outside production', async () => {
+    const { requester } = await createCustomUiCspRequester();
+
+    await expect(
+      requester.patch('/sign-in-exp').send({
+        customUiCsp: {
+          scriptSrc: ['http://localhost:3000'],
+        },
+      })
+    ).resolves.toMatchObject({ status: 200 });
+
+    const productionRequester = await createCustomUiCspRequester({ isProduction: true });
+
+    await expect(
+      productionRequester.requester.patch('/sign-in-exp').send({
+        customUiCsp: {
+          scriptSrc: ['http://localhost:3000'],
+        },
+      })
+    ).resolves.toMatchObject({ status: 400 });
   });
 });
 /* eslint-enable max-lines */

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- This route module already hosts several Sign-in Experience endpoints; keep this API change colocated with the existing update flow. */
 import { DemoConnector } from '@logto/connector-kit';
 import { PasswordPolicyChecker } from '@logto/core-kit';
 import {
@@ -28,6 +29,7 @@ import { captureEvent } from '../../utils/posthog.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
 import customUiAssetsRoutes from './custom-ui-assets/index.js';
+import { hasCustomUiCspSources, normalizeCustomUiCsp } from './custom-ui-csp.js';
 
 const isMfaEnabled = (mfa: Optional<SignInExperience['mfa']>): boolean =>
   Boolean(mfa?.factors && mfa.factors.length > 0);
@@ -101,7 +103,13 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
     async (ctx, next) => {
       const {
         query: { removeUnusedDemoSocialConnector },
-        body: { socialSignInConnectorTargets, emailBlocklistPolicy, signUpProfileFields, ...rest },
+        body: {
+          socialSignInConnectorTargets,
+          emailBlocklistPolicy,
+          signUpProfileFields,
+          customUiCsp,
+          ...rest
+        },
       } = ctx.guard;
       const {
         languageInfo,
@@ -117,6 +125,8 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
       } = rest;
 
       const normalizedSignUpProfileFields = await normalizeProfileFields(signUpProfileFields);
+      const normalizedCustomUiCsp = conditional(customUiCsp && normalizeCustomUiCsp(customUiCsp));
+      const hasCustomUiCsp = hasCustomUiCspSources(normalizedCustomUiCsp);
 
       if (languageInfo) {
         await validateLanguageInfo(languageInfo);
@@ -261,6 +271,17 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
             details: 'Hide Logto branding is not supported in this environment',
           })
         );
+      }
+      if (hasCustomUiCsp) {
+        assertThat(
+          EnvSet.values.isCloud && EnvSet.values.isDevFeaturesEnabled,
+          new RequestError({
+            code: 'request.invalid_input',
+            details: 'Custom UI CSP configuration is not available',
+          })
+        );
+      }
+      if (hideLogtoBranding === true || hasCustomUiCsp) {
         await quota.guardTenantUsageByKey('bringYourUiEnabled');
       }
       if (passkeySignIn?.enabled) {
@@ -283,6 +304,11 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         ...conditional(
           normalizedSignUpProfileFields !== undefined && {
             signUpProfileFields: normalizedSignUpProfileFields,
+          }
+        ),
+        ...conditional(
+          normalizedCustomUiCsp !== undefined && {
+            customUiCsp: normalizedCustomUiCsp,
           }
         ),
       };
@@ -354,3 +380,4 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
 
   customUiAssetsRoutes(...args);
 }
+/* eslint-enable max-lines */


### PR DESCRIPTION
## Summary
Support updating `customUiCsp` through `PATCH /api/sign-in-exp` for Cloud-only Custom UI usage.

- Validate and normalize `scriptSrc` and `connectSrc` source expressions before persisting.
- Reject unsupported directives, unsafe CSP keywords, unsupported schemes, semicolons, and malformed wildcard hosts.
- Gate non-empty updates behind Cloud + dev features and check the `bringYourUiEnabled` quota.
- Allow clearing the config without quota checks.
- Document `customUiCsp` in the sign-in experience OpenAPI supplement.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
