### PR TITLE
feat(core): apply custom UI CSP to experience security headers

### DIFF
--- a/packages/core/src/middleware/koa-security-headers.test.ts
+++ b/packages/core/src/middleware/koa-security-headers.test.ts
@@ -3,32 +3,65 @@ import { createMockUtils } from '@logto/shared/esm';
 import { noop } from '@silverhand/essentials';
 import type Koa from 'koa';
 
+import type Queries from '#src/tenants/Queries.js';
 import createMockContext from '#src/test-utils/jest-koa-mocks/create-mock-context.js';
 
 const { jest } = import.meta;
 const { mockEsmWithActual } = createMockUtils(jest);
 
+const getIsDevFeaturesEnabled = jest.fn(() => false);
+
 await mockEsmWithActual('#src/env-set/index.js', () => ({
   EnvSet: {
     get values() {
-      return new GlobalValues();
+      return { ...new GlobalValues(), isDevFeaturesEnabled: getIsDevFeaturesEnabled() };
     },
   },
   AdminApps: { Console: 'console', Welcome: 'welcome' },
-  UserApps: { AccountCenter: 'account-center' },
+  UserApps: { AccountCenter: 'account' },
   getTenantEndpoint: () => new URL('https://tenant.example.com'),
 }));
 
-const { default: koaSecurityHeaders } = await import('./koa-security-headers.js');
+const { default: koaSecurityHeaders, koaExperienceSecurityHeaders } = await import(
+  './koa-security-headers.js'
+);
 
 const koaNoop = noop as unknown as Koa.Next;
+const customScriptSource = 'https://scripts.example.com';
+const customConnectSource = 'https://api.example.com';
+const customUiAssets = Object.freeze({ id: 'custom_ui_assets_id', createdAt: 1 });
+
+type CustomUiSettings = {
+  readonly customUiAssets?: { readonly id: string; readonly createdAt: number };
+  readonly customUiCsp?: Record<string, string[]>;
+};
+
+const createQueries = ({ customUiAssets, customUiCsp = {} }: CustomUiSettings = {}) =>
+  ({
+    signInExperiences: {
+      findDefaultSignInExperience: jest.fn(async () => ({
+        customUiAssets: customUiAssets ?? null,
+        customUiCsp,
+      })),
+    },
+  }) as unknown as Queries;
 
 const getCsp = (ctx: Koa.Context): string => {
   const value = ctx.res.getHeader('Content-Security-Policy');
   return typeof value === 'string' ? value : '';
 };
 
+const getCspDirective = (ctx: Koa.Context, directiveName: string): string | undefined =>
+  getCsp(ctx)
+    .split(';')
+    .map((directive) => directive.trim())
+    .find((directive) => directive.startsWith(`${directiveName} `));
+
 describe('koaSecurityHeaders() middleware — experience CSP', () => {
+  beforeEach(() => {
+    getIsDevFeaturesEnabled.mockReturnValue(false);
+  });
+
   it('includes the hardcoded custom tenant allowlist (e.g. LaunchDarkly) in connect-src', async () => {
     const run = koaSecurityHeaders([], 'default');
     // Any path that isn't an admin app / user app / mounted app falls through
@@ -37,22 +70,123 @@ describe('koaSecurityHeaders() middleware — experience CSP', () => {
 
     await run(ctx, koaNoop);
 
-    const csp = getCsp(ctx);
-    const connectSource = csp
-      .split(';')
-      .map((directive) => directive.trim())
-      .find((directive) => directive.startsWith('connect-src '));
+    const connectSource = getCspDirective(ctx, 'connect-src');
 
     expect(connectSource).toBeDefined();
     expect(connectSource).toContain('https://*.launchdarkly.com');
   });
 
-  it('does not leak the custom allowlist into the admin console CSP', async () => {
+  it('skips the hardcoded LaunchDarkly allowlist when dev features are enabled', async () => {
+    getIsDevFeaturesEnabled.mockReturnValue(true);
     const run = koaSecurityHeaders([], 'default');
-    const ctx = createMockContext({ method: 'GET', url: '/console' });
+    const ctx = createMockContext({ method: 'GET', url: '/sign-in' });
 
     await run(ctx, koaNoop);
 
-    expect(getCsp(ctx)).not.toContain('launchdarkly');
+    expect(getCspDirective(ctx, 'connect-src')).not.toContain('https://*.launchdarkly.com');
+  });
+
+  it('adds Custom UI CSP sources to the matching experience directives', async () => {
+    const run = koaExperienceSecurityHeaders(
+      'default',
+      createQueries({
+        customUiAssets,
+        customUiCsp: {
+          scriptSrc: [customScriptSource],
+          connectSrc: [customConnectSource],
+        },
+      })
+    );
+    const ctx = createMockContext({ method: 'GET', url: '/sign-in' });
+
+    await run(ctx, koaNoop);
+
+    const scriptSource = getCspDirective(ctx, 'script-src');
+    const connectSource = getCspDirective(ctx, 'connect-src');
+
+    expect(scriptSource).toContain("'self'");
+    expect(scriptSource).toContain(customScriptSource);
+    expect(scriptSource).not.toContain(customConnectSource);
+    expect(connectSource).toContain('https://tenant.example.com');
+    expect(connectSource).toContain(customConnectSource);
+    expect(connectSource).not.toContain(customScriptSource);
+  });
+
+  it('does not add Custom UI CSP sources when Custom UI assets are not configured', async () => {
+    const run = koaExperienceSecurityHeaders(
+      'default',
+      createQueries({
+        customUiCsp: {
+          scriptSrc: [customScriptSource],
+          connectSrc: [customConnectSource],
+        },
+      })
+    );
+    const ctx = createMockContext({ method: 'GET', url: '/sign-in' });
+
+    await run(ctx, koaNoop);
+
+    const scriptSource = getCspDirective(ctx, 'script-src');
+    const connectSource = getCspDirective(ctx, 'connect-src');
+
+    expect(scriptSource).toContain("'self'");
+    expect(scriptSource).not.toContain(customScriptSource);
+    expect(connectSource).toContain('https://tenant.example.com');
+    expect(connectSource).not.toContain(customConnectSource);
+  });
+
+  it('does not leak Custom UI CSP sources outside hosted experience routes', async () => {
+    const run = koaSecurityHeaders(['api', 'oidc', '.well-known', 'demo-app'], 'default');
+    const urlsWithDedicatedCsp = ['/console', '/account', '/account/callback/social/google'];
+    const mountedAppUrls = ['/oidc/auth', '/api/.well-known', '/demo-app'];
+
+    const cspHeaders = await Promise.all(
+      urlsWithDedicatedCsp.map(async (url) => {
+        const ctx = createMockContext({ method: 'GET', url });
+
+        await run(ctx, koaNoop);
+
+        return getCsp(ctx);
+      })
+    );
+
+    for (const cspHeader of cspHeaders) {
+      expect(cspHeader).not.toContain(customScriptSource);
+      expect(cspHeader).not.toContain(customConnectSource);
+    }
+
+    const mountedAppCspHeaders = await Promise.all(
+      mountedAppUrls.map(async (url) => {
+        const ctx = createMockContext({ method: 'GET', url });
+
+        await run(ctx, koaNoop);
+
+        return getCsp(ctx);
+      })
+    );
+
+    expect(mountedAppCspHeaders).toEqual(['', '', '']);
+  });
+
+  it('does not override mounted app CSP when the experience middleware is reached later', async () => {
+    const queries = createQueries({
+      customUiAssets,
+      customUiCsp: {
+        scriptSrc: [customScriptSource],
+      },
+    });
+    const runSecurityHeaders = koaSecurityHeaders(['console'], 'default');
+    const runExperienceSecurityHeaders = koaExperienceSecurityHeaders('default', queries, [
+      'console',
+    ]);
+    const ctx = createMockContext({ method: 'GET', url: '/console/organizations' });
+
+    await runSecurityHeaders(ctx, async () => runExperienceSecurityHeaders(ctx, koaNoop));
+
+    const scriptSource = getCspDirective(ctx, 'script-src');
+
+    expect(scriptSource).toContain('https://cdn.jsdelivr.net/');
+    expect(scriptSource).not.toContain(customScriptSource);
+    expect(queries.signInExperiences.findDefaultSignInExperience).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -1,11 +1,13 @@
 import { type IncomingMessage, type ServerResponse } from 'node:http';
 import { promisify } from 'node:util';
 
+import type { CustomUiCsp } from '@logto/schemas';
 import { conditionalArray } from '@silverhand/essentials';
 import helmet, { type HelmetOptions } from 'helmet';
 import type { MiddlewareType } from 'koa';
 
 import { EnvSet, AdminApps, UserApps, getTenantEndpoint } from '#src/env-set/index.js';
+import type Queries from '#src/tenants/Queries.js';
 
 /**
  * Apply security headers to the response using helmet
@@ -35,11 +37,21 @@ const getOssServerOrigins = (): string[] => {
   }
 };
 
-export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
-  mountedApps: string[],
-  tenantId: string
-): MiddlewareType<StateT, ContextT, ResponseBodyT> {
-  const { isProduction, isCloud, urlSet, adminUrlSet, cloudUrlSet } = EnvSet.values;
+type SecurityHeaderSettings = {
+  readonly basicSecurityHeaderSettings: HelmetOptions;
+  readonly consoleSecurityHeaderSettings: HelmetOptions;
+  readonly accountCenterSecurityHeaderSettings: HelmetOptions;
+  readonly defaultExperienceSecurityHeaderSettings: HelmetOptions;
+  readonly getExperienceSecurityHeaderSettings: (customUiCsp?: CustomUiCsp) => HelmetOptions;
+};
+
+const appendCustomSources = (sources: string[], customSources: string[] = []) => [
+  ...new Set([...sources, ...customSources]),
+];
+
+const createSecurityHeaderSettings = (tenantId: string): SecurityHeaderSettings => {
+  const { isProduction, isCloud, isDevFeaturesEnabled, urlSet, adminUrlSet, cloudUrlSet } =
+    EnvSet.values;
 
   const tenantEndpointOrigin = getTenantEndpoint(tenantId, EnvSet.values).origin;
   // Logto Cloud uses cloud service to serve the admin console; while Logto OSS uses a fixed path under the admin URL set.
@@ -68,12 +80,14 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
 
   /**
    * Temporary hardcoded tenant-level `connect-src` allowlist for BYO-UI customers.
-   * TODO: migrate to DB so tenants can self-manage. Review each entry for trust.
+   * Keep it until Custom UI CSP is generally available and customers have migrated.
    */
-  const customTenantConnectSourceAllowlist = [
-    // LaunchDarkly — A/B testing SDK (flag eval, streaming, events).
-    'https://*.launchdarkly.com',
-  ];
+  const customTenantConnectSourceAllowlist = conditionalArray(
+    !isDevFeaturesEnabled && [
+      // LaunchDarkly — A/B testing SDK (flag eval, streaming, events).
+      'https://*.launchdarkly.com',
+    ]
+  );
 
   // We have the following use cases:
   //
@@ -113,60 +127,69 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
     },
   };
 
-  // @ts-expect-error: helmet typings has lots of {A?: T, B?: never} | {A?: never, B?: T} options definitions. Optional settings type can not inferred correctly.
-  const experienceSecurityHeaderSettings: HelmetOptions = {
-    ...basicSecurityHeaderSettings,
-    // Guarded by CSP header below
-    frameguard: false,
-    // Allow being loaded by console preview iframe
-    crossOriginResourcePolicy: {
-      policy: 'cross-origin',
-    },
-    contentSecurityPolicy: {
-      useDefaults: true,
-      directives: {
-        'upgrade-insecure-requests': null,
-        imgSrc: ["'self'", 'data:', 'https:'],
-        scriptSrc: [
-          "'self'",
-          "'unsafe-inline'",
-          "'unsafe-hashes'",
-          `${gsiOrigin}client`,
-          // Some of our users may use the Cloudflare Web Analytics service. We need to allow it to
-          // load its scripts.
-          'https://static.cloudflareinsights.com/',
-          // Cloudflare Turnstile
-          'https://challenges.cloudflare.com/turnstile/v0/api.js',
-          // Google Recaptcha Enterprise
-          'https://www.google.com/recaptcha/enterprise.js',
-          'https://recaptcha.net/recaptcha/enterprise.js',
-          // Google Recaptcha static resources
-          'https://www.gstatic.com/recaptcha/',
-          'https://www.gstatic.cn/recaptcha/',
-          // Allow "unsafe-eval" for debugging purpose in non-production environment
-          ...conditionalArray(!isProduction && "'unsafe-eval'"),
-        ],
-        scriptSrcAttr: ["'unsafe-inline'"],
-        connectSrc: [
-          "'self'",
-          gsiOrigin,
-          tenantEndpointOrigin,
-          // Allow reCAPTCHA API calls
-          'https://www.google.com/recaptcha/',
-          'https://recaptcha.net/recaptcha/',
-          'https://www.gstatic.com/recaptcha/',
-          'https://www.gstatic.cn/recaptcha/',
-          ...customTenantConnectSourceAllowlist,
-          ...developmentOrigins,
-        ],
-        // WARNING (high risk): Need to allow self-hosted terms of use page loaded in an iframe
-        frameSrc: ["'self'", 'https:', gsiOrigin],
-        // Allow being loaded by console preview iframe
-        frameAncestors: ["'self'", ...adminOrigins],
-        defaultSrc: ["'self'", gsiOrigin],
+  const experienceScriptSource = [
+    "'self'",
+    "'unsafe-inline'",
+    "'unsafe-hashes'",
+    `${gsiOrigin}client`,
+    // Some of our users may use the Cloudflare Web Analytics service. We need to allow it to
+    // load its scripts.
+    'https://static.cloudflareinsights.com/',
+    // Cloudflare Turnstile
+    'https://challenges.cloudflare.com/turnstile/v0/api.js',
+    // Google Recaptcha Enterprise
+    'https://www.google.com/recaptcha/enterprise.js',
+    'https://recaptcha.net/recaptcha/enterprise.js',
+    // Google Recaptcha static resources
+    'https://www.gstatic.com/recaptcha/',
+    'https://www.gstatic.cn/recaptcha/',
+    // Allow "unsafe-eval" for debugging purpose in non-production environment
+    ...conditionalArray(!isProduction && "'unsafe-eval'"),
+  ];
+
+  const experienceConnectSource = [
+    "'self'",
+    gsiOrigin,
+    tenantEndpointOrigin,
+    // Allow reCAPTCHA API calls
+    'https://www.google.com/recaptcha/',
+    'https://recaptcha.net/recaptcha/',
+    'https://www.gstatic.com/recaptcha/',
+    'https://www.gstatic.cn/recaptcha/',
+    ...customTenantConnectSourceAllowlist,
+    ...developmentOrigins,
+  ];
+
+  const getExperienceSecurityHeaderSettings = (customUiCsp: CustomUiCsp = {}) => {
+    // @ts-expect-error: helmet typings has lots of {A?: T, B?: never} | {A?: never, B?: T} options definitions. Optional settings type can not inferred correctly.
+    const settings: HelmetOptions = {
+      ...basicSecurityHeaderSettings,
+      // Guarded by CSP header below
+      frameguard: false,
+      // Allow being loaded by console preview iframe
+      crossOriginResourcePolicy: {
+        policy: 'cross-origin',
       },
-    },
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          'upgrade-insecure-requests': null,
+          imgSrc: ["'self'", 'data:', 'https:'],
+          scriptSrc: appendCustomSources(experienceScriptSource, customUiCsp.scriptSrc),
+          scriptSrcAttr: ["'unsafe-inline'"],
+          connectSrc: appendCustomSources(experienceConnectSource, customUiCsp.connectSrc),
+          // WARNING (high risk): Need to allow self-hosted terms of use page loaded in an iframe
+          frameSrc: ["'self'", 'https:', gsiOrigin],
+          // Allow being loaded by console preview iframe
+          frameAncestors: ["'self'", ...adminOrigins],
+          defaultSrc: ["'self'", gsiOrigin],
+        },
+      },
+    };
+
+    return settings;
   };
+  const defaultExperienceSecurityHeaderSettings = getExperienceSecurityHeaderSettings();
 
   // @ts-expect-error: helmet typings has lots of {A?: T, B?: never} | {A?: never, B?: T} options definitions. Optional settings type can not inferred correctly.
   const accountCenterSecurityHeaderSettings: HelmetOptions = {
@@ -219,6 +242,55 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
     },
   };
 
+  return {
+    basicSecurityHeaderSettings,
+    consoleSecurityHeaderSettings,
+    accountCenterSecurityHeaderSettings,
+    defaultExperienceSecurityHeaderSettings,
+    getExperienceSecurityHeaderSettings,
+  };
+};
+
+export const koaExperienceSecurityHeaders = <StateT, ContextT, ResponseBodyT>(
+  tenantId: string,
+  queries: Queries,
+  mountedApps: string[] = []
+): MiddlewareType<StateT, ContextT, ResponseBodyT> => {
+  const { defaultExperienceSecurityHeaderSettings, getExperienceSecurityHeaderSettings } =
+    createSecurityHeaderSettings(tenantId);
+
+  return async (ctx, next) => {
+    if (mountedApps.some((app) => app !== '' && ctx.request.path.startsWith(`/${app}`))) {
+      return next();
+    }
+
+    const { req, res } = ctx;
+    const { customUiAssets, customUiCsp } =
+      await queries.signInExperiences.findDefaultSignInExperience();
+
+    await helmetPromise(
+      customUiAssets
+        ? getExperienceSecurityHeaderSettings(customUiCsp)
+        : defaultExperienceSecurityHeaderSettings,
+      req,
+      res
+    );
+
+    return next();
+  };
+};
+
+export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
+  mountedApps: string[],
+  tenantId: string
+): MiddlewareType<StateT, ContextT, ResponseBodyT> {
+  const {
+    basicSecurityHeaderSettings,
+    consoleSecurityHeaderSettings,
+    accountCenterSecurityHeaderSettings,
+    defaultExperienceSecurityHeaderSettings,
+  } = createSecurityHeaderSettings(tenantId);
+
   return async (ctx, next) => {
     const { request, req, res } = ctx;
     const requestPath = request.path;
@@ -247,7 +319,7 @@ export default function koaSecurityHeaders<StateT, ContextT, ResponseBodyT>(
     }
 
     // Experience
-    await helmetPromise(experienceSecurityHeaderSettings, req, res);
+    await helmetPromise(defaultExperienceSecurityHeaderSettings, req, res);
 
     return next();
   };

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -21,7 +21,9 @@ import koaErrorHandler from '#src/middleware/koa-error-handler.js';
 import koaExperienceSsr from '#src/middleware/koa-experience-ssr.js';
 import koaI18next from '#src/middleware/koa-i18next.js';
 import koaOidcErrorHandler from '#src/middleware/koa-oidc-error-handler.js';
-import koaSecurityHeaders from '#src/middleware/koa-security-headers.js';
+import koaSecurityHeaders, {
+  koaExperienceSecurityHeaders,
+} from '#src/middleware/koa-security-headers.js';
 import koaSlonikErrorHandler from '#src/middleware/koa-slonik-error-handler.js';
 import koaSpaProxy from '#src/middleware/koa-spa-proxy.js';
 import koaSpaSessionGuard from '#src/middleware/koa-spa-session-guard.js';
@@ -234,6 +236,7 @@ export default class Tenant implements TenantContext {
     // Mount experience app
     app.use(
       compose([
+        koaExperienceSecurityHeaders(id, queries, mountedApps),
         koaExperienceSsr(libraries, queries),
         koaSpaSessionGuard(provider, queries),
         mount(


### PR DESCRIPTION
## Summary
Apply tenant Custom UI CSP sources to hosted sign-in experience security headers.

This PR adds an experience-only security headers middleware that reads `customUiCsp` from sign-in experience config and additively merges `scriptSrc` into `script-src` and `connectSrc` into `connect-src`, while keeping baseline Logto CSP sources intact. It also keeps the temporary LaunchDarkly `connect-src` fallback when dev features are disabled and skips it when dev features are enabled.

The Custom UI CSP middleware is mounted only inside the experience app compose, so Console, Account Center, OIDC, APIs, well-known routes, and other mounted apps do not receive tenant custom sources.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments