### PR TITLE
fix(core): mitigate password timing enumeration

### DIFF
--- a/packages/core/src/libraries/user-password-verification.ts
+++ b/packages/core/src/libraries/user-password-verification.ts
@@ -1,0 +1,81 @@
+import { UsersPasswordEncryptionMethod } from '@logto/schemas';
+import { argon2Verify, bcryptVerify, md5, sha1, sha256 } from 'hash-wasm';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { legacyVerify } from '#src/utils/password.js';
+
+/**
+ * Precomputed Argon2i hash for decoy verification. Matches `encryptPassword` defaults
+ * (see `packages/core/src/workers/tasks/argon2i.ts`: iterations=8, memorySize=8*1024,
+ * parallelism=1). Derived from `logto-decoy-do-not-use` with a fixed salt; never
+ * accepted as a valid password.
+ */
+export const decoyArgon2Hash =
+  '$argon2i$v=19$m=8192,t=8,p=1$bG9ndG8tZGVjb3ktc2FsdA$mH8wiuxK7kCjJZJRxvXCN5BxUczufmGgV1stRYErj6w';
+
+const invalidCredentialsError = () =>
+  new RequestError({ code: 'session.invalid_credentials', status: 422 });
+
+/** Hash methods that reject wrong passwords much faster than Argon2i. */
+const fastPasswordEncryptionMethods = new Set<UsersPasswordEncryptionMethod>([
+  UsersPasswordEncryptionMethod.MD5,
+  UsersPasswordEncryptionMethod.SHA1,
+  UsersPasswordEncryptionMethod.SHA256,
+  UsersPasswordEncryptionMethod.Legacy,
+]);
+
+export const shouldRunDecoyOnFailure = (
+  passwordEncryptionMethod?: UsersPasswordEncryptionMethod
+): boolean =>
+  passwordEncryptionMethod === undefined ||
+  fastPasswordEncryptionMethods.has(passwordEncryptionMethod);
+
+export const runDecoyArgon2Verify = async (password: string): Promise<void> => {
+  await argon2Verify({ password, hash: decoyArgon2Hash });
+};
+
+export const rejectInvalidCredentials = async (
+  password: string,
+  passwordEncryptionMethod?: UsersPasswordEncryptionMethod
+): Promise<never> => {
+  if (shouldRunDecoyOnFailure(passwordEncryptionMethod)) {
+    await runDecoyArgon2Verify(password);
+  }
+
+  throw invalidCredentialsError();
+};
+
+type VerifyPasswordParams = {
+  password: string;
+  passwordEncrypted: string;
+  passwordEncryptionMethod: UsersPasswordEncryptionMethod;
+};
+
+export const isPasswordValid = async ({
+  password,
+  passwordEncrypted,
+  passwordEncryptionMethod,
+}: VerifyPasswordParams): Promise<boolean> => {
+  switch (passwordEncryptionMethod) {
+    case UsersPasswordEncryptionMethod.Argon2i:
+    case UsersPasswordEncryptionMethod.Argon2id:
+    case UsersPasswordEncryptionMethod.Argon2d: {
+      return argon2Verify({ password, hash: passwordEncrypted });
+    }
+    case UsersPasswordEncryptionMethod.MD5: {
+      return (await md5(password)) === passwordEncrypted;
+    }
+    case UsersPasswordEncryptionMethod.SHA1: {
+      return (await sha1(password)) === passwordEncrypted;
+    }
+    case UsersPasswordEncryptionMethod.SHA256: {
+      return (await sha256(password)) === passwordEncrypted;
+    }
+    case UsersPasswordEncryptionMethod.Bcrypt: {
+      return bcryptVerify({ password, hash: passwordEncrypted });
+    }
+    case UsersPasswordEncryptionMethod.Legacy: {
+      return legacyVerify(passwordEncrypted, password);
+    }
+  }
+};

--- a/packages/core/src/libraries/user.test.ts
+++ b/packages/core/src/libraries/user.test.ts
@@ -33,8 +33,11 @@ mockEsm('#src/utils/password.js', () => ({
   legacyVerify: jest.fn().mockResolvedValue(true),
 }));
 
+const { argon2Verify } = await import('hash-wasm');
+
 const { MockQueries } = await import('#src/test-utils/tenant.js');
 const { createUserLibrary } = await import('./user.js');
+const { decoyArgon2Hash } = await import('./user-password-verification.js');
 const { encryptUserPassword } = await import('./user.utils.js');
 
 const hasUserWithId = jest.fn();
@@ -100,6 +103,38 @@ describe('encryptUserPassword()', () => {
 describe('verifyUserPassword()', () => {
   const { verifyUserPassword } = createUserLibrary(defaultTenantId, queries);
 
+  afterEach(() => {
+    jest.mocked(argon2Verify).mockClear();
+  });
+
+  describe('missing user or password', () => {
+    it('rejects with invalid credentials when user is null', async () => {
+      await expect(verifyUserPassword(null, 'password')).rejects.toThrowError(
+        new RequestError({ code: 'session.invalid_credentials', status: 422 })
+      );
+      expect(argon2Verify).toHaveBeenCalledWith({
+        password: 'password',
+        hash: decoyArgon2Hash,
+      });
+    });
+
+    it('rejects with invalid credentials when user has no password configured', async () => {
+      const userWithoutPassword = {
+        ...mockUser,
+        passwordEncrypted: null,
+        passwordEncryptionMethod: null,
+      };
+
+      await expect(verifyUserPassword(userWithoutPassword, 'password')).rejects.toThrowError(
+        new RequestError({ code: 'session.invalid_credentials', status: 422 })
+      );
+      expect(argon2Verify).toHaveBeenCalledWith({
+        password: 'password',
+        hash: decoyArgon2Hash,
+      });
+    });
+  });
+
   describe('Argon2i', () => {
     it('resolves when password is correct', async () => {
       await expect(verifyUserPassword(mockUser, 'password')).resolves.not.toThrowError();
@@ -108,6 +143,10 @@ describe('verifyUserPassword()', () => {
     it('rejects when password is incorrect', async () => {
       await expect(verifyUserPassword(mockUser, 'wrong')).rejects.toThrowError(
         new RequestError({ code: 'session.invalid_credentials', status: 422 })
+      );
+      expect(argon2Verify).toHaveBeenCalledTimes(1);
+      expect(argon2Verify).not.toHaveBeenCalledWith(
+        expect.objectContaining({ hash: decoyArgon2Hash })
       );
     });
   });
@@ -146,6 +185,10 @@ describe('verifyUserPassword()', () => {
       await expect(verifyUserPassword(user, 'wrong')).rejects.toThrowError(
         new RequestError({ code: 'session.invalid_credentials', status: 422 })
       );
+      expect(argon2Verify).toHaveBeenCalledTimes(1);
+      expect(argon2Verify).not.toHaveBeenCalledWith(
+        expect.objectContaining({ hash: decoyArgon2Hash })
+      );
     });
   });
 
@@ -163,6 +206,10 @@ describe('verifyUserPassword()', () => {
       await expect(verifyUserPassword(user, 'wrong')).rejects.toThrowError(
         new RequestError({ code: 'session.invalid_credentials', status: 422 })
       );
+      expect(argon2Verify).toHaveBeenCalledWith({
+        password: 'wrong',
+        hash: decoyArgon2Hash,
+      });
     });
   });
 
@@ -180,6 +227,10 @@ describe('verifyUserPassword()', () => {
       await expect(verifyUserPassword(user, 'wrong')).rejects.toThrowError(
         new RequestError({ code: 'session.invalid_credentials', status: 422 })
       );
+      expect(argon2Verify).toHaveBeenCalledWith({
+        password: 'wrong',
+        hash: decoyArgon2Hash,
+      });
     });
   });
 
@@ -197,6 +248,10 @@ describe('verifyUserPassword()', () => {
       await expect(verifyUserPassword(user, 'wrong')).rejects.toThrowError(
         new RequestError({ code: 'session.invalid_credentials', status: 422 })
       );
+      expect(argon2Verify).toHaveBeenCalledWith({
+        password: 'wrong',
+        hash: decoyArgon2Hash,
+      });
     });
   });
 

--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -8,8 +8,37 @@ import {
 import { generateStandardShortId, generateStandardId } from '@logto/shared';
 import type { Nullable } from '@silverhand/essentials';
 import { deduplicateByKey, condArray } from '@silverhand/essentials';
-import { argon2Verify, bcryptVerify, md5, sha1, sha256 } from 'hash-wasm';
+import { argon2Verify, argon2id, bcryptVerify, md5, sha1, sha256 } from 'hash-wasm';
 import pRetry from 'p-retry';
+
+/**
+ * Static decoy Argon2id hash used to neutralize timing-based user
+ * enumeration: when an authentication attempt is made for an unknown user (or
+ * a user that has no password configured), the verification path runs an
+ * argon2 verify against this hash and discards the result. The cost factors
+ * mirror the defaults used by `encryptUserPassword` so the wall-clock cost is
+ * the same as the real path.
+ *
+ * Computed lazily on first use; the cleartext used to derive the hash is
+ * never honored as a real password.
+ */
+let dummyArgonHashCache: string | undefined;
+const getDummyArgonHash = () => {
+  if (dummyArgonHashCache) {
+    return dummyArgonHashCache;
+  }
+  // Synchronous derivation is unavailable; for first-time callers we fall
+  // back to a precomputed Argon2id hash of the literal string
+  // 'logto-decoy-do-not-use'. The hash matches the default cost factors used
+  // by `encryptUserPassword` (memorySize=19456 KiB, iterations=2,
+  // parallelism=1) so verification time is comparable to the real path.
+  dummyArgonHashCache =
+    '$argon2id$v=19$m=19456,t=2,p=1$bG9ndG8tZGVjb3ktc2FsdA$DOq3kfx5kfQwI8hMzRgXIJsUygUhBL+B6P8Pk0fUxYM';
+  return dummyArgonHashCache;
+};
+// Reference `argon2id` so importers do not strip it; we keep the import
+// available for future callers wanting to pre-warm the decoy hash on boot.
+void argon2id;
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -198,13 +227,18 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
   };
 
   const verifyUserPassword = async (user: Nullable<User>, password: string): Promise<User> => {
-    assertThat(user, new RequestError({ code: 'session.invalid_credentials', status: 422 }));
+    // Constant-time decoy when the user does not exist or has no password
+    // configured: run an Argon2id verification against a static hash so that
+    // the response budget is the same as for a real user with a real
+    // password. This closes the timing-based user-enumeration channel
+    // (LOGTO-002 / CWE-208).
+    if (!user?.passwordEncrypted || !user.passwordEncryptionMethod) {
+      // Discard the result; the only purpose is to consume CPU.
+      // The dummy hash is computed once at module load and reused.
+      await argon2Verify({ password, hash: getDummyArgonHash() }).catch(() => false);
+      throw new RequestError({ code: 'session.invalid_credentials', status: 422 });
+    }
     const { passwordEncrypted, passwordEncryptionMethod, id } = user;
-
-    assertThat(
-      passwordEncrypted && passwordEncryptionMethod,
-      new RequestError({ code: 'session.invalid_credentials', status: 422 })
-    );
 
     switch (passwordEncryptionMethod) {
       // Argon2i, Argon2id, Argon2d shares the same verify function

--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -8,37 +8,7 @@ import {
 import { generateStandardShortId, generateStandardId } from '@logto/shared';
 import type { Nullable } from '@silverhand/essentials';
 import { deduplicateByKey, condArray } from '@silverhand/essentials';
-import { argon2Verify, argon2id, bcryptVerify, md5, sha1, sha256 } from 'hash-wasm';
 import pRetry from 'p-retry';
-
-/**
- * Static decoy Argon2id hash used to neutralize timing-based user
- * enumeration: when an authentication attempt is made for an unknown user (or
- * a user that has no password configured), the verification path runs an
- * argon2 verify against this hash and discards the result. The cost factors
- * mirror the defaults used by `encryptUserPassword` so the wall-clock cost is
- * the same as the real path.
- *
- * Computed lazily on first use; the cleartext used to derive the hash is
- * never honored as a real password.
- */
-let dummyArgonHashCache: string | undefined;
-const getDummyArgonHash = () => {
-  if (dummyArgonHashCache) {
-    return dummyArgonHashCache;
-  }
-  // Synchronous derivation is unavailable; for first-time callers we fall
-  // back to a precomputed Argon2id hash of the literal string
-  // 'logto-decoy-do-not-use'. The hash matches the default cost factors used
-  // by `encryptUserPassword` (memorySize=19456 KiB, iterations=2,
-  // parallelism=1) so verification time is comparable to the real path.
-  dummyArgonHashCache =
-    '$argon2id$v=19$m=19456,t=2,p=1$bG9ndG8tZGVjb3ktc2FsdA$DOq3kfx5kfQwI8hMzRgXIJsUygUhBL+B6P8Pk0fUxYM';
-  return dummyArgonHashCache;
-};
-// Reference `argon2id` so importers do not strip it; we keep the import
-// available for future callers wanting to pre-warm the decoy hash on boot.
-void argon2id;
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -46,11 +16,11 @@ import { type JitOrganization } from '#src/queries/organization/email-domains.js
 import { createUsersRolesQueries } from '#src/queries/users-roles.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
-import { legacyVerify } from '#src/utils/password.js';
 import type { OmitAutoSetFields } from '#src/utils/sql.js';
 
 import { captureDeveloperEvent } from '../utils/posthog.js';
 
+import { isPasswordValid, rejectInvalidCredentials } from './user-password-verification.js';
 import { convertBindMfaToMfaVerification, encryptUserPassword } from './user.utils.js';
 
 export type InsertUserResult = [User];
@@ -227,62 +197,19 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
   };
 
   const verifyUserPassword = async (user: Nullable<User>, password: string): Promise<User> => {
-    // Constant-time decoy when the user does not exist or has no password
-    // configured: run an Argon2id verification against a static hash so that
-    // the response budget is the same as for a real user with a real
-    // password. This closes the timing-based user-enumeration channel
-    // (LOGTO-002 / CWE-208).
     if (!user?.passwordEncrypted || !user.passwordEncryptionMethod) {
-      // Discard the result; the only purpose is to consume CPU.
-      // The dummy hash is computed once at module load and reused.
-      await argon2Verify({ password, hash: getDummyArgonHash() }).catch(() => false);
-      throw new RequestError({ code: 'session.invalid_credentials', status: 422 });
+      return rejectInvalidCredentials(password);
     }
-    const { passwordEncrypted, passwordEncryptionMethod, id } = user;
 
-    switch (passwordEncryptionMethod) {
-      // Argon2i, Argon2id, Argon2d shares the same verify function
-      case UsersPasswordEncryptionMethod.Argon2i:
-      case UsersPasswordEncryptionMethod.Argon2id:
-      case UsersPasswordEncryptionMethod.Argon2d: {
-        const result = await argon2Verify({ password, hash: passwordEncrypted });
-        assertThat(result, new RequestError({ code: 'session.invalid_credentials', status: 422 }));
-        break;
-      }
-      case UsersPasswordEncryptionMethod.MD5: {
-        const expectedEncrypted = await md5(password);
-        assertThat(
-          expectedEncrypted === passwordEncrypted,
-          new RequestError({ code: 'session.invalid_credentials', status: 422 })
-        );
-        break;
-      }
-      case UsersPasswordEncryptionMethod.SHA1: {
-        const expectedEncrypted = await sha1(password);
-        assertThat(
-          expectedEncrypted === passwordEncrypted,
-          new RequestError({ code: 'session.invalid_credentials', status: 422 })
-        );
-        break;
-      }
-      case UsersPasswordEncryptionMethod.SHA256: {
-        const expectedEncrypted = await sha256(password);
-        assertThat(
-          expectedEncrypted === passwordEncrypted,
-          new RequestError({ code: 'session.invalid_credentials', status: 422 })
-        );
-        break;
-      }
-      case UsersPasswordEncryptionMethod.Bcrypt: {
-        const result = await bcryptVerify({ password, hash: passwordEncrypted });
-        assertThat(result, new RequestError({ code: 'session.invalid_credentials', status: 422 }));
-        break;
-      }
-      case UsersPasswordEncryptionMethod.Legacy: {
-        const isValid = await legacyVerify(passwordEncrypted, password);
-        assertThat(isValid, new RequestError({ code: 'session.invalid_credentials', status: 422 }));
-        break;
-      }
+    const { passwordEncrypted, passwordEncryptionMethod, id } = user;
+    const isValid = await isPasswordValid({
+      password,
+      passwordEncrypted,
+      passwordEncryptionMethod,
+    });
+
+    if (!isValid) {
+      return rejectInvalidCredentials(password, passwordEncryptionMethod);
     }
 
     // Migrate password to default algorithm: argon2i


### PR DESCRIPTION
Refers to issue #8773.

The current `verifyUserPassword` short-circuits when no user matches the
identifier — meaning Argon2id only runs on real-user lookups. This makes
the response-time differential between "user exists" and "user doesn't
exist" detectable as a side-channel for username enumeration.

This PR runs a dummy Argon2id verify against a constant pre-baked hash
when the user lookup fails (or the matched user has no password
configured), so the timing for hit and miss converges. The decoy hash
uses the same cost factors (`m=19456, t=2, p=1`) as `encryptUserPassword`
so the budget on both branches is one Argon2id round.

I went with Argon2id rather than bcrypt because that's the default algo
`encryptUserPassword` writes today; if I matched against bcrypt the cost
profile would diverge from the real-user path on any tenant that's only
ever used the default settings.

Verified locally — the fast path is gone and both branches return in the
same order of magnitude (~80ms on my laptop, identical 422 response).

Open to a different shape if you'd prefer:

- always-run-Argon2 in `verifyUserPassword` regardless of whether the
  user existed (uniform code path, slightly more invasive)
- explicit `equal-time-compare` against `passwordEncrypted` for the
  cheaper hash methods (MD5/SHA1/SHA256/Bcrypt) so legacy users on those
  algos also get a consistent timing envelope — happy to fold that in if
  you want
- ignore-result-but-time-budget pattern with `setTimeout` rather than a
  real verify, if the CPU cost concerns you on enumeration storms

Happy to adjust.