### PR TITLE
feat(account): display account profile fields

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -294,6 +294,7 @@ const App = () => (
           UserScope.Phone,
           UserScope.Address,
           UserScope.Identities,
+          UserScope.CustomData,
         ],
       }}
     >

--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -292,6 +292,7 @@ const App = () => (
           UserScope.Profile,
           UserScope.Email,
           UserScope.Phone,
+          UserScope.Address,
           UserScope.Identities,
         ],
       }}

--- a/packages/account/src/pages/Profile/index.module.scss
+++ b/packages/account/src/pages/Profile/index.module.scss
@@ -1,0 +1,63 @@
+@use '@experience/shared/scss/underscore' as _;
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1.5);
+}
+
+.card {
+  background: var(--color-bg-body);
+  border-radius: 12px;
+  overflow: clip;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(0, 200px) minmax(0, 1fr);
+  column-gap: _.unit(6);
+  align-items: center;
+  padding: _.unit(5) _.unit(6);
+  min-height: 64px;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--color-line-divider);
+  }
+}
+
+.name {
+  min-width: 0;
+  font: var(--font-label-2);
+  color: var(--color-type-primary);
+}
+
+.value {
+  min-width: 0;
+  font: var(--font-body-2);
+  color: var(--color-type-primary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.secondaryValue {
+  color: var(--color-type-secondary);
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  object-fit: cover;
+  display: block;
+}
+
+:global(body.mobile) {
+  .row {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: _.unit(1);
+    padding: _.unit(4);
+  }
+}

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -34,7 +34,7 @@ type ProfileFieldRow = {
   value?: React.ReactNode;
 };
 
-const profileFieldKeySet = new Set<string>([...userProfileKeys, 'fullname']);
+const profileFieldKeySet = new Set<string>(userProfileKeys);
 const fullnameKeySet = new Set<string>(fullnameKeys);
 const addressKeySet = new Set<string>(userProfileAddressKeys);
 
@@ -51,6 +51,9 @@ const getAccountCenterProfileFields = (settings?: AccountCenter): AccountCenterP
 const isCompositeProfileField = (field?: CustomProfileField): boolean =>
   field?.type === CustomProfileFieldType.Fullname || field?.type === CustomProfileFieldType.Address;
 
+const isBuiltInProfileField = (fieldName: string, field?: CustomProfileField): boolean =>
+  profileFieldKeySet.has(fieldName) || (fieldName === 'fullname' && field === undefined);
+
 const getProfileFieldControlKey = (
   fieldName: string,
   field?: CustomProfileField
@@ -59,7 +62,7 @@ const getProfileFieldControlKey = (
     return fieldName;
   }
 
-  if (profileFieldKeySet.has(fieldName) || isCompositeProfileField(field)) {
+  if (isBuiltInProfileField(fieldName, field) || isCompositeProfileField(field)) {
     return 'profile';
   }
 
@@ -204,7 +207,7 @@ const getProfileFieldValue = (
     return getCompositeFieldValue(userInfo, field);
   }
 
-  if (profileFieldKeySet.has(fieldName)) {
+  if (isBuiltInProfileField(fieldName, field)) {
     return getBuiltInProfileFieldValue(userInfo?.profile, fieldName);
   }
 

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -100,37 +100,37 @@ const getBuiltInProfileFieldValue = (
       return getFullnameValue(profile);
     }
     case 'familyName': {
-      return profile?.familyName;
+      return getPrimitiveValue(profile?.familyName);
     }
     case 'givenName': {
-      return profile?.givenName;
+      return getPrimitiveValue(profile?.givenName);
     }
     case 'middleName': {
-      return profile?.middleName;
+      return getPrimitiveValue(profile?.middleName);
     }
     case 'nickname': {
-      return profile?.nickname;
+      return getPrimitiveValue(profile?.nickname);
     }
     case 'preferredUsername': {
-      return profile?.preferredUsername;
+      return getPrimitiveValue(profile?.preferredUsername);
     }
     case 'profile': {
-      return profile?.profile;
+      return getPrimitiveValue(profile?.profile);
     }
     case 'website': {
-      return profile?.website;
+      return getPrimitiveValue(profile?.website);
     }
     case 'gender': {
-      return profile?.gender;
+      return getPrimitiveValue(profile?.gender);
     }
     case 'birthdate': {
-      return profile?.birthdate;
+      return getPrimitiveValue(profile?.birthdate);
     }
     case 'zoneinfo': {
-      return profile?.zoneinfo;
+      return getPrimitiveValue(profile?.zoneinfo);
     }
     case 'locale': {
-      return profile?.locale;
+      return getPrimitiveValue(profile?.locale);
     }
     case 'address': {
       return getAddressValue(profile?.address);
@@ -179,12 +179,12 @@ const getProfileFieldValue = (
 ): React.ReactNode | undefined => {
   if (fieldName === 'avatar') {
     return userInfo?.avatar ? (
-      <img className={styles.avatar} src={userInfo.avatar} alt={fieldName} />
+      <img className={styles.avatar} src={userInfo.avatar} alt="" />
     ) : undefined;
   }
 
   if (fieldName === 'name') {
-    return userInfo?.name;
+    return getPrimitiveValue(userInfo?.name);
   }
 
   if (

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -1,25 +1,279 @@
+import {
+  AccountCenterControlValue,
+  CustomProfileFieldType,
+  fullnameKeys,
+  userProfileAddressKeys,
+  userProfileKeys,
+  type AccountCenter,
+  type AccountCenterFieldControl,
+  type AccountCenterProfileFields,
+  type CustomProfileField,
+  type UserProfile,
+  type UserProfileResponse,
+} from '@logto/schemas';
 import classNames from 'classnames';
+import { useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import PageFooter from '@ac/components/PageFooter';
 import { layoutClassNames } from '@ac/constants/layout';
 
-import styles from '../Home/index.module.scss';
+import homeStyles from '../Home/index.module.scss';
+
+import styles from './index.module.scss';
+
+type ProfileFieldControlKey = Extract<
+  keyof AccountCenterFieldControl,
+  'name' | 'avatar' | 'profile' | 'customData'
+>;
+
+type ProfileFieldRow = {
+  name: string;
+  label: string;
+  value?: React.ReactNode;
+};
+
+const profileFieldKeySet = new Set<string>([...userProfileKeys, 'fullname']);
+const fullnameKeySet = new Set<string>(fullnameKeys);
+const addressKeySet = new Set<string>(userProfileAddressKeys);
+
+const profileLabelKeys: Record<string, string> = {
+  name: 'profile.name',
+  avatar: 'profile.avatar',
+  fullname: 'profile.fullname',
+  address: 'profile.address.formatted',
+};
+
+const getAccountCenterProfileFields = (settings?: AccountCenter): AccountCenterProfileFields =>
+  settings?.profileFields ?? [];
+
+const getProfileFieldControlKey = (fieldName: string): ProfileFieldControlKey => {
+  if (fieldName === 'name' || fieldName === 'avatar') {
+    return fieldName;
+  }
+
+  if (profileFieldKeySet.has(fieldName)) {
+    return 'profile';
+  }
+
+  return 'customData';
+};
+
+const joinValues = (values: Array<string | undefined>, separator = ' '): string | undefined => {
+  const value = values.filter(Boolean).join(separator);
+
+  return value || undefined;
+};
+
+const getPrimitiveValue = (value: unknown): string | undefined => {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+};
+
+const getFullnameValue = (profile?: UserProfile): string | undefined =>
+  joinValues(fullnameKeys.map((name) => profile?.[name]));
+
+const getAddressValue = (address?: UserProfile['address']): string | undefined =>
+  joinValues(
+    userProfileAddressKeys.map((name) => address?.[name]),
+    ', '
+  );
+
+const isFullnameKey = (name: string): name is (typeof fullnameKeys)[number] =>
+  fullnameKeySet.has(name);
+
+const isAddressKey = (name: string): name is (typeof userProfileAddressKeys)[number] =>
+  addressKeySet.has(name);
+
+const getBuiltInProfileFieldValue = (
+  profile: UserProfile | undefined,
+  fieldName: string
+): string | undefined => {
+  switch (fieldName) {
+    case 'fullname': {
+      return getFullnameValue(profile);
+    }
+    case 'familyName': {
+      return profile?.familyName;
+    }
+    case 'givenName': {
+      return profile?.givenName;
+    }
+    case 'middleName': {
+      return profile?.middleName;
+    }
+    case 'nickname': {
+      return profile?.nickname;
+    }
+    case 'preferredUsername': {
+      return profile?.preferredUsername;
+    }
+    case 'profile': {
+      return profile?.profile;
+    }
+    case 'website': {
+      return profile?.website;
+    }
+    case 'gender': {
+      return profile?.gender;
+    }
+    case 'birthdate': {
+      return profile?.birthdate;
+    }
+    case 'zoneinfo': {
+      return profile?.zoneinfo;
+    }
+    case 'locale': {
+      return profile?.locale;
+    }
+    case 'address': {
+      return getAddressValue(profile?.address);
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+
+const getCompositeFieldValue = (
+  userInfo: Partial<UserProfileResponse> | undefined,
+  field: CustomProfileField
+): string | undefined => {
+  const { profile } = userInfo ?? {};
+  const enabledParts = field.config.parts?.filter(({ enabled }) => enabled) ?? [];
+
+  if (field.type === CustomProfileFieldType.Fullname) {
+    const partNames = enabledParts.length > 0 ? enabledParts.map(({ name }) => name) : fullnameKeys;
+
+    return joinValues(
+      partNames
+        .filter((name): name is (typeof fullnameKeys)[number] => isFullnameKey(name))
+        .map((name) => profile?.[name])
+    );
+  }
+
+  if (field.type === CustomProfileFieldType.Address) {
+    const address = profile?.address;
+    const partNames =
+      enabledParts.length > 0 ? enabledParts.map(({ name }) => name) : userProfileAddressKeys;
+
+    return joinValues(
+      partNames
+        .filter((name): name is (typeof userProfileAddressKeys)[number] => isAddressKey(name))
+        .map((name) => address?.[name]),
+      ', '
+    );
+  }
+};
+
+const getProfileFieldValue = (
+  userInfo: Partial<UserProfileResponse> | undefined,
+  fieldName: string,
+  field?: CustomProfileField
+): React.ReactNode | undefined => {
+  if (fieldName === 'avatar') {
+    return userInfo?.avatar ? (
+      <img className={styles.avatar} src={userInfo.avatar} alt={fieldName} />
+    ) : undefined;
+  }
+
+  if (fieldName === 'name') {
+    return userInfo?.name;
+  }
+
+  if (
+    field?.type === CustomProfileFieldType.Fullname ||
+    field?.type === CustomProfileFieldType.Address
+  ) {
+    return getCompositeFieldValue(userInfo, field);
+  }
+
+  if (profileFieldKeySet.has(fieldName)) {
+    return getBuiltInProfileFieldValue(userInfo?.profile, fieldName);
+  }
+
+  return getPrimitiveValue(userInfo?.customData?.[fieldName]);
+};
 
 const Profile = () => {
   const { t } = useTranslation();
+  const { accountCenterSettings, experienceSettings, userInfo } = useContext(PageContext);
+  const profileFields = getAccountCenterProfileFields(accountCenterSettings);
+
+  const fieldRows = useMemo(() => {
+    const customProfileFields = experienceSettings?.customProfileFields ?? [];
+    const customProfileFieldMap = new Map(customProfileFields.map((field) => [field.name, field]));
+
+    return profileFields.reduce<ProfileFieldRow[]>((rows, { name }) => {
+      const controlKey = getProfileFieldControlKey(name);
+
+      const controlValue = accountCenterSettings?.fields[controlKey];
+
+      if (!controlValue || controlValue === AccountCenterControlValue.Off) {
+        return rows;
+      }
+
+      const field = customProfileFieldMap.get(name);
+      const labelKey = profileLabelKeys[name] ?? `profile.${name}`;
+      const label =
+        field?.label === undefined || field.label === ''
+          ? t(labelKey, { defaultValue: name })
+          : field.label;
+
+      return [
+        ...rows,
+        {
+          name,
+          label,
+          value:
+            name === 'gender' && userInfo?.profile?.gender
+              ? t(`profile.gender_options.${userInfo.profile.gender}`, {
+                  defaultValue: userInfo.profile.gender,
+                })
+              : getProfileFieldValue(userInfo, name, field),
+        },
+      ];
+    }, []);
+  }, [
+    accountCenterSettings?.fields,
+    experienceSettings?.customProfileFields,
+    profileFields,
+    t,
+    userInfo,
+  ]);
 
   return (
-    <div className={styles.container}>
-      <div className={styles.header}>
-        <div className={classNames(styles.title, layoutClassNames.pageTitle)}>
+    <div className={homeStyles.container}>
+      <div className={homeStyles.header}>
+        <div className={classNames(homeStyles.title, layoutClassNames.pageTitle)}>
           {t('account_center.page.profile_title')}
         </div>
-        <div className={classNames(styles.description, layoutClassNames.pageDescription)}>
+        <div className={classNames(homeStyles.description, layoutClassNames.pageDescription)}>
           {t('account_center.page.profile_description')}
         </div>
       </div>
-      <div className={classNames(styles.content, layoutClassNames.pageContent)} />
+      <div className={classNames(homeStyles.content, layoutClassNames.pageContent)}>
+        {fieldRows.length > 0 && (
+          <div className={classNames(styles.section, layoutClassNames.section)}>
+            <div className={classNames(styles.card, layoutClassNames.card)}>
+              {fieldRows.map(({ name, label, value }) => (
+                <div key={name} className={classNames(styles.row, layoutClassNames.row)}>
+                  <div className={styles.name}>{label}</div>
+                  <div className={classNames(styles.value, !value && styles.secondaryValue)}>
+                    {value ?? t('account_center.security.not_set')}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
       <PageFooter />
     </div>
   );

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -212,16 +212,18 @@ const getProfileFieldValue = (
     return getCompositeFieldValue(userInfo, field);
   }
 
-  if (isBuiltInProfileField(fieldName, field)) {
-    return getBuiltInProfileFieldValue(userInfo?.profile, fieldName);
-  }
-
   if (field?.type === CustomProfileFieldType.Select) {
-    const value = getPrimitiveValue(userInfo?.customData?.[fieldName]);
+    const value = isBuiltInProfileField(fieldName, field)
+      ? getBuiltInProfileFieldValue(userInfo?.profile, fieldName)
+      : getPrimitiveValue(userInfo?.customData?.[fieldName]);
 
     return value === undefined
       ? undefined
       : (field.config.options?.find((option) => option.value === value)?.label ?? value);
+  }
+
+  if (isBuiltInProfileField(fieldName, field)) {
+    return getBuiltInProfileFieldValue(userInfo?.profile, fieldName);
   }
 
   return getPrimitiveValue(userInfo?.customData?.[fieldName]);
@@ -257,12 +259,7 @@ const Profile = () => {
         {
           name,
           label,
-          value:
-            name === 'gender' && userInfo?.profile?.gender
-              ? t(`profile.gender_options.${userInfo.profile.gender}`, {
-                  defaultValue: userInfo.profile.gender,
-                })
-              : getProfileFieldValue(userInfo, name, label, field),
+          value: getProfileFieldValue(userInfo, name, label, field),
         },
       ];
     }, []);

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -188,11 +188,16 @@ const getCompositeFieldValue = (
 const getProfileFieldValue = (
   userInfo: Partial<UserProfileResponse> | undefined,
   fieldName: string,
+  fieldLabel: string,
   field?: CustomProfileField
 ): React.ReactNode | undefined => {
   if (fieldName === 'avatar') {
     return userInfo?.avatar ? (
-      <img className={styles.avatar} src={userInfo.avatar} alt="" />
+      <img
+        className={styles.avatar}
+        src={userInfo.avatar}
+        alt={getPrimitiveValue(userInfo.name) ?? fieldLabel}
+      />
     ) : undefined;
   }
 
@@ -209,6 +214,14 @@ const getProfileFieldValue = (
 
   if (isBuiltInProfileField(fieldName, field)) {
     return getBuiltInProfileFieldValue(userInfo?.profile, fieldName);
+  }
+
+  if (field?.type === CustomProfileFieldType.Select) {
+    const value = getPrimitiveValue(userInfo?.customData?.[fieldName]);
+
+    return value === undefined
+      ? undefined
+      : (field.config.options?.find((option) => option.value === value)?.label ?? value);
   }
 
   return getPrimitiveValue(userInfo?.customData?.[fieldName]);
@@ -249,7 +262,7 @@ const Profile = () => {
               ? t(`profile.gender_options.${userInfo.profile.gender}`, {
                   defaultValue: userInfo.profile.gender,
                 })
-              : getProfileFieldValue(userInfo, name, field),
+              : getProfileFieldValue(userInfo, name, label, field),
         },
       ];
     }, []);

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -48,12 +48,18 @@ const profileLabelKeys: Record<string, string> = {
 const getAccountCenterProfileFields = (settings?: AccountCenter): AccountCenterProfileFields =>
   settings?.profileFields ?? [];
 
-const getProfileFieldControlKey = (fieldName: string): ProfileFieldControlKey => {
+const isCompositeProfileField = (field?: CustomProfileField): boolean =>
+  field?.type === CustomProfileFieldType.Fullname || field?.type === CustomProfileFieldType.Address;
+
+const getProfileFieldControlKey = (
+  fieldName: string,
+  field?: CustomProfileField
+): ProfileFieldControlKey => {
   if (fieldName === 'name' || fieldName === 'avatar') {
     return fieldName;
   }
 
-  if (profileFieldKeySet.has(fieldName)) {
+  if (profileFieldKeySet.has(fieldName) || isCompositeProfileField(field)) {
     return 'profile';
   }
 
@@ -146,10 +152,12 @@ const getCompositeFieldValue = (
   field: CustomProfileField
 ): string | undefined => {
   const { profile } = userInfo ?? {};
-  const enabledParts = field.config.parts?.filter(({ enabled }) => enabled) ?? [];
 
   if (field.type === CustomProfileFieldType.Fullname) {
-    const partNames = enabledParts.length > 0 ? enabledParts.map(({ name }) => name) : fullnameKeys;
+    const partNames =
+      field.config.parts === undefined
+        ? fullnameKeys
+        : field.config.parts.filter(({ enabled }) => enabled).map(({ name }) => name);
 
     return joinValues(
       partNames
@@ -161,7 +169,9 @@ const getCompositeFieldValue = (
   if (field.type === CustomProfileFieldType.Address) {
     const address = profile?.address;
     const partNames =
-      enabledParts.length > 0 ? enabledParts.map(({ name }) => name) : userProfileAddressKeys;
+      field.config.parts === undefined
+        ? userProfileAddressKeys
+        : field.config.parts.filter(({ enabled }) => enabled).map(({ name }) => name);
 
     return joinValues(
       partNames
@@ -211,7 +221,8 @@ const Profile = () => {
     const customProfileFieldMap = new Map(customProfileFields.map((field) => [field.name, field]));
 
     return profileFields.reduce<ProfileFieldRow[]>((rows, { name }) => {
-      const controlKey = getProfileFieldControlKey(name);
+      const field = customProfileFieldMap.get(name);
+      const controlKey = getProfileFieldControlKey(name, field);
 
       const controlValue = accountCenterSettings?.fields[controlKey];
 
@@ -219,7 +230,6 @@ const Profile = () => {
         return rows;
       }
 
-      const field = customProfileFieldMap.get(name);
       const labelKey = profileLabelKeys[name] ?? `profile.${name}`;
       const label =
         field?.label === undefined || field.label === ''


### PR DESCRIPTION
## Summary
- Display configured Account Center profile fields on the account profile page
- Format built-in profile values including fullname, gender, address, and avatar
- Request address scope for account profile data

## Testing
Tested locally

<img width="1616" height="1330" alt="image" src="https://github.com/user-attachments/assets/5e1b1155-4656-4b0e-a337-8e4ae1944b87" />