### PR TITLE
fix(account): adjust social card mobile layout

### DIFF
--- a/packages/account/src/App.module.scss
+++ b/packages/account/src/App.module.scss
@@ -73,7 +73,7 @@
   .main {
     width: auto;
     flex: 1;
-    padding: _.unit(4) _.unit(5);
+    padding: _.unit(4);
     background: var(--color-bg-float-base);
   }
 
@@ -124,7 +124,7 @@
   @media only screen and (max-width: 800px) {
     .main:not(.cardMain) {
       width: auto;
-      padding: _.unit(3) _.unit(5);
+      padding: _.unit(4);
     }
   }
 

--- a/packages/account/src/pages/Security/SocialSection/index.module.scss
+++ b/packages/account/src/pages/Security/SocialSection/index.module.scss
@@ -121,23 +121,24 @@
   color: var(--color-danger-default);
 }
 
-:global(body.mobile) {
+@mixin mobile-layout {
   .sectionTitle {
     padding-left: 0;
   }
 
   .row {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     min-height: 0;
-    flex-direction: column;
-    align-items: stretch;
-    gap: _.unit(1);
+    align-items: center;
+    gap: _.unit(2) _.unit(3);
     padding: _.unit(4);
   }
 
   .actions {
-    display: flex;
-    flex-wrap: wrap;
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
     justify-content: flex-end;
   }
 
@@ -152,10 +153,22 @@
   }
 
   .connectorInfo {
-    width: 100%;
+    display: contents;
+  }
+
+  .connectorLogo {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .connectorName {
+    grid-column: 1 / -1;
+    grid-row: 2;
   }
 
   .identityInfo {
+    grid-column: 1 / -1;
+    grid-row: 3;
     width: 100%;
     align-items: flex-start;
   }
@@ -164,5 +177,15 @@
     padding: 0;
     white-space: normal;
     text-align: left;
+  }
+}
+
+:global(body.mobile) {
+  @include mobile-layout;
+}
+
+:global(body.desktop) {
+  @media only screen and (max-width: 800px) {
+    @include mobile-layout;
   }
 }


### PR DESCRIPTION
## Summary

- Adjust account center mobile full-page padding to 16px.
- Update the social sign-in card mobile layout to show the social icon/actions first, connector name second, and identity info third.

## Testing

- Tested locally
- Unit tests

<img width="349" height="135" alt="Screenshot 2026-05-11 at 4 00 02 PM" src="https://github.com/user-attachments/assets/1afc4fb5-3902-4650-8905-1206134a9107" />
