### PR TITLE
fix(account): clarify two-step verification toggle label

### DIFF
--- a/.changeset/clarify-two-step-toggle-label.md
+++ b/.changeset/clarify-two-step-toggle-label.md
@@ -1,0 +1,6 @@
+---
+"@logto/account": patch
+"@logto/phrases-experience": patch
+---
+
+clarify Account Center 2-step verification toggle label

--- a/packages/account/src/pages/Security/MfaSection/index.tsx
+++ b/packages/account/src/pages/Security/MfaSection/index.tsx
@@ -112,11 +112,7 @@ const MfaContent = ({
         <div className={styles.toggleRow}>
           <div className={styles.toggleInfo}>
             <div className={styles.toggleTitle}>
-              {t(
-                isTwoStepEnabled
-                  ? 'account_center.security.turn_off_2_step_verification'
-                  : 'account_center.security.turn_on_2_step_verification'
-              )}
+              {t('account_center.security.two_step_verification')}
             </div>
             <div className={styles.toggleDescription}>
               {t('account_center.security.turn_on_2_step_verification_description')}

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -95,7 +95,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} رموز متبقية',
     view: 'عرض',
     manage: 'إدارة',
-    turn_on_2_step_verification: 'تفعيل التحقق بخطوتين',
     turn_on_2_step_verification_description:
       'أضف طبقة أمان إضافية. ستتم مطالبتك بخطوة تحقق ثانية عند تسجيل الدخول.',
     turn_off_2_step_verification: 'إيقاف التحقق بخطوتين',

--- a/packages/phrases-experience/src/locales/cs/account-center.ts
+++ b/packages/phrases-experience/src/locales/cs/account-center.ts
@@ -95,7 +95,6 @@ const account_center = {
     backup_codes_count_other: 'zbývá {{count}} kódů',
     view: 'Zobrazit',
     manage: 'Spravovat',
-    turn_on_2_step_verification: 'Zapnout dvoufázové ověření',
     turn_on_2_step_verification_description:
       'Přidejte další vrstvu zabezpečení. Při přihlášení budete vyzváni k druhému ověřovacímu kroku.',
     turn_off_2_step_verification: 'Vypnout dvoufázové ověření',

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -102,7 +102,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} Codes verbleibend',
     view: 'Ansehen',
     manage: 'Verwalten',
-    turn_on_2_step_verification: '2-Faktor-Verifizierung aktivieren',
     turn_on_2_step_verification_description:
       'Fügen Sie eine zusätzliche Sicherheitsebene hinzu. Sie werden bei der Anmeldung zu einem zweiten Verifizierungsschritt aufgefordert.',
     turn_off_2_step_verification: '2-Faktor-Verifizierung deaktivieren',

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -92,7 +92,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} codes remaining',
     view: 'View',
     manage: 'Manage',
-    turn_on_2_step_verification: 'Turn on 2-step verification',
     turn_on_2_step_verification_description:
       "Add an extra layer of security. You'll be prompted for a second verification step at sign-in.",
     turn_off_2_step_verification: 'Turn off 2-step verification',

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -99,7 +99,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} códigos restantes',
     view: 'Ver',
     manage: 'Gestionar',
-    turn_on_2_step_verification: 'Activar verificación en dos pasos',
     turn_on_2_step_verification_description:
       'Añade una capa extra de seguridad. Se te pedirá un segundo paso de verificación al iniciar sesión.',
     turn_off_2_step_verification: 'Desactivar verificación en dos pasos',

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -101,7 +101,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} codes restants',
     view: 'Voir',
     manage: 'Gérer',
-    turn_on_2_step_verification: 'Activer la vérification en deux étapes',
     turn_on_2_step_verification_description:
       'Ajoutez une couche de sécurité supplémentaire. Vous serez invité à effectuer une deuxième étape de vérification lors de la connexion.',
     turn_off_2_step_verification: 'Désactiver la vérification en deux étapes',

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -100,7 +100,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} codici rimanenti',
     view: 'Visualizza',
     manage: 'Gestisci',
-    turn_on_2_step_verification: 'Attiva la verifica in due passaggi',
     turn_on_2_step_verification_description:
       "Aggiungi un ulteriore livello di sicurezza. Ti verrà richiesto un secondo passaggio di verifica all'accesso.",
     turn_off_2_step_verification: 'Disattiva la verifica in due passaggi',

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -95,7 +95,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} 個のコード',
     view: '表示',
     manage: '管理',
-    turn_on_2_step_verification: '2段階認証を有効にする',
     turn_on_2_step_verification_description:
       'セキュリティを強化します。サインイン時に2段階目の認証が求められます。',
     turn_off_2_step_verification: '2段階認証を無効にする',

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -94,7 +94,6 @@ const account_center = {
     backup_codes_count_other: '{{count}}개의 코드',
     view: '보기',
     manage: '관리',
-    turn_on_2_step_verification: '2단계 인증 켜기',
     turn_on_2_step_verification_description:
       '추가 보안 계층을 추가합니다. 로그인 시 두 번째 인증 단계가 요청됩니다.',
     turn_off_2_step_verification: '2단계 인증 끄기',

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -96,7 +96,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} kody pozostałe',
     view: 'Wyświetl',
     manage: 'Zarządzaj',
-    turn_on_2_step_verification: 'Włącz weryfikację dwuetapową',
     turn_on_2_step_verification_description:
       'Dodaj dodatkową warstwę bezpieczeństwa. Podczas logowania zostaniesz poproszony o drugi krok weryfikacji.',
     turn_off_2_step_verification: 'Wyłącz weryfikację dwuetapową',

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -98,7 +98,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} códigos restantes',
     view: 'Visualizar',
     manage: 'Gerenciar',
-    turn_on_2_step_verification: 'Ativar verificação em duas etapas',
     turn_on_2_step_verification_description:
       'Adicione uma camada extra de segurança. Você será solicitado a realizar uma segunda etapa de verificação ao fazer login.',
     turn_off_2_step_verification: 'Desativar verificação em duas etapas',

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -99,7 +99,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} códigos restantes',
     view: 'Ver',
     manage: 'Gerir',
-    turn_on_2_step_verification: 'Ativar verificação em duas etapas',
     turn_on_2_step_verification_description:
       'Adicione uma camada extra de segurança. Será solicitada uma segunda etapa de verificação ao iniciar sessão.',
     turn_off_2_step_verification: 'Desativar verificação em duas etapas',

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -95,7 +95,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} кодов осталось',
     view: 'Просмотр',
     manage: 'Управление',
-    turn_on_2_step_verification: 'Включить двухэтапную верификацию',
     turn_on_2_step_verification_description:
       'Добавьте дополнительный уровень безопасности. При входе вам будет предложен второй шаг верификации.',
     turn_off_2_step_verification: 'Отключить двухэтапную верификацию',

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -95,7 +95,6 @@ const account_center = {
     backup_codes_count_other: 'เหลือ {{count}} รหัส',
     view: 'ดู',
     manage: 'จัดการ',
-    turn_on_2_step_verification: 'เปิดการยืนยันตัวตนสองขั้นตอน',
     turn_on_2_step_verification_description:
       'เพิ่มชั้นความปลอดภัยเพิ่มเติม คุณจะถูกขอให้ทำการยืนยันขั้นตอนที่สองเมื่อลงชื่อเข้าใช้',
     turn_off_2_step_verification: 'ปิดการยืนยันตัวตนสองขั้นตอน',

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -96,7 +96,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} kod kaldı',
     view: 'Görüntüle',
     manage: 'Yönet',
-    turn_on_2_step_verification: '2 adımlı doğrulamayı aç',
     turn_on_2_step_verification_description:
       'Ekstra bir güvenlik katmanı ekleyin. Oturum açarken ikinci bir doğrulama adımı istenecektir.',
     turn_off_2_step_verification: '2 adımlı doğrulamayı kapat',

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -97,7 +97,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} кодів залишилось',
     view: 'Перегляд',
     manage: 'Керування',
-    turn_on_2_step_verification: 'Увімкнути двоетапну верифікацію',
     turn_on_2_step_verification_description:
       'Додайте додатковий рівень безпеки. При вході вам буде запропоновано другий крок верифікації.',
     turn_off_2_step_verification: 'Вимкнути двоетапну верифікацію',

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -94,7 +94,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} 个备用码',
     view: '查看',
     manage: '管理',
-    turn_on_2_step_verification: '开启两步验证',
     turn_on_2_step_verification_description: '增加一层额外的安全保护。登录时将要求进行第二步验证。',
     turn_off_2_step_verification: '关闭两步验证',
     turn_off_2_step_verification_description:

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -94,7 +94,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} 個備用碼',
     view: '檢視',
     manage: '管理',
-    turn_on_2_step_verification: '開啟兩步驗證',
     turn_on_2_step_verification_description: '增加額外的安全保護。登入時將要求進行第二步驗證。',
     turn_off_2_step_verification: '關閉兩步驗證',
     turn_off_2_step_verification_description:

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -94,7 +94,6 @@ const account_center = {
     backup_codes_count_other: '{{count}} 個備用碼',
     view: '檢視',
     manage: '管理',
-    turn_on_2_step_verification: '開啟兩步驟驗證',
     turn_on_2_step_verification_description: '增加額外的安全保護。登入時將要求進行第二步驟驗證。',
     turn_off_2_step_verification: '關閉兩步驟驗證',
     turn_off_2_step_verification_description:


### PR DESCRIPTION
## Summary
- Use a neutral "2-step verification" label for the account security MFA toggle so the switch clearly represents the feature state.

Fixes #8791

## Testing
- Unit tests