### PR TITLE
fix(console): add BYO UI captcha notice

### DIFF
--- a/packages/console/src/consts/external-links.ts
+++ b/packages/console/src/consts/external-links.ts
@@ -62,6 +62,7 @@ export const security = '/security';
 export const captcha = '/security/captcha';
 export const recaptchaEnterpriseBringYourUi =
   '/security/captcha/recaptcha-enterprise#bring-your-ui';
+export const turnstileBringYourUi = '/security/captcha/turnstile#bring-your-ui';
 export const sentinel = '/security/identifier-lockout';
 export const emailBlocklist = '/security/blocklist';
 export const passwordPolicy = '/security/password-policy';

--- a/packages/console/src/consts/external-links.ts
+++ b/packages/console/src/consts/external-links.ts
@@ -60,6 +60,8 @@ export const emailConnectors = '/connectors/email-connectors';
 export const enterpriseSso = '/connectors/enterprise-connectors';
 export const security = '/security';
 export const captcha = '/security/captcha';
+export const recaptchaEnterpriseBringYourUi =
+  '/security/captcha/recaptcha-enterprise#bring-your-ui';
 export const sentinel = '/security/identifier-lockout';
 export const emailBlocklist = '/security/blocklist';
 export const passwordPolicy = '/security/password-policy';

--- a/packages/console/src/pages/Security/Captcha/index.module.scss
+++ b/packages/console/src/pages/Security/Captcha/index.module.scss
@@ -9,3 +9,7 @@
 .upsellNotice {
   margin-bottom: _.unit(4);
 }
+
+.customUiNotice {
+  margin-bottom: _.unit(4);
+}

--- a/packages/console/src/pages/Security/Captcha/index.tsx
+++ b/packages/console/src/pages/Security/Captcha/index.tsx
@@ -5,7 +5,7 @@ import useSWR from 'swr';
 import { z } from 'zod';
 
 import { FormCardSkeleton } from '@/components/FormCard';
-import { recaptchaEnterpriseBringYourUi } from '@/consts/external-links';
+import { recaptchaEnterpriseBringYourUi, turnstileBringYourUi } from '@/consts/external-links';
 import InlineNotification from '@/ds-components/InlineNotification';
 import TextLink from '@/ds-components/TextLink';
 import { type RequestError } from '@/hooks/use-api';
@@ -31,6 +31,10 @@ function Captcha() {
   const guideType = z.nativeEnum(CaptchaType).safeParse(guideId);
   const navigate = useNavigate();
   const shouldShowCustomUiCaptchaNotice = Boolean(signInExpData?.customUiAssets);
+  const customUiCaptchaGuideLink =
+    data?.config.type === CaptchaType.Turnstile
+      ? turnstileBringYourUi
+      : recaptchaEnterpriseBringYourUi;
 
   if (guideType.success) {
     return (
@@ -53,7 +57,7 @@ function Captcha() {
             components={{
               a: (
                 <TextLink
-                  href={getDocumentationUrl(recaptchaEnterpriseBringYourUi)}
+                  href={getDocumentationUrl(customUiCaptchaGuideLink)}
                   targetBlank="noopener"
                 />
               ),

--- a/packages/console/src/pages/Security/Captcha/index.tsx
+++ b/packages/console/src/pages/Security/Captcha/index.tsx
@@ -1,10 +1,15 @@
 import { CaptchaType, type SignInExperience } from '@logto/schemas';
+import { Trans } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import useSWR from 'swr';
 import { z } from 'zod';
 
 import { FormCardSkeleton } from '@/components/FormCard';
+import { recaptchaEnterpriseBringYourUi } from '@/consts/external-links';
+import InlineNotification from '@/ds-components/InlineNotification';
+import TextLink from '@/ds-components/TextLink';
 import { type RequestError } from '@/hooks/use-api';
+import useDocumentationUrl from '@/hooks/use-documentation-url';
 
 import PaywallNotification from '../PaywallNotification';
 
@@ -20,10 +25,12 @@ function Captcha() {
     RequestError
   >('api/sign-in-exp');
   const isLoading = isDataLoading || isSignInExpLoading;
+  const { getDocumentationUrl } = useDocumentationUrl();
 
   const { guideId } = useParams();
   const guideType = z.nativeEnum(CaptchaType).safeParse(guideId);
   const navigate = useNavigate();
+  const shouldShowCustomUiCaptchaNotice = Boolean(signInExpData?.customUiAssets);
 
   if (guideType.success) {
     return (
@@ -39,6 +46,22 @@ function Captcha() {
   return (
     <div className={styles.content}>
       <PaywallNotification className={styles.upsellNotice} />
+      {shouldShowCustomUiCaptchaNotice && (
+        <InlineNotification className={styles.customUiNotice} severity="alert">
+          <Trans
+            i18nKey="admin_console.security.bot_protection.custom_ui_captcha_notice"
+            components={{
+              a: (
+                <TextLink
+                  href={getDocumentationUrl(recaptchaEnterpriseBringYourUi)}
+                  targetBlank="noopener"
+                />
+              ),
+              code: <code />,
+            }}
+          />
+        </InlineNotification>
+      )}
       {isLoading || !signInExpData ? (
         <FormCardSkeleton formFieldCount={2} />
       ) : (

--- a/packages/phrases/src/locales/en/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/security.ts
@@ -21,6 +21,8 @@ const security = {
     enable_captcha: 'Enable CAPTCHA',
     enable_captcha_description:
       'Enable CAPTCHA verification for sign-up, sign-in, and password recovery flows.',
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. After enabling CAPTCHA, your custom UI must load the CAPTCHA script, run verification, and send the resulting token as <code>captchaToken</code> in <code>PUT /api/experience</code>. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'Setup CAPTCHA',

--- a/packages/phrases/src/locales/en/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/security.ts
@@ -22,7 +22,7 @@ const security = {
     enable_captcha_description:
       'Enable CAPTCHA verification for sign-up, sign-in, and password recovery flows.',
     custom_ui_captcha_notice:
-      'You are using Bring your UI. After enabling CAPTCHA, your custom UI must load the CAPTCHA script, run verification, and send the resulting token as <code>captchaToken</code> in <code>PUT /api/experience</code>. <a>View setup guide</a>.',
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'Setup CAPTCHA',


### PR DESCRIPTION
## Summary
- Add a CAPTCHA settings notice when Bring your UI is enabled.
- Link the notice to the reCAPTCHA Enterprise Bring your UI guide.

## Testing
Tested locally

<img width="900" height="254" alt="image" src="https://github.com/user-attachments/assets/b7509dbb-cede-4037-a794-89e71df9fbd1" />

