### PR TITLE
feat(core): add enableCap query param to bound countLogs scan

### DIFF
--- a/.changeset/logs-enable-cap.md
+++ b/.changeset/logs-enable-cap.md
@@ -1,0 +1,13 @@
+---
+"@logto/core": minor
+---
+
+add `enableCap=true` query parameter to `GET /logs` and `GET /hooks/:id/recent-logs` to reduce the chance of `statement_timeout` on tenants with very large log volumes.
+
+When the param is passed:
+
+- The count query short-circuits at ~10,000 rows, returning `10001` as a saturation sentinel.
+- The response includes a `Total-Number-Is-Capped: true` header when the cap is hit.
+- In capped responses, both `Link: rel="last"` and `Link: rel="next"` are omitted because the saturated count makes the derived page count unreliable. Clients should construct page URLs themselves and stop on an empty response.
+
+Default request behavior (without `enableCap`) is unchanged.

--- a/packages/core/src/middleware/koa-pagination.test.ts
+++ b/packages/core/src/middleware/koa-pagination.test.ts
@@ -148,3 +148,49 @@ describe('response', () => {
     });
   });
 });
+
+describe('capped totalCount', () => {
+  it('emits `Total-Number-Is-Capped: true` and omits both `last` and `next` when capped', async () => {
+    // Stripe-style: when the count is capped, the saturated `totalPage` is a
+    // lie, so neither `last` nor `next` can be answered honestly. Both are
+    // dropped together; clients walk by URL construction and stop on empty.
+    const ctx = createContext({});
+    await koaPagination({ defaultPageSize: 20 })(ctx, async () => {
+      ctx.pagination.totalCount = 10_001;
+      ctx.pagination.totalCountIsCapped = true;
+    });
+    expect(setHeader).toHaveBeenCalledWith('Total-Number', '10001');
+    expect(setHeader).toHaveBeenCalledWith('Total-Number-Is-Capped', 'true');
+    expect(links.has('<?page=1>; rel="first"')).toBeTruthy();
+    expect([...links].some((link) => link.includes('rel="last"'))).toBeFalsy();
+    expect([...links].some((link) => link.includes('rel="next"'))).toBeFalsy();
+  });
+
+  it('still emits `prev` when capped and not on the first page', async () => {
+    const ctx = createContext({ page: '3' });
+    await koaPagination({ defaultPageSize: 20 })(ctx, async () => {
+      ctx.pagination.totalCount = 10_001;
+      ctx.pagination.totalCountIsCapped = true;
+    });
+    expect(links.has('<?page=2>; rel="prev"')).toBeTruthy();
+  });
+
+  it('keeps full Link set when totalCountIsCapped is false', async () => {
+    const ctx = createContext({});
+    await koaPagination({ defaultPageSize: 20 })(ctx, async () => {
+      ctx.pagination.totalCount = 30;
+      ctx.pagination.totalCountIsCapped = false;
+    });
+    expect(setHeader).not.toHaveBeenCalledWith('Total-Number-Is-Capped', 'true');
+    expect(links.has('<?page=2>; rel="last"')).toBeTruthy();
+  });
+
+  it('keeps full Link set when totalCountIsCapped is undefined', async () => {
+    const ctx = createContext({});
+    await koaPagination({ defaultPageSize: 20 })(ctx, async () => {
+      ctx.pagination.totalCount = 30;
+    });
+    expect(setHeader).not.toHaveBeenCalledWith('Total-Number-Is-Capped', 'true');
+    expect(links.has('<?page=2>; rel="last"')).toBeTruthy();
+  });
+});

--- a/packages/core/src/middleware/koa-pagination.ts
+++ b/packages/core/src/middleware/koa-pagination.ts
@@ -9,6 +9,8 @@ type Pagination = {
   offset: number;
   limit: number;
   totalCount?: number;
+  /** When `true`, `totalCount` is a lower bound; middleware signals the saturation downstream. */
+  totalCountIsCapped?: boolean;
   disabled?: false;
 };
 
@@ -95,23 +97,32 @@ function koaPagination<StateT, ContextT, ResponseBodyT, IsOptional extends boole
       throw new Error('missing totalCount');
     }
 
-    const { limit, offset, totalCount } = ctx.pagination;
+    const { limit, offset, totalCount, totalCountIsCapped } = ctx.pagination;
     const totalPage = Math.ceil(totalCount / limit) || 1; // Minimum page number is 1
 
     // Our custom response header: Total-Number
     ctx.set('Total-Number', String(totalCount));
+    if (totalCountIsCapped) {
+      ctx.set('Total-Number-Is-Capped', 'true');
+    }
 
     // Response header's `Link`: https://datatracker.ietf.org/doc/html/rfc5988
     const page = Math.floor(offset / limit) + 1; // Start from 1
     ctx.append('Link', buildLink(ctx.request, 1, 'first'));
-    ctx.append('Link', buildLink(ctx.request, totalPage, 'last'));
 
     if (page > 1) {
       ctx.append('Link', buildLink(ctx.request, page - 1, 'prev'));
     }
 
-    if (page < totalPage) {
-      ctx.append('Link', buildLink(ctx.request, page + 1, 'next'));
+    // When capped, `totalPage` is derived from a saturated count and is no
+    // longer accurate, so neither `last` nor `next` can be emitted honestly.
+    // Clients should construct `?page=N+1` URLs themselves and stop on an
+    // empty response.
+    if (!totalCountIsCapped) {
+      ctx.append('Link', buildLink(ctx.request, totalPage, 'last'));
+      if (page < totalPage) {
+        ctx.append('Link', buildLink(ctx.request, page + 1, 'next'));
+      }
     }
   };
 

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -25,6 +25,19 @@ type LogCondition = {
   includeKeyPrefix?: AllowedKeyPrefix[];
 };
 
+/**
+ * Bounds the rows counted to avoid a full `count(*)` traversal on tenants with
+ * very large `logs` tables. When the inner row count reaches `LOGS_COUNT_CAP + 1`,
+ * the outer aggregate stops and reports the sentinel value, sharply reducing the
+ * chance of hitting `statement_timeout`.
+ */
+const LOGS_COUNT_CAP = 10_000;
+
+type CountLogsResult = {
+  count: number;
+  isCapped?: boolean;
+};
+
 const buildLogConditionSql = (logCondition: LogCondition) =>
   conditionalSql(logCondition, ({ logKey, payload, startTimeExclusive, includeKeyPrefix = [] }) => {
     const keyPrefixFilter = conditional(
@@ -56,12 +69,33 @@ const buildLogConditionSql = (logCondition: LogCondition) =>
 export const createLogQueries = (pool: CommonQueryMethods) => {
   const insertLog = buildInsertIntoWithPool(pool)(Logs);
 
-  const countLogs = async (condition: LogCondition) =>
-    pool.one<{ count: number }>(sql`
+  const countLogs = async (
+    condition: LogCondition,
+    options?: { capped?: boolean }
+  ): Promise<CountLogsResult> => {
+    if (!options?.capped) {
+      // Postgres returns a bigint for count(*), which Slonik surfaces as a string.
+      const { count } = await pool.one<{ count: string }>(sql`
+        select count(*)
+        from ${table}
+        ${buildLogConditionSql(condition)}
+      `);
+      return { count: Number(count) };
+    }
+
+    const cappedLimit = LOGS_COUNT_CAP + 1;
+    const { count } = await pool.one<{ count: string }>(sql`
       select count(*)
-      from ${table}
-      ${buildLogConditionSql(condition)}
+      from (
+        select 1
+        from ${table}
+        ${buildLogConditionSql(condition)}
+        limit ${cappedLimit}
+      ) s
     `);
+    const numericCount = Number(count);
+    return { count: numericCount, isCapped: numericCount > LOGS_COUNT_CAP };
+  };
 
   const findLogs = async (limit: number, offset: number, logCondition: LogCondition) =>
     pool.any<Log>(sql`

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -147,12 +147,15 @@ describe('hook routes', () => {
     await hookRequest.get(
       `/hooks/${hookId}/recent-logs?logKey=${logKey}&page=${page}&page_size=${pageSize}`
     );
-    expect(countLogs).toHaveBeenCalledWith({
-      payload: { hookId },
-      logKey,
-      startTimeExclusive,
-      includeKeyPrefix: [hook.Type.TriggerHook],
-    });
+    expect(countLogs).toHaveBeenCalledWith(
+      {
+        payload: { hookId },
+        logKey,
+        startTimeExclusive,
+        includeKeyPrefix: [hook.Type.TriggerHook],
+      },
+      { capped: false }
+    );
     expect(findLogs).toHaveBeenCalledWith(5, 0, {
       payload: { hookId },
       logKey,
@@ -161,6 +164,31 @@ describe('hook routes', () => {
     });
 
     jest.useRealTimers();
+  });
+
+  describe('GET /hooks/:id/recent-logs enableCap query param', () => {
+    afterEach(() => {
+      countLogs.mockResolvedValue({ count: 1 });
+    });
+
+    it('passes capped=true to countLogs and emits Total-Number-Is-Capped when enableCap=true', async () => {
+      countLogs.mockResolvedValueOnce({ count: 10_001, isCapped: true });
+
+      const response = await hookRequest.get(`/hooks/foo/recent-logs?enableCap=true`);
+      expect(response.status).toEqual(200);
+      expect(countLogs).toHaveBeenCalledWith(expect.any(Object), { capped: true });
+      expect(response.header).toHaveProperty('total-number', '10001');
+      expect(response.header).toHaveProperty('total-number-is-capped', 'true');
+      // Capped responses omit both `last` and `next` link rels.
+      const linkHeader = String(response.header.link ?? '');
+      expect(linkHeader).not.toContain('rel="last"');
+      expect(linkHeader).not.toContain('rel="next"');
+    });
+
+    it('passes capped=false to countLogs when enableCap is omitted', async () => {
+      await hookRequest.get(`/hooks/foo/recent-logs`);
+      expect(countLogs).toHaveBeenCalledWith(expect.any(Object), { capped: false });
+    });
   });
 
   it('POST /hooks', async () => {

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -121,7 +121,10 @@ export default function hookRoutes<T extends ManagementApiRouter>(
     koaPagination(),
     koaGuard({
       params: z.object({ id: z.string() }),
-      query: z.object({ logKey: z.string().optional() }),
+      query: z.object({
+        logKey: z.string().optional(),
+        enableCap: z.string().optional(),
+      }),
       response: Logs.guard.omit({ tenantId: true }).array(),
       status: 200,
     }),
@@ -130,19 +133,22 @@ export default function hookRoutes<T extends ManagementApiRouter>(
 
       const {
         params: { id },
-        query: { logKey },
+        query: { logKey, enableCap },
       } = ctx.guard;
 
       const includeKeyPrefix: WebhookLogPrefix[] = [hook.Type.TriggerHook];
       const startTimeExclusive = subDays(new Date(), 1).getTime();
 
-      const [{ count }, logs] = await Promise.all([
-        countLogs({
-          logKey,
-          payload: { hookId: id },
-          startTimeExclusive,
-          includeKeyPrefix,
-        }),
+      const [{ count, isCapped }, logs] = await Promise.all([
+        countLogs(
+          {
+            logKey,
+            payload: { hookId: id },
+            startTimeExclusive,
+            includeKeyPrefix,
+          },
+          { capped: yes(enableCap) }
+        ),
         findLogs(limit, offset, {
           logKey,
           payload: { hookId: id },
@@ -152,6 +158,7 @@ export default function hookRoutes<T extends ManagementApiRouter>(
       ]);
 
       ctx.pagination.totalCount = count;
+      ctx.pagination.totalCountIsCapped = isCapped;
       ctx.body = logs;
 
       return next();

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -42,19 +42,22 @@ describe('logRoutes', () => {
       await logRequest.get(
         `/logs?userId=${userId}&applicationId=${applicationId}&logKey=${logKey}&page=${page}&page_size=${pageSize}`
       );
-      expect(countLogs).toHaveBeenCalledWith({
-        payload: { userId, applicationId },
-        logKey,
-        includeKeyPrefix: [
-          token.Type.ExchangeTokenBy,
-          token.Type.RevokeToken,
-          token.Type.RevokeGrants,
-          interaction.prefix,
-          jwtCustomizer.prefix,
-          saml.prefix,
-          LogKeyUnknown,
-        ],
-      });
+      expect(countLogs).toHaveBeenCalledWith(
+        {
+          payload: { userId, applicationId },
+          logKey,
+          includeKeyPrefix: [
+            token.Type.ExchangeTokenBy,
+            token.Type.RevokeToken,
+            token.Type.RevokeGrants,
+            interaction.prefix,
+            jwtCustomizer.prefix,
+            saml.prefix,
+            LogKeyUnknown,
+          ],
+        },
+        { capped: false }
+      );
       expect(findLogs).toHaveBeenCalledWith(5, 0, {
         payload: { userId, applicationId },
         logKey,
@@ -75,6 +78,28 @@ describe('logRoutes', () => {
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(mockLogs);
       expect(response.header).toHaveProperty('total-number', `${mockLogs.length}`);
+      expect(response.header).not.toHaveProperty('total-number-is-capped');
+    });
+
+    describe('enableCap query param', () => {
+      afterEach(() => {
+        countLogs.mockResolvedValue({ count: mockLogs.length });
+      });
+
+      it('passes capped=true to countLogs when enableCap=true', async () => {
+        countLogs.mockResolvedValueOnce({ count: 10_001, isCapped: true });
+
+        const response = await logRequest.get(`/logs?enableCap=true`);
+        expect(response.status).toEqual(200);
+        expect(countLogs).toHaveBeenCalledWith(expect.any(Object), { capped: true });
+        expect(response.header).toHaveProperty('total-number', '10001');
+        expect(response.header).toHaveProperty('total-number-is-capped', 'true');
+      });
+
+      it('passes capped=false to countLogs when enableCap is omitted', async () => {
+        await logRequest.get(`/logs`);
+        expect(countLogs).toHaveBeenCalledWith(expect.any(Object), { capped: false });
+      });
     });
   });
 

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -7,6 +7,7 @@ import {
   saml,
   type AuditLogPrefix,
 } from '@logto/schemas';
+import { yes } from '@silverhand/essentials';
 import { object, string } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -27,6 +28,7 @@ export default function logRoutes<T extends ManagementApiRouter>(
         userId: string().optional(),
         applicationId: string().optional(),
         logKey: string().optional(),
+        enableCap: string().optional(),
       }),
       response: Logs.guard.array(),
       status: 200,
@@ -34,7 +36,7 @@ export default function logRoutes<T extends ManagementApiRouter>(
     async (ctx, next) => {
       const { limit, offset } = ctx.pagination;
       const {
-        query: { userId, applicationId, logKey },
+        query: { userId, applicationId, logKey, enableCap },
       } = ctx.guard;
 
       const includeKeyPrefix: AuditLogPrefix[] = [
@@ -48,12 +50,15 @@ export default function logRoutes<T extends ManagementApiRouter>(
       ];
 
       // TODO: @Gao refactor like user search
-      const [{ count }, logs] = await Promise.all([
-        countLogs({
-          logKey,
-          payload: { applicationId, userId },
-          includeKeyPrefix,
-        }),
+      const [{ count, isCapped }, logs] = await Promise.all([
+        countLogs(
+          {
+            logKey,
+            payload: { applicationId, userId },
+            includeKeyPrefix,
+          },
+          { capped: yes(enableCap) }
+        ),
         findLogs(limit, offset, {
           logKey,
           payload: { userId, applicationId },
@@ -63,6 +68,7 @@ export default function logRoutes<T extends ManagementApiRouter>(
 
       // Return totalCount to pagination middleware
       ctx.pagination.totalCount = count;
+      ctx.pagination.totalCountIsCapped = isCapped;
       ctx.body = logs;
 
       return next();

--- a/packages/integration-tests/src/api/logs.ts
+++ b/packages/integration-tests/src/api/logs.ts
@@ -3,8 +3,13 @@ import { conditionalString } from '@silverhand/essentials';
 
 import { authedAdminApi } from './api.js';
 
-export const getAuditLogs = async (params?: URLSearchParams) =>
-  authedAdminApi.get('logs?' + conditionalString(params?.toString())).json<Log[]>();
+export const getAuditLogsResponse = async (params?: URLSearchParams) =>
+  authedAdminApi.get('logs?' + conditionalString(params?.toString()));
+
+export const getAuditLogs = async (params?: URLSearchParams) => {
+  const response = await getAuditLogsResponse(params);
+  return response.json<Log[]>();
+};
 
 export const getWebhookRecentLogs = async (hookId: string, params?: URLSearchParams) =>
   authedAdminApi

--- a/packages/integration-tests/src/tests/api/audit-logs/count-cap.test.ts
+++ b/packages/integration-tests/src/tests/api/audit-logs/count-cap.test.ts
@@ -1,0 +1,31 @@
+import { getAuditLogsResponse } from '#src/api/logs.js';
+
+// The capped path is covered by unit tests in `koa-pagination.test.ts` and
+// `routes/log.test.ts`; reproducing it at integration level would require
+// seeding >10k matching rows per run.
+describe('GET /logs count cap signaling', () => {
+  it('emits the classic header set without enableCap', async () => {
+    const response = await getAuditLogsResponse(new URLSearchParams({ page_size: '20' }));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('total-number')).not.toBeNull();
+    expect(response.headers.get('total-number-is-capped')).toBeNull();
+
+    const linkHeader = response.headers.get('link') ?? '';
+    expect(linkHeader).toContain('rel="first"');
+    expect(linkHeader).toContain('rel="last"');
+  });
+
+  it('opts into the capped query when enableCap=true but stays unsaturated on small data', async () => {
+    const response = await getAuditLogsResponse(
+      new URLSearchParams({ page_size: '20', enableCap: 'true' })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('total-number')).not.toBeNull();
+    // Integration data is small, so the cap is opted into but not hit; behaves
+    // identically to the no-param path.
+    expect(response.headers.get('total-number-is-capped')).toBeNull();
+    expect(response.headers.get('link') ?? '').toContain('rel="last"');
+  });
+});


### PR DESCRIPTION
## Summary

Refs [LOG-13415](https://linear.app/silverhand/issue/LOG-13415).

A customer reported that `GET /logs` on the Management API consistently times out with a Slonik `StatementTimeoutError`. Tracing the stack pointed at `countLogs` (`pool.one(...)`), not `findLogs` — so the timeout is in `select count(*) from logs ...`, not the page fetch.

### Why it times out

For a tenant with millions of `logs` rows, `count(*)` is unavoidably row-scanning on Postgres. Combined with the `key LIKE 'prefix%'` OR-chain that the route applies by default, the planner falls back to bitmap heap scans that exceed `statement_timeout`. The recently added `logs__created_at_id` index helps `ORDER BY created_at DESC LIMIT` in `findLogs`, but does nothing for `count(*)`. The route also requires `totalCount` to be set, so even a fast page fetch can't return until the slow count resolves.

### What changed

Per-request opt-in via a new `?enableCap=true` query param on `GET /logs` and `GET /hooks/:id/recent-logs`. Default behavior is byte-for-byte identical to current master.

- **`packages/core/src/queries/log.ts`** — `countLogs` now accepts an optional `{ capped?: boolean }` option. When `capped` is true, it runs `select count(*) from (select 1 from logs <conds> limit 10001) s` so Postgres halts at the cap; when false (or omitted), the legacy uncapped query is used. Both branches follow the canonical `pool.one<{ count: string }>` + `Number(...)` pattern (matches `database/row-count.ts`). Return shape gains an optional `isCapped?: boolean`.
- **`packages/core/src/middleware/koa-pagination.ts`** — `Pagination` type gains an optional `totalCountIsCapped?: boolean`. When set, the middleware emits a `Total-Number-Is-Capped: true` response header and omits **both** `Link: rel="last"` and `Link: rel="next"`. The saturated `totalCount` makes the derived `totalPage` unreliable, so neither count-derived rel can be answered honestly. Capped responses emit only `first` and `prev`.
- **`packages/core/src/routes/log.ts` and `routes/hook.ts`** — accept `enableCap` via the zod guard, coerce with `yes(...)`, pass `{ capped: ... }` to `countLogs`, and propagate `isCapped` to `ctx.pagination.totalCountIsCapped`.

### Client navigation in capped mode

This matches the Stripe / cursor-style convention for unknown totals: when the server can't honestly answer "what's the last page" or "is there a next page", it doesn't emit those rels. Clients in capped mode walk forward by constructing `?page=N+1` URLs themselves and stop on an empty response. This is the stable contract (documented in [LOG-13434](https://linear.app/silverhand/issue/LOG-13434)) — not a transitional state.

### Why per-request, not a global flag

Earlier draft of this PR used `EnvSet.values.isDevFeaturesEnabled` as a global gate. A per-request query param is strictly better:

- Existing third-party clients are **guaranteed** unaffected — no behavioral change unless they explicitly opt in.
- The customer can self-remediate by deploying a one-line change to their HTTP client.
- The Console's adoption ([LOG-13417](https://linear.app/silverhand/issue/LOG-13417)) is independent of any backend rollout coordination.
- No release-day surprise window, no per-tenant feature-flag operations.

### Backward compatibility

- Default `GET /logs` request (no `enableCap`): identical to current master. Same SQL behavior (now with the canonical `{ count: string }` typing applied to both branches), same `{ count }` destructure-compatible return shape, same headers, same Link rels.
- `Pagination` type gains an optional field; existing paginated routes that don't set it are unaffected.
- `countLogs` signature gains an optional `options` parameter; both existing call sites in this PR are updated, no external callers.
- No schema changes. No new env vars. No feature flag to flip.

### Reviewer notes

- Capped SQL uses `select 1 ... limit N` in a subquery so Postgres can stream and halt at N without sorting. No `ORDER BY`, no materialize node.
- The `Total-Number-Is-Capped` header and the `last`/`next` rel omissions only fire when the handler sets `totalCountIsCapped = true`. Other paginated routes are unaffected because they don't set the field.
- Capped-path coverage is at the unit-test level (mocked `countLogs` returning `isCapped: true`, middleware test setting `totalCountIsCapped = true` directly). Integration coverage of the actual saturated SQL would require seeding > 10k rows per run; we deemed the unit coverage sufficient.

## Testing

Unit tests, integration tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments