### PR TITLE
refactor(toolkit): move custom UI CSP validation utilities

### DIFF
--- a/packages/core/src/routes/sign-in-experience/custom-ui-csp.test.ts
+++ b/packages/core/src/routes/sign-in-experience/custom-ui-csp.test.ts
@@ -1,3 +1,5 @@
+import { CustomUiCspSourceValidationErrorCode } from '@logto/core-kit';
+
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 
@@ -33,6 +35,23 @@ describe('normalizeCustomUiCsp()', () => {
 
     expect(() => normalizeCustomUiCsp({ scriptSrc: ['wss://events.example.com'] })).toThrow(
       RequestError
+    );
+  });
+
+  it('should expose validation error code in data and readable description in message', () => {
+    expect(() => normalizeCustomUiCsp({ scriptSrc: ['wss://events.example.com'] })).toThrow(
+      new RequestError(
+        {
+          code: 'request.invalid_input',
+          details:
+            'Invalid customUiCsp.scriptSrc source "wss://events.example.com": Unsupported scheme',
+        },
+        {
+          directive: 'scriptSrc',
+          source: 'wss://events.example.com',
+          validationErrorCode: CustomUiCspSourceValidationErrorCode.UnsupportedScheme,
+        }
+      )
     );
   });
 

--- a/packages/core/src/routes/sign-in-experience/custom-ui-csp.ts
+++ b/packages/core/src/routes/sign-in-experience/custom-ui-csp.ts
@@ -1,130 +1,50 @@
-import { type CustomUiCsp } from '@logto/schemas';
+import {
+  CustomUiCspSourceValidationErrorCode,
+  normalizeCustomUiCsp as normalizeCustomUiCspConfig,
+  type CustomUiCsp,
+  type CustomUiCspSourceValidationError,
+} from '@logto/core-kit';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 
-const customUiCspDirectives = Object.freeze(['scriptSrc', 'connectSrc'] as const);
+const customUiCspSourceValidationErrorCodeDescriptions = Object.freeze({
+  [CustomUiCspSourceValidationErrorCode.EmptySource]: 'Empty source',
+  [CustomUiCspSourceValidationErrorCode.SemicolonNotAllowed]: 'Semicolons are not allowed',
+  [CustomUiCspSourceValidationErrorCode.CspKeywordNotSupported]: 'CSP keywords are not supported',
+  [CustomUiCspSourceValidationErrorCode.MalformedUrl]: 'Malformed URL',
+  [CustomUiCspSourceValidationErrorCode.DisallowedUrlParts]:
+    'Credentials, query strings, and fragments are not allowed',
+  [CustomUiCspSourceValidationErrorCode.UnsupportedScheme]: 'Unsupported scheme',
+  [CustomUiCspSourceValidationErrorCode.MalformedWildcardHost]: 'Malformed wildcard host',
+  [CustomUiCspSourceValidationErrorCode.MalformedHost]: 'Malformed host',
+} satisfies Record<CustomUiCspSourceValidationErrorCode, string>);
 
-type CustomUiCspDirective = (typeof customUiCspDirectives)[number];
-
-const validHostLabelRegEx = /^[\da-z](?:[\da-z-]{0,61}[\da-z])?$/;
-
-const createInvalidSourceError = (
-  directive: CustomUiCspDirective,
-  source: string,
-  reason: string
-) =>
+const createInvalidSourceError = ({
+  directive,
+  source,
+  code: validationErrorCode,
+}: CustomUiCspSourceValidationError) =>
   new RequestError(
     {
       code: 'request.invalid_input',
-      details: `Invalid customUiCsp.${directive} source "${source}": ${reason}`,
+      details: `Invalid customUiCsp.${directive} source "${source}": ${customUiCspSourceValidationErrorCodeDescriptions[validationErrorCode]}`,
     },
-    { directive, source, reason }
+    { directive, source, validationErrorCode }
   );
 
-const isValidHostLabel = (label: string) => validHostLabelRegEx.test(label);
+export const normalizeCustomUiCsp = (customUiCsp: CustomUiCsp): CustomUiCsp => {
+  const { customUiCsp: normalizedCustomUiCsp, errors } = normalizeCustomUiCspConfig(customUiCsp, {
+    isProduction: EnvSet.values.isProduction,
+  });
 
-const validateHostname = (directive: CustomUiCspDirective, source: string, hostname: string) => {
-  if (hostname === 'localhost') {
-    return;
+  const [firstError] = errors;
+
+  if (firstError) {
+    throw createInvalidSourceError(firstError);
   }
 
-  const labels = hostname.split('.');
-  const wildcardCount = labels.filter((label) => label === '*').length;
-
-  if (wildcardCount > 0) {
-    if (labels[0] !== '*' || wildcardCount !== 1 || labels.length < 3) {
-      throw createInvalidSourceError(directive, source, 'Malformed wildcard host');
-    }
-
-    for (const label of labels.slice(1)) {
-      if (!isValidHostLabel(label)) {
-        throw createInvalidSourceError(directive, source, 'Malformed wildcard host');
-      }
-    }
-
-    return;
-  }
-
-  if (labels.length < 2 || labels.some((label) => !isValidHostLabel(label))) {
-    throw createInvalidSourceError(directive, source, 'Malformed host');
-  }
+  return normalizedCustomUiCsp;
 };
 
-const validateScheme = (directive: CustomUiCspDirective, source: string, url: URL) => {
-  const isLocalhostHttpSource =
-    !EnvSet.values.isProduction &&
-    url.protocol === 'http:' &&
-    url.hostname === 'localhost' &&
-    url.port;
-
-  if (isLocalhostHttpSource) {
-    return;
-  }
-
-  const allowedSchemes = directive === 'connectSrc' ? ['https:', 'wss:'] : ['https:'];
-
-  if (!allowedSchemes.includes(url.protocol)) {
-    throw createInvalidSourceError(directive, source, 'Unsupported scheme');
-  }
-};
-
-const normalizeSourceExpression = (directive: CustomUiCspDirective, rawSource: string) => {
-  const source = rawSource.trim();
-
-  if (!source) {
-    throw createInvalidSourceError(directive, rawSource, 'Empty source');
-  }
-
-  if (source.includes(';')) {
-    throw createInvalidSourceError(directive, rawSource, 'Semicolons are not allowed');
-  }
-
-  if (source.includes("'")) {
-    throw createInvalidSourceError(directive, rawSource, 'CSP keywords are not supported');
-  }
-
-  try {
-    const url = new URL(source);
-
-    if (url.username || url.password || url.search || url.hash) {
-      throw createInvalidSourceError(
-        directive,
-        rawSource,
-        'Credentials, query strings, and fragments are not allowed'
-      );
-    }
-
-    validateScheme(directive, rawSource, url);
-    validateHostname(directive, rawSource, url.hostname);
-
-    return `${url.protocol}//${url.host}${url.pathname === '/' ? '' : url.pathname}`;
-  } catch (error: unknown) {
-    if (error instanceof RequestError) {
-      throw error;
-    }
-
-    throw createInvalidSourceError(directive, rawSource, 'Malformed URL');
-  }
-};
-
-export const normalizeCustomUiCsp = (customUiCsp: CustomUiCsp): CustomUiCsp =>
-  customUiCspDirectives.reduce<CustomUiCsp>((normalizedCustomUiCsp, directive) => {
-    const sources = customUiCsp[directive];
-
-    if (!sources?.length) {
-      return normalizedCustomUiCsp;
-    }
-
-    const normalizedSources = [
-      ...new Set(sources.map((source) => normalizeSourceExpression(directive, source))),
-    ];
-
-    return {
-      ...normalizedCustomUiCsp,
-      [directive]: normalizedSources,
-    };
-  }, {});
-
-export const hasCustomUiCspSources = (customUiCsp?: CustomUiCsp): boolean =>
-  Boolean(customUiCsp && customUiCspDirectives.some((directive) => customUiCsp[directive]?.length));
+export { hasCustomUiCspSources } from '@logto/core-kit';

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
@@ -273,18 +273,6 @@ export const customUiAssetsGuard = z.object({
 
 export type CustomUiAssets = z.infer<typeof customUiAssetsGuard>;
 
-export type CustomUiCsp = {
-  scriptSrc?: string[];
-  connectSrc?: string[];
-};
-
-export const customUiCspGuard = z
-  .object({
-    scriptSrc: z.string().array().optional(),
-    connectSrc: z.string().array().optional(),
-  })
-  .strict() satisfies ToZodObject<CustomUiCsp>;
-
 export const captchaPolicyGuard = z.object({
   enabled: z.boolean().optional(),
 });
@@ -376,3 +364,5 @@ export const signUpProfileFieldItemGuard = z.object({
 export const signUpProfileFieldsGuard = z.array(signUpProfileFieldItemGuard);
 
 export type SignUpProfileFields = z.infer<typeof signUpProfileFieldsGuard>;
+
+export { customUiCspGuard, type CustomUiCsp } from '@logto/core-kit';

--- a/packages/toolkit/core-kit/src/custom-ui-csp.test.ts
+++ b/packages/toolkit/core-kit/src/custom-ui-csp.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CustomUiCspSourceValidationErrorCode,
+  customUiCspGuard,
+  hasCustomUiCspSources,
+  normalizeCustomUiCsp,
+  normalizeCustomUiCspSourceExpression,
+} from './custom-ui-csp.js';
+
+describe('customUiCspGuard', () => {
+  it.each([
+    {},
+    { scriptSrc: ['https://example.com'] },
+    { connectSrc: ['https://api.example.com'] },
+    {
+      scriptSrc: ['https://example.com'],
+      connectSrc: ['https://api.example.com'],
+    },
+  ])('accepts %p', (value) => {
+    expect(customUiCspGuard.safeParse(value).success).toBe(true);
+  });
+
+  it('rejects unsupported directives', () => {
+    expect(customUiCspGuard.safeParse({ imgSrc: ['https://example.com'] }).success).toBe(false);
+  });
+});
+
+describe('normalizeCustomUiCspSourceExpression()', () => {
+  it.each([
+    ['scriptSrc', 'https://example.com', 'https://example.com'],
+    ['scriptSrc', 'https://*.example.com/path/', 'https://*.example.com/path/'],
+    ['connectSrc', 'wss://events.example.com', 'wss://events.example.com'],
+    ['connectSrc', ' https://api.example.com ', 'https://api.example.com'],
+  ] as const)('normalizes %s source %s', (directive, source, value) => {
+    expect(normalizeCustomUiCspSourceExpression(directive, source)).toEqual({
+      isValid: true,
+      value,
+    });
+  });
+
+  it.each([
+    [
+      'scriptSrc',
+      'wss://events.example.com',
+      CustomUiCspSourceValidationErrorCode.UnsupportedScheme,
+    ],
+    ['connectSrc', 'http://example.com', CustomUiCspSourceValidationErrorCode.UnsupportedScheme],
+    [
+      'scriptSrc',
+      'https://example.com; report-uri /csp',
+      CustomUiCspSourceValidationErrorCode.SemicolonNotAllowed,
+    ],
+    ['scriptSrc', "'unsafe-inline'", CustomUiCspSourceValidationErrorCode.CspKeywordNotSupported],
+    [
+      'scriptSrc',
+      'https://user@example.com',
+      CustomUiCspSourceValidationErrorCode.DisallowedUrlParts,
+    ],
+    [
+      'scriptSrc',
+      'https://example.com?foo=bar',
+      CustomUiCspSourceValidationErrorCode.DisallowedUrlParts,
+    ],
+    [
+      'connectSrc',
+      'https://*.*.example.com',
+      CustomUiCspSourceValidationErrorCode.MalformedWildcardHost,
+    ],
+    ['connectSrc', 'https://example', CustomUiCspSourceValidationErrorCode.MalformedHost],
+  ] as const)('rejects %s source %s', (directive, source, code) => {
+    expect(normalizeCustomUiCspSourceExpression(directive, source)).toEqual({
+      isValid: false,
+      code,
+    });
+  });
+
+  it('allows localhost HTTP sources only outside production', () => {
+    expect(normalizeCustomUiCspSourceExpression('scriptSrc', 'http://localhost:3000')).toEqual({
+      isValid: true,
+      value: 'http://localhost:3000',
+    });
+
+    expect(
+      normalizeCustomUiCspSourceExpression('scriptSrc', 'http://localhost:3000', {
+        isProduction: true,
+      })
+    ).toEqual({
+      isValid: false,
+      code: CustomUiCspSourceValidationErrorCode.UnsupportedScheme,
+    });
+  });
+});
+
+describe('normalizeCustomUiCsp()', () => {
+  it('normalizes, deduplicates, and drops empty directive arrays', () => {
+    expect(
+      normalizeCustomUiCsp({
+        scriptSrc: [' https://EXAMPLE.com ', 'https://example.com', 'https://*.example.com/path/'],
+        connectSrc: [],
+      })
+    ).toEqual({
+      customUiCsp: {
+        scriptSrc: ['https://example.com', 'https://*.example.com/path/'],
+      },
+      errors: [],
+    });
+  });
+
+  it('collects validation errors with directive context', () => {
+    expect(
+      normalizeCustomUiCsp({
+        scriptSrc: ["'unsafe-inline'"],
+        connectSrc: ['https://example'],
+      })
+    ).toEqual({
+      customUiCsp: {},
+      errors: [
+        {
+          directive: 'scriptSrc',
+          source: "'unsafe-inline'",
+          code: CustomUiCspSourceValidationErrorCode.CspKeywordNotSupported,
+        },
+        {
+          directive: 'connectSrc',
+          source: 'https://example',
+          code: CustomUiCspSourceValidationErrorCode.MalformedHost,
+        },
+      ],
+    });
+  });
+});
+
+describe('hasCustomUiCspSources()', () => {
+  it('returns whether any supported directive has configured sources', () => {
+    expect(hasCustomUiCspSources()).toBe(false);
+    expect(hasCustomUiCspSources({})).toBe(false);
+    expect(hasCustomUiCspSources({ scriptSrc: [] })).toBe(false);
+    expect(hasCustomUiCspSources({ connectSrc: ['https://example.com'] })).toBe(true);
+  });
+});

--- a/packages/toolkit/core-kit/src/custom-ui-csp.ts
+++ b/packages/toolkit/core-kit/src/custom-ui-csp.ts
@@ -1,0 +1,225 @@
+import { z } from 'zod';
+
+export const customUiCspDirectives = Object.freeze(['scriptSrc', 'connectSrc'] as const);
+
+export type CustomUiCspDirective = (typeof customUiCspDirectives)[number];
+
+export type CustomUiCsp = {
+  scriptSrc?: string[];
+  connectSrc?: string[];
+};
+
+export const customUiCspGuard = z
+  .object({
+    scriptSrc: z.string().array().optional(),
+    connectSrc: z.string().array().optional(),
+  })
+  .strict() satisfies z.ZodType<CustomUiCsp>;
+
+export enum CustomUiCspSourceValidationErrorCode {
+  EmptySource = 'empty_source',
+  SemicolonNotAllowed = 'semicolon_not_allowed',
+  CspKeywordNotSupported = 'csp_keyword_not_supported',
+  MalformedUrl = 'malformed_url',
+  DisallowedUrlParts = 'disallowed_url_parts',
+  UnsupportedScheme = 'unsupported_scheme',
+  MalformedWildcardHost = 'malformed_wildcard_host',
+  MalformedHost = 'malformed_host',
+}
+
+export type CustomUiCspSourceValidationError = {
+  readonly directive: CustomUiCspDirective;
+  readonly source: string;
+  readonly code: CustomUiCspSourceValidationErrorCode;
+};
+
+export type CustomUiCspSourceValidationResult =
+  | {
+      readonly isValid: true;
+      readonly value: string;
+    }
+  | {
+      readonly isValid: false;
+      readonly code: CustomUiCspSourceValidationErrorCode;
+    };
+
+type CustomUiCspValidationOptions = {
+  readonly isProduction?: boolean;
+};
+
+type NormalizedDirectiveSources = {
+  readonly sources: string[];
+  readonly errors: CustomUiCspSourceValidationError[];
+};
+
+type SourceNormalizationResult = {
+  readonly source: string;
+  readonly result: CustomUiCspSourceValidationResult;
+};
+
+export type NormalizeCustomUiCspResult = {
+  readonly customUiCsp: CustomUiCsp;
+  readonly errors: CustomUiCspSourceValidationError[];
+};
+
+const validHostLabelRegEx = /^[\da-z](?:[\da-z-]{0,61}[\da-z])?$/;
+
+const isValidHostLabel = (label: string) => validHostLabelRegEx.test(label);
+
+const validateHostname = (hostname: string): CustomUiCspSourceValidationErrorCode | undefined => {
+  if (hostname === 'localhost') {
+    return;
+  }
+
+  const labels = hostname.split('.');
+  const wildcardCount = labels.filter((label) => label === '*').length;
+
+  if (wildcardCount > 0) {
+    return labels[0] === '*' &&
+      wildcardCount === 1 &&
+      labels.length >= 3 &&
+      labels.slice(1).every((label) => isValidHostLabel(label))
+      ? undefined
+      : CustomUiCspSourceValidationErrorCode.MalformedWildcardHost;
+  }
+
+  return labels.length >= 2 && labels.every((label) => isValidHostLabel(label))
+    ? undefined
+    : CustomUiCspSourceValidationErrorCode.MalformedHost;
+};
+
+const validateScheme = (
+  directive: CustomUiCspDirective,
+  url: URL,
+  { isProduction = false }: CustomUiCspValidationOptions
+): CustomUiCspSourceValidationErrorCode | undefined => {
+  const isLocalhostHttpSource =
+    !isProduction && url.protocol === 'http:' && url.hostname === 'localhost' && url.port;
+
+  if (isLocalhostHttpSource) {
+    return;
+  }
+
+  const allowedSchemes = directive === 'connectSrc' ? ['https:', 'wss:'] : ['https:'];
+
+  return allowedSchemes.includes(url.protocol)
+    ? undefined
+    : CustomUiCspSourceValidationErrorCode.UnsupportedScheme;
+};
+
+const getInvalidPlainSourceCode = (
+  source: string
+): CustomUiCspSourceValidationErrorCode | undefined => {
+  if (!source) {
+    return CustomUiCspSourceValidationErrorCode.EmptySource;
+  }
+
+  if (source.includes(';')) {
+    return CustomUiCspSourceValidationErrorCode.SemicolonNotAllowed;
+  }
+
+  return source.includes("'")
+    ? CustomUiCspSourceValidationErrorCode.CspKeywordNotSupported
+    : undefined;
+};
+
+const hasDisallowedUrlParts = (url: URL) =>
+  Boolean(url.username || url.password || url.search || url.hash);
+
+const normalizeParsedSourceExpression = (
+  directive: CustomUiCspDirective,
+  url: URL,
+  options?: CustomUiCspValidationOptions
+): CustomUiCspSourceValidationResult => {
+  if (hasDisallowedUrlParts(url)) {
+    return {
+      isValid: false,
+      code: CustomUiCspSourceValidationErrorCode.DisallowedUrlParts,
+    };
+  }
+
+  const invalidSchemeCode = validateScheme(directive, url, options ?? {});
+
+  if (invalidSchemeCode) {
+    return { isValid: false, code: invalidSchemeCode };
+  }
+
+  const invalidHostCode = validateHostname(url.hostname);
+
+  if (invalidHostCode) {
+    return { isValid: false, code: invalidHostCode };
+  }
+
+  return {
+    isValid: true,
+    value: `${url.protocol}//${url.host}${url.pathname === '/' ? '' : url.pathname}`,
+  };
+};
+
+export const normalizeCustomUiCspSourceExpression = (
+  directive: CustomUiCspDirective,
+  rawSource: string,
+  options?: CustomUiCspValidationOptions
+): CustomUiCspSourceValidationResult => {
+  const source = rawSource.trim();
+  const invalidSourceCode = getInvalidPlainSourceCode(source);
+
+  if (invalidSourceCode) {
+    return { isValid: false, code: invalidSourceCode };
+  }
+
+  try {
+    return normalizeParsedSourceExpression(directive, new URL(source), options);
+  } catch {
+    return { isValid: false, code: CustomUiCspSourceValidationErrorCode.MalformedUrl };
+  }
+};
+
+const normalizeDirectiveSources = (
+  directive: CustomUiCspDirective,
+  sources: string[],
+  options?: CustomUiCspValidationOptions
+): NormalizedDirectiveSources => {
+  const results = sources.map<SourceNormalizationResult>((source) => ({
+    source,
+    result: normalizeCustomUiCspSourceExpression(directive, source, options),
+  }));
+
+  return {
+    sources: [...new Set(results.flatMap(({ result }) => (result.isValid ? [result.value] : [])))],
+    errors: results.flatMap(({ source, result }) =>
+      result.isValid ? [] : [{ directive, source, code: result.code }]
+    ),
+  };
+};
+
+export const normalizeCustomUiCsp = (
+  customUiCsp: CustomUiCsp,
+  options?: CustomUiCspValidationOptions
+): NormalizeCustomUiCspResult =>
+  customUiCspDirectives.reduce<NormalizeCustomUiCspResult>(
+    ({ customUiCsp: normalizedCustomUiCsp, errors }, directive) => {
+      const sources = customUiCsp[directive];
+
+      if (!sources?.length) {
+        return { customUiCsp: normalizedCustomUiCsp, errors };
+      }
+
+      const result = normalizeDirectiveSources(directive, sources, options);
+
+      return {
+        customUiCsp:
+          result.sources.length > 0
+            ? {
+                ...normalizedCustomUiCsp,
+                [directive]: result.sources,
+              }
+            : normalizedCustomUiCsp,
+        errors: [...errors, ...result.errors],
+      };
+    },
+    { customUiCsp: {}, errors: [] }
+  );
+
+export const hasCustomUiCspSources = (customUiCsp?: CustomUiCsp): boolean =>
+  Boolean(customUiCsp && customUiCspDirectives.some((directive) => customUiCsp[directive]?.length));

--- a/packages/toolkit/core-kit/src/index.ts
+++ b/packages/toolkit/core-kit/src/index.ts
@@ -1,4 +1,5 @@
 export * from './utils/index.js';
+export * from './custom-ui-csp.js';
 export * from './regex.js';
 export * from './openid.js';
 export * from './models/index.js';


### PR DESCRIPTION
## Summary
Move Custom UI CSP type, zod guard, source validation, and normalization helpers into @logto/core-kit. Keep @logto/schemas as the DB contract facade by re-exporting the type and guard, and make Core consume the shared core-kit helpers through a thin RequestError wrapper.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments