### PR TITLE
feat(console): adopt enableCap=true on audit logs behind dev-features

### DIFF
--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -7,6 +7,7 @@ import useSWR from 'swr';
 import ApplicationName from '@/components/ApplicationName';
 import UserName from '@/components/UserName';
 import { auditLogEventTitle, defaultPageSize } from '@/consts';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import Table from '@/ds-components/Table';
 import type { Column } from '@/ds-components/Table/types';
 import type { RequestError } from '@/hooks/use-api';
@@ -57,12 +58,13 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
     ...conditional(event && { logKey: event }),
     ...conditional(searchApplicationId && { applicationId: searchApplicationId }),
     ...conditional(userId && { userId }),
+    ...conditional(isDevFeaturesEnabled && { enableCap: 'true' }),
   });
 
-  const { data, error, mutate } = useSWR<[Log[], number], RequestError>(url);
+  const { data, error, mutate } = useSWR<[Log[], number, boolean], RequestError>(url);
   const isLoading = !data && !error;
   const { navigate } = useTenantPathname();
-  const [logs, totalCount] = data ?? [];
+  const [logs, totalCount, isTotalCountCapped] = data ?? [];
   const isUserColumnVisible =
     !userId && specifiedApplication?.type !== ApplicationType.MachineToMachine;
 
@@ -149,6 +151,7 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
       pagination={{
         page,
         totalCount,
+        isTotalCountCapped,
         pageSize,
         onChange: (page) => {
           updateSearchParameters({ page });

--- a/packages/console/src/ds-components/Pagination/index.module.scss
+++ b/packages/console/src/ds-components/Pagination/index.module.scss
@@ -10,6 +10,25 @@
     color: var(--color-text-secondary);
   }
 
+  .cappedNav {
+    display: flex;
+    gap: _.unit(2);
+
+    .button {
+      display: block;
+      border-radius: 6px;
+      min-width: 28px;
+      padding: 0 6px;
+      height: 28px;
+      border: 1px solid var(--color-border);
+
+      svg {
+        width: 20px;
+        height: 20px;
+      }
+    }
+  }
+
   .pagination {
     display: flex;
     justify-content: right;

--- a/packages/console/src/ds-components/Pagination/index.tsx
+++ b/packages/console/src/ds-components/Pagination/index.tsx
@@ -19,9 +19,22 @@ export type Props = {
   readonly className?: string;
   readonly mode?: 'normal' | 'pico';
   readonly onChange?: (pageIndex: number) => void;
+  /**
+   * When `true`, `totalCount` is a lower bound (server short-circuited at a cap).
+   * Renders Prev/Next only — the numbered jumper and position label are hidden.
+   */
+  readonly isTotalCountCapped?: boolean;
 };
 
-function Pagination({ page, totalCount, pageSize, className, mode = 'normal', onChange }: Props) {
+function Pagination({
+  page,
+  totalCount,
+  pageSize,
+  className,
+  mode = 'normal',
+  onChange,
+  isTotalCountCapped,
+}: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   /**
@@ -30,6 +43,46 @@ function Pagination({ page, totalCount, pageSize, className, mode = 'normal', on
    * Cache `totalCount` to solve this problem.
    */
   const cachedTotalCount = useCacheValue(totalCount) ?? 0;
+  const cachedIsTotalCountCapped = useCacheValue(isTotalCountCapped) ?? false;
+  const isPicoMode = mode === 'pico';
+
+  if (cachedIsTotalCountCapped) {
+    // Pico mode is intentionally not applied here — the `.pico` overrides
+    // target `.pagination` (ReactPaginate), which the capped path doesn't use.
+    return (
+      <div className={classNames(styles.container, className)}>
+        <div className={styles.cappedNav}>
+          <Button
+            className={styles.button}
+            size="small"
+            icon={
+              <FlipOnRtl>
+                <ArrowLeft />
+              </FlipOnRtl>
+            }
+            aria-label={t('general.back')}
+            disabled={page === 1}
+            onClick={() => {
+              onChange?.(page - 1);
+            }}
+          />
+          <Button
+            className={styles.button}
+            size="small"
+            icon={
+              <FlipOnRtl>
+                <ArrowRight />
+              </FlipOnRtl>
+            }
+            aria-label={t('general.next')}
+            onClick={() => {
+              onChange?.(page + 1);
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
 
   const pageCount = Math.ceil(cachedTotalCount / pageSize);
 
@@ -39,7 +92,6 @@ function Pagination({ page, totalCount, pageSize, className, mode = 'normal', on
 
   const min = (page - 1) * pageSize + 1;
   const max = Math.min(page * pageSize, cachedTotalCount);
-  const isPicoMode = mode === 'pico';
 
   return (
     <div className={classNames(styles.container, isPicoMode && styles.pico, className)}>

--- a/packages/console/src/hooks/use-swr-fetcher.ts
+++ b/packages/console/src/hooks/use-swr-fetcher.ts
@@ -8,7 +8,7 @@ import { RequestError } from './use-api';
 
 type KyInstance = typeof ky;
 
-type WithTotalNumber<T> = Array<Awaited<T> | number>;
+type WithTotalNumber<T> = Array<Awaited<T> | number | boolean>;
 
 type UseSwrFetcherHook = {
   <T>(api: KyInstance): Fetcher<T>;
@@ -35,7 +35,11 @@ const useSwrFetcher: UseSwrFetcherHook = <T>(api: KyInstance) => {
               throw new Error(t('errors.missing_total_number'));
             }
 
-            return [data, Number(number)];
+            // Optional 3rd element signals that the server short-circuited the
+            // count query at a cap (see `Total-Number-Is-Capped` on /api/logs).
+            // Consumers that don't care keep destructuring [data, total].
+            const isCapped = response.headers.get('Total-Number-Is-Capped') === 'true';
+            return [data, Number(number), isCapped];
           }
         }
 


### PR DESCRIPTION
## Summary

Refs [LOG-13417](https://linear.app/silverhand/issue/LOG-13417). Stacked on top of #8796.

When `isDevFeaturesEnabled` is on, the Audit Logs page now passes `?enableCap=true` to `GET /api/logs` so it can survive on tenants whose log volumes would otherwise trip the count-query `statement_timeout` (the bug fixed in #8796). When the server responds with `Total-Number-Is-Capped: true`, the shared Pagination component switches to a Prev/Next-only layout — the saturated `Total-Number` makes the page-count math unreliable, so the numbered jumper and position label are dropped.

### What changed

- **`packages/console/src/components/AuditLogTable/index.tsx`** — appends `enableCap=true` to the request URL when `isDevFeaturesEnabled`. Destructures the new optional 3rd element from the SWR result as `isTotalCountCapped`.
- **`packages/console/src/hooks/use-swr-fetcher.ts`** — for paginated requests, reads `Total-Number-Is-Capped` and appends it as an optional boolean 3rd element. Other consumers continue destructuring `[data, totalCount]` and are unaffected.
- **`packages/console/src/ds-components/Pagination/index.tsx` + SCSS** — new `isTotalCountCapped?: boolean` prop. When true, the component renders a small Prev/Next control (Prev disabled on page 1, Next always enabled so users can walk past the saturated estimate). The existing exact-count UI is unchanged.

### Dev-features guard

The whole new behavior is gated by `isDevFeaturesEnabled` at the URL builder:

```ts
...conditional(isDevFeaturesEnabled && { enableCap: 'true' }),
```

When the flag is off (production default), the URL has no `enableCap` param → the server returns today's exact-count response → the new Pagination prop is never `true` → rendered UI is byte-for-byte identical to current master.

### Backward compatibility

- Other paginated pages (Applications, Roles, SSO, etc.) continue to use the shared SWR fetcher and destructure `[data, totalCount]`. They see no behavioral or visual change.
- Old Console builds against a backend that doesn't yet emit `Total-Number-Is-Capped` still work — the header is absent, the 3rd element is `false`, capped mode never activates.

### Why not a bespoke fetcher in AuditLogTable

An earlier draft of this PR added a custom SWR fetcher inside `AuditLogTable` to read the new header. Reviewer feedback pointed out that the shared `use-swr-fetcher` is the natural place to surface a pagination-related header, and the additive 3rd-element approach keeps existing call sites unaffected. The current diff reflects that refactor.

### Reviewer notes

- The Pagination component's capped layout uses `Button` directly instead of `ReactPaginate`. The SCSS for `.cappedNav` was ordered before `.pagination` to satisfy the `no-descending-specificity` stylelint rule.
- The Button component handles its own disabled visual state, so the SCSS doesn't override `&:disabled`.
- Console doesn't have an established pattern for testing components with deep transitive imports (Pagination → Button → useTenantPathname → env). The existing `DynamicT/index.test.tsx` is a leaf-component test. A unit test for the new Pagination mode was prototyped but pulled in `import.meta.env` and the tenants provider, requiring many mocks; I left it out and verified manually under the dev-features flag toggle.

## Testing

Tested locally

<img width="848" height="112" alt="image" src="https://github.com/user-attachments/assets/c2ef55c7-5afa-44b7-8a03-2ec1fe698c16" />



<img width="2800" height="3068" alt="image" src="https://github.com/user-attachments/assets/fbd2631f-be5f-4d80-bf53-139f94ae8c7a" />



## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments