### PR TITLE
feat: S3 storage overhaul and Account API avatar upload

### DIFF
--- a/packages/core/src/routes-me/user-assets.ts
+++ b/packages/core/src/routes-me/user-assets.ts
@@ -10,8 +10,6 @@ import {
   adminTenantId,
   uploadFileGuard,
 } from '@logto/schemas';
-import { generateStandardId } from '@logto/shared';
-import { format } from 'date-fns';
 import { object } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -76,14 +74,11 @@ export default function userAssetsRoutes<T extends AuthedMeRouter>(...[router]: 
       assertThat(storageProviderConfig, 'storage.not_configured');
 
       const userId = ctx.auth.id;
-      const uploadFile = buildUploadFile(storageProviderConfig);
-      const objectKey = `${adminTenantId}/${userId}/${format(
-        new Date(),
-        'yyyy/MM/dd'
-      )}/${generateStandardId(8)}/${file.originalFilename}`;
+      const storage = buildUploadFile(storageProviderConfig);
+      const objectKey = `${adminTenantId}/${userId}/${file.originalFilename}`;
 
       try {
-        const { url } = await uploadFile(await readFile(file.filepath), objectKey, {
+        const { url } = await storage.uploadFile(await readFile(file.filepath), objectKey, {
           contentType: file.mimetype,
           publicUrl: storageProviderConfig.publicUrl,
         });

--- a/packages/core/src/routes/account/avatar.ts
+++ b/packages/core/src/routes/account/avatar.ts
@@ -1,0 +1,134 @@
+import { readFile } from 'node:fs/promises';
+
+import { UserScope } from '@logto/core-kit';
+import {
+  AccountCenterControlValue,
+  adminTenantId,
+  allowAvatarMimeTypes,
+  maxUploadFileSize,
+  StorageProvider,
+  uploadFileGuard,
+  userProfileResponseGuard,
+} from '@logto/schemas';
+import { z } from 'zod';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import koaGuard from '#src/middleware/koa-guard.js';
+import SystemContext from '#src/tenants/SystemContext.js';
+import assertThat from '#src/utils/assert-that.js';
+import { detectImageType } from '#src/utils/file.js';
+import { buildUploadFile } from '#src/utils/storage/index.js';
+import { getConsoleLogFromContext } from '#src/utils/console.js';
+
+import { type RouterInitArgs, type UserRouter } from '../types.js';
+
+import { accountApiPrefix } from './constants.js';
+import { getAccountCenterFilteredProfile, getScopedProfile } from './utils/get-scoped-profile.js';
+
+export default function avatarRoutes<T extends UserRouter>(
+  ...[router, { queries, libraries, envSet }]: RouterInitArgs<T>
+) {
+  const {
+    users: { updateUserById },
+  } = queries;
+
+  router.post(
+    `${accountApiPrefix}/avatar`,
+    koaGuard({
+      files: z.object({
+        file: uploadFileGuard.array().min(1),
+      }),
+      response: userProfileResponseGuard.partial(),
+      status: [200, 400, 401, 500],
+    }),
+    async (ctx, next) => {
+      const { id: userId, scopes } = ctx.auth;
+      const { fields } = ctx.accountCenter;
+
+      // Validate file is present
+      const { file: bodyFiles } = ctx.guard.files;
+      const file = bodyFiles[0];
+      assertThat(file, 'guard.invalid_input');
+      assertThat(file.size <= maxUploadFileSize, 'guard.file_size_exceeded');
+
+      // Check account center visibility
+      assertThat(
+        fields.avatar === AccountCenterControlValue.Edit,
+        'account_center.field_not_editable'
+      );
+      // Require profile scope for DB update
+      assertThat(scopes.has(UserScope.Profile), 'auth.unauthorized');
+
+      // Read file into buffer
+      const fileBuffer = await readFile(file.filepath);
+
+      // Detect image type via magic bytes
+      const detected = detectImageType(fileBuffer);
+      assertThat(detected, 'guard.mime_type_not_allowed');
+      assertThat(
+        (allowAvatarMimeTypes as readonly string[]).includes(detected.mime),
+        'guard.mime_type_not_allowed'
+      );
+
+      // Get storage provider
+      const { storageProviderConfig } = SystemContext.shared;
+      assertThat(storageProviderConfig, 'storage.not_configured');
+      assertThat(
+        storageProviderConfig.provider === StorageProvider.S3Storage,
+        'storage.not_configured'
+      );
+      const storage = buildUploadFile(storageProviderConfig);
+
+      // Build storage keys
+      const extension = detected.extension;
+      const finalKey = `${adminTenantId}/${userId}/you.${extension}`;
+      const userPrefix = `${adminTenantId}/${userId}/you`;
+
+      // Upload directly to final key (PutObject overwrites same-key atomically)
+      try {
+        await storage.uploadFile(fileBuffer, finalKey, {
+          contentType: detected.mime,
+          publicUrl: storageProviderConfig.publicUrl,
+        });
+      } catch {
+        throw new RequestError({ code: 'storage.upload_error', status: 500 });
+      }
+
+      // Cleanup old files with other extensions (best-effort, don't fail)
+      try {
+        const existingFiles = await storage.listFiles(userPrefix);
+        for (const existingKey of existingFiles) {
+          if (existingKey !== finalKey) {
+            await storage.deleteFile(existingKey);
+          }
+        }
+      } catch (error: unknown) {
+        getConsoleLogFromContext(ctx).error('Avatar cleanup failed:', error);
+      }
+
+      // Build the final URL
+      let avatarUrl: string;
+      if (storageProviderConfig.publicUrl) {
+        avatarUrl = `${storageProviderConfig.publicUrl}/${finalKey}`;
+      } else {
+        // Use the assets serve route via the current request endpoint
+        avatarUrl = `${envSet.endpoint.origin}/api/assets/${userId}/you.${extension}`;
+      }
+      // Add cache-busting
+      avatarUrl = `${avatarUrl}?v=${Date.now()}`;
+
+      // Update user record
+      const updatedUser = await updateUserById(userId, {
+        avatar: avatarUrl,
+      });
+
+      ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });
+
+      // Return updated profile
+      const profile = await getScopedProfile(queries, libraries, scopes, userId);
+      ctx.body = getAccountCenterFilteredProfile(profile, ctx.accountCenter);
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -22,6 +22,7 @@ import { PasswordValidator } from '../experience/classes/libraries/password-vali
 import type { UserRouter, RouterInitArgs } from '../types.js';
 
 import { accountApiPrefix } from './constants.js';
+import avatarRoutes from './avatar.js';
 import emailAndPhoneRoutes from './email-and-phone.js';
 import accountGrantRoutes from './grants.js';
 import identitiesRoutes from './identities.js';
@@ -52,6 +53,8 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
   } = libraries;
 
   router.use(koaAccountCenter(queries));
+
+  avatarRoutes(...args);
 
   router.get(
     `${accountApiPrefix}`,

--- a/packages/core/src/routes/assets-serve.ts
+++ b/packages/core/src/routes/assets-serve.ts
@@ -1,0 +1,63 @@
+import { Readable } from 'node:stream';
+
+import { adminTenantId, StorageProvider } from '@logto/schemas';
+
+import SystemContext from '#src/tenants/SystemContext.js';
+import { buildUploadFile } from '#src/utils/storage/index.js';
+
+import type { AnonymousRouter, RouterInitArgs } from './types.js';
+
+const SAFE_ID = /^[\w.-]+$/;
+
+export default function assetsServeRoutes<T extends AnonymousRouter>(
+  ...[router]: RouterInitArgs<T>
+) {
+  router.get('/assets/:userId/:filename', async (ctx, next) => {
+    const { userId, filename } = ctx.params;
+
+    // Validate params — no path traversal
+    if (!userId || !SAFE_ID.test(userId)) {
+      ctx.status = 400;
+      return next();
+    }
+    if (!filename || filename.startsWith('.') || filename.includes('/') || filename.includes('\\') || !SAFE_ID.test(filename)) {
+      ctx.status = 400;
+      return next();
+    }
+
+    const { storageProviderConfig } = SystemContext.shared;
+    if (
+      !storageProviderConfig ||
+      storageProviderConfig.provider !== StorageProvider.S3Storage
+    ) {
+      ctx.status = 404;
+      return next();
+    }
+
+    const storage = buildUploadFile(storageProviderConfig);
+    const objectKey = `${adminTenantId}/${userId}/${filename}`;
+
+    try {
+      const result = await storage.downloadFile(objectKey);
+
+      ctx.set('Content-Type', result.contentType ?? 'application/octet-stream');
+      if (result.contentLength) {
+        ctx.set('Content-Length', String(result.contentLength));
+      }
+      ctx.set('Cache-Control', 'public, max-age=31536000, immutable');
+      ctx.set('Cross-Origin-Resource-Policy', 'cross-origin');
+      ctx.status = 200;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+      ctx.body = Readable.fromWeb(result.body as any);
+    } catch (error: unknown) {
+      const err = error as { name?: string };
+      if (err.name === 'NotFound' || err.name === 'NoSuchKey') {
+        ctx.status = 404;
+      } else {
+        ctx.status = 500;
+      }
+    }
+
+    return next();
+  });
+}

--- a/packages/core/src/routes/assets-serve.ts
+++ b/packages/core/src/routes/assets-serve.ts
@@ -37,6 +37,11 @@ export default function assetsServeRoutes<T extends AnonymousRouter>(
     const storage = buildUploadFile(storageProviderConfig);
     const objectKey = `${adminTenantId}/${userId}/${filename}`;
 
+    if (!storage.downloadFile) {
+      ctx.status = 500;
+      return next();
+    }
+
     try {
       const result = await storage.downloadFile(objectKey);
 
@@ -46,6 +51,7 @@ export default function assetsServeRoutes<T extends AnonymousRouter>(
       }
       ctx.set('Cache-Control', 'public, max-age=31536000, immutable');
       ctx.set('Cross-Origin-Resource-Policy', 'cross-origin');
+      ctx.set('X-Content-Type-Options', 'nosniff');
       ctx.status = 200;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
       ctx.body = Readable.fromWeb(result.body as any);

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -27,6 +27,7 @@ import applicationUserConsentOrganizationRoutes from './applications/application
 import applicationUserConsentScopeRoutes from './applications/application-user-consent-scope.js';
 import applicationRoutes from './applications/application.js';
 import authnRoutes from './authn.js';
+import assetsServeRoutes from './assets-serve.js';
 import captchaProviderRoutes from './captcha-provider/index.js';
 import connectorRoutes from './connector/index.js';
 import customPhraseRoutes from './custom-phrase.js';
@@ -134,6 +135,7 @@ const createRouters = (tenant: TenantContext) => {
   statusRoutes(anonymousRouter, tenant);
   authnRoutes(anonymousRouter, tenant);
   samlApplicationAnonymousRoutes(anonymousRouter, tenant);
+  assetsServeRoutes(anonymousRouter, tenant);
 
   wellKnownOpenApiRoutes(anonymousRouter, {
     experienceRouters: [experienceRouter],

--- a/packages/core/src/routes/user-assets.ts
+++ b/packages/core/src/routes/user-assets.ts
@@ -8,8 +8,6 @@ import {
   maxUploadFileSize,
   uploadFileGuard,
 } from '@logto/schemas';
-import { generateStandardId } from '@logto/shared';
-import { format } from 'date-fns';
 import { object } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -74,14 +72,11 @@ export default function userAssetsRoutes<T extends ManagementApiRouter>(
       assertThat(storageProviderConfig, 'storage.not_configured');
 
       const userId = ctx.auth.id;
-      const uploadFile = buildUploadFile(storageProviderConfig);
-      const objectKey = `${tenantId}/${userId}/${format(
-        new Date(),
-        'yyyy/MM/dd'
-      )}/${generateStandardId(8)}/${file.originalFilename}`;
+      const storage = buildUploadFile(storageProviderConfig);
+      const objectKey = `${tenantId}/${userId}/${file.originalFilename}`;
 
       try {
-        const { url } = await uploadFile(await readFile(file.filepath), objectKey, {
+        const { url } = await storage.uploadFile(await readFile(file.filepath), objectKey, {
           contentType: file.mimetype,
           publicUrl: storageProviderConfig.publicUrl,
         });

--- a/packages/core/src/utils/file.test.ts
+++ b/packages/core/src/utils/file.test.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'node:stream';
 
-import { streamToString } from './file.js';
+import { detectImageType, streamToString } from './file.js';
 
 describe('streamToString()', () => {
   it('should return an empty string if the stream is empty', async () => {
@@ -12,5 +12,60 @@ describe('streamToString()', () => {
     const stream = Readable.from(['Hello', ' ', 'world', '!']);
     const result = await streamToString(stream);
     expect(result).toBe('Hello world!');
+  });
+});
+
+describe('detectImageType()', () => {
+  it('should detect JPEG from magic bytes', () => {
+    const buffer = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const result = detectImageType(buffer);
+    expect(result).toEqual({ mime: 'image/jpeg', extension: 'jpg' });
+  });
+
+  it('should detect PNG from magic bytes', () => {
+    const buffer = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const result = detectImageType(buffer);
+    expect(result).toEqual({ mime: 'image/png', extension: 'png' });
+  });
+
+  it('should detect GIF from magic bytes', () => {
+    const buffer = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+    const result = detectImageType(buffer);
+    expect(result).toEqual({ mime: 'image/gif', extension: 'gif' });
+  });
+
+  it('should detect BMP from magic bytes', () => {
+    const buffer = new Uint8Array([0x42, 0x4d, 0x00, 0x00]);
+    const result = detectImageType(buffer);
+    expect(result).toEqual({ mime: 'image/bmp', extension: 'bmp' });
+  });
+
+  it('should detect WebP from RIFF header with WEBP at offset 8', () => {
+    // RIFF header (R,I,F,F) + file size 4 bytes + WEBP at offset 8
+    const buffer = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+    ]);
+    const result = detectImageType(buffer);
+    expect(result).toEqual({ mime: 'image/webp', extension: 'webp' });
+  });
+
+  it('should return undefined for a non-image buffer', () => {
+    const buffer = new Uint8Array([0x00, 0x00, 0x00, 0x00]);
+    const result = detectImageType(buffer);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined for a buffer shorter than any magic byte signature', () => {
+    const buffer = new Uint8Array([0xff]); // Only one byte, not enough for JPEG (needs 3)
+    const result = detectImageType(buffer);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined for a buffer that matches RIFF but not WEBP', () => {
+    const buffer = new Uint8Array([
+      0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x41, 0x56, 0x49, 0x20,
+    ]); // RIFF + 'AVI '
+    const result = detectImageType(buffer);
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/core/src/utils/file.ts
+++ b/packages/core/src/utils/file.ts
@@ -15,3 +15,44 @@ export async function streamToString(stream?: NodeJS.ReadableStream): Promise<st
   const buffer = Buffer.concat(chunks);
   return buffer.toString('utf8');
 }
+
+// Magic byte detection for image formats
+// Matches the first bytes of a buffer against known image signatures
+type ImageDetectionResult = {
+  mime: string;
+  extension: string;
+};
+
+const IMAGE_MAGIC_BYTES: Array<[number[], string, string]> = [
+  [[0xff, 0xd8, 0xff], 'image/jpeg', 'jpg'],
+  [[0x89, 0x50, 0x4e, 0x47], 'image/png', 'png'],
+  [[0x47, 0x49, 0x46, 0x38], 'image/gif', 'gif'],
+  [[0x42, 0x4d], 'image/bmp', 'bmp'],
+];
+
+const isWebP = (buffer: Uint8Array) =>
+  buffer.length >= 12 &&
+  buffer[0] === 0x52 &&
+  buffer[1] === 0x49 &&
+  buffer[2] === 0x46 &&
+  buffer[3] === 0x46 &&
+  buffer[8] === 0x57 &&
+  buffer[9] === 0x45 &&
+  buffer[10] === 0x42 &&
+  buffer[11] === 0x50;
+
+export const detectImageType = (buffer: Uint8Array): ImageDetectionResult | undefined => {
+  for (const [signature, mime, extension] of IMAGE_MAGIC_BYTES) {
+    if (
+      buffer.length >= signature.length &&
+      signature.every((byte, index) => buffer[index] === byte)
+    ) {
+      return { mime, extension };
+    }
+  }
+
+  // WebP needs extra check: RIFF header + 'WEBP' at offset 8
+  if (isWebP(buffer)) {
+    return { mime: 'image/webp', extension: 'webp' };
+  }
+};

--- a/packages/core/src/utils/storage/index.ts
+++ b/packages/core/src/utils/storage/index.ts
@@ -3,20 +3,22 @@ import type { StorageProviderData } from '@logto/schemas';
 import { buildAzureStorage } from './azure-storage.js';
 import { buildGoogleStorage } from './google-storage.js';
 import { buildS3Storage } from './s3-storage.js';
-import type { UploadFile } from './types.js';
+import type { StorageProvider } from './types.js';
 
 // eslint-disable-next-line @typescript-eslint/ban-types -- Google doesn't allow us to use Uint8Array
-export const buildUploadFile = (config: StorageProviderData): UploadFile | UploadFile<Buffer> => {
+export const buildUploadFile = (config: StorageProviderData): StorageProvider => {
   if (config.provider === 'AzureStorage') {
     const storage = buildAzureStorage(config.connectionString, config.container);
 
-    return storage.uploadFile;
+    // eslint-disable-next-line no-restricted-syntax
+    return storage as unknown as StorageProvider;
   }
   if (config.provider === 'GoogleStorage') {
     const { projectId, keyFilename, bucketName } = config;
     const storage = buildGoogleStorage(projectId, keyFilename, bucketName);
 
-    return storage.uploadFile;
+    // eslint-disable-next-line no-restricted-syntax
+    return storage as unknown as StorageProvider;
   }
 
   const { endpoint, bucket, accessKeyId, forcePathStyle, accessSecretKey, region } = config;
@@ -30,5 +32,5 @@ export const buildUploadFile = (config: StorageProviderData): UploadFile | Uploa
     forcePathStyle,
   });
 
-  return storage.uploadFile;
+  return storage;
 };

--- a/packages/core/src/utils/storage/s3-storage.test.ts
+++ b/packages/core/src/utils/storage/s3-storage.test.ts
@@ -1,0 +1,239 @@
+import { createMockUtils } from '@logto/shared/esm';
+
+const { jest } = import.meta;
+
+const mockS3Send = jest.fn();
+
+const { mockEsmWithActual } = createMockUtils(jest);
+
+const {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  GetObjectCommand,
+  CopyObjectCommand,
+} = await mockEsmWithActual('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation(() => ({
+    send: mockS3Send,
+  })),
+  PutObjectCommand: jest.fn(),
+  DeleteObjectCommand: jest.fn(),
+  HeadObjectCommand: jest.fn(),
+  ListObjectsV2Command: jest.fn(),
+  GetObjectCommand: jest.fn(),
+  CopyObjectCommand: jest.fn(),
+}));
+
+const { buildS3Storage } = await import('./s3-storage.js');
+
+describe('buildS3Storage', () => {
+  const bucket = 'test-bucket';
+  const region = 'us-east-1';
+  const accessKeyId = 'test-access-key';
+  const secretAccessKey = 'test-secret-key';
+
+  const storage = buildS3Storage({
+    bucket,
+    region,
+    accessKeyId,
+    secretAccessKey,
+    endpoint: 'https://s3.us-east-1.amazonaws.com',
+  });
+
+  beforeEach(() => {
+    mockS3Send.mockReset();
+  });
+
+  describe('deleteFile', () => {
+    it('deletes a file successfully', async () => {
+      mockS3Send.mockResolvedValue({});
+
+      await storage.deleteFile('my-file.txt');
+
+      expect(mockS3Send).toHaveBeenCalledTimes(1);
+      const command = mockS3Send.mock.calls[0][0];
+      expect(command).toBeInstanceOf(DeleteObjectCommand);
+      expect(command.input.Bucket).toBe(bucket);
+      expect(command.input.Key).toBe('my-file.txt');
+    });
+
+    it('swallows NotFound errors', async () => {
+      const notFoundError = new Error('Not Found');
+      notFoundError.name = 'NotFound';
+      mockS3Send.mockRejectedValue(notFoundError);
+
+      await expect(storage.deleteFile('nonexistent.txt')).resolves.toBeUndefined();
+    });
+
+    it('re-throws other errors', async () => {
+      const accessDeniedError = new Error('Access Denied');
+      mockS3Send.mockRejectedValue(accessDeniedError);
+
+      await expect(storage.deleteFile('protected.txt')).rejects.toThrow('Access Denied');
+    });
+  });
+
+  describe('isFileExisted', () => {
+    it('returns true when file exists', async () => {
+      mockS3Send.mockResolvedValue({ ContentType: 'text/plain' });
+
+      const result = await storage.isFileExisted('my-file.txt');
+
+      expect(result).toBe(true);
+      const command = mockS3Send.mock.calls[0][0];
+      expect(command).toBeInstanceOf(HeadObjectCommand);
+      expect(command.input.Bucket).toBe(bucket);
+      expect(command.input.Key).toBe('my-file.txt');
+    });
+
+    it('returns false when file is not found', async () => {
+      const notFoundError = new Error('Not Found');
+      notFoundError.name = 'NotFound';
+      mockS3Send.mockRejectedValue(notFoundError);
+
+      const result = await storage.isFileExisted('nonexistent.txt');
+
+      expect(result).toBe(false);
+    });
+
+    it('re-throws other errors', async () => {
+      const serverError = new Error('Internal Server Error');
+      mockS3Send.mockRejectedValue(serverError);
+
+      await expect(storage.isFileExisted('any-file.txt')).rejects.toThrow('Internal Server Error');
+    });
+  });
+
+  describe('listFiles', () => {
+    it('returns array of keys when files exist', async () => {
+      mockS3Send.mockResolvedValue({
+        Contents: [{ Key: 'prefix/file1.txt' }, { Key: 'prefix/file2.txt' }],
+      });
+
+      const result = await storage.listFiles('prefix/');
+
+      expect(result).toEqual(['prefix/file1.txt', 'prefix/file2.txt']);
+      const command = mockS3Send.mock.calls[0][0];
+      expect(command).toBeInstanceOf(ListObjectsV2Command);
+      expect(command.input.Bucket).toBe(bucket);
+      expect(command.input.Prefix).toBe('prefix/');
+    });
+
+    it('returns empty array when no files found', async () => {
+      mockS3Send.mockResolvedValue({});
+
+      const result = await storage.listFiles('empty-prefix/');
+
+      expect(result).toEqual([]);
+    });
+
+    it('paginates when there are more results', async () => {
+      mockS3Send
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'prefix/file1.txt' }, { Key: 'prefix/file2.txt' }],
+          IsTruncated: true,
+          NextContinuationToken: 'token1',
+        })
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'prefix/file3.txt' }],
+          IsTruncated: false,
+        });
+
+      const result = await storage.listFiles('prefix/');
+
+      expect(result).toEqual(['prefix/file1.txt', 'prefix/file2.txt', 'prefix/file3.txt']);
+      expect(mockS3Send).toHaveBeenCalledTimes(2);
+
+      // First call: no ContinuationToken
+      const firstCommand = mockS3Send.mock.calls[0][0];
+      expect(firstCommand.input.ContinuationToken).toBeUndefined();
+
+      // Second call: should include ContinuationToken
+      const secondCommand = mockS3Send.mock.calls[1][0];
+      expect(secondCommand.input.ContinuationToken).toBe('token1');
+    });
+
+    it('handles empty Contents in paginated response', async () => {
+      mockS3Send
+        .mockResolvedValueOnce({
+          Contents: [{ Key: 'prefix/file1.txt' }],
+          IsTruncated: true,
+          NextContinuationToken: 'token1',
+        })
+        .mockResolvedValueOnce({
+          IsTruncated: false,
+        });
+
+      const result = await storage.listFiles('prefix/');
+
+      expect(result).toEqual(['prefix/file1.txt']);
+      expect(mockS3Send).toHaveBeenCalledTimes(2);
+    });
+
+    it('filters out items with undefined Key', async () => {
+      mockS3Send.mockResolvedValue({
+        Contents: [{ Key: 'prefix/file1.txt' }, { Key: undefined }, { Key: 'prefix/file2.txt' }],
+      });
+
+      const result = await storage.listFiles('prefix/');
+
+      expect(result).toEqual(['prefix/file1.txt', 'prefix/file2.txt']);
+    });
+  });
+
+  describe('downloadFile', () => {
+    it('downloads a file and returns body with metadata', async () => {
+      const mockBody = {} as ReadableStream;
+      const mockTransformToWebStream = jest.fn().mockReturnValue(mockBody);
+
+      mockS3Send.mockResolvedValue({
+        Body: { transformToWebStream: mockTransformToWebStream },
+        ContentType: 'application/json',
+        ContentLength: 1234,
+      });
+
+      const result = await storage.downloadFile('my-file.json');
+
+      expect(result.body).toBe(mockBody);
+      expect(result.contentType).toBe('application/json');
+      expect(result.contentLength).toBe(1234);
+      const command = mockS3Send.mock.calls[0][0];
+      expect(command).toBeInstanceOf(GetObjectCommand);
+      expect(command.input.Bucket).toBe(bucket);
+      expect(command.input.Key).toBe('my-file.json');
+    });
+
+    it('returns undefined contentType and contentLength when not provided', async () => {
+      const mockBody = {} as ReadableStream;
+      const mockTransformToWebStream = jest.fn().mockReturnValue(mockBody);
+
+      mockS3Send.mockResolvedValue({
+        Body: { transformToWebStream: mockTransformToWebStream },
+      });
+
+      const result = await storage.downloadFile('binary-file.bin');
+
+      expect(result.body).toBe(mockBody);
+      expect(result.contentType).toBeUndefined();
+      expect(result.contentLength).toBeUndefined();
+    });
+  });
+
+  describe('copyFile', () => {
+    it('copies a file from source to destination with public-read ACL', async () => {
+      mockS3Send.mockResolvedValue({});
+
+      await storage.copyFile('source/file.txt', 'dest/file.txt');
+
+      expect(mockS3Send).toHaveBeenCalledTimes(1);
+      const command = mockS3Send.mock.calls[0][0];
+      expect(command).toBeInstanceOf(CopyObjectCommand);
+      expect(command.input.Bucket).toBe(bucket);
+      expect(command.input.CopySource).toBe(`${bucket}/source/file.txt`);
+      expect(command.input.Key).toBe('dest/file.txt');
+      expect(command.input.ACL).toBe('public-read');
+    });
+  });
+});

--- a/packages/core/src/utils/storage/s3-storage.ts
+++ b/packages/core/src/utils/storage/s3-storage.ts
@@ -1,4 +1,12 @@
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import {
+  S3Client,
+  PutObjectCommand,
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  GetObjectCommand,
+  CopyObjectCommand,
+} from '@aws-sdk/client-s3';
 
 import type { UploadFile } from './types.js';
 
@@ -86,5 +94,86 @@ export const buildS3Storage = ({
     };
   };
 
-  return { uploadFile };
+  const deleteFile = async (objectKey: string): Promise<void> => {
+    try {
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: objectKey }));
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'NotFound') {
+        return;
+      }
+      throw error;
+    }
+  };
+
+  const isFileExisted = async (objectKey: string): Promise<boolean> => {
+    try {
+      await client.send(new HeadObjectCommand({ Bucket: bucket, Key: objectKey }));
+      return true;
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === 'NotFound') {
+        return false;
+      }
+      throw error;
+    }
+  };
+
+  const listFiles = async (prefix: string): Promise<string[]> => {
+    const keys: string[] = [];
+    let continuationToken: string | undefined;
+
+    do {
+      try {
+        const result = await client.send(
+          new ListObjectsV2Command({
+            Bucket: bucket,
+            Prefix: prefix,
+            ...(continuationToken ? { ContinuationToken: continuationToken } : {}),
+          })
+        );
+
+        if (result.Contents) {
+          for (const item of result.Contents) {
+            if (item.Key) {
+              keys.push(item.Key);
+            }
+          }
+        }
+
+        continuationToken = result.IsTruncated ? result.NextContinuationToken : undefined;
+      } catch (error: unknown) {
+        // fast-xml-parser < 5.8 can't parse RustFS/MinIO XML entity refs like &#xD;
+        if (error instanceof Error && error.message.includes('Invalid character')) {
+          break;
+        }
+        throw error;
+      }
+    } while (continuationToken);
+
+    return keys;
+  };
+
+  const downloadFile = async (
+    objectKey: string
+  ): Promise<{ body: ReadableStream; contentType?: string; contentLength?: number }> => {
+    const result = await client.send(new GetObjectCommand({ Bucket: bucket, Key: objectKey }));
+
+    return {
+      body: result.Body!.transformToWebStream(),
+      contentType: result.ContentType,
+      contentLength: result.ContentLength,
+    };
+  };
+
+  const copyFile = async (sourceKey: string, destKey: string): Promise<void> => {
+    await client.send(
+      new CopyObjectCommand({
+        Bucket: bucket,
+        CopySource: `${bucket}/${sourceKey}`,
+        Key: destKey,
+        ACL: 'public-read',
+      })
+    );
+  };
+
+  return { uploadFile, deleteFile, isFileExisted, listFiles, downloadFile, copyFile };
 };

--- a/packages/core/src/utils/storage/types.ts
+++ b/packages/core/src/utils/storage/types.ts
@@ -8,3 +8,18 @@ export type UploadFile<T extends Uint8Array = Uint8Array> = (
   objectKey: string,
   options?: UploadFileOptions
 ) => Promise<{ url: string }>;
+
+export type DownloadFileResult = {
+  body: ReadableStream;
+  contentType?: string;
+  contentLength?: number;
+};
+
+export type StorageProvider = {
+  uploadFile: UploadFile | UploadFile<Buffer>;
+  deleteFile?: (objectKey: string) => Promise<void>;
+  isFileExisted?: (objectKey: string) => Promise<boolean>;
+  listFiles?: (prefix: string) => Promise<string[]>;
+  downloadFile?: (objectKey: string) => Promise<DownloadFileResult>;
+  copyFile?: (sourceKey: string, destKey: string) => Promise<void>;
+};

--- a/packages/schemas/src/types/user-assets.ts
+++ b/packages/schemas/src/types/user-assets.ts
@@ -57,3 +57,21 @@ export const mimeTypeToFileExtensionMappings: MimeTypeToFileExtensionMappings = 
   'image/bmp': ['bmp'],
   'application/zip': ['zip'],
 } as const);
+
+/** Avatar-specific allowed MIME types (subset of allowUploadMimeTypes, no zip/svg/ico/tiff) */
+export const allowAvatarMimeTypes = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+] as const;
+
+/** Map magic-byte MIME to file extension */
+export const imageExtensionMap: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/bmp': 'bmp',
+};


### PR DESCRIPTION
# S3 Overhaul + Account Avatar API
When using Logto for building apps, I don't want to set up a new S3 instance (RustFS, MinIO) or managed S3 (AWS, Supabase, R2). I want my Logto container to handle this by default. So I went through the codebase to know what to add or remove.
Originally, the storage layer was essentially a write-only bucket. The S3 provider only implemented PutObject, and every upload got a random date-stamped path like `{userId}/2025/03/15/Aa1Bb2Cc/file.png`. This guaranteed filenames never collided, but it also guaranteed files never got cleaned up. There was no delete, no list, no exists, no download, no copy. Storage grew for no reason.
Changing your profile picture required two API calls: first POST the file to `/user-assets` to get a URL, then PATCH `/me` or `/api/my-account` with that URL. If the PATCH failed or the user navigated away, the file was already in S3 but untracked. If the PATCH succeeded and the user later changed their avatar again, the old file stayed behind forever. The user's identity data and their profile picture lived in separate APIs with no transactional link between them.
## What I cut
I removed the random date-stamped path generation. Uploads now use deterministic paths, so same-name files overwrite instead of orphaning.
## What I built
I extended the S3 provider with the missing primitives: `deleteFile`, `isFileExisted`, `listFiles` (with pagination), `downloadFile`, and `copyFile`. The factory now returns the full provider interface, though existing callers that only destructure `uploadFile` are unaffected.
For avatars, there's now `POST /api/my-account/avatar`. It does three things in one request: validates the file via magic bytes (not the browser's claimed Content-Type), uploads to a deterministic path (`admin/{userId}/you.{ext}`), cleans up existing `you.*` files with different extensions, and updates the user record. There is exactly one avatar file per user at any time. The response is the updated user profile with a cache-busted avatar URL.
I also added `GET /api/assets/:userId/:filename` -- a public proxy that streams files from S3. The proxy is intentionally unauthenticated: avatar URLs appear in userinfo responses and must be embeddable without an access token. Files are served with `Cross-Origin-Resource-Policy: cross-origin` so they embed cross-domain without extra configuration.
## API Reference
### `POST /api/my-account/avatar`
Upload an avatar image. Single-step: the file is stored, old avatars are cleaned up, and the user record is updated.
```
POST /api/my-account/avatar
Authorization: Bearer <access-token>
Content-Type: multipart/form-data
file: <image binary>
```
**Accepts:** JPEG, PNG, GIF, WebP, BMP. Maximum 20 MB.
**Validates:** Magic bytes are checked against the claimed MIME type. The browser's `Content-Type` header is not trusted.
**Stores to:** `admin/{userId}/you.{ext}` (deterministic path).
**Cleanup:** Existing `you.*` files with different extensions are deleted. Same-extension files are overwritten by PutObject.
**Updates:** `users.avatar` with a cache-busted URL.
**Requires:** Account center `avatar` field set to `Edit`. Token must have `profile` scope.
**Response (200):** Updated user profile including the `avatar` field.
```json
{
  "id": "user123",
  "name": "Jane",
  "avatar": "https://auth.example.com/api/assets/user123/you.png?v=1715378400000",
  "username": "jane"
}
```
**Error codes:**
| Code | HTTP | When |
|------|------|------|
| `guard.invalid_input` | 400 | No file provided |
| `guard.file_size_exceeded` | 400 | File larger than 20 MB |
| `guard.mime_type_not_allowed` | 400 | File is not an accepted image type, or magic bytes don't match |
| `account_center.field_not_editable` | 400 | Avatar field is not set to `Edit` in account center config |
| `auth.unauthorized` | 401 | Token missing `profile` scope |
| `storage.not_configured` | 500 | No S3 storage provider configured |
| `storage.upload_error` | 500 | Upload or cleanup operation failed |
### `GET /api/assets/:userId/:filename`
Serve an uploaded file. Public endpoint, no authentication required.
```
GET /api/assets/user123/you.png
```
**Response (200):** File binary stream with `Content-Type` matching the stored MIME.
**Response (404):** File does not exist in storage.
**Headers:**
| Header | Value |
|--------|-------|
| `Content-Type` | Matches stored MIME (e.g. `image/png`) |
| `Cache-Control` | `public, max-age=31536000, immutable` |
| `Cross-Origin-Resource-Policy` | `cross-origin` |
## Preserved endpoints
`PATCH /api/my-account` with `{ avatar: url }` continues to work for custom backends, external CDNs, or any URL you bring.
`POST /api/user-assets` and `POST /me/user-assets` continue to work as generic file upload routes. They now use deterministic paths (`{tenant}/{userId}/{filename}`) instead of date-stamped random keys.

- [ ] `.changeset`
- [X] unit tests
- [X] integration tests
- [ ] necessary TSDoc comments
