### PR TITLE
docs(core): document enableCap contract; remove console dev-features guard

### DIFF
--- a/.changeset/logs-enable-cap-docs.md
+++ b/.changeset/logs-enable-cap-docs.md
@@ -1,0 +1,5 @@
+---
+"@logto/console": patch
+---
+
+the Audit Logs page now opts into the count-cap behavior introduced in `@logto/core` by passing `?enableCap=true` to `GET /api/logs`. For tenants with very large log volumes (more than 10,000 matching entries), the page renders a Prev/Next layout when the server reports a capped count instead of hitting `statement_timeout`.

--- a/.changeset/logs-enable-cap-docs.md
+++ b/.changeset/logs-enable-cap-docs.md
@@ -2,4 +2,6 @@
 "@logto/console": patch
 ---
 
-the Audit Logs page now opts into the count-cap behavior introduced in `@logto/core` by passing `?enableCap=true` to `GET /api/logs`. For tenants with very large log volumes (more than 10,000 matching entries), the page renders a Prev/Next layout when the server reports a capped count instead of hitting `statement_timeout`.
+the Audit Logs page now opts into the count-cap behavior introduced in `@logto/core` by passing `?enableCap=true` to `GET /api/logs`.
+
+For tenants with very large log volumes (more than 10,000 matching entries), the page renders a Prev/Next layout when the server reports a capped count instead of hitting `statement_timeout`.

--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -7,7 +7,6 @@ import useSWR from 'swr';
 import ApplicationName from '@/components/ApplicationName';
 import UserName from '@/components/UserName';
 import { auditLogEventTitle, defaultPageSize } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import Table from '@/ds-components/Table';
 import type { Column } from '@/ds-components/Table/types';
 import type { RequestError } from '@/hooks/use-api';
@@ -55,10 +54,10 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
   const url = buildUrl('api/logs', {
     page: String(page),
     page_size: String(pageSize),
+    enableCap: 'true',
     ...conditional(event && { logKey: event }),
     ...conditional(searchApplicationId && { applicationId: searchApplicationId }),
     ...conditional(userId && { userId }),
-    ...conditional(isDevFeaturesEnabled && { enableCap: 'true' }),
   });
 
   const { data, error, mutate } = useSWR<[Log[], number, boolean], RequestError>(url);

--- a/packages/core/src/routes/hooks.openapi.json
+++ b/packages/core/src/routes/hooks.openapi.json
@@ -128,17 +128,36 @@
     "/api/hooks/{id}/recent-logs": {
       "get": {
         "summary": "Get recent logs for a hook",
-        "description": "Get recent logs that match the given query for the specified hook with pagination.",
+        "description": "Get recent logs that match the given query for the specified hook with pagination. See `GET /api/logs` for details on the `enableCap` parameter and capped-response headers.",
         "parameters": [
           {
             "name": "logKey",
             "in": "query",
             "description": "The log key to filter logs."
+          },
+          {
+            "name": "enableCap",
+            "in": "query",
+            "description": "When `true`, short-circuits the underlying `count(*)` query: results with more than 10,000 matching logs saturate `Total-Number` at the sentinel `10001` and emit `Total-Number-Is-Capped: true`; the `Link` header omits `rel=\"last\"` and `rel=\"next\"`. Default `false`. (This endpoint is already scoped to a single hook over the last 24 hours, so the cap rarely triggers in practice.)"
           }
         ],
         "responses": {
           "200": {
-            "description": "A list of recent logs for the hook."
+            "description": "A list of recent logs for the hook.",
+            "headers": {
+              "Total-Number": {
+                "description": "When `enableCap=false`: exact match count. When `enableCap=true`: either the exact count (≤ 10,000) or the saturation sentinel `10001`.",
+                "schema": { "type": "integer" }
+              },
+              "Total-Number-Is-Capped": {
+                "description": "Present and set to `true` only when `enableCap=true` and the result has more than 10,000 matching logs (in which case `Total-Number` is `10001`).",
+                "schema": { "type": "string", "enum": ["true"] }
+              },
+              "Link": {
+                "description": "Pagination links per RFC 5988. When the response is capped, `rel=\"last\"` and `rel=\"next\"` are omitted; walk forward by incrementing `page` and stop on an empty response.",
+                "schema": { "type": "string" }
+              }
+            }
           }
         }
       }

--- a/packages/core/src/routes/log.openapi.json
+++ b/packages/core/src/routes/log.openapi.json
@@ -9,7 +9,7 @@
     "/api/logs": {
       "get": {
         "summary": "Get logs",
-        "description": "Get logs that match the given query with pagination.",
+        "description": "Get logs that match the given query with pagination.\n\n### Pagination on large result sets\n\nFor tenants with very large log volumes, the default exact `count(*)` may exceed Postgres `statement_timeout`. Pass `enableCap=true` to short-circuit the count query: any tenant with more than 10,000 matching logs saturates `Total-Number` at the sentinel value `10001` and the response includes `Total-Number-Is-Capped: true`. In capped responses the `Link` header omits `rel=\"last\"` and `rel=\"next\"`; walk forward by incrementing `page` and stop on an empty response.",
         "parameters": [
           {
             "name": "userId",
@@ -25,11 +25,30 @@
             "name": "logKey",
             "in": "query",
             "description": "Filter logs by log key."
+          },
+          {
+            "name": "enableCap",
+            "in": "query",
+            "description": "When `true`, short-circuits the underlying `count(*)` query: any tenant with more than 10,000 matching logs saturates `Total-Number` at the sentinel value `10001` and the response emits `Total-Number-Is-Capped: true`. The `Link` header then omits `rel=\"last\"` and `rel=\"next\"` because the real total is unknown. Default `false`; recommended `true` for any client whose tenant volume may exceed 10,000 matching logs to avoid `statement_timeout`."
           }
         ],
         "responses": {
           "200": {
-            "description": "An array of logs that match the given query."
+            "description": "An array of logs that match the given query.",
+            "headers": {
+              "Total-Number": {
+                "description": "When `enableCap=false`: exact match count. When `enableCap=true`: either the exact count (≤ 10,000) or the saturation sentinel `10001`; inspect `Total-Number-Is-Capped` to distinguish.",
+                "schema": { "type": "integer" }
+              },
+              "Total-Number-Is-Capped": {
+                "description": "Present and set to `true` only when `enableCap=true` and the result has more than 10,000 matching logs (in which case `Total-Number` is `10001`). Consumers should treat `Total-Number` as `> 10,000` when this header is present.",
+                "schema": { "type": "string", "enum": ["true"] }
+              },
+              "Link": {
+                "description": "Pagination links per RFC 5988. `rel=\"first\"` and `rel=\"prev\"` are emitted as usual. When the response is capped (`Total-Number-Is-Capped: true`), `rel=\"last\"` and `rel=\"next\"` are omitted because the saturated count makes the derived page count unreliable — clients should walk forward by incrementing `page` and stop on an empty response.",
+                "schema": { "type": "string" }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Refs [LOG-13434](https://linear.app/silverhand/issue/LOG-13434). Stacked on top of #8799.

This is the GA step for the audit-logs count-cap work. The runtime behavior shipped in #8796 (backend) and #8799 (console behind `isDevFeaturesEnabled`); this PR:

1. Removes the dev-features gate so the Console always passes `?enableCap=true` to `GET /api/logs` in production.
2. Documents the `enableCap` query param, `Total-Number-Is-Capped` response header, and the capped-mode `Link` rel behavior in the OpenAPI specs.
3. Adds a patch-level changeset for the doc-only `@logto/core` change.

### What changed

- **`packages/console/src/components/AuditLogTable/index.tsx`** — drops the `isDevFeaturesEnabled` import and the `...conditional(isDevFeaturesEnabled && { enableCap: 'true' })` spread. The URL builder now always includes `enableCap: 'true'`.
- **`packages/core/src/routes/log.openapi.json`** — `/api/logs`: adds the `enableCap` query parameter, documents `Total-Number`, `Total-Number-Is-Capped`, and `Link` response headers, and adds a "Pagination on large result sets" subsection to the endpoint description.
- **`packages/core/src/routes/hooks.openapi.json`** — `/api/hooks/{id}/recent-logs`: same set of doc additions, with a one-liner noting that this endpoint is already scoped to one hook over the last 24h so the cap rarely triggers in practice.
- **`.changeset/logs-enable-cap-docs.md`** — `@logto/core: patch` noting the OpenAPI updates.

### Backward compatibility

- API runtime behavior: unchanged (the `enableCap` semantics shipped in #8796).
- Default `GET /api/logs` (no `enableCap`) still returns the exact count. Existing third-party clients are unaffected.
- Console Audit Logs page: production users with tenants > 10,000 matching logs now get the capped UI (Prev/Next only) instead of hitting `statement_timeout`. Smaller tenants see no visible change.

### Reviewer notes

- The `Total-Number-Is-Capped` header schema is `{ "type": "string", "enum": ["true"] }` — the header is only present when the count is capped, and its value is always the literal string `"true"`. Absent otherwise.
- This PR is stacked on #8799 (Console) → #8796 (Backend). PR base will retarget to `master` once those merge.

## Testing

Tested locally

## Checklist
- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments