### PR TITLE
fix(phrases): ignore max-lines for locale files

### DIFF
--- a/packages/phrases/package.json
+++ b/packages/phrases/package.json
@@ -51,7 +51,17 @@
     "extends": "@silverhand",
     "rules": {
       "no-template-curly-in-string": "off"
-    }
+    },
+    "overrides": [
+      {
+        "files": [
+          "src/locales/**/*.ts"
+        ],
+        "rules": {
+          "max-lines": "off"
+        }
+      }
+    ]
   },
   "prettier": "@silverhand/eslint-config/.prettierrc"
 }


### PR DESCRIPTION
## Summary

- Disable the `max-lines` rule for locale translation files in `@logto/phrases`.
- Fix master lint failure caused by the new German and French `social_change` translations exceeding the 300-line limit.

## Testing

Tested locally