### PR TITLE
feat(core): add start_time and end_time query params on audit log routes

### DIFF
--- a/.changeset/logs-time-window.md
+++ b/.changeset/logs-time-window.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": minor
+---
+
+add `start_time` and `end_time` query parameters to `GET /api/logs` and `GET /api/hooks/{id}/recent-logs` for filtering logs by a time window.
+
+Both are exclusive bounds in unix milliseconds (`createdAt > start_time AND createdAt < end_time`). Either value is optional; when both are present, the endpoint returns `400` if `start_time >= end_time`. Either value being non-numeric also returns `400`.
+
+On `GET /api/hooks/{id}/recent-logs`, supplying either `start_time` or `end_time` replaces the endpoint's default 24-hour lower bound so callers can query an arbitrary historical window. Default behavior (no time params supplied) is unchanged: the endpoint still returns logs from the last 24 hours.

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -21,7 +21,10 @@ type AllowedKeyPrefix = AuditLogPrefix | WebhookLogPrefix;
 type LogCondition = {
   logKey?: string;
   payload?: { applicationId?: string; userId?: string; hookId?: string };
-  startTimeExclusive?: number;
+  /** Exclusive lower bound on `createdAt`, in unix milliseconds. */
+  startTime?: number;
+  /** Exclusive upper bound on `createdAt`, in unix milliseconds. */
+  endTime?: number;
   includeKeyPrefix?: AllowedKeyPrefix[];
 };
 
@@ -39,7 +42,7 @@ type CountLogsResult = {
 };
 
 const buildLogConditionSql = (logCondition: LogCondition) =>
-  conditionalSql(logCondition, ({ logKey, payload, startTimeExclusive, includeKeyPrefix = [] }) => {
+  conditionalSql(logCondition, ({ logKey, payload, startTime, endTime, includeKeyPrefix = [] }) => {
     const keyPrefixFilter = conditional(
       includeKeyPrefix.length > 0 &&
         includeKeyPrefix.map((prefix) => sql`${fields.key} like ${`${prefix}%`}`)
@@ -56,11 +59,15 @@ const buildLogConditionSql = (logCondition: LogCondition) =>
           )
       ),
       conditionalSql(logKey, (logKey) => sql`${fields.key}=${logKey}`),
-      conditionalSql(
-        startTimeExclusive,
-        (startTimeExclusive) =>
-          sql`${fields.createdAt} > to_timestamp(${startTimeExclusive}::double precision / 1000)`
-      ),
+      // Use `!== undefined` (not `conditionalSql`) so a legitimate `start_time=0`
+      // or `end_time=0` window still applies — `conditionalSql` treats `0` as
+      // falsy and would silently drop the filter.
+      startTime === undefined
+        ? sql``
+        : sql`${fields.createdAt} > to_timestamp(${startTime}::double precision / 1000)`,
+      endTime === undefined
+        ? sql``
+        : sql`${fields.createdAt} < to_timestamp(${endTime}::double precision / 1000)`,
     ].filter(({ sql }) => sql);
 
     return subConditions.length > 0 ? sql`where ${sql.join(subConditions, sql` and `)}` : sql``;

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- hook route tests cover hooks CRUD + recent-logs + executions; splitting fragments the shared mock setup. */
 import {
   InteractionHookEvent,
   LogResult,
@@ -142,7 +143,7 @@ describe('hook routes', () => {
     const page = 1;
     const pageSize = 5;
 
-    const startTimeExclusive = subDays(new Date(100_000), 1).getTime();
+    const startTime = subDays(new Date(100_000), 1).getTime();
 
     await hookRequest.get(
       `/hooks/${hookId}/recent-logs?logKey=${logKey}&page=${page}&page_size=${pageSize}`
@@ -151,7 +152,7 @@ describe('hook routes', () => {
       {
         payload: { hookId },
         logKey,
-        startTimeExclusive,
+        startTime,
         includeKeyPrefix: [hook.Type.TriggerHook],
       },
       { capped: false }
@@ -159,7 +160,7 @@ describe('hook routes', () => {
     expect(findLogs).toHaveBeenCalledWith(5, 0, {
       payload: { hookId },
       logKey,
-      startTimeExclusive,
+      startTime,
       includeKeyPrefix: [hook.Type.TriggerHook],
     });
 
@@ -188,6 +189,81 @@ describe('hook routes', () => {
     it('passes capped=false to countLogs when enableCap is omitted', async () => {
       await hookRequest.get(`/hooks/foo/recent-logs`);
       expect(countLogs).toHaveBeenCalledWith(expect.any(Object), { capped: false });
+    });
+  });
+
+  describe('GET /hooks/:id/recent-logs start_time / end_time params', () => {
+    const now = 100_000_000;
+    const internalFloor = subDays(new Date(now), 1).getTime();
+
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(now);
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('uses the 24h default when no time params are supplied', async () => {
+      await hookRequest.get(`/hooks/foo/recent-logs`);
+      expect(countLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTime: internalFloor,
+          endTime: undefined,
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('skips the 24h default and honors start_time as-is', async () => {
+      // 48 hours ago — older than the default 24h, but the user's value wins
+      // because they supplied an explicit window.
+      const userStart = now - 48 * 60 * 60 * 1000;
+      await hookRequest.get(`/hooks/foo/recent-logs?start_time=${userStart}`);
+      expect(countLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTime: userStart,
+          endTime: undefined,
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('skips the 24h default when only end_time is supplied', async () => {
+      const userEnd = now - 60_000;
+      await hookRequest.get(`/hooks/foo/recent-logs?end_time=${userEnd}`);
+      expect(countLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTime: undefined,
+          endTime: userEnd,
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('honors both start_time and end_time when supplied', async () => {
+      const userStart = now - 60 * 60 * 1000;
+      const userEnd = now - 60_000;
+      await hookRequest.get(`/hooks/foo/recent-logs?start_time=${userStart}&end_time=${userEnd}`);
+      expect(countLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startTime: userStart,
+          endTime: userEnd,
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('returns 400 when start_time >= end_time', async () => {
+      const response = await hookRequest.get(
+        `/hooks/foo/recent-logs?start_time=2000&end_time=1000`
+      );
+      expect(response.status).toEqual(400);
+    });
+
+    it('returns 400 when start_time is not a finite number', async () => {
+      const response = await hookRequest.get(`/hooks/foo/recent-logs?start_time=oops`);
+      expect(response.status).toEqual(400);
     });
   });
 
@@ -412,3 +488,4 @@ describe('hook routes', () => {
     );
   });
 });
+/* eslint-enable max-lines */

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -21,6 +21,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { koaReportSubscriptionUpdates, koaQuotaGuard } from '#src/middleware/koa-quota-guard.js';
 import assertThat from '#src/utils/assert-that.js';
+import { parseTimestampParam, validateTimeWindow } from '#src/utils/time-window.js';
 
 import { captureEvent } from '../utils/posthog.js';
 
@@ -124,27 +125,39 @@ export default function hookRoutes<T extends ManagementApiRouter>(
       query: z.object({
         logKey: z.string().optional(),
         enableCap: z.string().optional(),
+        start_time: z.string().optional(),
+        end_time: z.string().optional(),
       }),
       response: Logs.guard.omit({ tenantId: true }).array(),
-      status: 200,
+      status: [200, 400],
     }),
     async (ctx, next) => {
       const { limit, offset } = ctx.pagination;
 
       const {
         params: { id },
-        query: { logKey, enableCap },
+        query: { logKey, enableCap, start_time, end_time },
       } = ctx.guard;
 
+      const userStart = parseTimestampParam(start_time, 'start_time');
+      const userEnd = parseTimestampParam(end_time, 'end_time');
+      validateTimeWindow(userStart, userEnd);
+
       const includeKeyPrefix: WebhookLogPrefix[] = [hook.Type.TriggerHook];
-      const startTimeExclusive = subDays(new Date(), 1).getTime();
+      // Backward compat: when neither time param is supplied, fall back to the
+      // historical 24h lower bound. When the caller supplies either bound,
+      // honor their window as-is and skip the default.
+      const hasExplicitWindow = userStart !== undefined || userEnd !== undefined;
+      const startTime = hasExplicitWindow ? userStart : subDays(new Date(), 1).getTime();
+      const endTime = userEnd;
 
       const [{ count, isCapped }, logs] = await Promise.all([
         countLogs(
           {
             logKey,
             payload: { hookId: id },
-            startTimeExclusive,
+            startTime,
+            endTime,
             includeKeyPrefix,
           },
           { capped: yes(enableCap) }
@@ -152,7 +165,8 @@ export default function hookRoutes<T extends ManagementApiRouter>(
         findLogs(limit, offset, {
           logKey,
           payload: { hookId: id },
-          startTimeExclusive,
+          startTime,
+          endTime,
           includeKeyPrefix,
         }),
       ]);

--- a/packages/core/src/routes/hooks.openapi.json
+++ b/packages/core/src/routes/hooks.openapi.json
@@ -136,12 +136,25 @@
             "description": "The log key to filter logs."
           },
           {
+            "name": "start_time",
+            "in": "query",
+            "description": "Exclusive lower bound on `createdAt`, in unix milliseconds. Supplying either `start_time` or `end_time` replaces the endpoint's default 24-hour lower bound, so callers can query an arbitrary historical window. Returns `400` if `start_time >= end_time` when both are present."
+          },
+          {
+            "name": "end_time",
+            "in": "query",
+            "description": "Exclusive upper bound on `createdAt`, in unix milliseconds. Supplying either `start_time` or `end_time` replaces the endpoint's default 24-hour lower bound."
+          },
+          {
             "name": "enableCap",
             "in": "query",
             "description": "When `true`, short-circuits the underlying `count(*)` query: results with more than 10,000 matching logs saturate `Total-Number` at the sentinel `10001` and emit `Total-Number-Is-Capped: true`; the `Link` header omits `rel=\"last\"` and `rel=\"next\"`. Default `false`. (This endpoint is already scoped to a single hook over the last 24 hours, so the cap rarely triggers in practice.)"
           }
         ],
         "responses": {
+          "400": {
+            "description": "Returned when `start_time` or `end_time` is not a finite number, or when `start_time >= end_time`."
+          },
           "200": {
             "description": "A list of recent logs for the hook.",
             "headers": {

--- a/packages/core/src/routes/log.openapi.json
+++ b/packages/core/src/routes/log.openapi.json
@@ -27,12 +27,25 @@
             "description": "Filter logs by log key."
           },
           {
+            "name": "start_time",
+            "in": "query",
+            "description": "Exclusive lower bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt > start_time`. Recommended for clients paginating across very large log ranges to keep query latency consistent."
+          },
+          {
+            "name": "end_time",
+            "in": "query",
+            "description": "Exclusive upper bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt < end_time`. Returns `400` if `start_time >= end_time` when both are present."
+          },
+          {
             "name": "enableCap",
             "in": "query",
             "description": "When `true`, short-circuits the underlying `count(*)` query: any tenant with more than 10,000 matching logs saturates `Total-Number` at the sentinel value `10001` and the response emits `Total-Number-Is-Capped: true`. The `Link` header then omits `rel=\"last\"` and `rel=\"next\"` because the real total is unknown. Default `false`; recommended `true` for any client whose tenant volume may exceed 10,000 matching logs to avoid `statement_timeout`."
           }
         ],
         "responses": {
+          "400": {
+            "description": "Returned when `start_time` or `end_time` is not a finite number, or when `start_time >= end_time`."
+          },
           "200": {
             "description": "An array of logs that match the given query.",
             "headers": {

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -101,6 +101,63 @@ describe('logRoutes', () => {
         expect(countLogs).toHaveBeenCalledWith(expect.any(Object), { capped: false });
       });
     });
+
+    describe('start_time / end_time query params', () => {
+      it('passes startTime to countLogs and findLogs when start_time is set', async () => {
+        await logRequest.get(`/logs?start_time=1000`);
+        expect(countLogs).toHaveBeenCalledWith(
+          expect.objectContaining({ startTime: 1000, endTime: undefined }),
+          expect.any(Object)
+        );
+        expect(findLogs).toHaveBeenCalledWith(
+          expect.any(Number),
+          expect.any(Number),
+          expect.objectContaining({ startTime: 1000, endTime: undefined })
+        );
+      });
+
+      it('passes endTime to countLogs and findLogs when end_time is set', async () => {
+        await logRequest.get(`/logs?end_time=2000`);
+        expect(countLogs).toHaveBeenCalledWith(
+          expect.objectContaining({ startTime: undefined, endTime: 2000 }),
+          expect.any(Object)
+        );
+        expect(findLogs).toHaveBeenCalledWith(
+          expect.any(Number),
+          expect.any(Number),
+          expect.objectContaining({ startTime: undefined, endTime: 2000 })
+        );
+      });
+
+      it('passes both bounds when start_time and end_time are set', async () => {
+        await logRequest.get(`/logs?start_time=1000&end_time=2000`);
+        expect(countLogs).toHaveBeenCalledWith(
+          expect.objectContaining({ startTime: 1000, endTime: 2000 }),
+          expect.any(Object)
+        );
+      });
+
+      it('returns 400 when start_time >= end_time', async () => {
+        const response = await logRequest.get(`/logs?start_time=2000&end_time=1000`);
+        expect(response.status).toEqual(400);
+        expect(countLogs).not.toHaveBeenCalled();
+      });
+
+      it('returns 400 when start_time equals end_time', async () => {
+        const response = await logRequest.get(`/logs?start_time=1000&end_time=1000`);
+        expect(response.status).toEqual(400);
+      });
+
+      it('returns 400 when start_time is not a finite number', async () => {
+        const response = await logRequest.get(`/logs?start_time=abc`);
+        expect(response.status).toEqual(400);
+      });
+
+      it('returns 400 when end_time is not a finite number', async () => {
+        const response = await logRequest.get(`/logs?end_time=NaN`);
+        expect(response.status).toEqual(400);
+      });
+    });
   });
 
   describe('GET /logs/:id', () => {

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -12,6 +12,7 @@ import { object, string } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
+import { parseTimestampParam, validateTimeWindow } from '#src/utils/time-window.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 
@@ -29,15 +30,21 @@ export default function logRoutes<T extends ManagementApiRouter>(
         applicationId: string().optional(),
         logKey: string().optional(),
         enableCap: string().optional(),
+        start_time: string().optional(),
+        end_time: string().optional(),
       }),
       response: Logs.guard.array(),
-      status: 200,
+      status: [200, 400],
     }),
     async (ctx, next) => {
       const { limit, offset } = ctx.pagination;
       const {
-        query: { userId, applicationId, logKey, enableCap },
+        query: { userId, applicationId, logKey, enableCap, start_time, end_time },
       } = ctx.guard;
+
+      const startTime = parseTimestampParam(start_time, 'start_time');
+      const endTime = parseTimestampParam(end_time, 'end_time');
+      validateTimeWindow(startTime, endTime);
 
       const includeKeyPrefix: AuditLogPrefix[] = [
         token.Type.ExchangeTokenBy,
@@ -55,6 +62,8 @@ export default function logRoutes<T extends ManagementApiRouter>(
           {
             logKey,
             payload: { applicationId, userId },
+            startTime,
+            endTime,
             includeKeyPrefix,
           },
           { capped: yes(enableCap) }
@@ -62,6 +71,8 @@ export default function logRoutes<T extends ManagementApiRouter>(
         findLogs(limit, offset, {
           logKey,
           payload: { userId, applicationId },
+          startTime,
+          endTime,
           includeKeyPrefix,
         }),
       ]);

--- a/packages/core/src/utils/time-window.ts
+++ b/packages/core/src/utils/time-window.ts
@@ -1,0 +1,29 @@
+import RequestError from '#src/errors/RequestError/index.js';
+
+/**
+ * Parse a unix-ms string query param into a finite number, or throw 400 with
+ * `guard.invalid_input`. Returns `undefined` when the input is absent.
+ */
+export const parseTimestampParam = (
+  raw: string | undefined,
+  paramName: string
+): number | undefined => {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const value = Number(raw);
+  if (!Number.isFinite(value)) {
+    throw new RequestError({ code: 'guard.invalid_input', type: paramName });
+  }
+  return value;
+};
+
+/**
+ * Validate a parsed time window: when both bounds are present, `start` must be
+ * strictly less than `end`. Throws 400 with `log.invalid_time_window` otherwise.
+ */
+export const validateTimeWindow = (start: number | undefined, end: number | undefined): void => {
+  if (start !== undefined && end !== undefined && start >= end) {
+    throw new RequestError({ code: 'log.invalid_time_window', status: 400 });
+  }
+};

--- a/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
+++ b/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
@@ -1,0 +1,132 @@
+import { InteractionEvent, SignInIdentifier, interaction } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+import { HTTPError } from 'ky';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { getAuditLogs, getAuditLogsResponse } from '#src/api/logs.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateNewUserProfile } from '#src/helpers/user.js';
+import { parseInteractionCookie } from '#src/utils.js';
+
+// Integration coverage for the `start_time` / `end_time` query params on
+// `GET /api/logs`. Validation paths (400 responses) are covered exhaustively;
+// behavioral filtering is verified against an interaction-triggered log
+// captured at "now", since integration tests don't have direct DB access to
+// seed logs with arbitrary `createdAt` timestamps.
+describe('GET /logs start_time / end_time params', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods({
+      identifiers: [SignInIdentifier.Username],
+      password: true,
+      verify: false,
+    });
+  });
+
+  describe('validation', () => {
+    it('returns 400 when start_time >= end_time', async () => {
+      const response = await getAuditLogsResponse(
+        new URLSearchParams({ start_time: '2000', end_time: '1000' })
+      ).catch((error: unknown) => error);
+      expect(response instanceof HTTPError && response.response.status).toBe(400);
+    });
+
+    it('returns 400 when start_time equals end_time', async () => {
+      const response = await getAuditLogsResponse(
+        new URLSearchParams({ start_time: '1000', end_time: '1000' })
+      ).catch((error: unknown) => error);
+      expect(response instanceof HTTPError && response.response.status).toBe(400);
+    });
+
+    it('returns 400 when start_time is not a finite number', async () => {
+      const response = await getAuditLogsResponse(new URLSearchParams({ start_time: 'abc' })).catch(
+        (error: unknown) => error
+      );
+      expect(response instanceof HTTPError && response.response.status).toBe(400);
+    });
+
+    it('returns 400 when end_time is not a finite number', async () => {
+      const response = await getAuditLogsResponse(new URLSearchParams({ end_time: 'NaN' })).catch(
+        (error: unknown) => error
+      );
+      expect(response instanceof HTTPError && response.response.status).toBe(400);
+    });
+  });
+
+  describe('default behavior (no params)', () => {
+    it('returns logs as before when neither param is supplied', async () => {
+      const response = await getAuditLogsResponse(new URLSearchParams({ page_size: '5' }));
+      expect(response.status).toBe(200);
+      expect(response.headers.get('total-number')).not.toBeNull();
+    });
+  });
+
+  describe('time-window filtering', () => {
+    it('includes a log created within the window and excludes it from a non-overlapping window', async () => {
+      // Capture the moment we kick off an interaction.
+      const beforeStart = Date.now();
+      const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
+      const interactionCookie = client.parsedCookies.get('_interaction');
+      assert(interactionCookie, new Error('No interaction found in cookie'));
+      const interactionId = parseInteractionCookie(interactionCookie)['demo-app'];
+      const afterStart = Date.now();
+
+      // Sanity: the interaction.create log must be in [beforeStart-1s, afterStart+1s].
+      const matchingWindow = await getAuditLogs(
+        new URLSearchParams({
+          logKey: `${interaction.prefix}.${interaction.Action.Create}`,
+          start_time: String(beforeStart - 1000),
+          end_time: String(afterStart + 1000),
+        })
+      );
+      expect(
+        matchingWindow.some((log) => log.payload.interactionId === interactionId)
+      ).toBeTruthy();
+
+      // A window that ends before the interaction started must exclude the log.
+      const nonOverlappingWindow = await getAuditLogs(
+        new URLSearchParams({
+          logKey: `${interaction.prefix}.${interaction.Action.Create}`,
+          end_time: String(beforeStart),
+        })
+      );
+      expect(
+        nonOverlappingWindow.some((log) => log.payload.interactionId === interactionId)
+      ).toBeFalsy();
+
+      // Same for a window that starts after the interaction ended.
+      const futureWindow = await getAuditLogs(
+        new URLSearchParams({
+          logKey: `${interaction.prefix}.${interaction.Action.Create}`,
+          start_time: String(afterStart + 60_000),
+        })
+      );
+      expect(futureWindow.some((log) => log.payload.interactionId === interactionId)).toBeFalsy();
+
+      // Process the interaction so the test user can be cleaned up.
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
+      await client.updateProfile({ type: SignInIdentifier.Username, value: username });
+      await client.updateProfile({ type: 'password', value: password });
+      await client.identifyUser();
+      const response = await client.submitInteraction();
+      await client.processSession(response.redirectTo);
+      const { sub: userId } = await client.getIdTokenClaims();
+      await client.signOut();
+      await deleteUser(userId);
+    });
+
+    it('composes with other filters (AND semantics)', async () => {
+      // Sanity check: combining start_time with logKey returns a non-error
+      // response. Empirical row count varies with test ordering, so we only
+      // assert the request shape is accepted and well-formed.
+      const response = await getAuditLogsResponse(
+        new URLSearchParams({
+          start_time: String(Date.now() - 60_000),
+          end_time: String(Date.now() + 60_000),
+          logKey: `${interaction.prefix}.${interaction.Action.Create}`,
+        })
+      );
+      expect(response.status).toBe(200);
+    });
+  });
+});

--- a/packages/phrases/src/locales/ar/errors/log.ts
+++ b/packages/phrases/src/locales/ar/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'نوع السجل غير صالح.',
+  invalid_time_window: 'يجب أن يكون `end_time` بعد `start_time`.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/de/errors/log.ts
+++ b/packages/phrases/src/locales/de/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'Der Log Typ ist ungültig.',
+  invalid_time_window: '`end_time` muss nach `start_time` liegen.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/en/errors/log.ts
+++ b/packages/phrases/src/locales/en/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'The log type is invalid.',
+  invalid_time_window: '`end_time` must be after `start_time`.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/es/errors/log.ts
+++ b/packages/phrases/src/locales/es/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'El tipo de registro es inválido.',
+  invalid_time_window: '`end_time` debe ser posterior a `start_time`.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/fr/errors/log.ts
+++ b/packages/phrases/src/locales/fr/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'Type de journalisation invalide.',
+  invalid_time_window: '`end_time` doit être postérieur à `start_time`.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/it/errors/log.ts
+++ b/packages/phrases/src/locales/it/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'Il tipo di registro non è valido.',
+  invalid_time_window: '`end_time` deve essere successivo a `start_time`.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/ja/errors/log.ts
+++ b/packages/phrases/src/locales/ja/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'ログタイプが無効です。',
+  invalid_time_window: '`end_time` は `start_time` より後である必要があります。',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/ko/errors/log.ts
+++ b/packages/phrases/src/locales/ko/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: '로그 종류가 유효하지 않아요.',
+  invalid_time_window: '`end_time`은 `start_time` 이후여야 해요.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/pl-pl/errors/log.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'Typ dziennika jest nieprawidłowy.',
+  invalid_time_window: '`end_time` musi być późniejsze niż `start_time`.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/pt-br/errors/log.ts
+++ b/packages/phrases/src/locales/pt-br/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'O tipo de registro é inválido.',
+  invalid_time_window: '`end_time` deve ser posterior a `start_time`.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/pt-pt/errors/log.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'O tipo de registro é inválido.',
+  invalid_time_window: '`end_time` deve ser posterior a `start_time`.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/ru/errors/log.ts
+++ b/packages/phrases/src/locales/ru/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'Тип журнала недействительный.',
+  invalid_time_window: '`end_time` должно быть позже, чем `start_time`.',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/th/errors/log.ts
+++ b/packages/phrases/src/locales/th/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'ประเภทบันทึกไม่ถูกต้อง',
+  invalid_time_window: '`end_time` ต้องอยู่หลัง `start_time`',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/tr-tr/errors/log.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: 'Geçersiz günlük türü.',
+  invalid_time_window: "`end_time`, `start_time`'dan sonra olmalıdır.",
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/zh-cn/errors/log.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: '日志类型无效。',
+  invalid_time_window: '`end_time` 必须晚于 `start_time`。',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/zh-hk/errors/log.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: '日誌類型無效。',
+  invalid_time_window: '`end_time` 必須晚於 `start_time`。',
 };
 
 export default Object.freeze(log);

--- a/packages/phrases/src/locales/zh-tw/errors/log.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/log.ts
@@ -1,5 +1,6 @@
 const log = {
   invalid_type: '日誌類型無效。',
+  invalid_time_window: '`end_time` 必須晚於 `start_time`。',
 };
 
 export default Object.freeze(log);


### PR DESCRIPTION
## Summary
Closes LOG-13418. Stacked on #8802.

Adds optional `start_time` and `end_time` unix-ms query parameters to `GET /api/logs` and `GET /api/hooks/:id/recent-logs`, letting callers narrow the time window so the count scan is cheaper and so the Console can build a time-range picker on top.

### What changed
- `packages/core/src/queries/log.ts` — `LogCondition` gains `startTime` / `endTime` (exclusive, in unix-ms). `buildLogConditionSql` emits a symmetric `to_timestamp(value::double precision / 1000)` clause for each bound.
- `packages/core/src/utils/time-window.ts` (new) — shared `parseTimestampParam` (throws 400 `guard.invalid_input` on non-finite input) and `validateTimeWindow` (throws 400 `log.invalid_time_window` when both bounds are present and `start >= end`).
- `packages/core/src/routes/log.ts` — accepts both params, declares 400 in `koaGuard.status`.
- `packages/core/src/routes/hook.ts` — same wiring, preserving the historical 24-hour lower bound only when **neither** param is supplied (`hasExplicitWindow` flag). Any explicit bound replaces the default, so callers stay in control.
- New error code `log.invalid_time_window` added to all 17 locales (the route declares 400 explicitly because `koaGuard` only auto-bypasses status assertion for `guard.*` codes).
- OpenAPI: both endpoints document the new params, exclusive-bound semantics, and the new 400 response. The hooks endpoint notes that supplying either bound replaces the 24h default.

### Expected behavior
- No params → existing behavior unchanged (audit logs unbounded; webhook recent-logs uses the 24h default).
- Either param supplied → `createdAt` strictly between the bounds (`>` / `<`); webhook endpoint drops its 24h default.
- `start_time >= end_time` (including equal) or non-finite values → 400 with `log.invalid_time_window` / `guard.invalid_input`.

### Reviewer notes
- The 24h backward-compat on `/hooks/:id/recent-logs` is intentional and exhaustively covered by unit tests across all four combinations (none / start-only / end-only / both).
- Integration test captures timestamps around an interaction-driven log (no DB seeding available), then asserts inclusion in a matching window and exclusion from non-overlapping windows.

## Testing
Unit tests, integration tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments