### PR TITLE
feat(console): add time-range picker on audit logs page behind dev features

### DIFF
--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/index.module.scss
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/index.module.scss
@@ -1,0 +1,31 @@
+@use '@/scss/underscore' as _;
+
+.timeRangePicker {
+  display: flex;
+  align-items: center;
+}
+
+.selectWrapper {
+  width: 180px;
+}
+
+.customRange {
+  display: flex;
+  align-items: center;
+  margin-inline-start: _.unit(2);
+}
+
+.dateField {
+  display: flex;
+  align-items: center;
+
+  + .dateField {
+    margin-inline-start: _.unit(2);
+  }
+}
+
+.dateLabel {
+  color: var(--color-text-secondary);
+  font: var(--font-body-2);
+  margin-inline-end: _.unit(1);
+}

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/index.tsx
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/index.tsx
@@ -1,0 +1,103 @@
+import { format } from 'date-fns';
+import type { ChangeEventHandler } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Select from '@/ds-components/Select';
+import TextInput from '@/ds-components/TextInput';
+
+import styles from './index.module.scss';
+import { type PresetRange, customRange, isPresetRange } from './preset';
+
+type Props = {
+  /** Either a preset name (`'7d'`) or `'custom'` when a custom range is active. */
+  readonly value: PresetRange | typeof customRange;
+  readonly customStartDate?: string;
+  readonly customEndDate?: string;
+  readonly onChange: (next: { range: PresetRange | typeof customRange }) => void;
+  readonly onCustomDatesChange: (next: { startDate?: string; endDate?: string }) => void;
+};
+
+/**
+ * Time-range picker for the Audit Logs page. Renders a preset dropdown with an
+ * optional pair of date inputs when the custom-range option is selected. URL
+ * state ownership belongs to the parent — this component is purely a
+ * controlled view over the `range` / `start_time` / `end_time` query params.
+ */
+function TimeRangePicker({
+  value,
+  customStartDate,
+  customEndDate,
+  onChange,
+  onCustomDatesChange,
+}: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  // I18n keys must be literals.
+  const options = [
+    { value: '1h', title: t('logs.last_1_hour') },
+    { value: '1d', title: t('logs.last_24_hours') },
+    { value: '7d', title: t('logs.last_7_days') },
+    { value: '30d', title: t('logs.last_30_days') },
+    { value: customRange, title: t('logs.custom_range') },
+  ];
+
+  const handleSelectChange = (next?: string) => {
+    if (!next) {
+      return;
+    }
+    if (next === customRange) {
+      onChange({ range: customRange });
+      return;
+    }
+    if (isPresetRange(next)) {
+      onChange({ range: next });
+    }
+  };
+
+  const today = format(Date.now(), 'yyyy-MM-dd');
+
+  const handleStartDateChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    onCustomDatesChange({ startDate: event.target.value || undefined });
+  };
+
+  const handleEndDateChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+    onCustomDatesChange({ endDate: event.target.value || undefined });
+  };
+
+  return (
+    <div className={styles.timeRangePicker}>
+      <div className={styles.selectWrapper}>
+        <Select<string>
+          value={value}
+          options={options}
+          size="medium"
+          onChange={handleSelectChange}
+        />
+      </div>
+      {value === customRange && (
+        <div className={styles.customRange}>
+          <label className={styles.dateField}>
+            <span className={styles.dateLabel}>{t('logs.from')}</span>
+            <TextInput
+              type="date"
+              max={today}
+              value={customStartDate ?? ''}
+              onChange={handleStartDateChange}
+            />
+          </label>
+          <label className={styles.dateField}>
+            <span className={styles.dateLabel}>{t('logs.to')}</span>
+            <TextInput
+              type="date"
+              max={today}
+              value={customEndDate ?? ''}
+              onChange={handleEndDateChange}
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TimeRangePicker;

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.test.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.test.ts
@@ -1,0 +1,90 @@
+import { addDays, startOfDay } from 'date-fns';
+
+import {
+  customRange,
+  defaultPresetRange,
+  isPresetRange,
+  parsePresetMs,
+  presetRanges,
+  resolveTimeWindow,
+} from './preset';
+
+describe('preset', () => {
+  describe('isPresetRange', () => {
+    it.each(presetRanges)('returns true for the canonical preset %s', (preset) => {
+      expect(isPresetRange(preset)).toBe(true);
+    });
+
+    it.each(['', customRange, '5m', '1y', 'last 7 days'])(
+      'returns false for non-preset value %p',
+      (value) => {
+        expect(isPresetRange(value)).toBe(false);
+      }
+    );
+  });
+
+  describe('parsePresetMs', () => {
+    it.each([
+      ['1h', 60 * 60 * 1000],
+      ['1d', 24 * 60 * 60 * 1000],
+      ['7d', 7 * 24 * 60 * 60 * 1000],
+      ['30d', 30 * 24 * 60 * 60 * 1000],
+    ])('translates %s into %d ms', (preset, expected) => {
+      expect(parsePresetMs(preset)).toBe(expected);
+    });
+
+    it.each(['', customRange, '5m', '1y'])('returns undefined for non-preset value %p', (value) => {
+      expect(parsePresetMs(value)).toBeUndefined();
+    });
+  });
+
+  it('uses 7d as the default preset', () => {
+    expect(defaultPresetRange).toBe('7d');
+    expect(isPresetRange(defaultPresetRange)).toBe(true);
+  });
+
+  describe('resolveTimeWindow', () => {
+    const fixedNow = new Date('2026-05-13T00:00:00Z').getTime();
+    const now = () => fixedNow;
+
+    it('returns a rolling lower bound for a known preset and no upper bound', () => {
+      const window = resolveTimeWindow('7d', '', '', now);
+      expect(window.startTime).toBe(fixedNow - 7 * 24 * 60 * 60 * 1000);
+      expect(window.endTime).toBeUndefined();
+    });
+
+    it('falls back to the default preset for an unknown range value', () => {
+      const window = resolveTimeWindow('bogus', '', '', now);
+      expect(window.startTime).toBe(fixedNow - 7 * 24 * 60 * 60 * 1000);
+      expect(window.endTime).toBeUndefined();
+    });
+
+    it('parses a yyyy-MM-dd custom range with bounds tuned for the API exclusive semantics', () => {
+      const window = resolveTimeWindow(customRange, '2026-04-13', '2026-04-15', now);
+      // Start: (startOfDay - 1ms) so `>` includes midnight of the picked day.
+      expect(window.startTime).toBe(startOfDay(new Date(2026, 3, 13)).getTime() - 1);
+      // End: startOfDay of the day _after_ so `<` includes 23:59:59.999 of the picked day.
+      expect(window.endTime).toBe(startOfDay(addDays(new Date(2026, 3, 15), 1)).getTime());
+    });
+
+    it('drops malformed custom-range strings (regression: NaN crash)', () => {
+      // Manual URL edit, e.g. `?range=custom&start_time=garbage`
+      const window = resolveTimeWindow(customRange, 'garbage', '', now);
+      expect(window.startTime).toBeUndefined();
+      expect(window.endTime).toBeUndefined();
+    });
+
+    it('rejects full ISO timestamps so the table filter never disagrees with the input', () => {
+      // Without the shape check, `parseISO('2026-04-13T00:00:00Z')` would succeed
+      // and the API would be filtered while the date input renders blank.
+      const window = resolveTimeWindow(customRange, '2026-04-13T00:00:00Z', '', now);
+      expect(window.startTime).toBeUndefined();
+    });
+
+    it('omits a custom bound when its raw value is empty', () => {
+      const window = resolveTimeWindow(customRange, '', '2026-04-15', now);
+      expect(window.startTime).toBeUndefined();
+      expect(window.endTime).toBe(startOfDay(addDays(new Date(2026, 3, 15), 1)).getTime());
+    });
+  });
+});

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.ts
@@ -1,0 +1,103 @@
+import { addDays, isValid, parseISO, startOfDay } from 'date-fns';
+
+/**
+ * Canonical preset names persisted in the URL (`?range=…`). Stable across
+ * sessions and bookmarkable: `Date.now() - parsePresetMs('7d')` is always
+ * "7 days before _now_" rather than a frozen window from the moment the link
+ * was saved.
+ */
+export const presetRanges = ['1h', '1d', '7d', '30d'] as const;
+
+export type PresetRange = (typeof presetRanges)[number];
+
+/** Value used in the URL when the user picks the custom-range option. */
+export const customRange = 'custom';
+
+/** Default preset selected on first render. */
+export const defaultPresetRange: PresetRange = '7d';
+
+const presetMs: Record<PresetRange, number> = {
+  '1h': 60 * 60 * 1000,
+  '1d': 24 * 60 * 60 * 1000,
+  '7d': 7 * 24 * 60 * 60 * 1000,
+  '30d': 30 * 24 * 60 * 60 * 1000,
+};
+
+export const isPresetRange = (value: string): value is PresetRange =>
+  Object.hasOwn(presetMs, value);
+
+/**
+ * Translate a preset name (e.g. `'7d'`) into a millisecond offset suitable for
+ * `Date.now() - parsePresetMs(range)`. Returns `undefined` for unknown inputs
+ * so the caller can fall back to the default preset.
+ */
+export const parsePresetMs = (value: string): number | undefined =>
+  isPresetRange(value) ? presetMs[value] : undefined;
+
+/** Native `<input type="date">` shape — shared by the URL → input and URL → API paths. */
+const dateInputShape = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Whether `raw` is a calendar-date string in the `yyyy-MM-dd` shape the picker
+ * emits and the URL persists. Centralized so the URL → input check and the
+ * URL → API filter cannot disagree (which would leave the input blank while
+ * the table is still filtered by a parsed timestamp).
+ */
+export const isDateInputValue = (raw: string): boolean => dateInputShape.test(raw);
+
+/**
+ * Parse a `yyyy-MM-dd` calendar-date string (as emitted by a native
+ * `<input type="date">`) and apply the supplied transform in the local
+ * timezone. Returns `undefined` for empty, shape-mismatched, or unparseable
+ * strings — guarding against stray query params that survive a manual URL
+ * edit (e.g. a full ISO timestamp `parseISO` would otherwise accept).
+ */
+const parseDateAndTransform = (
+  raw: string,
+  transform: (date: Date) => Date
+): number | undefined => {
+  if (!raw || !isDateInputValue(raw)) {
+    return undefined;
+  }
+  const parsed = parseISO(raw);
+  return isValid(parsed) ? transform(parsed).getTime() : undefined;
+};
+
+/**
+ * Resolve URL state (`range` / `start_time` / `end_time`) into the absolute
+ * window the API expects. Custom-range values are stored as `yyyy-MM-dd`
+ * strings (matching the date input value); we widen them to whole-day local
+ * boundaries here. Presets return a rolling lower bound and no upper bound.
+ *
+ * The API treats both bounds as exclusive (`createdAt > start_time AND
+ * createdAt < end_time`). To honor the "include all events on the picked
+ * date" expectation:
+ *   * `start_time` is `(startOfDay - 1ms)` so `>` includes midnight itself.
+ *   * `end_time` is `startOfDay` of the day _after_ the picked end date so
+ *     `<` includes events up to `23:59:59.999` of the picked end date.
+ *
+ * Callers are expected to memoize the result — the preset path snapshots
+ * `Date.now()` and would otherwise re-evaluate on every render and thrash any
+ * URL-keyed cache (e.g. SWR).
+ */
+export const resolveTimeWindow = (
+  range: string,
+  rawStartTime: string,
+  rawEndTime: string,
+  now: () => number = Date.now
+): { startTime?: number; endTime?: number } => {
+  if (range === customRange) {
+    return {
+      startTime: parseDateAndTransform(
+        rawStartTime,
+        (date) => new Date(startOfDay(date).getTime() - 1)
+      ),
+      endTime: parseDateAndTransform(rawEndTime, (date) => startOfDay(addDays(date, 1))),
+    };
+  }
+  const presetOffset = parsePresetMs(range) ?? parsePresetMs(defaultPresetRange);
+  return {
+    startTime: presetOffset === undefined ? undefined : now() - presetOffset,
+    endTime: undefined,
+  };
+};

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window.test.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window.test.ts
@@ -1,0 +1,179 @@
+import { renderHook } from '@testing-library/react';
+import { format } from 'date-fns';
+
+import { customRange } from './preset';
+import useAuditLogTimeWindow from './use-audit-log-time-window';
+
+const dateInputPattern = 'yyyy-MM-dd';
+
+type HookArgs = Parameters<typeof useAuditLogTimeWindow>[0];
+type UpdateSearchParameters = HookArgs['updateSearchParameters'];
+type UpdatePayload = Parameters<UpdateSearchParameters>[0];
+
+const renderWith = (overrides: Partial<HookArgs> = {}) => {
+  const updateSearchParameters = jest.fn<void, [UpdatePayload]>();
+  const { result, rerender } = renderHook(
+    (props: Partial<HookArgs>) =>
+      useAuditLogTimeWindow({
+        range: '7d',
+        startTimeRaw: '',
+        endTimeRaw: '',
+        updateSearchParameters,
+        ...overrides,
+        ...props,
+      }),
+    { initialProps: {} }
+  );
+  return { result, rerender, updateSearchParameters };
+};
+
+describe('useAuditLogTimeWindow', () => {
+  describe('handleRangeChange', () => {
+    it('clears custom timestamps when switching from custom to a preset', () => {
+      const { result, updateSearchParameters } = renderWith({
+        range: customRange,
+        startTimeRaw: '2026-04-13',
+        endTimeRaw: '2026-04-15',
+      });
+
+      result.current.handleRangeChange({ range: '1d' });
+
+      expect(updateSearchParameters).toHaveBeenCalledWith({
+        range: '1d',
+        page: undefined,
+        start_time: undefined,
+        end_time: undefined,
+      });
+    });
+
+    it('seeds the custom inputs with the resolved window when switching to custom', () => {
+      const { result, updateSearchParameters } = renderWith({
+        range: '7d',
+        startTimeRaw: '',
+        endTimeRaw: '',
+      });
+
+      result.current.handleRangeChange({ range: customRange });
+
+      // Avoid asserting on `Date.now()` race — assert structure + dateInput format.
+      expect(updateSearchParameters).toHaveBeenCalledTimes(1);
+      const [payload] = updateSearchParameters.mock.calls[0]!;
+      expect(payload.range).toBe(customRange);
+      expect(payload.page).toBeUndefined();
+      expect(payload.start_time).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(payload.end_time).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('does not clobber custom dates when "custom" is re-selected while already on custom', () => {
+      const { result, updateSearchParameters } = renderWith({
+        range: customRange,
+        startTimeRaw: '2026-04-13',
+        endTimeRaw: '2026-04-15',
+      });
+
+      result.current.handleRangeChange({ range: customRange });
+
+      expect(updateSearchParameters).toHaveBeenCalledWith({
+        range: customRange,
+        page: undefined,
+      });
+    });
+  });
+
+  describe('handleCustomDatesChange (regression: C1)', () => {
+    it('preserves end_time when only startDate is supplied', () => {
+      const { result, updateSearchParameters } = renderWith({
+        range: customRange,
+        startTimeRaw: '',
+        endTimeRaw: '2026-04-15',
+      });
+
+      result.current.handleCustomDatesChange({ startDate: '2026-04-13' });
+
+      // Critical: no `end_time` key in the call → existing URL value is left intact.
+      expect(updateSearchParameters).toHaveBeenCalledWith({
+        start_time: '2026-04-13',
+        page: undefined,
+      });
+    });
+
+    it('preserves start_time when only endDate is supplied', () => {
+      const { result, updateSearchParameters } = renderWith({
+        range: customRange,
+        startTimeRaw: '2026-04-13',
+        endTimeRaw: '',
+      });
+
+      result.current.handleCustomDatesChange({ endDate: '2026-04-15' });
+
+      expect(updateSearchParameters).toHaveBeenCalledWith({
+        end_time: '2026-04-15',
+        page: undefined,
+      });
+    });
+
+    it('clears a single bound when its value is undefined', () => {
+      const { result, updateSearchParameters } = renderWith({
+        range: customRange,
+        startTimeRaw: '2026-04-13',
+        endTimeRaw: '2026-04-15',
+      });
+
+      result.current.handleCustomDatesChange({ startDate: undefined });
+
+      expect(updateSearchParameters).toHaveBeenCalledWith({
+        start_time: undefined,
+        page: undefined,
+      });
+    });
+  });
+
+  describe('toDateInputValue (indirectly via customStartDate / customEndDate)', () => {
+    it('passes valid yyyy-MM-dd through unchanged', () => {
+      const { result } = renderWith({
+        range: customRange,
+        startTimeRaw: '2026-04-13',
+        endTimeRaw: '2026-04-15',
+      });
+      expect(result.current.customStartDate).toBe('2026-04-13');
+      expect(result.current.customEndDate).toBe('2026-04-15');
+    });
+
+    it('drops malformed strings and empty values', () => {
+      const { result } = renderWith({
+        range: customRange,
+        startTimeRaw: 'garbage',
+        endTimeRaw: '',
+      });
+      expect(result.current.customStartDate).toBeUndefined();
+      expect(result.current.customEndDate).toBeUndefined();
+    });
+
+    it('rejects full ISO timestamps that parse but break <input type="date">', () => {
+      const { result } = renderWith({
+        range: customRange,
+        startTimeRaw: '2026-04-13T00:00:00Z',
+        endTimeRaw: '',
+      });
+      expect(result.current.customStartDate).toBeUndefined();
+    });
+  });
+
+  it('pickerRangeValue normalizes unknown URL values to the default preset', () => {
+    const { result } = renderWith({ range: 'bogus' });
+    expect(result.current.pickerRangeValue).toBe('7d');
+  });
+
+  it('exposes a memoized window: same inputs return referentially equal output', () => {
+    const { result, rerender } = renderWith({ range: '7d' });
+    const first = result.current.startTime;
+    rerender({ range: '7d' });
+    // Memoized: same inputs → same snapshot (avoids SWR cache thrash from Date.now() drift).
+    expect(result.current.startTime).toBe(first);
+  });
+
+  it('formats Date.now() consistently with the date input pattern', () => {
+    // Sanity guard: the `max` attribute and the seeded custom values share format.
+    expect(format(Date.now(), dateInputPattern)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window.ts
@@ -1,0 +1,130 @@
+import { format, isValid, parseISO } from 'date-fns';
+import { useMemo } from 'react';
+
+import {
+  type PresetRange,
+  customRange,
+  defaultPresetRange,
+  isDateInputValue,
+  isPresetRange,
+  resolveTimeWindow,
+} from './preset';
+
+const dateInputPattern = 'yyyy-MM-dd';
+
+/**
+ * Validate a raw URL value before handing it to the date input. Empty,
+ * shape-mismatched, or unparseable strings collapse to `undefined`. Shares
+ * `isDateInputValue` with the API-side parser so the input and the filter
+ * cannot disagree on what counts as a valid custom-range value.
+ */
+const toDateInputValue = (raw: string): string | undefined => {
+  if (!raw || !isDateInputValue(raw)) {
+    return undefined;
+  }
+  return isValid(parseISO(raw)) ? raw : undefined;
+};
+
+type UpdateSearchParameters = (parameters: Record<string, string | number | undefined>) => void;
+
+type Args = {
+  range: string;
+  startTimeRaw: string;
+  endTimeRaw: string;
+  updateSearchParameters: UpdateSearchParameters;
+};
+
+type Result = {
+  /** Absolute lower bound in unix-ms; `undefined` when no bound is active. */
+  startTime?: number;
+  /** Absolute upper bound in unix-ms; `undefined` when no bound is active. */
+  endTime?: number;
+  /** Either a known preset or `'custom'`; never a stray string from the URL. */
+  pickerRangeValue: PresetRange | typeof customRange;
+  /** `yyyy-MM-dd` string suitable for the custom-range date input, or `undefined`. */
+  customStartDate?: string;
+  /** `yyyy-MM-dd` string suitable for the custom-range date input, or `undefined`. */
+  customEndDate?: string;
+  /** Update the preset URL state and reset pagination + custom timestamps. */
+  handleRangeChange: (next: { range: PresetRange | typeof customRange }) => void;
+  /**
+   * Partial update of the custom-range URL state. Only mutates the fields
+   * explicitly present in `next` — passing `{ startDate: '…' }` leaves
+   * `end_time` alone, preventing accidental erasure of the other bound.
+   */
+  handleCustomDatesChange: (next: { startDate?: string; endDate?: string }) => void;
+};
+
+/**
+ * Encapsulates the URL-state ↔ time-window contract for the Audit Logs page:
+ * snapshots a memoized window per URL change (preventing SWR cache thrash from
+ * a per-render `Date.now()`), exposes typed handlers that also clear the
+ * surrounding state, and normalizes arbitrary URL strings down to a known
+ * preset or `'custom'`.
+ */
+const useAuditLogTimeWindow = ({
+  range,
+  startTimeRaw,
+  endTimeRaw,
+  updateSearchParameters,
+}: Args): Result => {
+  const { startTime, endTime } = useMemo(
+    () => resolveTimeWindow(range, startTimeRaw, endTimeRaw),
+    [range, startTimeRaw, endTimeRaw]
+  );
+
+  const pickerRangeValue: PresetRange | typeof customRange = isPresetRange(range)
+    ? range
+    : range === customRange
+      ? customRange
+      : defaultPresetRange;
+
+  const handleRangeChange: Result['handleRangeChange'] = ({ range: nextRange }) => {
+    if (nextRange === customRange) {
+      // Switching to custom from a preset: seed the date inputs with the
+      // current resolved window so the rows on screen remain continuous
+      // instead of silently broadening to the full retention window.
+      // When already on `custom`, leave any existing dates intact.
+      const isAlreadyCustom = range === customRange;
+      const seedStart =
+        !isAlreadyCustom && startTime !== undefined
+          ? format(startTime, dateInputPattern)
+          : undefined;
+      const seedEnd = isAlreadyCustom ? undefined : format(Date.now(), dateInputPattern);
+      updateSearchParameters({
+        range: nextRange,
+        page: undefined,
+        ...(seedStart !== undefined && { start_time: seedStart }),
+        ...(seedEnd !== undefined && { end_time: seedEnd }),
+      });
+      return;
+    }
+    // Preset path: drop any custom-range leftovers.
+    updateSearchParameters({
+      range: nextRange,
+      page: undefined,
+      start_time: undefined,
+      end_time: undefined,
+    });
+  };
+
+  const handleCustomDatesChange: Result['handleCustomDatesChange'] = (next) => {
+    updateSearchParameters({
+      ...('startDate' in next && { start_time: next.startDate ?? undefined }),
+      ...('endDate' in next && { end_time: next.endDate ?? undefined }),
+      page: undefined,
+    });
+  };
+
+  return {
+    startTime,
+    endTime,
+    pickerRangeValue,
+    customStartDate: toDateInputValue(startTimeRaw),
+    customEndDate: toDateInputValue(endTimeRaw),
+    handleRangeChange,
+    handleCustomDatesChange,
+  };
+};
+
+export default useAuditLogTimeWindow;

--- a/packages/console/src/components/AuditLogTable/index.module.scss
+++ b/packages/console/src/components/AuditLogTable/index.module.scss
@@ -19,4 +19,8 @@
     width: 250px;
     margin-inline-start: _.unit(2);
   }
+
+  .timeRangePicker {
+    margin-inline-start: _.unit(2);
+  }
 }

--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -7,6 +7,7 @@ import useSWR from 'swr';
 import ApplicationName from '@/components/ApplicationName';
 import UserName from '@/components/UserName';
 import { auditLogEventTitle, defaultPageSize } from '@/consts';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import Table from '@/ds-components/Table';
 import type { Column } from '@/ds-components/Table/types';
 import type { RequestError } from '@/hooks/use-api';
@@ -19,6 +20,9 @@ import EmptyDataPlaceholder from '../EmptyDataPlaceholder';
 import ApplicationSelector from './components/ApplicationSelector';
 import EventName from './components/EventName';
 import EventSelector from './components/EventSelector';
+import TimeRangePicker from './components/TimeRangePicker';
+import { defaultPresetRange } from './components/TimeRangePicker/preset';
+import useAuditLogTimeWindow from './components/TimeRangePicker/use-audit-log-time-window';
 import styles from './index.module.scss';
 
 const auditLogEventOptions = Object.entries(auditLogEventTitle).map(([value, title]) => ({
@@ -36,13 +40,20 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const pageSize = defaultPageSize;
 
-  const [{ page, event, applicationId: applicationIdFromSearch }, updateSearchParameters] =
-    useSearchParametersWatcher({
-      page: 1,
-      event: '',
-      // If `applicationId` not specified when init this component, then search parameter of `applicationId` can be accepted.
-      ...conditional(!applicationId && { applicationId: '' }),
-    });
+  // URL values are untyped; validated downstream via `isPresetRange`.
+  const initialRange: string = defaultPresetRange;
+  const [
+    { page, event, applicationId: applicationIdFromSearch, range, start_time, end_time },
+    updateSearchParameters,
+  ] = useSearchParametersWatcher({
+    page: 1,
+    event: '',
+    range: initialRange,
+    start_time: '',
+    end_time: '',
+    // If `applicationId` not specified when init this component, then search parameter of `applicationId` can be accepted.
+    ...conditional(!applicationId && { applicationId: '' }),
+  });
 
   // TODO: LOG-7135, revisit this fallback logic and see whether this should be done outside of this component.
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -51,6 +62,21 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
     applicationId && `api/applications/${applicationId}`
   );
 
+  const {
+    startTime,
+    endTime,
+    pickerRangeValue,
+    customStartDate,
+    customEndDate,
+    handleRangeChange,
+    handleCustomDatesChange,
+  } = useAuditLogTimeWindow({
+    range,
+    startTimeRaw: start_time,
+    endTimeRaw: end_time,
+    updateSearchParameters,
+  });
+
   const url = buildUrl('api/logs', {
     page: String(page),
     page_size: String(pageSize),
@@ -58,6 +84,10 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
     ...conditional(event && { logKey: event }),
     ...conditional(searchApplicationId && { applicationId: searchApplicationId }),
     ...conditional(userId && { userId }),
+    ...conditional(
+      isDevFeaturesEnabled && startTime !== undefined && { start_time: String(startTime) }
+    ),
+    ...conditional(isDevFeaturesEnabled && endTime !== undefined && { end_time: String(endTime) }),
   });
 
   const { data, error, mutate } = useSWR<[Log[], number, boolean], RequestError>(url);
@@ -141,6 +171,17 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
                     page: undefined,
                   });
                 }}
+              />
+            </div>
+          )}
+          {isDevFeaturesEnabled && (
+            <div className={styles.timeRangePicker}>
+              <TimeRangePicker
+                value={pickerRangeValue}
+                customStartDate={customStartDate}
+                customEndDate={customEndDate}
+                onChange={handleRangeChange}
+                onCustomDatesChange={handleCustomDatesChange}
               />
             </div>
           )}

--- a/packages/phrases/src/locales/ar/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: 'تطبيق',
   time: 'الوقت',
   filter_by: 'تصفية حسب',
+  last_1_hour: 'آخر ساعة',
+  last_24_hours: 'آخر 24 ساعة',
+  last_7_days: 'آخر 7 أيام',
+  last_30_days: 'آخر 30 يومًا',
+  custom_range: 'نطاق مخصص',
+  from: 'من',
+  to: 'إلى',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/de/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/logs.ts
@@ -8,6 +8,13 @@ const logs = {
   application: 'Anwendung',
   time: 'Zeit',
   filter_by: 'Filter nach',
+  last_1_hour: 'Letzte Stunde',
+  last_24_hours: 'Letzte 24 Stunden',
+  last_7_days: 'Letzte 7 Tage',
+  last_30_days: 'Letzte 30 Tage',
+  custom_range: 'Benutzerdefiniert',
+  from: 'Von',
+  to: 'Bis',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/en/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: 'Application',
   time: 'Time',
   filter_by: 'Filter by',
+  last_1_hour: 'Last 1 hour',
+  last_24_hours: 'Last 24 hours',
+  last_7_days: 'Last 7 days',
+  last_30_days: 'Last 30 days',
+  custom_range: 'Custom range',
+  from: 'From',
+  to: 'To',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/es/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: 'Aplicación',
   time: 'Tiempo',
   filter_by: 'Filtrar por',
+  last_1_hour: 'Última hora',
+  last_24_hours: 'Últimas 24 horas',
+  last_7_days: 'Últimos 7 días',
+  last_30_days: 'Últimos 30 días',
+  custom_range: 'Rango personalizado',
+  from: 'Desde',
+  to: 'Hasta',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/fr/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/logs.ts
@@ -8,6 +8,13 @@ const logs = {
   application: 'Application',
   time: 'Temps',
   filter_by: 'Filtrer par',
+  last_1_hour: 'Dernière heure',
+  last_24_hours: 'Dernières 24 heures',
+  last_7_days: '7 derniers jours',
+  last_30_days: '30 derniers jours',
+  custom_range: 'Plage personnalisée',
+  from: 'Du',
+  to: 'Au',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/it/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/logs.ts
@@ -8,6 +8,13 @@ const logs = {
   application: 'Applicazione',
   time: 'Tempo',
   filter_by: 'Filtra per',
+  last_1_hour: 'Ultima ora',
+  last_24_hours: 'Ultime 24 ore',
+  last_7_days: 'Ultimi 7 giorni',
+  last_30_days: 'Ultimi 30 giorni',
+  custom_range: 'Intervallo personalizzato',
+  from: 'Dal',
+  to: 'Al',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/ja/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: 'アプリケーション',
   time: '時間',
   filter_by: 'フィルター',
+  last_1_hour: '過去1時間',
+  last_24_hours: '過去24時間',
+  last_7_days: '過去7日間',
+  last_30_days: '過去30日間',
+  custom_range: 'カスタム範囲',
+  from: '開始',
+  to: '終了',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/ko/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: '어플리케이션',
   time: '시간',
   filter_by: '필터',
+  last_1_hour: '최근 1시간',
+  last_24_hours: '최근 24시간',
+  last_7_days: '최근 7일',
+  last_30_days: '최근 30일',
+  custom_range: '사용자 지정 범위',
+  from: '시작',
+  to: '종료',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/logs.ts
@@ -8,6 +8,13 @@ const logs = {
   application: 'Aplikacja',
   time: 'Czas',
   filter_by: 'Filtruj według',
+  last_1_hour: 'Ostatnia godzina',
+  last_24_hours: 'Ostatnie 24 godziny',
+  last_7_days: 'Ostatnie 7 dni',
+  last_30_days: 'Ostatnie 30 dni',
+  custom_range: 'Zakres niestandardowy',
+  from: 'Od',
+  to: 'Do',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/logs.ts
@@ -8,6 +8,13 @@ const logs = {
   application: 'Aplicativo',
   time: 'Tempo',
   filter_by: 'Filtrar por',
+  last_1_hour: 'Última hora',
+  last_24_hours: 'Últimas 24 horas',
+  last_7_days: 'Últimos 7 dias',
+  last_30_days: 'Últimos 30 dias',
+  custom_range: 'Intervalo personalizado',
+  from: 'De',
+  to: 'Até',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: 'Aplicação',
   time: 'Hora',
   filter_by: 'Filtrar pors',
+  last_1_hour: 'Última hora',
+  last_24_hours: 'Últimas 24 horas',
+  last_7_days: 'Últimos 7 dias',
+  last_30_days: 'Últimos 30 dias',
+  custom_range: 'Intervalo personalizado',
+  from: 'De',
+  to: 'Até',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/ru/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: 'Приложение',
   time: 'Время',
   filter_by: 'Фильтр по',
+  last_1_hour: 'Последний час',
+  last_24_hours: 'Последние 24 часа',
+  last_7_days: 'Последние 7 дней',
+  last_30_days: 'Последние 30 дней',
+  custom_range: 'Произвольный период',
+  from: 'С',
+  to: 'По',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/th/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: 'แอปพลิเคชัน',
   time: 'เวลา',
   filter_by: 'กรองตาม',
+  last_1_hour: '1 ชั่วโมงล่าสุด',
+  last_24_hours: '24 ชั่วโมงล่าสุด',
+  last_7_days: '7 วันล่าสุด',
+  last_30_days: '30 วันล่าสุด',
+  custom_range: 'กำหนดเอง',
+  from: 'จาก',
+  to: 'ถึง',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/logs.ts
@@ -8,6 +8,13 @@ const logs = {
   application: 'Uygulama',
   time: 'Süre',
   filter_by: 'Göre filtrele',
+  last_1_hour: 'Son 1 saat',
+  last_24_hours: 'Son 24 saat',
+  last_7_days: 'Son 7 gün',
+  last_30_days: 'Son 30 gün',
+  custom_range: 'Özel aralık',
+  from: 'Başlangıç',
+  to: 'Bitiş',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: '应用',
   time: '时间',
   filter_by: '过滤',
+  last_1_hour: '最近 1 小时',
+  last_24_hours: '最近 24 小时',
+  last_7_days: '最近 7 天',
+  last_30_days: '最近 30 天',
+  custom_range: '自定义范围',
+  from: '从',
+  to: '至',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: '應用',
   time: '時間',
   filter_by: '過濾',
+  last_1_hour: '最近 1 小時',
+  last_24_hours: '最近 24 小時',
+  last_7_days: '最近 7 天',
+  last_30_days: '最近 30 天',
+  custom_range: '自訂範圍',
+  from: '從',
+  to: '至',
 };
 
 export default Object.freeze(logs);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/logs.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/logs.ts
@@ -7,6 +7,13 @@ const logs = {
   application: '應用程式',
   time: '時間',
   filter_by: '過濾',
+  last_1_hour: '最近 1 小時',
+  last_24_hours: '最近 24 小時',
+  last_7_days: '最近 7 天',
+  last_30_days: '最近 30 天',
+  custom_range: '自訂範圍',
+  from: '從',
+  to: '至',
 };
 
 export default Object.freeze(logs);


### PR DESCRIPTION
## Summary
Closes LOG-13420. Stacked on #8806.

Adds a time-range picker to the Console's Audit Logs page (`packages/console/src/components/AuditLogTable`) with a 7-day default. Behind `isDevFeaturesEnabled`; production behavior is identical to current master. Removal of the guard ships in LOG-13442.

### What changed
- New `TimeRangePicker` component (`packages/console/src/components/AuditLogTable/components/TimeRangePicker/`) with a preset dropdown (`Last 1 hour` / `Last 24 hours` / `Last 7 days` / `Last 30 days` / `Custom range…`) and two `<TextInput type="date" />` inputs for the custom path (same vocabulary as the Dashboard's daily-active-users picker).
- `preset.ts` — canonical preset names, `parsePresetMs`, `isPresetRange`, and `resolveTimeWindow` (collapses URL state → absolute window, normalizing custom dates via `startOfDay` / `endOfDay`).
- `use-audit-log-time-window.ts` hook — owns the URL ↔ window contract: memoizes the absolute window, maps stray URL strings to a valid picker value, exposes typed change handlers that also reset page + clear stale state.
- `AuditLogTable/index.tsx` — wires the picker behind `isDevFeaturesEnabled`. When the flag is off the picker is not rendered and the API request carries no `start_time` / `end_time`. When on, the absolute window from the hook is appended to the SWR URL.
- 17 locale files updated (`time_range`, `last_1_hour`, `last_24_hours`, `last_7_days`, `last_30_days`, `custom_range`, `from`, `to`) under `logs.*` — sibling of the existing `logs.filter_by`.

### Expected behavior
- Flag off (production default): identical to current master. No picker, no `range` in the URL, no `start_time` in the API request.
- Flag on: picker visible; URL gains `range` (and `start_time` / `end_time` in custom mode); audit logs default to the last 7 days.
- `Date.now()` is snapshotted once per URL change via `useMemo` — SWR's URL-keyed cache stays stable across unrelated re-renders.
- Switching the range resets `page=1` so the new window is browsed from the top.
- Switching from `custom` back to a preset clears the lingering `start_time` / `end_time` query params.
- The Webhook recent-logs page is untouched and still relies on the API's internal 24h default.

### Scope reconciliation vs original plan
1. i18n keys live under `logs.*` (not `general.*`) — sibling of `logs.filter_by`, cohesive with the page they belong to.
2. Custom range uses `<TextInput type="date" />` (matches the Dashboard pattern, no new dep). Day-level granularity normalized via `startOfDay` / `endOfDay`.
3. `refreshNonce` deferred — the table already exposes a manual retry path (`mutate(undefined, true)`); add only if QA hits a real staleness issue.

### Reviewer notes
- The `range` URL value is widened to `string` via a typed local (`initialRange: string = defaultPresetRange`) rather than an `as` cast — `range === customRange` becomes a meaningful comparison without violating the `no-restricted-syntax` rule.
- Unknown `range` values from the URL fall back to the default preset rather than confusing the picker UI.

## Testing
Unit tests

Test locally
<img width="2690" height="1128" alt="image" src="https://github.com/user-attachments/assets/f8d8687b-8da2-4376-8f7f-73e3208e9079" />
<img width="2762" height="2532" alt="image" src="https://github.com/user-attachments/assets/4563e3be-77ac-44e0-af09-5339066610c6" />


## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments