### PR TITLE
release(console): ga the audit logs time-range picker

### DIFF
--- a/.changeset/console-audit-logs-time-picker.md
+++ b/.changeset/console-audit-logs-time-picker.md
@@ -1,0 +1,7 @@
+---
+"@logto/console": minor
+---
+
+add a time-range picker to the audit logs page with a default of the last 7 days.
+
+the picker offers preset windows (`Last 1 hour` / `Last 24 hours` / `Last 7 days` / `Last 30 days`) plus a custom date range. it scopes every request to a bounded `start_time` / `end_time` window — reducing latency on tenants with very large log volumes — while keeping older logs reachable by widening the range.

--- a/packages/console/src/components/AuditLogTable/index.tsx
+++ b/packages/console/src/components/AuditLogTable/index.tsx
@@ -7,7 +7,6 @@ import useSWR from 'swr';
 import ApplicationName from '@/components/ApplicationName';
 import UserName from '@/components/UserName';
 import { auditLogEventTitle, defaultPageSize } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import Table from '@/ds-components/Table';
 import type { Column } from '@/ds-components/Table/types';
 import type { RequestError } from '@/hooks/use-api';
@@ -84,10 +83,8 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
     ...conditional(event && { logKey: event }),
     ...conditional(searchApplicationId && { applicationId: searchApplicationId }),
     ...conditional(userId && { userId }),
-    ...conditional(
-      isDevFeaturesEnabled && startTime !== undefined && { start_time: String(startTime) }
-    ),
-    ...conditional(isDevFeaturesEnabled && endTime !== undefined && { end_time: String(endTime) }),
+    ...conditional(startTime !== undefined && { start_time: String(startTime) }),
+    ...conditional(endTime !== undefined && { end_time: String(endTime) }),
   });
 
   const { data, error, mutate } = useSWR<[Log[], number, boolean], RequestError>(url);
@@ -174,17 +171,15 @@ function AuditLogTable({ applicationId, userId, className }: Props) {
               />
             </div>
           )}
-          {isDevFeaturesEnabled && (
-            <div className={styles.timeRangePicker}>
-              <TimeRangePicker
-                value={pickerRangeValue}
-                customStartDate={customStartDate}
-                customEndDate={customEndDate}
-                onChange={handleRangeChange}
-                onCustomDatesChange={handleCustomDatesChange}
-              />
-            </div>
-          )}
+          <div className={styles.timeRangePicker}>
+            <TimeRangePicker
+              value={pickerRangeValue}
+              customStartDate={customStartDate}
+              customEndDate={customEndDate}
+              onChange={handleRangeChange}
+              onCustomDatesChange={handleCustomDatesChange}
+            />
+          </div>
         </div>
       }
       placeholder={<EmptyDataPlaceholder />}


### PR DESCRIPTION
## Summary
Closes LOG-13442. Stacked on #8809.

Removes the `isDevFeaturesEnabled` guard on the Audit Logs time-range picker (landed in #8809) and adds the Console changeset. After this lands, all Console users see the picker and the 7-day default on the Audit Logs page.

### What changed
- `packages/console/src/components/AuditLogTable/index.tsx`:
  - Drop `import { isDevFeaturesEnabled } from '@/consts/env';`.
  - Remove the gate on `start_time` / `end_time` query params in the SWR URL (always sent now).
  - Remove the gate on the `TimeRangePicker` render (always rendered now).
- `.changeset/console-audit-logs-time-picker.md` — `@logto/console: minor` describing the new picker and its 7-day default.

### Expected behavior
- Audit Logs page now defaults to "Last 7 days" instead of "All time" on first load.
- Picker is unconditionally visible; widening the range is a single click.
- API contract unchanged (the core `start_time` / `end_time` params landed unguarded in #8806).

### Reviewer notes
- The unit tests under `TimeRangePicker/` are not gated by any dev-features wrapper, so no test changes are needed.
- No core or schemas changes — purely Console + changeset.

## Testing
Tested locally

## Checklist
- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments