### PR TITLE
chore: remove dev feature guard for custom UI CSP configuration

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.tsx
@@ -5,7 +5,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import CloudUploadIcon from '@/assets/icons/cloud-upload.svg?react';
 import CustomCssEditorField from '@/components/CustomCssEditorField';
 import { CloudTag } from '@/components/FeatureTag';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { latestProPlanId } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import Card from '@/ds-components/Card';
@@ -116,7 +116,7 @@ function CustomUiForm() {
             />
           </FormField>
         )}
-        {isCloud && isDevFeaturesEnabled && <CustomUiCspForm isDisabled={!isBringYourUiEnabled} />}
+        {isCloud && <CustomUiCspForm isDisabled={!isBringYourUiEnabled} />}
         {shouldShowOssBringYourUi && <OssBringYourUiCard />}
       </Card>
     </>

--- a/packages/console/src/pages/SignInExperience/PageContent/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/index.tsx
@@ -13,7 +13,7 @@ import { useParams } from 'react-router-dom';
 
 import SubmitFormChangesActionBar from '@/components/SubmitFormChangesActionBar';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import ConfirmModal from '@/ds-components/ConfirmModal';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
@@ -73,8 +73,7 @@ function PageContent({ data, onSignInExperienceUpdated, onAccountCenterUpdated }
   const { isUploading, cancelUpload } = useContext(SignInExperienceContext);
   const { currentSubscriptionQuota } = useContext(SubscriptionDataContext);
   const { isConnectorTypeEnabled, ready: isConnectorsReady } = useEnabledConnectorTypes();
-  const isCustomUiCspEnabled =
-    isCloud && isDevFeaturesEnabled && currentSubscriptionQuota.bringYourUiEnabled;
+  const isCustomUiCspEnabled = isCloud && currentSubscriptionQuota.bringYourUiEnabled;
 
   const [dataToCompare, setDataToCompare] = useState<SignInExperiencePageManagedData>();
 

--- a/packages/core/src/middleware/koa-security-headers.test.ts
+++ b/packages/core/src/middleware/koa-security-headers.test.ts
@@ -9,12 +9,10 @@ import createMockContext from '#src/test-utils/jest-koa-mocks/create-mock-contex
 const { jest } = import.meta;
 const { mockEsmWithActual } = createMockUtils(jest);
 
-const getIsDevFeaturesEnabled = jest.fn(() => false);
-
 await mockEsmWithActual('#src/env-set/index.js', () => ({
   EnvSet: {
     get values() {
-      return { ...new GlobalValues(), isDevFeaturesEnabled: getIsDevFeaturesEnabled() };
+      return new GlobalValues();
     },
   },
   AdminApps: { Console: 'console', Welcome: 'welcome' },
@@ -58,34 +56,6 @@ const getCspDirective = (ctx: Koa.Context, directiveName: string): string | unde
     .find((directive) => directive.startsWith(`${directiveName} `));
 
 describe('koaSecurityHeaders() middleware — experience CSP', () => {
-  beforeEach(() => {
-    getIsDevFeaturesEnabled.mockReturnValue(false);
-  });
-
-  it('includes the hardcoded custom tenant allowlist (e.g. LaunchDarkly) in connect-src', async () => {
-    const run = koaSecurityHeaders([], 'default');
-    // Any path that isn't an admin app / user app / mounted app falls through
-    // to the experience CSP settings.
-    const ctx = createMockContext({ method: 'GET', url: '/sign-in' });
-
-    await run(ctx, koaNoop);
-
-    const connectSource = getCspDirective(ctx, 'connect-src');
-
-    expect(connectSource).toBeDefined();
-    expect(connectSource).toContain('https://*.launchdarkly.com');
-  });
-
-  it('skips the hardcoded LaunchDarkly allowlist when dev features are enabled', async () => {
-    getIsDevFeaturesEnabled.mockReturnValue(true);
-    const run = koaSecurityHeaders([], 'default');
-    const ctx = createMockContext({ method: 'GET', url: '/sign-in' });
-
-    await run(ctx, koaNoop);
-
-    expect(getCspDirective(ctx, 'connect-src')).not.toContain('https://*.launchdarkly.com');
-  });
-
   it('adds Custom UI CSP sources to the matching experience directives', async () => {
     const run = koaExperienceSecurityHeaders(
       'default',

--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -50,8 +50,7 @@ const appendCustomSources = (sources: string[], customSources: string[] = []) =>
 ];
 
 const createSecurityHeaderSettings = (tenantId: string): SecurityHeaderSettings => {
-  const { isProduction, isCloud, isDevFeaturesEnabled, urlSet, adminUrlSet, cloudUrlSet } =
-    EnvSet.values;
+  const { isProduction, isCloud, urlSet, adminUrlSet, cloudUrlSet } = EnvSet.values;
 
   const tenantEndpointOrigin = getTenantEndpoint(tenantId, EnvSet.values).origin;
   // Logto Cloud uses cloud service to serve the admin console; while Logto OSS uses a fixed path under the admin URL set.
@@ -77,17 +76,6 @@ const createSecurityHeaderSettings = (tenantId: string): SecurityHeaderSettings 
 
   // Parse the OSS survey endpoint origin for CSP connect-src allowlisting.
   const ossSurveyOrigins = getOssServerOrigins();
-
-  /**
-   * Temporary hardcoded tenant-level `connect-src` allowlist for BYO-UI customers.
-   * Keep it until Custom UI CSP is generally available and customers have migrated.
-   */
-  const customTenantConnectSourceAllowlist = conditionalArray(
-    !isDevFeaturesEnabled && [
-      // LaunchDarkly — A/B testing SDK (flag eval, streaming, events).
-      'https://*.launchdarkly.com',
-    ]
-  );
 
   // We have the following use cases:
   //
@@ -156,7 +144,6 @@ const createSecurityHeaderSettings = (tenantId: string): SecurityHeaderSettings 
     'https://recaptcha.net/recaptcha/',
     'https://www.gstatic.com/recaptcha/',
     'https://www.gstatic.cn/recaptcha/',
-    ...customTenantConnectSourceAllowlist,
     ...developmentOrigins,
   ];
 

--- a/packages/core/src/routes/sign-in-experience/index.openapi.json
+++ b/packages/core/src/routes/sign-in-experience/index.openapi.json
@@ -52,6 +52,17 @@
                     "customContent": {
                       "description": "Custom content to display on experience flow pages. the page pathname will be the config key, the content will be the config value."
                     },
+                    "customUiCsp": {
+                      "description": "Cloud only. Additional Content Security Policy source expressions for Custom UI assets. These values are applied to the hosted sign-in page only when Custom UI assets are configured.",
+                      "properties": {
+                        "scriptSrc": {
+                          "description": "Additional source expressions appended to the `script-src` directive for scripts loaded by Custom UI assets. HTTPS sources are supported. HTTP localhost sources are allowed only outside production."
+                        },
+                        "connectSrc": {
+                          "description": "Additional source expressions appended to the `connect-src` directive for network requests made by Custom UI assets. HTTPS and WSS sources are supported. HTTP localhost sources are allowed only outside production."
+                        }
+                      }
+                    },
                     "passwordPolicy": {
                       "description": "Password policies to adjust the password strength requirements."
                     },
@@ -143,6 +154,17 @@
                   },
                   "customContent": {
                     "description": "Custom content to display on experience flow pages. the page pathname will be the config key, the content will be the config value."
+                  },
+                  "customUiCsp": {
+                    "description": "Cloud only. Configure additional Content Security Policy source expressions for Custom UI assets. These values are applied to the hosted sign-in page only when Custom UI assets are configured.",
+                    "properties": {
+                      "scriptSrc": {
+                        "description": "Additional source expressions to append to the `script-src` directive for scripts loaded by Custom UI assets. Use HTTPS sources; HTTP localhost sources are allowed only outside production."
+                      },
+                      "connectSrc": {
+                        "description": "Additional source expressions to append to the `connect-src` directive for network requests made by Custom UI assets. Use HTTPS or WSS sources; HTTP localhost sources are allowed only outside production."
+                      }
+                    }
                   },
                   "passwordPolicy": {
                     "description": "Password policies to adjust the password strength requirements."

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -710,7 +710,7 @@ describe('PATCH /sign-in-exp customUiCsp', () => {
     expect(guardTenantUsageByKey).not.toHaveBeenCalled();
   });
 
-  it('should reject non-empty Custom UI CSP updates when dev features are disabled', async () => {
+  it('should allow non-empty Custom UI CSP updates when dev features are disabled', async () => {
     const { requester, updateDefaultSignInExperience, guardTenantUsageByKey } =
       await createCustomUiCspRequester({ isDevFeaturesEnabled: false });
 
@@ -720,9 +720,13 @@ describe('PATCH /sign-in-exp customUiCsp', () => {
       },
     });
 
-    expect(response.status).toEqual(400);
-    expect(updateDefaultSignInExperience).not.toHaveBeenCalled();
-    expect(guardTenantUsageByKey).not.toHaveBeenCalled();
+    expect(response.status).toEqual(200);
+    expect(updateDefaultSignInExperience).toHaveBeenCalledWith({
+      customUiCsp: {
+        scriptSrc: ['https://example.com'],
+      },
+    });
+    expect(guardTenantUsageByKey).toHaveBeenCalledWith('bringYourUiEnabled');
   });
 
   it('should reject non-empty Custom UI CSP updates outside Cloud', async () => {

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -274,7 +274,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
       }
       if (hasCustomUiCsp) {
         assertThat(
-          EnvSet.values.isCloud && EnvSet.values.isDevFeaturesEnabled,
+          EnvSet.values.isCloud,
           new RequestError({
             code: 'request.invalid_input',
             details: 'Custom UI CSP configuration is not available',


### PR DESCRIPTION
## Summary
Release Custom UI CSP configuration for Cloud tenants. This exposes the CSP settings in Console for eligible tenants, restores the Management API OpenAPI docs for `customUiCsp`, and removes the temporary hardcoded connect-src fallback now that tenants can configure their own Custom UI CSP sources.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
