### PR TITLE
perf(schemas): index organization_user_relations on (tenant_id, user_id)

### DIFF
--- a/.changeset/index-organization-user-relations-user-id.md
+++ b/.changeset/index-organization-user-relations-user-id.md
@@ -1,0 +1,7 @@
+---
+"@logto/schemas": patch
+---
+
+add secondary index on `organization_user_relations (tenant_id, user_id)` to speed up reverse lookups
+
+The primary key column order is `(tenant_id, organization_id, user_id)`, which prevents queries that filter by `user_id` without specifying `organization_id` from using the index. This pattern is hit on every sign-in (via `getOrganizationsByUserId`) and on every request to the `/organizations/:id/users/:userId/roles` family (via the membership-existence middleware).

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ dump.rdb
 
 # Claude local files
 .claude/
+docs/superpowers/
 
 # connectors
 /packages/core/connectors

--- a/packages/schemas/alterations/next-1778500000-add-organization-user-relations-user-id-index.ts
+++ b/packages/schemas/alterations/next-1778500000-add-organization-user-relations-user-id-index.ts
@@ -1,0 +1,41 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    /**
+     * Secondary index for `user_id` lookups; the PK `(tenant_id, organization_id, user_id)`
+     * cannot serve queries that filter by `tenant_id` and `user_id` alone.
+     *
+     * Built `concurrently` to avoid the write-blocking `SHARE` lock that a plain
+     * `create index` holds on the table for the duration of the build. The table is hot
+     * on every sign-in, so a multi-second lock on a large tenant translates directly
+     * into request stalls. `if not exists` keeps the migration idempotent if a later
+     * step in the transaction fails and the alteration needs to be re-run.
+     */
+    await pool.query(sql`
+      create index concurrently if not exists organization_user_relations__tenant_id_user_id
+        on organization_user_relations (tenant_id, user_id);
+    `);
+  },
+  up: async () => {
+    /**
+     * The index must be created outside of a transaction to avoid table locks.
+     * 'concurrently' cannot be used inside a transaction, so this up is intentionally left empty.
+     */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently if exists organization_user_relations__tenant_id_user_id;
+    `);
+  },
+  down: async () => {
+    /**
+     * The index must be dropped outside of a transaction to avoid table locks.
+     * 'concurrently' cannot be used inside a transaction, so this down is intentionally left empty.
+     */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/organization_user_relations.sql
+++ b/packages/schemas/tables/organization_user_relations.sql
@@ -13,3 +13,6 @@ create table organization_user_relations (
     foreign key (tenant_id, user_id)
       references users (tenant_id, id) on update cascade on delete cascade
 );
+
+create index organization_user_relations__tenant_id_user_id
+  on organization_user_relations (tenant_id, user_id);


### PR DESCRIPTION
## Summary

Refs [LOG-13472](https://linear.app/silverhand/issue/LOG-13472). First task in the Phase 0.5 performance milestone surfaced by the audit before LOG-13462 lands.

### What changed

- `packages/schemas/alterations/next-1778500000-add-organization-user-relations-user-id-index.ts` — new migration that adds `create index concurrently if not exists organization_user_relations__tenant_id_user_id on organization_user_relations (tenant_id, user_id)`. Built `concurrently` via the `beforeUp` hook so no table lock is held during the build. Reversible via `beforeDown` running `drop index concurrently if exists`.
- `packages/schemas/tables/organization_user_relations.sql` — mirrors the new index inline so fresh installs get it without replaying the alteration.
- `.changeset/index-organization-user-relations-user-id.md` — `@logto/schemas` patch.

### Expected result

- Queries that filter by `(tenant_id, user_id)` without specifying `organization_id` switch from a partial PK scan to an `Index Scan` on the new secondary index. The two hot call sites this fixes:
  - `getOrganizationsByUserId` (`packages/core/src/queries/organization/user-relations.ts:78-99`) — runs on every token exchange / sign-in / org-list endpoint.
  - The membership-existence middleware on `/organizations/:id/users/:userId/roles` and `/users/:userId/scopes` (`packages/core/src/utils/RelationQueries.ts:249-265` invoked from `routes/organization/user/role-relations.ts:34`).
- No schema, API, or behavior change. Index is purely additive.

### Reviewer notes

- The PK column order `(tenant_id, organization_id, user_id)` does not serve `user_id`-only lookups, so they currently degrade. The FK constraint added in `1.30.0-1753669579-add-organization-user-relations-foreign-key.ts` only indexes the referenced side (`users (tenant_id, id)`) — Postgres does not auto-index the referencing side.
- Build runs via the `beforeUp` / `beforeDown` non-transactional hooks so `CONCURRENTLY` can be used without holding the write-blocking `SHARE` lock that a plain `CREATE INDEX` would hold for the duration of the build. This matches the pattern in `1.35.0-1765183934-add-logs-created-at-id-index.ts`, `1.35.0-1765631949-drop-redundant-logs-id-index.ts`, and `1.38.0-1772615848-add-oidc-model-instances-grant-id-partial-index.ts`. `if not exists` / `if exists` keep both directions idempotent against transient failures.
- Index name follows the repo's `<table>__<columns>` convention. Confirmed unique via grep.

## Testing

Tested locally

## Checklist
- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
