### PR TITLE
perf(schemas): index organization_role_user_relations on (tenant_id, organization_id, user_id)

### DIFF
--- a/.changeset/index-organization-role-user-relations-org-user.md
+++ b/.changeset/index-organization-role-user-relations-org-user.md
@@ -1,0 +1,7 @@
+---
+"@logto/schemas": patch
+---
+
+add secondary index on `organization_role_user_relations (tenant_id, organization_id, user_id)` to speed up per-user role lookups
+
+The primary key column order is `(tenant_id, organization_id, organization_role_id, user_id)`, which prevents queries that filter by `(organization_id, user_id)` without specifying `organization_role_id` from using the index. This pattern is hit by `getUserScopes` (called on every `GET /organizations/:id/users/:userId/scopes`) and by the per-user role join in `getUsersByOrganizationId`.

--- a/packages/schemas/alterations/next-1778500001-add-organization-role-user-relations-org-user-index.ts
+++ b/packages/schemas/alterations/next-1778500001-add-organization-role-user-relations-org-user-index.ts
@@ -1,0 +1,43 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    /**
+     * Secondary index for `(organization_id, user_id)` lookups; the PK
+     * `(tenant_id, organization_id, organization_role_id, user_id)` cannot serve
+     * queries that skip `organization_role_id`.
+     *
+     * Built `concurrently` to avoid the write-blocking `SHARE` lock that a plain
+     * `create index` holds on the table for the duration of the build. The table is
+     * hot on every authorization decision through `getUserScopes`, so a multi-second
+     * lock on a large tenant translates directly into request stalls. `if not exists`
+     * keeps the migration idempotent if a later step in the transaction fails and the
+     * alteration needs to be re-run.
+     */
+    await pool.query(sql`
+      create index concurrently if not exists organization_role_user_relations__tenant_id_org_id_user_id
+        on organization_role_user_relations (tenant_id, organization_id, user_id);
+    `);
+  },
+  up: async () => {
+    /**
+     * The index must be created outside of a transaction to avoid table locks.
+     * 'concurrently' cannot be used inside a transaction, so this up is intentionally left empty.
+     */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently if exists organization_role_user_relations__tenant_id_org_id_user_id;
+    `);
+  },
+  down: async () => {
+    /**
+     * The index must be dropped outside of a transaction to avoid table locks.
+     * 'concurrently' cannot be used inside a transaction, so this down is intentionally left empty.
+     */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/organization_role_user_relations.sql
+++ b/packages/schemas/tables/organization_role_user_relations.sql
@@ -16,3 +16,6 @@ create table organization_role_user_relations (
   constraint organization_role_user_relations__role_type
     check (check_organization_role_type(organization_role_id, 'User'))
 );
+
+create index organization_role_user_relations__tenant_id_org_id_user_id
+  on organization_role_user_relations (tenant_id, organization_id, user_id);


### PR DESCRIPTION
## Summary

Refs [LOG-13473](https://linear.app/silverhand/issue/LOG-13473). Second migration in the Phase 0.5 performance milestone. Independent of [LOG-13472](https://linear.app/silverhand/issue/LOG-13472) (separate table, no shared call sites); branch is cut from master, not stacked on #8818.

### What changed

- `packages/schemas/alterations/next-1778500001-add-organization-role-user-relations-org-user-index.ts` — new migration that adds `create index concurrently if not exists organization_role_user_relations__tenant_id_org_id_user_id on organization_role_user_relations (tenant_id, organization_id, user_id)`. Built `concurrently` via the `beforeUp` hook so no table lock is held during the build. Reversible via `beforeDown` running `drop index concurrently if exists`.
- `packages/schemas/tables/organization_role_user_relations.sql` — mirrors the new index inline so fresh installs get it without replaying the alteration.
- `.changeset/index-organization-role-user-relations-org-user.md` — `@logto/schemas` patch.

### Expected result

Queries that filter by `(organization_id, user_id)` without specifying `organization_role_id` switch from a partial PK scan to an `Index Scan` on the new secondary index. Three hot call sites this fixes:

- `getUserScopes` (`packages/core/src/queries/organization/user-role-relations.ts:27-46`) — every `GET /organizations/:id/users/:userId/scopes`.
- The per-user role JOIN inside `getUsersByOrganizationId` (`packages/core/src/queries/organization/user-relations.ts:121-141`) — fan-out into this table on every paginated list-users request.
- The DELETE clause in `UserRoleRelationQueries.replace()` — filter `(organization_id, user_id)`.

No schema, API, or behavior change. Index is purely additive.

### Reviewer notes

- The PK column order `(tenant_id, organization_id, organization_role_id, user_id)` does not serve queries that skip `organization_role_id`. Postgres can use the PK efficiently only when all preceding columns are equality-matched; skipping `organization_role_id` forces a partial scan.
- Effective WHERE clauses include `tenant_id` because every table in `packages/schemas/tables/` carries the `_after_each.sql` RLS policy injecting `tenant_id = (select id from tenants where db_user = current_user)`. The index column order matches.
- Name abbreviation: the unabbreviated name (`organization_role_user_relations__tenant_id_organization_id_user_id`) is 67 chars and would be silently truncated by Postgres at the 63-char identifier limit. Abbreviated to `org_id`. Confirmed unique via grep.
- Build runs via the `beforeUp` / `beforeDown` non-transactional hooks so `CONCURRENTLY` can be used without holding the write-blocking `SHARE` lock that a plain `CREATE INDEX` would hold for the duration of the build. This matches the pattern in `1.35.0-1765183934-add-logs-created-at-id-index.ts` and `1.38.0-1772615848-add-oidc-model-instances-grant-id-partial-index.ts`. `if not exists` / `if exists` keep both directions idempotent against transient failures.

## Testing

Tested locally

## Checklist
- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
