### PR TITLE
perf(core): add TwoRelationsQueries.replaceWithDelta(); switch org-user PUT to use it

### DIFF
--- a/.changeset/perf-relation-queries-replace-delta.md
+++ b/.changeset/perf-relation-queries-replace-delta.md
@@ -1,0 +1,11 @@
+---
+"@logto/core": minor
+---
+
+add `TwoRelationsQueries.replaceWithDelta()` for high-cardinality relation tables; switch `PUT /organizations/:id/users` to use it
+
+The existing `replace()` runs `DELETE WHERE schema1_id = X` + bulk `INSERT` inside a transaction, rewriting O(N) rows on every call. The new `replaceWithDelta()` computes the added/removed sets in a single CTE statement, so a no-op call writes zero rows and a one-row delta writes exactly one row. It returns `{ added, removed }` so downstream consumers (notably the membership-webhook payload work in LOG-13462) can read the delta without a re-query.
+
+`replace()` is unchanged. The new method is opt-in. This PR migrates one call site — `PUT /organizations/:id/users` — where organization membership can grow into the 10k+ range. The other nine `TwoRelationsQueries` subclasses continue to use `replace()`.
+
+For relation tables upstream of an `on delete cascade` FK (e.g. `organization_user_relations` → `organization_role_user_relations`), `replace()` cascades for every current row on every call — silently dropping dependents of unchanged members. `replaceWithDelta()` only cascades for truly-departing rows, so dependents of surviving members are preserved. The migrated `PUT /organizations/:id/users` now keeps a member's role assignments when their membership survives the PUT; a new integration test guards this.

--- a/.changeset/perf-relation-queries-replace-delta.md
+++ b/.changeset/perf-relation-queries-replace-delta.md
@@ -1,5 +1,5 @@
 ---
-"@logto/core": minor
+"@logto/core": patch
 ---
 
 add `TwoRelationsQueries.replaceWithDelta()` for high-cardinality relation tables; switch `PUT /organizations/:id/users` to use it

--- a/packages/core/src/routes/organization/user/index.ts
+++ b/packages/core/src/routes/organization/user/index.ts
@@ -113,7 +113,8 @@ export default function userRoutes(
         });
       }
 
-      await organizations.relations.users.replace(id, userIds);
+      // Membership can grow large; use the delta variant to avoid rewriting all rows.
+      await organizations.relations.users.replaceWithDelta(id, userIds);
 
       ctx.status = 204;
 

--- a/packages/core/src/utils/RelationQueries.test.ts
+++ b/packages/core/src/utils/RelationQueries.test.ts
@@ -1,0 +1,104 @@
+import { Organizations, Users } from '@logto/schemas';
+import {
+  createMockPool,
+  createMockQueryResult,
+  type DatabasePool,
+  type QueryResultRow,
+} from '@silverhand/slonik';
+import { type PrimitiveValueExpression } from '@silverhand/slonik/dist/src/types.js';
+
+import { TwoRelationsQueries } from './RelationQueries.js';
+
+/** Records each SQL statement issued (including the ones inside `pool.transaction`). */
+type CapturedQuery = {
+  sql: string;
+  values: readonly PrimitiveValueExpression[];
+};
+
+const createCapturingPool = (
+  responses: QueryResultRow[]
+): { pool: DatabasePool; captured: CapturedQuery[] } => {
+  const captured: CapturedQuery[] = [];
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let cursor = 0;
+  const pool = createMockPool({
+    query: async (sql, values) => {
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+      captured.push({ sql, values });
+      const row = responses[cursor];
+      if (row === undefined) {
+        // Fail loudly on unexpected extra queries so tests can't silently pass over a
+        // refactor that issues more SQL than the scenario was set up for.
+        throw new Error(
+          `Capturing pool received ${cursor + 1} queries but only ${responses.length} responses were provisioned. Last SQL: ${sql}`
+        );
+      }
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      cursor += 1;
+      return createMockQueryResult([row]);
+    },
+  });
+  return { pool, captured };
+};
+
+describe('TwoRelationsQueries.replaceWithDelta()', () => {
+  it('acquires a row lock on the schema1 entity before issuing the delta statement', async () => {
+    const { pool, captured } = createCapturingPool([
+      { id: 'org-1' }, // Row lock select ... for update.
+      { added: ['u-new'], removed: ['u-old'] }, // CTE statement.
+    ]);
+    const queries = new TwoRelationsQueries(
+      pool,
+      'organization_user_relations',
+      Organizations,
+      Users
+    );
+
+    await queries.replaceWithDelta('org-1', ['u-new', 'u-keep']);
+
+    // First statement must be the parent-row lock so concurrent membership operations on the
+    // same Schema1 entity serialize behind it.
+    expect(captured[0]?.sql).toMatch(/select id\s+from\s+"organizations"\s+where\s+id\s+=/i);
+    expect(captured[0]?.sql).toMatch(/for update/i);
+  });
+
+  it('issues a single delta statement that performs the INSERT and DELETE in CTEs and returns both id sets', async () => {
+    const { pool, captured } = createCapturingPool([
+      { id: 'org-1' },
+      { added: ['u-new'], removed: ['u-old'] },
+    ]);
+    const queries = new TwoRelationsQueries(
+      pool,
+      'organization_user_relations',
+      Organizations,
+      Users
+    );
+
+    const result = await queries.replaceWithDelta('org-1', ['u-new', 'u-keep']);
+
+    expect(result).toEqual({ added: ['u-new'], removed: ['u-old'] });
+    // Delta statement is the second query (the first is the row lock).
+    const delta = captured[1]?.sql ?? '';
+    expect(delta).toMatch(/\bwith\b/i);
+    expect(delta).toMatch(/next_set\s+as/i);
+    expect(delta).toMatch(/inserted\s+as\s*\(\s*insert into "organization_user_relations"/i);
+    expect(delta).toMatch(/on conflict do nothing/i);
+    expect(delta).toMatch(/returning\s+"user_id"/i);
+    expect(delta).toMatch(/deleted\s+as\s*\(\s*delete from "organization_user_relations"/i);
+    expect(delta).toMatch(/array_agg\(\s*id\s*\)\s+from\s+inserted/i);
+    expect(delta).toMatch(/array_agg\(\s*id\s*\)\s+from\s+deleted/i);
+  });
+
+  it('returns empty added and removed arrays when the database reports neither', async () => {
+    const { pool } = createCapturingPool([{ id: 'org-1' }, { added: [], removed: [] }]);
+    const queries = new TwoRelationsQueries(
+      pool,
+      'organization_user_relations',
+      Organizations,
+      Users
+    );
+
+    const result = await queries.replaceWithDelta('org-1', []);
+    expect(result).toEqual({ added: [], removed: [] });
+  });
+});

--- a/packages/core/src/utils/RelationQueries.ts
+++ b/packages/core/src/utils/RelationQueries.ts
@@ -318,4 +318,76 @@ export class TwoRelationsQueries<
       `);
     });
   }
+
+  /**
+   * Opt-in alternative to {@link TwoRelationsQueries.replace} that writes only the rows
+   * that actually change and returns the added / removed ids. Picked over `replace()`
+   * when the membership set may be large, or when callers need the delta for downstream
+   * use (e.g. webhook payloads).
+   *
+   * Differs from `replace()` for cascade-bearing tables: only truly-departing rows are
+   * deleted, so FK cascades fire for those rows alone. `replace()` cascades for every
+   * current row on every call. Tables without downstream cascades see no behavior delta.
+   * The `select ... for update` Schema1 row lock matches `replace()`; concurrent
+   * `insert()` calls are not serialized (same race as `replace()`).
+   *
+   * @param schema1Id The id of the `Schema1` entity.
+   * @param schema2Ids Desired final set of Schema2 ids. Empty deletes all relations.
+   * Duplicates are collapsed by `ON CONFLICT DO NOTHING`.
+   * @returns `{ added, removed }` — the Schema2 ids that gained and lost a row.
+   */
+  async replaceWithDelta(
+    schema1Id: string,
+    schema2Ids: readonly string[]
+  ): Promise<{ added: readonly string[]; removed: readonly string[] }> {
+    return this.pool.transaction(async (transaction) => {
+      // Lock schema1 row.
+      await transaction.query(sql`
+        select id
+        from ${sql.identifier([this.schemas[0].table])}
+        where id = ${schema1Id}
+        for update
+      `);
+
+      const schema1IdField = sql.identifier([this.schemas[0].tableSingular + '_id']);
+      const schema2IdField = sql.identifier([this.schemas[1].tableSingular + '_id']);
+      const nextIds = sql.array(schema2Ids, 'varchar');
+
+      const row = await transaction.one<{
+        added: readonly string[];
+        removed: readonly string[];
+      }>(sql`
+        with
+          next_set as (
+            select unnest(${nextIds}) as id
+          ),
+          existing as (
+            select ${schema2IdField} as id from ${this.table}
+            where ${schema1IdField} = ${schema1Id}
+          ),
+          inserted as (
+            insert into ${this.table} (${schema1IdField}, ${schema2IdField})
+            select ${schema1Id}, next_set.id
+            from next_set
+            left join existing on existing.id = next_set.id
+            where existing.id is null
+            on conflict do nothing
+            returning ${schema2IdField} as id
+          ),
+          deleted as (
+            delete from ${this.table}
+            where ${schema1IdField} = ${schema1Id}
+              and not exists (
+                select 1 from next_set where next_set.id = ${schema2IdField}
+              )
+            returning ${schema2IdField} as id
+          )
+        select
+          coalesce((select array_agg(id) from inserted), array[]::varchar[]) as added,
+          coalesce((select array_agg(id) from deleted), array[]::varchar[]) as removed
+      `);
+
+      return { added: row.added, removed: row.removed };
+    });
+  }
 }

--- a/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
@@ -134,4 +134,124 @@ describe('organization user APIs', () => {
       expect(response.response.status).toBe(404);
     });
   });
+
+  describe('PUT /organizations/:id/users delta semantics', () => {
+    const organizationApi = new OrganizationApiTest();
+    const userApi = new UserApiTest();
+
+    afterEach(async () => {
+      await Promise.all([organizationApi.cleanUp(), userApi.cleanUp()]);
+    });
+
+    it('should make zero changes when PUT body matches the current membership exactly', async () => {
+      const organization = await organizationApi.create({ name: 'test' });
+      const [userA, userB] = await Promise.all([
+        userApi.create({ username: generateTestName() }),
+        userApi.create({ username: generateTestName() }),
+      ]);
+
+      await organizationApi.addUsers(organization.id, [userA.id, userB.id]);
+      const [usersBefore, totalBefore] = await organizationApi.getUsers(organization.id);
+      const idsBefore = usersBefore
+        .map(({ id }) => id)
+        .slice()
+        .sort();
+
+      // A no-op PUT must still succeed and must not change the membership.
+      await organizationApi.replaceUsers(organization.id, [userA.id, userB.id]);
+
+      const [usersAfter, totalAfter] = await organizationApi.getUsers(organization.id);
+      expect(totalAfter).toBe(totalBefore);
+      expect(
+        usersAfter
+          .map(({ id }) => id)
+          .slice()
+          .sort()
+      ).toEqual(idsBefore);
+    });
+
+    it('should add only new members and remove only departing members on a partial-overlap PUT', async () => {
+      const organization = await organizationApi.create({ name: 'test' });
+      const [userKeep, userDrop, userAdd] = await Promise.all([
+        userApi.create({ username: generateTestName() }),
+        userApi.create({ username: generateTestName() }),
+        userApi.create({ username: generateTestName() }),
+      ]);
+
+      // Initial membership: { userKeep, userDrop }.
+      await organizationApi.addUsers(organization.id, [userKeep.id, userDrop.id]);
+
+      // Target membership: { userKeep, userAdd }. So userDrop leaves, userAdd joins, userKeep stays.
+      await organizationApi.replaceUsers(organization.id, [userKeep.id, userAdd.id]);
+
+      const [users, totalCount] = await organizationApi.getUsers(organization.id);
+      expect(totalCount).toBe(2);
+      expect(
+        users
+          .map(({ id }) => id)
+          .slice()
+          .sort()
+      ).toEqual([userKeep.id, userAdd.id].slice().sort());
+    });
+
+    it('should remove all members when PUT body is empty', async () => {
+      const organization = await organizationApi.create({ name: 'test' });
+      const [userA, userB] = await Promise.all([
+        userApi.create({ username: generateTestName() }),
+        userApi.create({ username: generateTestName() }),
+      ]);
+      await organizationApi.addUsers(organization.id, [userA.id, userB.id]);
+
+      await organizationApi.replaceUsers(organization.id, []);
+
+      const [users, totalCount] = await organizationApi.getUsers(organization.id);
+      expect(totalCount).toBe(0);
+      expect(users).toEqual([]);
+    });
+
+    it('should add all members when PUT body has no overlap with current membership', async () => {
+      const organization = await organizationApi.create({ name: 'test' });
+      const [userA, userB] = await Promise.all([
+        userApi.create({ username: generateTestName() }),
+        userApi.create({ username: generateTestName() }),
+      ]);
+      // Start with an empty membership; PUT in two new users.
+      await organizationApi.replaceUsers(organization.id, [userA.id, userB.id]);
+
+      const [users, totalCount] = await organizationApi.getUsers(organization.id);
+      expect(totalCount).toBe(2);
+      expect(
+        users
+          .map(({ id }) => id)
+          .slice()
+          .sort()
+      ).toEqual([userA.id, userB.id].slice().sort());
+    });
+
+    it('should preserve role assignments of members whose membership survives a PUT', async () => {
+      // This is the cascade-correctness regression test. Master's full-rewrite `replace()`
+      // ran `DELETE WHERE org_id = X` which cascaded to `organization_role_user_relations`,
+      // dropping every member's roles on every PUT — even no-op PUTs. `replaceWithDelta()`
+      // only deletes rows for members actually leaving, so surviving members keep their roles.
+      const organization = await organizationApi.create({ name: 'test' });
+      const [userKeep, userDrop] = await Promise.all([
+        userApi.create({ username: generateTestName() }),
+        userApi.create({ username: generateTestName() }),
+      ]);
+      const role = await organizationApi.roleApi.create({ name: generateTestName() });
+
+      await organizationApi.addUsers(organization.id, [userKeep.id, userDrop.id]);
+      await organizationApi.addUserRoles(organization.id, userKeep.id, [role.id]);
+
+      // Sanity-check the role was assigned.
+      const rolesBefore = await organizationApi.getUserRoles(organization.id, userKeep.id);
+      expect(rolesBefore.map(({ id }) => id)).toEqual([role.id]);
+
+      // PUT that drops userDrop but keeps userKeep. userKeep's role assignment must survive.
+      await organizationApi.replaceUsers(organization.id, [userKeep.id]);
+
+      const rolesAfter = await organizationApi.getUserRoles(organization.id, userKeep.id);
+      expect(rolesAfter.map(({ id }) => id)).toEqual([role.id]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Refs [LOG-13474](https://linear.app/silverhand/issue/LOG-13474). Third task in the Phase 0.5 performance milestone. Stacked on [#8818](https://github.com/logto-io/logto/pull/8818) (Perf-A — the `organization_user_relations (tenant_id, user_id)` index) which the new method's delta CTE depends on at scale.

### What changed

- `packages/core/src/utils/RelationQueries.ts` — adds a new opt-in method `replaceWithDelta(schema1Id, schema2Ids)` on `TwoRelationsQueries`. Computes added/removed id sets in a single CTE statement (Postgres supports `INSERT` and `DELETE` in `WITH`) and returns `{ added, removed }`. Preserves the `select ... for update` row lock on the Schema1 entity that `replace()` already takes. The existing `replace()` method is left untouched.
- `packages/core/src/routes/organization/user/index.ts` — switches `PUT /organizations/:id/users` to call `replaceWithDelta()` instead of `replace()`. This is the only call site that migrates in this PR.
- `packages/core/src/utils/RelationQueries.test.ts` — new file. 3 unit tests using a slonik mock pool that captures every query: verifies the row lock fires first, the delta CTE structure (`with` graph + `returning` + `array_agg`), and the empty-result return shape.
- `packages/integration-tests/src/tests/api/organization/organization-user.test.ts` — 5 new integration cases under `PUT /organizations/:id/users delta semantics`: no-op PUT, partial-overlap, empty body, no-overlap-from-empty, and a role-preservation regression test that fails on master and passes after this change.
- `.changeset/perf-relation-queries-replace-delta.md` — `@logto/core`patch.

### Expected result

- `PUT /organizations/:id/users` with a no-op body produces zero row writes against `organization_user_relations` (master: ~2N).
- A one-row delta on an N-row membership produces exactly one row write.
- Members whose membership survives a PUT keep their role assignments. Previously, the `DELETE WHERE org_id = X` in `replace()` cascaded through `organization_role_user_relations` and silently dropped every member's roles on every PUT — even no-op PUTs. New behavior is strictly more correct.
- API response shape is unchanged (`204 No Content`). `replaceWithDelta`'s return value is discarded by this caller; it is wired up for downstream consumption by Phase 1 ([LOG-13462](https://linear.app/silverhand/issue/LOG-13462)).
- The other nine `TwoRelationsQueries` subclasses (SSO connector relations, the four `application_user_consent_*` tables, `organization_role_scope_relations`, `organization_role_resource_scope_relations`, `organization_invitation_role_relations`, `organization_jit_roles`) continue to use `replace()` and see no behavior change.

### Reviewer notes

- `replaceWithDelta` was kept as a separate method rather than rewriting `replace()` in place because of the cascade-preservation behavior difference. Of the ten `TwoRelationsQueries` subclasses, only two sit upstream of FK cascades (`organization_user_relations` and `organization_application_relations`), and only one of those (`organization_user_relations`) is the membership-set hot path. Opt-in migration bounds the blast radius to call sites that explicitly want the new semantics, and lets reviewers reason about each migration on its own.
- The `NOT IN` form for the deleted CTE was rewritten to `NOT EXISTS` after a self-review surfaced its NULL-fragility. `next_set.id` from `unnest(varchar[])` can't be NULL in normal operation, but the rewrite is null-safe and a touch more index-friendly.
- The unit-test mock pool is hand-rolled because slonik's `createMockPool` only exposes a `query` override, not `transaction`. The mock records every query (including the ones inside `pool.transaction(cb)`), which is sufficient for asserting structural invariants without locking in line-by-line SQL.

## Testing

Unit tests, integration tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
