### PR TITLE
feat(console): locale-aware date picker for audit log time window

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -101,6 +101,7 @@
     "react-animate-height": "^3.0.4",
     "react-color-palette": "^7.2.1",
     "react-confetti": "^6.1.0",
+    "react-day-picker": "^8.10.2",
     "react-dnd": "^16.0.0",
     "react-dnd-html5-backend": "^16.0.0",
     "react-dom": "^18.3.1",

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -20,6 +20,8 @@ import '@fontsource/roboto-mono';
 // eslint-disable-next-line import/no-unassigned-import
 import 'react-color-palette/css';
 
+import 'react-day-picker/dist/style.css';
+
 import CloudAppRoutes from '@/cloud/AppRoutes';
 import AppLoading from '@/components/AppLoading';
 import { isCloud, postHogHost, postHogUiHost, postHogKey } from '@/consts/env';

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/index.tsx
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/index.tsx
@@ -1,12 +1,11 @@
-import { format } from 'date-fns';
-import type { ChangeEventHandler } from 'react';
+import { format, isValid, parseISO, startOfDay } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
+import DatePicker from '@/ds-components/DatePicker';
 import Select from '@/ds-components/Select';
-import TextInput from '@/ds-components/TextInput';
 
 import styles from './index.module.scss';
-import { type PresetRange, customRange, isPresetRange } from './preset';
+import { type PresetRange, customRange, isDateInputValue, isPresetRange } from './preset';
 
 type Props = {
   /** Either a preset name (`'7d'`) or `'custom'` when a custom range is active. */
@@ -17,11 +16,21 @@ type Props = {
   readonly onCustomDatesChange: (next: { startDate?: string; endDate?: string }) => void;
 };
 
+/** URL ↔ `Date` conversion. The `DatePicker` ds-component speaks only `Date`. */
+const parseDateInputValue = (raw?: string): Date | undefined => {
+  if (!raw || !isDateInputValue(raw)) {
+    return undefined;
+  }
+  const parsed = parseISO(raw);
+  return isValid(parsed) ? parsed : undefined;
+};
+
+const toDateInputValue = (date: Date | undefined): string | undefined =>
+  date ? format(startOfDay(date), 'yyyy-MM-dd') : undefined;
+
 /**
- * Time-range picker for the Audit Logs page. Renders a preset dropdown with an
- * optional pair of date inputs when the custom-range option is selected. URL
- * state ownership belongs to the parent — this component is purely a
- * controlled view over the `range` / `start_time` / `end_time` query params.
+ * Audit Logs time-range picker. Controlled view over the `range` /
+ * `start_time` / `end_time` query params — URL state lives in the parent.
  */
 function TimeRangePicker({
   value,
@@ -54,14 +63,21 @@ function TimeRangePicker({
     }
   };
 
-  const today = format(Date.now(), 'yyyy-MM-dd');
+  // Recompute every render. A `useMemo([])` here would freeze `today` on the
+  // mount day, and the Audit Logs tab is commonly left open for days —
+  // freezing would lock out the actual current day until remount.
+  // `react-day-picker` matches dates by value rather than identity, so
+  // identity churn is harmless.
+  const today = startOfDay(new Date());
+  const startDate = parseDateInputValue(customStartDate);
+  const endDate = parseDateInputValue(customEndDate);
 
-  const handleStartDateChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    onCustomDatesChange({ startDate: event.target.value || undefined });
+  const handleStartDateChange = (next: Date | undefined) => {
+    onCustomDatesChange({ startDate: toDateInputValue(next) });
   };
 
-  const handleEndDateChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    onCustomDatesChange({ endDate: event.target.value || undefined });
+  const handleEndDateChange = (next: Date | undefined) => {
+    onCustomDatesChange({ endDate: toDateInputValue(next) });
   };
 
   return (
@@ -76,24 +92,34 @@ function TimeRangePicker({
       </div>
       {value === customRange && (
         <div className={styles.customRange}>
-          <label className={styles.dateField}>
+          <div className={styles.dateField}>
             <span className={styles.dateLabel}>{t('logs.from')}</span>
-            <TextInput
-              type="date"
-              max={today}
-              value={customStartDate ?? ''}
+            <DatePicker
+              ariaLabel={t('logs.from')}
+              value={startDate}
+              // Cap the start date by the (already-picked) end date so the
+              // user can't choose a window where end < start. `endDate` is
+              // itself capped at today, so this also covers the future-day
+              // case when no end date is set yet.
+              max={endDate ?? today}
+              todayLabel={t('general.today')}
+              clearLabel={t('general.clear')}
               onChange={handleStartDateChange}
             />
-          </label>
-          <label className={styles.dateField}>
+          </div>
+          <div className={styles.dateField}>
             <span className={styles.dateLabel}>{t('logs.to')}</span>
-            <TextInput
-              type="date"
+            <DatePicker
+              ariaLabel={t('logs.to')}
+              value={endDate}
+              // Floor the end date at the (already-picked) start date.
+              min={startDate}
               max={today}
-              value={customEndDate ?? ''}
+              todayLabel={t('general.today')}
+              clearLabel={t('general.clear')}
               onChange={handleEndDateChange}
             />
-          </label>
+          </div>
         </div>
       )}
     </div>

--- a/packages/console/src/components/AuditLogTable/index.module.scss
+++ b/packages/console/src/components/AuditLogTable/index.module.scss
@@ -23,4 +23,18 @@
   .timeRangePicker {
     margin-inline-start: _.unit(2);
   }
+
+  // When the time-range picker is part of the filter row (especially in its
+  // custom-range state, which adds two date inputs), the row gets very wide.
+  // Shrink the upstream selectors a bit so the whole bar still fits without
+  // wrapping or pushing the table layout around.
+  &:has(.timeRangePicker) {
+    .eventSelector {
+      width: _.unit(60);
+    }
+
+    .applicationSelector {
+      width: _.unit(50);
+    }
+  }
 }

--- a/packages/console/src/ds-components/DatePicker/index.module.scss
+++ b/packages/console/src/ds-components/DatePicker/index.module.scss
@@ -1,0 +1,121 @@
+@use '@/scss/underscore' as _;
+
+.trigger {
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  outline: 3px solid transparent;
+  transition-property: outline, border;
+  transition-timing-function: ease-in-out;
+  transition-duration: 0.2s;
+  padding: _.unit(1.5) _.unit(3);
+  font: var(--font-body-2);
+  display: flex;
+  align-items: center;
+  gap: _.unit(2);
+  min-width: 140px;
+  cursor: pointer;
+  background: var(--color-layer-1);
+  color: var(--color-text);
+
+  &:focus,
+  &.highlight {
+    border-color: var(--color-primary);
+    outline-color: var(--color-focused-variant);
+  }
+}
+
+.icon {
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+}
+
+.value {
+  flex: 1;
+  color: var(--color-text);
+}
+
+.placeholder {
+  color: var(--color-placeholder);
+}
+
+/* stylelint-disable selector-class-pattern -- third-party library class names. */
+.calendar {
+  background: var(--color-layer-1);
+  color: var(--color-text);
+  // Anchor font-family: the calendar renders inside a `react-modal` portal
+  // under <body>, which falls back to generic `sans-serif`.
+  font-family: var(--font-family);
+  padding: _.unit(2);
+  border-radius: 8px;
+
+  // react-day-picker re-declares `--rdp-*` on `.rdp` itself, so overrides
+  // must live at that same scope to win the cascade.
+  :global(.rdp) {
+    --rdp-accent-color: var(--color-primary);
+    --rdp-background-color: var(--color-hover-variant);
+    --rdp-accent-color-dark: var(--color-primary);
+    --rdp-background-color-dark: var(--color-hover-variant);
+    --rdp-outline: 2px solid var(--color-focused-variant);
+    --rdp-outline-selected: 2px solid var(--color-primary);
+    --rdp-selected-color: var(--color-static-white);
+    margin: 0;
+  }
+
+  // Chrome bits not driven by `--rdp-*` need explicit theme-aware colors.
+  :global(.rdp-caption_label),
+  :global(.rdp-head_cell) {
+    color: var(--color-text);
+  }
+
+  :global(.rdp-nav_button) {
+    color: var(--color-text-secondary);
+    border-radius: 6px;
+
+    &:hover:not([disabled]) {
+      background: var(--color-hover-variant);
+      color: var(--color-text);
+    }
+  }
+
+  :global(.rdp-day) {
+    border-radius: 50%;
+    transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
+  }
+
+  :global(.rdp-day_today:not(.rdp-day_selected)) {
+    color: var(--color-primary);
+    font-weight: 600;
+  }
+
+  :global(.rdp-day_disabled) {
+    color: var(--color-placeholder);
+  }
+}
+
+.footer {
+  display: flex;
+  justify-content: space-between;
+  gap: _.unit(2);
+  padding: _.unit(2) _.unit(3) _.unit(1);
+}
+
+.footerButton {
+  appearance: none;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: _.unit(1) _.unit(2);
+  border-radius: 6px;
+  color: var(--color-primary);
+  font: var(--font-label-2);
+  font-family: var(--font-family);
+
+  &:hover {
+    background: var(--color-hover-variant);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-focused-variant);
+    outline-offset: 1px;
+  }
+}

--- a/packages/console/src/ds-components/DatePicker/index.tsx
+++ b/packages/console/src/ds-components/DatePicker/index.tsx
@@ -1,0 +1,160 @@
+import classNames from 'classnames';
+import { startOfDay } from 'date-fns';
+import { useRef, useState } from 'react';
+import { DayPicker, type Matcher } from 'react-day-picker';
+
+import CalendarIcon from '@/assets/icons/calendar-outline.svg?react';
+import { onKeyDownHandler } from '@/utils/a11y';
+
+import Dropdown from '../Dropdown';
+
+import styles from './index.module.scss';
+
+type Props = {
+  readonly value?: Date;
+  readonly onChange: (next: Date | undefined) => void;
+  /** Inclusive lower bound for selectable days. */
+  readonly min?: Date;
+  /** Inclusive upper bound for selectable days. */
+  readonly max?: Date;
+  readonly placeholder?: string;
+  readonly ariaLabel?: string;
+  readonly className?: string;
+  /** Shown verbatim on a footer button that jumps the selection to today. */
+  readonly todayLabel?: string;
+  /** Shown verbatim on a footer button that clears the current selection. */
+  readonly clearLabel?: string;
+};
+
+/**
+ * Replaces the native `<input type="date">` so the displayed date format
+ * follows `navigator.language` (matching `toLocaleDateString()` elsewhere)
+ * instead of the OS regional setting Chrome locks the native input to.
+ */
+function DatePicker({
+  value,
+  onChange,
+  min,
+  max,
+  placeholder = '__ / __ / __',
+  ariaLabel,
+  className,
+  todayLabel,
+  clearLabel,
+}: Props) {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const displayValue = value ? value.toLocaleDateString() : '';
+
+  const open = () => {
+    setIsOpen(true);
+  };
+
+  const handleSelect = (date: Date | undefined) => {
+    setIsOpen(false);
+    // Ignore `onSelect(undefined)` from react-day-picker's click-on-selected
+    // toggle — clearing is reached through the footer button instead.
+    if (date) {
+      onChange(date);
+    }
+  };
+
+  const handleToday = () => {
+    setIsOpen(false);
+    // Normalize to start-of-day so the emitted `Date` lines up with the
+    // calendar's day-level matchers — a `new Date()` carries wall-clock time
+    // which can fall just outside a day-precision `max` bound.
+    onChange(startOfDay(new Date()));
+  };
+
+  const disabledMatchers: Matcher[] = [
+    ...(min ? [{ before: min }] : []),
+    ...(max ? [{ after: max }] : []),
+  ];
+
+  const handleClear = () => {
+    setIsOpen(false);
+    onChange(undefined);
+  };
+
+  const showToday = todayLabel !== undefined;
+  const showClear = clearLabel !== undefined;
+  const footer =
+    showToday || showClear ? (
+      <div className={styles.footer}>
+        {showClear && (
+          <button type="button" className={styles.footerButton} onClick={handleClear}>
+            {clearLabel}
+          </button>
+        )}
+        {showToday && (
+          <button type="button" className={styles.footerButton} onClick={handleToday}>
+            {todayLabel}
+          </button>
+        )}
+      </div>
+    ) : undefined;
+
+  return (
+    <div
+      ref={anchorRef}
+      tabIndex={0}
+      role="button"
+      aria-label={ariaLabel}
+      aria-haspopup="dialog"
+      aria-expanded={isOpen}
+      className={classNames(styles.trigger, isOpen && styles.highlight, className)}
+      onClick={open}
+      onKeyDown={onKeyDownHandler(open)}
+    >
+      <span className={classNames(styles.value, !displayValue && styles.placeholder)}>
+        {displayValue || placeholder}
+      </span>
+      <CalendarIcon aria-hidden className={styles.icon} />
+      <Dropdown
+        hasOverflowContent
+        anchorRef={anchorRef}
+        isOpen={isOpen}
+        horizontalAlign="start"
+        onClose={() => {
+          setIsOpen(false);
+        }}
+      >
+        {/*
+         * Event boundary. `onClick` keeps month-nav clicks from tripping
+         * Dropdown's auto-close. `onKeyDown` lets `DayPicker` handle Enter /
+         * Space for day selection without bubbling into Dropdown's
+         * close-on-Enter handler — Esc still bubbles so the standard close
+         * shortcut works.
+         */}
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+        <div
+          className={styles.calendar}
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.stopPropagation();
+            }
+          }}
+        >
+          <DayPicker
+            mode="single"
+            selected={value}
+            // Open at the latest selectable month: prefer the current value,
+            // then the upper bound, then the lower bound. With none of these
+            // set, react-day-picker defaults to today.
+            defaultMonth={value ?? max ?? min}
+            disabled={disabledMatchers.length > 0 ? disabledMatchers : undefined}
+            footer={footer}
+            onSelect={handleSelect}
+          />
+        </div>
+      </Dropdown>
+    </div>
+  );
+}
+
+export default DatePicker;

--- a/packages/phrases/src/locales/ar/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'بحث',
   search_placeholder: 'بحث',
   clear_result: 'مسح النتائج',
+  today: 'اليوم',
+  clear: 'مسح',
   save: 'حفظ',
   save_changes: 'حفظ التغييرات',
   saved: 'تم الحفظ',

--- a/packages/phrases/src/locales/de/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Suche',
   search_placeholder: 'Suchen',
   clear_result: 'Ergebnisse löschen',
+  today: 'Heute',
+  clear: 'Löschen',
   save: 'Speichern',
   save_changes: 'Änderungen speichern',
   saved: 'Gespeichert',

--- a/packages/phrases/src/locales/en/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Search',
   search_placeholder: 'Search',
   clear_result: 'Clear results',
+  today: 'Today',
+  clear: 'Clear',
   save: 'Save',
   save_changes: 'Save changes',
   saved: 'Saved',

--- a/packages/phrases/src/locales/es/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Buscar',
   search_placeholder: 'Buscar',
   clear_result: 'Borrar Resultados',
+  today: 'Hoy',
+  clear: 'Borrar',
   save: 'Guardar',
   save_changes: 'Guardar Cambios',
   saved: 'Guardado',

--- a/packages/phrases/src/locales/fr/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Recherche',
   search_placeholder: 'Recherche...',
   clear_result: 'Effacer les résultats',
+  today: "Aujourd'hui",
+  clear: 'Effacer',
   save: 'Sauvegarder',
   save_changes: 'Sauvegarder les modifications',
   saved: 'Sauvegardé',

--- a/packages/phrases/src/locales/it/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Cerca',
   search_placeholder: 'Cerca',
   clear_result: 'Cancella risultati',
+  today: 'Oggi',
+  clear: 'Cancella',
   save: 'Salva',
   save_changes: 'Salva modifiche',
   saved: 'Salvato',

--- a/packages/phrases/src/locales/ja/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: '検索',
   search_placeholder: '検索',
   clear_result: '検索結果をクリアする',
+  today: '今日',
+  clear: 'クリア',
   save: '保存',
   save_changes: '変更を保存する',
   saved: '保存しました',

--- a/packages/phrases/src/locales/ko/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: '검색',
   search_placeholder: '검색',
   clear_result: '결과 지우기',
+  today: '오늘',
+  clear: '지우기',
   save: '저장',
   save_changes: '변경 내용 저장',
   saved: '저장됨',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Szukaj',
   search_placeholder: 'Szukaj',
   clear_result: 'Wyczyść Wyniki',
+  today: 'Dzisiaj',
+  clear: 'Wyczyść',
   save: 'Zapisz',
   save_changes: 'Zapisz zmiany',
   saved: 'Zapisane',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Buscar',
   search_placeholder: 'Buscar',
   clear_result: 'Limpar resultados',
+  today: 'Hoje',
+  clear: 'Limpar',
   save: 'Salvar',
   save_changes: 'Salvar alterações',
   saved: 'Salvo',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Pesquisar',
   search_placeholder: 'Pesquisar',
   clear_result: 'Limpar resultados',
+  today: 'Hoje',
+  clear: 'Limpar',
   save: 'Guardar',
   save_changes: 'Guardar alterações',
   saved: 'Guardado',

--- a/packages/phrases/src/locales/ru/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Поиск',
   search_placeholder: 'Поиск',
   clear_result: 'Очистить результаты',
+  today: 'Сегодня',
+  clear: 'Очистить',
   save: 'Сохранить',
   save_changes: 'Сохранить изменения',
   saved: 'Сохранено',

--- a/packages/phrases/src/locales/th/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'ค้นหา',
   search_placeholder: 'ค้นหา',
   clear_result: 'ล้างผลลัพธ์',
+  today: 'วันนี้',
+  clear: 'ล้าง',
   save: 'บันทึก',
   save_changes: 'บันทึกการเปลี่ยนแปลง',
   saved: 'บันทึกแล้ว',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: 'Ara',
   search_placeholder: 'Ara',
   clear_result: 'Sonuçları Temizle',
+  today: 'Bugün',
+  clear: 'Temizle',
   save: 'Kaydet',
   save_changes: 'Değişiklikleri Kaydet',
   saved: 'Kaydedildi',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: '搜索',
   search_placeholder: '搜索',
   clear_result: '清除结果',
+  today: '今天',
+  clear: '清除',
   save: '保存',
   save_changes: '保存更改',
   saved: '保存成功',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: '搜索',
   search_placeholder: '搜索',
   clear_result: '清除結果',
+  today: '今天',
+  clear: '清除',
   save: '儲存',
   save_changes: '儲存變更',
   saved: '已儲存',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/general.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/general.ts
@@ -9,6 +9,8 @@ const general = {
   search: '搜索',
   search_placeholder: '搜索',
   clear_result: '清除結果',
+  today: '今天',
+  clear: '清除',
   save: '儲存',
   save_changes: '儲存更改',
   saved: '儲存成功',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3726,6 +3726,9 @@ importers:
       react-confetti:
         specifier: ^6.1.0
         version: 6.1.0(react@18.3.1)
+      react-day-picker:
+        specifier: ^8.10.2
+        version: 8.10.2(date-fns@2.29.3)(react@18.3.1)
       react-dnd:
         specifier: ^16.0.0
         version: 16.0.0(@types/node@22.14.1)(@types/react@18.3.3)(react@18.3.1)
@@ -13768,6 +13771,12 @@ packages:
     peerDependencies:
       react: ^16.3.0 || ^17.0.1 || ^18.0.0
 
+  react-day-picker@8.10.2:
+    resolution: {integrity: sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==}
+    peerDependencies:
+      date-fns: ^2.28.0 || ^3.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-device-detect@2.2.3:
     resolution: {integrity: sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==}
     peerDependencies:
@@ -18725,7 +18734,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.5.3)
@@ -22299,7 +22308,7 @@ snapshots:
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -22367,7 +22376,7 @@ snapshots:
       eslint: 8.57.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -26846,6 +26855,11 @@ snapshots:
     dependencies:
       react: 18.3.1
       tween-functions: 1.2.0
+
+  react-day-picker@8.10.2(date-fns@2.29.3)(react@18.3.1):
+    dependencies:
+      date-fns: 2.29.3
+      react: 18.3.1
 
   react-device-detect@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
Closes [LOG-13477](https://linear.app/silverhand/issue/LOG-13477) and [LOG-13476](https://linear.app/silverhand/issue/LOG-13476).

### Context
- LOG-13477: the native `<input type="date">` in the Audit Logs time-range picker renders dates using the OS regional setting (Chrome doesn't honor `navigator.language` for this control), which can disagree on the same machine with `toLocaleDateString()` used in the Time column — e.g. picker shows `2026/05/08` while the table row shows `05/08/2026`.
- LOG-13476: the same picker accepted illegal ranges (end < start, future days) until the server validated them.

### What changed
- **New ds-component `DatePicker`** (`packages/console/src/ds-components/DatePicker/`)
  - Trigger button shows the selected date via `toLocaleDateString()` (same locale signal as the Time column).
  - Calendar popover built on `react-day-picker@^8.10.2`, hosted in the existing `Dropdown` ds-component.
  - Light/dark theme overrides: `--rdp-*` variables redeclared on `:global(.rdp)` so they win the cascade against the library's defaults; explicit theme-aware colors for caption, weekday labels, nav arrows, today-marker, disabled days.
  - Font family anchored to `var(--font-family)` (the calendar renders in a `react-modal` portal which would otherwise inherit body's generic `sans-serif`).
  - Trailing calendar icon, locale-neutral placeholder `__ / __ / __`, optional Today / Clear footer buttons.
  - `min` / `max` `Date` props compiled into `react-day-picker`'s disabled matchers — out-of-range days render disabled and are non-clickable.
- **TimeRangePicker rewire** (`packages/console/src/components/AuditLogTable/components/TimeRangePicker/index.tsx`)
  - Replaces both `<TextInput type=\"date\">` inputs with `<DatePicker>`.
  - Local `yyyy-MM-dd` ↔ `Date` round-trip preserves the existing URL contract.
  - Cross-field constraints: start picker `max = endDate ?? today`; end picker `min = startDate, max = today`. `today` pinned via `useMemo` so identity is stable across renders.
- **Filter-bar layout** (`packages/console/src/components/AuditLogTable/index.module.scss`): when the time-range picker is present, `:has(.timeRangePicker)` shrinks the event selector to `_.unit(60)` (240px) and the application selector to `_.unit(50)` (200px) so the row doesn't push the table layout.
- **Phrases** (17 locales): added `today` and `clear` keys to `admin-console/general.ts` for the footer buttons.
- **Dep**: `react-day-picker@^8.10.2` added to `packages/console/package.json`; CSS imported once in `App.tsx`.

### Expected result
- Dates in the time-range picker and the Time column now resolve from the same locale signal (`navigator.language`).
- The user can no longer pick a window where end < start or end > today via the calendar UI.
- Calendar follows the active Console theme (light / dark) and uses Logto's font stack.

### Reviewer notes
- The `:global(.rdp)` override scope is load-bearing — see comment in `DatePicker/index.module.scss`. The library declares `--rdp-*` directly on `.rdp`, so an outer wrapper would lose the cascade.
- The calendar event-boundary `<div onClick={stopPropagation}>` carries an `eslint-disable jsx-a11y` comment with justification (pure event boundary, no interactive role of its own).
- `:has()` is already used in the console codebase, so no new browser-support concern.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments