### PR TITLE
fix(console): snap day-labelled audit log presets to start-of-day

### DIFF
--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.test.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.test.ts
@@ -47,15 +47,36 @@ describe('preset', () => {
     const fixedNow = new Date('2026-05-13T00:00:00Z').getTime();
     const now = () => fixedNow;
 
-    it('returns a rolling lower bound for a known preset and no upper bound', () => {
-      const window = resolveTimeWindow('7d', '', '', now);
-      expect(window.startTime).toBe(fixedNow - 7 * 24 * 60 * 60 * 1000);
+    it('keeps 1h time-labelled preset rolling (LOG-13478: no startOfDay snap)', () => {
+      const window = resolveTimeWindow('1h', '', '', now);
+      expect(window.startTime).toBe(fixedNow - 60 * 60 * 1000);
       expect(window.endTime).toBeUndefined();
     });
 
-    it('falls back to the default preset for an unknown range value', () => {
+    it('keeps 1d (24h) time-labelled preset rolling', () => {
+      const window = resolveTimeWindow('1d', '', '', now);
+      expect(window.startTime).toBe(fixedNow - 24 * 60 * 60 * 1000);
+      expect(window.endTime).toBeUndefined();
+    });
+
+    it('snaps 7d to start-of-day so day-labelled presets match the custom picker (LOG-13478)', () => {
+      const window = resolveTimeWindow('7d', '', '', now);
+      const rolledBack = fixedNow - 7 * 24 * 60 * 60 * 1000;
+      expect(window.startTime).toBe(startOfDay(rolledBack).getTime() - 1);
+      expect(window.endTime).toBeUndefined();
+    });
+
+    it('snaps 30d to start-of-day', () => {
+      const window = resolveTimeWindow('30d', '', '', now);
+      const rolledBack = fixedNow - 30 * 24 * 60 * 60 * 1000;
+      expect(window.startTime).toBe(startOfDay(rolledBack).getTime() - 1);
+      expect(window.endTime).toBeUndefined();
+    });
+
+    it('falls back to the default preset (7d, snapped) for an unknown range value', () => {
       const window = resolveTimeWindow('bogus', '', '', now);
-      expect(window.startTime).toBe(fixedNow - 7 * 24 * 60 * 60 * 1000);
+      const rolledBack = fixedNow - 7 * 24 * 60 * 60 * 1000;
+      expect(window.startTime).toBe(startOfDay(rolledBack).getTime() - 1);
       expect(window.endTime).toBeUndefined();
     });
 

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.ts
@@ -1,11 +1,6 @@
 import { addDays, isValid, parseISO, startOfDay } from 'date-fns';
 
-/**
- * Canonical preset names persisted in the URL (`?range=…`). Stable across
- * sessions and bookmarkable: `Date.now() - parsePresetMs('7d')` is always
- * "7 days before _now_" rather than a frozen window from the moment the link
- * was saved.
- */
+/** Canonical preset names persisted in the URL (`?range=…`). */
 export const presetRanges = ['1h', '1d', '7d', '30d'] as const;
 
 export type PresetRange = (typeof presetRanges)[number];
@@ -23,34 +18,29 @@ const presetMs: Record<PresetRange, number> = {
   '30d': 30 * 24 * 60 * 60 * 1000,
 };
 
+/** Day-labelled presets that snap to start-of-day, in calendar-day units. */
+const dayBoundaryPresetDays: Partial<Record<PresetRange, number>> = {
+  '7d': 7,
+  '30d': 30,
+};
+
 export const isPresetRange = (value: string): value is PresetRange =>
   Object.hasOwn(presetMs, value);
 
-/**
- * Translate a preset name (e.g. `'7d'`) into a millisecond offset suitable for
- * `Date.now() - parsePresetMs(range)`. Returns `undefined` for unknown inputs
- * so the caller can fall back to the default preset.
- */
+/** Translate a preset name into a millisecond offset, or `undefined` if unknown. */
 export const parsePresetMs = (value: string): number | undefined =>
   isPresetRange(value) ? presetMs[value] : undefined;
 
 /** Native `<input type="date">` shape — shared by the URL → input and URL → API paths. */
 const dateInputShape = /^\d{4}-\d{2}-\d{2}$/;
 
-/**
- * Whether `raw` is a calendar-date string in the `yyyy-MM-dd` shape the picker
- * emits and the URL persists. Centralized so the URL → input check and the
- * URL → API filter cannot disagree (which would leave the input blank while
- * the table is still filtered by a parsed timestamp).
- */
+/** Whether `raw` is a `yyyy-MM-dd` calendar-date string. */
 export const isDateInputValue = (raw: string): boolean => dateInputShape.test(raw);
 
 /**
- * Parse a `yyyy-MM-dd` calendar-date string (as emitted by a native
- * `<input type="date">`) and apply the supplied transform in the local
- * timezone. Returns `undefined` for empty, shape-mismatched, or unparseable
- * strings — guarding against stray query params that survive a manual URL
- * edit (e.g. a full ISO timestamp `parseISO` would otherwise accept).
+ * Parse a `yyyy-MM-dd` value and apply `transform` in local time. Returns
+ * `undefined` for empty / malformed input — keeps stray URL edits (full ISO
+ * timestamps, garbage strings) from leaking into the filter.
  */
 const parseDateAndTransform = (
   raw: string,
@@ -64,21 +54,10 @@ const parseDateAndTransform = (
 };
 
 /**
- * Resolve URL state (`range` / `start_time` / `end_time`) into the absolute
- * window the API expects. Custom-range values are stored as `yyyy-MM-dd`
- * strings (matching the date input value); we widen them to whole-day local
- * boundaries here. Presets return a rolling lower bound and no upper bound.
- *
- * The API treats both bounds as exclusive (`createdAt > start_time AND
- * createdAt < end_time`). To honor the "include all events on the picked
- * date" expectation:
- *   * `start_time` is `(startOfDay - 1ms)` so `>` includes midnight itself.
- *   * `end_time` is `startOfDay` of the day _after_ the picked end date so
- *     `<` includes events up to `23:59:59.999` of the picked end date.
- *
- * Callers are expected to memoize the result — the preset path snapshots
- * `Date.now()` and would otherwise re-evaluate on every render and thrash any
- * URL-keyed cache (e.g. SWR).
+ * Resolve URL state into the absolute window the API expects. Bounds are
+ * exclusive (`createdAt > start_time AND createdAt < end_time`); the `±1ms`
+ * / next-day biases below ensure the picked day is included. Callers should
+ * memoize — the preset path snapshots `Date.now()` per call.
  */
 export const resolveTimeWindow = (
   range: string,
@@ -95,9 +74,13 @@ export const resolveTimeWindow = (
       endTime: parseDateAndTransform(rawEndTime, (date) => startOfDay(addDays(date, 1))),
     };
   }
-  const presetOffset = parsePresetMs(range) ?? parsePresetMs(defaultPresetRange);
-  return {
-    startTime: presetOffset === undefined ? undefined : now() - presetOffset,
-    endTime: undefined,
-  };
+  const presetRange: PresetRange = isPresetRange(range) ? range : defaultPresetRange;
+  const daysBack = dayBoundaryPresetDays[presetRange];
+  // `addDays` is calendar-aware so the snap stays on the right calendar day
+  // across DST transitions.
+  const startTime =
+    daysBack === undefined
+      ? now() - presetMs[presetRange]
+      : startOfDay(addDays(now(), -daysBack)).getTime() - 1;
+  return { startTime, endTime: undefined };
 };

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window.ts
@@ -86,9 +86,11 @@ const useAuditLogTimeWindow = ({
       // instead of silently broadening to the full retention window.
       // When already on `custom`, leave any existing dates intact.
       const isAlreadyCustom = range === customRange;
+      // `+ 1` undoes the day-snap preset's `-1ms` bias — without it the seed
+      // formats to the day before the preset's actual window.
       const seedStart =
         !isAlreadyCustom && startTime !== undefined
-          ? format(startTime, dateInputPattern)
+          ? format(startTime + 1, dateInputPattern)
           : undefined;
       const seedEnd = isAlreadyCustom ? undefined : format(Date.now(), dateInputPattern);
       updateSearchParameters({


### PR DESCRIPTION
## Summary
Closes [LOG-13478](https://linear.app/silverhand/issue/LOG-13478).

The Audit Logs custom date picker rounds its bounds to calendar-day boundaries (start of selected day → start of day-after-selected-end, both biased by ±1ms to honor the API's exclusive comparisons). The preset path doesn't — picking "Last 7 days" at 15:30 returns logs from exactly `now − 7×24h` (i.e. 15:30 seven days ago) rather than from the start of the calendar day seven days ago.

That asymmetry is visible to users: switching between "Last 7 days" and the custom picker produces subtly different windows for the same nominal range, and the preset's behavior is the one that mismatches user expectation for a day-labelled control.

### What changed
- `packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.ts`: in `resolveTimeWindow`, branch the preset path on a new `dayBoundaryPresets = {'7d', '30d'}` set. Date-labelled presets now snap their lower bound to `startOfDay(now − offset) − 1ms`, mirroring the custom-range picker. Time-labelled presets (`1h`, `1d` / 24h) keep their rolling exact-time-ago bound — "last 1 hour" should still mean the past sixty minutes, not "from local midnight."
- `packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.test.ts`: split the prior `7d` rolling-bound test into four cases — `1h` rolling, `1d` rolling, `7d` snapped, `30d` snapped — and updated the unknown-range fallback expectation to match the new default behavior.

### Expected result
- "Last 7 days" at 2026-05-15 15:30 local now resolves to `startOfDay(2026-05-08) − 1ms` (the API's exclusive `>` then includes `2026-05-08 00:00:00.000` onward), instead of `2026-05-08 15:30`.
- "Last 30 days" gets the same snap.
- "Last 1 hour" and "Last 24 hours" remain rolling — sub-day labels keep their literal meaning.
- The end bound stays `undefined` for all presets (open-ended at "now"). Only the lower bound changes.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments