### PR TITLE
perf(core): aggregate roles via LATERAL in getUsersByOrganizationId

### DIFF
--- a/.changeset/perf-list-org-users-lateral.md
+++ b/.changeset/perf-list-org-users-lateral.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": patch
+---
+
+speed up `GET /organizations/:id/users` on large memberships by aggregating roles via `LATERAL`
+
+The entities query for `getUsersByOrganizationId` joined `organization_role_user_relations` and `organization_roles` before applying `GROUP BY users.id` + `LIMIT`. Postgres had to build the entire `members × roles_per_member` intermediate result on every paginated request, aggregate it, then slice. A 20-row page over a 10k-member org with 3 roles each materialized ~30k intermediate rows regardless of page size.
+
+The rewrite moves the role aggregation into a `LATERAL` subquery joined per user row. `LIMIT` now prunes the outer user set before the role-table lookups fire, so the aggregation runs `limit` times instead of once over the full join, and each lateral lookup hits `organization_role_user_relations__tenant_id_org_id_user_id` (added in the prior Phase 0.5 migration) directly. The row ordering, previously incidental under the `GROUP BY` plan, is now pinned by an explicit `ORDER BY` so pagination is deterministic across calls.

--- a/packages/core/src/queries/organization/user-relations.ts
+++ b/packages/core/src/queries/organization/user-relations.ts
@@ -141,24 +141,40 @@ export class UserRelationQueries extends TwoRelationsQueries<typeof Organization
         where ${fields.organizationId} = ${organizationId}
         ${buildSearchSql(Users, search, sql`and `)}
       `),
+      // Aggregate roles via LATERAL so the per-user role lookup runs at most `limit` times
+      // instead of once over the full join. `order by` is explicit because the prior
+      // GROUP BY's ordering was incidental (Postgres does not guarantee GROUP BY ordering)
+      // and the rewrite removes the implementation accident that made it appear stable.
       this.pool.any<UserWithOrganizationRoles>(sql`
         select
           ${sql.join(
             userInfoSelectFields.map((field) => users.fields[field]),
             sql`, `
           )},
-          ${aggregateRoles()}
+          user_roles.${sql.identifier(['organizationRoles'])}
         from ${this.table}
         left join ${users.table}
           on ${fields.userId} = ${users.fields.id}
-        left join ${relations.table}
-          on ${relations.fields.userId} = ${users.fields.id}
-          and ${fields.organizationId} = ${relations.fields.organizationId}
-        left join ${roles.table}
-          on ${relations.fields.organizationRoleId} = ${roles.fields.id}
+        left join lateral (
+          select coalesce(
+            json_agg(
+              json_build_object(
+                'id', ${roles.fields.id},
+                'name', ${roles.fields.name}
+              )
+              order by ${roles.fields.name}
+            ),
+            '[]'::json
+          ) as ${sql.identifier(['organizationRoles'])}
+          from ${relations.table}
+          join ${roles.table}
+            on ${relations.fields.organizationRoleId} = ${roles.fields.id}
+          where ${relations.fields.organizationId} = ${organizationId}
+            and ${relations.fields.userId} = ${users.fields.id}
+        ) as user_roles on true
         where ${fields.organizationId} = ${organizationId}
         ${buildSearchSql(Users, search, sql`and `)}
-        group by ${users.fields.id}
+        order by ${fields.userId}
         limit ${limit}
         offset ${offset}
       `),

--- a/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-user.test.ts
@@ -206,4 +206,66 @@ describe('organization user APIs', () => {
       expect(users.map(({ id }) => id)).toEqual([user.id]);
     });
   });
+
+  describe('GET /organizations/:id/users role aggregation', () => {
+    // Self-contained coverage for the LATERAL role-aggregation rewrite. Each test builds
+    // its own organization + users + roles so test ordering is irrelevant.
+    const organizationApi = new OrganizationApiTest();
+    const userApi = new UserApiTest();
+
+    afterEach(async () => {
+      await Promise.all([organizationApi.cleanUp(), userApi.cleanUp()]);
+    });
+
+    it('should return an empty organizationRoles array for a member with no role assignments', async () => {
+      // The LATERAL subquery wraps `json_agg` in `coalesce(..., '[]'::json)`. A regression
+      // that drops the coalesce would surface here as `null` leaking into the response.
+      const organization = await organizationApi.create({ name: generateTestName() });
+      const user = await userApi.create({ username: generateTestName() });
+      await organizationApi.addUsers(organization.id, [user.id]);
+
+      const [users, totalCount] = await organizationApi.getUsers(organization.id);
+
+      expect(totalCount).toBe(1);
+      expect(users[0]!.organizationRoles).toEqual([]);
+    });
+
+    it('should correlate per-user role arrays correctly and sort each by role name', async () => {
+      // Three users on the same page with 2 / 1 / 0 role assignments. Two assertions in
+      // one test: (1) the LATERAL is correctly correlated (no crosswiring between rows),
+      // (2) `order by ${roles.fields.name}` is honored within each user's role array.
+      const organization = await organizationApi.create({ name: generateTestName() });
+      const [twoRoleUser, oneRoleUser, zeroRoleUser] = await Promise.all([
+        userApi.create({ username: generateTestName() }),
+        userApi.create({ username: generateTestName() }),
+        userApi.create({ username: generateTestName() }),
+      ]);
+      await organizationApi.addUsers(organization.id, [
+        twoRoleUser.id,
+        oneRoleUser.id,
+        zeroRoleUser.id,
+      ]);
+
+      // Name `roleB` with a `z-` prefix and `roleA` with an `a-` prefix so insertion order
+      // (B, then A) differs from name order (A, then B) — the assertion catches any
+      // accidental fallback to insertion ordering.
+      const roleB = await organizationApi.roleApi.create({ name: 'z-' + generateTestName() });
+      const roleA = await organizationApi.roleApi.create({ name: 'a-' + generateTestName() });
+      await organizationApi.addUserRoles(organization.id, twoRoleUser.id, [roleB.id, roleA.id]);
+      await organizationApi.addUserRoles(organization.id, oneRoleUser.id, [roleA.id]);
+
+      const [users, totalCount] = await organizationApi.getUsers(organization.id);
+      expect(totalCount).toBe(3);
+
+      const usersById = new Map(users.map((row) => [row.id, row]));
+      expect(usersById.get(twoRoleUser.id)!.organizationRoles).toEqual([
+        expect.objectContaining({ id: roleA.id, name: roleA.name }),
+        expect.objectContaining({ id: roleB.id, name: roleB.name }),
+      ]);
+      expect(usersById.get(oneRoleUser.id)!.organizationRoles).toEqual([
+        expect.objectContaining({ id: roleA.id, name: roleA.name }),
+      ]);
+      expect(usersById.get(zeroRoleUser.id)!.organizationRoles).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Refs [LOG-13475](https://linear.app/silverhand/issue/LOG-13475). Fourth task in the Phase 0.5 performance milestone. Branched from current master — both prerequisite indexes (Perf-A merged via #8818, Perf-B merged via #8819) are already there.

### What changed

- `packages/core/src/queries/organization/user-relations.ts` — `getUsersByOrganizationId` entities query rewritten:
  - Role aggregation moved from `LEFT JOIN organization_role_user_relations JOIN organization_roles GROUP BY users.id` to a `LEFT JOIN LATERAL (...) ON TRUE` subquery that produces exactly one `organizationRoles` JSON array per user row.
  - The lateral subquery does an `INNER JOIN` between `organization_role_user_relations` and `organization_roles`, so the `filter (where roles.id is not null)` guard from `aggregateRoles()` is no longer needed; `coalesce(json_agg(...), '[]'::json)` handles the empty-role case.
  - `ORDER BY fields.userId` (the relation table's `user_id`, NOT NULL by table definition) is added explicitly. The previous query relied on `GROUP BY users.id` to stabilize pagination row order; without it, page boundaries would be non-deterministic. Using `fields.userId` instead of `users.fields.id` keeps the sort key non-null even if the LEFT JOIN to `users` were ever to produce an orphan row.
- The count branch is untouched — it doesn't join role tables and its `count(*)` remains consistent with the entities branch.
- `.changeset/perf-list-org-users-lateral.md` — `@logto/core` patch.

### Expected result

- `GET /organizations/:id/users?page=1&page_size=20` on a 10k-member org with an average of 3 roles per user runs the role-aggregation lateral ~20 times (one per user in the page) instead of materializing a ~30k-row intermediate join. Each lateral execution hits `organization_role_user_relations__tenant_id_org_id_user_id` (added by [LOG-13473 / #8819](https://github.com/logto-io/logto/pull/8819)) directly.
- Response shape is unchanged: same user fields, same `organizationRoles` array contents (ids + names, ordered by role name), same `[]` for users with no roles, same `[totalCount, entities]` return shape, same pagination semantics.
- Behavior is unchanged for clients.

### Reviewer notes

- The lateral form is required because the role-set fan-out **per user** is what the optimizer can't push past `GROUP BY` in master; a CTE wouldn't help because the planner still needs to know whether to materialize the full join before LIMIT.
- `aggregateRoles()` in `queries/organization/utils.ts` is still in use by `getOrganizationsByUserId` (which has the symmetric problem on the org-side but isn't in this PR's scope). The aggregation is inlined here instead of reusing the helper because the lateral form uses an INNER JOIN inside the subquery, so the helper's `filter (where roles.id is not null)` guard isn't needed.
- A behavior-parity self-review confirmed: same row set for any (org, search) combination, same `organizationRoles` contents, same orphan-row behavior, same identifier casing on the returned column.

## Testing

Tested locally

## Checklist
- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
