### PR TITLE
fix(core): use custom domain for protected app SDK endpoint

### DIFF
--- a/packages/core/src/libraries/protected-app.test.ts
+++ b/packages/core/src/libraries/protected-app.test.ts
@@ -1,6 +1,7 @@
-import { type Application } from '@logto/schemas';
+import { DomainStatus, type Application, type Domain } from '@logto/schemas';
 import { createMockUtils } from '@logto/shared/esm';
 
+import { mockDomain } from '#src/__mocks__/domain.js';
 import {
   mockProtectedAppConfigProviderConfig,
   mockCloudflareData,
@@ -8,6 +9,7 @@ import {
   mockProtectedApplication,
 } from '#src/__mocks__/index.js';
 import { protectedAppSignInCallbackUrl } from '#src/constants/index.js';
+import { EnvSet, getTenantEndpoint } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import {
   defaultProtectedAppPageRules,
@@ -32,13 +34,16 @@ const { updateProtectedAppSiteConfigs, deleteCustomHostname } = await mockEsmWit
 const { MockQueries } = await import('#src/test-utils/tenant.js');
 const { createProtectedAppLibrary } = await import('./protected-app.js');
 
+const findApplications = jest.fn(async (): Promise<Application[]> => [mockProtectedApplication]);
 const findApplicationById = jest.fn(async (): Promise<Application> => mockProtectedApplication);
 const updateApplicationById = jest.fn(async (id: string, data: Partial<Application>) => ({
   ...mockProtectedApplication,
   ...data,
 }));
+const findAllDomains = jest.fn(async (): Promise<Domain[]> => []);
 const {
   syncAppConfigsToRemote,
+  syncAllAppConfigsToRemote,
   buildProtectedAppData,
   syncAppCustomDomainStatus,
   getDefaultDomain,
@@ -46,11 +51,16 @@ const {
 } = createProtectedAppLibrary(
   new MockQueries({
     applications: {
+      findApplications,
       findApplicationById,
       updateApplicationById,
     },
+    domains: {
+      findAllDomains,
+    },
   })
 );
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 
 const protectedAppConfigProviderConfig = {
   accountIdentifier: 'fake_account_id',
@@ -78,6 +88,10 @@ afterAll(() => {
 
 afterEach(() => {
   updateProtectedAppSiteConfigs.mockClear();
+  findApplications.mockClear();
+  findAllDomains.mockReset();
+  findAllDomains.mockResolvedValue([]);
+  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
 });
 
 describe('syncAppConfigsToRemote()', () => {
@@ -135,6 +149,90 @@ describe('syncAppConfigsToRemote()', () => {
         },
       }
     );
+  });
+
+  it('should use active tenant custom domain as SDK endpoint when dev features are enabled', async () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+    const activeDomain = {
+      ...mockDomain,
+      domain: 'secure.example.com',
+      status: DomainStatus.Active,
+    };
+    findAllDomains.mockResolvedValueOnce([activeDomain]);
+    findApplicationById.mockResolvedValueOnce({
+      ...mockProtectedApplication,
+      protectedAppMetadata: {
+        ...mockProtectedApplication.protectedAppMetadata,
+        customDomains: [mockCustomDomain],
+      },
+    });
+
+    await expect(syncAppConfigsToRemote(mockProtectedApplication.id)).resolves.not.toThrow();
+
+    const { id, secret } = mockProtectedApplication;
+    expect(updateProtectedAppSiteConfigs).toHaveBeenNthCalledWith(
+      1,
+      protectedAppConfigProviderConfig,
+      mockProtectedApplication.protectedAppMetadata.host,
+      expect.objectContaining({
+        sdkConfig: {
+          appId: id,
+          appSecret: secret,
+          endpoint: 'https://secure.example.com',
+        },
+      })
+    );
+    expect(updateProtectedAppSiteConfigs).toHaveBeenLastCalledWith(
+      protectedAppConfigProviderConfig,
+      mockCustomDomain.domain,
+      expect.objectContaining({
+        host: mockCustomDomain.domain,
+        sdkConfig: {
+          appId: id,
+          appSecret: secret,
+          endpoint: 'https://secure.example.com',
+        },
+      })
+    );
+  });
+
+  it('should keep the default SDK endpoint when dev features are disabled', async () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    findAllDomains.mockResolvedValueOnce([
+      {
+        ...mockDomain,
+        domain: 'secure.example.com',
+        status: DomainStatus.Active,
+      },
+    ]);
+    findApplicationById.mockResolvedValueOnce(mockProtectedApplication);
+
+    await expect(syncAppConfigsToRemote(mockProtectedApplication.id)).resolves.not.toThrow();
+
+    const { id, secret, tenantId } = mockProtectedApplication;
+    expect(findAllDomains).not.toHaveBeenCalled();
+    expect(updateProtectedAppSiteConfigs).toHaveBeenCalledWith(
+      protectedAppConfigProviderConfig,
+      mockProtectedApplication.protectedAppMetadata.host,
+      expect.objectContaining({
+        sdkConfig: {
+          appId: id,
+          appSecret: secret,
+          endpoint: getTenantEndpoint(tenantId, EnvSet.values).origin,
+        },
+      })
+    );
+  });
+});
+
+describe('syncAllAppConfigsToRemote()', () => {
+  it('should skip syncing all protected app configs when dev features are disabled', async () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+
+    await expect(syncAllAppConfigsToRemote()).resolves.not.toThrow();
+
+    expect(findApplications).not.toHaveBeenCalled();
+    expect(updateProtectedAppSiteConfigs).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/libraries/protected-app.ts
+++ b/packages/core/src/libraries/protected-app.ts
@@ -1,5 +1,7 @@
 import {
+  ApplicationType,
   DomainStatus,
+  SearchJointMode,
   type Application,
   type ProtectedAppMetadata,
   type CustomDomain,
@@ -148,8 +150,27 @@ const deleteDomainFromRemote = async (id: string) => {
 
 export const createProtectedAppLibrary = (queries: Queries) => {
   const {
-    applications: { findApplicationById, updateApplicationById },
+    applications: { findApplications, findApplicationById, updateApplicationById },
+    domains: { findAllDomains },
   } = queries;
+
+  const getSdkEndpoint = async (tenantId: string) => {
+    const defaultEndpoint = getTenantEndpoint(tenantId, EnvSet.values).origin;
+
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return defaultEndpoint;
+    }
+
+    const domains = await findAllDomains();
+    const activeCustomDomain = domains
+      .filter(({ status }) => status === DomainStatus.Active)
+      .slice()
+      .sort((left, right) => right.createdAt - left.createdAt)[0];
+
+    return activeCustomDomain
+      ? new URL(`https://${activeCustomDomain.domain}`).origin
+      : defaultEndpoint;
+  };
 
   const syncAppConfigsToRemote = async (applicationId: string): Promise<void> => {
     // Skip for integration test, we don't do third party call in integration test
@@ -165,13 +186,14 @@ export const createProtectedAppLibrary = (queries: Queries) => {
     }
 
     const { customDomains, ...rest } = protectedAppMetadata;
+    const sdkEndpoint = await getSdkEndpoint(tenantId);
 
     const siteConfigs = {
       ...rest,
       sdkConfig: {
         appId: id,
         appSecret: secret,
-        endpoint: getTenantEndpoint(tenantId, EnvSet.values).origin,
+        endpoint: sdkEndpoint,
       },
     };
 
@@ -193,6 +215,19 @@ export const createProtectedAppLibrary = (queries: Queries) => {
         })
       );
     }
+  };
+
+  const syncAllAppConfigsToRemote = async (): Promise<void> => {
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    const protectedApplications = await findApplications({
+      search: { matches: [], joint: SearchJointMode.Or, isCaseSensitive: false },
+      types: [ApplicationType.Protected],
+    });
+
+    await Promise.all(protectedApplications.map(async ({ id }) => syncAppConfigsToRemote(id)));
   };
 
   /**
@@ -276,5 +311,6 @@ export const createProtectedAppLibrary = (queries: Queries) => {
     addDomainToRemote,
     syncAppCustomDomainStatus,
     deleteDomainFromRemote,
+    syncAllAppConfigsToRemote,
   };
 };

--- a/packages/core/src/routes/domain.test.ts
+++ b/packages/core/src/routes/domain.test.ts
@@ -52,6 +52,9 @@ const mockLibraries = {
   samlApplications: {
     syncCustomDomainsToSamlApplicationRedirectUrls: jest.fn(),
   },
+  protectedApps: {
+    syncAllAppConfigsToRemote: jest.fn(),
+  },
 };
 
 const tenantContext = new MockTenant(undefined, { domains }, undefined, mockLibraries);
@@ -118,6 +121,7 @@ describe('domain routes', () => {
     expect(
       mockLibraries.samlApplications.syncCustomDomainsToSamlApplicationRedirectUrls
     ).toHaveBeenCalledTimes(1);
+    expect(mockLibraries.protectedApps.syncAllAppConfigsToRemote).toHaveBeenCalledTimes(1);
     expect(response.body).toEqual({
       scannedCount: 3,
       deletedCount: 1,

--- a/packages/core/src/routes/domain.ts
+++ b/packages/core/src/routes/domain.ts
@@ -21,10 +21,22 @@ export default function domainRoutes<T extends ManagementApiRouter>(
   const {
     domains: { syncDomainStatus, addDomain, deleteDomain, cleanupDomains },
     samlApplications: { syncCustomDomainsToSamlApplicationRedirectUrls },
+    protectedApps: { syncAllAppConfigsToRemote },
     quota,
   } = libraries;
 
   const isPrivateRegionFeature = EnvSet.values.isMultipleCustomDomainsEnabled;
+  const syncCustomDomainDependentConfigs = async (
+    domains: Awaited<ReturnType<typeof findAllDomains>>
+  ) => {
+    await trySafe(async () =>
+      syncCustomDomainsToSamlApplicationRedirectUrls(tenantId, [...domains])
+    );
+
+    if (EnvSet.values.isDevFeaturesEnabled) {
+      await trySafe(async () => syncAllAppConfigsToRemote());
+    }
+  };
 
   router.get(
     '/domains',
@@ -35,9 +47,7 @@ export default function domainRoutes<T extends ManagementApiRouter>(
         domains.map(async (domain) => syncDomainStatus(domain))
       );
 
-      void trySafe(async () =>
-        syncCustomDomainsToSamlApplicationRedirectUrls(tenantId, [...syncedDomains])
-      );
+      void syncCustomDomainDependentConfigs(syncedDomains);
 
       ctx.body = syncedDomains.map((domain) => pick(domain, ...domainSelectFields));
 
@@ -65,7 +75,7 @@ export default function domainRoutes<T extends ManagementApiRouter>(
         const syncedDomains = await Promise.all(
           domains.map(async (domain) => syncDomainStatus(domain))
         );
-        await syncCustomDomainsToSamlApplicationRedirectUrls(tenantId, [...syncedDomains]);
+        await syncCustomDomainDependentConfigs(syncedDomains);
       });
 
       ctx.body = pick(syncedDomain, ...domainSelectFields);
@@ -135,7 +145,7 @@ export default function domainRoutes<T extends ManagementApiRouter>(
         const syncedDomains = await Promise.all(
           domains.map(async (domain) => syncDomainStatus(domain))
         );
-        await syncCustomDomainsToSamlApplicationRedirectUrls(tenantId, [...syncedDomains]);
+        await syncCustomDomainDependentConfigs(syncedDomains);
       });
 
       ctx.status = 200;
@@ -160,7 +170,7 @@ export default function domainRoutes<T extends ManagementApiRouter>(
         const syncedDomains = await Promise.all(
           domains.map(async (domain) => syncDomainStatus(domain))
         );
-        await syncCustomDomainsToSamlApplicationRedirectUrls(tenantId, [...syncedDomains]);
+        await syncCustomDomainDependentConfigs(syncedDomains);
       });
 
       ctx.status = 204;


### PR DESCRIPTION
## Summary

- Use the active tenant custom domain for Protected App SDK endpoint when syncing remote configs.
- Resync Protected App remote configs after tenant custom domain status changes.

## Testing

Unit tests