### PR TITLE
feat(account): support editing profile fields

### DIFF
--- a/packages/account/src/apis/account.ts
+++ b/packages/account/src/apis/account.ts
@@ -1,4 +1,5 @@
-import { conditional } from '@silverhand/essentials';
+import type { JsonObject, UserProfile } from '@logto/schemas';
+import { conditional, type Nullable } from '@silverhand/essentials';
 
 import { createAuthenticatedKy } from './base-ky';
 
@@ -41,6 +42,24 @@ export const deleteUsername = async (accessToken: string, verificationRecordId: 
   await createAuthenticatedKy(accessToken).patch('/api/my-account', {
     json: { username: null },
     headers: { [verificationRecordIdHeader]: verificationRecordId },
+  });
+};
+
+export const updateName = async (accessToken: string, payload: { name: Nullable<string> }) => {
+  await createAuthenticatedKy(accessToken).patch('/api/my-account', {
+    json: payload,
+  });
+};
+
+export const updateProfile = async (accessToken: string, payload: UserProfile) => {
+  await createAuthenticatedKy(accessToken).patch('/api/my-account/profile', {
+    json: payload,
+  });
+};
+
+export const updateCustomData = async (accessToken: string, payload: JsonObject) => {
+  await createAuthenticatedKy(accessToken).patch('/api/my-account', {
+    json: { customData: payload },
   });
 };
 

--- a/packages/account/src/pages/Profile/EditProfileFieldModal.module.scss
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal.module.scss
@@ -1,0 +1,82 @@
+@use '@experience/shared/scss/underscore' as _;
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: var(--color-bg-mask);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal {
+  background: var(--color-bg-float);
+  border-radius: _.unit(4);
+  padding: _.unit(6);
+  max-width: 600px;
+  width: calc(100% - _.unit(8));
+  box-shadow: var(--shadow-2);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  gap: _.unit(4);
+  margin-bottom: _.unit(6);
+}
+
+.title {
+  flex: 1;
+  font: var(--font-title-2);
+  color: var(--color-type-primary);
+}
+
+.closeButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: _.unit(6);
+  height: _.unit(6);
+  padding: 0;
+  border: none;
+  color: var(--color-type-secondary);
+  background: none;
+  cursor: pointer;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(4);
+  margin-bottom: _.unit(6);
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: _.unit(3);
+}
+
+.checkboxField {
+  display: flex;
+  align-items: center;
+  gap: _.unit(2);
+  font: var(--font-body-2);
+  color: var(--color-type-primary);
+  cursor: pointer;
+
+  input {
+    cursor: pointer;
+  }
+}
+
+.description,
+.errorMessage {
+  margin-inline-start: _.unit(0.5);
+  @include _.text-hint;
+}
+
+.errorMessage {
+  color: var(--color-danger-default);
+}

--- a/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
@@ -1,0 +1,236 @@
+import SelectField from '@experience/components/InputFields/SelectField';
+import CloseIcon from '@experience/shared/assets/icons/nav-close.svg?react';
+import Button from '@experience/shared/components/Button';
+import InputField from '@experience/shared/components/InputFields/InputField';
+import { CustomProfileFieldType, type JsonObject, type UserProfileResponse } from '@logto/schemas';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import ReactModal from 'react-modal';
+
+import { updateCustomData, updateName, updateProfile } from '@ac/apis/account';
+import useApi from '@ac/hooks/use-api';
+import useErrorHandler from '@ac/hooks/use-error-handler';
+
+import DateField from './EditProfileFieldModal/DateField';
+import {
+  buildEditableFields,
+  getCustomDataValue,
+  getDateFormat,
+  getProfileValue,
+  getValidationError,
+  type EditableField,
+  type EditableValue,
+} from './EditProfileFieldModal/utils';
+import styles from './EditProfileFieldModal.module.scss';
+import { getSelectOptionLabel } from './select-options';
+import type { ProfileFieldRow } from './types';
+
+type Props = {
+  readonly field?: ProfileFieldRow;
+  readonly userInfo?: Partial<UserProfileResponse>;
+  readonly onClose: () => void;
+  readonly onUpdated: () => Promise<void>;
+};
+
+const getSelectOptions = (
+  { config, required }: EditableField,
+  emptyOptionLabel: string,
+  translate: (key: string) => string
+) => [
+  ...(required ? [] : [{ value: '', label: emptyOptionLabel }]),
+  ...(config?.options?.map(({ label, value }) => ({
+    value,
+    label: getSelectOptionLabel(value, label, translate),
+  })) ?? []),
+];
+
+const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) => {
+  const { t } = useTranslation();
+  const updateNameRequest = useApi(updateName);
+  const updateProfileRequest = useApi(updateProfile);
+  const updateCustomDataRequest = useApi(updateCustomData);
+  const handleError = useErrorHandler();
+
+  const fields = useMemo(() => buildEditableFields(field, userInfo, t), [field, t, userInfo]);
+
+  const [values, setValues] = useState<Record<string, EditableValue>>({});
+  const [errors, setErrors] = useState<Record<string, string | undefined>>({});
+
+  useEffect(() => {
+    setValues(Object.fromEntries(fields.map(({ name, value }) => [name, value])));
+    setErrors({});
+  }, [fields]);
+
+  const validate = useCallback(() => {
+    const nextErrors = Object.fromEntries(
+      fields.map((field) => [field.name, getValidationError(values[field.name] ?? '', field, t)])
+    );
+
+    setErrors(nextErrors);
+    return Object.values(nextErrors).every((error) => !error);
+  }, [fields, t, values]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!field || !validate()) {
+      return;
+    }
+
+    const [firstField] = fields;
+    const [error] =
+      field.controlKey === 'name'
+        ? await updateNameRequest({ name: getProfileValue(values.name ?? '').trim() || null })
+        : field.controlKey === 'customData' && firstField
+          ? await updateCustomDataRequest({
+              ...userInfo?.customData,
+              [field.name]: getCustomDataValue(firstField, values[field.name] ?? ''),
+            } satisfies JsonObject)
+          : await updateProfileRequest({
+              ...userInfo?.profile,
+              ...(field.name === 'address' || field.field?.type === CustomProfileFieldType.Address
+                ? {
+                    address: {
+                      ...userInfo?.profile?.address,
+                      ...Object.fromEntries(
+                        fields.map(({ name }) => [name, getProfileValue(values[name] ?? '')])
+                      ),
+                    },
+                  }
+                : Object.fromEntries(
+                    fields.map(({ name }) => [name, getProfileValue(values[name] ?? '')])
+                  )),
+            });
+
+    if (error) {
+      await handleError(error);
+      return;
+    }
+
+    await onUpdated();
+    onClose();
+  }, [
+    field,
+    fields,
+    handleError,
+    onClose,
+    onUpdated,
+    updateCustomDataRequest,
+    updateNameRequest,
+    updateProfileRequest,
+    userInfo?.customData,
+    userInfo?.profile,
+    validate,
+    values,
+  ]);
+
+  return (
+    <ReactModal
+      shouldCloseOnEsc
+      shouldCloseOnOverlayClick
+      isOpen={Boolean(field)}
+      className={styles.modal}
+      overlayClassName={styles.overlay}
+      onRequestClose={onClose}
+    >
+      {field && (
+        <>
+          <div className={styles.header}>
+            <div className={styles.title}>{t('action.change', { method: field.label })}</div>
+            <button type="button" className={styles.closeButton} onClick={onClose}>
+              <CloseIcon />
+            </button>
+          </div>
+          <div className={styles.content}>
+            {fields.map((editableField) => {
+              const value = values[editableField.name] ?? editableField.value;
+
+              return editableField.type === CustomProfileFieldType.Checkbox ? (
+                <label key={editableField.name} className={styles.checkboxField}>
+                  <input
+                    type="checkbox"
+                    checked={Boolean(value)}
+                    onChange={({ currentTarget }) => {
+                      setValues((previous) => ({
+                        ...previous,
+                        [editableField.name]: currentTarget.checked,
+                      }));
+                    }}
+                  />
+                  <span>{editableField.label}</span>
+                </label>
+              ) : editableField.type === CustomProfileFieldType.Select ? (
+                <SelectField
+                  key={editableField.name}
+                  name={editableField.name}
+                  label={editableField.label}
+                  value={getProfileValue(value)}
+                  options={getSelectOptions(editableField, t('account_center.security.not_set'), t)}
+                  description={editableField.description}
+                  errorMessage={errors[editableField.name]}
+                  required={editableField.required}
+                  placeholder={editableField.config?.placeholder}
+                  onChange={(value) => {
+                    setValues((previous) => ({
+                      ...previous,
+                      [editableField.name]: value,
+                    }));
+                  }}
+                />
+              ) : editableField.type === CustomProfileFieldType.Date ? (
+                <DateField
+                  key={editableField.name}
+                  name={editableField.name}
+                  label={editableField.label}
+                  dateFormat={getDateFormat(editableField.config)}
+                  value={value}
+                  description={editableField.description}
+                  errorMessage={errors[editableField.name]}
+                  isRequired={editableField.required}
+                  placeholder={editableField.config?.placeholder}
+                  onChange={(value) => {
+                    setValues((previous) => ({
+                      ...previous,
+                      [editableField.name]: value,
+                    }));
+                  }}
+                />
+              ) : (
+                <InputField
+                  key={editableField.name}
+                  // eslint-disable-next-line jsx-a11y/no-autofocus
+                  autoFocus={fields[0]?.name === editableField.name}
+                  name={editableField.name}
+                  label={editableField.label}
+                  type={editableField.type === CustomProfileFieldType.Number ? 'number' : 'text'}
+                  required={editableField.required}
+                  value={getProfileValue(value)}
+                  description={editableField.description}
+                  errorMessage={errors[editableField.name]}
+                  isDanger={Boolean(errors[editableField.name])}
+                  placeholder={editableField.config?.placeholder}
+                  onChange={({ currentTarget }) => {
+                    setValues((previous) => ({
+                      ...previous,
+                      [editableField.name]: currentTarget.value,
+                    }));
+                  }}
+                />
+              );
+            })}
+          </div>
+          <div className={styles.footer}>
+            <Button title="action.cancel" type="secondary" onClick={onClose} />
+            <Button
+              title="action.save"
+              type="primary"
+              onClick={() => {
+                void handleSubmit();
+              }}
+            />
+          </div>
+        </>
+      )}
+    </ReactModal>
+  );
+};
+
+export default EditProfileFieldModal;

--- a/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
@@ -49,7 +49,6 @@ const getSelectOptions = (
 type SubmitFieldUpdateParams = {
   readonly field: ProfileFieldRow;
   readonly fields: readonly EditableField[];
-  readonly firstField?: EditableField;
   readonly userInfo?: Partial<UserProfileResponse>;
   readonly values: Readonly<Record<string, EditableValue>>;
   readonly updateNameRequest: (payload: {
@@ -66,7 +65,6 @@ type SubmitFieldUpdateParams = {
 const submitFieldUpdate = async ({
   field,
   fields,
-  firstField,
   userInfo,
   values,
   updateNameRequest,
@@ -77,10 +75,16 @@ const submitFieldUpdate = async ({
     return updateNameRequest({ name: getProfileValue(values.name ?? '').trim() || null });
   }
 
-  if (field.controlKey === 'customData' && firstField) {
+  if (field.controlKey === 'customData') {
+    const [customField] = fields;
+
+    if (!customField) {
+      throw new TypeError('Expected a custom data field to edit');
+    }
+
     return updateCustomDataRequest({
       ...userInfo?.customData,
-      [field.name]: getCustomDataValue(firstField, values[field.name] ?? ''),
+      [field.name]: getCustomDataValue(customField, values[field.name] ?? ''),
     } satisfies JsonObject);
   }
 
@@ -132,11 +136,9 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
       return;
     }
 
-    const [firstField] = fields;
     const [error] = await submitFieldUpdate({
       field,
       fields,
-      firstField,
       userInfo,
       values,
       updateNameRequest,

--- a/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
@@ -3,6 +3,7 @@ import CloseIcon from '@experience/shared/assets/icons/nav-close.svg?react';
 import Button from '@experience/shared/components/Button';
 import InputField from '@experience/shared/components/InputFields/InputField';
 import { CustomProfileFieldType, type JsonObject, type UserProfileResponse } from '@logto/schemas';
+import type { Nullable } from '@silverhand/essentials';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactModal from 'react-modal';
@@ -45,6 +46,54 @@ const getSelectOptions = (
   })) ?? []),
 ];
 
+type SubmitFieldUpdateParams = {
+  readonly field: ProfileFieldRow;
+  readonly fields: readonly EditableField[];
+  readonly firstField?: EditableField;
+  readonly userInfo?: Partial<UserProfileResponse>;
+  readonly values: Readonly<Record<string, EditableValue>>;
+  readonly updateNameRequest: (payload: {
+    name: Nullable<string>;
+  }) => Promise<readonly [Nullable<unknown>, void?]>;
+  readonly updateCustomDataRequest: (
+    payload: JsonObject
+  ) => Promise<readonly [Nullable<unknown>, void?]>;
+  readonly updateProfileRequest: (
+    payload: Parameters<typeof updateProfile>[1]
+  ) => Promise<readonly [Nullable<unknown>, void?]>;
+};
+
+const submitFieldUpdate = async ({
+  field,
+  fields,
+  firstField,
+  userInfo,
+  values,
+  updateNameRequest,
+  updateCustomDataRequest,
+  updateProfileRequest,
+}: SubmitFieldUpdateParams) => {
+  if (field.controlKey === 'name') {
+    return updateNameRequest({ name: getProfileValue(values.name ?? '').trim() || null });
+  }
+
+  if (field.controlKey === 'customData' && firstField) {
+    return updateCustomDataRequest({
+      ...userInfo?.customData,
+      [field.name]: getCustomDataValue(firstField, values[field.name] ?? ''),
+    } satisfies JsonObject);
+  }
+
+  return updateProfileRequest({
+    ...userInfo?.profile,
+    ...(field.name === 'address' || field.field?.type === CustomProfileFieldType.Address
+      ? {
+          address: buildAddressProfileValue(userInfo?.profile?.address, fields, values),
+        }
+      : Object.fromEntries(fields.map(({ name }) => [name, getProfileValue(values[name] ?? '')]))),
+  });
+};
+
 const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) => {
   const { t } = useTranslation();
   const updateNameRequest = useApi(updateName);
@@ -58,9 +107,16 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
 
   useEffect(() => {
-    setValues(Object.fromEntries(fields.map(({ name, value }) => [name, value])));
+    if (!field) {
+      return;
+    }
+
+    const initialFields = buildEditableFields(field, userInfo, t);
+    setValues(Object.fromEntries(initialFields.map(({ name, value }) => [name, value])));
     setErrors({});
-  }, [fields]);
+    // Only reset when switching fields; ignore background userInfo refreshes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [field?.name]);
 
   const validate = useCallback(() => {
     const nextErrors = Object.fromEntries(
@@ -77,24 +133,16 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
     }
 
     const [firstField] = fields;
-    const [error] =
-      field.controlKey === 'name'
-        ? await updateNameRequest({ name: getProfileValue(values.name ?? '').trim() || null })
-        : field.controlKey === 'customData' && firstField
-          ? await updateCustomDataRequest({
-              ...userInfo?.customData,
-              [field.name]: getCustomDataValue(firstField, values[field.name] ?? ''),
-            } satisfies JsonObject)
-          : await updateProfileRequest({
-              ...userInfo?.profile,
-              ...(field.name === 'address' || field.field?.type === CustomProfileFieldType.Address
-                ? {
-                    address: buildAddressProfileValue(userInfo?.profile?.address, fields, values),
-                  }
-                : Object.fromEntries(
-                    fields.map(({ name }) => [name, getProfileValue(values[name] ?? '')])
-                  )),
-            });
+    const [error] = await submitFieldUpdate({
+      field,
+      fields,
+      firstField,
+      userInfo,
+      values,
+      updateNameRequest,
+      updateCustomDataRequest,
+      updateProfileRequest,
+    });
 
     if (error) {
       await handleError(error);

--- a/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
@@ -13,14 +13,15 @@ import useErrorHandler from '@ac/hooks/use-error-handler';
 
 import DateField from './EditProfileFieldModal/DateField';
 import {
+  buildAddressProfileValue,
   buildEditableFields,
   getCustomDataValue,
   getDateFormat,
   getProfileValue,
-  getValidationError,
   type EditableField,
   type EditableValue,
 } from './EditProfileFieldModal/utils';
+import { getValidationError } from './EditProfileFieldModal/validation';
 import styles from './EditProfileFieldModal.module.scss';
 import { getSelectOptionLabel } from './select-options';
 import type { ProfileFieldRow } from './types';
@@ -88,12 +89,7 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
               ...userInfo?.profile,
               ...(field.name === 'address' || field.field?.type === CustomProfileFieldType.Address
                 ? {
-                    address: {
-                      ...userInfo?.profile?.address,
-                      ...Object.fromEntries(
-                        fields.map(({ name }) => [name, getProfileValue(values[name] ?? '')])
-                      ),
-                    },
+                    address: buildAddressProfileValue(userInfo?.profile?.address, fields, values),
                   }
                 : Object.fromEntries(
                     fields.map(({ name }) => [name, getProfileValue(values[name] ?? '')])

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.module.scss
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.module.scss
@@ -1,0 +1,85 @@
+@use '@experience/shared/scss/underscore' as _;
+
+.dateFieldContainer {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1);
+}
+
+.dateInputWrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: _.unit(1.5);
+  height: 44px;
+  padding: 0 _.unit(4);
+  border: 1px solid var(--color-line-border);
+  border-radius: var(--radius);
+  background: inherit;
+  color: var(--color-type-primary);
+
+  &.active {
+    border-color: var(--color-brand-default);
+    box-shadow: 0 0 0 3px var(--color-overlay-brand-focused);
+  }
+
+  &.danger {
+    border-color: var(--color-danger-default);
+    box-shadow: 0 0 0 3px var(--color-overlay-danger-focused);
+  }
+}
+
+.label {
+  position: absolute;
+  inset-inline-start: _.unit(3);
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 0 _.unit(1);
+  background: var(--color-bg-float);
+  color: var(--color-type-secondary);
+  font: var(--font-body-2);
+  pointer-events: none;
+
+  &.active {
+    top: 0;
+    color: var(--color-type-link);
+    font: var(--font-body-3);
+  }
+}
+
+.part {
+  display: flex;
+  align-items: center;
+  gap: _.unit(1.5);
+
+  input {
+    width: auto;
+    min-width: 2ch;
+    max-width: 5ch;
+    padding: 0;
+    border: none;
+    outline: none;
+    background: inherit;
+    color: var(--color-type-primary);
+    font: var(--font-body-2);
+
+    &::placeholder {
+      color: var(--color-type-secondary);
+    }
+  }
+}
+
+.separator {
+  color: var(--color-line-border);
+  font: var(--font-body-2);
+}
+
+.description,
+.errorMessage {
+  margin-inline-start: _.unit(0.5);
+  @include _.text-hint;
+}
+
+.errorMessage {
+  color: var(--color-danger-default);
+}

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.tsx
@@ -107,6 +107,7 @@ const DateField = ({
         {formatConfig.parts.map((part, index) => (
           <div key={`${name}-${part}`} className={styles.part}>
             <input
+              name={`${name}.${part}`}
               aria-label={`${label} ${part}`}
               value={dateParts[index] ?? ''}
               placeholder={part.toUpperCase()}
@@ -116,7 +117,13 @@ const DateField = ({
               onFocus={() => {
                 setIsFocused(true);
               }}
-              onBlur={() => {
+              onBlur={({ currentTarget, relatedTarget }) => {
+                const wrapper = currentTarget.closest(`.${styles.dateInputWrapper}`);
+
+                if (wrapper?.contains(relatedTarget)) {
+                  return;
+                }
+
                 setIsFocused(false);
               }}
               onChange={({ currentTarget }) => {

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.tsx
@@ -1,0 +1,138 @@
+import InputField from '@experience/shared/components/InputFields/InputField';
+import { SupportedDateFormat } from '@logto/schemas';
+import classNames from 'classnames';
+import { useMemo, useState } from 'react';
+
+import styles from './DateField.module.scss';
+import type { EditableValue } from './utils';
+
+type Props = {
+  readonly name: string;
+  readonly label: string;
+  readonly value: EditableValue;
+  readonly dateFormat?: string;
+  readonly description?: string;
+  readonly errorMessage?: string;
+  readonly isRequired: boolean;
+  readonly placeholder?: string;
+  readonly onChange: (value: string) => void;
+};
+
+type DateFormatConfig = {
+  separator: string;
+  parts: string[];
+  maxLengths: number[];
+};
+
+const isSupportedDateFormat = (dateFormat?: string): dateFormat is SupportedDateFormat =>
+  dateFormat === SupportedDateFormat.US ||
+  dateFormat === SupportedDateFormat.UK ||
+  dateFormat === SupportedDateFormat.ISO;
+
+const getDateFormatConfig = (dateFormat: SupportedDateFormat): DateFormatConfig => {
+  const separator = dateFormat === SupportedDateFormat.ISO ? '-' : '/';
+  const parts = dateFormat.split(separator);
+
+  return {
+    separator,
+    parts,
+    maxLengths: parts.map((part) => part.length),
+  };
+};
+
+const DateField = ({
+  name,
+  label,
+  value,
+  dateFormat,
+  description,
+  errorMessage,
+  isRequired,
+  placeholder,
+  onChange,
+}: Props) => {
+  const valueString = typeof value === 'boolean' ? '' : value;
+  const [isFocused, setIsFocused] = useState(false);
+  const formatConfig = useMemo(
+    () => (isSupportedDateFormat(dateFormat) ? getDateFormatConfig(dateFormat) : undefined),
+    [dateFormat]
+  );
+  const dateParts = useMemo(() => {
+    if (!valueString || !formatConfig) {
+      return ['', '', ''];
+    }
+
+    return valueString.split(formatConfig.separator);
+  }, [formatConfig, valueString]);
+
+  if (!formatConfig) {
+    return (
+      <InputField
+        name={name}
+        label={label}
+        required={isRequired}
+        value={valueString}
+        description={description}
+        errorMessage={errorMessage}
+        isDanger={Boolean(errorMessage)}
+        placeholder={placeholder ?? dateFormat}
+        onChange={({ currentTarget }) => {
+          onChange(currentTarget.value);
+        }}
+      />
+    );
+  }
+
+  const handleChange = (index: number, nextValue: string) => {
+    const maxLength = formatConfig.maxLengths[index];
+    const nextParts = dateParts.map((part, partIndex) =>
+      partIndex === index ? nextValue.replaceAll(/\D/g, '').slice(0, maxLength) : part
+    );
+    const nextDate = nextParts.every((part) => !part) ? '' : nextParts.join(formatConfig.separator);
+    onChange(nextDate);
+  };
+
+  return (
+    <div className={styles.dateFieldContainer}>
+      <div
+        className={classNames(
+          styles.dateInputWrapper,
+          isFocused && styles.active,
+          errorMessage && styles.danger
+        )}
+      >
+        <span className={classNames(styles.label, (isFocused || valueString) && styles.active)}>
+          {label}
+        </span>
+        {formatConfig.parts.map((part, index) => (
+          <div key={`${name}-${part}`} className={styles.part}>
+            <input
+              aria-label={`${label} ${part}`}
+              value={dateParts[index] ?? ''}
+              placeholder={part.toUpperCase()}
+              maxLength={formatConfig.maxLengths[index]}
+              inputMode="numeric"
+              pattern="[0-9]*"
+              onFocus={() => {
+                setIsFocused(true);
+              }}
+              onBlur={() => {
+                setIsFocused(false);
+              }}
+              onChange={({ currentTarget }) => {
+                handleChange(index, currentTarget.value);
+              }}
+            />
+            {index < formatConfig.parts.length - 1 && (
+              <span className={styles.separator}>{formatConfig.separator}</span>
+            )}
+          </div>
+        ))}
+      </div>
+      {description && <div className={styles.description}>{description}</div>}
+      {errorMessage && <div className={styles.errorMessage}>{errorMessage}</div>}
+    </div>
+  );
+};
+
+export default DateField;

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/utils.test.ts
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/utils.test.ts
@@ -1,6 +1,7 @@
 import {
   AccountCenterControlValue,
   CustomProfileFieldType,
+  SupportedDateFormat,
   type CustomProfileField,
 } from '@logto/schemas';
 
@@ -60,6 +61,22 @@ describe('EditProfileFieldModal utils', () => {
     const [editableField] = buildEditableFields(getProfileFieldRow(field), {}, translate);
 
     expect(editableField?.value).toBe(false);
+  });
+
+  it('returns a validation error instead of throwing for invalid date format config', () => {
+    const field = {
+      name: 'startDate',
+      label: 'Start date',
+      value: '2024-01-01',
+      type: CustomProfileFieldType.Date,
+      required: false,
+      config: {
+        format: SupportedDateFormat.Custom,
+        customFormat: 'invalid-format-token',
+      },
+    } satisfies EditableField;
+
+    expect(getValidationError('2024-01-01', field, translate)).toBe('error.general_invalid');
   });
 
   it('returns a validation error instead of throwing for invalid regex config', () => {

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/utils.test.ts
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/utils.test.ts
@@ -1,0 +1,137 @@
+import {
+  AccountCenterControlValue,
+  CustomProfileFieldType,
+  type CustomProfileField,
+} from '@logto/schemas';
+
+import type { ProfileFieldRow } from '../types';
+
+import { buildAddressProfileValue, buildEditableFields, type EditableField } from './utils';
+import { getValidationError } from './validation';
+
+const translate = (key: string) => key;
+
+const getCustomProfileField = (override: Partial<CustomProfileField> = {}): CustomProfileField => ({
+  tenantId: 'default',
+  id: 'custom-field-id',
+  name: 'customField',
+  type: CustomProfileFieldType.Text,
+  label: 'Custom field',
+  description: null,
+  required: false,
+  config: {},
+  createdAt: 0,
+  sieOrder: 0,
+  ...override,
+});
+
+const getProfileFieldRow = (field: CustomProfileField): ProfileFieldRow => ({
+  name: field.name,
+  label: field.label,
+  controlKey: 'customData',
+  controlValue: AccountCenterControlValue.Edit,
+  field,
+});
+
+describe('EditProfileFieldModal utils', () => {
+  it('preserves saved checkbox string values from custom data', () => {
+    const field = getCustomProfileField({
+      name: 'newsletter',
+      type: CustomProfileFieldType.Checkbox,
+      config: { defaultValue: 'false' },
+    });
+
+    const [editableField] = buildEditableFields(
+      getProfileFieldRow(field),
+      { customData: { newsletter: 'true' } },
+      translate
+    );
+
+    expect(editableField?.value).toBe(true);
+  });
+
+  it('falls back to false for checkbox fields without config', () => {
+    const field = getCustomProfileField({
+      name: 'newsletter',
+      type: CustomProfileFieldType.Checkbox,
+      config: undefined as unknown as CustomProfileField['config'],
+    });
+
+    const [editableField] = buildEditableFields(getProfileFieldRow(field), {}, translate);
+
+    expect(editableField?.value).toBe(false);
+  });
+
+  it('returns a validation error instead of throwing for invalid regex config', () => {
+    const field = {
+      name: 'employeeCode',
+      label: 'Employee code',
+      value: '',
+      type: CustomProfileFieldType.Regex,
+      required: false,
+      config: { format: '[' },
+    } satisfies EditableField;
+
+    expect(getValidationError('ABC-12', field, translate)).toBe('error.general_invalid');
+  });
+
+  it('recomputes hidden formatted address from editable address parts', () => {
+    const fields = [
+      {
+        name: 'streetAddress',
+        label: 'Street address',
+        value: 'Old street',
+        type: CustomProfileFieldType.Text,
+        required: false,
+      },
+      {
+        name: 'country',
+        label: 'Country',
+        value: 'CA',
+        type: CustomProfileFieldType.Text,
+        required: false,
+      },
+    ] satisfies EditableField[];
+
+    expect(
+      buildAddressProfileValue({ formatted: 'Old summary', locality: 'Springfield' }, fields, {
+        streetAddress: '123 Main St',
+        country: 'US',
+      })
+    ).toEqual({
+      formatted: '123 Main St, US',
+      locality: 'Springfield',
+      streetAddress: '123 Main St',
+      country: 'US',
+    });
+  });
+
+  it('keeps explicitly edited formatted address values', () => {
+    const fields = [
+      {
+        name: 'formatted',
+        label: 'Address',
+        value: 'Old summary',
+        type: CustomProfileFieldType.Text,
+        required: false,
+      },
+      {
+        name: 'streetAddress',
+        label: 'Street address',
+        value: 'Old street',
+        type: CustomProfileFieldType.Text,
+        required: false,
+      },
+    ] satisfies EditableField[];
+
+    expect(
+      buildAddressProfileValue({ formatted: 'Old summary' }, fields, {
+        formatted: 'Manual summary',
+        streetAddress: '123 Main St',
+      })
+    ).toEqual({
+      formatted: 'Manual summary',
+      streetAddress: '123 Main St',
+    });
+  });
+});

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/utils.ts
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/utils.ts
@@ -1,0 +1,347 @@
+import { isValidUrl } from '@logto/core-kit';
+import {
+  CustomProfileFieldType,
+  Gender,
+  SupportedDateFormat,
+  fullnameKeys,
+  userProfileAddressKeys,
+  type CustomProfileField,
+  type CustomProfileFieldBaseConfig,
+  type FieldPart,
+  type UserProfile,
+  type UserProfileResponse,
+} from '@logto/schemas';
+import { format, isValid, parse } from 'date-fns';
+
+import type { ProfileFieldRow } from '../types';
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+export type EditableValue = string | boolean;
+
+export type EditableField = {
+  name: string;
+  label: string;
+  value: EditableValue;
+  type: CustomProfileFieldType;
+  required: boolean;
+  description?: string;
+  config?: CustomProfileFieldBaseConfig;
+};
+
+const profilePartLabelKeys: Record<string, string> = {
+  familyName: 'profile.familyName',
+  givenName: 'profile.givenName',
+  middleName: 'profile.middleName',
+  formatted: 'profile.address.formatted',
+  streetAddress: 'profile.address.streetAddress',
+  locality: 'profile.address.locality',
+  region: 'profile.address.region',
+  postalCode: 'profile.address.postalCode',
+  country: 'profile.address.country',
+};
+
+const getStringValue = (value: unknown): string => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  return '';
+};
+
+const getCustomFieldValue = (
+  userInfo: Partial<UserProfileResponse> | undefined,
+  field: CustomProfileField | undefined,
+  fieldName: string
+): EditableValue => {
+  const value = userInfo?.customData?.[fieldName];
+
+  if (field?.type === CustomProfileFieldType.Checkbox) {
+    return typeof value === 'boolean' ? value : field.config.defaultValue === 'true';
+  }
+
+  return getStringValue(value);
+};
+
+const getEnabledParts = (field: CustomProfileField, fallback: readonly string[]): FieldPart[] =>
+  field.config.parts?.filter(({ enabled }) => enabled) ??
+  fallback.map((name) => ({
+    enabled: true,
+    name,
+    type: CustomProfileFieldType.Text,
+    required: field.required,
+  }));
+
+const getFallbackCustomProfileField = (
+  field: ProfileFieldRow,
+  type: CustomProfileFieldType
+): CustomProfileField => ({
+  ...field,
+  tenantId: '',
+  id: '',
+  type,
+  description: null,
+  required: false,
+  config: {},
+  createdAt: 0,
+  sieOrder: 0,
+});
+
+const profileValueGetters: Record<string, (profile: UserProfile | undefined) => unknown> = {
+  familyName: (profile) => profile?.familyName,
+  givenName: (profile) => profile?.givenName,
+  middleName: (profile) => profile?.middleName,
+  nickname: (profile) => profile?.nickname,
+  preferredUsername: (profile) => profile?.preferredUsername,
+  profile: (profile) => profile?.profile,
+  website: (profile) => profile?.website,
+  gender: (profile) => profile?.gender,
+  birthdate: (profile) => profile?.birthdate,
+  zoneinfo: (profile) => profile?.zoneinfo,
+  locale: (profile) => profile?.locale,
+};
+
+const addressValueGetters: Record<
+  string,
+  (address: UserProfile['address'] | undefined) => unknown
+> = {
+  formatted: (address) => address?.formatted,
+  streetAddress: (address) => address?.streetAddress,
+  locality: (address) => address?.locality,
+  region: (address) => address?.region,
+  postalCode: (address) => address?.postalCode,
+  country: (address) => address?.country,
+};
+
+export const getDateFormat = (config?: CustomProfileFieldBaseConfig): string | undefined =>
+  config?.format === SupportedDateFormat.Custom ? config.customFormat : config?.format;
+
+const getBuiltInFieldType = (name: string): CustomProfileFieldType => {
+  if (name === 'birthdate') {
+    return CustomProfileFieldType.Date;
+  }
+
+  if (name === 'gender') {
+    return CustomProfileFieldType.Select;
+  }
+
+  if (name === 'profile' || name === 'website') {
+    return CustomProfileFieldType.Url;
+  }
+
+  return CustomProfileFieldType.Text;
+};
+
+const getBuiltInFieldConfig = (
+  name: string,
+  translate: Translate
+): CustomProfileFieldBaseConfig | undefined => {
+  if (name === 'birthdate') {
+    return {
+      format: SupportedDateFormat.ISO,
+      placeholder: SupportedDateFormat.ISO,
+    };
+  }
+
+  if (name === 'gender') {
+    return {
+      options: Object.values(Gender).map((value) => ({
+        value,
+        label: translate(`profile.gender_options.${value}`),
+      })),
+    };
+  }
+};
+
+const isValidDate = (value: string, config?: CustomProfileFieldBaseConfig): boolean => {
+  const dateFormat = getDateFormat(config);
+
+  if (!dateFormat) {
+    return true;
+  }
+
+  const parsedDate = parse(value, dateFormat, new Date(), {
+    useAdditionalDayOfYearTokens: true,
+    useAdditionalWeekYearTokens: true,
+  });
+
+  return isValid(parsedDate) && format(parsedDate, dateFormat) === value;
+};
+
+export const buildEditableFields = (
+  field: ProfileFieldRow | undefined,
+  userInfo: Partial<UserProfileResponse> | undefined,
+  translate: Translate
+): EditableField[] => {
+  if (!field) {
+    return [];
+  }
+
+  if (field.controlKey === 'name') {
+    return [
+      {
+        name: 'name',
+        label: field.label,
+        value: getStringValue(userInfo?.name),
+        type: CustomProfileFieldType.Text,
+        required: false,
+      },
+    ];
+  }
+
+  if (field.controlKey === 'customData') {
+    return [
+      {
+        name: field.name,
+        label: field.label,
+        value: getCustomFieldValue(userInfo, field.field, field.name),
+        type: field.field?.type ?? CustomProfileFieldType.Text,
+        required: field.field?.required ?? false,
+        description: field.field?.description ?? undefined,
+        config: field.field?.config,
+      },
+    ];
+  }
+
+  if (field.field?.type === CustomProfileFieldType.Fullname || field.name === 'fullname') {
+    const parts = getEnabledParts(
+      field.field ?? getFallbackCustomProfileField(field, CustomProfileFieldType.Fullname),
+      fullnameKeys
+    );
+
+    return parts.map((part) => ({
+      name: part.name,
+      label: part.label ?? translate(profilePartLabelKeys[part.name] ?? `profile.${part.name}`),
+      value: getStringValue(profileValueGetters[part.name]?.(userInfo?.profile)),
+      type: part.type,
+      required: part.required,
+      description: part.description,
+      config: part.config,
+    }));
+  }
+
+  if (field.field?.type === CustomProfileFieldType.Address || field.name === 'address') {
+    const parts = getEnabledParts(
+      field.field ?? getFallbackCustomProfileField(field, CustomProfileFieldType.Address),
+      userProfileAddressKeys
+    );
+
+    return parts.map((part) => ({
+      name: part.name,
+      label:
+        part.label ?? translate(profilePartLabelKeys[part.name] ?? `profile.address.${part.name}`),
+      value: getStringValue(addressValueGetters[part.name]?.(userInfo?.profile?.address)),
+      type: part.type,
+      required: part.required,
+      description: part.description,
+      config: part.config,
+    }));
+  }
+
+  return [
+    {
+      name: field.name,
+      label: field.label,
+      value: getStringValue(profileValueGetters[field.name]?.(userInfo?.profile)),
+      type: field.field?.type ?? getBuiltInFieldType(field.name),
+      required: field.field?.required ?? false,
+      description: field.field?.description ?? undefined,
+      config: field.field?.config ?? getBuiltInFieldConfig(field.name, translate),
+    },
+  ];
+};
+
+const getNumberValidationError = (
+  value: string,
+  config: CustomProfileFieldBaseConfig,
+  invalidMessage: string,
+  translate: Translate
+): string | undefined => {
+  const numberValue = Number(value);
+
+  if (Number.isNaN(numberValue)) {
+    return invalidMessage;
+  }
+
+  if (
+    (config.minValue !== undefined && numberValue < config.minValue) ||
+    (config.maxValue !== undefined && numberValue > config.maxValue)
+  ) {
+    return translate('error.invalid_min_max_input', {
+      minValue: config.minValue,
+      maxValue: config.maxValue,
+    });
+  }
+};
+
+const getTextValidationError = (
+  value: string,
+  config: CustomProfileFieldBaseConfig,
+  translate: Translate
+): string | undefined => {
+  if (
+    (config.minLength !== undefined && value.length < config.minLength) ||
+    (config.maxLength !== undefined && value.length > config.maxLength)
+  ) {
+    return translate('error.invalid_min_max_length', {
+      minLength: config.minLength,
+      maxLength: config.maxLength,
+    });
+  }
+};
+
+export const getValidationError = (
+  value: EditableValue,
+  field: EditableField,
+  translate: Translate
+): string | undefined => {
+  if (field.required && (value === '' || value === false)) {
+    return translate('error.general_required', { types: [field.label] });
+  }
+
+  if (value === '' || typeof value === 'boolean') {
+    return;
+  }
+
+  const { config = {}, type } = field;
+  const invalidMessage = translate('error.general_invalid', { types: [field.label] });
+
+  if (type === CustomProfileFieldType.Date) {
+    return isValidDate(value, config) ? undefined : invalidMessage;
+  }
+
+  if (type === CustomProfileFieldType.Regex && config.format) {
+    return new RegExp(config.format).test(value) ? undefined : invalidMessage;
+  }
+
+  if (type === CustomProfileFieldType.Url) {
+    return isValidUrl(value) ? undefined : invalidMessage;
+  }
+
+  if (type === CustomProfileFieldType.Number) {
+    return getNumberValidationError(value, config, invalidMessage, translate);
+  }
+
+  if (type === CustomProfileFieldType.Text) {
+    return getTextValidationError(value, config, translate);
+  }
+};
+
+export const getCustomDataValue = ({ type }: EditableField, value: EditableValue) => {
+  if (type === CustomProfileFieldType.Checkbox) {
+    return Boolean(value);
+  }
+
+  if (type === CustomProfileFieldType.Number && value !== '') {
+    return Number(value);
+  }
+
+  return String(value);
+};
+
+export const getProfileValue = (value: EditableValue): string =>
+  typeof value === 'boolean' ? '' : value;

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/utils.ts
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/utils.ts
@@ -1,4 +1,3 @@
-import { isValidUrl } from '@logto/core-kit';
 import {
   CustomProfileFieldType,
   Gender,
@@ -11,7 +10,6 @@ import {
   type UserProfile,
   type UserProfileResponse,
 } from '@logto/schemas';
-import { format, isValid, parse } from 'date-fns';
 
 import type { ProfileFieldRow } from '../types';
 
@@ -53,6 +51,12 @@ const getStringValue = (value: unknown): string => {
   return '';
 };
 
+const getCheckboxDefaultValue = ({
+  config,
+}: {
+  readonly config?: CustomProfileField['config'];
+}): boolean => config?.defaultValue === 'true';
+
 const getCustomFieldValue = (
   userInfo: Partial<UserProfileResponse> | undefined,
   field: CustomProfileField | undefined,
@@ -61,7 +65,15 @@ const getCustomFieldValue = (
   const value = userInfo?.customData?.[fieldName];
 
   if (field?.type === CustomProfileFieldType.Checkbox) {
-    return typeof value === 'boolean' ? value : field.config.defaultValue === 'true';
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (value === 'true' || value === 'false') {
+      return value === 'true';
+    }
+
+    return getCheckboxDefaultValue(field);
   }
 
   return getStringValue(value);
@@ -157,21 +169,6 @@ const getBuiltInFieldConfig = (
   }
 };
 
-const isValidDate = (value: string, config?: CustomProfileFieldBaseConfig): boolean => {
-  const dateFormat = getDateFormat(config);
-
-  if (!dateFormat) {
-    return true;
-  }
-
-  const parsedDate = parse(value, dateFormat, new Date(), {
-    useAdditionalDayOfYearTokens: true,
-    useAdditionalWeekYearTokens: true,
-  });
-
-  return isValid(parsedDate) && format(parsedDate, dateFormat) === value;
-};
-
 export const buildEditableFields = (
   field: ProfileFieldRow | undefined,
   userInfo: Partial<UserProfileResponse> | undefined,
@@ -255,82 +252,6 @@ export const buildEditableFields = (
   ];
 };
 
-const getNumberValidationError = (
-  value: string,
-  config: CustomProfileFieldBaseConfig,
-  invalidMessage: string,
-  translate: Translate
-): string | undefined => {
-  const numberValue = Number(value);
-
-  if (Number.isNaN(numberValue)) {
-    return invalidMessage;
-  }
-
-  if (
-    (config.minValue !== undefined && numberValue < config.minValue) ||
-    (config.maxValue !== undefined && numberValue > config.maxValue)
-  ) {
-    return translate('error.invalid_min_max_input', {
-      minValue: config.minValue,
-      maxValue: config.maxValue,
-    });
-  }
-};
-
-const getTextValidationError = (
-  value: string,
-  config: CustomProfileFieldBaseConfig,
-  translate: Translate
-): string | undefined => {
-  if (
-    (config.minLength !== undefined && value.length < config.minLength) ||
-    (config.maxLength !== undefined && value.length > config.maxLength)
-  ) {
-    return translate('error.invalid_min_max_length', {
-      minLength: config.minLength,
-      maxLength: config.maxLength,
-    });
-  }
-};
-
-export const getValidationError = (
-  value: EditableValue,
-  field: EditableField,
-  translate: Translate
-): string | undefined => {
-  if (field.required && (value === '' || value === false)) {
-    return translate('error.general_required', { types: [field.label] });
-  }
-
-  if (value === '' || typeof value === 'boolean') {
-    return;
-  }
-
-  const { config = {}, type } = field;
-  const invalidMessage = translate('error.general_invalid', { types: [field.label] });
-
-  if (type === CustomProfileFieldType.Date) {
-    return isValidDate(value, config) ? undefined : invalidMessage;
-  }
-
-  if (type === CustomProfileFieldType.Regex && config.format) {
-    return new RegExp(config.format).test(value) ? undefined : invalidMessage;
-  }
-
-  if (type === CustomProfileFieldType.Url) {
-    return isValidUrl(value) ? undefined : invalidMessage;
-  }
-
-  if (type === CustomProfileFieldType.Number) {
-    return getNumberValidationError(value, config, invalidMessage, translate);
-  }
-
-  if (type === CustomProfileFieldType.Text) {
-    return getTextValidationError(value, config, translate);
-  }
-};
-
 export const getCustomDataValue = ({ type }: EditableField, value: EditableValue) => {
   if (type === CustomProfileFieldType.Checkbox) {
     return Boolean(value);
@@ -345,3 +266,44 @@ export const getCustomDataValue = ({ type }: EditableField, value: EditableValue
 
 export const getProfileValue = (value: EditableValue): string =>
   typeof value === 'boolean' ? '' : value;
+
+type UserProfileAddress = NonNullable<UserProfile['address']>;
+
+const userProfileAddressKeySet = new Set<string>(userProfileAddressKeys);
+
+const isUserProfileAddressKey = (key: string): key is keyof UserProfileAddress =>
+  userProfileAddressKeySet.has(key);
+
+export const buildAddressProfileValue = (
+  currentAddress: UserProfile['address'] | undefined,
+  fields: readonly EditableField[],
+  values: Readonly<Record<string, EditableValue>>
+): UserProfileAddress => {
+  const editedAddress = fields.reduce<UserProfileAddress>((address, { name }) => {
+    if (!isUserProfileAddressKey(name)) {
+      return address;
+    }
+
+    return {
+      ...address,
+      [name]: getProfileValue(values[name] ?? ''),
+    };
+  }, {});
+
+  const address = {
+    ...currentAddress,
+    ...editedAddress,
+  };
+
+  if (fields.some(({ name }) => name === 'formatted')) {
+    return address;
+  }
+
+  return {
+    ...address,
+    formatted: fields
+      .map(({ name }) => (isUserProfileAddressKey(name) ? address[name] : undefined))
+      .filter(Boolean)
+      .join(', '),
+  };
+};

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/utils.ts
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/utils.ts
@@ -299,6 +299,7 @@ export const buildAddressProfileValue = (
     return address;
   }
 
+  // Match sign-up AddressSubForm: formatted is derived from enabled parts only.
   return {
     ...address,
     formatted: fields

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/validation.ts
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/validation.ts
@@ -13,12 +13,16 @@ const isValidDate = (value: string, config?: CustomProfileFieldBaseConfig): bool
     return true;
   }
 
-  const parsedDate = parse(value, dateFormat, new Date(), {
-    useAdditionalDayOfYearTokens: true,
-    useAdditionalWeekYearTokens: true,
-  });
+  try {
+    const parsedDate = parse(value, dateFormat, new Date(), {
+      useAdditionalDayOfYearTokens: true,
+      useAdditionalWeekYearTokens: true,
+    });
 
-  return isValid(parsedDate) && format(parsedDate, dateFormat) === value;
+    return isValid(parsedDate) && format(parsedDate, dateFormat) === value;
+  } catch {
+    return false;
+  }
 };
 
 const getNumberValidationError = (

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/validation.ts
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/validation.ts
@@ -1,0 +1,114 @@
+import { isValidUrl } from '@logto/core-kit';
+import { CustomProfileFieldType, type CustomProfileFieldBaseConfig } from '@logto/schemas';
+import { format, isValid, parse } from 'date-fns';
+
+import { getDateFormat, type EditableField, type EditableValue } from './utils';
+
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+const isValidDate = (value: string, config?: CustomProfileFieldBaseConfig): boolean => {
+  const dateFormat = getDateFormat(config);
+
+  if (!dateFormat) {
+    return true;
+  }
+
+  const parsedDate = parse(value, dateFormat, new Date(), {
+    useAdditionalDayOfYearTokens: true,
+    useAdditionalWeekYearTokens: true,
+  });
+
+  return isValid(parsedDate) && format(parsedDate, dateFormat) === value;
+};
+
+const getNumberValidationError = (
+  value: string,
+  config: CustomProfileFieldBaseConfig,
+  invalidMessage: string,
+  translate: Translate
+): string | undefined => {
+  const numberValue = Number(value);
+
+  if (Number.isNaN(numberValue)) {
+    return invalidMessage;
+  }
+
+  if (
+    (config.minValue !== undefined && numberValue < config.minValue) ||
+    (config.maxValue !== undefined && numberValue > config.maxValue)
+  ) {
+    return translate('error.invalid_min_max_input', {
+      minValue: config.minValue,
+      maxValue: config.maxValue,
+    });
+  }
+};
+
+const getTextValidationError = (
+  value: string,
+  config: CustomProfileFieldBaseConfig,
+  translate: Translate
+): string | undefined => {
+  if (
+    (config.minLength !== undefined && value.length < config.minLength) ||
+    (config.maxLength !== undefined && value.length > config.maxLength)
+  ) {
+    return translate('error.invalid_min_max_length', {
+      minLength: config.minLength,
+      maxLength: config.maxLength,
+    });
+  }
+};
+
+const getRegexValidationError = (
+  value: string,
+  config: CustomProfileFieldBaseConfig,
+  invalidMessage: string
+): string | undefined => {
+  if (!config.format) {
+    return;
+  }
+
+  try {
+    return new RegExp(config.format).test(value) ? undefined : invalidMessage;
+  } catch {
+    return invalidMessage;
+  }
+};
+
+export const getValidationError = (
+  value: EditableValue,
+  field: EditableField,
+  translate: Translate
+): string | undefined => {
+  if (field.required && (value === '' || value === false)) {
+    return translate('error.general_required', { types: [field.label] });
+  }
+
+  if (value === '' || typeof value === 'boolean') {
+    return;
+  }
+
+  const { config = {}, type } = field;
+  const invalidMessage = translate('error.general_invalid', { types: [field.label] });
+
+  if (type === CustomProfileFieldType.Date) {
+    return isValidDate(value, config) ? undefined : invalidMessage;
+  }
+
+  if (type === CustomProfileFieldType.Regex) {
+    return getRegexValidationError(value, config, invalidMessage);
+  }
+
+  if (type === CustomProfileFieldType.Url) {
+    return isValidUrl(value) ? undefined : invalidMessage;
+  }
+
+  if (type === CustomProfileFieldType.Number) {
+    return getNumberValidationError(value, config, invalidMessage, translate);
+  }
+
+  if (type === CustomProfileFieldType.Text) {
+    return getTextValidationError(value, config, translate);
+  }
+};

--- a/packages/account/src/pages/Profile/index.module.scss
+++ b/packages/account/src/pages/Profile/index.module.scss
@@ -14,7 +14,8 @@
 
 .row {
   display: grid;
-  grid-template-columns: minmax(0, 200px) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 200px) minmax(0, 1fr) auto;
+  grid-auto-flow: dense;
   column-gap: _.unit(6);
   align-items: center;
   padding: _.unit(5) _.unit(6);
@@ -25,13 +26,19 @@
   }
 }
 
+.topLine {
+  display: contents;
+}
+
 .name {
+  grid-column: 1;
   min-width: 0;
   font: var(--font-label-2);
   color: var(--color-type-primary);
 }
 
 .value {
+  grid-column: 2;
   min-width: 0;
   font: var(--font-body-2);
   color: var(--color-type-primary);
@@ -51,6 +58,28 @@
   display: block;
 }
 
+.actions {
+  grid-column: 3;
+  display: flex;
+  align-items: center;
+  gap: _.unit(6);
+  flex-shrink: 0;
+}
+
+.changeButton {
+  font: var(--font-label-2);
+  color: var(--color-type-link);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: _.unit(0.5) 0;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
 :global(body.mobile) {
   .row {
     display: flex;
@@ -59,5 +88,29 @@
     align-items: stretch;
     gap: _.unit(1);
     padding: _.unit(4);
+  }
+
+  .topLine {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: _.unit(3);
+    width: 100%;
+  }
+
+  .name,
+  .value {
+    width: 100%;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .changeButton {
+    padding: 0;
+    white-space: normal;
+    text-align: left;
   }
 }

--- a/packages/account/src/pages/Profile/index.test.tsx
+++ b/packages/account/src/pages/Profile/index.test.tsx
@@ -1,0 +1,222 @@
+import type { SignInExperienceResponse } from '@experience/shared/types';
+import {
+  AccountCenterControlValue,
+  CustomProfileFieldType,
+  Gender,
+  type AccountCenter,
+  type CustomProfileField,
+  type UserProfileResponse,
+} from '@logto/schemas';
+import { fireEvent, waitFor } from '@testing-library/react';
+
+import type { PageContextType } from '@ac/Providers/PageContextProvider/PageContext';
+import renderWithPageContext, {
+  mockAccountCenterSettings,
+  mockSignInExperienceSettings,
+  mockUserInfo,
+} from '@ac/__mocks__/RenderWithPageContext';
+
+import { updateCustomData, updateName, updateProfile } from '../../apis/account';
+
+import Profile from '.';
+
+const mockGetAccessToken = jest.fn().mockResolvedValue('access-token');
+
+jest.mock('@logto/react', () => ({
+  useLogto: () => ({
+    getAccessToken: mockGetAccessToken,
+  }),
+}));
+
+jest.mock('../../apis/account', () => ({
+  updateCustomData: jest.fn(),
+  updateName: jest.fn(),
+  updateProfile: jest.fn(),
+}));
+
+type ProfileRenderOptions = {
+  readonly accountCenterSettings?: Omit<Partial<AccountCenter>, 'fields'> & {
+    readonly fields?: Partial<AccountCenter['fields']>;
+  };
+  readonly experienceSettings?: Partial<SignInExperienceResponse>;
+  readonly userInfo?: Partial<UserProfileResponse>;
+  readonly refreshUserInfo?: () => Promise<void>;
+  readonly setToast?: PageContextType['setToast'];
+};
+
+const favoriteColorField = {
+  tenantId: 'default',
+  id: 'favoriteColor',
+  name: 'favoriteColor',
+  type: CustomProfileFieldType.Select,
+  label: 'Favorite color',
+  description: null,
+  required: false,
+  config: {
+    options: [
+      { label: 'Red', value: 'red' },
+      { label: 'Blue', value: 'blue' },
+    ],
+  },
+  createdAt: 0,
+  sieOrder: 0,
+} satisfies CustomProfileField;
+
+const renderProfile = ({
+  accountCenterSettings,
+  experienceSettings,
+  userInfo,
+  refreshUserInfo,
+  setToast,
+}: ProfileRenderOptions = {}) => {
+  const { fields, ...accountCenterSettingsOverrides } = accountCenterSettings ?? {};
+
+  return renderWithPageContext(
+    <Profile />,
+    {
+      future: {
+        v7_relativeSplatPath: true,
+        v7_startTransition: true,
+      },
+    },
+    {
+      pageContext: {
+        accountCenterSettings: {
+          ...mockAccountCenterSettings,
+          profileFields: [
+            { name: 'name' },
+            { name: 'avatar' },
+            { name: 'birthdate' },
+            { name: 'favoriteColor' },
+          ],
+          fields: {
+            ...mockAccountCenterSettings.fields,
+            ...fields,
+          },
+          ...accountCenterSettingsOverrides,
+        },
+        experienceSettings: {
+          ...mockSignInExperienceSettings,
+          customProfileFields: [favoriteColorField],
+          ...experienceSettings,
+        },
+        userInfo: {
+          ...mockUserInfo,
+          avatar: 'https://example.com/avatar.png',
+          profile: {
+            birthdate: '2023-08-20',
+          },
+          customData: {
+            favoriteColor: 'red',
+            retained: 'value',
+          },
+          ...userInfo,
+        },
+        ...(refreshUserInfo && { refreshUserInfo }),
+        ...(setToast && { setToast }),
+      },
+    }
+  );
+};
+
+describe('<Profile />', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockGetAccessToken.mockResolvedValue('access-token');
+    jest.mocked(updateCustomData).mockResolvedValue(undefined);
+    jest.mocked(updateName).mockResolvedValue(undefined);
+    jest.mocked(updateProfile).mockResolvedValue(undefined);
+  });
+
+  it('renders change actions for editable non-avatar fields', () => {
+    const { queryAllByText } = renderProfile();
+
+    expect(queryAllByText('account_center.security.change')).toHaveLength(3);
+  });
+
+  it('updates the name field from the edit modal', async () => {
+    const refreshUserInfo = jest.fn().mockResolvedValue(undefined);
+    const setToast = jest.fn();
+    const { getByDisplayValue, getByText, queryAllByText } = renderProfile({
+      refreshUserInfo,
+      setToast,
+    });
+
+    fireEvent.click(queryAllByText('account_center.security.change')[0]!);
+    fireEvent.change(getByDisplayValue('Alex'), { target: { value: 'Alex Changed' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(updateName).toHaveBeenCalledWith('access-token', { name: 'Alex Changed' });
+    });
+    expect(refreshUserInfo).toHaveBeenCalledTimes(1);
+    expect(setToast).toHaveBeenCalledWith('account_center.update_success.default.description');
+  });
+
+  it('updates custom data fields without dropping existing custom data', async () => {
+    const { getByText, queryAllByText } = renderProfile();
+
+    fireEvent.click(queryAllByText('account_center.security.change')[2]!);
+    fireEvent.click(document.querySelector('input[name="favoriteColor"]')!);
+    fireEvent.click(getByText('Blue'));
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(updateCustomData).toHaveBeenCalledWith('access-token', {
+        favoriteColor: 'blue',
+        retained: 'value',
+      });
+    });
+  });
+
+  it('renders built-in gender with translated label', () => {
+    const { getByText } = renderProfile({
+      accountCenterSettings: {
+        profileFields: [{ name: 'gender' }],
+      },
+      userInfo: {
+        profile: {
+          gender: Gender.Male,
+        },
+      },
+    });
+
+    expect(getByText('profile.gender_options.male')).toBeTruthy();
+  });
+
+  it('edits birthdate with segmented date inputs', async () => {
+    const { getByText, queryAllByText } = renderProfile();
+
+    fireEvent.click(queryAllByText('account_center.security.change')[1]!);
+
+    const [yearInput, monthInput, dayInput] = document.querySelectorAll(
+      'input[inputmode="numeric"]'
+    );
+
+    fireEvent.change(yearInput!, { target: { value: '2024' } });
+    fireEvent.change(monthInput!, { target: { value: '01' } });
+    fireEvent.change(dayInput!, { target: { value: '02' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(updateProfile).toHaveBeenCalledWith('access-token', {
+        birthdate: '2024-01-02',
+      });
+    });
+  });
+
+  it('does not show change actions for read-only fields', () => {
+    const { queryByText } = renderProfile({
+      accountCenterSettings: {
+        fields: {
+          name: AccountCenterControlValue.ReadOnly,
+          avatar: AccountCenterControlValue.ReadOnly,
+          profile: AccountCenterControlValue.ReadOnly,
+          customData: AccountCenterControlValue.ReadOnly,
+        },
+      },
+    });
+
+    expect(queryByText('account_center.security.change')).toBeNull();
+  });
+});

--- a/packages/account/src/pages/Profile/index.test.tsx
+++ b/packages/account/src/pages/Profile/index.test.tsx
@@ -44,6 +44,19 @@ type ProfileRenderOptions = {
   readonly setToast?: PageContextType['setToast'];
 };
 
+const requiredNicknameField = {
+  tenantId: 'default',
+  id: 'nickname',
+  name: 'nickname',
+  type: CustomProfileFieldType.Text,
+  label: 'Nickname',
+  description: null,
+  required: true,
+  config: {},
+  createdAt: 0,
+  sieOrder: 0,
+} satisfies CustomProfileField;
+
 const favoriteColorField = {
   tenantId: 'default',
   id: 'favoriteColor',
@@ -202,6 +215,86 @@ describe('<Profile />', () => {
       expect(updateProfile).toHaveBeenCalledWith('access-token', {
         birthdate: '2024-01-02',
       });
+    });
+  });
+
+  it('keeps the modal open and reports errors when the update API fails', async () => {
+    const refreshUserInfo = jest.fn().mockResolvedValue(undefined);
+    const setToast = jest.fn();
+    jest.mocked(updateName).mockRejectedValue(new Error('network error'));
+
+    const { getByDisplayValue, getByText, queryAllByText } = renderProfile({
+      refreshUserInfo,
+      setToast,
+    });
+
+    fireEvent.click(queryAllByText('account_center.security.change')[0]!);
+    fireEvent.change(getByDisplayValue('Alex'), { target: { value: 'Alex Changed' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(setToast).toHaveBeenCalledWith('error.unknown');
+    });
+    expect(refreshUserInfo).not.toHaveBeenCalled();
+    expect(getByText('action.save')).toBeTruthy();
+  });
+
+  it('blocks submit for required fields and does not call the update API', async () => {
+    const { getByText, queryAllByText } = renderProfile({
+      accountCenterSettings: {
+        profileFields: [{ name: 'nickname' }],
+      },
+      experienceSettings: {
+        customProfileFields: [requiredNicknameField],
+      },
+      userInfo: {
+        profile: {
+          nickname: 'Alex',
+        },
+      },
+    });
+
+    fireEvent.click(queryAllByText('account_center.security.change')[0]!);
+    fireEvent.change(document.querySelector('input[name="nickname"]')!, {
+      target: { value: '' },
+    });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(getByText('error.general_required')).toBeTruthy();
+    });
+    expect(updateProfile).not.toHaveBeenCalled();
+  });
+
+  it('shows a validation error for invalid birthdate input', async () => {
+    const { getByText, queryAllByText } = renderProfile();
+
+    fireEvent.click(queryAllByText('account_center.security.change')[1]!);
+
+    const [yearInput, monthInput, dayInput] = document.querySelectorAll(
+      'input[inputmode="numeric"]'
+    );
+
+    fireEvent.change(yearInput!, { target: { value: '2024' } });
+    fireEvent.change(monthInput!, { target: { value: '13' } });
+    fireEvent.change(dayInput!, { target: { value: '01' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(getByText('error.general_invalid')).toBeTruthy();
+    });
+    expect(updateProfile).not.toHaveBeenCalled();
+  });
+
+  it('clears the name field by sending null to the update API', async () => {
+    const { getByDisplayValue, getByText, queryAllByText } = renderProfile();
+
+    fireEvent.click(queryAllByText('account_center.security.change')[0]!);
+    fireEvent.change(getByDisplayValue('Alex'), { target: { value: '' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(updateName).toHaveBeenCalledWith('access-token', { name: null });
     });
   });
 

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -5,14 +5,13 @@ import {
   userProfileAddressKeys,
   userProfileKeys,
   type AccountCenter,
-  type AccountCenterFieldControl,
   type AccountCenterProfileFields,
   type CustomProfileField,
   type UserProfile,
   type UserProfileResponse,
 } from '@logto/schemas';
 import classNames from 'classnames';
-import { useContext, useMemo } from 'react';
+import { useCallback, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
@@ -21,18 +20,10 @@ import { layoutClassNames } from '@ac/constants/layout';
 
 import homeStyles from '../Home/index.module.scss';
 
+import EditProfileFieldModal from './EditProfileFieldModal';
 import styles from './index.module.scss';
-
-type ProfileFieldControlKey = Extract<
-  keyof AccountCenterFieldControl,
-  'name' | 'avatar' | 'profile' | 'customData'
->;
-
-type ProfileFieldRow = {
-  name: string;
-  label: string;
-  value?: React.ReactNode;
-};
+import { getSelectOptionLabel } from './select-options';
+import type { ProfileFieldControlKey, ProfileFieldRow } from './types';
 
 const profileFieldKeySet = new Set<string>(userProfileKeys);
 const fullnameKeySet = new Set<string>(fullnameKeys);
@@ -187,8 +178,8 @@ const getCompositeFieldValue = (
 
 const getProfileFieldValue = (
   userInfo: Partial<UserProfileResponse> | undefined,
-  fieldName: string,
-  fieldLabel: string,
+  { name: fieldName, label: fieldLabel }: { readonly name: string; readonly label: string },
+  translate: (key: string) => string,
   field?: CustomProfileField
 ): React.ReactNode | undefined => {
   if (fieldName === 'avatar') {
@@ -217,13 +208,17 @@ const getProfileFieldValue = (
       ? getBuiltInProfileFieldValue(userInfo?.profile, fieldName)
       : getPrimitiveValue(userInfo?.customData?.[fieldName]);
 
-    return value === undefined
-      ? undefined
-      : (field.config.options?.find((option) => option.value === value)?.label ?? value);
+    const option = field.config.options?.find((option) => option.value === value);
+
+    return value === undefined ? undefined : getSelectOptionLabel(value, option?.label, translate);
   }
 
   if (isBuiltInProfileField(fieldName, field)) {
-    return getBuiltInProfileFieldValue(userInfo?.profile, fieldName);
+    const value = getBuiltInProfileFieldValue(userInfo?.profile, fieldName);
+
+    return fieldName === 'gender' && value
+      ? getSelectOptionLabel(value, undefined, translate)
+      : value;
   }
 
   return getPrimitiveValue(userInfo?.customData?.[fieldName]);
@@ -231,8 +226,10 @@ const getProfileFieldValue = (
 
 const Profile = () => {
   const { t } = useTranslation();
-  const { accountCenterSettings, experienceSettings, userInfo } = useContext(PageContext);
+  const { accountCenterSettings, experienceSettings, userInfo, refreshUserInfo, setToast } =
+    useContext(PageContext);
   const profileFields = getAccountCenterProfileFields(accountCenterSettings);
+  const [editingField, setEditingField] = useState<ProfileFieldRow>();
 
   const fieldRows = useMemo(() => {
     const customProfileFields = experienceSettings?.customProfileFields ?? [];
@@ -259,7 +256,10 @@ const Profile = () => {
         {
           name,
           label,
-          value: getProfileFieldValue(userInfo, name, label, field),
+          value: getProfileFieldValue(userInfo, { name, label }, t, field),
+          controlKey,
+          controlValue,
+          field,
         },
       ];
     }, []);
@@ -271,34 +271,68 @@ const Profile = () => {
     userInfo,
   ]);
 
+  const handleUpdated = useCallback(async () => {
+    await refreshUserInfo();
+    setToast(t('account_center.update_success.default.description'));
+  }, [refreshUserInfo, setToast, t]);
+
   return (
-    <div className={homeStyles.container}>
-      <div className={homeStyles.header}>
-        <div className={classNames(homeStyles.title, layoutClassNames.pageTitle)}>
-          {t('account_center.page.profile_title')}
-        </div>
-        <div className={classNames(homeStyles.description, layoutClassNames.pageDescription)}>
-          {t('account_center.page.profile_description')}
-        </div>
-      </div>
-      <div className={classNames(homeStyles.content, layoutClassNames.pageContent)}>
-        {fieldRows.length > 0 && (
-          <div className={classNames(styles.section, layoutClassNames.section)}>
-            <div className={classNames(styles.card, layoutClassNames.card)}>
-              {fieldRows.map(({ name, label, value }) => (
-                <div key={name} className={classNames(styles.row, layoutClassNames.row)}>
-                  <div className={styles.name}>{label}</div>
-                  <div className={classNames(styles.value, !value && styles.secondaryValue)}>
-                    {value ?? t('account_center.security.not_set')}
-                  </div>
-                </div>
-              ))}
-            </div>
+    <>
+      <div className={homeStyles.container}>
+        <div className={homeStyles.header}>
+          <div className={classNames(homeStyles.title, layoutClassNames.pageTitle)}>
+            {t('account_center.page.profile_title')}
           </div>
-        )}
+          <div className={classNames(homeStyles.description, layoutClassNames.pageDescription)}>
+            {t('account_center.page.profile_description')}
+          </div>
+        </div>
+        <div className={classNames(homeStyles.content, layoutClassNames.pageContent)}>
+          {fieldRows.length > 0 && (
+            <div className={classNames(styles.section, layoutClassNames.section)}>
+              <div className={classNames(styles.card, layoutClassNames.card)}>
+                {fieldRows.map((fieldRow) => {
+                  const { name, label, value, controlValue } = fieldRow;
+
+                  return (
+                    <div key={name} className={classNames(styles.row, layoutClassNames.row)}>
+                      <div className={styles.topLine}>
+                        <div className={styles.name}>{label}</div>
+                        {name !== 'avatar' && controlValue === AccountCenterControlValue.Edit && (
+                          <div className={styles.actions}>
+                            <button
+                              type="button"
+                              className={styles.changeButton}
+                              onClick={() => {
+                                setEditingField(fieldRow);
+                              }}
+                            >
+                              {t('account_center.security.change')}
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                      <div className={classNames(styles.value, !value && styles.secondaryValue)}>
+                        {value ?? t('account_center.security.not_set')}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+        <PageFooter />
       </div>
-      <PageFooter />
-    </div>
+      <EditProfileFieldModal
+        field={editingField}
+        userInfo={userInfo}
+        onUpdated={handleUpdated}
+        onClose={() => {
+          setEditingField(undefined);
+        }}
+      />
+    </>
   );
 };
 

--- a/packages/account/src/pages/Profile/select-options.ts
+++ b/packages/account/src/pages/Profile/select-options.ts
@@ -1,0 +1,18 @@
+import { Gender } from '@logto/schemas';
+
+type Translate = (key: string) => string;
+
+const isGenderOptionKey = (key: string): key is Gender =>
+  Object.values<string>(Gender).includes(key);
+
+export const getSelectOptionLabel = (
+  value: string,
+  label: string | undefined,
+  translate: Translate
+) => {
+  if (!label && isGenderOptionKey(value)) {
+    return translate(`profile.gender_options.${value}`);
+  }
+
+  return label ?? value;
+};

--- a/packages/account/src/pages/Profile/types.ts
+++ b/packages/account/src/pages/Profile/types.ts
@@ -1,0 +1,19 @@
+import {
+  type AccountCenterControlValue,
+  type AccountCenterFieldControl,
+  type CustomProfileField,
+} from '@logto/schemas';
+
+export type ProfileFieldControlKey = Extract<
+  keyof AccountCenterFieldControl,
+  'name' | 'avatar' | 'profile' | 'customData'
+>;
+
+export type ProfileFieldRow = {
+  name: string;
+  label: string;
+  value?: React.ReactNode;
+  controlKey: ProfileFieldControlKey;
+  controlValue: AccountCenterControlValue;
+  field?: CustomProfileField;
+};


### PR DESCRIPTION
## Summary
- Add editable Account Center profile field modal and update APIs for name, profile, and custom data changes.
- Reuse the experience select field for select inputs and show translated gender labels.
- Add tests for profile field editing and display behavior.

## Testing
Unit tests