### PR TITLE
fix(account): redirect expired sessions without error flash

### DIFF
--- a/.changeset/soft-plums-return.md
+++ b/.changeset/soft-plums-return.md
@@ -1,0 +1,5 @@
+---
+"@logto/account": patch
+---
+
+redirect expired account center sessions without flashing the manual sign-in error

--- a/packages/account/src/pages/SessionExpired/index.test.tsx
+++ b/packages/account/src/pages/SessionExpired/index.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import renderWithPageContext from '@ac/__mocks__/RenderWithPageContext';
+
+import SessionExpired from '.';
+
+const mockSignIn = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@logto/react', () => ({
+  useLogto: () => ({
+    signIn: mockSignIn,
+  }),
+}));
+
+jest.mock('@ac/components/GlobalLoading', () => () => <div>Loading</div>);
+
+jest.mock(
+  '@ac/components/ErrorPage',
+  () =>
+    ({
+      action,
+    }: {
+      readonly action?: { readonly titleKey: string; readonly onClick: () => void };
+    }) => (
+      <div>
+        <div>Error page</div>
+        {action && <button onClick={action.onClick}>{action.titleKey}</button>}
+      </div>
+    )
+);
+
+describe('SessionExpired', () => {
+  beforeEach(() => {
+    mockSignIn.mockResolvedValue(undefined);
+    window.history.replaceState({}, '', '/account/security');
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects to sign-in without showing the error page first', async () => {
+    renderWithPageContext(<SessionExpired />);
+
+    expect(screen.getByText('Loading')).not.toBeNull();
+    expect(screen.queryByText('Error page')).toBeNull();
+
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledWith({ redirectUri: 'http://localhost/account' });
+    });
+  });
+
+  it('shows manual sign-in action when automatic redirect fails', async () => {
+    mockSignIn.mockRejectedValueOnce(new Error('Failed to redirect'));
+
+    renderWithPageContext(<SessionExpired />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Error page')).not.toBeNull();
+    });
+
+    mockSignIn.mockResolvedValue(undefined);
+    fireEvent.click(screen.getByText('action.sign_in'));
+
+    expect(screen.getByText('Loading')).not.toBeNull();
+
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/account/src/pages/SessionExpired/index.test.tsx
+++ b/packages/account/src/pages/SessionExpired/index.test.tsx
@@ -1,14 +1,17 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 
 import renderWithPageContext from '@ac/__mocks__/RenderWithPageContext';
 
 import SessionExpired from '.';
 
 const mockSignIn = jest.fn().mockResolvedValue(undefined);
+const mockSignInError = jest.fn<Error | undefined, never[]>();
 
 jest.mock('@logto/react', () => ({
   useLogto: () => ({
     signIn: mockSignIn,
+    error: mockSignInError(),
   }),
 }));
 
@@ -29,9 +32,28 @@ jest.mock(
     )
 );
 
+const SessionExpiredTest = () => {
+  const [version, setVersion] = useState(0);
+
+  return (
+    <div data-version={version}>
+      <button
+        type="button"
+        onClick={() => {
+          setVersion((value) => value + 1);
+        }}
+      >
+        Rerender
+      </button>
+      <SessionExpired />
+    </div>
+  );
+};
+
 describe('SessionExpired', () => {
   beforeEach(() => {
     mockSignIn.mockResolvedValue(undefined);
+    mockSignInError.mockReturnValue(undefined);
     window.history.replaceState({}, '', '/account/security');
     sessionStorage.clear();
   });
@@ -52,21 +74,38 @@ describe('SessionExpired', () => {
   });
 
   it('shows manual sign-in action when automatic redirect fails', async () => {
-    mockSignIn.mockRejectedValueOnce(new Error('Failed to redirect'));
+    renderWithPageContext(<SessionExpiredTest />);
 
-    renderWithPageContext(<SessionExpired />);
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledWith({ redirectUri: 'http://localhost/account' });
+    });
+
+    mockSignInError.mockReturnValue(new Error('Failed to redirect'));
+    fireEvent.click(screen.getByText('Rerender'));
 
     await waitFor(() => {
       expect(screen.getByText('Error page')).not.toBeNull();
     });
 
-    mockSignIn.mockResolvedValue(undefined);
     fireEvent.click(screen.getByText('action.sign_in'));
 
     expect(screen.getByText('Loading')).not.toBeNull();
 
     await waitFor(() => {
       expect(mockSignIn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('ignores the initial sign-in error before the redirect attempt', async () => {
+    mockSignInError.mockReturnValue(new Error('Existing session error'));
+
+    renderWithPageContext(<SessionExpired />);
+
+    expect(screen.getByText('Loading')).not.toBeNull();
+    expect(screen.queryByText('Error page')).toBeNull();
+
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledWith({ redirectUri: 'http://localhost/account' });
     });
   });
 });

--- a/packages/account/src/pages/SessionExpired/index.tsx
+++ b/packages/account/src/pages/SessionExpired/index.tsx
@@ -1,12 +1,38 @@
 import { useLogto } from '@logto/react';
+import { useCallback, useEffect, useState } from 'react';
 
 import ErrorPage from '@ac/components/ErrorPage';
+import GlobalLoading from '@ac/components/GlobalLoading';
 import { accountCenterBasePath, setRouteRestore } from '@ac/utils/account-center-route';
 
 const redirectUri = `${window.location.origin}${accountCenterBasePath}`;
 
 const SessionExpired = () => {
   const { signIn } = useLogto();
+  const [hasSignInError, setHasSignInError] = useState(false);
+
+  const redirectToSignIn = useCallback(() => {
+    setHasSignInError(false);
+    setRouteRestore(window.location.pathname);
+
+    const run = async () => {
+      try {
+        await signIn({ redirectUri });
+      } catch {
+        setHasSignInError(true);
+      }
+    };
+
+    void run();
+  }, [signIn]);
+
+  useEffect(() => {
+    redirectToSignIn();
+  }, [redirectToSignIn]);
+
+  if (!hasSignInError) {
+    return <GlobalLoading />;
+  }
 
   return (
     <ErrorPage
@@ -14,10 +40,7 @@ const SessionExpired = () => {
       messageKey="error.invalid_session"
       action={{
         titleKey: 'action.sign_in',
-        onClick: () => {
-          setRouteRestore(window.location.pathname);
-          void signIn({ redirectUri });
-        },
+        onClick: redirectToSignIn,
       }}
     />
   );

--- a/packages/account/src/pages/SessionExpired/index.tsx
+++ b/packages/account/src/pages/SessionExpired/index.tsx
@@ -1,5 +1,5 @@
 import { useLogto } from '@logto/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import ErrorPage from '@ac/components/ErrorPage';
 import GlobalLoading from '@ac/components/GlobalLoading';
@@ -8,27 +8,28 @@ import { accountCenterBasePath, setRouteRestore } from '@ac/utils/account-center
 const redirectUri = `${window.location.origin}${accountCenterBasePath}`;
 
 const SessionExpired = () => {
-  const { signIn } = useLogto();
+  const { signIn, error } = useLogto();
+  const initialSignInErrorRef = useRef(error);
   const [hasSignInError, setHasSignInError] = useState(false);
+  const [hasTriedSignIn, setHasTriedSignIn] = useState(false);
 
   const redirectToSignIn = useCallback(() => {
     setHasSignInError(false);
+    setHasTriedSignIn(true);
     setRouteRestore(window.location.pathname);
 
-    const run = async () => {
-      try {
-        await signIn({ redirectUri });
-      } catch {
-        setHasSignInError(true);
-      }
-    };
-
-    void run();
+    void signIn({ redirectUri });
   }, [signIn]);
 
   useEffect(() => {
     redirectToSignIn();
   }, [redirectToSignIn]);
+
+  useEffect(() => {
+    if (hasTriedSignIn && error && error !== initialSignInErrorRef.current) {
+      setHasSignInError(true);
+    }
+  }, [error, hasTriedSignIn]);
 
   if (!hasSignInError) {
     return <GlobalLoading />;


### PR DESCRIPTION
## Summary

- Automatically redirect expired Account Center sessions to sign-in behind the loading state.
- Keep the manual sign-in error action only as a fallback when automatic redirect fails.
- Add coverage for the expired session redirect flow.

Closes #8825

## Testing

Unit tests