### PR TITLE
refactor(console): use shared DatePicker on dashboard

### DIFF
--- a/packages/console/src/pages/Dashboard/index.tsx
+++ b/packages/console/src/pages/Dashboard/index.tsx
@@ -1,5 +1,4 @@
-import { format } from 'date-fns';
-import type { ChangeEventHandler } from 'react';
+import { format, startOfDay } from 'date-fns';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -16,7 +15,7 @@ import useSWR from 'swr';
 import AppError from '@/components/AppError';
 import PageMeta from '@/components/PageMeta';
 import Card from '@/ds-components/Card';
-import TextInput from '@/ds-components/TextInput';
+import DatePicker from '@/ds-components/DatePicker';
 import type { RequestError } from '@/hooks/use-api';
 
 import Block from './components/Block';
@@ -37,7 +36,8 @@ const tickFormatter = new Intl.NumberFormat('en-US', {
 });
 
 function Dashboard() {
-  const [date, setDate] = useState<string>(format(Date.now(), 'yyyy-MM-dd'));
+  const [date, setDate] = useState<Date>(() => startOfDay(new Date()));
+  const dateString = format(date, 'yyyy-MM-dd');
   const { data: totalData, error: totalError } = useSWR<TotalUsersResponse, RequestError>(
     'api/dashboard/users/total'
   );
@@ -45,7 +45,7 @@ function Dashboard() {
     'api/dashboard/users/new'
   );
   const { data: activeData, error: activeError } = useSWR<ActiveUsersResponse, RequestError>(
-    `api/dashboard/users/active?date=${date}`
+    `api/dashboard/users/active?date=${dateString}`
   );
   const { t, i18n } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const isRtl = i18n.dir() === 'rtl';
@@ -68,8 +68,10 @@ function Dashboard() {
   const error = totalError ?? newError ?? activeError;
   const isLoading = (!totalData || !newData || !activeData) && !error;
 
-  const handleDateChange: ChangeEventHandler<HTMLInputElement> = (event) => {
-    setDate(event.target.value || format(Date.now(), 'yyyy-MM-dd'));
+  const handleDateChange = (next: Date | undefined) => {
+    // Mirror the previous native-input behavior: clearing the field falls
+    // back to today so the chart always has a date to query.
+    setDate(startOfDay(next ?? new Date()));
   };
 
   return (
@@ -111,7 +113,12 @@ function Dashboard() {
               variant="plain"
             />
             <div className={styles.datePicker}>
-              <TextInput type="date" value={date} onChange={handleDateChange} />
+              <DatePicker
+                value={date}
+                max={startOfDay(new Date())}
+                todayLabel={t('general.today')}
+                onChange={handleDateChange}
+              />
             </div>
             <div className={styles.curve}>
               <ResponsiveContainer>


### PR DESCRIPTION
## Summary
The Dashboard's daily-active-users chart still used a native `<input type="date">` (via `TextInput type="date"`), which renders dates in the OS regional format and disagrees with `toLocaleDateString()` on the same machine. The Audit Logs page already replaced its native picker with the shared `DatePicker` ds-component (PR #8822); this PR brings the Dashboard onto the same component so the two surfaces look and behave consistently.

### What changed
- `packages/console/src/pages/Dashboard/index.tsx`
  - Swap `TextInput type="date"` for `<DatePicker>` from `@/ds-components/DatePicker`.
  - State holds a `Date` (seeded with `startOfDay(new Date())`) instead of a `yyyy-MM-dd` string; the API URL derives `dateString` via `format(date, 'yyyy-MM-dd')` at the boundary.
  - `handleDateChange` accepts `Date | undefined` and falls back to today on clear — preserves the previous native-input behavior where blanking the field reset to today.
  - `max = startOfDay(new Date())` caps selection at today, matching the previous server-side validation.

### Expected result
- Dashboard date picker now displays the selected date via `toLocaleDateString()` (browser language), matching the Time column and the Audit Logs picker.
- Calendar popover follows the active Console theme (light / dark) and uses Logto's font stack.
- API contract (`api/dashboard/users/active?date=YYYY-MM-DD`) is unchanged.

## Testing
Tested locally

<img width="2650" height="1564" alt="image" src="https://github.com/user-attachments/assets/1e4d7975-298d-42fc-9641-70828b5a5608" />


## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments