### PR TITLE
feat(core): emit addedUserIds/removedUserIds on org user-membership webhooks

### DIFF
--- a/packages/core/src/libraries/hook/context-manager.ts
+++ b/packages/core/src/libraries/hook/context-manager.ts
@@ -49,7 +49,14 @@ type UserContext = {
  * A map of data hook event to its context type for better type hinting.
  */
 type DataHookContextMap = {
-  'Organization.Membership.Updated': { organizationId: string };
+  /** Delta fields are omitted when empty (consumers must treat absence as "no change") and each capped at 5000 entries — see truncateMembershipDelta. */
+  'Organization.Membership.Updated': {
+    organizationId: string;
+    addedUserIds?: readonly string[];
+    removedUserIds?: readonly string[];
+    addedApplicationIds?: readonly string[];
+    removedApplicationIds?: readonly string[];
+  };
   'User.Created': UserContext;
   'User.Data.Updated': UserContext;
   'User.Deleted': UserContext;

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -16,7 +16,12 @@ mockEsm('#src/utils/sign.js', () => ({
   sign: () => mockSignature,
 }));
 
-const { generateHookTestPayload, sendWebhookRequest } = await import('./utils.js');
+const {
+  generateHookTestPayload,
+  sendWebhookRequest,
+  truncateMembershipDelta,
+  MEMBERSHIP_DELTA_CAP,
+} = await import('./utils.js');
 
 describe('sendWebhookRequest', () => {
   it('should call got.post with correct values', async () => {
@@ -46,5 +51,34 @@ describe('sendWebhookRequest', () => {
       retry: { limit: 3 },
       timeout: 10_000,
     });
+  });
+});
+
+describe('truncateMembershipDelta', () => {
+  it('passes non-empty arrays at or below cap through unchanged', () => {
+    const out = truncateMembershipDelta({ addedUserIds: ['u1', 'u2'] });
+    expect(out).toEqual({ addedUserIds: ['u1', 'u2'] });
+  });
+
+  it('omits empty and absent fields so empty-delta operations carry no marker', () => {
+    expect(truncateMembershipDelta({ addedUserIds: ['u1'], removedUserIds: [] })).toEqual({
+      addedUserIds: ['u1'],
+    });
+    expect(truncateMembershipDelta({ addedUserIds: [], removedUserIds: [] })).toEqual({});
+    expect(truncateMembershipDelta({})).toEqual({});
+  });
+
+  it('caps each oversized array independently across all four fields', () => {
+    const oversized = Array.from({ length: MEMBERSHIP_DELTA_CAP + 100 }, (_, index) => `u${index}`);
+    const out = truncateMembershipDelta({
+      addedUserIds: oversized,
+      removedUserIds: ['u1'],
+      addedApplicationIds: oversized,
+      removedApplicationIds: oversized,
+    });
+    expect(out.addedUserIds).toHaveLength(MEMBERSHIP_DELTA_CAP);
+    expect(out.addedApplicationIds).toHaveLength(MEMBERSHIP_DELTA_CAP);
+    expect(out.removedApplicationIds).toHaveLength(MEMBERSHIP_DELTA_CAP);
+    expect(out.removedUserIds).toEqual(['u1']);
   });
 });

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -139,3 +139,32 @@ export const buildManagementApiContext = (
     matchedRoute: matchedRoute && String(matchedRoute),
   };
 };
+
+/** Per-array cap. 5000 × ~21-char IDs + JSON overhead ≈ 117KB per array; up to four such arrays per payload. LOG-13492. */
+export const MEMBERSHIP_DELTA_CAP = 5000;
+
+const membershipDeltaFields = [
+  'addedUserIds',
+  'removedUserIds',
+  'addedApplicationIds',
+  'removedApplicationIds',
+] as const;
+
+type MembershipDeltaInput = Partial<
+  Record<(typeof membershipDeltaFields)[number], readonly string[]>
+>;
+
+/** Caps non-empty arrays at {@link MEMBERSHIP_DELTA_CAP}; empty/absent fields are omitted. */
+export const truncateMembershipDelta = (input: MembershipDeltaInput): MembershipDeltaInput => {
+  const result: MembershipDeltaInput = {};
+  for (const key of membershipDeltaFields) {
+    const value = input[key];
+    if (!value || value.length === 0) {
+      continue;
+    }
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    result[key] =
+      value.length > MEMBERSHIP_DELTA_CAP ? value.slice(0, MEMBERSHIP_DELTA_CAP) : value;
+  }
+  return result;
+};

--- a/packages/core/src/routes/organization/user/index.ts
+++ b/packages/core/src/routes/organization/user/index.ts
@@ -7,7 +7,8 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
-import { buildManagementApiContext } from '#src/libraries/hook/utils.js';
+import { EnvSet } from '#src/env-set/index.js';
+import { buildManagementApiContext, truncateMembershipDelta } from '#src/libraries/hook/utils.js';
 import { type QuotaLibrary } from '#src/libraries/quota.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
@@ -89,10 +90,11 @@ export default function userRoutes(
       ctx.body = { userIds: rawUserIds };
       ctx.status = 201;
 
-      // Trigger hook event
       ctx.appendDataHookContext('Organization.Membership.Updated', {
         ...buildManagementApiContext(ctx),
         organizationId: id,
+        ...(EnvSet.values.isDevFeaturesEnabled &&
+          truncateMembershipDelta({ addedUserIds: newUserIds })),
       });
 
       return next();
@@ -131,15 +133,20 @@ export default function userRoutes(
         });
       }
 
-      // Membership can grow large; use the delta variant to avoid rewriting all rows.
-      await organizations.relations.users.replaceWithDelta(id, userIds);
+      // Delta is used only for the webhook payload; the pre-write quota guard
+      // above (computed from the requested set size) remains authoritative.
+      const { added, removed } = await organizations.relations.users.replaceWithDelta(id, userIds);
 
       ctx.status = 204;
 
-      // Trigger hook event
       ctx.appendDataHookContext('Organization.Membership.Updated', {
         ...buildManagementApiContext(ctx),
         organizationId: id,
+        ...(EnvSet.values.isDevFeaturesEnabled &&
+          truncateMembershipDelta({
+            addedUserIds: added,
+            removedUserIds: removed,
+          })),
       });
 
       return next();
@@ -161,10 +168,11 @@ export default function userRoutes(
 
       ctx.status = 204;
 
-      // Trigger hook event
       ctx.appendDataHookContext('Organization.Membership.Updated', {
         ...buildManagementApiContext(ctx),
         organizationId: id,
+        ...(EnvSet.values.isDevFeaturesEnabled &&
+          truncateMembershipDelta({ removedUserIds: [userId] })),
       });
 
       return next();

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
@@ -32,6 +32,8 @@ import {
   roleDataHookTestCases,
   scopesDataHookTestCases,
   userDataHookTestCases,
+  type HookPayloadArgs,
+  type SetupContext,
 } from './test-cases.js';
 
 const mockHookResponseGuard = z.object({
@@ -250,10 +252,20 @@ describe('organization data hook events', () => {
 
   it.each(organizationDataHookTestCases)(
     'test case %#: %p',
-    async ({ route, event, method, endpoint, payload, hookPayload }) => {
+    async ({ route, event, method, endpoint, payload, hookPayload, setup }) => {
       // TODO: Remove this check
       if (route.includes('applications') && !isDevFeaturesEnabled) {
         return;
+      }
+
+      if (setup) {
+        const setupContext: SetupContext = {
+          organizationApi,
+          organizationId,
+          userId,
+          applicationId,
+        };
+        await setup(setupContext);
       }
 
       await authedAdminApi[method](
@@ -272,7 +284,29 @@ describe('organization data hook events', () => {
       const hook = await getWebhookResult(route);
       expect(hook?.payload.event).toBe(event);
       if (hookPayload) {
-        expect(hook?.payload).toMatchObject(hookPayload);
+        const resolved =
+          typeof hookPayload === 'function'
+            ? hookPayload({
+                userId,
+                organizationId,
+                applicationId,
+                isDevFeaturesEnabled,
+              } satisfies HookPayloadArgs)
+            : hookPayload;
+        expect(hook?.payload).toMatchObject(resolved);
+        // `toMatchObject` is partial-match; assert absence of every delta field
+        // a case did not declare so the dev-features gate and the omit-empty
+        // contract are regression-protected end-to-end.
+        for (const field of [
+          'addedUserIds',
+          'removedUserIds',
+          'addedApplicationIds',
+          'removedApplicationIds',
+        ]) {
+          if (!(field in resolved)) {
+            expect(hook?.payload).not.toHaveProperty(field);
+          }
+        }
       }
     }
   );

--- a/packages/integration-tests/src/tests/api/hook/test-cases.ts
+++ b/packages/integration-tests/src/tests/api/hook/test-cases.ts
@@ -1,15 +1,39 @@
+import { trySafe } from '@silverhand/essentials';
+
+import { type OrganizationApiTest } from '#src/helpers/organization.js';
 import { generateName } from '#src/utils.js';
+
+type PlaceholderIds = {
+  userId?: string;
+  applicationId?: string;
+  organizationId?: string;
+  organizationRoleId?: string;
+};
+
+type HookPayloadArgs = PlaceholderIds & {
+  isDevFeaturesEnabled: boolean;
+};
+
+type SetupContext = {
+  organizationApi?: OrganizationApiTest;
+  organizationId?: string;
+  userId?: string;
+  applicationId?: string;
+  organizationRoleId?: string;
+};
 
 type TestCase = {
   route: string;
   event: string;
   method: 'patch' | 'post' | 'delete' | 'put';
   endpoint: string;
-  /** The payload that should be sent to the route. */
   payload: Record<string, unknown>;
-  /** The payload that should be sent to the webhook. */
-  hookPayload?: Record<string, unknown>;
+  hookPayload?: Record<string, unknown> | ((args: HookPayloadArgs) => Record<string, unknown>);
+  /** Idempotent precondition; runs before the route is hit. */
+  setup?: (ctx: SetupContext) => Promise<void>;
 };
+
+export type { PlaceholderIds, HookPayloadArgs, SetupContext, TestCase };
 
 export const userDataHookTestCases: TestCase[] = [
   {
@@ -111,7 +135,18 @@ export const organizationDataHookTestCases: TestCase[] = [
     method: 'post',
     endpoint: `organizations/{organizationId}/users`,
     payload: { userIds: ['{userId}'] },
-    hookPayload: { organizationId: expect.any(String) },
+    setup: async ({ organizationApi, organizationId, userId }) => {
+      if (!organizationApi || !organizationId || !userId) {
+        return;
+      }
+      await trySafe(organizationApi.deleteUser(organizationId, userId));
+    },
+    hookPayload: ({ userId, isDevFeaturesEnabled }) => ({
+      organizationId: expect.any(String),
+      ...(isDevFeaturesEnabled && {
+        addedUserIds: [userId],
+      }),
+    }),
   },
   {
     route: 'PUT /organizations/:id/users',
@@ -119,6 +154,13 @@ export const organizationDataHookTestCases: TestCase[] = [
     method: 'put',
     endpoint: `organizations/{organizationId}/users`,
     payload: { userIds: ['{userId}'] },
+    setup: async ({ organizationApi, organizationId, userId }) => {
+      if (!organizationApi || !organizationId || !userId) {
+        return;
+      }
+      await trySafe(organizationApi.addUsers(organizationId, [userId]));
+    },
+    // No-op delta: helper omits both empty arrays, payload matches legacy shape.
     hookPayload: { organizationId: expect.any(String) },
   },
   {
@@ -127,7 +169,18 @@ export const organizationDataHookTestCases: TestCase[] = [
     method: 'delete',
     endpoint: `organizations/{organizationId}/users/{userId}`,
     payload: {},
-    hookPayload: { organizationId: expect.any(String) },
+    setup: async ({ organizationApi, organizationId, userId }) => {
+      if (!organizationApi || !organizationId || !userId) {
+        return;
+      }
+      await trySafe(organizationApi.addUsers(organizationId, [userId]));
+    },
+    hookPayload: ({ userId, isDevFeaturesEnabled }) => ({
+      organizationId: expect.any(String),
+      ...(isDevFeaturesEnabled && {
+        removedUserIds: [userId],
+      }),
+    }),
   },
   {
     route: 'POST /organizations/:id/applications',


### PR DESCRIPTION
## Summary
Closes #7961, #6757. Supersedes #8752 — thanks @chiche84 for the original proposal.

### Context
Today the `Organization.Membership.Updated` webhook payload only carries `{ organizationId }`, forcing consumers to re-query the Management API to learn which users actually changed. Community PR #8752 set out to fix this for the three user-membership routes. This PR delivers the same outcome on top of the Phase 0 / Phase 0.5 work that has since merged (`replaceWithDelta()`, secondary indexes, LATERAL role aggregation, dedup + quota fix).

The new payload fields are **gated behind** `EnvSet.values.isDevFeaturesEnabled` so production behavior is byte-identical to today's master until the project's release task ([LOG-13467](https://linear.app/silverhand/issue/LOG-13467)) flips the gate.

### What changed
- `packages/core/src/libraries/hook/context-manager.ts` — extend `DataHookContextMap['Organization.Membership.Updated']` with optional `addedUserIds` / `removedUserIds` / `addedApplicationIds` / `removedApplicationIds` (`readonly string[]`). Application fields are placeholders for Phase 2.
- `packages/core/src/libraries/hook/utils.ts` — add `MEMBERSHIP_DELTA_CAP = 5000` and `truncateMembershipDelta(input)`. The helper caps each non-empty array at 5000 and **omits empty/absent fields entirely** so the payload only carries deltas that actually changed something.
- `packages/core/src/routes/organization/user/index.ts`:
  - POST emits `{ addedUserIds: newUserIds }` only (Phase 0's `newUserIds` is the truly-new subset; no `removedUserIds: []`).
  - PUT captures `replaceWithDelta()`'s `{ added, removed }` return value and emits whichever side is non-empty. Pre-write quota guard ordering (read `currentCount`, guard, then write) is preserved.
  - DELETE emits `{ removedUserIds: [userId] }` only.
- `packages/integration-tests/src/tests/api/hook/test-cases.ts` — add `HookPayloadArgs` / `SetupContext` / `PlaceholderIds` types; rewrite POST/PUT/DELETE org-user cases with `setup` callbacks (idempotent preconditions via `trySafe`) and dev-aware `hookPayload` callbacks.
- `packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts` — runner now resolves function-style `hookPayload` with `{ userId, organizationId, applicationId, isDevFeaturesEnabled }` and runs each case's `setup`. After `toMatchObject`, the runner asserts `not.toHaveProperty(field)` for every delta field a case did not declare — this protects the dev-features gate AND the omit-empty contract end-to-end, since `toMatchObject` alone is partial-match.

### Expected result
- Production payload shape is unchanged from master (gate keeps it at `{ organizationId }`).
- Under `DEV_FEATURES_ENABLED=1`:
  - POST `/organizations/:id/users` carries `addedUserIds` (only the truly-new members).
  - PUT `/organizations/:id/users` carries whichever of `addedUserIds` / `removedUserIds` is non-empty; a no-op replace emits neither.
  - DELETE `/organizations/:id/users/:userId` carries `removedUserIds: [userId]`.
- Each delta array is capped at 5000 entries silently. Consumers reconciling unusually large bulk admin operations refetch via the Management API.
- Empty deltas are omitted entirely — consumers must treat field absence as "no change on that side," not "empty array."

### Differences vs. #8752 (reviewer note)
- **Omit-empty contract.** #8752 always emits both arrays, with the unused side set to `[]`. This PR omits empty/absent fields. Matches the GitHub `push.commits` precedent; documented for the public webhook reference under [LOG-13492](https://linear.app/silverhand/issue/LOG-13492).
- **PUT `addedUserIds` semantics.** #8752 reports *all declared* users on PUT. This PR reports only the *actual* delta from `replaceWithDelta()` — if a user was already a member and the PUT keeps them, they are not in `addedUserIds`. Consumers asking "who got added?" get a truthful answer.
- **Dev-features gate.** #8752 ships the shape change unconditionally; this PR gates it for staged rollout via [LOG-13467](https://linear.app/silverhand/issue/LOG-13467).
- **5000-entry cap.** #8752 emits unbounded arrays; this PR bounds the payload at ~117KB per array.

### No changeset
Intentional. The behavior is gated; the consolidated changeset lands with the gate removal in [LOG-13467](https://linear.app/silverhand/issue/LOG-13467) so the GA announcement is a single release-notes entry covering Phases 1–3 together.

## Testing
Unit tests, integration tests

- `pnpm -F @logto/core test:only` — 209 suites / 1858 tests pass; new `truncateMembershipDelta` cases cover pass-through, omit-empty (single + double), and four-field cap.
- `pnpm -F @logto/integration-tests` `hook.trigger.data.test` org block — verified end-to-end against a local dev server under `DEV_FEATURES_ENABLED=1`: POST emits only `addedUserIds`, PUT no-op emits the legacy shape, DELETE emits only `removedUserIds`. The new `not.toHaveProperty` runner check protects the gate + omit-empty contracts.

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments