### PR TITLE
feat(core): emit addedApplicationIds/removedApplicationIds on org application-membership webhooks

### DIFF
--- a/packages/core/src/queries/organization/application-relations.ts
+++ b/packages/core/src/queries/organization/application-relations.ts
@@ -26,6 +26,31 @@ export class ApplicationRelationQueries extends TwoRelationsQueries<
     super(pool, OrganizationApplicationRelations.table, Organizations, Applications);
   }
 
+  /**
+   * Given a candidate set of application IDs, return the subset that already have a
+   * row in `organization_application_relations` for the organization. Bounded by
+   * `applicationIds.length`. `tenant_id` is auto-injected by the tenant-scoped pool;
+   * the `(tenant_id, organization_id, application_id)` PK serves this lookup.
+   */
+  async getExistingApplicationIds(
+    organizationId: string,
+    applicationIds: string[]
+  ): Promise<string[]> {
+    if (applicationIds.length === 0) {
+      return [];
+    }
+
+    const { fields } = convertToIdentifiers(OrganizationApplicationRelations, true);
+    const rows = await this.pool.any<{ applicationId: string }>(sql`
+      select ${fields.applicationId}
+      from ${this.table}
+      where ${fields.organizationId} = ${organizationId}
+        and ${fields.applicationId} = any(${sql.array(applicationIds, 'varchar')})
+    `);
+
+    return rows.map((row) => row.applicationId);
+  }
+
   async getOrganizationsByApplicationId(
     applicationId: string,
     options?: GetEntitiesOptions

--- a/packages/core/src/routes/organization/application/index.ts
+++ b/packages/core/src/routes/organization/application/index.ts
@@ -18,10 +18,13 @@ import { parseSearchOptions } from '#src/utils/search.js';
 import applicationRoleRelationRoutes from './role-relations.js';
 
 /**
- * Mounts the org-application membership routes. Dev-features-off keeps master's
- * generic `addRelationRoutes` path (legacy `{ organizationId }`-only webhook payload).
- * Dev-features-on mounts custom POST/PUT/DELETE handlers that compute and emit the
- * `addedApplicationIds` / `removedApplicationIds` delta.
+ * Org-application membership endpoints. When `isDevFeaturesEnabled` is off we fall
+ * back to the generic `addRelationRoutes` mount, which only emits `{ organizationId }`
+ * on the membership webhook. When it is on, we own POST/PUT/DELETE so we can include
+ * the `addedApplicationIds` / `removedApplicationIds` delta in the payload.
+ *
+ * The dev-features branch and the legacy fallback should be collapsed once the
+ * delta payload graduates to GA (LOG-13467).
  */
 const mountMembershipRoutes = (
   router: SchemaRouter<OrganizationKeys, CreateOrganization, Organization>,
@@ -90,7 +93,6 @@ const mountMembershipRoutes = (
 
       const applicationIds = [...new Set(rawApplicationIds)];
 
-      // Delta is used only for the webhook payload.
       const { added, removed } = await organizations.relations.apps.replaceWithDelta(
         id,
         applicationIds

--- a/packages/core/src/routes/organization/application/index.ts
+++ b/packages/core/src/routes/organization/application/index.ts
@@ -6,6 +6,8 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
+import { buildManagementApiContext, truncateMembershipDelta } from '#src/libraries/hook/utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { applicationSearchKeys } from '#src/queries/application.js';
@@ -15,17 +17,131 @@ import { parseSearchOptions } from '#src/utils/search.js';
 
 import applicationRoleRelationRoutes from './role-relations.js';
 
+/**
+ * Mounts the org-application membership routes. Dev-features-off keeps master's
+ * generic `addRelationRoutes` path (legacy `{ organizationId }`-only webhook payload).
+ * Dev-features-on mounts custom POST/PUT/DELETE handlers that compute and emit the
+ * `addedApplicationIds` / `removedApplicationIds` delta.
+ */
+const mountMembershipRoutes = (
+  router: SchemaRouter<OrganizationKeys, CreateOrganization, Organization>,
+  organizations: OrganizationQueries
+) => {
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    router.addRelationRoutes(organizations.relations.apps, undefined, {
+      disabled: { get: true },
+      hookEvent: 'Organization.Membership.Updated',
+    });
+    return;
+  }
+
+  router.post(
+    '/:id/applications',
+    koaGuard({
+      params: z.object({ id: z.string().min(1) }),
+      body: z.object({ applicationIds: z.string().min(1).array().nonempty() }),
+      status: [201, 422],
+    }),
+    async (ctx, next) => {
+      const {
+        params: { id },
+        body: { applicationIds: rawApplicationIds },
+      } = ctx.guard;
+
+      // Dedup body and filter against current members so the webhook delta only
+      // reflects truly-new additions. The base `insert()` uses ON CONFLICT DO NOTHING,
+      // so the filter is purely for delta correctness — not for row-level safety.
+      const applicationIds = [...new Set(rawApplicationIds)];
+      const existingApplicationIds = new Set(
+        await organizations.relations.apps.getExistingApplicationIds(id, applicationIds)
+      );
+      const newApplicationIds = applicationIds.filter(
+        (applicationId) => !existingApplicationIds.has(applicationId)
+      );
+
+      await organizations.relations.apps.insert(
+        ...applicationIds.map((applicationId) => ({ organizationId: id, applicationId }))
+      );
+
+      ctx.status = 201;
+
+      ctx.appendDataHookContext('Organization.Membership.Updated', {
+        ...buildManagementApiContext(ctx),
+        organizationId: id,
+        ...truncateMembershipDelta({ addedApplicationIds: newApplicationIds }),
+      });
+
+      return next();
+    }
+  );
+
+  router.put(
+    '/:id/applications',
+    koaGuard({
+      params: z.object({ id: z.string().min(1) }),
+      body: z.object({ applicationIds: z.string().min(1).array() }),
+      status: [204, 422],
+    }),
+    async (ctx, next) => {
+      const {
+        params: { id },
+        body: { applicationIds: rawApplicationIds },
+      } = ctx.guard;
+
+      const applicationIds = [...new Set(rawApplicationIds)];
+
+      // Delta is used only for the webhook payload.
+      const { added, removed } = await organizations.relations.apps.replaceWithDelta(
+        id,
+        applicationIds
+      );
+
+      ctx.status = 204;
+
+      ctx.appendDataHookContext('Organization.Membership.Updated', {
+        ...buildManagementApiContext(ctx),
+        organizationId: id,
+        ...truncateMembershipDelta({
+          addedApplicationIds: added,
+          removedApplicationIds: removed,
+        }),
+      });
+
+      return next();
+    }
+  );
+
+  router.delete(
+    '/:id/applications/:applicationId',
+    koaGuard({
+      params: z.object({ id: z.string().min(1), applicationId: z.string().min(1) }),
+      status: [204, 422],
+    }),
+    async (ctx, next) => {
+      const {
+        params: { id, applicationId },
+      } = ctx.guard;
+
+      await organizations.relations.apps.delete({ organizationId: id, applicationId });
+
+      ctx.status = 204;
+
+      ctx.appendDataHookContext('Organization.Membership.Updated', {
+        ...buildManagementApiContext(ctx),
+        organizationId: id,
+        ...truncateMembershipDelta({ removedApplicationIds: [applicationId] }),
+      });
+
+      return next();
+    }
+  );
+};
+
 /** Mounts the application-related routes on the organization router. */
 export default function applicationRoutes(
   router: SchemaRouter<OrganizationKeys, CreateOrganization, Organization>,
   organizations: OrganizationQueries
 ) {
-  // MARK: Organization - application relation routes
-  router.addRelationRoutes(organizations.relations.apps, undefined, {
-    disabled: { get: true },
-    hookEvent: 'Organization.Membership.Updated',
-  });
-
   router.get(
     '/:id/applications',
     koaPagination(),
@@ -51,6 +167,8 @@ export default function applicationRoutes(
       return next();
     }
   );
+
+  mountMembershipRoutes(router, organizations);
 
   router.post(
     '/:id/applications/roles',

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
@@ -7,7 +7,7 @@ import {
   managementApiHooksRegistration,
   type Role,
 } from '@logto/schemas';
-import { assert } from '@silverhand/essentials';
+import { assert, noop } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import { authedAdminApi } from '#src/api/api.js';
@@ -221,6 +221,7 @@ describe('organization data hook events', () => {
   let organizationId: string;
   let userId: string;
   let applicationId: string;
+  let applicationIdB: string;
   /* eslint-enable @silverhand/fp/no-let */
 
   const organizationApi = new OrganizationApiTest();
@@ -234,11 +235,13 @@ describe('organization data hook events', () => {
 
     const user = await userApi.create({ name: generateName() });
     const application = await createApplication(generateName(), ApplicationType.MachineToMachine);
+    const applicationB = await createApplication(generateName(), ApplicationType.MachineToMachine);
 
     /* eslint-disable @silverhand/fp/no-mutation */
     organizationId = organization.id;
     userId = user.id;
     applicationId = application.id;
+    applicationIdB = applicationB.id;
     /* eslint-enable @silverhand/fp/no-mutation */
 
     const organizationCreateHook = await getWebhookResult('POST /organizations');
@@ -246,8 +249,11 @@ describe('organization data hook events', () => {
   });
 
   afterAll(async () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    await Promise.all([userApi.cleanUp(), deleteApplication(applicationId).catch(() => {})]);
+    await Promise.all([
+      userApi.cleanUp(),
+      deleteApplication(applicationId).catch(noop),
+      deleteApplication(applicationIdB).catch(noop),
+    ]);
   });
 
   it.each(organizationDataHookTestCases)(
@@ -259,6 +265,7 @@ describe('organization data hook events', () => {
           organizationId,
           userId,
           applicationId,
+          applicationIdB,
         };
         await setup(setupContext);
       }
@@ -267,11 +274,13 @@ describe('organization data hook events', () => {
         endpoint
           .replace('{organizationId}', organizationId)
           .replace('{userId}', userId)
+          .replace('{applicationIdB}', applicationIdB)
           .replace('{applicationId}', applicationId),
         {
           json: JSON.parse(
             JSON.stringify(payload)
               .replace('{userId}', userId)
+              .replace('{applicationIdB}', applicationIdB)
               .replace('{applicationId}', applicationId)
           ),
         }
@@ -285,6 +294,7 @@ describe('organization data hook events', () => {
                 userId,
                 organizationId,
                 applicationId,
+                applicationIdB,
                 isDevFeaturesEnabled,
               } satisfies HookPayloadArgs)
             : hookPayload;

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts
@@ -253,11 +253,6 @@ describe('organization data hook events', () => {
   it.each(organizationDataHookTestCases)(
     'test case %#: %p',
     async ({ route, event, method, endpoint, payload, hookPayload, setup }) => {
-      // TODO: Remove this check
-      if (route.includes('applications') && !isDevFeaturesEnabled) {
-        return;
-      }
-
       if (setup) {
         const setupContext: SetupContext = {
           organizationApi,

--- a/packages/integration-tests/src/tests/api/hook/test-cases.ts
+++ b/packages/integration-tests/src/tests/api/hook/test-cases.ts
@@ -188,7 +188,18 @@ export const organizationDataHookTestCases: TestCase[] = [
     method: 'post',
     endpoint: `organizations/{organizationId}/applications`,
     payload: { applicationIds: ['{applicationId}'] },
-    hookPayload: { organizationId: expect.any(String) },
+    setup: async ({ organizationApi, organizationId, applicationId }) => {
+      if (!organizationApi || !organizationId || !applicationId) {
+        return;
+      }
+      await trySafe(organizationApi.applications.delete(organizationId, applicationId));
+    },
+    hookPayload: ({ applicationId, isDevFeaturesEnabled }) => ({
+      organizationId: expect.any(String),
+      ...(isDevFeaturesEnabled && {
+        addedApplicationIds: [applicationId],
+      }),
+    }),
   },
   {
     route: 'PUT /organizations/:id/applications',
@@ -196,6 +207,13 @@ export const organizationDataHookTestCases: TestCase[] = [
     method: 'put',
     endpoint: `organizations/{organizationId}/applications`,
     payload: { applicationIds: ['{applicationId}'] },
+    setup: async ({ organizationApi, organizationId, applicationId }) => {
+      if (!organizationApi || !organizationId || !applicationId) {
+        return;
+      }
+      await trySafe(organizationApi.applications.add(organizationId, [applicationId]));
+    },
+    // No-op delta: helper omits both empty arrays, payload matches legacy shape.
     hookPayload: { organizationId: expect.any(String) },
   },
   {
@@ -204,7 +222,18 @@ export const organizationDataHookTestCases: TestCase[] = [
     method: 'delete',
     endpoint: `organizations/{organizationId}/applications/{applicationId}`,
     payload: {},
-    hookPayload: { organizationId: expect.any(String) },
+    setup: async ({ organizationApi, organizationId, applicationId }) => {
+      if (!organizationApi || !organizationId || !applicationId) {
+        return;
+      }
+      await trySafe(organizationApi.applications.add(organizationId, [applicationId]));
+    },
+    hookPayload: ({ applicationId, isDevFeaturesEnabled }) => ({
+      organizationId: expect.any(String),
+      ...(isDevFeaturesEnabled && {
+        removedApplicationIds: [applicationId],
+      }),
+    }),
   },
   {
     route: 'DELETE /organizations/:id',

--- a/packages/integration-tests/src/tests/api/hook/test-cases.ts
+++ b/packages/integration-tests/src/tests/api/hook/test-cases.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- flat fixture file; splitting by domain would fragment related cases across imports for no readability benefit */
 import { trySafe } from '@silverhand/essentials';
 
 import { type OrganizationApiTest } from '#src/helpers/organization.js';
@@ -6,6 +7,8 @@ import { generateName } from '#src/utils.js';
 type PlaceholderIds = {
   userId?: string;
   applicationId?: string;
+  /** Second application fixture; used by cases that exercise a two-sided PUT delta. */
+  applicationIdB?: string;
   organizationId?: string;
   organizationRoleId?: string;
 };
@@ -19,6 +22,7 @@ type SetupContext = {
   organizationId?: string;
   userId?: string;
   applicationId?: string;
+  applicationIdB?: string;
   organizationRoleId?: string;
 };
 
@@ -202,6 +206,26 @@ export const organizationDataHookTestCases: TestCase[] = [
     }),
   },
   {
+    // Re-POST of an already-member exercises the `getExistingApplicationIds` filter:
+    // the request body is a known-member, so `newApplicationIds` is empty and the
+    // helper omits `addedApplicationIds` from the payload. The setup uses `replace`
+    // (PUT route) rather than `add` (POST route) so the precondition does not
+    // overwrite the shared `POST /organizations/:id/applications` entry in the
+    // webhook-results map between the previous POST case and this one.
+    route: 'POST /organizations/:id/applications',
+    event: 'Organization.Membership.Updated',
+    method: 'post',
+    endpoint: `organizations/{organizationId}/applications`,
+    payload: { applicationIds: ['{applicationId}'] },
+    setup: async ({ organizationApi, organizationId, applicationId }) => {
+      if (!organizationApi || !organizationId || !applicationId) {
+        return;
+      }
+      await trySafe(organizationApi.applications.replace(organizationId, [applicationId]));
+    },
+    hookPayload: { organizationId: expect.any(String) },
+  },
+  {
     route: 'PUT /organizations/:id/applications',
     event: 'Organization.Membership.Updated',
     method: 'put',
@@ -215,6 +239,31 @@ export const organizationDataHookTestCases: TestCase[] = [
     },
     // No-op delta: helper omits both empty arrays, payload matches legacy shape.
     hookPayload: { organizationId: expect.any(String) },
+  },
+  {
+    // Replace A with B exercises the `replaceWithDelta` plumbing end-to-end:
+    // both `added` and `removed` are non-empty, so both delta fields must be
+    // present in the payload (under the dev gate).
+    route: 'PUT /organizations/:id/applications',
+    event: 'Organization.Membership.Updated',
+    method: 'put',
+    endpoint: `organizations/{organizationId}/applications`,
+    payload: { applicationIds: ['{applicationIdB}'] },
+    setup: async ({ organizationApi, organizationId, applicationId, applicationIdB }) => {
+      if (!organizationApi || !organizationId || !applicationId || !applicationIdB) {
+        return;
+      }
+      // Ensure A is the sole pre-existing member; B is absent.
+      await trySafe(organizationApi.applications.add(organizationId, [applicationId]));
+      await trySafe(organizationApi.applications.delete(organizationId, applicationIdB));
+    },
+    hookPayload: ({ applicationId, applicationIdB, isDevFeaturesEnabled }) => ({
+      organizationId: expect.any(String),
+      ...(isDevFeaturesEnabled && {
+        addedApplicationIds: [applicationIdB],
+        removedApplicationIds: [applicationId],
+      }),
+    }),
   },
   {
     route: 'DELETE /organizations/:id/applications/:applicationId',
@@ -298,3 +347,4 @@ export const organizationRoleDataHookTestCases: TestCase[] = [
     payload: {},
   },
 ];
+/* eslint-enable max-lines */


### PR DESCRIPTION
## Summary
Relates to #6757. Stacked on top of #8833 (Phase 1) — retargets to `master` once Phase 1 merges.

### Context
Phase 2 of the `Organization.Membership.Updated` payload-enrichment project. Phase 1 ([LOG-13462](https://linear.app/silverhand/issue/LOG-13462) / #8833) shipped the user-side delta fields, the `truncateMembershipDelta` helper, the dual-mode test scaffolding, and the four-field type extension on `DataHookContextMap`. Phase 2 wires the application-side delta fields onto the same payload, gated behind the same `EnvSet.values.isDevFeaturesEnabled` flag.

### Approach choice: custom handlers, not a generic `SchemaRouter` callback
The original plan ([LOG-13463](https://linear.app/silverhand/issue/LOG-13463)) proposed extending `SchemaRouter.addRelationRoutes` with a `buildHookContext` callback. The §2.1 validity review surfaced three concerns: (a) timing mismatch on POST (the existing SchemaRouter handler calls `insert` then emits, but the truly-new filter needs pre-insert state), (b) PUT contract change (existing PUT calls `replace()`; reading `{ added, removed }` would require switching to `replaceWithDelta()` for all 6+ consumers), and (c) YAGNI — only one of the six `addRelationRoutes` call sites carries delta semantics.

This PR follows Phase 1's precedent: replace the `router.addRelationRoutes(organizations.relations.apps, ...)` call with explicit POST/PUT/DELETE handlers in `routes/organization/application/index.ts`. `SchemaRouter` is untouched, so five unrelated callers (org roles ↔ scopes, JIT roles, SSO connectors, org-application roles) are guaranteed unaffected. The trade-off is a small amount of duplication vs. Phase 1's user routes — accepted because it keeps the generic helper a single-responsibility router.

### What changed
- `packages/core/src/queries/organization/application-relations.ts` — add `getExistingApplicationIds(organizationId, applicationIds)`. Relation-table-only fetch via the `(organization_id, application_id)` PK index. Mirror of `UserRelationQueries.getExistingUserIds` shipped in Phase 0.
- `packages/core/src/routes/organization/application/index.ts` — replace the `addRelationRoutes(...apps...)` call with three explicit handlers:
  - **POST**: dedup body, filter against `getExistingApplicationIds` for truly-new IDs, `insert(...)` with the deduped set (ON CONFLICT DO NOTHING), emit gated `truncateMembershipDelta({ addedApplicationIds: newApplicationIds })`. Empty deltas omitted.
  - **PUT**: dedup, call `replaceWithDelta(id, applicationIds)`, capture `{ added, removed }`, emit gated `truncateMembershipDelta({ addedApplicationIds: added, removedApplicationIds: removed })`. A no-op replace emits `{ organizationId }` only (helper omits both empty arrays).
  - **DELETE**: emit gated `truncateMembershipDelta({ removedApplicationIds: [applicationId] })`. `addedApplicationIds` omitted.
  - GET (custom query for `applicationWithOrganizationRolesGuard`) and the `/applications/roles` POST + role-relations sub-routes are unchanged.
- `packages/integration-tests/src/tests/api/hook/test-cases.ts` — convert the three app POST/PUT/DELETE cases to dev-aware function-style `hookPayload` callbacks with `setup` preconditions (`trySafe`-wrapped, matching Phase 1's pattern).
- `packages/integration-tests/src/tests/api/hook/hook.trigger.data.test.ts` — remove the pre-existing apps-only `route.includes('applications') && !isDevFeaturesEnabled` short-circuit. The per-case `hookPayload` callbacks now handle both flag modes via the dual-mode contract Phase 1 established, and the runner-level `not.toHaveProperty` invariant from Phase 1 regression-protects the gate + omit-empty contracts for app routes the same way it does for user routes.

### Expected result
- Production payload shape is unchanged from master (gate keeps it at `{ organizationId }`).
- Under `DEV_FEATURES_ENABLED=1`:
  - POST `/organizations/:id/applications` carries `addedApplicationIds` (only the truly-new members).
  - PUT carries whichever of `addedApplicationIds` / `removedApplicationIds` is non-empty; a no-op replace emits neither.
  - DELETE `/organizations/:id/applications/:applicationId` carries `removedApplicationIds: [applicationId]`.
- Same 5000-entry per-array cap as user routes (no helper change — `truncateMembershipDelta` already iterates all four fields).
- Same omit-empty contract: consumers must treat field absence as "no change on that side," not "empty array."

### Carried-over Phase 1 design choices (applied to apps)
- **Omit-empty contract**: empty/absent delta arrays are not emitted.
- **Truthful PUT semantics**: `addedApplicationIds` carries only the actual delta from `replaceWithDelta()`, not the full declared set.
- **Dev-features gate**: keep on the emit sites; removed at release time in [LOG-13467](https://linear.app/silverhand/issue/LOG-13467).
- **No changeset**: intentional, per the consolidated-changeset policy synced into [LOG-13467](https://linear.app/silverhand/issue/LOG-13467).

### Reviewer notes
- `SchemaRouter.ts` is untouched. A grep confirms five other callers (org-role scopes, JIT roles, SSO connectors, org-application roles, organization JIT) keep their existing behavior.
- The POST handler keeps `insert(...)` operating on the full dedup'd `applicationIds` set (not just `newApplicationIds`) — matches Phase 1's user-POST style; `ON CONFLICT DO NOTHING` makes the re-inserts a no-op.
- M2M applications aren't capped per-org, so no quota guard is needed in the PUT handler (unlike Phase 1's user PUT).

## Testing
Integration tests

- `pnpm -F @logto/core test:only` — 209 suites / 1858 tests pass (no new unit tests; `truncateMembershipDelta`'s four-field unit test from Phase 1 already exercises `addedApplicationIds` / `removedApplicationIds`).
- `pnpm -F @logto/integration-tests` `hook.trigger.data.test` org block — verified end-to-end against a local dev server under `DEV_FEATURES_ENABLED=1`: POST emits only `addedApplicationIds`, PUT no-op emits the legacy shape, DELETE emits only `removedApplicationIds`. The runner-level `not.toHaveProperty` check protects the gate + omit-empty contracts.

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments