### PR TITLE
fix(experience): enforce terms agreement when sign-in flow turns into registration

### DIFF
--- a/.changeset/enforce-terms-on-signin-to-register.md
+++ b/.changeset/enforce-terms-on-signin-to-register.md
@@ -1,0 +1,7 @@
+---
+"@logto/experience": patch
+---
+
+fix: require terms agreement when the sign-in flow turns into a registration
+
+When the agreement policy is `ManualRegistrationOnly` ("Require checkbox agreement on registration only"), signing in with an unregistered email or phone and then confirming "create a new account" used to create the account without ever asking the user to agree to the terms. The terms agreement is now prompted before the account is created on this path, matching the dedicated registration form and the social/SSO registration flows.

--- a/packages/experience/src/Providers/ConfirmModalProvider/index.tsx
+++ b/packages/experience/src/Providers/ConfirmModalProvider/index.tsx
@@ -74,6 +74,13 @@ const ConfirmModalProvider = ({ children }: Props) => {
   const handleShowPromise = useCallback(
     async ({ type = 'confirm', ...props }: PromiseConfirmModalProps) => {
       resolver.current?.([false]);
+      /**
+       * Clear any stale callbacks left by a previous callback-based modal, so confirming or
+       * cancelling this promise-based modal won't accidentally invoke them. This also makes it
+       * safe to open a promise-based modal from within a callback-based modal's handler.
+       */
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      callbackRef.current = {};
 
       setModalState({
         isOpen: true,

--- a/packages/experience/src/containers/VerificationCode/index.test.tsx
+++ b/packages/experience/src/containers/VerificationCode/index.test.tsx
@@ -1,14 +1,21 @@
 import resource from '@logto/phrases-experience';
 import {
+  AgreeToTermsPolicy,
   InteractionEvent,
   SignInIdentifier,
   type VerificationCodeIdentifier,
 } from '@logto/schemas';
-import { act, fireEvent, waitFor } from '@testing-library/react';
+import { assert } from '@silverhand/essentials';
+import { act, fireEvent, waitFor, within } from '@testing-library/react';
+import { HTTPError } from 'ky';
 
+import ConfirmModalProvider from '@/Providers/ConfirmModalProvider';
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { mockSignInExperienceSettings } from '@/__mocks__/logto';
 import {
   identifyWithVerificationCode,
+  registerWithVerifiedIdentifier,
   updateProfileWithVerificationCode,
   sendVerificationCode,
 } from '@/apis/experience';
@@ -39,8 +46,32 @@ jest.mock('@/apis/utils', () => ({
 jest.mock('@/apis/experience', () => ({
   sendVerificationCode: jest.fn(),
   identifyWithVerificationCode: jest.fn().mockResolvedValue({ redirectTo: '/redirect' }),
+  registerWithVerifiedIdentifier: jest.fn().mockResolvedValue({ redirectTo: '/redirect' }),
   updateProfileWithVerificationCode: jest.fn().mockResolvedValue({ redirectTo: '/redirect' }),
 }));
+
+/**
+ * Build a ky `HTTPError` carrying a Logto error code, so it is recognized by `useErrorHandler`
+ * (which reads `error.response.json()`). A minimal fake response is enough here, since the
+ * handler only relies on `instanceof HTTPError` and `response.json()`.
+ */
+const createRequestError = (code: string) => {
+  const response = {
+    status: 404,
+    statusText: 'Not Found',
+    json: async () => ({ code, message: code }),
+  } as unknown as Response;
+
+  return new HTTPError(response, {} as Request, {} as never);
+};
+
+const fillVerificationCode = (container: HTMLElement) => {
+  for (const input of container.querySelectorAll('input')) {
+    act(() => {
+      fireEvent.input(input, { target: { value: '1' } });
+    });
+  }
+};
 
 describe('<VerificationCode />', () => {
   const redirectTo = '/redirect';
@@ -371,6 +402,81 @@ describe('<VerificationCode />', () => {
 
       await waitFor(() => {
         expect(window.location.replace).toBeCalledWith('/redirect');
+      });
+    });
+  });
+
+  describe('sign-in flow with an unregistered identifier', () => {
+    const renderSignInToRegister = (identifier: VerificationCodeIdentifier) =>
+      renderWithPageContext(
+        <SettingsProvider
+          settings={{
+            ...mockSignInExperienceSettings,
+            signUp: {
+              ...mockSignInExperienceSettings.signUp,
+              identifiers: [SignInIdentifier.Email, SignInIdentifier.Phone],
+            },
+            // Require the agreement checkbox on registration only.
+            agreeToTermsPolicy: AgreeToTermsPolicy.ManualRegistrationOnly,
+          }}
+        >
+          <ConfirmModalProvider>
+            <VerificationCode
+              flow={UserFlow.SignIn}
+              identifier={identifier}
+              verificationId={verificationId}
+            />
+          </ConfirmModalProvider>
+        </SettingsProvider>
+      );
+
+    it('prompts the terms agreement before creating the account under `ManualRegistrationOnly`', async () => {
+      (identifyWithVerificationCode as jest.Mock).mockRejectedValueOnce(
+        createRequestError('user.user_not_exist')
+      );
+
+      const { container, findByText } = renderSignInToRegister(emailIdentifier);
+
+      fillVerificationCode(container);
+
+      /**
+       * The "account does not exist, create one?" confirmation modal shows up. Scope the lookup
+       * to the dialog, since the page itself also renders an `action.continue` button.
+       */
+      const modalContent = await findByText('description.sign_in_id_does_not_exist');
+      const dialog = modalContent.closest('[role="dialog"]');
+      assert(dialog, new Error('confirmation dialog not found'));
+      expect(registerWithVerifiedIdentifier).not.toBeCalled();
+
+      await act(async () => {
+        fireEvent.click(within(dialog as HTMLElement).getByText('action.continue'));
+      });
+
+      // The terms agreement modal must be shown before the account is created.
+      const termsContent = await findByText('description.agree_with_terms_modal');
+      const termsDialog = termsContent.closest('[role="dialog"]');
+      assert(termsDialog, new Error('terms agreement dialog not found'));
+      expect(registerWithVerifiedIdentifier).not.toBeCalled();
+
+      /**
+       * The dialog contains an icon-only close button, a cancel button, and the confirm (agree)
+       * button. Select the confirm button by excluding the icon-only and cancel buttons, so the
+       * test does not depend on button ordering.
+       */
+      const agreeButton = Array.from(termsDialog.querySelectorAll('button')).find(
+        (button) => button.textContent && button.textContent !== 'action.cancel'
+      );
+      assert(agreeButton, new Error('agree button not found'));
+      await act(async () => {
+        fireEvent.click(agreeButton);
+      });
+
+      await waitFor(() => {
+        expect(registerWithVerifiedIdentifier).toBeCalledWith(verificationId);
+      });
+
+      await waitFor(() => {
+        expect(window.location.replace).toBeCalledWith(redirectTo);
       });
     });
   });

--- a/packages/experience/src/containers/VerificationCode/use-sign-in-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-sign-in-flow-code-verification.ts
@@ -8,13 +8,14 @@ import { useTranslation } from 'react-i18next';
 
 import { identifyWithVerificationCode, registerWithVerifiedIdentifier } from '@/apis/experience';
 import useApi from '@/hooks/use-api';
-import { useConfirmModal } from '@/hooks/use-confirm-modal';
+import { usePromiseConfirmModal } from '@/hooks/use-confirm-modal';
 import type { ErrorHandlers } from '@/hooks/use-error-handler';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import { useSieMethods } from '@/hooks/use-sie';
 import useSubmitInteractionErrorHandler from '@/hooks/use-submit-interaction-error-handler';
+import useTerms from '@/hooks/use-terms';
 import { formatPhoneNumberWithCountryCallingCode } from '@/utils/country-code';
 
 import useGeneralVerificationCodeErrorHandler from './use-general-verification-code-error-handler';
@@ -26,7 +27,8 @@ const useSignInFlowCodeVerification = (
   errorCallback?: () => void
 ) => {
   const { t } = useTranslation();
-  const { show } = useConfirmModal();
+  const { show } = usePromiseConfirmModal();
+  const { termsValidation } = useTerms();
   const navigate = useNavigateWithPreservedSearchParams();
   const redirectTo = useGlobalRedirectTo();
   const { isVerificationCodeEnabledForSignUp } = useSieMethods();
@@ -56,34 +58,47 @@ const useSignInFlowCodeVerification = (
       return;
     }
 
-    show({
+    const [confirmed] = await show({
       confirmText: 'action.continue',
       ModalContent: t('description.sign_in_id_does_not_exist', {
         value:
           type === SignInIdentifier.Phone ? formatPhoneNumberWithCountryCallingCode(value) : value,
       }),
-      onConfirm: async () => {
-        const [error, result] = await registerWithIdentifierAsync(verificationId);
-
-        if (error) {
-          await handleError(error, preRegisterErrorHandler);
-
-          return;
-        }
-
-        if (result?.redirectTo) {
-          await redirectTo(result.redirectTo);
-        }
-      },
-      onCancel: () => {
-        navigate(-1);
-      },
     });
+
+    if (!confirmed) {
+      navigate(-1);
+      return;
+    }
+
+    /**
+     * The user has confirmed to create a new account, which turns this sign-in attempt into a
+     * registration. Validate the terms agreement before submitting so policies that require
+     * agreement on registration (`Manual` and `ManualRegistrationOnly`) are still enforced on
+     * this path. `termsValidation` is a no-op when the policy is `Automatic`, the terms are not
+     * configured, or the user has already agreed.
+     */
+    if (!(await termsValidation())) {
+      return;
+    }
+
+    const [error, result] = await registerWithIdentifierAsync(verificationId);
+
+    if (error) {
+      await handleError(error, preRegisterErrorHandler);
+
+      return;
+    }
+
+    if (result?.redirectTo) {
+      await redirectTo(result.redirectTo);
+    }
   }, [
     identifier,
     isVerificationCodeEnabledForSignUp,
     show,
     t,
+    termsValidation,
     showIdentifierErrorAlert,
     registerWithIdentifierAsync,
     verificationId,


### PR DESCRIPTION
## Summary

When the sign-in experience agreement policy is set to **`ManualRegistrationOnly`** ("Require checkbox agreement on registration only"), the verification-code sign-in flow had a gap: signing in with an **unregistered** email/phone, then confirming the "this account doesn't exist, create a new account?" prompt, created the account **without ever showing the terms agreement**.

Root cause: agreement is enforced purely on the frontend, and this "sign-in turns into registration" path (`use-sign-in-flow-code-verification.ts`) submitted the registration directly from the confirm modal's `onConfirm`, never calling `termsValidation()`. The dedicated registration form and the social/SSO registration callbacks already validate terms; only this path was missing it.

### Changes

- **`use-sign-in-flow-code-verification.ts`**: switch the "create a new account?" confirmation from the callback-based modal to the promise-based `usePromiseConfirmModal`, and on confirm run `termsValidation()` **before** registering. `termsValidation()` is a no-op for `Automatic`, when terms are not configured, or when the user already agreed (e.g. `Manual`, where agreement is collected up front on the sign-in form), so no double prompt occurs.
- **`ConfirmModalProvider`**: defensively clear `callbackRef` when a promise-based modal opens, so a stale callback from a previous callback-based modal can't be invoked when the promise modal is confirmed/cancelled. This also makes it safe to open a promise modal from within a callback modal's handler.

Behavior by policy on this path: `Automatic` → no prompt (unchanged); `ManualRegistrationOnly` → **now prompts** before account creation; `Manual` → already agreed on the sign-in form, no change.

## Testing

unit tests — added a case in `VerificationCode/index.test.tsx` asserting that under `ManualRegistrationOnly`, the terms modal is shown and registration only happens after the user agrees. Verified it fails without the fix and passes with it.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments