### PR TITLE
fix(experience): prevent duplicate verification code submission on sign-in to register

### DIFF
--- a/packages/experience/src/containers/VerificationCode/index.test.tsx
+++ b/packages/experience/src/containers/VerificationCode/index.test.tsx
@@ -430,12 +430,16 @@ describe('<VerificationCode />', () => {
         </SettingsProvider>
       );
 
-    it('prompts the terms agreement before creating the account under `ManualRegistrationOnly`', async () => {
+    /**
+     * Drive the flow up to the terms agreement dialog: fail the sign-in with `user_not_exist`,
+     * fill the code, confirm the "account does not exist" modal, and return the terms dialog.
+     */
+    const reachTermsDialog = async (identifier: VerificationCodeIdentifier) => {
       (identifyWithVerificationCode as jest.Mock).mockRejectedValueOnce(
         createRequestError('user.user_not_exist')
       );
 
-      const { container, findByText } = renderSignInToRegister(emailIdentifier);
+      const { container, findByText } = renderSignInToRegister(identifier);
 
       fillVerificationCode(container);
 
@@ -446,7 +450,6 @@ describe('<VerificationCode />', () => {
       const modalContent = await findByText('description.sign_in_id_does_not_exist');
       const dialog = modalContent.closest('[role="dialog"]');
       assert(dialog, new Error('confirmation dialog not found'));
-      expect(registerWithVerifiedIdentifier).not.toBeCalled();
 
       await act(async () => {
         fireEvent.click(within(dialog as HTMLElement).getByText('action.continue'));
@@ -457,6 +460,12 @@ describe('<VerificationCode />', () => {
       const termsDialog = termsContent.closest('[role="dialog"]');
       assert(termsDialog, new Error('terms agreement dialog not found'));
       expect(registerWithVerifiedIdentifier).not.toBeCalled();
+
+      return termsDialog as HTMLElement;
+    };
+
+    it('prompts the terms agreement before creating the account under `ManualRegistrationOnly`', async () => {
+      const termsDialog = await reachTermsDialog(emailIdentifier);
 
       /**
        * The dialog contains an icon-only close button, a cancel button, and the confirm (agree)
@@ -478,6 +487,30 @@ describe('<VerificationCode />', () => {
       await waitFor(() => {
         expect(window.location.replace).toBeCalledWith(redirectTo);
       });
+
+      /**
+       * Agreeing rebuilds the submission callback; the already-consumed code must not be
+       * auto-submitted again, which would fail with `verification_code.not_found`.
+       */
+      expect(identifyWithVerificationCode).toHaveBeenCalledTimes(1);
+    });
+
+    it('navigates back without creating the account when the terms agreement is declined', async () => {
+      const termsDialog = await reachTermsDialog(emailIdentifier);
+
+      await act(async () => {
+        fireEvent.click(within(termsDialog).getByText('action.cancel'));
+      });
+
+      /**
+       * Declining the terms must not submit the registration. The verification code is already
+       * consumed, so the user is navigated back instead of being left on a page where retrying
+       * would fail with `verification_code.not_found`.
+       */
+      await waitFor(() => {
+        expect(mockedNavigate).toBeCalledWith(-1);
+      });
+      expect(registerWithVerifiedIdentifier).not.toBeCalled();
     });
   });
 });

--- a/packages/experience/src/containers/VerificationCode/index.tsx
+++ b/packages/experience/src/containers/VerificationCode/index.tsx
@@ -1,6 +1,6 @@
 import { type VerificationCodeIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslation, Trans } from 'react-i18next';
 
 import SwitchToVerificationMethodsLink from '@/components/SwitchToVerificationMethodsLink';
@@ -62,22 +62,39 @@ const VerificationCode = ({
 
   const handleSubmit = useCallback(
     async (code: string[]) => {
-      setInputErrorMessage(undefined);
+      if (isSubmitting) {
+        return;
+      }
 
+      setInputErrorMessage(undefined);
       setIsSubmitting(true);
 
-      await onSubmit(code.join(''));
-
-      setIsSubmitting(false);
+      try {
+        await onSubmit(code.join(''));
+      } finally {
+        // Always reset, even if `onSubmit` throws, so the button does not spin forever.
+        setIsSubmitting(false);
+      }
     },
-    [onSubmit]
+    [isSubmitting, onSubmit]
   );
+
+  /**
+   * Auto-submit once the code is fully entered. `handleSubmit` is intentionally accessed through
+   * a ref so this effect does not depend on its identity: the submission callback chain is rebuilt
+   * mid-flow (e.g. agreeing to the terms when a sign-in turns into a registration updates
+   * `termsAgreement`), and depending on it would re-run this effect and resubmit the same — already
+   * consumed — code, surfacing a spurious `verification_code.not_found` error.
+   */
+  const handleSubmitRef = useRef(handleSubmit);
+  // eslint-disable-next-line @silverhand/fp/no-mutation
+  handleSubmitRef.current = handleSubmit;
 
   useEffect(() => {
     if (isCodeInputReady) {
-      void handleSubmit(codeInput);
+      void handleSubmitRef.current(codeInput);
     }
-  }, [codeInput, handleSubmit, isCodeInputReady]);
+  }, [codeInput, isCodeInputReady]);
 
   return (
     <form className={classNames(styles.form, className)}>

--- a/packages/experience/src/containers/VerificationCode/use-sign-in-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-sign-in-flow-code-verification.ts
@@ -77,8 +77,14 @@ const useSignInFlowCodeVerification = (
      * agreement on registration (`Manual` and `ManualRegistrationOnly`) are still enforced on
      * this path. `termsValidation` is a no-op when the policy is `Automatic`, the terms are not
      * configured, or the user has already agreed.
+     *
+     * If the user declines the terms, navigate back to the identifier page (same as cancelling
+     * the confirmation above). The verification code has already been consumed by the failed
+     * sign-in attempt, so keeping the user on this page would only let them retry with a dead
+     * code and hit a confusing `verification_code.not_found` error.
      */
     if (!(await termsValidation())) {
+      navigate(-1);
       return;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #8835, on the sign-in-with-verification-code → registration path. When the identifier (email/phone) is not registered, the code is already consumed by the failed sign-in attempt before the "create a new account" confirmation is shown. Two issues on this path are fixed:

- **Dead-end after declining the terms.** Declining the terms agreement that follows the "create a new account" confirmation used to leave the user on the verification code page. Since the code is already consumed, retrying there fails with `verification_code.not_found`. The flow now navigates back (consistent with cancelling the confirmation), so the user can request a fresh code.
- **Duplicate auto-submission.** Agreeing to the terms updates `termsAgreement`, which rebuilds the submit callback. The verification code page auto-submits whenever that callback changes while a complete code is still present, so the already-consumed code was submitted a second time and surfaced `verification_code.not_found`. Added a guard so the same code is auto-submitted only once.

This change ships under the existing `@logto/experience` changeset from #8835, so no new changeset is added here.

## Testing

unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
