### PR TITLE
feat(core): ga organization.membership.updated delta payload

### DIFF
--- a/.changeset/membership-webhook-delta-ga.md
+++ b/.changeset/membership-webhook-delta-ga.md
@@ -1,0 +1,15 @@
+---
+"@logto/core": minor
+---
+
+enrich `Organization.Membership.Updated` webhook payload with explicit delta fields describing the exact membership change:
+
+- `addedUserIds` / `removedUserIds` on `POST/PUT/DELETE /organizations/:id/users`.
+- `addedApplicationIds` / `removedApplicationIds` on `POST/PUT/DELETE /organizations/:id/applications`.
+- `addedUserIds` on invitation accept (`PUT /organization-invitations/:id/status`) and experience-flow just-in-time provisioning (email-domain JIT and enterprise SSO JIT during sign-up / sign-in).
+
+Each delta array is capped silently at 5000 entries; for bulk operations that exceed the cap, consumers should reconcile authoritative membership via `GET /organizations/:id/users` or `GET /organizations/:id/applications`. Empty deltas are omitted from the payload entirely — consumers must treat a missing field as "no change on that side," not as "an empty change." The `PUT` replace handlers report the truly-new and truly-removed IDs (not the entire declared set). Re-accepting an invitation by a user who is already a member and re-provisioning an already-provisioned JIT user both produce the legacy `{ organizationId }`-only shape.
+
+No breaking change: the four delta fields are additive optional fields; the previously emitted `data: null` field is unchanged. See the [webhook reference](https://docs.logto.io/developers/webhooks/webhooks-request#organizationmembershipupdated-payload) for the full payload contract.
+
+Supersedes #8752 — thanks @chiche84.

--- a/.changeset/membership-webhook-delta-ga.md
+++ b/.changeset/membership-webhook-delta-ga.md
@@ -4,12 +4,12 @@
 
 enrich `Organization.Membership.Updated` webhook payload with explicit delta fields describing the exact membership change:
 
-- `addedUserIds` / `removedUserIds` on `POST/PUT/DELETE /organizations/:id/users`.
-- `addedApplicationIds` / `removedApplicationIds` on `POST/PUT/DELETE /organizations/:id/applications`.
+- `addedUserIds` / `removedUserIds` on `POST /organizations/:id/users`, `PUT /organizations/:id/users`, and `DELETE /organizations/:id/users/:userId`.
+- `addedApplicationIds` / `removedApplicationIds` on `POST /organizations/:id/applications`, `PUT /organizations/:id/applications`, and `DELETE /organizations/:id/applications/:applicationId`.
 - `addedUserIds` on invitation accept (`PUT /organization-invitations/:id/status`) and experience-flow just-in-time provisioning (email-domain JIT and enterprise SSO JIT during sign-up / sign-in).
 
-Each delta array is capped silently at 5000 entries; for bulk operations that exceed the cap, consumers should reconcile authoritative membership via `GET /organizations/:id/users` or `GET /organizations/:id/applications`. Empty deltas are omitted from the payload entirely — consumers must treat a missing field as "no change on that side," not as "an empty change." The `PUT` replace handlers report the truly-new and truly-removed IDs (not the entire declared set). Re-accepting an invitation by a user who is already a member and re-provisioning an already-provisioned JIT user both produce the legacy `{ organizationId }`-only shape.
+Each delta array is capped silently at 5000 entries; for bulk operations that exceed the cap, consumers should reconcile authoritative membership via `GET /organizations/:id/users` or `GET /organizations/:id/applications`. Empty deltas are omitted from the payload entirely, and consumers must treat a missing field as "no change on that side," not as "an empty change." The `PUT` replace handlers report the truly-new and truly-removed IDs (not the entire declared set). Re-accepting an invitation by a user who is already a member still produces the legacy `{ organizationId }`-only shape.
 
 No breaking change: the four delta fields are additive optional fields; the previously emitted `data: null` field is unchanged. See the [webhook reference](https://docs.logto.io/developers/webhooks/webhooks-request#organizationmembershipupdated-payload) for the full payload contract.
 
-Supersedes #8752 — thanks @chiche84.
+Supersedes #8752, thanks @chiche84.

--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -308,9 +308,8 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
   // TODO: If the user's email is not verified, we should not provision the user into any organization.
   /**
    * Provision the user with JIT organizations and roles based on the user's email domain and the
-   * enterprise SSO connector. When `isDevFeaturesEnabled` is on, returns only the JIT orgs where
-   * the user was newly added (so the caller emits accurate `addedUserIds`); otherwise returns
-   * every JIT org, preserving master's webhook behavior.
+   * enterprise SSO connector. Returns only the JIT orgs where the user was newly added — callers
+   * use this to emit accurate `addedUserIds` on `Organization.Membership.Updated`.
    */
   const provisionOrganizations = async ({
     userId,
@@ -331,16 +330,11 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
     }
 
     // Snapshot pre-existing memberships before the insert; afterwards
-    // `getExistingOrganizationIds` cannot distinguish pre-existing from newly-added
-    // rows. Gated behind dev-features because the snapshot is only consulted by the
-    // dev-features branch of the return below; in production (dev-OFF) we return
-    // every JIT org unfiltered, so the snapshot would be unused DB work.
+    // `getExistingOrganizationIds` cannot distinguish pre-existing from newly-added rows.
     const jitOrganizationIds = jitOrganizations.map(({ organizationId }) => organizationId);
-    const existingOrganizationIds = EnvSet.values.isDevFeaturesEnabled
-      ? new Set(
-          await organizations.relations.users.getExistingOrganizationIds(userId, jitOrganizationIds)
-        )
-      : new Set<string>();
+    const existingOrganizationIds = new Set(
+      await organizations.relations.users.getExistingOrganizationIds(userId, jitOrganizationIds)
+    );
 
     await organizations.relations.users.insert(
       ...jitOrganizationIds.map((organizationId) => ({ organizationId, userId }))
@@ -357,11 +351,9 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
       await organizations.relations.usersRoles.insert(...data);
     }
 
-    return EnvSet.values.isDevFeaturesEnabled
-      ? jitOrganizations.filter(
-          ({ organizationId }) => !existingOrganizationIds.has(organizationId)
-        )
-      : jitOrganizations;
+    return jitOrganizations.filter(
+      ({ organizationId }) => !existingOrganizationIds.has(organizationId)
+    );
   };
 
   return {

--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -308,8 +308,9 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
   // TODO: If the user's email is not verified, we should not provision the user into any organization.
   /**
    * Provision the user with JIT organizations and roles based on the user's email domain and the
-   * enterprise SSO connector. Returns only the JIT orgs where the user was newly added — callers
-   * use this to emit accurate `addedUserIds` on `Organization.Membership.Updated`.
+   * enterprise SSO connector. Returns only the JIT orgs the user was newly added to (i.e. orgs
+   * the user was not already a member of) so callers can decide whether to emit
+   * `Organization.Membership.Updated` for each org and what `addedUserIds` to include.
    */
   const provisionOrganizations = async ({
     userId,

--- a/packages/core/src/routes/experience/classes/libraries/provision-library.ts
+++ b/packages/core/src/routes/experience/classes/libraries/provision-library.ts
@@ -155,8 +155,7 @@ export class ProvisionLibrary {
     for (const { organizationId } of provisionedOrganizations) {
       this.ctx.appendDataHookContext('Organization.Membership.Updated', {
         organizationId,
-        ...(EnvSet.values.isDevFeaturesEnabled &&
-          truncateMembershipDelta({ addedUserIds: [payload.userId] })),
+        ...truncateMembershipDelta({ addedUserIds: [payload.userId] }),
       });
     }
 

--- a/packages/core/src/routes/organization-invitation/index.ts
+++ b/packages/core/src/routes/organization-invitation/index.ts
@@ -6,7 +6,6 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildManagementApiContext, truncateMembershipDelta } from '#src/libraries/hook/utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -160,24 +159,15 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
         })
       );
 
-      // Snapshot pre-existing membership only when dev features are on. In production
-      // (dev-OFF) the webhook payload is the legacy `{ organizationId }`-only shape,
-      // so the snapshot would be unused DB work. The snapshot must run before
-      // `updateStatus` — the underlying insert uses ON CONFLICT DO NOTHING, so after
-      // it runs we cannot distinguish a real addition from a re-accept of an existing
-      // member. Returns the accurate `addedUserIds` for the webhook payload:
-      // `[acceptedUserId]` on a real addition, `[]` on a re-accept.
-      const addedUserIds = await (async (): Promise<string[]> => {
-        if (!EnvSet.values.isDevFeaturesEnabled) {
-          return [];
-        }
-        const invitation = await queries.organizations.invitations.findById(id);
-        const existingUserIds = await queries.organizations.relations.users.getExistingUserIds(
-          invitation.organizationId,
-          [acceptedUserId]
-        );
-        return existingUserIds.length > 0 ? [] : [acceptedUserId];
-      })();
+      // Snapshot pre-existing membership before `updateStatus` runs the insert (which
+      // uses ON CONFLICT DO NOTHING); afterwards the row is always present and we cannot
+      // distinguish a real addition from a re-accept of an existing member.
+      const invitation = await queries.organizations.invitations.findById(id);
+      const existingUserIds = await queries.organizations.relations.users.getExistingUserIds(
+        invitation.organizationId,
+        [acceptedUserId]
+      );
+      const addedUserIds = existingUserIds.length > 0 ? [] : [acceptedUserId];
 
       const result = await organizationInvitations.updateStatus(id, status, acceptedUserId);
 
@@ -186,15 +176,14 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
       // koa-default 404 in the webhook payload.
       ctx.status = 200;
 
-      // Always emit, matching every other Organization.Membership.Updated trigger in
-      // this project: the dev-features gate lives inside the spread, and
-      // `truncateMembershipDelta` omits empty arrays so a re-accept (no real change)
-      // produces the legacy `{ organizationId }`-only shape, identical to dev-OFF.
+      // Always emit, matching every other Organization.Membership.Updated trigger. The
+      // helper omits empty arrays, so a re-accept (no real change) reduces to the legacy
+      // `{ organizationId }`-only shape.
       const { organizationId } = result;
       ctx.appendDataHookContext('Organization.Membership.Updated', {
         ...buildManagementApiContext(ctx),
         organizationId,
-        ...(EnvSet.values.isDevFeaturesEnabled && truncateMembershipDelta({ addedUserIds })),
+        ...truncateMembershipDelta({ addedUserIds }),
       });
 
       return next();

--- a/packages/core/src/routes/organization-invitation/index.ts
+++ b/packages/core/src/routes/organization-invitation/index.ts
@@ -162,7 +162,7 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
       // Snapshot pre-existing membership before `updateStatus` runs the insert (which
       // uses ON CONFLICT DO NOTHING); afterwards the row is always present and we cannot
       // distinguish a real addition from a re-accept of an existing member.
-      const invitation = await queries.organizations.invitations.findById(id);
+      const invitation = await invitations.findById(id);
       const existingUserIds = await queries.organizations.relations.users.getExistingUserIds(
         invitation.organizationId,
         [acceptedUserId]

--- a/packages/core/src/routes/organization/application/index.ts
+++ b/packages/core/src/routes/organization/application/index.ts
@@ -6,7 +6,6 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import { buildManagementApiContext, truncateMembershipDelta } from '#src/libraries/hook/utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
@@ -18,26 +17,14 @@ import { parseSearchOptions } from '#src/utils/search.js';
 import applicationRoleRelationRoutes from './role-relations.js';
 
 /**
- * Org-application membership endpoints. When `isDevFeaturesEnabled` is off we fall
- * back to the generic `addRelationRoutes` mount, which only emits `{ organizationId }`
- * on the membership webhook. When it is on, we own POST/PUT/DELETE so we can include
- * the `addedApplicationIds` / `removedApplicationIds` delta in the payload.
- *
- * The dev-features branch and the legacy fallback should be collapsed once the
- * delta payload graduates to GA (LOG-13467).
+ * Org-application membership endpoints. POST/PUT/DELETE own their own handlers so the
+ * `Organization.Membership.Updated` webhook payload carries an accurate
+ * `addedApplicationIds` / `removedApplicationIds` delta.
  */
 const mountMembershipRoutes = (
   router: SchemaRouter<OrganizationKeys, CreateOrganization, Organization>,
   organizations: OrganizationQueries
 ) => {
-  if (!EnvSet.values.isDevFeaturesEnabled) {
-    router.addRelationRoutes(organizations.relations.apps, undefined, {
-      disabled: { get: true },
-      hookEvent: 'Organization.Membership.Updated',
-    });
-    return;
-  }
-
   router.post(
     '/:id/applications',
     koaGuard({

--- a/packages/core/src/routes/organization/user/index.ts
+++ b/packages/core/src/routes/organization/user/index.ts
@@ -7,7 +7,6 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import { buildManagementApiContext, truncateMembershipDelta } from '#src/libraries/hook/utils.js';
 import { type QuotaLibrary } from '#src/libraries/quota.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -93,8 +92,7 @@ export default function userRoutes(
       ctx.appendDataHookContext('Organization.Membership.Updated', {
         ...buildManagementApiContext(ctx),
         organizationId: id,
-        ...(EnvSet.values.isDevFeaturesEnabled &&
-          truncateMembershipDelta({ addedUserIds: newUserIds })),
+        ...truncateMembershipDelta({ addedUserIds: newUserIds }),
       });
 
       return next();
@@ -142,11 +140,10 @@ export default function userRoutes(
       ctx.appendDataHookContext('Organization.Membership.Updated', {
         ...buildManagementApiContext(ctx),
         organizationId: id,
-        ...(EnvSet.values.isDevFeaturesEnabled &&
-          truncateMembershipDelta({
-            addedUserIds: added,
-            removedUserIds: removed,
-          })),
+        ...truncateMembershipDelta({
+          addedUserIds: added,
+          removedUserIds: removed,
+        }),
       });
 
       return next();
@@ -171,8 +168,7 @@ export default function userRoutes(
       ctx.appendDataHookContext('Organization.Membership.Updated', {
         ...buildManagementApiContext(ctx),
         organizationId: id,
-        ...(EnvSet.values.isDevFeaturesEnabled &&
-          truncateMembershipDelta({ removedUserIds: [userId] })),
+        ...truncateMembershipDelta({ removedUserIds: [userId] }),
       });
 
       return next();

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.organization.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.organization.test.ts
@@ -3,7 +3,6 @@ import { assert, noop } from '@silverhand/essentials';
 
 import { authedAdminApi } from '#src/api/api.js';
 import { createApplication, deleteApplication } from '#src/api/application.js';
-import { isDevFeaturesEnabled } from '#src/constants.js';
 import {
   OrganizationApiTest,
   OrganizationInvitationApiTest,
@@ -112,13 +111,12 @@ describe('organization data hook events', () => {
                 organizationId,
                 applicationId,
                 applicationIdB,
-                isDevFeaturesEnabled,
               } satisfies HookPayloadArgs)
             : hookPayload;
         expect(hook?.payload).toMatchObject(resolved);
         // `toMatchObject` is partial-match; assert absence of every delta field
-        // a case did not declare so the dev-features gate and the omit-empty
-        // contract are regression-protected end-to-end.
+        // a case did not declare so the omit-empty contract is regression-protected
+        // end-to-end.
         for (const field of [
           'addedUserIds',
           'removedUserIds',
@@ -237,15 +235,10 @@ describe('organization invitation membership webhook', () => {
 
     const hook = await getWebhookResult('PUT /organization-invitations/:id/status');
     expect(hook?.payload.event).toBe('Organization.Membership.Updated');
-    if (isDevFeaturesEnabled) {
-      expect(hook?.payload).toMatchObject({
-        organizationId: organization.id,
-        addedUserIds: [user.id],
-      });
-    } else {
-      expect(hook?.payload).toMatchObject({ organizationId: organization.id });
-      expect(hook?.payload).not.toHaveProperty('addedUserIds');
-    }
+    expect(hook?.payload).toMatchObject({
+      organizationId: organization.id,
+      addedUserIds: [user.id],
+    });
     expect(hook?.payload).not.toHaveProperty('removedUserIds');
   });
 
@@ -269,7 +262,6 @@ describe('organization invitation membership webhook', () => {
     // Re-accept of an already-member still emits (matches the project-wide
     // "no-op still emits" contract used by every other Organization.Membership.Updated
     // trigger), but with no delta fields because there was no real membership change.
-    // The shape is therefore identical in dev-on and dev-off modes.
     const hook = await getWebhookResult('PUT /organization-invitations/:id/status');
     expect(hook?.payload.event).toBe('Organization.Membership.Updated');
     expect(hook?.payload).toMatchObject({ organizationId: organization.id });

--- a/packages/integration-tests/src/tests/api/hook/test-cases-organization.ts
+++ b/packages/integration-tests/src/tests/api/hook/test-cases-organization.ts
@@ -24,11 +24,9 @@ export const organizationDataHookTestCases: TestCase[] = [
       }
       await trySafe(organizationApi.deleteUser(organizationId, userId));
     },
-    hookPayload: ({ userId, isDevFeaturesEnabled }) => ({
+    hookPayload: ({ userId }) => ({
       organizationId: expect.any(String),
-      ...(isDevFeaturesEnabled && {
-        addedUserIds: [userId],
-      }),
+      addedUserIds: [userId],
     }),
   },
   {
@@ -58,11 +56,9 @@ export const organizationDataHookTestCases: TestCase[] = [
       }
       await trySafe(organizationApi.addUsers(organizationId, [userId]));
     },
-    hookPayload: ({ userId, isDevFeaturesEnabled }) => ({
+    hookPayload: ({ userId }) => ({
       organizationId: expect.any(String),
-      ...(isDevFeaturesEnabled && {
-        removedUserIds: [userId],
-      }),
+      removedUserIds: [userId],
     }),
   },
   {
@@ -77,11 +73,9 @@ export const organizationDataHookTestCases: TestCase[] = [
       }
       await trySafe(organizationApi.applications.delete(organizationId, applicationId));
     },
-    hookPayload: ({ applicationId, isDevFeaturesEnabled }) => ({
+    hookPayload: ({ applicationId }) => ({
       organizationId: expect.any(String),
-      ...(isDevFeaturesEnabled && {
-        addedApplicationIds: [applicationId],
-      }),
+      addedApplicationIds: [applicationId],
     }),
   },
   {
@@ -121,8 +115,8 @@ export const organizationDataHookTestCases: TestCase[] = [
   },
   {
     // Replace A with B exercises the `replaceWithDelta` plumbing end-to-end:
-    // both `added` and `removed` are non-empty, so both delta fields must be
-    // present in the payload (under the dev gate).
+    // both `added` and `removed` are non-empty, so both delta fields appear
+    // in the payload.
     route: 'PUT /organizations/:id/applications',
     event: 'Organization.Membership.Updated',
     method: 'put',
@@ -136,12 +130,10 @@ export const organizationDataHookTestCases: TestCase[] = [
       await trySafe(organizationApi.applications.add(organizationId, [applicationId]));
       await trySafe(organizationApi.applications.delete(organizationId, applicationIdB));
     },
-    hookPayload: ({ applicationId, applicationIdB, isDevFeaturesEnabled }) => ({
+    hookPayload: ({ applicationId, applicationIdB }) => ({
       organizationId: expect.any(String),
-      ...(isDevFeaturesEnabled && {
-        addedApplicationIds: [applicationIdB],
-        removedApplicationIds: [applicationId],
-      }),
+      addedApplicationIds: [applicationIdB],
+      removedApplicationIds: [applicationId],
     }),
   },
   {
@@ -156,11 +148,9 @@ export const organizationDataHookTestCases: TestCase[] = [
       }
       await trySafe(organizationApi.applications.add(organizationId, [applicationId]));
     },
-    hookPayload: ({ applicationId, isDevFeaturesEnabled }) => ({
+    hookPayload: ({ applicationId }) => ({
       organizationId: expect.any(String),
-      ...(isDevFeaturesEnabled && {
-        removedApplicationIds: [applicationId],
-      }),
+      removedApplicationIds: [applicationId],
     }),
   },
   {

--- a/packages/integration-tests/src/tests/api/hook/test-cases.ts
+++ b/packages/integration-tests/src/tests/api/hook/test-cases.ts
@@ -10,9 +10,7 @@ type PlaceholderIds = {
   organizationRoleId?: string;
 };
 
-type HookPayloadArgs = PlaceholderIds & {
-  isDevFeaturesEnabled: boolean;
-};
+type HookPayloadArgs = PlaceholderIds;
 
 type SetupContext = {
   organizationApi?: OrganizationApiTest;


### PR DESCRIPTION
## Summary
Refs [LOG-13467](https://linear.app/silverhand/issue/LOG-13467). Closes #7961 and #6757. Supersedes #8752 — thanks @chiche84.

Removes the `EnvSet.values.isDevFeaturesEnabled` guards that have kept the Phase 1–3 `Organization.Membership.Updated` payload enrichment behind dev-features. After this PR lands, every production deployment emits the four delta fields (`addedUserIds` / `removedUserIds` / `addedApplicationIds` / `removedApplicationIds`) on every supported trigger.

### What changed
- **`packages/core/src/routes/organization/user/index.ts`** — POST/PUT/DELETE handlers drop the `EnvSet.values.isDevFeaturesEnabled && truncateMembershipDelta(...)` guard. The spread is now unconditional; `truncateMembershipDelta` continues to omit empty arrays so no-op operations still produce the legacy `{ organizationId }`-only shape.
- **`packages/core/src/routes/organization/application/index.ts`** — `mountMembershipRoutes` no longer branches on the dev-features flag. The bespoke POST/PUT/DELETE handlers always own the route; the previous `addRelationRoutes` fallback (which only emitted `{ organizationId }`) is gone.
- **`packages/core/src/routes/organization-invitation/index.ts`** — the snapshot IIFE collapses to straight imperative code (the dev-OFF early-return is removed). The webhook emit is now an unconditional spread.
- **`packages/core/src/routes/experience/classes/libraries/provision-library.ts`** — JIT emit spread is unconditional.
- **`packages/core/src/libraries/user.ts`** — `provisionOrganizations` now always snapshots pre-existing memberships and always returns only the truly-new JIT orgs. The previous dev-OFF fast-path (return everything unfiltered) is gone.
- **`packages/integration-tests/src/tests/api/hook/test-cases.ts`** — `HookPayloadArgs` no longer carries `isDevFeaturesEnabled`.
- **`packages/integration-tests/src/tests/api/hook/test-cases-organization.ts`** — every `hookPayload` callback flattens its `...(isDevFeaturesEnabled && { … })` wrapper to a plain object. The runner-level `not.toHaveProperty` check stays — it now guards the omit-empty contract alone.
- **`packages/integration-tests/src/tests/api/hook/hook.trigger.organization.test.ts`** — invitation-accept regression test drops its dev-on / dev-off branching; both modes now expect the same delta-bearing payload. Unused `isDevFeaturesEnabled` import removed.
- **`.changeset/membership-webhook-delta-ga.md`** — single consolidated minor changeset enumerating the GA behaviors (delta fields, 5000-entry cap, omit-empty rule, accurate PUT delta).

### Expected result
- Production webhook consumers receive `addedUserIds` / `removedUserIds` / `addedApplicationIds` / `removedApplicationIds` on `Organization.Membership.Updated` from every supported trigger.
- Each delta array is capped at 5000 entries with silent truncation; bulk-operation consumers reconcile via the Management API per the [webhook reference](https://docs.logto.io/developers/webhooks/webhooks-request#organizationmembershipupdated-payload).
- Empty deltas remain omitted; absent ≠ empty change.
- Deprecated `routes/interaction/*` paths are intentionally untouched — they were never gated to begin with (the Linear issue's bullet for those routes is stale and reflects an earlier scope).

### Reviewer notes
- Net delete: 8 source files, +52 / −109. The only added code is the changeset.
- `EnvSet` import stays in `libraries/user.ts` and `provision-library.ts` — both files retain other (unrelated) `EnvSet.values.*` reads.
- Verified locally: `pnpm -F @logto/core build`, `pnpm -F @logto/integration-tests build`, both `lint`, and `pnpm -F @logto/core test:only` (1862/1862 pass).

## Testing
Unit tests

## Checklist
- [x] \`.changeset\`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments