### PR TITLE
release(core,console): ga protected app v2 bug bash features

### DIFF
--- a/.changeset/protected-app-v2-ga.md
+++ b/.changeset/protected-app-v2-ga.md
@@ -3,6 +3,6 @@
 "@logto/core": minor
 ---
 
-general availability for protected app v2 features validated in bug bash
+add protected app ID token claim scopes and tenant custom domain SDK endpoint support
 
-Protected App settings now expose ID token claim scopes in Console, sync them to remote config, and use the tenant custom domain for the SDK endpoint when one is active. Application secret rotation and custom domain behavior from the bug bash are now available without dev features enabled.
+Protected App settings in Console let you choose which ID token claims (such as `roles`, `custom_data`, and `organizations`) are forwarded to your origin via the `Logto-ID-Token` header. When a tenant custom domain is active, Protected App remote config uses that domain as the SDK endpoint.

--- a/.changeset/protected-app-v2-ga.md
+++ b/.changeset/protected-app-v2-ga.md
@@ -1,0 +1,8 @@
+---
+"@logto/console": minor
+"@logto/core": minor
+---
+
+general availability for protected app v2 features validated in bug bash
+
+Protected App settings now expose ID token claim scopes in Console, sync them to remote config, and use the tenant custom domain for the SDK endpoint when one is active. Application secret rotation and custom domain behavior from the bug bash are now available without dev features enabled.

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.tsx
@@ -18,11 +18,7 @@ import DomainStatusTag from '@/components/DomainStatusTag';
 import FormCard from '@/components/FormCard';
 import OpenExternalLink from '@/components/OpenExternalLink';
 import { protectedApp, protectedAppLocalDev, protectOriginServer } from '@/consts';
-import {
-  isDevFeaturesEnabled,
-  isProtectedAppEnabled,
-  isProtectedAppLocalDevEnabled,
-} from '@/consts/env';
+import { isProtectedAppEnabled, isProtectedAppLocalDevEnabled } from '@/consts/env';
 import { openIdProviderConfigPath } from '@/consts/oidc';
 import Button from '@/ds-components/Button';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
@@ -300,7 +296,7 @@ function ProtectedAppSettings({ data }: Props) {
         </FormField>
       </FormCard>
       <EndpointsAndCredentials app={data} oidcConfig={oidcConfig} onApplicationUpdated={mutate} />
-      {isDevFeaturesEnabled && <AdditionalScopesForm />}
+      <AdditionalScopesForm />
       <SessionForm data={data} />
     </>
   );

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/utils.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/utils.ts
@@ -1,7 +1,6 @@
 import { customClientMetadataDefault, type ApplicationResponse } from '@logto/schemas';
 import { cond, conditional, type DeepPartial } from '@silverhand/essentials';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { isJsonObject } from '@/utils/json';
 
 type ProtectedAppMetadataType = ApplicationResponse['protectedAppMetadata'];
@@ -26,11 +25,8 @@ const mapToUriOriginFormatArrays = (value?: string[]) =>
 const parseProtectedAppMetadataFromResponse = (
   protectedAppMetadata: NonNullable<ProtectedAppMetadataType>
 ): ApplicationForm['protectedAppMetadata'] => {
-  const { additionalScopes, ...rest } = protectedAppMetadata;
-
   return {
-    ...rest,
-    ...conditional(isDevFeaturesEnabled && { additionalScopes }),
+    ...protectedAppMetadata,
     sessionDuration: protectedAppMetadata.sessionDuration / 3600 / 24,
   };
 };
@@ -38,11 +34,8 @@ const parseProtectedAppMetadataFromResponse = (
 const parseProtectedAppMetadataToPayload = (
   protectedAppMetadata: NonNullable<ApplicationForm['protectedAppMetadata']>
 ): NonNullable<DeepPartial<ApplicationResponse>['protectedAppMetadata']> => {
-  const { additionalScopes, ...rest } = protectedAppMetadata;
-
   return {
-    ...rest,
-    ...conditional(isDevFeaturesEnabled && { additionalScopes }),
+    ...protectedAppMetadata,
     sessionDuration: protectedAppMetadata.sessionDuration * 3600 * 24,
   };
 };

--- a/packages/core/src/libraries/protected-app.test.ts
+++ b/packages/core/src/libraries/protected-app.test.ts
@@ -1,5 +1,3 @@
-// eslint-disable-next-line eslint-comments/disable-enable-pair -- max-lines applies to whole file
-/* eslint-disable max-lines */
 import { UserScope } from '@logto/core-kit';
 import {
   ApplicationType,
@@ -43,12 +41,7 @@ const { updateProtectedAppSiteConfigs, deleteCustomHostname } = await mockEsmWit
 
 const { MockQueries } = await import('#src/test-utils/tenant.js');
 const { createProtectedAppLibrary } = await import('./protected-app.js');
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 const originalIsProtectedAppLocalDevEnabled = EnvSet.values.isProtectedAppLocalDevEnabled;
-const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
-  // eslint-disable-next-line @silverhand/fp/no-mutation
-  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
-};
 
 const findApplications = jest.fn(async (): Promise<Application[]> => [mockProtectedApplication]);
 const findApplicationById = jest.fn(async (): Promise<Application> => mockProtectedApplication);
@@ -141,7 +134,6 @@ afterAll(() => {
 });
 
 afterEach(() => {
-  setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
   setProtectedAppLocalDevEnabled(originalIsProtectedAppLocalDevEnabled);
   // eslint-disable-next-line @silverhand/fp/no-mutation
   SystemContext.shared.protectedAppConfigProviderConfig = protectedAppConfigProviderConfig;
@@ -230,8 +222,7 @@ describe('syncAppConfigsToRemote()', () => {
     );
   });
 
-  it('should use active tenant custom domain as SDK endpoint when dev features are enabled', async () => {
-    setDevFeaturesEnabled(true);
+  it('should use active tenant custom domain as SDK endpoint', async () => {
     findAllDomains.mockResolvedValueOnce([activeDomain]);
     findApplicationById.mockResolvedValueOnce(mockProtectedApplicationWithCustomDomain);
 
@@ -255,14 +246,12 @@ describe('syncAppConfigsToRemote()', () => {
     );
   });
 
-  it('should keep the default SDK endpoint when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
-    findAllDomains.mockResolvedValueOnce([activeDomain]);
+  it('should keep the default SDK endpoint when tenant has no active custom domain', async () => {
+    findAllDomains.mockResolvedValueOnce([]);
     findApplicationById.mockResolvedValueOnce(mockProtectedApplication);
 
     await expect(syncAppConfigsToRemote(mockProtectedApplication.id)).resolves.not.toThrow();
 
-    expect(findAllDomains).not.toHaveBeenCalled();
     expect(updateProtectedAppSiteConfigs).toHaveBeenCalledWith(
       protectedAppConfigProviderConfig,
       mockProtectedApplication.protectedAppMetadata.host,
@@ -285,8 +274,7 @@ describe('syncAppConfigsToRemote()', () => {
     expect(updateProtectedAppSiteConfigs).not.toHaveBeenCalled();
   });
 
-  it('should omit additional scopes when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
+  it('should sync additional scopes to remote', async () => {
     findApplicationById.mockResolvedValueOnce({
       ...mockProtectedApplication,
       protectedAppMetadata: {
@@ -300,24 +288,15 @@ describe('syncAppConfigsToRemote()', () => {
     expect(updateProtectedAppSiteConfigs).toHaveBeenCalledWith(
       mockProtectedAppConfigProviderConfig,
       mockProtectedApplication.protectedAppMetadata.host,
-      expect.any(Object)
+      expect.objectContaining({
+        additionalScopes: [UserScope.CustomData],
+      })
     );
-    expect(updateProtectedAppSiteConfigs.mock.calls[0]?.[2]).not.toHaveProperty('additionalScopes');
   });
 });
 
 describe('syncAllAppConfigsToRemote()', () => {
-  it('should skip syncing all protected app configs when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
-
-    await expect(syncAllAppConfigsToRemote()).resolves.not.toThrow();
-
-    expect(findApplications).not.toHaveBeenCalled();
-    expect(updateProtectedAppSiteConfigs).not.toHaveBeenCalled();
-  });
-
-  it('should sync all protected app configs when dev features are enabled', async () => {
-    setDevFeaturesEnabled(true);
+  it('should sync all protected app configs', async () => {
     const anotherProtectedApplication = {
       ...mockProtectedApplication,
       id: 'protected-app-id-2',
@@ -383,25 +362,6 @@ describe('buildProtectedAppData()', () => {
         sessionDuration: defaultProtectedAppSessionDuration,
         pageRules: defaultProtectedAppPageRules,
         additionalScopes: [],
-      },
-      oidcClientMetadata: {
-        redirectUris: [`https://${host}/${protectedAppSignInCallbackUrl}`],
-        postLogoutRedirectUris: [`https://${host}`],
-      },
-    });
-  });
-
-  it('should omit additional scopes when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
-    const subDomain = 'a';
-    const host = `${subDomain}.${mockProtectedAppConfigProviderConfig.domain}`;
-
-    await expect(buildProtectedAppData({ subDomain, origin })).resolves.toEqual({
-      protectedAppMetadata: {
-        host,
-        origin,
-        sessionDuration: defaultProtectedAppSessionDuration,
-        pageRules: defaultProtectedAppPageRules,
       },
       oidcClientMetadata: {
         redirectUris: [`https://${host}/${protectedAppSignInCallbackUrl}`],

--- a/packages/core/src/libraries/protected-app.ts
+++ b/packages/core/src/libraries/protected-app.ts
@@ -113,7 +113,7 @@ const buildProtectedAppData = async ({
       origin,
       sessionDuration: defaultProtectedAppSessionDuration,
       pageRules: defaultProtectedAppPageRules,
-      ...conditional(EnvSet.values.isDevFeaturesEnabled && { additionalScopes: [] }),
+      additionalScopes: [],
     },
     oidcClientMetadata: {
       redirectUris: [`https://${host}/${protectedAppSignInCallbackUrl}`],
@@ -190,10 +190,6 @@ export const createProtectedAppLibrary = (queries: Queries) => {
   const getSdkEndpoint = async (tenantId: string) => {
     const defaultEndpoint = getTenantEndpoint(tenantId, EnvSet.values).origin;
 
-    if (!EnvSet.values.isDevFeaturesEnabled) {
-      return defaultEndpoint;
-    }
-
     const domains = await findAllDomains();
     const activeCustomDomain = domains
       .filter(({ status }) => status === DomainStatus.Active)
@@ -228,9 +224,7 @@ export const createProtectedAppLibrary = (queries: Queries) => {
 
     const siteConfigs = {
       ...rest,
-      ...conditional(
-        EnvSet.values.isDevFeaturesEnabled && additionalScopes !== undefined && { additionalScopes }
-      ),
+      ...conditional(additionalScopes !== undefined && { additionalScopes }),
       sdkConfig: {
         appId: id,
         appSecret: activeSecret.value,
@@ -259,10 +253,6 @@ export const createProtectedAppLibrary = (queries: Queries) => {
   };
 
   const syncAllAppConfigsToRemote = async (): Promise<void> => {
-    if (!EnvSet.values.isDevFeaturesEnabled) {
-      return;
-    }
-
     const protectedApplications = await findApplications({
       search: { matches: [], joint: SearchJointMode.Or, isCaseSensitive: false },
       types: [ApplicationType.Protected],

--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -10,7 +10,6 @@ import {
   mockProtectedApplication,
 } from '#src/__mocks__/index.js';
 import { protectedAppSignInCallbackUrl } from '#src/constants/index.js';
-import { EnvSet } from '#src/env-set/index.js';
 import { mockId, mockIdGenerators } from '#src/test-utils/nanoid.js';
 import { createMockQuotaLibrary } from '#src/test-utils/quota.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -75,11 +74,6 @@ const tenantContext = new MockTenant(
 
 const { createRequester } = await import('#src/utils/test-utils.js');
 const applicationRoutes = await pickDefault(import('./application.js'));
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
-  // eslint-disable-next-line @silverhand/fp/no-mutation
-  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
-};
 
 const customClientMetadata = {
   corsAllowedOrigins: [
@@ -94,7 +88,6 @@ const customClientMetadata = {
 
 describe('application route', () => {
   afterEach(() => {
-    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
     updateApplicationById.mockClear();
     syncAppConfigsToRemote.mockClear();
     deleteRemoteAppConfigs.mockClear();
@@ -225,23 +218,6 @@ describe('application route', () => {
     });
   });
 
-  it('GET /applications/:id hides additional scopes when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
-    findApplicationById.mockResolvedValueOnce(mockProtectedApplication);
-    const { additionalScopes, ...protectedAppMetadata } =
-      mockProtectedApplication.protectedAppMetadata;
-    expect(additionalScopes).toEqual([]);
-
-    const response = await applicationRequest.get('/applications/foo');
-
-    expect(response.status).toEqual(200);
-    expect(response.body).toEqual({
-      ...mockProtectedApplication,
-      protectedAppMetadata,
-      isAdmin: false,
-    });
-  });
-
   it('PATCH /applications/:applicationId', async () => {
     const name = 'FooApplication';
     const description = 'FooDescription';
@@ -275,8 +251,7 @@ describe('application route', () => {
     });
   });
 
-  it('PATCH /applications/:applicationId preserves existing additional scopes when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
+  it('PATCH /applications/:applicationId updates additional scopes for protected app', async () => {
     const existingProtectedAppMetadata: ProtectedAppMetadata = {
       ...mockProtectedApplication.protectedAppMetadata,
       additionalScopes: [UserScope.CustomData],
@@ -286,11 +261,12 @@ describe('application route', () => {
       protectedAppMetadata: existingProtectedAppMetadata,
     });
     const origin = 'https://example.com';
+    const additionalScopes = [UserScope.CustomData, UserScope.Roles];
 
     const response = await applicationRequest.patch('/applications/foo').send({
       protectedAppMetadata: {
         origin,
-        additionalScopes: [UserScope.CustomData, UserScope.Sessions],
+        additionalScopes,
       },
     });
 
@@ -300,6 +276,7 @@ describe('application route', () => {
       protectedAppMetadata: {
         ...existingProtectedAppMetadata,
         origin,
+        additionalScopes,
       },
     });
   });

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -1,6 +1,6 @@
 // TODO: @darcyYe refactor this file later to remove disable max line comment
 /* eslint-disable max-lines */
-import type { Role, Application, ProtectedAppMetadata } from '@logto/schemas';
+import type { Role, Application } from '@logto/schemas';
 import {
   adminTenantId,
   Applications,
@@ -16,7 +16,6 @@ import { generateStandardId, generateStandardSecret } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
 import { boolean, object, string, z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
@@ -55,46 +54,14 @@ const assertThirdPartyApplicationTokenExchangeDisabled = (
   }
 };
 
-const hideProtectedAppMetadataDevFeatures = (application: Application): Application => {
-  if (EnvSet.values.isDevFeaturesEnabled || !application.protectedAppMetadata) {
-    return application;
-  }
-
-  const { additionalScopes, ...protectedAppMetadata } = application.protectedAppMetadata;
-
-  if (additionalScopes === undefined) {
-    return application;
-  }
-
-  return {
-    ...application,
-    protectedAppMetadata,
-  };
-};
-
-const normalizeProtectedAppMetadataPatch = (
-  protectedAppMetadata: Partial<ProtectedAppMetadata>
-): Partial<ProtectedAppMetadata> => {
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    return protectedAppMetadata;
-  }
-
-  const { additionalScopes: _additionalScopes, ...protectedAppMetadataPatch } =
-    protectedAppMetadata;
-
-  return protectedAppMetadataPatch;
-};
-
-const hideOidcClientMetadataForSamlApp = (application: Application) => {
-  return hideProtectedAppMetadataDevFeatures({
-    ...application,
-    ...conditional(
-      application.type === ApplicationType.SAML && {
-        oidcClientMetadata: buildOidcClientMetadata(),
-      }
-    ),
-  });
-};
+const hideOidcClientMetadataForSamlApp = (application: Application) => ({
+  ...application,
+  ...conditional(
+    application.type === ApplicationType.SAML && {
+      oidcClientMetadata: buildOidcClientMetadata(),
+    }
+  ),
+});
 
 const hideOidcClientMetadataForSamlApps = (applications: readonly Application[]) => {
   return applications.map((application) => hideOidcClientMetadataForSamlApp(application));
@@ -282,7 +249,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
         }
       }
 
-      ctx.body = hideProtectedAppMetadataDevFeatures(application);
+      ctx.body = application;
 
       if (rest.type === ApplicationType.MachineToMachine) {
         void quota.reportSubscriptionUpdatesUsage('machineToMachineLimit');
@@ -428,12 +395,10 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
             status: 422,
           })
         );
-        const normalizedProtectedAppMetadataPatch =
-          normalizeProtectedAppMetadataPatch(protectedAppMetadata);
         await queries.applications.updateApplicationById(id, {
           protectedAppMetadata: {
             ...originProtectedAppMetadata,
-            ...normalizedProtectedAppMetadataPatch,
+            ...protectedAppMetadata,
           },
         });
         try {
@@ -452,7 +417,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
           ? await queries.applications.updateApplicationById(id, rest, 'replace')
           : pendingUpdateApplication;
 
-      ctx.body = hideProtectedAppMetadataDevFeatures(updatedApplication);
+      ctx.body = updatedApplication;
 
       return next();
     }

--- a/packages/core/src/routes/applications/types.ts
+++ b/packages/core/src/routes/applications/types.ts
@@ -5,8 +5,6 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
-
 const protectedAppAdditionalScopeGuard = z.enum(protectedAppAdditionalScopes);
 
 export const applicationCreateGuard = originalApplicationCreateGuard
@@ -39,10 +37,7 @@ export const applicationPatchGuard = originalApplicationPatchGuard
             })
           )
           .optional(),
-        additionalScopes: z.preprocess(
-          (value) => (EnvSet.values.isDevFeaturesEnabled ? value : undefined),
-          z.array(protectedAppAdditionalScopeGuard).optional()
-        ),
+        additionalScopes: z.array(protectedAppAdditionalScopeGuard).optional(),
       })
       .nullish(),
   });

--- a/packages/core/src/routes/domain.ts
+++ b/packages/core/src/routes/domain.ts
@@ -45,7 +45,7 @@ export default function domainRoutes<T extends ManagementApiRouter>(
       syncCustomDomainsToSamlApplicationRedirectUrls(tenantId, [...domains])
     );
 
-    if (shouldSyncProtectedAppConfigs && EnvSet.values.isDevFeaturesEnabled) {
+    if (shouldSyncProtectedAppConfigs) {
       await trySafe(async () => syncAllAppConfigsToRemote());
     }
   };


### PR DESCRIPTION
## Summary

- Remove `isDevFeaturesEnabled` guards for Protected App ID token claim scopes (#8798), tenant custom domain SDK endpoints (#8828), and related config sync paths validated in [LOG-13494](https://linear.app/silverhand/issue/LOG-13494/bug-bash)
- Always show the **ID token claims** settings in Console and persist `additionalScopes` through Management API and remote config sync
- Resync all protected app configs when tenant custom domain status changes, without requiring dev features
- Add changeset for `@logto/console` and `@logto/core`

## Test plan

- [x] Unit tests
- [ ] Tested locally


Made with [Cursor](https://cursor.com)