### PR TITLE
test(account): add username update page tests

### DIFF
--- a/packages/account/src/pages/Username/index.test.tsx
+++ b/packages/account/src/pages/Username/index.test.tsx
@@ -1,0 +1,203 @@
+import { AccountCenterControlValue, type AccountCenter } from '@logto/schemas';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { HTTPError, type NormalizedOptions } from 'ky';
+import { Route, Routes } from 'react-router-dom';
+
+import type { PageContextType } from '@ac/Providers/PageContextProvider/PageContext';
+import renderWithPageContext, {
+  mockAccountCenterSettings,
+} from '@ac/__mocks__/RenderWithPageContext';
+
+import { updateUsername } from '../../apis/account';
+
+import Username from '.';
+
+const mockGetAccessToken = jest.fn().mockResolvedValue('access-token');
+
+jest.mock('@logto/react', () => ({
+  useLogto: () => ({
+    getAccessToken: mockGetAccessToken,
+  }),
+}));
+
+jest.mock('../../apis/account', () => ({
+  updateUsername: jest.fn(),
+}));
+
+jest.mock('@ac/components/VerificationMethodList', () => () => <div>Verification methods</div>);
+
+const createHttpError = (code: string, status: number) =>
+  new HTTPError(
+    {
+      status,
+      json: async () => ({ code, message: code }),
+    } as Response,
+    {} as Request,
+    {} as NormalizedOptions
+  );
+
+type UsernameRenderOptions = {
+  readonly pageContext?: Omit<Partial<PageContextType>, 'accountCenterSettings'> & {
+    readonly accountCenterSettings?: Omit<Partial<AccountCenter>, 'fields'> & {
+      readonly fields?: Partial<AccountCenter['fields']>;
+    };
+  };
+};
+
+const renderUsername = ({ pageContext }: UsernameRenderOptions = {}) =>
+  renderWithPageContext(
+    <Routes>
+      <Route path="/username" element={<Username />} />
+      <Route path="/username/success" element={<div>Success page</div>} />
+    </Routes>,
+    {
+      initialEntries: ['/username'],
+      future: {
+        v7_relativeSplatPath: true,
+        v7_startTransition: true,
+      },
+    },
+    {
+      pageContext: {
+        ...pageContext,
+        accountCenterSettings: {
+          ...mockAccountCenterSettings,
+          ...pageContext?.accountCenterSettings,
+          fields: {
+            ...mockAccountCenterSettings.fields,
+            ...pageContext?.accountCenterSettings?.fields,
+          },
+        },
+        verificationId:
+          pageContext && 'verificationId' in pageContext
+            ? pageContext.verificationId
+            : 'verification-record-id',
+      },
+    }
+  );
+
+describe('<Username />', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockGetAccessToken.mockResolvedValue('access-token');
+    jest.mocked(updateUsername).mockResolvedValue(undefined);
+  });
+
+  it('shows an error page when username editing is disabled', () => {
+    const { getByText } = renderUsername({
+      pageContext: {
+        accountCenterSettings: {
+          fields: {
+            username: AccountCenterControlValue.ReadOnly,
+          },
+        },
+      },
+    });
+
+    expect(getByText('error.feature_not_enabled')).toBeTruthy();
+  });
+
+  it('shows verification methods when identity is not verified', () => {
+    const { getByText } = renderUsername({
+      pageContext: {
+        verificationId: undefined,
+      },
+    });
+
+    expect(getByText('Verification methods')).toBeTruthy();
+  });
+
+  it('updates username and navigates to the success page', async () => {
+    const refreshUserInfo = jest.fn().mockResolvedValue(undefined);
+    const { getByText, container } = renderUsername({
+      pageContext: {
+        refreshUserInfo,
+      },
+    });
+
+    const usernameInput = container.querySelector('input[name="username"]');
+    fireEvent.change(usernameInput!, { target: { value: 'new_username' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(updateUsername).toHaveBeenCalledWith('access-token', 'verification-record-id', {
+        username: 'new_username',
+      });
+    });
+    expect(refreshUserInfo).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(getByText('Success page')).toBeTruthy();
+    });
+  });
+
+  it('shows a validation error when username is empty', async () => {
+    const { getByText, container } = renderUsername();
+
+    const usernameInput = container.querySelector('input[name="username"]');
+    fireEvent.change(usernameInput!, { target: { value: '   ' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(getByText('error.username_required')).toBeTruthy();
+    });
+    expect(updateUsername).not.toHaveBeenCalled();
+  });
+
+  it('shows a validation error when username starts with a number', async () => {
+    const { getByText, container } = renderUsername();
+
+    const usernameInput = container.querySelector('input[name="username"]');
+    fireEvent.change(usernameInput!, { target: { value: '1invalid' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(getByText('error.username_should_not_start_with_number')).toBeTruthy();
+    });
+    expect(updateUsername).not.toHaveBeenCalled();
+  });
+
+  it('shows a toast when the username is already in use', async () => {
+    const setToast = jest.fn();
+    jest
+      .mocked(updateUsername)
+      .mockRejectedValue(createHttpError('user.username_already_in_use', 422));
+
+    const { getByText, container } = renderUsername({
+      pageContext: {
+        setToast,
+      },
+    });
+
+    const usernameInput = container.querySelector('input[name="username"]');
+    fireEvent.change(usernameInput!, { target: { value: 'taken_username' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(setToast).toHaveBeenCalledWith('error.username_exists');
+    });
+  });
+
+  it('clears verification and prompts re-verification when permission is denied', async () => {
+    const setVerificationId = jest.fn();
+    const setToast = jest.fn();
+    jest
+      .mocked(updateUsername)
+      .mockRejectedValue(createHttpError('verification_record.permission_denied', 401));
+
+    const { getByText, container } = renderUsername({
+      pageContext: {
+        setVerificationId,
+        setToast,
+      },
+    });
+
+    const usernameInput = container.querySelector('input[name="username"]');
+    fireEvent.change(usernameInput!, { target: { value: 'new_username' } });
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(setVerificationId).toHaveBeenCalledWith(undefined);
+      expect(setToast).toHaveBeenCalledWith('account_center.verification.verification_required');
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds unit tests for the Account Center username edit page (`/username`), following the same patterns as the Profile page tests.

## Changes

- New `packages/account/src/pages/Username/index.test.tsx` covering:
  - Feature gating when username editing is disabled
  - Verification method list when identity is not verified
  - Successful username update and navigation to the success page
  - Client-side validation (empty username, username starting with a number)
  - API error handling (username already in use, verification permission denied)

## Testing

Unit tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8249aeda-bce8-4c52-ba8e-1ee051fcd018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8249aeda-bce8-4c52-ba8e-1ee051fcd018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

