### PR TITLE
feat(schemas): add application access control schema

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -51,6 +51,7 @@ export const mockApplication: Application = {
   },
   protectedAppMetadata: null,
   isThirdParty: false,
+  appLevelAccessControlEnabled: false,
   createdAt: 1_645_334_775_356,
   customData: {},
 };
@@ -81,6 +82,7 @@ export const mockProtectedApplication: Omit<Application, 'protectedAppMetadata'>
     additionalScopes: [],
   },
   isThirdParty: false,
+  appLevelAccessControlEnabled: false,
   createdAt: 1_645_334_775_356,
   customData: {},
 };

--- a/packages/schemas/alterations/next-1779421396-add-application-access-control-schema.ts
+++ b/packages/schemas/alterations/next-1779421396-add-application-access-control-schema.ts
@@ -1,0 +1,90 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const accessControlRelationTables = Object.freeze([
+  'application_access_control_user_relations',
+  'application_access_control_user_role_relations',
+  'application_access_control_organization_relations',
+  'application_access_control_org_role_relations',
+]);
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table applications
+        add column app_level_access_control_enabled boolean not null default false;
+
+      create table application_access_control_user_relations (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        application_id varchar(21) not null
+          references applications (id) on update cascade on delete cascade,
+        user_id varchar(21) not null
+          references users (id) on update cascade on delete cascade,
+        primary key (tenant_id, application_id, user_id)
+      );
+
+      create table application_access_control_user_role_relations (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        application_id varchar(21) not null
+          references applications (id) on update cascade on delete cascade,
+        role_id varchar(21) not null
+          references roles (id) on update cascade on delete cascade,
+        primary key (tenant_id, application_id, role_id),
+        constraint application_access_control_user_role_relations__role_type
+          check (public.check_role_type(role_id, 'User'))
+      );
+
+      create table application_access_control_organization_relations (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        application_id varchar(21) not null
+          references applications (id) on update cascade on delete cascade,
+        organization_id varchar(21) not null
+          references organizations (id) on update cascade on delete cascade,
+        primary key (tenant_id, application_id, organization_id)
+      );
+
+      create table application_access_control_org_role_relations (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        application_id varchar(21) not null
+          references applications (id) on update cascade on delete cascade,
+        organization_id varchar(21) not null
+          references organizations (id) on update cascade on delete cascade,
+        organization_role_id varchar(21) not null
+          references organization_roles (id) on update cascade on delete cascade,
+        primary key (tenant_id, application_id, organization_id, organization_role_id),
+        constraint application_access_control_org_role_relations__role_type
+          check (check_organization_role_type(organization_role_id, 'User'))
+      );
+    `);
+
+    for (const table of accessControlRelationTables) {
+      // eslint-disable-next-line no-await-in-loop
+      await applyTableRls(pool, table);
+    }
+  },
+  down: async (pool) => {
+    for (const table of accessControlRelationTables) {
+      // eslint-disable-next-line no-await-in-loop
+      await dropTableRls(pool, table);
+    }
+
+    await pool.query(sql`
+      drop table application_access_control_org_role_relations;
+      drop table application_access_control_organization_relations;
+      drop table application_access_control_user_role_relations;
+      drop table application_access_control_user_relations;
+
+      alter table applications
+        drop column app_level_access_control_enabled;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/application.ts
+++ b/packages/schemas/src/seeds/application.ts
@@ -42,6 +42,7 @@ const buildSpaApplicationData = (
   customClientMetadata: {},
   protectedAppMetadata: null,
   isThirdParty: false,
+  appLevelAccessControlEnabled: false,
   createdAt: 0,
   customData: {},
 });
@@ -82,6 +83,7 @@ const buildNativeApplicationData = (
   customClientMetadata: { isDeviceFlow: true },
   protectedAppMetadata: null,
   isThirdParty: false,
+  appLevelAccessControlEnabled: false,
   createdAt: 0,
   customData: {},
 });

--- a/packages/schemas/src/types/application.test.ts
+++ b/packages/schemas/src/types/application.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applicationAccessControlGuard,
+  createDefaultApplicationAccessControl,
+} from './application.js';
+
+describe('applicationAccessControlGuard', () => {
+  it('deduplicates direct user and role rules', () => {
+    expect(
+      applicationAccessControlGuard.parse({
+        userIds: ['user-1', 'user-2', 'user-1'],
+        userRoleIds: ['role-1', 'role-1', 'role-2'],
+        organizationIds: ['organization-1', 'organization-1', 'organization-2'],
+        organizationRoleRules: [],
+      })
+    ).toMatchObject({
+      userIds: ['user-1', 'user-2'],
+      userRoleIds: ['role-1', 'role-2'],
+      organizationIds: ['organization-1', 'organization-2'],
+      organizationRoleRules: [],
+    });
+  });
+
+  it('merges organization role rules by organization', () => {
+    expect(
+      applicationAccessControlGuard.parse({
+        userIds: [],
+        userRoleIds: [],
+        organizationIds: [],
+        organizationRoleRules: [
+          {
+            organizationId: 'organization-1',
+            organizationRoleIds: ['organization-role-1', 'organization-role-2'],
+          },
+          {
+            organizationId: 'organization-1',
+            organizationRoleIds: ['organization-role-1', 'organization-role-3'],
+          },
+          {
+            organizationId: 'organization-2',
+            organizationRoleIds: ['organization-role-1'],
+          },
+        ],
+      })
+    ).toMatchObject({
+      userIds: [],
+      userRoleIds: [],
+      organizationIds: [],
+      organizationRoleRules: [
+        {
+          organizationId: 'organization-1',
+          organizationRoleIds: [
+            'organization-role-1',
+            'organization-role-2',
+            'organization-role-3',
+          ],
+        },
+        {
+          organizationId: 'organization-2',
+          organizationRoleIds: ['organization-role-1'],
+        },
+      ],
+    });
+  });
+
+  it('creates a fresh default rule set', () => {
+    const first = createDefaultApplicationAccessControl();
+    const second = createDefaultApplicationAccessControl();
+
+    expect(first).not.toBe(second);
+    expect(first.userIds).not.toBe(second.userIds);
+    expect(first.userRoleIds).not.toBe(second.userRoleIds);
+    expect(first.organizationIds).not.toBe(second.organizationIds);
+    expect(first.organizationRoleRules).not.toBe(second.organizationRoleRules);
+  });
+
+  it('rejects oversized rule lists', () => {
+    const oversizedIds = Array.from({ length: 1001 }, (_, index) => `id-${index}`);
+    const emptyAccessControl = createDefaultApplicationAccessControl();
+
+    expect(() =>
+      applicationAccessControlGuard.parse({ ...emptyAccessControl, userIds: oversizedIds })
+    ).toThrow();
+    expect(() =>
+      applicationAccessControlGuard.parse({
+        ...emptyAccessControl,
+        organizationRoleRules: oversizedIds.map((organizationId) => ({
+          organizationId,
+          organizationRoleIds: [],
+        })),
+      })
+    ).toThrow();
+    expect(() =>
+      applicationAccessControlGuard.parse({
+        ...emptyAccessControl,
+        organizationRoleRules: [
+          { organizationId: 'organization-1', organizationRoleIds: oversizedIds },
+        ],
+      })
+    ).toThrow();
+  });
+
+  it('enforces rule list limits after normalization', () => {
+    const emptyAccessControl = createDefaultApplicationAccessControl();
+    const duplicateHeavyIds = Array.from({ length: 1001 }, () => 'user-1');
+    const mergedOrganizationRoleRules = [
+      {
+        organizationId: 'organization-1',
+        organizationRoleIds: Array.from({ length: 1000 }, (_, index) => `role-${index}`),
+      },
+      {
+        organizationId: 'organization-1',
+        organizationRoleIds: ['role-1000'],
+      },
+    ];
+
+    expect(
+      applicationAccessControlGuard.parse({ ...emptyAccessControl, userIds: duplicateHeavyIds })
+    ).toMatchObject({ userIds: ['user-1'] });
+    expect(() =>
+      applicationAccessControlGuard.parse({
+        ...emptyAccessControl,
+        organizationRoleRules: mergedOrganizationRoleRules,
+      })
+    ).toThrow();
+  });
+
+  it('rejects overly large raw rule inputs before normalization', () => {
+    const emptyAccessControl = createDefaultApplicationAccessControl();
+    const oversizedDuplicateIds = Array.from({ length: 2001 }, () => 'id-1');
+
+    expect(() =>
+      applicationAccessControlGuard.parse({ ...emptyAccessControl, userIds: oversizedDuplicateIds })
+    ).toThrow();
+    expect(() =>
+      applicationAccessControlGuard.parse({
+        ...emptyAccessControl,
+        organizationRoleRules: oversizedDuplicateIds.map(() => ({
+          organizationId: 'organization-1',
+          organizationRoleIds: [],
+        })),
+      })
+    ).toThrow();
+    expect(() =>
+      applicationAccessControlGuard.parse({
+        ...emptyAccessControl,
+        organizationRoleRules: [
+          { organizationId: 'organization-1', organizationRoleIds: oversizedDuplicateIds },
+        ],
+      })
+    ).toThrow();
+  });
+});

--- a/packages/schemas/src/types/application.ts
+++ b/packages/schemas/src/types/application.ts
@@ -27,6 +27,7 @@ export const featuredApplicationGuard = Applications.guard.pick({
 
 export const applicationCreateGuard = Applications.createGuard
   .omit({
+    appLevelAccessControlEnabled: true,
     id: true,
     createdAt: true,
     secret: true,
@@ -38,6 +39,74 @@ export const applicationCreateGuard = Applications.createGuard
 export const applicationPatchGuard = applicationCreateGuard.partial().omit({
   type: true,
   isThirdParty: true,
+});
+
+const applicationAccessControlRuleLimit = 1000;
+const applicationAccessControlRawRuleLimit = applicationAccessControlRuleLimit * 2;
+const uniqueStringArrayGuard = z
+  .array(z.string())
+  .max(applicationAccessControlRawRuleLimit)
+  .transform((values) => [...new Set(values)])
+  .pipe(z.array(z.string()).max(applicationAccessControlRuleLimit));
+
+/** The guard for one organization role access-control rule group. */
+export const applicationAccessControlOrganizationRoleRuleGuard = z.object({
+  organizationId: z.string(),
+  organizationRoleIds: uniqueStringArrayGuard,
+});
+
+/** The guard for application-level access control rule payloads. */
+export const applicationAccessControlGuard = z
+  .object({
+    userIds: uniqueStringArrayGuard,
+    userRoleIds: uniqueStringArrayGuard,
+    organizationIds: uniqueStringArrayGuard,
+    organizationRoleRules: z
+      .array(applicationAccessControlOrganizationRoleRuleGuard)
+      .max(applicationAccessControlRawRuleLimit),
+  })
+  .transform(({ organizationRoleRules, ...rest }) => {
+    const organizationRoleRulesMap = new Map<string, Set<string>>();
+
+    for (const { organizationId, organizationRoleIds } of organizationRoleRules) {
+      const roleIds = organizationRoleRulesMap.get(organizationId) ?? new Set<string>();
+
+      for (const roleId of organizationRoleIds) {
+        roleIds.add(roleId);
+      }
+
+      organizationRoleRulesMap.set(organizationId, roleIds);
+    }
+
+    return {
+      ...rest,
+      organizationRoleRules: [...organizationRoleRulesMap.entries()].map(
+        ([organizationId, organizationRoleIds]) => ({
+          organizationId,
+          organizationRoleIds: [...organizationRoleIds],
+        })
+      ),
+    };
+  })
+  .pipe(
+    z.object({
+      userIds: z.array(z.string()).max(applicationAccessControlRuleLimit),
+      userRoleIds: z.array(z.string()).max(applicationAccessControlRuleLimit),
+      organizationIds: z.array(z.string()).max(applicationAccessControlRuleLimit),
+      organizationRoleRules: z
+        .array(applicationAccessControlOrganizationRoleRuleGuard)
+        .max(applicationAccessControlRuleLimit),
+    })
+  );
+
+export type ApplicationAccessControl = z.infer<typeof applicationAccessControlGuard>;
+
+/** Create an empty application-level access control rule set. */
+export const createDefaultApplicationAccessControl = (): ApplicationAccessControl => ({
+  userIds: [],
+  userRoleIds: [],
+  organizationIds: [],
+  organizationRoleRules: [],
 });
 
 const resourceScopesGuard = z.array(

--- a/packages/schemas/tables/application_access_control_org_role_relations.sql
+++ b/packages/schemas/tables/application_access_control_org_role_relations.sql
@@ -1,0 +1,16 @@
+/* init_order = 2 */
+
+/** The organization role allow relations for application-level access control. */
+create table application_access_control_org_role_relations (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  application_id varchar(21) not null
+    references applications (id) on update cascade on delete cascade,
+  organization_id varchar(21) not null
+    references organizations (id) on update cascade on delete cascade,
+  organization_role_id varchar(21) not null
+    references organization_roles (id) on update cascade on delete cascade,
+  primary key (tenant_id, application_id, organization_id, organization_role_id),
+  constraint application_access_control_org_role_relations__role_type
+    check (check_organization_role_type(organization_role_id, 'User'))
+);

--- a/packages/schemas/tables/application_access_control_organization_relations.sql
+++ b/packages/schemas/tables/application_access_control_organization_relations.sql
@@ -1,0 +1,12 @@
+/* init_order = 2 */
+
+/** The organization membership allow relations for application-level access control. */
+create table application_access_control_organization_relations (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  application_id varchar(21) not null
+    references applications (id) on update cascade on delete cascade,
+  organization_id varchar(21) not null
+    references organizations (id) on update cascade on delete cascade,
+  primary key (tenant_id, application_id, organization_id)
+);

--- a/packages/schemas/tables/application_access_control_user_relations.sql
+++ b/packages/schemas/tables/application_access_control_user_relations.sql
@@ -1,0 +1,12 @@
+/* init_order = 2 */
+
+/** The direct user allow relations for application-level access control. */
+create table application_access_control_user_relations (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  application_id varchar(21) not null
+    references applications (id) on update cascade on delete cascade,
+  user_id varchar(21) not null
+    references users (id) on update cascade on delete cascade,
+  primary key (tenant_id, application_id, user_id)
+);

--- a/packages/schemas/tables/application_access_control_user_role_relations.sql
+++ b/packages/schemas/tables/application_access_control_user_role_relations.sql
@@ -1,0 +1,14 @@
+/* init_order = 2 */
+
+/** The user role allow relations for application-level access control. */
+create table application_access_control_user_role_relations (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  application_id varchar(21) not null
+    references applications (id) on update cascade on delete cascade,
+  role_id varchar(21) not null
+    references roles (id) on update cascade on delete cascade,
+  primary key (tenant_id, application_id, role_id),
+  constraint application_access_control_user_role_relations__role_type
+    check (public.check_role_type(role_id, 'User'))
+);

--- a/packages/schemas/tables/applications.sql
+++ b/packages/schemas/tables/applications.sql
@@ -16,6 +16,7 @@ create table applications (
   protected_app_metadata jsonb /* @use ProtectedAppMetadata */,
   custom_data jsonb /* @use JsonObject */ not null default '{}'::jsonb,
   is_third_party boolean not null default false,
+  app_level_access_control_enabled boolean not null default false,
   created_at timestamptz not null default(now()),
   primary key (id)
 );


### PR DESCRIPTION
## Summary
Add the schema foundation for app-level access control in @logto/schemas. This introduces a disabled-by-default application flag, allow-rule tables for direct users, user roles, organization membership, and organization roles, plus the alteration script with RLS setup.

The access-control payload is rules-only; application enablement lives on the application row. This PR intentionally stays at the schema layer, with only fixture updates needed by the new application field.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
