### PR TITLE
refactor(schemas): drop legacy oidc-model-instances grant-id index

### DIFF
--- a/packages/schemas/alterations/next-1779710400-drop-oidc-model-instances-legacy-grant-id-index.ts
+++ b/packages/schemas/alterations/next-1779710400-drop-oidc-model-instances-legacy-grant-id-index.ts
@@ -1,0 +1,25 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently if exists oidc_model_instances__model_name_payload_grant_id;
+    `);
+  },
+  up: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      create index concurrently if not exists oidc_model_instances__model_name_payload_grant_id
+        on oidc_model_instances (tenant_id, model_name, (payload->>'grantId'));
+    `);
+  },
+  down: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/alterations/next-1780358400-drop-oidc-model-instances-legacy-grant-id-index.ts
+++ b/packages/schemas/alterations/next-1780358400-drop-oidc-model-instances-legacy-grant-id-index.ts
@@ -1,0 +1,25 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently if exists oidc_model_instances__model_name_payload_grant_id;
+    `);
+  },
+  up: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      create index concurrently if not exists oidc_model_instances__model_name_payload_grant_id
+        on oidc_model_instances (tenant_id, model_name, (payload->>'grantId'));
+    `);
+  },
+  down: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/oidc_model_instances.sql
+++ b/packages/schemas/tables/oidc_model_instances.sql
@@ -27,14 +27,6 @@ create index oidc_model_instances__model_name_payload_uid
     (payload->>'uid')
   );
 
-/* TODO: Consider dropping this full data index if the partial index proves to be effective and safe. */
-create index oidc_model_instances__model_name_payload_grant_id
-  on oidc_model_instances (
-    tenant_id,
-    model_name,
-    (payload->>'grantId')
-  );
-
 create index oidc_model_instances__model_name_payload_grant_id_partial
   on oidc_model_instances (tenant_id, model_name, (payload->>'grantId'))
   where payload ? 'grantId';


### PR DESCRIPTION
## Summary
Follow-up to #8427. Drops the legacy full index `oidc_model_instances__model_name_payload_grant_id` on `oidc_model_instances`. The partial index `oidc_model_instances__model_name_payload_grant_id_partial` introduced in #8427 already covers `revokeInstanceByGrantId` — which was updated in the same PR to include the `payload ? 'grantId'` predicate that lets the planner pick the partial index — so the legacy full-data variant is now redundant.

### What changed
- `packages/schemas/tables/oidc_model_instances.sql`: removed the legacy index definition and the TODO that flagged it for removal.
- `packages/schemas/alterations/next-1779710400-drop-oidc-model-instances-legacy-grant-id-index.ts`: drops the legacy index with `drop index concurrently if exists` in `beforeUp`; `beforeDown` recreates it concurrently for rollback. `up`/`down` are intentionally empty because `concurrently` cannot run inside a transaction.

### Expected result
- Less write amplification and storage on the hot revoke-by-grant path; only the partial index is maintained.
- A fresh init from the table SQL and an existing DB stepped through the alteration converge on the same final state.

### Reviewer notes
- Deployment order: this alteration must ship in a release that already contains the #8427 core query change. Rolling it out earlier would leave `revokeInstanceByGrantId` without an index match.
- No other call site in `packages/core` filters `oidc_model_instances` by `payload->>'grantId'` — verified by grep.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments