### PR TITLE
feat(cli): add --dapc seed flag for air-gapped OSS admin

### DIFF
--- a/.changeset/ravens-swallows-comet.md
+++ b/.changeset/ravens-swallows-comet.md
@@ -1,0 +1,5 @@
+---
+"@logto/cli": minor
+---
+
+add --dapc seed option (alias --disable-admin-pwned-password-check) to disable the HIBP password breach check on the admin tenant for air-gapped OSS deployments

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -9,12 +9,21 @@ import { getAlterationDirectory } from '../alteration/utils.js';
 
 import { createTables, seedCloud, seedTables, seedTest } from './tables.js';
 
+type SeedByPoolOptions = {
+  cloud?: boolean;
+  test?: boolean;
+  encryptBaseRole?: boolean;
+  disablePwnedPasswordCheck?: boolean;
+};
+
 export const seedByPool = async (
   pool: DatabasePool,
-  cloud = false,
-  test = false,
-  encryptBaseRole = false,
-  disablePwnedPasswordCheck = false
+  {
+    cloud = false,
+    test = false,
+    encryptBaseRole = false,
+    disablePwnedPasswordCheck = false,
+  }: SeedByPoolOptions = {}
 ) => {
   await pool.transaction(async (connection) => {
     // Check alteration scripts available in order to insert correct timestamp
@@ -125,7 +134,7 @@ const seed: CommandModule<
     }
 
     try {
-      await seedByPool(pool, cloud, test, encryptBaseRole, dapc);
+      await seedByPool(pool, { cloud, test, encryptBaseRole, disablePwnedPasswordCheck: dapc });
     } catch (error: unknown) {
       consoleLog.error(error);
       consoleLog.error(

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -13,7 +13,8 @@ export const seedByPool = async (
   pool: DatabasePool,
   cloud = false,
   test = false,
-  encryptBaseRole = false
+  encryptBaseRole = false,
+  disablePwnedPasswordCheck = false
 ) => {
   await pool.transaction(async (connection) => {
     // Check alteration scripts available in order to insert correct timestamp
@@ -34,7 +35,7 @@ export const seedByPool = async (
       consoleLog.info('base role password:', tableInfo.password);
     }
 
-    await seedTables(connection, latestTimestamp, cloud);
+    await seedTables(connection, latestTimestamp, cloud, { disablePwnedPasswordCheck });
 
     if (cloud) {
       await seedCloud(connection);
@@ -60,6 +61,7 @@ const seed: CommandModule<
     test?: boolean;
     'legacy-test-data'?: boolean;
     'encrypt-base-role'?: boolean;
+    dapc?: boolean;
   }
 > = {
   command: 'seed [type]',
@@ -87,8 +89,19 @@ const seed: CommandModule<
       .option('encrypt-base-role', {
         describe: 'Seed base role with password',
         type: 'boolean',
+      })
+      .option('dapc', {
+        describe:
+          "Seed the admin tenant's sign-in experience with the HaveIBeenPwned (HIBP) " +
+          'password breach check disabled. Use this for air-gapped or offline OSS deployments ' +
+          'where api.pwnedpasswords.com is unreachable, otherwise creating the first admin ' +
+          'user from the Welcome page will hang on the breach check. Scope: admin tenant only ' +
+          "— the default tenant's password policy is unaffected and stays admin-controlled " +
+          'via the Admin Console.',
+        alias: 'disable-admin-pwned-password-check',
+        type: 'boolean',
       }),
-  handler: async ({ swe, cloud, test, legacyTestData, encryptBaseRole }) => {
+  handler: async ({ swe, cloud, test, legacyTestData, encryptBaseRole, dapc }) => {
     const pool = await createPoolAndDatabaseIfNeeded();
 
     if (legacyTestData) {
@@ -112,7 +125,7 @@ const seed: CommandModule<
     }
 
     try {
-      await seedByPool(pool, cloud, test, encryptBaseRole);
+      await seedByPool(pool, cloud, test, encryptBaseRole, dapc);
     } catch (error: unknown) {
       consoleLog.error(error);
       consoleLog.error(

--- a/packages/cli/src/commands/database/seed/tables.ts
+++ b/packages/cli/src/commands/database/seed/tables.ts
@@ -151,7 +151,8 @@ export const createTables = async (
 export const seedTables = async (
   connection: DatabaseTransactionConnection,
   latestTimestamp: number,
-  isCloud: boolean
+  isCloud: boolean,
+  options: { disablePwnedPasswordCheck?: boolean } = {}
 ) => {
   await createTenant(connection, defaultTenantId);
   await seedOidcConfigs(connection, defaultTenantId);
@@ -207,7 +208,9 @@ export const seedTables = async (
     connection.query(
       insertInto(createDefaultSignInExperience(defaultTenantId, isCloud), SignInExperiences.table)
     ),
-    connection.query(insertInto(createAdminTenantSignInExperience(), SignInExperiences.table)),
+    connection.query(
+      insertInto(createAdminTenantSignInExperience(options), SignInExperiences.table)
+    ),
     connection.query(insertInto(createDefaultAdminConsoleApplication(), Applications.table)),
     connection.query(insertInto(createDefaultAccountCenter(defaultTenantId), AccountCenters.table)),
     connection.query(insertInto(createAdminTenantAccountCenter(), AccountCenters.table)),

--- a/packages/cli/src/commands/database/seed/tables.ts
+++ b/packages/cli/src/commands/database/seed/tables.ts
@@ -11,6 +11,7 @@ import {
   createMeApiInAdminTenant,
   createDefaultSignInExperience,
   createAdminTenantSignInExperience,
+  type AdminSignInExperienceSeedOptions,
   createDefaultAdminConsoleApplication,
   createCloudApi,
   createTenantApplicationRole,
@@ -152,7 +153,7 @@ export const seedTables = async (
   connection: DatabaseTransactionConnection,
   latestTimestamp: number,
   isCloud: boolean,
-  options: { disablePwnedPasswordCheck?: boolean } = {}
+  options: AdminSignInExperienceSeedOptions = {}
 ) => {
   await createTenant(connection, defaultTenantId);
   await seedOidcConfigs(connection, defaultTenantId);

--- a/packages/cli/src/commands/install/utils.ts
+++ b/packages/cli/src/commands/install/utils.ts
@@ -164,7 +164,7 @@ export const decompress = async (toPath: string, tarPath: string) => {
 export const seedDatabase = async (instancePath: string, cloud: boolean) => {
   try {
     const pool = await createPoolAndDatabaseIfNeeded();
-    await seedByPool(pool, cloud);
+    await seedByPool(pool, { cloud });
     await pool.end();
   } catch (error: unknown) {
     consoleLog.error(error);

--- a/packages/schemas/src/seeds/sign-in-experience.test.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createAdminTenantSignInExperience,
+  createDefaultSignInExperience,
+} from './sign-in-experience.js';
+import { adminTenantId } from './tenant.js';
+
+describe('createAdminTenantSignInExperience', () => {
+  it('seeds an empty passwordPolicy by default', () => {
+    const row = createAdminTenantSignInExperience();
+    expect(row.passwordPolicy).toEqual({});
+  });
+
+  it('seeds an empty passwordPolicy when option is explicitly false', () => {
+    const row = createAdminTenantSignInExperience({ disablePwnedPasswordCheck: false });
+    expect(row.passwordPolicy).toEqual({});
+  });
+
+  it('seeds rejects.pwned=false when disablePwnedPasswordCheck is true', () => {
+    const row = createAdminTenantSignInExperience({ disablePwnedPasswordCheck: true });
+    expect(row.passwordPolicy).toEqual({ rejects: { pwned: false } });
+  });
+
+  it('still targets the admin tenant id when the option is set', () => {
+    const row = createAdminTenantSignInExperience({ disablePwnedPasswordCheck: true });
+    expect(row.tenantId).toBe(adminTenantId);
+  });
+});
+
+describe('createDefaultSignInExperience (unchanged contract)', () => {
+  it('still has a two-parameter signature and seeds an empty passwordPolicy', () => {
+    const row = createDefaultSignInExperience('some-tenant-id', false);
+    expect(row.passwordPolicy).toEqual({});
+  });
+});

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -66,8 +66,21 @@ export const createDefaultSignInExperience = (
 /** @deprecated Use `createDefaultSignInExperience()` instead. */
 export const defaultSignInExperience = createDefaultSignInExperience(defaultTenantId, false);
 
+export type AdminSignInExperienceSeedOptions = {
+  /**
+   * When true, the seeded admin-tenant `passwordPolicy` explicitly disables the
+   * HaveIBeenPwned (HIBP) breach check by setting `rejects.pwned = false`. Intended
+   * for air-gapped or offline OSS deployments where `api.pwnedpasswords.com` is
+   * unreachable; otherwise the first admin sign-up will hang on the breach check.
+   *
+   * Defaults to `false`, which preserves the historical seeded value (`{}`) and lets
+   * the runtime fall back to the default policy (HIBP check enabled).
+   */
+  disablePwnedPasswordCheck?: boolean;
+};
+
 export const createAdminTenantSignInExperience = (
-  options: { disablePwnedPasswordCheck?: boolean } = {}
+  options: AdminSignInExperienceSeedOptions = {}
 ): Readonly<CreateSignInExperience> =>
   Object.freeze({
     ...defaultSignInExperience,

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -66,7 +66,9 @@ export const createDefaultSignInExperience = (
 /** @deprecated Use `createDefaultSignInExperience()` instead. */
 export const defaultSignInExperience = createDefaultSignInExperience(defaultTenantId, false);
 
-export const createAdminTenantSignInExperience = (): Readonly<CreateSignInExperience> =>
+export const createAdminTenantSignInExperience = (
+  options: { disablePwnedPasswordCheck?: boolean } = {}
+): Readonly<CreateSignInExperience> =>
   Object.freeze({
     ...defaultSignInExperience,
     tenantId: adminTenantId,
@@ -79,6 +81,9 @@ export const createAdminTenantSignInExperience = (): Readonly<CreateSignInExperi
       logoUrl: 'https://logto.io/logo.svg',
       darkLogoUrl: 'https://logto.io/logo-dark.svg',
     },
+    passwordPolicy: options.disablePwnedPasswordCheck
+      ? { rejects: { pwned: false } }
+      : defaultSignInExperience.passwordPolicy,
     mfa: {
       factors: [MfaFactor.TOTP, MfaFactor.WebAuthn, MfaFactor.BackupCode],
       policy: MfaPolicy.NoPrompt,


### PR DESCRIPTION
## Summary

- Adds a new `logto db seed` flag `--dapc` (alias `--disable-admin-pwned-password-check`) that seeds the **admin tenant's** `sign_in_experiences.password_policy` as `{ "rejects": { "pwned": false } }` instead of the default `{}`.
- Unblocks first-admin sign-up on air-gapped or offline OSS Logto deployments where `api.pwnedpasswords.com` is unreachable; otherwise the Welcome-page sign-up hangs on the HIBP breach check.
- **Scope is admin-tenant only.** The default tenant's password policy is intentionally untouched and stays admin-controlled via the Admin Console post-install. No runtime password-validation logic is changed.
- Internal refactor: `seedByPool` now takes an options bag instead of positional booleans. `seedByPool` is not exported from `@logto/cli`'s public surface; both in-repo callers were updated.

## Changeset

\`@logto/cli\` minor (propagates to the rest of the fixed group via \`.changeset/config.json\`):

> add --dapc seed option (alias --disable-admin-pwned-password-check) to disable the HIBP password breach check on the admin tenant for air-gapped OSS deployments

## Test plan

- [x] \`@logto/schemas\` unit tests (70/70) — includes 5 new cases pinning the factory contract for \`createAdminTenantSignInExperience\`.
- [x] \`@logto/cli\` unit tests (17/17).
- [x] Per-package build + lint clean across both packages (zero new warnings).
- [x] Smoke-tested against a local Postgres for three scenarios:
  - \`--dapc\` (short): admin row = \`{ rejects: { pwned: false } }\`, default row = \`{}\`
  - \`--disable-admin-pwned-password-check\` (long alias): same as above
  - no flag: both tenants = \`{}\` (unchanged default behavior)

## Follow-ups (out of scope of this PR)

- Public docs at docs.logto.io should mention \`--dapc\` once this merges.
- \`hasBeenPwned\` in \`packages/toolkit/core-kit/src/password-policy.ts\` has no fetch timeout — a future hardening PR could add an \`AbortController\` so the call cannot hang indefinitely on slow/broken networks even outside the air-gapped scenario.
- An env-var equivalent (e.g. \`LOGTO_SEED_DISABLE_ADMIN_PWNED_CHECK\`) could be considered for Docker-entrypoint orchestration. Deliberately deferred for now to keep the surface narrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)