### PR TITLE
feat(cli): add --dapc seed flag for air-gapped OSS admin

### DIFF
--- a/.changeset/ravens-swallows-comet.md
+++ b/.changeset/ravens-swallows-comet.md
@@ -1,5 +1,6 @@
 ---
 "@logto/cli": minor
+"@logto/schemas": patch
 ---
 
 add `--dapc` (alias `--disable-admin-pwned-password-check`) option to both `install` and `db seed` commands for air-gapped OSS deployments.

--- a/.changeset/ravens-swallows-comet.md
+++ b/.changeset/ravens-swallows-comet.md
@@ -1,0 +1,5 @@
+---
+"@logto/cli": minor
+---
+
+add --dapc seed option (alias --disable-admin-pwned-password-check) to disable the HIBP password breach check on the admin tenant for air-gapped OSS deployments

--- a/.changeset/ravens-swallows-comet.md
+++ b/.changeset/ravens-swallows-comet.md
@@ -2,4 +2,6 @@
 "@logto/cli": minor
 ---
 
-add `--disable-admin-pwned-password-check` (alias `--dapc`) option to both `install` and `db seed` commands to disable the HIBP password breach check on the admin tenant for air-gapped OSS deployments
+add `--dapc` (alias `--disable-admin-pwned-password-check`) option to both `install` and `db seed` commands for air-gapped OSS deployments.
+
+The admin tenant's seeded password policy enables the Have I Been Pwned (HIBP) breach check by default, which sends an outbound request to `api.pwnedpasswords.com` on every admin password submission. This causes the first admin sign-up to hang on deployments where the endpoint is unreachable. Passing the option seeds the policy with the breach check disabled, so admin sign-up no longer depends on outbound network access.

--- a/.changeset/ravens-swallows-comet.md
+++ b/.changeset/ravens-swallows-comet.md
@@ -2,4 +2,4 @@
 "@logto/cli": minor
 ---
 
-add --dapc seed option (alias --disable-admin-pwned-password-check) to disable the HIBP password breach check on the admin tenant for air-gapped OSS deployments
+add `--disable-admin-pwned-password-check` (alias `--dapc`) option to both `install` and `db seed` commands to disable the HIBP password breach check on the admin tenant for air-gapped OSS deployments

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -9,12 +9,21 @@ import { getAlterationDirectory } from '../alteration/utils.js';
 
 import { createTables, seedCloud, seedTables, seedTest } from './tables.js';
 
+type SeedByPoolOptions = {
+  cloud?: boolean;
+  test?: boolean;
+  encryptBaseRole?: boolean;
+  disablePwnedPasswordCheck?: boolean;
+};
+
 export const seedByPool = async (
   pool: DatabasePool,
-  cloud = false,
-  test = false,
-  encryptBaseRole = false,
-  disablePwnedPasswordCheck = false
+  {
+    cloud = false,
+    test = false,
+    encryptBaseRole = false,
+    disablePwnedPasswordCheck = false,
+  }: SeedByPoolOptions = {}
 ) => {
   await pool.transaction(async (connection) => {
     // Check alteration scripts available in order to insert correct timestamp
@@ -125,7 +134,7 @@ const seed: CommandModule<
     }
 
     try {
-      await seedByPool(pool, cloud, test, encryptBaseRole, dapc);
+      await seedByPool(pool, { cloud, test, encryptBaseRole, disablePwnedPasswordCheck: dapc });
     } catch (error: unknown) {
       consoleLog.error(error);
       consoleLog.error(

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -71,7 +71,7 @@ const seed: CommandModule<
     test?: boolean;
     'legacy-test-data'?: boolean;
     'encrypt-base-role'?: boolean;
-    'disable-admin-pwned-password-check'?: boolean;
+    dapc?: boolean;
   }
 > = {
   command: 'seed [type]',
@@ -100,19 +100,12 @@ const seed: CommandModule<
         describe: 'Seed base role with password',
         type: 'boolean',
       })
-      .option('disable-admin-pwned-password-check', {
+      .option('dapc', {
         describe: disableAdminPwnedPasswordCheckDescription,
-        alias: 'dapc',
+        alias: 'disable-admin-pwned-password-check',
         type: 'boolean',
       }),
-  handler: async ({
-    swe,
-    cloud,
-    test,
-    legacyTestData,
-    encryptBaseRole,
-    disableAdminPwnedPasswordCheck,
-  }) => {
+  handler: async ({ swe, cloud, test, legacyTestData, encryptBaseRole, dapc }) => {
     const pool = await createPoolAndDatabaseIfNeeded();
 
     if (legacyTestData) {
@@ -140,7 +133,7 @@ const seed: CommandModule<
         cloud,
         test,
         encryptBaseRole,
-        disablePwnedPasswordCheck: disableAdminPwnedPasswordCheck,
+        disablePwnedPasswordCheck: dapc,
       });
     } catch (error: unknown) {
       consoleLog.error(error);

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -70,7 +70,7 @@ const seed: CommandModule<
     test?: boolean;
     'legacy-test-data'?: boolean;
     'encrypt-base-role'?: boolean;
-    dapc?: boolean;
+    'disable-admin-pwned-password-check'?: boolean;
   }
 > = {
   command: 'seed [type]',
@@ -99,18 +99,25 @@ const seed: CommandModule<
         describe: 'Seed base role with password',
         type: 'boolean',
       })
-      .option('dapc', {
+      .option('disable-admin-pwned-password-check', {
         describe:
-          "Seed the admin tenant's sign-in experience with the HaveIBeenPwned (HIBP) " +
+          "Seed the admin tenant's sign-in experience with the Have I Been Pwned (HIBP) " +
           'password breach check disabled. Use this for air-gapped or offline OSS deployments ' +
           'where api.pwnedpasswords.com is unreachable, otherwise creating the first admin ' +
           'user from the Welcome page will hang on the breach check. Scope: admin tenant only ' +
           "— the default tenant's password policy is unaffected and stays admin-controlled " +
           'via the Admin Console.',
-        alias: 'disable-admin-pwned-password-check',
+        alias: 'dapc',
         type: 'boolean',
       }),
-  handler: async ({ swe, cloud, test, legacyTestData, encryptBaseRole, dapc }) => {
+  handler: async ({
+    swe,
+    cloud,
+    test,
+    legacyTestData,
+    encryptBaseRole,
+    disableAdminPwnedPasswordCheck,
+  }) => {
     const pool = await createPoolAndDatabaseIfNeeded();
 
     if (legacyTestData) {
@@ -134,7 +141,12 @@ const seed: CommandModule<
     }
 
     try {
-      await seedByPool(pool, { cloud, test, encryptBaseRole, disablePwnedPasswordCheck: dapc });
+      await seedByPool(pool, {
+        cloud,
+        test,
+        encryptBaseRole,
+        disablePwnedPasswordCheck: disableAdminPwnedPasswordCheck,
+      });
     } catch (error: unknown) {
       consoleLog.error(error);
       consoleLog.error(

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -7,6 +7,7 @@ import { consoleLog, oraPromise } from '../../../utils.js';
 import { getLatestAlterationTimestamp } from '../alteration/index.js';
 import { getAlterationDirectory } from '../alteration/utils.js';
 
+import { disableAdminPwnedPasswordCheckDescription } from './options.js';
 import { createTables, seedCloud, seedTables, seedTest } from './tables.js';
 
 type SeedByPoolOptions = {
@@ -100,13 +101,7 @@ const seed: CommandModule<
         type: 'boolean',
       })
       .option('disable-admin-pwned-password-check', {
-        describe:
-          "Seed the admin tenant's sign-in experience with the Have I Been Pwned (HIBP) " +
-          'password breach check disabled. Use this for air-gapped or offline OSS deployments ' +
-          'where api.pwnedpasswords.com is unreachable, otherwise creating the first admin ' +
-          'user from the Welcome page will hang on the breach check. Scope: admin tenant only ' +
-          "— the default tenant's password policy is unaffected and stays admin-controlled " +
-          'via the Admin Console.',
+        describe: disableAdminPwnedPasswordCheckDescription,
         alias: 'dapc',
         type: 'boolean',
       }),

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -13,7 +13,8 @@ export const seedByPool = async (
   pool: DatabasePool,
   cloud = false,
   test = false,
-  encryptBaseRole = false
+  encryptBaseRole = false,
+  disablePwnedPasswordCheck = false
 ) => {
   await pool.transaction(async (connection) => {
     // Check alteration scripts available in order to insert correct timestamp
@@ -34,7 +35,7 @@ export const seedByPool = async (
       consoleLog.info('base role password:', tableInfo.password);
     }
 
-    await seedTables(connection, latestTimestamp, cloud);
+    await seedTables(connection, latestTimestamp, cloud, { disablePwnedPasswordCheck });
 
     if (cloud) {
       await seedCloud(connection);
@@ -60,6 +61,7 @@ const seed: CommandModule<
     test?: boolean;
     'legacy-test-data'?: boolean;
     'encrypt-base-role'?: boolean;
+    dapc?: boolean;
   }
 > = {
   command: 'seed [type]',
@@ -87,8 +89,19 @@ const seed: CommandModule<
       .option('encrypt-base-role', {
         describe: 'Seed base role with password',
         type: 'boolean',
+      })
+      .option('dapc', {
+        describe:
+          "Seed the admin tenant's sign-in experience with the HaveIBeenPwned (HIBP) " +
+          'password breach check disabled. Use this for air-gapped or offline OSS deployments ' +
+          'where api.pwnedpasswords.com is unreachable, otherwise creating the first admin ' +
+          'user from the Welcome page will hang on the breach check. Scope: admin tenant only ' +
+          "— the default tenant's password policy is unaffected and stays admin-controlled " +
+          'via the Admin Console.',
+        alias: 'disable-admin-pwned-password-check',
+        type: 'boolean',
       }),
-  handler: async ({ swe, cloud, test, legacyTestData, encryptBaseRole }) => {
+  handler: async ({ swe, cloud, test, legacyTestData, encryptBaseRole, dapc }) => {
     const pool = await createPoolAndDatabaseIfNeeded();
 
     if (legacyTestData) {
@@ -112,7 +125,7 @@ const seed: CommandModule<
     }
 
     try {
-      await seedByPool(pool, cloud, test, encryptBaseRole);
+      await seedByPool(pool, cloud, test, encryptBaseRole, dapc);
     } catch (error: unknown) {
       consoleLog.error(error);
       consoleLog.error(

--- a/packages/cli/src/commands/database/seed/options.ts
+++ b/packages/cli/src/commands/database/seed/options.ts
@@ -1,0 +1,7 @@
+export const disableAdminPwnedPasswordCheckDescription =
+  "Seed the admin tenant's sign-in experience with the Have I Been Pwned (HIBP) " +
+  'password breach check disabled. Use this for air-gapped or offline OSS deployments ' +
+  'where api.pwnedpasswords.com is unreachable, otherwise creating the first admin ' +
+  'user from the Welcome page will hang on the breach check. Scope: admin tenant only ' +
+  "— the default tenant's password policy is unaffected and stays admin-controlled " +
+  'via the Admin Console.';

--- a/packages/cli/src/commands/database/seed/tables.ts
+++ b/packages/cli/src/commands/database/seed/tables.ts
@@ -151,7 +151,8 @@ export const createTables = async (
 export const seedTables = async (
   connection: DatabaseTransactionConnection,
   latestTimestamp: number,
-  isCloud: boolean
+  isCloud: boolean,
+  options: { disablePwnedPasswordCheck?: boolean } = {}
 ) => {
   await createTenant(connection, defaultTenantId);
   await seedOidcConfigs(connection, defaultTenantId);
@@ -207,7 +208,9 @@ export const seedTables = async (
     connection.query(
       insertInto(createDefaultSignInExperience(defaultTenantId, isCloud), SignInExperiences.table)
     ),
-    connection.query(insertInto(createAdminTenantSignInExperience(), SignInExperiences.table)),
+    connection.query(
+      insertInto(createAdminTenantSignInExperience(options), SignInExperiences.table)
+    ),
     connection.query(insertInto(createDefaultAdminConsoleApplication(), Applications.table)),
     connection.query(insertInto(createDefaultAccountCenter(defaultTenantId), AccountCenters.table)),
     connection.query(insertInto(createAdminTenantAccountCenter(), AccountCenters.table)),

--- a/packages/cli/src/commands/database/seed/tables.ts
+++ b/packages/cli/src/commands/database/seed/tables.ts
@@ -11,6 +11,7 @@ import {
   createMeApiInAdminTenant,
   createDefaultSignInExperience,
   createAdminTenantSignInExperience,
+  type AdminSignInExperienceSeedOptions,
   createDefaultAdminConsoleApplication,
   createCloudApi,
   createTenantApplicationRole,
@@ -152,7 +153,7 @@ export const seedTables = async (
   connection: DatabaseTransactionConnection,
   latestTimestamp: number,
   isCloud: boolean,
-  options: { disablePwnedPasswordCheck?: boolean } = {}
+  options: AdminSignInExperienceSeedOptions = {}
 ) => {
   await createTenant(connection, defaultTenantId);
   await seedOidcConfigs(connection, defaultTenantId);

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -73,7 +73,7 @@ const install: CommandModule<
     ss: boolean;
     cloud: boolean;
     du?: string;
-    'disable-admin-pwned-password-check'?: boolean;
+    dapc?: boolean;
   }
 > = {
   command: ['init', 'i', 'install'],
@@ -103,20 +103,20 @@ const install: CommandModule<
         type: 'string',
         hidden: true,
       },
-      'disable-admin-pwned-password-check': {
+      dapc: {
         describe: disableAdminPwnedPasswordCheckDescription,
-        alias: 'dapc',
+        alias: 'disable-admin-pwned-password-check',
         type: 'boolean',
         default: false,
       },
     }),
-  handler: async ({ p, ss, cloud, du, disableAdminPwnedPasswordCheck }) => {
+  handler: async ({ p, ss, cloud, du, dapc }) => {
     await installLogto({
       path: p,
       skipSeed: ss,
       cloud,
       downloadUrl: du,
-      disableAdminPwnedPasswordCheck,
+      disableAdminPwnedPasswordCheck: dapc,
     });
   },
 };

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -21,9 +21,16 @@ export type InstallArgs = {
   skipSeed: boolean;
   cloud: boolean;
   downloadUrl?: string;
+  disableAdminPwnedPasswordCheck?: boolean;
 };
 
-const installLogto = async ({ path, skipSeed, downloadUrl, cloud }: InstallArgs) => {
+const installLogto = async ({
+  path,
+  skipSeed,
+  downloadUrl,
+  cloud,
+  disableAdminPwnedPasswordCheck,
+}: InstallArgs) => {
   validateNodeVersion();
 
   // Get install location path
@@ -45,7 +52,10 @@ const installLogto = async ({ path, skipSeed, downloadUrl, cloud }: InstallArgs)
       )} command to seed database when ready.\n`
     );
   } else {
-    await seedDatabase(installPath, cloud);
+    await seedDatabase(installPath, {
+      cloud,
+      disablePwnedPasswordCheck: disableAdminPwnedPasswordCheck,
+    });
   }
 
   // Save to dot env
@@ -62,6 +72,7 @@ const install: CommandModule<
     ss: boolean;
     cloud: boolean;
     du?: string;
+    'disable-admin-pwned-password-check'?: boolean;
   }
 > = {
   command: ['init', 'i', 'install'],
@@ -91,9 +102,27 @@ const install: CommandModule<
         type: 'string',
         hidden: true,
       },
+      'disable-admin-pwned-password-check': {
+        describe:
+          "Seed the admin tenant's sign-in experience with the Have I Been Pwned (HIBP) " +
+          'password breach check disabled. Use this for air-gapped or offline OSS deployments ' +
+          'where api.pwnedpasswords.com is unreachable, otherwise creating the first admin ' +
+          'user from the Welcome page will hang on the breach check. Scope: admin tenant only ' +
+          "— the default tenant's password policy is unaffected and stays admin-controlled " +
+          'via the Admin Console.',
+        alias: 'dapc',
+        type: 'boolean',
+        default: false,
+      },
     }),
-  handler: async ({ p, ss, cloud, du }) => {
-    await installLogto({ path: p, skipSeed: ss, cloud, downloadUrl: du });
+  handler: async ({ p, ss, cloud, du, disableAdminPwnedPasswordCheck }) => {
+    await installLogto({
+      path: p,
+      skipSeed: ss,
+      cloud,
+      downloadUrl: du,
+      disableAdminPwnedPasswordCheck,
+    });
   },
 };
 

--- a/packages/cli/src/commands/install/index.ts
+++ b/packages/cli/src/commands/install/index.ts
@@ -3,6 +3,7 @@ import type { CommandModule } from 'yargs';
 
 import { getDatabaseUrlFromConfig } from '../../database.js';
 import { consoleLog } from '../../utils.js';
+import { disableAdminPwnedPasswordCheckDescription } from '../database/seed/options.js';
 
 import {
   validateNodeVersion,
@@ -103,13 +104,7 @@ const install: CommandModule<
         hidden: true,
       },
       'disable-admin-pwned-password-check': {
-        describe:
-          "Seed the admin tenant's sign-in experience with the Have I Been Pwned (HIBP) " +
-          'password breach check disabled. Use this for air-gapped or offline OSS deployments ' +
-          'where api.pwnedpasswords.com is unreachable, otherwise creating the first admin ' +
-          'user from the Welcome page will hang on the breach check. Scope: admin tenant only ' +
-          "— the default tenant's password policy is unaffected and stays admin-controlled " +
-          'via the Admin Console.',
+        describe: disableAdminPwnedPasswordCheckDescription,
         alias: 'dapc',
         type: 'boolean',
         default: false,

--- a/packages/cli/src/commands/install/utils.ts
+++ b/packages/cli/src/commands/install/utils.ts
@@ -161,10 +161,18 @@ export const decompress = async (toPath: string, tarPath: string) => {
   );
 };
 
-export const seedDatabase = async (instancePath: string, cloud: boolean) => {
+type SeedDatabaseOptions = {
+  cloud: boolean;
+  disablePwnedPasswordCheck?: boolean;
+};
+
+export const seedDatabase = async (
+  instancePath: string,
+  { cloud, disablePwnedPasswordCheck }: SeedDatabaseOptions
+) => {
   try {
     const pool = await createPoolAndDatabaseIfNeeded();
-    await seedByPool(pool, { cloud });
+    await seedByPool(pool, { cloud, disablePwnedPasswordCheck });
     await pool.end();
   } catch (error: unknown) {
     consoleLog.error(error);

--- a/packages/cli/src/commands/install/utils.ts
+++ b/packages/cli/src/commands/install/utils.ts
@@ -164,7 +164,7 @@ export const decompress = async (toPath: string, tarPath: string) => {
 export const seedDatabase = async (instancePath: string, cloud: boolean) => {
   try {
     const pool = await createPoolAndDatabaseIfNeeded();
-    await seedByPool(pool, cloud);
+    await seedByPool(pool, { cloud });
     await pool.end();
   } catch (error: unknown) {
     consoleLog.error(error);

--- a/packages/schemas/src/seeds/sign-in-experience.test.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createAdminTenantSignInExperience,
+  createDefaultSignInExperience,
+} from './sign-in-experience.js';
+import { adminTenantId } from './tenant.js';
+
+describe('createAdminTenantSignInExperience', () => {
+  it('seeds an empty passwordPolicy by default', () => {
+    const row = createAdminTenantSignInExperience();
+    expect(row.passwordPolicy).toEqual({});
+  });
+
+  it('seeds an empty passwordPolicy when option is explicitly false', () => {
+    const row = createAdminTenantSignInExperience({ disablePwnedPasswordCheck: false });
+    expect(row.passwordPolicy).toEqual({});
+  });
+
+  it('seeds rejects.pwned=false when disablePwnedPasswordCheck is true', () => {
+    const row = createAdminTenantSignInExperience({ disablePwnedPasswordCheck: true });
+    expect(row.passwordPolicy).toEqual({ rejects: { pwned: false } });
+  });
+
+  it('still targets the admin tenant id when the option is set', () => {
+    const row = createAdminTenantSignInExperience({ disablePwnedPasswordCheck: true });
+    expect(row.tenantId).toBe(adminTenantId);
+  });
+});
+
+describe('createDefaultSignInExperience (unchanged contract)', () => {
+  it('still has a two-parameter signature and seeds an empty passwordPolicy', () => {
+    const row = createDefaultSignInExperience('some-tenant-id', false);
+    expect(row.passwordPolicy).toEqual({});
+  });
+});

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -66,8 +66,21 @@ export const createDefaultSignInExperience = (
 /** @deprecated Use `createDefaultSignInExperience()` instead. */
 export const defaultSignInExperience = createDefaultSignInExperience(defaultTenantId, false);
 
+export type AdminSignInExperienceSeedOptions = {
+  /**
+   * When true, the seeded admin-tenant `passwordPolicy` explicitly disables the
+   * HaveIBeenPwned (HIBP) breach check by setting `rejects.pwned = false`. Intended
+   * for air-gapped or offline OSS deployments where `api.pwnedpasswords.com` is
+   * unreachable; otherwise the first admin sign-up will hang on the breach check.
+   *
+   * Defaults to `false`, which preserves the historical seeded value (`{}`) and lets
+   * the runtime fall back to the default policy (HIBP check enabled).
+   */
+  disablePwnedPasswordCheck?: boolean;
+};
+
 export const createAdminTenantSignInExperience = (
-  options: { disablePwnedPasswordCheck?: boolean } = {}
+  options: AdminSignInExperienceSeedOptions = {}
 ): Readonly<CreateSignInExperience> =>
   Object.freeze({
     ...defaultSignInExperience,

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -95,7 +95,13 @@ export const createAdminTenantSignInExperience = (
       darkLogoUrl: 'https://logto.io/logo-dark.svg',
     },
     passwordPolicy: options.disablePwnedPasswordCheck
-      ? { rejects: { pwned: false } }
+      ? {
+          ...defaultSignInExperience.passwordPolicy,
+          rejects: {
+            ...defaultSignInExperience.passwordPolicy?.rejects,
+            pwned: false,
+          },
+        }
       : defaultSignInExperience.passwordPolicy,
     mfa: {
       factors: [MfaFactor.TOTP, MfaFactor.WebAuthn, MfaFactor.BackupCode],

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -66,7 +66,9 @@ export const createDefaultSignInExperience = (
 /** @deprecated Use `createDefaultSignInExperience()` instead. */
 export const defaultSignInExperience = createDefaultSignInExperience(defaultTenantId, false);
 
-export const createAdminTenantSignInExperience = (): Readonly<CreateSignInExperience> =>
+export const createAdminTenantSignInExperience = (
+  options: { disablePwnedPasswordCheck?: boolean } = {}
+): Readonly<CreateSignInExperience> =>
   Object.freeze({
     ...defaultSignInExperience,
     tenantId: adminTenantId,
@@ -79,6 +81,9 @@ export const createAdminTenantSignInExperience = (): Readonly<CreateSignInExperi
       logoUrl: 'https://logto.io/logo.svg',
       darkLogoUrl: 'https://logto.io/logo-dark.svg',
     },
+    passwordPolicy: options.disablePwnedPasswordCheck
+      ? { rejects: { pwned: false } }
+      : defaultSignInExperience.passwordPolicy,
     mfa: {
       factors: [MfaFactor.TOTP, MfaFactor.WebAuthn, MfaFactor.BackupCode],
       policy: MfaPolicy.NoPrompt,


### PR DESCRIPTION
## Summary

Adds a new `logto db seed` flag `--disable-admin-pwned-password-check` (alias `--dapc`) that seeds the admin tenant's seeded password policy with the HIBP breach check disabled. This unblocks first-admin sign-up on air-gapped or offline OSS deployments where `api.pwnedpasswords.com` is unreachable; otherwise the Welcome-page interaction sign-up hangs on the Have I Been Pwned (HIBP) breach check.

Scope is admin-tenant only. The default tenant's seeded policy is intentionally untouched and remains admin-controlled via the Admin Console after install. No runtime password-validation logic is changed.

A new exported type `AdminSignInExperienceSeedOptions` in `@logto/schemas` carries the option from the CLI handler through `seedByPool` and `seedTables` into `createAdminTenantSignInExperience`. `seedByPool`'s positional booleans are collapsed into an options bag so the public CLI surface gains the new flag without growing the function arity past the repo's `max-params` lint rule. Only in-repo callers in `@logto/cli` were updated; the type stays module-local to that package.

The admin can re-enable the HIBP check after install via Admin Console -> Sign-in experience -> Password policy.

### Companion docs PR

User-facing documentation for this flag lives in [logto-io/docs#1417](https://github.com/logto-io/docs/pull/1417), which adds a new "Seed for air-gapped or offline deployments" section under `Logto OSS > Logto CLI` and a cross-reference admonition under `Deployment and configuration > Database setup`. Reviewers can review both together so the released CLI option and its docs land in sync.

## Testing

Unit tests

## Checklist

- [x] `.changeset` (only when explicitly required)
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

