### PR TITLE
fix(account): custom profile field metadata for Account Center

### DIFF
--- a/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
@@ -246,7 +246,13 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
                   autoFocus={fields[0]?.name === editableField.name}
                   name={editableField.name}
                   label={editableField.label}
-                  type={editableField.type === CustomProfileFieldType.Number ? 'number' : 'text'}
+                  type={
+                    editableField.type === CustomProfileFieldType.Number
+                      ? 'number'
+                      : editableField.type === CustomProfileFieldType.Url
+                        ? 'url'
+                        : 'text'
+                  }
                   required={editableField.required}
                   value={getProfileValue(value)}
                   description={editableField.description}

--- a/packages/account/src/pages/Profile/index.test.tsx
+++ b/packages/account/src/pages/Profile/index.test.tsx
@@ -75,6 +75,19 @@ const favoriteColorField = {
   sieOrder: 0,
 } satisfies CustomProfileField;
 
+const newsletterField = {
+  tenantId: 'default',
+  id: 'newsletter',
+  name: 'newsletter',
+  type: CustomProfileFieldType.Checkbox,
+  label: 'Newsletter',
+  description: null,
+  required: false,
+  config: { defaultValue: 'false' },
+  createdAt: 0,
+  sieOrder: 0,
+} satisfies CustomProfileField;
+
 const renderProfile = ({
   accountCenterSettings,
   experienceSettings,
@@ -166,6 +179,52 @@ describe('<Profile />', () => {
     expect(setToast).toHaveBeenCalledWith('account_center.update_success.default.description');
   });
 
+  it('renders custom data checkbox fields with yes/no labels', () => {
+    const { getByText } = renderProfile({
+      accountCenterSettings: {
+        profileFields: [{ name: 'newsletter' }],
+      },
+      experienceSettings: {
+        customProfileFields: [newsletterField],
+      },
+      userInfo: {
+        customData: {
+          newsletter: true,
+        },
+      },
+    });
+
+    expect(getByText('Yes')).toBeTruthy();
+  });
+
+  it('updates custom data checkbox fields', async () => {
+    const { getByText, queryAllByText } = renderProfile({
+      accountCenterSettings: {
+        profileFields: [{ name: 'newsletter' }],
+      },
+      experienceSettings: {
+        customProfileFields: [newsletterField],
+      },
+      userInfo: {
+        customData: {
+          newsletter: false,
+          retained: 'value',
+        },
+      },
+    });
+
+    fireEvent.click(queryAllByText('account_center.security.change')[0]!);
+    fireEvent.click(document.querySelector('input[type="checkbox"]')!);
+    fireEvent.click(getByText('action.save'));
+
+    await waitFor(() => {
+      expect(updateCustomData).toHaveBeenCalledWith('access-token', {
+        newsletter: true,
+        retained: 'value',
+      });
+    });
+  });
+
   it('updates custom data fields without dropping existing custom data', async () => {
     const { getByText, queryAllByText } = renderProfile();
 
@@ -237,6 +296,28 @@ describe('<Profile />', () => {
     });
     expect(refreshUserInfo).not.toHaveBeenCalled();
     expect(getByText('action.save')).toBeTruthy();
+  });
+
+  it('does not mark required custom data fields as optional in the edit modal', () => {
+    const { queryByText, queryAllByText } = renderProfile({
+      accountCenterSettings: {
+        profileFields: [{ name: 'employeeId' }],
+      },
+      experienceSettings: {
+        customProfileFields: [],
+        customProfileFieldCatalog: [
+          {
+            ...requiredNicknameField,
+            name: 'employeeId',
+            label: 'Employee ID',
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(queryAllByText('account_center.security.change')[0]!);
+
+    expect(queryByText('(Optional)')).toBeNull();
   });
 
   it('blocks submit for required fields and does not call the update API', async () => {

--- a/packages/account/src/pages/Profile/index.test.tsx
+++ b/packages/account/src/pages/Profile/index.test.tsx
@@ -355,6 +355,30 @@ describe('<Profile />', () => {
     expect(getByText('Yes')).toBeTruthy();
   });
 
+  it('renders built-in checkbox fields from profile data', () => {
+    const { getByText } = renderProfile({
+      accountCenterSettings: {
+        profileFields: [{ name: 'nickname' }],
+      },
+      experienceSettings: {
+        customProfileFieldCatalog: [
+          {
+            ...requiredNicknameField,
+            type: CustomProfileFieldType.Checkbox,
+            config: { defaultValue: 'false' },
+          },
+        ],
+      },
+      userInfo: {
+        profile: {
+          nickname: 'true',
+        },
+      },
+    });
+
+    expect(getByText('Yes')).toBeTruthy();
+  });
+
   it('updates custom data checkbox fields', async () => {
     const { getByText, queryAllByText } = renderProfile({
       accountCenterSettings: {

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -1,15 +1,4 @@
-import {
-  AccountCenterControlValue,
-  CustomProfileFieldType,
-  fullnameKeys,
-  userProfileAddressKeys,
-  userProfileKeys,
-  type AccountCenter,
-  type AccountCenterProfileFields,
-  type CustomProfileField,
-  type UserProfile,
-  type UserProfileResponse,
-} from '@logto/schemas';
+import { AccountCenterControlValue, type CustomProfileField } from '@logto/schemas';
 import classNames from 'classnames';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -22,206 +11,18 @@ import homeStyles from '../Home/index.module.scss';
 
 import EditProfileFieldModal from './EditProfileFieldModal';
 import styles from './index.module.scss';
-import { getSelectOptionLabel } from './select-options';
-import type { ProfileFieldControlKey, ProfileFieldRow } from './types';
-
-const profileFieldKeySet = new Set<string>(userProfileKeys);
-const fullnameKeySet = new Set<string>(fullnameKeys);
-const addressKeySet = new Set<string>(userProfileAddressKeys);
+import {
+  getAccountCenterProfileFields,
+  getProfileFieldControlKey,
+  getProfileFieldValue,
+} from './profile-field-values';
+import type { ProfileFieldRow } from './types';
 
 const profileLabelKeys: Record<string, string> = {
   name: 'profile.name',
   avatar: 'profile.avatar',
   fullname: 'profile.fullname',
   address: 'profile.address.formatted',
-};
-
-const getAccountCenterProfileFields = (settings?: AccountCenter): AccountCenterProfileFields =>
-  settings?.profileFields ?? [];
-
-const isCompositeProfileField = (field?: CustomProfileField): boolean =>
-  field?.type === CustomProfileFieldType.Fullname || field?.type === CustomProfileFieldType.Address;
-
-const isBuiltInProfileField = (fieldName: string, field?: CustomProfileField): boolean =>
-  profileFieldKeySet.has(fieldName) || (fieldName === 'fullname' && field === undefined);
-
-const getProfileFieldControlKey = (
-  fieldName: string,
-  field?: CustomProfileField
-): ProfileFieldControlKey => {
-  if (fieldName === 'name' || fieldName === 'avatar') {
-    return fieldName;
-  }
-
-  if (isBuiltInProfileField(fieldName, field) || isCompositeProfileField(field)) {
-    return 'profile';
-  }
-
-  return 'customData';
-};
-
-const joinValues = (values: Array<string | undefined>, separator = ' '): string | undefined => {
-  const value = values.filter(Boolean).join(separator);
-
-  return value || undefined;
-};
-
-const getPrimitiveValue = (value: unknown): string | undefined => {
-  if (value === undefined || value === null || value === '') {
-    return;
-  }
-
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-    return String(value);
-  }
-};
-
-const getFullnameValue = (profile?: UserProfile): string | undefined =>
-  joinValues(fullnameKeys.map((name) => profile?.[name]));
-
-const getAddressValue = (address?: UserProfile['address']): string | undefined =>
-  joinValues(
-    userProfileAddressKeys.map((name) => address?.[name]),
-    ', '
-  );
-
-const isFullnameKey = (name: string): name is (typeof fullnameKeys)[number] =>
-  fullnameKeySet.has(name);
-
-const isAddressKey = (name: string): name is (typeof userProfileAddressKeys)[number] =>
-  addressKeySet.has(name);
-
-const getBuiltInProfileFieldValue = (
-  profile: UserProfile | undefined,
-  fieldName: string
-): string | undefined => {
-  switch (fieldName) {
-    case 'fullname': {
-      return getFullnameValue(profile);
-    }
-    case 'familyName': {
-      return getPrimitiveValue(profile?.familyName);
-    }
-    case 'givenName': {
-      return getPrimitiveValue(profile?.givenName);
-    }
-    case 'middleName': {
-      return getPrimitiveValue(profile?.middleName);
-    }
-    case 'nickname': {
-      return getPrimitiveValue(profile?.nickname);
-    }
-    case 'preferredUsername': {
-      return getPrimitiveValue(profile?.preferredUsername);
-    }
-    case 'profile': {
-      return getPrimitiveValue(profile?.profile);
-    }
-    case 'website': {
-      return getPrimitiveValue(profile?.website);
-    }
-    case 'gender': {
-      return getPrimitiveValue(profile?.gender);
-    }
-    case 'birthdate': {
-      return getPrimitiveValue(profile?.birthdate);
-    }
-    case 'zoneinfo': {
-      return getPrimitiveValue(profile?.zoneinfo);
-    }
-    case 'locale': {
-      return getPrimitiveValue(profile?.locale);
-    }
-    case 'address': {
-      return getAddressValue(profile?.address);
-    }
-    default: {
-      return undefined;
-    }
-  }
-};
-
-const getCompositeFieldValue = (
-  userInfo: Partial<UserProfileResponse> | undefined,
-  field: CustomProfileField
-): string | undefined => {
-  const { profile } = userInfo ?? {};
-
-  if (field.type === CustomProfileFieldType.Fullname) {
-    const partNames =
-      field.config.parts === undefined
-        ? fullnameKeys
-        : field.config.parts.filter(({ enabled }) => enabled).map(({ name }) => name);
-
-    return joinValues(
-      partNames
-        .filter((name): name is (typeof fullnameKeys)[number] => isFullnameKey(name))
-        .map((name) => profile?.[name])
-    );
-  }
-
-  if (field.type === CustomProfileFieldType.Address) {
-    const address = profile?.address;
-    const partNames =
-      field.config.parts === undefined
-        ? userProfileAddressKeys
-        : field.config.parts.filter(({ enabled }) => enabled).map(({ name }) => name);
-
-    return joinValues(
-      partNames
-        .filter((name): name is (typeof userProfileAddressKeys)[number] => isAddressKey(name))
-        .map((name) => address?.[name]),
-      ', '
-    );
-  }
-};
-
-const getProfileFieldValue = (
-  userInfo: Partial<UserProfileResponse> | undefined,
-  { name: fieldName, label: fieldLabel }: { readonly name: string; readonly label: string },
-  translate: (key: string) => string,
-  field?: CustomProfileField
-): React.ReactNode | undefined => {
-  if (fieldName === 'avatar') {
-    return userInfo?.avatar ? (
-      <img
-        className={styles.avatar}
-        src={userInfo.avatar}
-        alt={getPrimitiveValue(userInfo.name) ?? fieldLabel}
-      />
-    ) : undefined;
-  }
-
-  if (fieldName === 'name') {
-    return getPrimitiveValue(userInfo?.name);
-  }
-
-  if (
-    field?.type === CustomProfileFieldType.Fullname ||
-    field?.type === CustomProfileFieldType.Address
-  ) {
-    return getCompositeFieldValue(userInfo, field);
-  }
-
-  if (field?.type === CustomProfileFieldType.Select) {
-    const value = isBuiltInProfileField(fieldName, field)
-      ? getBuiltInProfileFieldValue(userInfo?.profile, fieldName)
-      : getPrimitiveValue(userInfo?.customData?.[fieldName]);
-
-    const option = field.config.options?.find((option) => option.value === value);
-
-    return value === undefined ? undefined : getSelectOptionLabel(value, option?.label, translate);
-  }
-
-  if (isBuiltInProfileField(fieldName, field)) {
-    const value = getBuiltInProfileFieldValue(userInfo?.profile, fieldName);
-
-    return fieldName === 'gender' && value
-      ? getSelectOptionLabel(value, undefined, translate)
-      : value;
-  }
-
-  return getPrimitiveValue(userInfo?.customData?.[fieldName]);
 };
 
 const Profile = () => {
@@ -232,8 +33,13 @@ const Profile = () => {
   const [editingField, setEditingField] = useState<ProfileFieldRow>();
 
   const fieldRows = useMemo(() => {
-    const customProfileFields = experienceSettings?.customProfileFields ?? [];
-    const customProfileFieldMap = new Map(customProfileFields.map((field) => [field.name, field]));
+    const customProfileFieldCatalog =
+      experienceSettings?.customProfileFieldCatalog ??
+      experienceSettings?.customProfileFields ??
+      [];
+    const customProfileFieldMap = new Map(
+      customProfileFieldCatalog.map((field: CustomProfileField) => [field.name, field])
+    );
 
     return profileFields.reduce<ProfileFieldRow[]>((rows, { name }) => {
       const field = customProfileFieldMap.get(name);
@@ -256,7 +62,7 @@ const Profile = () => {
         {
           name,
           label,
-          value: getProfileFieldValue(userInfo, { name, label }, t, field),
+          value: getProfileFieldValue(userInfo, { name, label }, t, field, styles.avatar),
           controlKey,
           controlValue,
           field,
@@ -265,6 +71,7 @@ const Profile = () => {
     }, []);
   }, [
     accountCenterSettings?.fields,
+    experienceSettings?.customProfileFieldCatalog,
     experienceSettings?.customProfileFields,
     profileFields,
     t,

--- a/packages/account/src/pages/Profile/profile-field-values.tsx
+++ b/packages/account/src/pages/Profile/profile-field-values.tsx
@@ -1,0 +1,233 @@
+import {
+  builtInCustomProfileFieldKeys,
+  CustomProfileFieldType,
+  fullnameKeys,
+  userProfileAddressKeys,
+  type AccountCenter,
+  type AccountCenterProfileFields,
+  type CustomProfileField,
+  type UserProfile,
+  type UserProfileResponse,
+} from '@logto/schemas';
+import type { ReactNode } from 'react';
+
+import { getSelectOptionLabel } from './select-options';
+import type { ProfileFieldControlKey } from './types';
+
+const builtInCustomProfileFieldKeySet = new Set<string>(builtInCustomProfileFieldKeys);
+const fullnameKeySet = new Set<string>(fullnameKeys);
+const addressKeySet = new Set<string>(userProfileAddressKeys);
+
+export const getAccountCenterProfileFields = (
+  settings?: AccountCenter
+): AccountCenterProfileFields => settings?.profileFields ?? [];
+
+const isCompositeProfileField = (field?: CustomProfileField): boolean =>
+  field?.type === CustomProfileFieldType.Fullname || field?.type === CustomProfileFieldType.Address;
+
+const isBuiltInProfileField = (fieldName: string, field?: CustomProfileField): boolean =>
+  (builtInCustomProfileFieldKeySet.has(fieldName) &&
+    fieldName !== 'name' &&
+    fieldName !== 'avatar') ||
+  (fieldName === 'fullname' && field === undefined);
+
+export const getProfileFieldControlKey = (
+  fieldName: string,
+  field?: CustomProfileField
+): ProfileFieldControlKey => {
+  if (fieldName === 'name' || fieldName === 'avatar') {
+    return fieldName;
+  }
+
+  if (isBuiltInProfileField(fieldName, field) || isCompositeProfileField(field)) {
+    return 'profile';
+  }
+
+  return 'customData';
+};
+
+const joinValues = (values: Array<string | undefined>, separator = ' '): string | undefined => {
+  const value = values.filter(Boolean).join(separator);
+
+  return value || undefined;
+};
+
+const getPrimitiveValue = (value: unknown): string | undefined => {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+};
+
+const getCheckboxDisplayValue = (
+  value: unknown,
+  translate: (key: string, options?: Record<string, unknown>) => string
+): string | undefined => {
+  if (value === undefined || value === null || value === '') {
+    return;
+  }
+
+  if (value === true || value === 'true') {
+    return translate('profile.checkbox_value.checked', { defaultValue: 'Yes' });
+  }
+
+  if (value === false || value === 'false') {
+    return translate('profile.checkbox_value.unchecked', { defaultValue: 'No' });
+  }
+};
+
+const getFullnameValue = (profile?: UserProfile): string | undefined =>
+  joinValues(fullnameKeys.map((name) => profile?.[name]));
+
+const getAddressValue = (address?: UserProfile['address']): string | undefined =>
+  joinValues(
+    userProfileAddressKeys.map((name) => address?.[name]),
+    ', '
+  );
+
+const isFullnameKey = (name: string): name is (typeof fullnameKeys)[number] =>
+  fullnameKeySet.has(name);
+
+const isAddressKey = (name: string): name is (typeof userProfileAddressKeys)[number] =>
+  addressKeySet.has(name);
+
+const getBuiltInProfileFieldValue = (
+  profile: UserProfile | undefined,
+  fieldName: string
+): string | undefined => {
+  switch (fieldName) {
+    case 'fullname': {
+      return getFullnameValue(profile);
+    }
+    case 'familyName': {
+      return getPrimitiveValue(profile?.familyName);
+    }
+    case 'givenName': {
+      return getPrimitiveValue(profile?.givenName);
+    }
+    case 'middleName': {
+      return getPrimitiveValue(profile?.middleName);
+    }
+    case 'nickname': {
+      return getPrimitiveValue(profile?.nickname);
+    }
+    case 'preferredUsername': {
+      return getPrimitiveValue(profile?.preferredUsername);
+    }
+    case 'profile': {
+      return getPrimitiveValue(profile?.profile);
+    }
+    case 'website': {
+      return getPrimitiveValue(profile?.website);
+    }
+    case 'gender': {
+      return getPrimitiveValue(profile?.gender);
+    }
+    case 'birthdate': {
+      return getPrimitiveValue(profile?.birthdate);
+    }
+    case 'zoneinfo': {
+      return getPrimitiveValue(profile?.zoneinfo);
+    }
+    case 'locale': {
+      return getPrimitiveValue(profile?.locale);
+    }
+    case 'address': {
+      return getAddressValue(profile?.address);
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+
+const getCompositeFieldValue = (
+  userInfo: Partial<UserProfileResponse> | undefined,
+  field: CustomProfileField
+): string | undefined => {
+  const { profile } = userInfo ?? {};
+
+  if (field.type === CustomProfileFieldType.Fullname) {
+    const partNames =
+      field.config.parts === undefined
+        ? fullnameKeys
+        : field.config.parts.filter(({ enabled }) => enabled).map(({ name }) => name);
+
+    return joinValues(
+      partNames
+        .filter((name): name is (typeof fullnameKeys)[number] => isFullnameKey(name))
+        .map((name) => profile?.[name])
+    );
+  }
+
+  if (field.type === CustomProfileFieldType.Address) {
+    const address = profile?.address;
+    const partNames =
+      field.config.parts === undefined
+        ? userProfileAddressKeys
+        : field.config.parts.filter(({ enabled }) => enabled).map(({ name }) => name);
+
+    return joinValues(
+      partNames
+        .filter((name): name is (typeof userProfileAddressKeys)[number] => isAddressKey(name))
+        .map((name) => address?.[name]),
+      ', '
+    );
+  }
+};
+
+export const getProfileFieldValue = (
+  userInfo: Partial<UserProfileResponse> | undefined,
+  { name: fieldName, label: fieldLabel }: { readonly name: string; readonly label: string },
+  translate: (key: string) => string,
+  field?: CustomProfileField,
+  avatarClassName?: string
+): ReactNode | undefined => {
+  if (fieldName === 'avatar') {
+    return userInfo?.avatar ? (
+      <img
+        className={avatarClassName}
+        src={userInfo.avatar}
+        alt={getPrimitiveValue(userInfo.name) ?? fieldLabel}
+      />
+    ) : undefined;
+  }
+
+  if (fieldName === 'name') {
+    return getPrimitiveValue(userInfo?.name);
+  }
+
+  if (
+    field?.type === CustomProfileFieldType.Fullname ||
+    field?.type === CustomProfileFieldType.Address
+  ) {
+    return getCompositeFieldValue(userInfo, field);
+  }
+
+  if (field?.type === CustomProfileFieldType.Select) {
+    const value = isBuiltInProfileField(fieldName, field)
+      ? getBuiltInProfileFieldValue(userInfo?.profile, fieldName)
+      : getPrimitiveValue(userInfo?.customData?.[fieldName]);
+
+    const option = field.config.options?.find((option) => option.value === value);
+
+    return value === undefined ? undefined : getSelectOptionLabel(value, option?.label, translate);
+  }
+
+  if (field?.type === CustomProfileFieldType.Checkbox) {
+    return getCheckboxDisplayValue(userInfo?.customData?.[fieldName], translate);
+  }
+
+  if (isBuiltInProfileField(fieldName, field)) {
+    const value = getBuiltInProfileFieldValue(userInfo?.profile, fieldName);
+
+    return fieldName === 'gender' && value
+      ? getSelectOptionLabel(value, undefined, translate)
+      : value;
+  }
+
+  return getPrimitiveValue(userInfo?.customData?.[fieldName]);
+};

--- a/packages/account/src/pages/Profile/profile-field-values.tsx
+++ b/packages/account/src/pages/Profile/profile-field-values.tsx
@@ -218,7 +218,11 @@ export const getProfileFieldValue = (
   }
 
   if (field?.type === CustomProfileFieldType.Checkbox) {
-    return getCheckboxDisplayValue(userInfo?.customData?.[fieldName], translate);
+    const value = isBuiltInProfileField(fieldName, field)
+      ? getBuiltInProfileFieldValue(userInfo?.profile, fieldName)
+      : userInfo?.customData?.[fieldName];
+
+    return getCheckboxDisplayValue(value, translate);
   }
 
   if (isBuiltInProfileField(fieldName, field)) {

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -183,6 +183,7 @@ describe('getFullSignInExperience()', () => {
       googleOneTap: undefined,
       captchaConfig: undefined,
       customProfileFields: mockCustomProfileFields,
+      customProfileFieldCatalog: mockCustomProfileFields,
       forgotPassword: {
         email: false,
         phone: false,
@@ -228,6 +229,7 @@ describe('getFullSignInExperience()', () => {
       },
       captchaConfig: undefined,
       customProfileFields: mockCustomProfileFields,
+      customProfileFieldCatalog: mockCustomProfileFields,
       forgotPassword: {
         email: false,
         phone: false,
@@ -254,6 +256,7 @@ describe('getFullSignInExperience()', () => {
       const fullSignInExperience = await getFullSignInExperience({ locale: 'en' });
 
       expect(fullSignInExperience.customProfileFields).toStrictEqual(mockCustomProfileFields);
+      expect(fullSignInExperience.customProfileFieldCatalog).toStrictEqual(mockCustomProfileFields);
     } finally {
       // eslint-disable-next-line @silverhand/fp/no-mutation
       (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -336,6 +336,7 @@ export const createSignInExperienceLibrary = (
       googleOneTap: getGoogleOneTap(),
       captchaConfig: await getCaptchaConfig(),
       customProfileFields: signUpCustomProfileFields,
+      customProfileFieldCatalog: customProfileFields,
     };
   };
 

--- a/packages/phrases-experience/src/locales/ar/profile.ts
+++ b/packages/phrases-experience/src/locales/ar/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'ذكر',
     prefer_not_to_say: 'أفضل عدم القول',
   },
+  checkbox_value: {
+    checked: 'نعم',
+    unchecked: 'لا',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/cs/profile.ts
+++ b/packages/phrases-experience/src/locales/cs/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Muž',
     prefer_not_to_say: 'Nechci uvádět',
   },
+  checkbox_value: {
+    checked: 'Ano',
+    unchecked: 'Ne',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/de/profile.ts
+++ b/packages/phrases-experience/src/locales/de/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Männlich',
     prefer_not_to_say: 'Keine Angabe',
   },
+  checkbox_value: {
+    checked: 'Ja',
+    unchecked: 'Nein',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/en/profile.ts
+++ b/packages/phrases-experience/src/locales/en/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Male',
     prefer_not_to_say: 'Prefer not to say',
   },
+  checkbox_value: {
+    checked: 'Yes',
+    unchecked: 'No',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/es/profile.ts
+++ b/packages/phrases-experience/src/locales/es/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Masculino',
     prefer_not_to_say: 'Prefiero no decir',
   },
+  checkbox_value: {
+    checked: 'Sí',
+    unchecked: 'No',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/fr/profile.ts
+++ b/packages/phrases-experience/src/locales/fr/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Homme',
     prefer_not_to_say: 'Préfère ne pas dire',
   },
+  checkbox_value: {
+    checked: 'Oui',
+    unchecked: 'Non',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/it/profile.ts
+++ b/packages/phrases-experience/src/locales/it/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Maschio',
     prefer_not_to_say: 'Preferisco non dire',
   },
+  checkbox_value: {
+    checked: 'Sì',
+    unchecked: 'No',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/ja/profile.ts
+++ b/packages/phrases-experience/src/locales/ja/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: '男性',
     prefer_not_to_say: '答えたくない',
   },
+  checkbox_value: {
+    checked: 'はい',
+    unchecked: 'いいえ',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/ko/profile.ts
+++ b/packages/phrases-experience/src/locales/ko/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: '남성',
     prefer_not_to_say: '답하지 않음',
   },
+  checkbox_value: {
+    checked: '예',
+    unchecked: '아니오',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/pl-pl/profile.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Mężczyzna',
     prefer_not_to_say: 'Wolę nie mówić',
   },
+  checkbox_value: {
+    checked: 'Tak',
+    unchecked: 'Nie',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/pt-br/profile.ts
+++ b/packages/phrases-experience/src/locales/pt-br/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Masculino',
     prefer_not_to_say: 'Prefiro não dizer',
   },
+  checkbox_value: {
+    checked: 'Sim',
+    unchecked: 'Não',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/pt-pt/profile.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Masculino',
     prefer_not_to_say: 'Prefiro não dizer',
   },
+  checkbox_value: {
+    checked: 'Sim',
+    unchecked: 'Não',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/ru/profile.ts
+++ b/packages/phrases-experience/src/locales/ru/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Мужской',
     prefer_not_to_say: 'Предпочитаю не говорить',
   },
+  checkbox_value: {
+    checked: 'Да',
+    unchecked: 'Нет',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/th/profile.ts
+++ b/packages/phrases-experience/src/locales/th/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'ชาย',
     prefer_not_to_say: 'ไม่ระบุ',
   },
+  checkbox_value: {
+    checked: 'ใช่',
+    unchecked: 'ไม่',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/tr-tr/profile.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Erkek',
     prefer_not_to_say: 'Söylememeyi tercih ederim',
   },
+  checkbox_value: {
+    checked: 'Evet',
+    unchecked: 'Hayır',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/uk-ua/profile.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: 'Чоловіча',
     prefer_not_to_say: 'Волію не говорити',
   },
+  checkbox_value: {
+    checked: 'Так',
+    unchecked: 'Ні',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/zh-cn/profile.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: '男性',
     prefer_not_to_say: '不愿透露',
   },
+  checkbox_value: {
+    checked: '是',
+    unchecked: '否',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/zh-hk/profile.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: '男性',
     prefer_not_to_say: '不願透露',
   },
+  checkbox_value: {
+    checked: '是',
+    unchecked: '否',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/phrases-experience/src/locales/zh-tw/profile.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/profile.ts
@@ -26,6 +26,10 @@ const profile = {
     male: '男性',
     prefer_not_to_say: '不願透露',
   },
+  checkbox_value: {
+    checked: '是',
+    unchecked: '否',
+  },
 };
 
 export default Object.freeze(profile);

--- a/packages/schemas/src/types/sign-in-experience.ts
+++ b/packages/schemas/src/types/sign-in-experience.ts
@@ -51,7 +51,15 @@ export type FullSignInExperience = Omit<SignInExperience, 'forgotPasswordMethods
     domain?: string;
     mode?: RecaptchaEnterpriseMode;
   };
+  /**
+   * Custom profile fields selected for the sign-up (Collect user profile) flow.
+   */
   customProfileFields?: Readonly<CustomProfileField[]>;
+  /**
+   * Full custom profile field catalog used to resolve field metadata (for example `required`
+   * and `type`) outside the sign-up field list, such as the account center profile page.
+   */
+  customProfileFieldCatalog?: Readonly<CustomProfileField[]>;
 };
 
 export const fullSignInExperienceGuard = SignInExperiences.guard
@@ -81,4 +89,5 @@ export const fullSignInExperienceGuard = SignInExperiences.guard
       })
       .optional(),
     customProfileFields: CustomProfileFields.guard.array(),
+    customProfileFieldCatalog: CustomProfileFields.guard.array().optional(),
   }) satisfies ToZodObject<FullSignInExperience>;


### PR DESCRIPTION
## Summary

- Expose `customProfileFieldCatalog` on well-known so Account Center can resolve field metadata (required, type, label) from the full Collect user profile catalog, not only the sign-up subset in `customProfileFields`.
- Use the catalog on `/account/profile` so required custom data fields no longer show `(Optional)` in the edit modal.
- Improve custom data display (checkbox Yes/No, URL input type) and add unit tests.

## Testing

- Unit tests


Made with [Cursor](https://cursor.com)