### PR TITLE
feat(core): add application access control management APIs

### DIFF
--- a/packages/core/src/queries/application-access-control.ts
+++ b/packages/core/src/queries/application-access-control.ts
@@ -1,0 +1,188 @@
+import {
+  applicationAccessControlGuard,
+  type ApplicationAccessControl,
+  Applications,
+  ApplicationAccessControlOrgRoleRelations,
+  ApplicationAccessControlOrganizationRelations,
+  ApplicationAccessControlUserRelations,
+  ApplicationAccessControlUserRoleRelations,
+} from '@logto/schemas';
+import type { CommonQueryMethods } from '@silverhand/slonik';
+import { sql } from '@silverhand/slonik';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import assertThat from '#src/utils/assert-that.js';
+import { convertToIdentifiers } from '#src/utils/sql.js';
+
+const applications = convertToIdentifiers(Applications);
+const userRelations = convertToIdentifiers(ApplicationAccessControlUserRelations);
+const userRoleRelations = convertToIdentifiers(ApplicationAccessControlUserRoleRelations);
+const organizationRelations = convertToIdentifiers(ApplicationAccessControlOrganizationRelations);
+const organizationRoleRelations = convertToIdentifiers(ApplicationAccessControlOrgRoleRelations);
+
+export const createApplicationAccessControlQueries = (pool: CommonQueryMethods) => {
+  const findApplicationAccessControl = async (
+    applicationId: string
+  ): Promise<ApplicationAccessControl> => {
+    const accessControl = await pool.one<ApplicationAccessControl>(sql`
+      select
+        coalesce((
+          select array_agg(${userRelations.fields.userId} order by ${userRelations.fields.userId})
+          from ${userRelations.table}
+          where ${userRelations.fields.applicationId} = ${applicationId}
+        ), array[]::varchar[]) as "userIds",
+        coalesce((
+          select array_agg(
+            ${userRoleRelations.fields.roleId}
+            order by ${userRoleRelations.fields.roleId}
+          )
+          from ${userRoleRelations.table}
+          where ${userRoleRelations.fields.applicationId} = ${applicationId}
+        ), array[]::varchar[]) as "userRoleIds",
+        coalesce((
+          select array_agg(
+            ${organizationRelations.fields.organizationId}
+            order by ${organizationRelations.fields.organizationId}
+          )
+          from ${organizationRelations.table}
+          where ${organizationRelations.fields.applicationId} = ${applicationId}
+        ), array[]::varchar[]) as "organizationIds",
+        coalesce((
+          select jsonb_agg(
+            jsonb_build_object(
+              'organizationId', organization_id,
+              'organizationRoleIds', organization_role_ids
+            )
+            order by organization_id
+          )
+          from (
+            select
+              ${organizationRoleRelations.fields.organizationId} as organization_id,
+              array_agg(
+                ${organizationRoleRelations.fields.organizationRoleId}
+                order by ${organizationRoleRelations.fields.organizationRoleId}
+              ) as organization_role_ids
+            from ${organizationRoleRelations.table}
+            where ${organizationRoleRelations.fields.applicationId} = ${applicationId}
+            group by ${organizationRoleRelations.fields.organizationId}
+          ) organization_role_rules
+        ), '[]'::jsonb) as "organizationRoleRules"
+    `);
+
+    return applicationAccessControlGuard.parse(accessControl);
+  };
+
+  const replaceApplicationAccessControl = async (
+    applicationId: string,
+    {
+      userIds,
+      userRoleIds,
+      organizationIds,
+      organizationRoleRules: organizationRoleRuleGroups,
+    }: ApplicationAccessControl
+  ) =>
+    pool.transaction(async (transaction) => {
+      const organizationRoleRuleRows = organizationRoleRuleGroups.flatMap(
+        ({ organizationId, organizationRoleIds }) =>
+          organizationRoleIds.map((organizationRoleId) => ({
+            organizationId,
+            organizationRoleId,
+          }))
+      );
+
+      const application = await transaction.maybeOne(sql`
+        select 1
+        from ${applications.table}
+        where ${applications.fields.id} = ${applicationId}
+        for update
+      `);
+
+      assertThat(
+        application,
+        new RequestError({
+          code: 'entity.not_exists_with_id',
+          status: 404,
+          name: Applications.table,
+          id: applicationId,
+        })
+      );
+
+      await transaction.query(sql`
+        delete from ${userRelations.table}
+        where ${userRelations.fields.applicationId} = ${applicationId}
+      `);
+      await transaction.query(sql`
+        delete from ${userRoleRelations.table}
+        where ${userRoleRelations.fields.applicationId} = ${applicationId}
+      `);
+      await transaction.query(sql`
+        delete from ${organizationRelations.table}
+        where ${organizationRelations.fields.applicationId} = ${applicationId}
+      `);
+      await transaction.query(sql`
+        delete from ${organizationRoleRelations.table}
+        where ${organizationRoleRelations.fields.applicationId} = ${applicationId}
+      `);
+
+      if (userIds.length > 0) {
+        await transaction.query(sql`
+          insert into ${userRelations.table} (
+            ${userRelations.fields.applicationId},
+            ${userRelations.fields.userId}
+          )
+          values ${sql.join(
+            userIds.map((userId) => sql`(${applicationId}, ${userId})`),
+            sql`, `
+          )}
+        `);
+      }
+
+      if (userRoleIds.length > 0) {
+        await transaction.query(sql`
+          insert into ${userRoleRelations.table} (
+            ${userRoleRelations.fields.applicationId},
+            ${userRoleRelations.fields.roleId}
+          )
+          values ${sql.join(
+            userRoleIds.map((roleId) => sql`(${applicationId}, ${roleId})`),
+            sql`, `
+          )}
+        `);
+      }
+
+      if (organizationIds.length > 0) {
+        await transaction.query(sql`
+          insert into ${organizationRelations.table} (
+            ${organizationRelations.fields.applicationId},
+            ${organizationRelations.fields.organizationId}
+          )
+          values ${sql.join(
+            organizationIds.map((organizationId) => sql`(${applicationId}, ${organizationId})`),
+            sql`, `
+          )}
+        `);
+      }
+
+      if (organizationRoleRuleRows.length > 0) {
+        await transaction.query(sql`
+          insert into ${organizationRoleRelations.table} (
+            ${organizationRoleRelations.fields.applicationId},
+            ${organizationRoleRelations.fields.organizationId},
+            ${organizationRoleRelations.fields.organizationRoleId}
+          )
+          values ${sql.join(
+            organizationRoleRuleRows.map(
+              ({ organizationId, organizationRoleId }) =>
+                sql`(${applicationId}, ${organizationId}, ${organizationRoleId})`
+            ),
+            sql`, `
+          )}
+        `);
+      }
+    });
+
+  return {
+    findApplicationAccessControl,
+    replaceApplicationAccessControl,
+  };
+};

--- a/packages/core/src/routes/applications/application-access-control.openapi.json
+++ b/packages/core/src/routes/applications/application-access-control.openapi.json
@@ -1,0 +1,64 @@
+{
+  "paths": {
+    "/api/applications/{applicationId}/access-control": {
+      "get": {
+        "tags": ["Dev feature"],
+        "summary": "Get application access-control rules",
+        "description": "Get the app-level access-control rule configuration for the specified application.",
+        "responses": {
+          "200": {
+            "description": "The app-level access-control rule configuration."
+          },
+          "404": {
+            "description": "The application was not found, or app-level access control is unavailable."
+          }
+        }
+      },
+      "put": {
+        "tags": ["Dev feature"],
+        "summary": "Replace application access-control rules",
+        "description": "Replace the app-level access-control rule configuration for the specified application.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "userIds": {
+                    "description": "An array of user IDs that can access the application."
+                  },
+                  "userRoleIds": {
+                    "description": "An array of user role IDs whose assigned users can access the application."
+                  },
+                  "organizationIds": {
+                    "description": "An array of organization IDs whose members can access the application."
+                  },
+                  "organizationRoleRules": {
+                    "description": "An array of organization-role rule groups. Each group contains an organization ID and the organization role IDs that can access the application in that organization.",
+                    "items": {
+                      "properties": {
+                        "organizationRoleIds": {
+                          "minItems": 1
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The app-level access-control rule configuration was replaced successfully."
+          },
+          "404": {
+            "description": "The application or referenced entities were not found, or app-level access control is unavailable."
+          },
+          "422": {
+            "description": "The access-control rule payload contains invalid role types or empty organization-role groups."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/applications/application-access-control.test.ts
+++ b/packages/core/src/routes/applications/application-access-control.test.ts
@@ -1,0 +1,189 @@
+import {
+  type Application,
+  type CreateApplication,
+  createDefaultApplicationAccessControl,
+  type ApplicationAccessControl,
+} from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockApplication } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+const { jest } = import.meta;
+
+const findApplicationById = jest.fn(async () => mockApplication);
+const updateApplicationById = jest.fn(
+  async (_, data: Partial<CreateApplication>): Promise<Application> => ({
+    ...mockApplication,
+    ...data,
+  })
+);
+const findApplicationAccessControl = jest.fn(async () => createDefaultApplicationAccessControl());
+const replaceApplicationAccessControl = jest.fn();
+
+const tenantContext = new MockTenant(undefined, {
+  applications: {
+    findApplicationById,
+    updateApplicationById,
+  },
+  applicationAccessControl: {
+    findApplicationAccessControl,
+    replaceApplicationAccessControl,
+  },
+});
+
+const { createRequester } = await import('#src/utils/test-utils.js');
+const applicationRoutes = await pickDefault(import('./application.js'));
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
+};
+
+const createApplicationRequest = (isDevFeaturesEnabled = true) => {
+  setDevFeaturesEnabled(isDevFeaturesEnabled);
+
+  return createRequester({ authedRoutes: applicationRoutes, tenantContext });
+};
+
+const buildAccessControl = (
+  patch: Partial<ApplicationAccessControl> = {}
+): ApplicationAccessControl => ({
+  userIds: ['user-1'],
+  userRoleIds: ['role-1'],
+  organizationIds: ['organization-1'],
+  organizationRoleRules: [
+    { organizationId: 'organization-2', organizationRoleIds: ['organization-role-1'] },
+  ],
+  ...patch,
+});
+
+describe('application access-control route', () => {
+  afterEach(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+    findApplicationById.mockClear();
+    updateApplicationById.mockClear();
+    findApplicationAccessControl.mockClear();
+    replaceApplicationAccessControl.mockClear();
+  });
+
+  it('PATCH /applications/:applicationId should gate app-level access control enablement by dev features', async () => {
+    const applicationRequest = createApplicationRequest();
+
+    const patch = { appLevelAccessControlEnabled: true };
+    const response = await applicationRequest.patch('/applications/foo').send(patch);
+
+    expect(response.status).toEqual(200);
+    expect(updateApplicationById).toHaveBeenCalledWith('foo', patch, 'replace');
+    expect(response.body).toMatchObject(patch);
+
+    updateApplicationById.mockClear();
+
+    const disabledResponse = await createApplicationRequest(false)
+      .patch('/applications/foo')
+      .send(patch);
+
+    expect(disabledResponse.status).toEqual(400);
+    expect(updateApplicationById).not.toHaveBeenCalled();
+  });
+
+  it('GET /applications/:applicationId/access-control should return empty rules by default', async () => {
+    const applicationRequest = createApplicationRequest();
+
+    const response = await applicationRequest.get('/applications/foo/access-control');
+
+    expect(response.status).toEqual(200);
+    expect(findApplicationById).toHaveBeenCalledWith('foo');
+    expect(findApplicationAccessControl).toHaveBeenCalledWith('foo');
+    expect(response.body).toEqual(createDefaultApplicationAccessControl());
+  });
+
+  it('GET /applications/:applicationId/access-control should be unavailable without dev features', async () => {
+    const applicationRequest = createApplicationRequest(false);
+
+    const response = await applicationRequest.get('/applications/foo/access-control');
+
+    expect(response.status).toEqual(404);
+    expect(findApplicationAccessControl).not.toHaveBeenCalled();
+  });
+
+  it('PUT /applications/:applicationId/access-control should validate and replace deduplicated rules', async () => {
+    const applicationRequest = createApplicationRequest();
+
+    const response = await applicationRequest.put('/applications/foo/access-control').send({
+      userIds: ['user-1', 'user-2', 'user-1'],
+      userRoleIds: ['role-1', 'role-1'],
+      organizationIds: ['organization-1', 'organization-1'],
+      organizationRoleRules: [
+        {
+          organizationId: 'organization-2',
+          organizationRoleIds: ['organization-role-1', 'organization-role-1'],
+        },
+        {
+          organizationId: 'organization-2',
+          organizationRoleIds: ['organization-role-2'],
+        },
+      ],
+    });
+
+    const expectedAccessControl = buildAccessControl({
+      userIds: ['user-1', 'user-2'],
+      organizationRoleRules: [
+        {
+          organizationId: 'organization-2',
+          organizationRoleIds: ['organization-role-1', 'organization-role-2'],
+        },
+      ],
+    });
+
+    expect(response.status).toEqual(200);
+    expect(findApplicationById).toHaveBeenCalledWith('foo');
+    expect(replaceApplicationAccessControl).toHaveBeenCalledWith('foo', expectedAccessControl);
+    expect(response.body).toEqual(expectedAccessControl);
+  });
+
+  it('PUT /applications/:applicationId/access-control should reject empty organization-role groups', async () => {
+    const applicationRequest = createApplicationRequest();
+
+    const response = await applicationRequest.put('/applications/foo/access-control').send(
+      buildAccessControl({
+        organizationRoleRules: [{ organizationId: 'organization-2', organizationRoleIds: [] }],
+      })
+    );
+
+    expect(response.status).toEqual(422);
+    expect(replaceApplicationAccessControl).not.toHaveBeenCalled();
+  });
+
+  it('PUT /applications/:applicationId/access-control should return 404 before validating references', async () => {
+    const applicationRequest = createApplicationRequest();
+    findApplicationById.mockRejectedValueOnce(
+      new RequestError({
+        code: 'entity.not_exists_with_id',
+        status: 404,
+        name: 'applications',
+        id: 'foo',
+      })
+    );
+
+    const response = await applicationRequest
+      .put('/applications/foo/access-control')
+      .send(buildAccessControl({ userIds: ['missing-user'] }));
+
+    expect(response.status).toEqual(404);
+    expect(replaceApplicationAccessControl).not.toHaveBeenCalled();
+  });
+
+  it('PUT /applications/:applicationId/access-control should be unavailable without dev features', async () => {
+    const applicationRequest = createApplicationRequest(false);
+
+    const response = await applicationRequest
+      .put('/applications/foo/access-control')
+      .send(buildAccessControl());
+
+    expect(response.status).toEqual(404);
+    expect(replaceApplicationAccessControl).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/routes/applications/application-access-control.ts
+++ b/packages/core/src/routes/applications/application-access-control.ts
@@ -1,0 +1,111 @@
+import { applicationAccessControlGuard, type ApplicationAccessControl } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import { z } from 'zod';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import koaGuard, { parse } from '#src/middleware/koa-guard.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
+
+// Keep this OpenAPI-friendly guard in sync with the canonical guard below. The canonical guard
+// uses transforms for dedupe/merge/limits, which do not round-trip cleanly through OpenAPI output.
+const applicationAccessControlOpenApiGuard = z.object({
+  userIds: z.array(z.string()),
+  userRoleIds: z.array(z.string()),
+  organizationIds: z.array(z.string()),
+  organizationRoleRules: z.array(
+    z.object({
+      organizationId: z.string(),
+      organizationRoleIds: z.array(z.string()),
+    })
+  ),
+}) satisfies z.ZodType<ApplicationAccessControl>;
+
+const applicationAccessControlBodyGuard: z.ZodType<ApplicationAccessControl> =
+  applicationAccessControlGuard;
+
+const assertNonEmptyOrganizationRoleRules = ({
+  organizationRoleRules,
+}: ApplicationAccessControl) => {
+  const emptyRule = organizationRoleRules.find(
+    ({ organizationRoleIds }) => organizationRoleIds.length === 0
+  );
+
+  assertThat(
+    !emptyRule,
+    new RequestError({
+      code: 'request.invalid_input',
+      status: 422,
+      details: 'Organization-role rule groups must include at least one organization role.',
+      ...conditional(emptyRule && { organizationId: emptyRule.organizationId }),
+    })
+  );
+};
+
+export default function applicationAccessControlRoutes<T extends ManagementApiRouter>(
+  ...[router, { queries }]: RouterInitArgs<T>
+) {
+  const {
+    applications: { findApplicationById },
+    applicationAccessControl: { findApplicationAccessControl, replaceApplicationAccessControl },
+  } = queries;
+
+  const pathname = '/applications/:applicationId/access-control';
+  const params = z.object({ applicationId: z.string().min(1) });
+
+  router.use(pathname, koaGuard({ params }), async (_, next) => {
+    assertThat(
+      EnvSet.values.isDevFeaturesEnabled,
+      new RequestError({ code: 'entity.not_found', status: 404 })
+    );
+
+    return next();
+  });
+
+  router.get(
+    pathname,
+    koaGuard({
+      params,
+      response: applicationAccessControlOpenApiGuard,
+      status: [200, 404],
+    }),
+    async (ctx, next) => {
+      const { applicationId } = ctx.guard.params;
+
+      await findApplicationById(applicationId);
+
+      ctx.body = await findApplicationAccessControl(applicationId);
+
+      return next();
+    }
+  );
+
+  router.put(
+    pathname,
+    koaGuard({
+      params,
+      body: applicationAccessControlOpenApiGuard,
+      response: applicationAccessControlOpenApiGuard,
+      status: [200, 404, 422],
+    }),
+    async (ctx, next) => {
+      const { applicationId } = ctx.guard.params;
+      const accessControl: ApplicationAccessControl = parse(
+        'body',
+        applicationAccessControlBodyGuard,
+        ctx.guard.body
+      );
+
+      assertNonEmptyOrganizationRoleRules(accessControl);
+      await findApplicationById(applicationId);
+
+      await replaceApplicationAccessControl(applicationId, accessControl);
+
+      ctx.body = accessControl;
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/applications/application.openapi.json
+++ b/packages/core/src/routes/applications/application.openapi.json
@@ -125,6 +125,11 @@
                 "properties": {
                   "isAdmin": {
                     "description": "Whether the application has admin access. User can enable the admin access for Machine-to-Machine apps."
+                  },
+                  "appLevelAccessControlEnabled": {
+                    "type": "boolean",
+                    "description": "Whether app-level access control is enabled for this application. This field is available only when dev features are enabled.",
+                    "x-logto-dev-feature": true
                   }
                 }
               }

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -16,6 +16,7 @@ import { generateStandardId, generateStandardSecret } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
 import { boolean, object, string, z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
@@ -26,6 +27,7 @@ import { parseSearchParamsForSearch } from '#src/utils/search.js';
 import { captureEvent } from '../../utils/posthog.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
+import applicationAccessControlRoutes from './application-access-control.js';
 import applicationCustomDataRoutes from './application-custom-data.js';
 import { generateInternalSecret } from './application-secret.js';
 import { applicationCreateGuard, applicationPatchGuard } from './types.js';
@@ -469,5 +471,9 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
   );
 
   applicationCustomDataRoutes(router, tenant);
+
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    applicationAccessControlRoutes(router, tenant);
+  }
 }
 /* eslint-enable max-lines */

--- a/packages/core/src/routes/applications/types.ts
+++ b/packages/core/src/routes/applications/types.ts
@@ -5,7 +5,16 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
+
 const protectedAppAdditionalScopeGuard = z.enum(protectedAppAdditionalScopes);
+
+const appLevelAccessControlEnabledGuard = z
+  .boolean()
+  .refine(() => EnvSet.values.isDevFeaturesEnabled, {
+    message: 'appLevelAccessControlEnabled is not available when dev features are disabled',
+  })
+  .optional();
 
 export const applicationCreateGuard = originalApplicationCreateGuard
   .omit({
@@ -25,6 +34,7 @@ export const applicationPatchGuard = originalApplicationPatchGuard
     protectedAppMetadata: true,
   })
   .extend({
+    appLevelAccessControlEnabled: appLevelAccessControlEnabledGuard,
     protectedAppMetadata: z
       .object({
         origin: z.string().optional(),

--- a/packages/core/src/routes/swagger/utils/general.test.ts
+++ b/packages/core/src/routes/swagger/utils/general.test.ts
@@ -1,0 +1,116 @@
+import { type OpenAPIV3 } from 'openapi-types';
+
+import { EnvSet } from '#src/env-set/index.js';
+import { type DeepPartial } from '#src/test-utils/tenant.js';
+
+import { devFeatureSchemaExtension, removeUnnecessaryOperations } from './general.js';
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Tests need to cover both dev-feature states.
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
+};
+
+const createDevFeatureBooleanSchema = () =>
+  ({
+    type: 'boolean',
+    [devFeatureSchemaExtension]: true,
+  }) satisfies OpenAPIV3.SchemaObject & Record<typeof devFeatureSchemaExtension, true>;
+
+const createDocument = (): DeepPartial<OpenAPIV3.Document> => ({
+  openapi: '3.0.1',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/api/mock': {
+      patch: {
+        requestBody: {
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['name', 'beta'],
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
+                  beta: createDevFeatureBooleanSchema(),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+describe('swagger general utils', () => {
+  afterEach(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
+  it('should remove dev feature schema properties when dev features are disabled', () => {
+    setDevFeaturesEnabled(false);
+
+    const document = removeUnnecessaryOperations(createDocument());
+
+    expect(document).toMatchObject({
+      paths: {
+        '/api/mock': {
+          patch: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    required: ['name'],
+                    properties: {
+                      name: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(document)).not.toContain('beta');
+    expect(JSON.stringify(document)).not.toContain(devFeatureSchemaExtension);
+  });
+
+  it('should keep dev feature schema properties without exposing the internal marker when dev features are enabled', () => {
+    setDevFeaturesEnabled(true);
+
+    const document = removeUnnecessaryOperations(createDocument());
+
+    expect(document).toMatchObject({
+      paths: {
+        '/api/mock': {
+          patch: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    required: ['name', 'beta'],
+                    properties: {
+                      beta: {
+                        type: 'boolean',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(document)).not.toContain(devFeatureSchemaExtension);
+  });
+});

--- a/packages/core/src/routes/swagger/utils/general.ts
+++ b/packages/core/src/routes/swagger/utils/general.ts
@@ -18,6 +18,8 @@ const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slic
 const cloudOnlyTag = 'Cloud only';
 /** The tag name is used in the supplement document to indicate that the corresponding API operation is a dev feature. */
 export const devFeatureTag = 'Dev feature';
+/** The OpenAPI schema extension that hides a schema property when dev features are disabled. */
+export const devFeatureSchemaExtension = 'x-logto-dev-feature';
 
 const reservedTags = new Set([cloudOnlyTag, devFeatureTag]);
 
@@ -258,8 +260,10 @@ export const validateSwaggerDocument = (document: OpenAPIV3.Document) => {
  * **CAUTION**: This function mutates the input document.
  *
  * Remove operations (path + method) that are tagged with `Cloud only` if the application is not
- * running in the cloud and remove operations with `Dev feature` tag if Logto's `isDevFeatureEnabled` flag
- * is set to be false.
+ * running in the cloud and remove operations with `Dev feature` tag if Logto's
+ * `isDevFeaturesEnabled` flag is set to be false. It also prunes schema properties marked with
+ * `x-logto-dev-feature` when dev features are disabled, and removes the internal marker when they
+ * are enabled.
  *
  * This will prevent the swagger validation from failing in the OSS environment.
  *
@@ -269,6 +273,9 @@ export const removeUnnecessaryOperations = (
   document: DeepPartial<OpenAPIV3.Document>
 ): DeepPartial<OpenAPIV3.Document> => {
   const { isCloud, isDevFeaturesEnabled } = EnvSet.values;
+
+  removeDevFeatureSchemaProperties(document);
+
   if ((isCloud && isDevFeaturesEnabled) || !document.paths) {
     return document;
   }
@@ -292,6 +299,82 @@ export const removeUnnecessaryOperations = (
   }
 
   return document;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> => isObject(value);
+
+const removeRequiredProperty = (
+  schema: Record<string, unknown>,
+  required: unknown,
+  propertyName: string
+) => {
+  if (!Array.isArray(required)) {
+    return;
+  }
+
+  const nextRequired = required.filter((item) => item !== propertyName);
+
+  if (nextRequired.length === 0) {
+    Reflect.deleteProperty(schema, 'required');
+
+    return;
+  }
+
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Pruning the supplement document is intentionally in-place.
+  schema.required = nextRequired;
+};
+
+const removeDevFeatureSchemaProperty = (
+  schema: Record<string, unknown>,
+  properties: Record<string, unknown>,
+  propertyName: string,
+  propertySchema: unknown
+) => {
+  if (!isRecord(propertySchema) || propertySchema[devFeatureSchemaExtension] !== true) {
+    return false;
+  }
+
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    Reflect.deleteProperty(properties, propertyName);
+    removeRequiredProperty(schema, schema.required, propertyName);
+
+    return true;
+  }
+
+  Reflect.deleteProperty(propertySchema, devFeatureSchemaExtension);
+
+  return false;
+};
+
+const removeDevFeatureSchemaProperties = (value: unknown) => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      removeDevFeatureSchemaProperties(item);
+    }
+
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  const schema = value;
+  const { properties } = schema;
+
+  if (isRecord(properties)) {
+    for (const [propertyName, propertySchema] of Object.entries(properties)) {
+      if (removeDevFeatureSchemaProperty(schema, properties, propertyName, propertySchema)) {
+        continue;
+      }
+    }
+  }
+
+  Reflect.deleteProperty(schema, devFeatureSchemaExtension);
+
+  for (const item of Object.values(schema)) {
+    removeDevFeatureSchemaProperties(item);
+  }
 };
 
 export const shouldThrow = () => !EnvSet.values.isProduction || EnvSet.values.isIntegrationTest;

--- a/packages/core/src/tenants/Queries.ts
+++ b/packages/core/src/tenants/Queries.ts
@@ -1,6 +1,7 @@
 import type { CommonQueryMethods } from '@silverhand/slonik';
 
 import { type WellKnownCache } from '#src/caches/well-known.js';
+import { createApplicationAccessControlQueries } from '#src/queries/application-access-control.js';
 import { ApplicationSecretQueries } from '#src/queries/application-secrets.js';
 import createApplicationSignInExperienceQueries from '#src/queries/application-sign-in-experience.js';
 import { createApplicationQueries } from '#src/queries/application.js';
@@ -49,6 +50,7 @@ import { VerificationRecordQueries } from '../queries/verification-records.js';
 
 export default class Queries {
   applications = createApplicationQueries(this.pool);
+  applicationAccessControl = createApplicationAccessControlQueries(this.pool);
   applicationSecrets = new ApplicationSecretQueries(this.pool);
   applicationSignInExperiences = createApplicationSignInExperienceQueries(this.pool);
   connectors = createConnectorQueries(this.pool, this.wellKnownCache);


### PR DESCRIPTION
## Summary
Add Management API support for app-level access-control configuration on top of the schema PR. This adds read/replace APIs for direct user, user role, organization, and organization role rules, validates referenced entities before writing, and replaces rule rows transactionally. It also wires application enablement into the application patch flow and documents the new APIs.

This also adds a schema-level OpenAPI supplement marker (`x-logto-dev-feature`) so dev-only schema properties can be hidden from generated public API documents while still being documented in dev-feature API docs.

Stacked on #8856.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
