### PR TITLE
test(account): add account password update integration tests

### DIFF
--- a/packages/integration-tests/src/tests/api/account/index.test.ts
+++ b/packages/integration-tests/src/tests/api/account/index.test.ts
@@ -3,13 +3,7 @@ import { hookEvents } from '@logto/schemas';
 
 import { enableAllAccountCenterFields } from '#src/api/account-center.js';
 import { authedAdminApi } from '#src/api/api.js';
-import {
-  getUserInfo,
-  updateOtherProfile,
-  updatePassword,
-  updateUser,
-} from '#src/api/my-account.js';
-import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { getUserInfo, updateOtherProfile, updateUser } from '#src/api/my-account.js';
 import { createVerificationRecordByPassword } from '#src/api/verification-record.js';
 import { setEmailConnector } from '#src/helpers/connector.js';
 import { getSupportedHookEvents, WebHookApiTest } from '#src/helpers/hook.js';
@@ -21,7 +15,7 @@ import {
   signInAndGetUserApi,
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { generateEmail, generatePassword, generateUsername } from '#src/utils.js';
+import { generateEmail, generateUsername } from '#src/utils.js';
 
 import WebhookMockServer from '../hook/WebhookMockServer.js';
 import { assertHookLogResult } from '../hook/utils.js';
@@ -347,93 +341,6 @@ describe('account', () => {
       });
 
       await deleteDefaultTenantUser(user.id);
-    });
-  });
-
-  describe('POST /my-account/password', () => {
-    it('should fail if verification record is invalid', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
-      const api = await signInAndGetUserApi(username, password);
-      const newPassword = generatePassword();
-
-      await expectRejects(updatePassword(api, 'invalid-varification-record-id', newPassword), {
-        code: 'verification_record.permission_denied',
-        status: 401,
-      });
-
-      await deleteDefaultTenantUser(user.id);
-    });
-
-    it('should fail if password does not meet the password policy', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
-      const api = await signInAndGetUserApi(username, password);
-      const newPassword = '123456';
-      const verificationRecordId = await createVerificationRecordByPassword(api, password);
-
-      await expectRejects(updatePassword(api, verificationRecordId, newPassword), {
-        code: 'password.rejected',
-        status: 422,
-      });
-
-      await deleteDefaultTenantUser(user.id);
-    });
-
-    it('should be able to update password', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
-      const api = await signInAndGetUserApi(username, password);
-      const verificationRecordId = await createVerificationRecordByPassword(api, password);
-      const newPassword = generatePassword();
-
-      await updatePassword(api, verificationRecordId, newPassword);
-
-      // Check if the hook is triggered
-      const hook = webHookApi.hooks.get(hookName)!;
-      await assertHookLogResult(hook, 'User.Data.Updated', {
-        hookPayload: {
-          event: 'User.Data.Updated',
-        },
-      });
-
-      // Sign in with new password
-      await initClientAndSignInForDefaultTenant(username, newPassword);
-
-      await deleteDefaultTenantUser(user.id);
-    });
-
-    it('should throw error and trigger sentinel policy when failed to verify password', async () => {
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
-      const api = await signInAndGetUserApi(username, password);
-
-      await updateSignInExperience({
-        sentinelPolicy: {
-          maxAttempts: 2,
-          lockoutDuration: 1,
-        },
-      });
-
-      await expectRejects(createVerificationRecordByPassword(api, 'wrong-password'), {
-        code: 'session.invalid_credentials',
-        status: 422,
-      });
-
-      // Second attempt to trigger the lockout
-      await expectRejects(createVerificationRecordByPassword(api, 'wrong-password'), {
-        code: 'session.verification_blocked_too_many_attempts',
-        status: 400,
-      });
-
-      const hook = webHookApi.hooks.get(hookName)!;
-      await assertHookLogResult(hook, 'Identifier.Lockout', {
-        hookPayload: {
-          event: 'Identifier.Lockout',
-        },
-      });
-
-      await deleteDefaultTenantUser(user.id);
-
-      await updateSignInExperience({
-        sentinelPolicy: {},
-      });
     });
   });
 });

--- a/packages/integration-tests/src/tests/api/account/password-update.test.ts
+++ b/packages/integration-tests/src/tests/api/account/password-update.test.ts
@@ -1,0 +1,183 @@
+import { hookEvents, SignInIdentifier } from '@logto/schemas';
+
+import { enableAllAccountCenterFields } from '#src/api/account-center.js';
+import { authedAdminApi } from '#src/api/api.js';
+import { getUserInfo, updatePassword } from '#src/api/my-account.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import {
+  createAndVerifyVerificationCode,
+  createVerificationRecordByPassword,
+} from '#src/api/verification-record.js';
+import { setEmailConnector } from '#src/helpers/connector.js';
+import { getSupportedHookEvents, WebHookApiTest } from '#src/helpers/hook.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+  initClientAndSignInForDefaultTenant,
+  signInAndGetUserApi,
+} from '#src/helpers/profile.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateEmail, generatePassword } from '#src/utils.js';
+
+import WebhookMockServer from '../hook/WebhookMockServer.js';
+import { assertHookLogResult } from '../hook/utils.js';
+
+describe('account password update', () => {
+  const webHookMockServer = new WebhookMockServer(9999);
+  const webHookApi = new WebHookApiTest();
+  const hookName = 'passwordUpdateHookEventListener';
+
+  beforeAll(async () => {
+    await webHookMockServer.listen();
+    await enableAllPasswordSignInMethods();
+    await enableAllAccountCenterFields();
+    await setEmailConnector(authedAdminApi);
+  });
+
+  afterAll(async () => {
+    await webHookMockServer.close();
+  });
+
+  beforeEach(async () => {
+    await webHookApi.create({
+      name: hookName,
+      events: getSupportedHookEvents([...hookEvents]),
+      config: { url: webHookMockServer.endpoint },
+    });
+  });
+
+  afterEach(async () => {
+    await webHookApi.cleanUp();
+  });
+
+  describe('POST /my-account/password', () => {
+    it('should fail if verification record is invalid', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+      const newPassword = generatePassword();
+
+      await expectRejects(updatePassword(api, 'invalid-verification-record-id', newPassword), {
+        code: 'verification_record.permission_denied',
+        status: 401,
+      });
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should fail if verification record is missing for a user with password', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+
+      await expectRejects(updatePassword(api, undefined, generatePassword()), {
+        code: 'verification_record.permission_denied',
+        status: 401,
+      });
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should fail if password does not meet the password policy', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      await expectRejects(updatePassword(api, verificationRecordId, '123456'), {
+        code: 'password.rejected',
+        status: 422,
+      });
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should fail if the new password is the same as the current password', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      await expectRejects(updatePassword(api, verificationRecordId, password), {
+        code: 'user.same_password',
+        status: 422,
+      });
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should be able to update password with password verification', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+      const newPassword = generatePassword();
+
+      await updatePassword(api, verificationRecordId, newPassword);
+
+      const hook = webHookApi.hooks.get(hookName)!;
+      await assertHookLogResult(hook, 'User.Data.Updated', {
+        hookPayload: {
+          event: 'User.Data.Updated',
+        },
+      });
+
+      const userInfo = await getUserInfo(api);
+      expect(userInfo).toHaveProperty('hasPassword', true);
+
+      await initClientAndSignInForDefaultTenant(username, newPassword);
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should be able to update password with email verification', async () => {
+      const primaryEmail = generateEmail();
+      const { user, username, password } = await createDefaultTenantUserWithPassword({
+        primaryEmail,
+      });
+      const api = await signInAndGetUserApi(username, password);
+      const verificationRecordId = await createAndVerifyVerificationCode(api, {
+        type: SignInIdentifier.Email,
+        value: primaryEmail,
+      });
+      const newPassword = generatePassword();
+
+      await updatePassword(api, verificationRecordId, newPassword);
+
+      await initClientAndSignInForDefaultTenant(username, newPassword);
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should throw error and trigger sentinel policy when failed to verify password', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password);
+
+      await updateSignInExperience({
+        sentinelPolicy: {
+          maxAttempts: 2,
+          lockoutDuration: 1,
+        },
+      });
+
+      await expectRejects(createVerificationRecordByPassword(api, 'wrong-password'), {
+        code: 'session.invalid_credentials',
+        status: 422,
+      });
+
+      await expectRejects(createVerificationRecordByPassword(api, 'wrong-password'), {
+        code: 'session.verification_blocked_too_many_attempts',
+        status: 400,
+      });
+
+      const hook = webHookApi.hooks.get(hookName)!;
+      await assertHookLogResult(hook, 'Identifier.Lockout', {
+        hookPayload: {
+          event: 'Identifier.Lockout',
+        },
+      });
+
+      await deleteDefaultTenantUser(user.id);
+
+      await updateSignInExperience({
+        sentinelPolicy: {},
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add dedicated API integration tests for the account center password update flow (`POST /api/my-account/password`) used by `packages/account`.

## Changes

- Add `packages/integration-tests/src/tests/api/account/password-update.test.ts` covering:
  - Invalid or missing verification record
  - Password policy rejection
  - Same-password rejection (`user.same_password`)
  - Successful update via password verification (webhook + `hasPassword` + sign-in)
  - Successful update via email verification
  - Sentinel lockout on repeated failed password verification
- Move existing password tests out of `account/index.test.ts` to avoid duplication

## Testing

Integration tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbaf8e63-ebb9-4e6b-8a6b-a3e502f3c0f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbaf8e63-ebb9-4e6b-8a6b-a3e502f3c0f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

