### PR TITLE
refactor(core): add timeout to redis cache set and delete

### DIFF
--- a/packages/core/src/caches/index.test.ts
+++ b/packages/core/src/caches/index.test.ts
@@ -30,6 +30,13 @@ mockEsm('redis', () => ({
 }));
 
 const { RedisCache, RedisClusterCache, redisCacheFactory } = await import('./index.js');
+const { cacheConsole } = await import('./utils.js');
+
+// Intentionally never resolve to simulate a stuck Redis command without extra timers.
+const hang = async () =>
+  new Promise<never>((resolve) => {
+    void resolve;
+  });
 
 describe('RedisCache', () => {
   it('should successfully construct with no REDIS_URL', async () => {
@@ -114,4 +121,34 @@ describe('RedisCache', () => {
     await expect(cache.get('foo')).resolves.toBeUndefined();
     expect(Date.now() - start).toBeGreaterThanOrEqual(900);
   }, 4000);
+
+  it('should fail fast when cache set/delete hang past the write timeout', async () => {
+    jest.clearAllMocks();
+    const cache = new RedisCache('redis://url');
+    jest.spyOn(cache.client!, 'set').mockImplementation(hang);
+    jest.spyOn(cache.client!, 'del').mockImplementation(hang);
+    // Capture timeout warnings — both to keep test output clean and to assert observability.
+    const warnSpy = jest.spyOn(cacheConsole, 'warn').mockReturnValue();
+
+    try {
+      const start = Date.now();
+      // Run set and delete in parallel so the suite only waits one write-timeout window.
+      await Promise.all([
+        expect(cache.set('foo', 'bar')).resolves.toBeUndefined(),
+        expect(cache.delete('foo')).resolves.toBeUndefined(),
+      ]);
+      const elapsed = Date.now() - start;
+
+      // Lower bound proves the 5s timeout fired; upper bound (with generous CI jitter headroom)
+      // catches regressions where the constant is accidentally bumped higher.
+      expect(elapsed).toBeGreaterThanOrEqual(4900);
+      expect(elapsed).toBeLessThan(7000);
+
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Redis SET on key "foo"'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Redis DEL on key "foo"'));
+    } finally {
+      // Restore in finally so the spy never leaks into later tests on assertion failure.
+      warnSpy.mockRestore();
+    }
+  }, 8000);
 });

--- a/packages/core/src/caches/index.ts
+++ b/packages/core/src/caches/index.ts
@@ -10,43 +10,69 @@ import { EnvSet } from '#src/env-set/index.js';
 import { type CacheStore } from './types.js';
 import { cacheConsole } from './utils.js';
 
-// Use a strict 1s read timeout so Redis stalls fail fast and don't hold API latency.
+// Reads are best-effort and short-circuit to a miss when Redis stalls.
 const redisCacheReadTimeout = 1000;
+// Writes are allowed more headroom but still bounded so a Redis stall can never hold a request.
+const redisCacheWriteTimeout = 5000;
+
+const timeoutSentinel = Symbol('redis-cache-timeout');
+
+/**
+ * Race a Redis command against a deadline so cache I/O can never block a request indefinitely.
+ * On timeout, logs a warning and resolves to `undefined` so callers degrade to a cache miss.
+ * Errors from the underlying Redis command are not caught here — they still reject as usual,
+ * and call sites wrap writes in `trySafe` to swallow them.
+ */
+const raceWithTimeout = async <T>(
+  operation: 'GET' | 'SET' | 'DEL',
+  key: string,
+  promise: Promise<T> | undefined,
+  timeoutMs: number
+): Promise<T | undefined> => {
+  if (!promise) {
+    return;
+  }
+
+  const abortController = new AbortController();
+  const timeoutPromise = setTimeout(timeoutMs, timeoutSentinel, {
+    // Cache is best-effort; timeout timers should not keep the process alive.
+    ref: false,
+    signal: abortController.signal,
+  });
+
+  try {
+    const result = await Promise.race([promise, timeoutPromise]);
+    if (result === timeoutSentinel) {
+      cacheConsole.warn(`Redis ${operation} on key "${key}" timed out after ${timeoutMs}ms`);
+      return;
+    }
+    return result;
+  } finally {
+    // Cancel pending timeout when Redis resolves first, preventing timer accumulation.
+    abortController.abort();
+  }
+};
 
 abstract class RedisCacheBase implements CacheStore {
   readonly client?: RedisClientType | RedisClusterType;
 
   async set(key: string, value: string, expire: number = 30 * 60) {
-    await this.client?.set(key, value, {
-      EX: expire,
-    });
+    await raceWithTimeout(
+      'SET',
+      key,
+      this.client?.set(key, value, { EX: expire }),
+      redisCacheWriteTimeout
+    );
   }
 
   async get(key: string): Promise<Optional<string>> {
-    const getPromise = this.client?.get(key);
-
-    if (!getPromise) {
-      return;
-    }
-
-    const timeoutAbortController = new AbortController();
-    const timeoutPromise = setTimeout(redisCacheReadTimeout, undefined, {
-      // Cache is best-effort; timeout timers should not keep the process alive.
-      ref: false,
-      signal: timeoutAbortController.signal,
-    });
-
-    try {
-      // Fail fast on cache read and gracefully fall back to cache miss behavior.
-      return conditional(await Promise.race([getPromise, timeoutPromise]));
-    } finally {
-      // Cancel pending timeout when Redis resolves first, preventing timer accumulation.
-      timeoutAbortController.abort();
-    }
+    return conditional(
+      await raceWithTimeout('GET', key, this.client?.get(key), redisCacheReadTimeout)
+    );
   }
 
   async delete(key: string) {
-    await this.client?.del(key);
+    await raceWithTimeout('DEL', key, this.client?.del(key), redisCacheWriteTimeout);
   }
 
   async connect() {


### PR DESCRIPTION
## Summary

### Context
Only `RedisCacheBase.get` had a 1s deadline. `set` and `delete` issued bare `await this.client?.set/del(...)`, so a hung TLS socket to Azure Cache for Redis could block any caller indefinitely. In production this surfaced as bursts of upstream `499` responses correlated with `cache error Error: read ETIMEDOUT` events: tenant-resolution and `Tenant.checkHealth` both await cache writes on the request hot path, and when those writes hung, requests sat past the upstream proxy timeout and the front end disconnected before Node ever responded.

### What changed
- `packages/core/src/caches/index.ts`: extracted a single `raceWithTimeout(operation, key, promise, timeoutMs)` helper. All three commands now use it — `GET` keeps the existing 1s deadline; `SET`/`DEL` get 5s. On timeout the helper logs a warning via `cacheConsole.warn` and resolves to `undefined` so existing `trySafe`-wrapped writes degrade to a cache miss instead of hanging.
- `packages/core/src/caches/index.test.ts`: added a test that hangs mocked `set` and `del` in parallel and asserts both resolve within the 5s window.

### Expected result
- A Redis stall can no longer hold a request open. The request returns normally (with a fresh, uncached value) and any timeout is observable as a `cacheConsole.warn` line.
- No behavior change in the happy path; no change to public API.

## Testing

Unit tests

## Checklist
<!-- The palest ink is better than the best memory -->
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments