### PR TITLE
refactor(core): read admin tenant signing keys from the database in OSS

### DIFF
--- a/.changeset/oss-admin-jwks-db-read.md
+++ b/.changeset/oss-admin-jwks-db-read.md
@@ -2,4 +2,4 @@
 "@logto/core": patch
 ---
 
-Reduce OSS deployment friction by reading admin tenant signing keys directly from the database in OSS, instead of fetching them through the admin tenant's OIDC discovery endpoint. This removes the requirement that the admin tenant endpoint be reachable from within the OSS instance itself, which previously broke setups behind reverse proxies or inside container networks where the admin URL is not self-loopback addressable.
+read admin tenant signing keys directly from the database in OSS to reduce self-hosted deployment friction

--- a/.changeset/oss-admin-jwks-db-read.md
+++ b/.changeset/oss-admin-jwks-db-read.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+Reduce OSS deployment friction by reading admin tenant signing keys directly from the database in OSS, instead of fetching them through the admin tenant's OIDC discovery endpoint. This removes the requirement that the admin tenant endpoint be reachable from within the OSS instance itself, which previously broke setups behind reverse proxies or inside container networks where the admin URL is not self-loopback addressable.

--- a/.changeset/oss-admin-jwks-db-read.md
+++ b/.changeset/oss-admin-jwks-db-read.md
@@ -3,3 +3,5 @@
 ---
 
 read admin tenant signing keys directly from the database in OSS to reduce self-hosted deployment friction
+
+Self-hosted OSS deployments no longer need extra host or DNS mappings that let the Logto container fetch its own admin tenant OIDC configuration through the externally configured endpoint.

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -9,6 +9,7 @@ import {
 import { conditional } from '@silverhand/essentials';
 import { createLocalJWKSet } from 'jose';
 
+import { getOidcProviderPublicJwks } from '#src/libraries/oidc-private-key.js';
 import { exportJWK } from '#src/utils/jwks.js';
 
 const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
@@ -20,9 +21,8 @@ const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
     ({ value }) => crypto.createPrivateKey(value)
   );
   const session = configs[LogtoOidcConfigKey.Session];
-  const publicKeys = privateKeys.map((key) => crypto.createPublicKey(key));
   const privateJwks = await Promise.all(privateKeys.map(async (key) => exportJWK(key)));
-  const publicJwks = await Promise.all(publicKeys.map(async (key) => exportJWK(key)));
+  const publicJwks = await getOidcProviderPublicJwks(configs[LogtoOidcConfigKey.PrivateKeys]);
   const localJWKSet = createLocalJWKSet({ keys: publicJwks });
   const currentPrivateJwk = await exportJWK(currentPrivateKey);
 

--- a/packages/core/src/libraries/oidc-private-key.test.ts
+++ b/packages/core/src/libraries/oidc-private-key.test.ts
@@ -1,8 +1,11 @@
+import { createPublicKey, generateKeyPairSync } from 'node:crypto';
+
 import { OidcSigningKeyStatus } from '@logto/schemas';
 
 import Queries from '#src/tenants/Queries.js';
 import { createMockCommonQueryMethods } from '#src/test-utils/query.js';
 import { MockWellKnownCache } from '#src/test-utils/tenant.js';
+import { exportJWK } from '#src/utils/jwks.js';
 
 import {
   OidcPrivateKeyLibrary,
@@ -11,6 +14,7 @@ import {
   getImmediatelyRotatedOidcPrivateKeys,
   getOidcPrivateKeysAfterDeletion,
   getOidcProviderPrivateKeys,
+  getOidcProviderPublicJwks,
   getStagedRotatedOidcPrivateKeys,
   normalizeOidcPrivateKeys,
   rotateOidcPrivateKeyStatuses,
@@ -24,6 +28,27 @@ const createPrivateKey = (id: string, createdAt: number, status?: OidcSigningKey
   createdAt,
   status,
 });
+
+const createPemPrivateKey = (id: string, status: OidcSigningKeyStatus, createdAt: number) => {
+  const { privateKey } = generateKeyPairSync('ec', {
+    namedCurve: 'P-384',
+    privateKeyEncoding: {
+      type: 'pkcs8',
+      format: 'pem',
+    },
+    publicKeyEncoding: {
+      type: 'spki',
+      format: 'pem',
+    },
+  });
+
+  return {
+    id,
+    value: privateKey,
+    createdAt,
+    status,
+  };
+};
 
 describe('normalizeOidcPrivateKeys', () => {
   it('normalizes legacy private keys without status into Current and Previous', () => {
@@ -103,6 +128,21 @@ describe('getOidcProviderPrivateKeys', () => {
       createPrivateKey('next', 1, OidcSigningKeyStatus.Next),
       createPrivateKey('previous', 3, OidcSigningKeyStatus.Previous),
     ]);
+  });
+});
+
+describe('getOidcProviderPublicJwks', () => {
+  it('exports public JWKS in oidc-provider key order', async () => {
+    const currentKey = createPemPrivateKey('current', OidcSigningKeyStatus.Current, 1);
+    const nextKey = createPemPrivateKey('next', OidcSigningKeyStatus.Next, 2);
+    const previousKey = createPemPrivateKey('previous', OidcSigningKeyStatus.Previous, 3);
+    const expectedKeys = await Promise.all(
+      [currentKey, nextKey, previousKey].map(async ({ value }) => exportJWK(createPublicKey(value)))
+    );
+
+    await expect(getOidcProviderPublicJwks([previousKey, nextKey, currentKey])).resolves.toEqual(
+      expectedKeys
+    );
   });
 });
 

--- a/packages/core/src/libraries/oidc-private-key.test.ts
+++ b/packages/core/src/libraries/oidc-private-key.test.ts
@@ -29,7 +29,7 @@ const createPrivateKey = (id: string, createdAt: number, status?: OidcSigningKey
   status,
 });
 
-const createPemPrivateKey = (id: string, status: OidcSigningKeyStatus, createdAt: number) => {
+const createPemPrivateKey = (id: string, status: OidcSigningKeyStatus) => {
   const { privateKey } = generateKeyPairSync('ec', {
     namedCurve: 'P-384',
     privateKeyEncoding: {
@@ -45,7 +45,7 @@ const createPemPrivateKey = (id: string, status: OidcSigningKeyStatus, createdAt
   return {
     id,
     value: privateKey,
-    createdAt,
+    createdAt: Date.now(),
     status,
   };
 };
@@ -133,9 +133,9 @@ describe('getOidcProviderPrivateKeys', () => {
 
 describe('getOidcProviderPublicJwks', () => {
   it('exports public JWKS in oidc-provider key order', async () => {
-    const currentKey = createPemPrivateKey('current', OidcSigningKeyStatus.Current, 1);
-    const nextKey = createPemPrivateKey('next', OidcSigningKeyStatus.Next, 2);
-    const previousKey = createPemPrivateKey('previous', OidcSigningKeyStatus.Previous, 3);
+    const currentKey = createPemPrivateKey('current', OidcSigningKeyStatus.Current);
+    const nextKey = createPemPrivateKey('next', OidcSigningKeyStatus.Next);
+    const previousKey = createPemPrivateKey('previous', OidcSigningKeyStatus.Previous);
     const expectedKeys = await Promise.all(
       [currentKey, nextKey, previousKey].map(async ({ value }) => exportJWK(createPublicKey(value)))
     );

--- a/packages/core/src/libraries/oidc-private-key.ts
+++ b/packages/core/src/libraries/oidc-private-key.ts
@@ -49,11 +49,13 @@ export const rotateOidcPrivateKeyStatuses = (privateKeys: OidcPrivateKey[]): Oid
   ];
 };
 
+/**
+ * Export public JWKS from private signing keys in oidc-provider key order.
+ */
 export const getOidcProviderPublicJwks = async (privateKeys: OidcPrivateKey[]): Promise<JWK[]> => {
-  const providerPrivateKeys = getOidcProviderPrivateKeys(privateKeys).map(({ value }) =>
-    crypto.createPrivateKey(value)
+  const publicKeys = getOidcProviderPrivateKeys(privateKeys).map(({ value }) =>
+    crypto.createPublicKey(value)
   );
-  const publicKeys = providerPrivateKeys.map((key) => crypto.createPublicKey(key));
 
   return Promise.all(publicKeys.map(async (key) => exportJWK(key)));
 };

--- a/packages/core/src/libraries/oidc-private-key.ts
+++ b/packages/core/src/libraries/oidc-private-key.ts
@@ -1,18 +1,23 @@
+import crypto from 'node:crypto';
+
 import type { OidcPrivateKey } from '@logto/schemas';
 import {
   OidcSigningKeyStatus,
   getCurrentOidcPrivateKey,
   getImmediatelyRotatedOidcPrivateKeys,
   getOidcPrivateKeysAfterDeletion,
+  getOidcProviderPrivateKeys,
   getRotationStateForStagedRotation,
   getStagedRotatedOidcPrivateKeys,
   normalizeOidcPrivateKeys,
 } from '@logto/schemas';
+import type { JWK } from 'jose';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { createLogtoConfigQueries } from '#src/queries/logto-config.js';
 import type Queries from '#src/tenants/Queries.js';
 import { syncSigningKeyRotationStateCache } from '#src/tenants/signing-key-rotation-state.js';
+import { exportJWK } from '#src/utils/jwks.js';
 
 export {
   getCanonicalOidcPrivateKeys,
@@ -42,6 +47,15 @@ export const rotateOidcPrivateKeyStatuses = (privateKeys: OidcPrivateKey[]): Oid
     { ...nextKey, status: OidcSigningKeyStatus.Current },
     { ...currentKey, status: OidcSigningKeyStatus.Previous },
   ];
+};
+
+export const getOidcProviderPublicJwks = async (privateKeys: OidcPrivateKey[]): Promise<JWK[]> => {
+  const providerPrivateKeys = getOidcProviderPrivateKeys(privateKeys).map(({ value }) =>
+    crypto.createPrivateKey(value)
+  );
+  const publicKeys = providerPrivateKeys.map((key) => crypto.createPublicKey(key));
+
+  return Promise.all(publicKeys.map(async (key) => exportJWK(key)));
 };
 
 export class OidcPrivateKeyLibrary {

--- a/packages/core/src/middleware/koa-auth/utils.test.ts
+++ b/packages/core/src/middleware/koa-auth/utils.test.ts
@@ -1,0 +1,173 @@
+import { createPublicKey, generateKeyPairSync } from 'node:crypto';
+
+import { OidcSigningKeyStatus } from '@logto/schemas';
+import { createMockUtils } from '@logto/shared/esm';
+import type { JWK } from 'jose';
+import Sinon from 'sinon';
+
+import { EnvSet } from '#src/env-set/index.js';
+import { createMockCommonQueryMethods, expectSqlString } from '#src/test-utils/query.js';
+import { exportJWK } from '#src/utils/jwks.js';
+
+const { jest } = import.meta;
+const { mockEsmDefault } = createMockUtils(jest);
+
+const ky = mockEsmDefault('ky', () => ({
+  get: jest.fn(),
+}));
+
+const { getAdminTenantTokenValidationSet } = await import('./utils.js');
+
+const createAdminUrlSet = (endpoint = 'https://admin.example.com') => ({
+  endpoint: new URL(endpoint),
+  deduplicated: jest.fn(() => [new URL(endpoint)]),
+});
+
+const createPrivateKey = (id: string, status: OidcSigningKeyStatus, createdAt = Date.now()) => {
+  const { privateKey } = generateKeyPairSync('ec', {
+    namedCurve: 'P-384',
+    privateKeyEncoding: {
+      type: 'pkcs8',
+      format: 'pem',
+    },
+    publicKeyEncoding: {
+      type: 'spki',
+      format: 'pem',
+    },
+  });
+
+  return {
+    id,
+    value: privateKey,
+    createdAt,
+    status,
+  };
+};
+
+const getPublicJwk = async ({ value }: ReturnType<typeof createPrivateKey>) =>
+  exportJWK(createPublicKey(value));
+
+const setEnvValues = ({
+  isCloud = false,
+  adminUrlSet = createAdminUrlSet(),
+}: {
+  isCloud?: boolean;
+  adminUrlSet?: ReturnType<typeof createAdminUrlSet>;
+} = {}) =>
+  Sinon.stub(EnvSet, 'values').value({
+    ...EnvSet.values,
+    isCloud,
+    isMultiTenancy: false,
+    adminUrlSet,
+  });
+
+describe('getAdminTenantTokenValidationSet', () => {
+  const methods = createMockCommonQueryMethods();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    methods.one.mockReset();
+    Sinon.stub(EnvSet, 'sharedPool').value(Promise.resolve(methods));
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  it('reads admin tenant signing keys from database in OSS without calling OIDC endpoints', async () => {
+    setEnvValues();
+    const privateKey = createPrivateKey('current', OidcSigningKeyStatus.Current);
+    methods.one.mockResolvedValueOnce({
+      value: [privateKey],
+    } as never);
+
+    const result = await getAdminTenantTokenValidationSet();
+    const expectedJwk = await getPublicJwk(privateKey);
+
+    expect(ky.get).not.toHaveBeenCalled();
+    expect(methods.one).toHaveBeenCalledWith(expectSqlString('from "logto_configs"'));
+    expect(methods.one).toHaveBeenCalledWith(expectSqlString('and "key" = $'));
+    expect(result).toEqual({
+      keys: [expectedJwk],
+      issuer: ['https://admin.example.com/oidc'],
+    });
+  });
+
+  it('keeps using remote OIDC discovery and JWKS in Cloud', async () => {
+    setEnvValues({ isCloud: true });
+    const cloudJwk: JWK = { kty: 'EC', kid: 'cloud-key' };
+    ky.get
+      .mockReturnValueOnce({
+        json: jest.fn(async () => ({
+          jwks_uri: 'https://admin.example.com/oidc/jwks',
+        })),
+      })
+      .mockReturnValueOnce({
+        json: jest.fn(async () => ({
+          keys: [cloudJwk],
+        })),
+      });
+
+    const result = await getAdminTenantTokenValidationSet();
+
+    expect(methods.one).not.toHaveBeenCalled();
+    expect(ky.get).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      keys: [cloudJwk],
+      issuer: ['https://admin.example.com/oidc'],
+    });
+  });
+
+  it('returns Current, Next, and Previous public keys from the OSS database path', async () => {
+    setEnvValues();
+    const currentKey = createPrivateKey('current', OidcSigningKeyStatus.Current, 1);
+    const nextKey = createPrivateKey('next', OidcSigningKeyStatus.Next, 2);
+    const previousKey = createPrivateKey('previous', OidcSigningKeyStatus.Previous, 3);
+    methods.one.mockResolvedValueOnce({
+      value: [previousKey, nextKey, currentKey],
+    } as never);
+
+    const result = await getAdminTenantTokenValidationSet();
+    const expectedKeys = await Promise.all(
+      [currentKey, nextKey, previousKey].map(async (key) => getPublicJwk(key))
+    );
+
+    expect(result.keys).toEqual(expectedKeys);
+  });
+
+  it('does not cache OSS database keys between calls', async () => {
+    setEnvValues();
+    const firstKey = createPrivateKey('first', OidcSigningKeyStatus.Current, 1);
+    const secondKey = createPrivateKey('second', OidcSigningKeyStatus.Current, 2);
+    methods.one
+      .mockResolvedValueOnce({
+        value: [firstKey],
+      } as never)
+      .mockResolvedValueOnce({
+        value: [secondKey],
+      } as never);
+
+    const firstResult = await getAdminTenantTokenValidationSet();
+    const secondResult = await getAdminTenantTokenValidationSet();
+
+    expect(methods.one).toHaveBeenCalledTimes(2);
+    expect(firstResult.keys).toEqual([await getPublicJwk(firstKey)]);
+    expect(secondResult.keys).toEqual([await getPublicJwk(secondKey)]);
+  });
+
+  it('returns an empty set when admin tenant validation is unnecessary', async () => {
+    setEnvValues({
+      adminUrlSet: {
+        endpoint: new URL('https://admin.example.com'),
+        deduplicated: jest.fn(() => []),
+      },
+    });
+
+    await expect(getAdminTenantTokenValidationSet()).resolves.toEqual({
+      keys: [],
+      issuer: [],
+    });
+    expect(methods.one).not.toHaveBeenCalled();
+    expect(ky.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/middleware/koa-auth/utils.test.ts
+++ b/packages/core/src/middleware/koa-auth/utils.test.ts
@@ -169,14 +169,25 @@ describe('getAdminTenantTokenValidationSet', () => {
 
   it('returns empty keys with issuer when OSS private keys are empty', async () => {
     setEnvValues({ adminUrlSet: createAdminUrlSet('https://empty.example.com') });
-    methods.one.mockResolvedValueOnce({
-      value: [],
-    } as never);
+    const key = createPrivateKey('recovered', OidcSigningKeyStatus.Current);
+    methods.one
+      .mockResolvedValueOnce({
+        value: [],
+      } as never)
+      .mockResolvedValueOnce({
+        value: [key],
+      } as never);
 
     await expect(getAdminTenantTokenValidationSet()).resolves.toEqual({
       keys: [],
       issuer: ['https://empty.example.com/oidc'],
     });
+
+    await expect(getAdminTenantTokenValidationSet()).resolves.toEqual({
+      keys: [await getPublicJwk(key)],
+      issuer: ['https://empty.example.com/oidc'],
+    });
+    expect(methods.one).toHaveBeenCalledTimes(2);
   });
 
   it('throws when OSS private keys are malformed', async () => {

--- a/packages/core/src/middleware/koa-auth/utils.test.ts
+++ b/packages/core/src/middleware/koa-auth/utils.test.ts
@@ -23,7 +23,7 @@ const createAdminUrlSet = (endpoint = 'https://admin.example.com') => ({
   deduplicated: jest.fn(() => [new URL(endpoint)]),
 });
 
-const createPrivateKey = (id: string, status: OidcSigningKeyStatus, createdAt = Date.now()) => {
+const createPrivateKey = (id: string, status: OidcSigningKeyStatus) => {
   const { privateKey } = generateKeyPairSync('ec', {
     namedCurve: 'P-384',
     privateKeyEncoding: {
@@ -39,7 +39,7 @@ const createPrivateKey = (id: string, status: OidcSigningKeyStatus, createdAt = 
   return {
     id,
     value: privateKey,
-    createdAt,
+    createdAt: Date.now(),
     status,
   };
 };
@@ -73,11 +73,12 @@ describe('getAdminTenantTokenValidationSet', () => {
   });
 
   afterEach(() => {
+    jest.useRealTimers();
     Sinon.restore();
   });
 
-  it('reads admin tenant signing keys from database in OSS without calling OIDC endpoints', async () => {
-    setEnvValues();
+  it('reads keys from DB in OSS, skips OIDC discovery', async () => {
+    setEnvValues({ adminUrlSet: createAdminUrlSet('https://db.example.com') });
     const privateKey = createPrivateKey('current', OidcSigningKeyStatus.Current);
     methods.one.mockResolvedValueOnce({
       value: [privateKey],
@@ -91,12 +92,12 @@ describe('getAdminTenantTokenValidationSet', () => {
     expect(methods.one).toHaveBeenCalledWith(expectSqlString('and "key" = $'));
     expect(result).toEqual({
       keys: [expectedJwk],
-      issuer: ['https://admin.example.com/oidc'],
+      issuer: ['https://db.example.com/oidc'],
     });
   });
 
   it('keeps using remote OIDC discovery and JWKS in Cloud', async () => {
-    setEnvValues({ isCloud: true });
+    setEnvValues({ isCloud: true, adminUrlSet: createAdminUrlSet('https://cloud.example.com') });
     const cloudJwk: JWK = { kty: 'EC', kid: 'cloud-key' };
     ky.get
       .mockReturnValueOnce({
@@ -116,15 +117,15 @@ describe('getAdminTenantTokenValidationSet', () => {
     expect(ky.get).toHaveBeenCalledTimes(2);
     expect(result).toEqual({
       keys: [cloudJwk],
-      issuer: ['https://admin.example.com/oidc'],
+      issuer: ['https://cloud.example.com/oidc'],
     });
   });
 
-  it('returns Current, Next, and Previous public keys from the OSS database path', async () => {
-    setEnvValues();
-    const currentKey = createPrivateKey('current', OidcSigningKeyStatus.Current, 1);
-    const nextKey = createPrivateKey('next', OidcSigningKeyStatus.Next, 2);
-    const previousKey = createPrivateKey('previous', OidcSigningKeyStatus.Previous, 3);
+  it('returns Current/Next/Previous in oidc-provider order', async () => {
+    setEnvValues({ adminUrlSet: createAdminUrlSet('https://order.example.com') });
+    const currentKey = createPrivateKey('current', OidcSigningKeyStatus.Current);
+    const nextKey = createPrivateKey('next', OidcSigningKeyStatus.Next);
+    const previousKey = createPrivateKey('previous', OidcSigningKeyStatus.Previous);
     methods.one.mockResolvedValueOnce({
       value: [previousKey, nextKey, currentKey],
     } as never);
@@ -137,10 +138,12 @@ describe('getAdminTenantTokenValidationSet', () => {
     expect(result.keys).toEqual(expectedKeys);
   });
 
-  it('does not cache OSS database keys between calls', async () => {
-    setEnvValues();
-    const firstKey = createPrivateKey('first', OidcSigningKeyStatus.Current, 1);
-    const secondKey = createPrivateKey('second', OidcSigningKeyStatus.Current, 2);
+  it('caches OSS public JWKS with the shared JWKS TTL', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    setEnvValues({ adminUrlSet: createAdminUrlSet('https://cache.example.com') });
+    const firstKey = createPrivateKey('first', OidcSigningKeyStatus.Current);
+    const secondKey = createPrivateKey('second', OidcSigningKeyStatus.Current);
     methods.one
       .mockResolvedValueOnce({
         value: [firstKey],
@@ -152,13 +155,44 @@ describe('getAdminTenantTokenValidationSet', () => {
     const firstResult = await getAdminTenantTokenValidationSet();
     const secondResult = await getAdminTenantTokenValidationSet();
 
-    expect(methods.one).toHaveBeenCalledTimes(2);
+    expect(methods.one).toHaveBeenCalledTimes(1);
     expect(firstResult.keys).toEqual([await getPublicJwk(firstKey)]);
-    expect(secondResult.keys).toEqual([await getPublicJwk(secondKey)]);
+    expect(secondResult.keys).toEqual([await getPublicJwk(firstKey)]);
+
+    jest.advanceTimersByTime(60 * 60 * 1000 + 1);
+
+    const thirdResult = await getAdminTenantTokenValidationSet();
+
+    expect(methods.one).toHaveBeenCalledTimes(2);
+    expect(thirdResult.keys).toEqual([await getPublicJwk(secondKey)]);
   });
 
-  it('derives the issuer through getTenantEndpoint when multi-tenancy is enabled', async () => {
-    setEnvValues({ isMultiTenancy: true });
+  it('returns empty keys with issuer when OSS private keys are empty', async () => {
+    setEnvValues({ adminUrlSet: createAdminUrlSet('https://empty.example.com') });
+    methods.one.mockResolvedValueOnce({
+      value: [],
+    } as never);
+
+    await expect(getAdminTenantTokenValidationSet()).resolves.toEqual({
+      keys: [],
+      issuer: ['https://empty.example.com/oidc'],
+    });
+  });
+
+  it('throws when OSS private keys are malformed', async () => {
+    setEnvValues({ adminUrlSet: createAdminUrlSet('https://malformed.example.com') });
+    methods.one.mockResolvedValueOnce({
+      value: [{ id: 'malformed' }],
+    } as never);
+
+    await expect(getAdminTenantTokenValidationSet()).rejects.toThrow();
+  });
+
+  it('derives issuer via getTenantEndpoint in multi-tenancy', async () => {
+    setEnvValues({
+      isMultiTenancy: true,
+      adminUrlSet: createAdminUrlSet('https://multi.example.com'),
+    });
     const privateKey = createPrivateKey('current', OidcSigningKeyStatus.Current);
     methods.one.mockResolvedValueOnce({
       value: [privateKey],
@@ -166,7 +200,7 @@ describe('getAdminTenantTokenValidationSet', () => {
 
     const result = await getAdminTenantTokenValidationSet();
 
-    expect(result.issuer).toEqual(['https://admin.example.com/oidc']);
+    expect(result.issuer).toEqual(['https://multi.example.com/oidc']);
   });
 
   it('returns an empty set when admin tenant validation is unnecessary', async () => {

--- a/packages/core/src/middleware/koa-auth/utils.test.ts
+++ b/packages/core/src/middleware/koa-auth/utils.test.ts
@@ -49,15 +49,17 @@ const getPublicJwk = async ({ value }: ReturnType<typeof createPrivateKey>) =>
 
 const setEnvValues = ({
   isCloud = false,
+  isMultiTenancy = false,
   adminUrlSet = createAdminUrlSet(),
 }: {
   isCloud?: boolean;
+  isMultiTenancy?: boolean;
   adminUrlSet?: ReturnType<typeof createAdminUrlSet>;
 } = {}) =>
   Sinon.stub(EnvSet, 'values').value({
     ...EnvSet.values,
     isCloud,
-    isMultiTenancy: false,
+    isMultiTenancy,
     adminUrlSet,
   });
 
@@ -153,6 +155,18 @@ describe('getAdminTenantTokenValidationSet', () => {
     expect(methods.one).toHaveBeenCalledTimes(2);
     expect(firstResult.keys).toEqual([await getPublicJwk(firstKey)]);
     expect(secondResult.keys).toEqual([await getPublicJwk(secondKey)]);
+  });
+
+  it('derives the issuer through getTenantEndpoint when multi-tenancy is enabled', async () => {
+    setEnvValues({ isMultiTenancy: true });
+    const privateKey = createPrivateKey('current', OidcSigningKeyStatus.Current);
+    methods.one.mockResolvedValueOnce({
+      value: [privateKey],
+    } as never);
+
+    const result = await getAdminTenantTokenValidationSet();
+
+    expect(result.issuer).toEqual(['https://admin.example.com/oidc']);
   });
 
   it('returns an empty set when admin tenant validation is unnecessary', async () => {

--- a/packages/core/src/middleware/koa-auth/utils.ts
+++ b/packages/core/src/middleware/koa-auth/utils.ts
@@ -72,8 +72,6 @@ const getOssAdminTenantTokenValidationSet = async (
   const privateKeys = await getAdminTenantPrivateSigningKeys();
 
   if (privateKeys.length === 0) {
-    jwksCache.set(issuer.href, []);
-
     return {
       keys: [],
       issuer: [issuer.href],

--- a/packages/core/src/middleware/koa-auth/utils.ts
+++ b/packages/core/src/middleware/koa-auth/utils.ts
@@ -7,32 +7,25 @@ import { type JWK } from 'jose';
 import ky from 'ky';
 
 import { EnvSet, getTenantEndpoint } from '#src/env-set/index.js';
+import { getOidcProviderPublicJwks } from '#src/libraries/oidc-private-key.js';
+import { getAdminTenantPrivateSigningKeys } from '#src/tenants/utils.js';
 
 import RequestError from '../../errors/RequestError/index.js';
 import assertThat from '../../utils/assert-that.js';
 
 const jwksCache = new TtlCache<string, JWK[]>(60 * 60 * 1000); // 1 hour
 
-/**
- * This function is to fetch OIDC public signing keys and the issuer from the admin tenant
- * in order to let user tenants recognize Access Tokens issued by the admin tenant.
- *
- * Usually you don't mean to call this function.
- */
-export const getAdminTenantTokenValidationSet = async (): Promise<{
-  keys: JWK[];
-  issuer: string[];
-}> => {
-  const { isMultiTenancy, adminUrlSet } = EnvSet.values;
-
-  if (!isMultiTenancy && adminUrlSet.deduplicated().length === 0) {
-    return { keys: [], issuer: [] };
-  }
-
-  const issuer = appendPath(
-    isMultiTenancy ? getTenantEndpoint(adminTenantId, EnvSet.values) : adminUrlSet.endpoint,
+const getAdminTenantIssuer = () =>
+  appendPath(
+    EnvSet.values.isMultiTenancy
+      ? getTenantEndpoint(adminTenantId, EnvSet.values)
+      : EnvSet.values.adminUrlSet.endpoint,
     '/oidc'
   );
+
+const getCloudAdminTenantTokenValidationSet = async (
+  issuer: URL
+): Promise<{ keys: JWK[]; issuer: string[] }> => {
   const cached = jwksCache.get(issuer.href);
 
   if (cached) {
@@ -62,6 +55,42 @@ export const getAdminTenantTokenValidationSet = async (): Promise<{
     keys: jwks.keys,
     issuer: [issuer.href],
   };
+};
+
+const getOssAdminTenantTokenValidationSet = async (
+  issuer: URL
+): Promise<{ keys: JWK[]; issuer: string[] }> => {
+  const privateKeys = await getAdminTenantPrivateSigningKeys();
+
+  return {
+    keys: await getOidcProviderPublicJwks(privateKeys),
+    issuer: [issuer.href],
+  };
+};
+
+/**
+ * This function is to fetch OIDC public signing keys and the issuer from the admin tenant
+ * in order to let user tenants recognize Access Tokens issued by the admin tenant.
+ *
+ * Usually you don't mean to call this function.
+ */
+export const getAdminTenantTokenValidationSet = async (): Promise<{
+  keys: JWK[];
+  issuer: string[];
+}> => {
+  const { isMultiTenancy, adminUrlSet } = EnvSet.values;
+
+  if (!isMultiTenancy && adminUrlSet.deduplicated().length === 0) {
+    return { keys: [], issuer: [] };
+  }
+
+  const issuer = getAdminTenantIssuer();
+
+  if (EnvSet.values.isCloud) {
+    return getCloudAdminTenantTokenValidationSet(issuer);
+  }
+
+  return getOssAdminTenantTokenValidationSet(issuer);
 };
 
 const bearerTokenIdentifier = 'Bearer';

--- a/packages/core/src/middleware/koa-auth/utils.ts
+++ b/packages/core/src/middleware/koa-auth/utils.ts
@@ -60,10 +60,32 @@ const getCloudAdminTenantTokenValidationSet = async (
 const getOssAdminTenantTokenValidationSet = async (
   issuer: URL
 ): Promise<{ keys: JWK[]; issuer: string[] }> => {
+  const cached = jwksCache.get(issuer.href);
+
+  if (cached) {
+    return {
+      keys: cached,
+      issuer: [issuer.href],
+    };
+  }
+
   const privateKeys = await getAdminTenantPrivateSigningKeys();
 
+  if (privateKeys.length === 0) {
+    jwksCache.set(issuer.href, []);
+
+    return {
+      keys: [],
+      issuer: [issuer.href],
+    };
+  }
+
+  const keys = await getOidcProviderPublicJwks(privateKeys);
+
+  jwksCache.set(issuer.href, keys);
+
   return {
-    keys: await getOidcProviderPublicJwks(privateKeys),
+    keys,
     issuer: [issuer.href],
   };
 };

--- a/packages/core/src/tenants/Tenant.test.ts
+++ b/packages/core/src/tenants/Tenant.test.ts
@@ -44,6 +44,7 @@ const adminMiddlewareList = middlewareList.map(
 
 mockEsm('./utils.js', () => ({
   getTenantDatabaseDsn: async () => 'postgres://mock.db.url',
+  getAdminTenantPrivateSigningKeys: async () => [],
 }));
 
 // eslint-disable-next-line unicorn/consistent-function-scoping

--- a/packages/core/src/tenants/utils.ts
+++ b/packages/core/src/tenants/utils.ts
@@ -55,7 +55,7 @@ export const getTenantDatabaseDsn = async (tenantId: string) => {
 };
 
 /**
- * Read admin tenant signing keys through the shared pool.
+ * Read admin tenant signing keys through the shared pool for OSS admin token validation.
  *
  * Like `getTenantDatabaseDsn`, this cannot use tenant-scoped Queries because callers may need
  * admin tenant keys while running in a user tenant whose pool is scoped by RLS.

--- a/packages/core/src/tenants/utils.ts
+++ b/packages/core/src/tenants/utils.ts
@@ -1,11 +1,21 @@
+import {
+  adminTenantId,
+  LogtoConfigs,
+  LogtoOidcConfigKey,
+  type OidcPrivateKey,
+  oidcPrivateKeyGuard,
+} from '@logto/schemas';
 import { Tenants } from '@logto/schemas/models';
 import { conditional } from '@silverhand/essentials';
 import { parseDsn, sql, stringifyDsn } from '@silverhand/slonik';
 import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
+import { convertToIdentifiers } from '#src/utils/sql.js';
 
 export class TenantNotFoundError extends Error {}
+
+const { table: logtoConfigsTable, fields: logtoConfigFields } = convertToIdentifiers(LogtoConfigs);
 
 /**
  * This function is to fetch the tenant password for the corresponding Postgres user.
@@ -42,4 +52,21 @@ export const getTenantDatabaseDsn = async (tenantId: string) => {
     username,
     password: conditional(typeof password === 'string' && password),
   });
+};
+
+/**
+ * Read admin tenant signing keys through the shared pool.
+ *
+ * Like `getTenantDatabaseDsn`, this cannot use tenant-scoped Queries because callers may need
+ * admin tenant keys while running in a user tenant whose pool is scoped by RLS.
+ */
+export const getAdminTenantPrivateSigningKeys = async (): Promise<OidcPrivateKey[]> => {
+  const pool = await EnvSet.sharedPool;
+  const { value } = await pool.one<{ value: unknown }>(sql`
+    select ${logtoConfigFields.value} from ${logtoConfigsTable}
+      where ${logtoConfigFields.tenantId} = ${adminTenantId}
+      and ${logtoConfigFields.key} = ${LogtoOidcConfigKey.PrivateKeys}
+  `);
+
+  return oidcPrivateKeyGuard.array().parse(value);
 };


### PR DESCRIPTION
## Summary

In OSS, validating Access Tokens issued by the admin tenant previously relied on fetching the admin tenant's OIDC discovery document and JWKS over HTTP from within the same Logto instance. This required the admin tenant endpoint to be reachable from the instance itself, which breaks several common OSS deployment topologies — reverse-proxied setups, containers where the public admin URL is not self-loopback addressable, environments with split DNS, etc. The issue has caused recurring confusion for self-hosters (see [#6048](https://github.com/logto-io/logto/issues/6048#issuecomment-2186108460) and related reports).

This PR makes the OSS path read the admin tenant signing keys directly from the database via the shared pool, then derives the public JWKS in process — no HTTP round trip needed. Cloud behavior is unchanged: it continues to use remote OIDC discovery and JWKS, since admin and user tenants may live on different services there.

- `getAdminTenantTokenValidationSet` now branches on `EnvSet.values.isCloud`:
  - Cloud → existing remote discovery + JWKS path (unchanged), still cached for 1 hour.
  - OSS → new `getOssAdminTenantTokenValidationSet`, which reads `oidc.privateKeys` for the admin tenant from `logto_configs` and exports the corresponding public JWKs in oidc-provider key order (`Current`, `Next`, `Previous`).
- Adds `getAdminTenantPrivateSigningKeys` in `tenants/utils.ts` that goes through `EnvSet.sharedPool`, mirroring `getTenantDatabaseDsn` — necessary because the caller may be running inside a user tenant whose pool is RLS-scoped.
- Adds `getOidcProviderPublicJwks` to `libraries/oidc-private-key.ts` to centralize the private-to-public JWK export and key ordering.

### Why cache the OSS path?

`getAdminTenantTokenValidationSet` runs for non-admin-tenant `koaAuth` requests, so OSS Management API traffic against the default tenant can hit this path frequently. To avoid adding a per-request database read and public-key derivation to that hot path, the OSS branch reuses the existing 1-hour JWKS cache.

This keeps the cache semantics aligned with the previous remote JWKS path and the Cloud branch: the data source changes from HTTP to the database in OSS, while the validation set is still cached by admin issuer.

## Testing

unit tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
