### PR TITLE
fix(phrases): correct Chinese translation of Passkey

### DIFF
--- a/.changeset/fix-passkey-zh-translation.md
+++ b/.changeset/fix-passkey-zh-translation.md
@@ -1,0 +1,5 @@
+---
+"@logto/phrases-experience": patch
+---
+
+correct Chinese translation of Passkey in MFA experience phrases

--- a/packages/phrases-experience/src/locales/zh-cn/mfa.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/mfa.ts
@@ -1,6 +1,6 @@
 const mfa = {
   totp: '身份验证应用 OTP',
-  webauthn: '通行证',
+  webauthn: '通行密钥',
   backup_code: '备份代码',
   email_verification_code: '电子邮件验证码',
   phone_verification_code: '短信验证码',
@@ -57,13 +57,13 @@ const mfa = {
   new_backup_codes_generated: '新的备份码已替换了你的旧码。请尽快将它们保存在安全的地方。',
   enter_a_backup_code: '输入备份代码',
   enter_backup_code_description: '输入初始启用两步验证时保存的备份代码。',
-  create_a_passkey: '创建通行证',
+  create_a_passkey: '创建通行密钥',
   create_passkey_description:
-    '使用设备生物识别、安全密钥（例如 YubiKey）或其他可用方法注册您的通行证。',
+    '使用设备生物识别、安全密钥（例如 YubiKey）或其他可用方法注册您的通行密钥。',
   try_another_verification_method: '尝试其他验证方法',
-  verify_via_passkey: '通过通行证验证',
+  verify_via_passkey: '通过通行密钥验证',
   verify_via_passkey_description:
-    '使用通行证通过设备密码或生物识别、扫描 QR 码或使用 USB 安全密钥（如 YubiKey）进行验证。',
+    '使用通行密钥通过设备密码或生物识别、扫描 QR 码或使用 USB 安全密钥（如 YubiKey）进行验证。',
   secret_key_copied: '密钥已复制。',
   backup_code_copied: '备份代码已复制。',
   webauthn_not_ready: 'WebAuthn 尚未准备就绪。请稍后重试。',

--- a/packages/phrases-experience/src/locales/zh-hk/mfa.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/mfa.ts
@@ -1,6 +1,6 @@
 const mfa = {
   totp: '身份驗證應用 OTP',
-  webauthn: '通行證',
+  webauthn: '通行密鑰',
   backup_code: '備份代碼',
   email_verification_code: '電子郵件驗證碼',
   phone_verification_code: '短訊驗證碼',
@@ -20,7 +20,7 @@ const mfa = {
   send_to_phone: '發送至 {{identifier}}',
   onboarding: '開啟兩步驗證',
   onboarding_description:
-    '使用兩步驗證保護您的帳戶。選擇一種或多種方式：通行密碼、身份驗證器（OTP）、短訊驗證碼或備用碼。',
+    '使用兩步驗證保護您的帳戶。選擇一種或多種方式：通行密鑰、身份驗證器（OTP）、短訊驗證碼或備份代碼。',
   enable_mfa: '啟用兩步驗證',
   add_mfa_factors: '添加兩步驗證',
   add_mfa_description: '已啟用兩步驗證。選擇第二種驗證方法進行安全登錄。',
@@ -57,13 +57,13 @@ const mfa = {
   new_backup_codes_generated: '新的備份碼已取代了你的舊碼。請盡快將它們儲存在安全的地方。',
   enter_a_backup_code: '輸入備份代碼',
   enter_backup_code_description: '輸入初始啟用兩步驗證時保存的備份代碼。',
-  create_a_passkey: '創建通行證',
+  create_a_passkey: '創建通行密鑰',
   create_passkey_description:
-    '使用設備生物識別、安全密鑰（例如 YubiKey）或其他可用方法註冊您的通行證。',
+    '使用設備生物識別、安全密鑰（例如 YubiKey）或其他可用方法註冊您的通行密鑰。',
   try_another_verification_method: '嘗試其他驗證方法',
-  verify_via_passkey: '通過通行證驗證',
+  verify_via_passkey: '通過通行密鑰驗證',
   verify_via_passkey_description:
-    '使用通行證通過設備密碼或生物識別、掃描 QR 碼或使用 USB 安全密鑰（如 YubiKey）進行驗證。',
+    '使用通行密鑰通過設備密碼或生物識別、掃描 QR 碼或使用 USB 安全密鑰（如 YubiKey）進行驗證。',
   secret_key_copied: '密鑰已複製。',
   backup_code_copied: '備份代碼已複製。',
   webauthn_not_ready: 'WebAuthn 尚未準備就緒。請稍後重試。',

--- a/packages/phrases-experience/src/locales/zh-tw/mfa.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/mfa.ts
@@ -1,6 +1,6 @@
 const mfa = {
   totp: '身份驗證應用 OTP',
-  webauthn: '通行證',
+  webauthn: '通行密鑰',
   backup_code: '備份代碼',
   email_verification_code: '電子郵件驗證碼',
   phone_verification_code: '簡訊驗證碼',
@@ -20,7 +20,7 @@ const mfa = {
   send_to_phone: '發送至 {{identifier}}',
   onboarding: '開啟兩步驗證',
   onboarding_description:
-    '使用兩步驗證保護您的帳戶。選擇一種或多種方式：通行密碼、身份驗證器（OTP）、簡訊驗證碼或備用碼。',
+    '使用兩步驗證保護您的帳戶。選擇一種或多種方式：通行密鑰、身份驗證器（OTP）、簡訊驗證碼或備份代碼。',
   enable_mfa: '啟用兩步驗證',
   add_mfa_factors: '添加兩步驗證',
   add_mfa_description: '已啟用兩步驗證。選擇第二種驗證方法進行安全登錄。',
@@ -57,13 +57,13 @@ const mfa = {
   new_backup_codes_generated: '新的備份碼已取代了你的舊碼。請盡快將它們儲存在安全的地方。',
   enter_a_backup_code: '輸入備份代碼',
   enter_backup_code_description: '輸入初始啟用兩步驗證時保存的備份代碼。',
-  create_a_passkey: '創建通行證',
+  create_a_passkey: '創建通行密鑰',
   create_passkey_description:
-    '使用設備生物識別、安全密鑰（例如 YubiKey）或其他可用方法註冊您的通行證。',
+    '使用設備生物識別、安全密鑰（例如 YubiKey）或其他可用方法註冊您的通行密鑰。',
   try_another_verification_method: '嘗試其他驗證方法',
-  verify_via_passkey: '通過通行證驗證',
+  verify_via_passkey: '通過通行密鑰驗證',
   verify_via_passkey_description:
-    '使用通行證通過設備密碼或生物識別、掃描 QR 碼或使用 USB 安全密鑰（如 YubiKey）進行驗證。',
+    '使用通行密鑰通過設備密碼或生物識別、掃描 QR 碼或使用 USB 安全密鑰（如 YubiKey）進行驗證。',
   secret_key_copied: '密鑰已複製。',
   backup_code_copied: '備份代碼已複製。',
   webauthn_not_ready: 'WebAuthn 尚未準備就緒。請稍後重試。',


### PR DESCRIPTION
## Summary

Fixes #8837

This PR aligns the Chinese translations of “Passkey” in MFA-related experience phrases.

- Uses `通行密钥` for zh-CN
- Uses `通行密鑰` for zh-HK and zh-TW

This replaces inconsistent translations such as `通行证` and `通行密碼`.

## Testing

Not run. This PR only updates locale strings.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments