### PR TITLE
fix(account): load manual languages in Account Center

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -47,7 +47,6 @@ import {
   verifiedActionRoute,
 } from './constants/routes';
 import initI18n from './i18n/init';
-import { resolveUiLocalesLanguage } from './i18n/utils';
 import BackupCodeBinding from './pages/BackupCodeBinding';
 import BackupCodeView from './pages/BackupCodeView';
 import Email from './pages/Email';
@@ -74,7 +73,7 @@ import { hasVisibleSecuritySection } from './utils/security-page';
 import '@experience/shared/scss/normalized.scss';
 
 handleAccountCenterRoute();
-void initI18n(resolveUiLocalesLanguage(getUiLocales()));
+void initI18n(getUiLocales());
 
 export const Main = () => {
   const params = new URLSearchParams(window.location.search);

--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -64,16 +64,12 @@ import UpdateSuccess from './pages/UpdateSuccess';
 import Username from './pages/Username';
 import VerifiedAction from './pages/VerifiedAction';
 import { useAuthRedirect } from './use-auth-redirect';
-import {
-  accountCenterBasePath,
-  getUiLocales,
-  handleAccountCenterRoute,
-} from './utils/account-center-route';
+import { accountCenterBasePath, handleAccountCenterRoute } from './utils/account-center-route';
 import { hasVisibleSecuritySection } from './utils/security-page';
 import '@experience/shared/scss/normalized.scss';
 
 handleAccountCenterRoute();
-void initI18n(getUiLocales());
+void initI18n();
 
 export const Main = () => {
   const params = new URLSearchParams(window.location.search);

--- a/packages/account/src/apis/phrases.ts
+++ b/packages/account/src/apis/phrases.ts
@@ -1,0 +1,35 @@
+import { conditional } from '@silverhand/essentials';
+import ky from 'ky';
+
+const buildSearchParameters = (record: Record<string, string | undefined>) => {
+  const entries = Object.entries(record).filter((entry): entry is [string, string] =>
+    Boolean(entry[0] && entry[1])
+  );
+
+  return conditional(entries.length > 0 && entries);
+};
+
+export const getPhrases = async ({
+  localLanguage,
+  language,
+}: {
+  localLanguage?: string;
+  language?: string;
+}) =>
+  ky
+    .extend({
+      hooks: {
+        beforeRequest: [
+          (request) => {
+            if (localLanguage) {
+              request.headers.set('Accept-Language', localLanguage);
+            }
+          },
+        ],
+      },
+    })
+    .get('/api/.well-known/phrases', {
+      searchParams: buildSearchParameters({
+        lng: language,
+      }),
+    });

--- a/packages/account/src/i18n/init.ts
+++ b/packages/account/src/i18n/init.ts
@@ -1,28 +1,21 @@
-import type { LanguageTag } from '@logto/language-kit';
-import resources from '@logto/phrases-experience';
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
-import { resolveLanguage } from '@ac/i18n/utils';
+import { getI18nResource } from '@ac/i18n/utils';
 
 i18next.use(initReactI18next);
 
-const initI18n = async (initialLanguage?: LanguageTag) => {
-  const normalizedLanguage =
-    typeof initialLanguage === 'string' ? resolveLanguage(initialLanguage) : undefined;
+const initI18n = async (initialLanguage?: string) => {
+  const { resources, lng } = await getI18nResource(initialLanguage);
 
   await i18next.init({
-    resources: {},
+    resources,
+    lng,
     fallbackLng: 'en',
-    lng: normalizedLanguage,
     interpolation: {
       escapeValue: false,
     },
   });
-
-  for (const [language, value] of Object.entries(resources)) {
-    i18next.addResourceBundle(language, 'translation', value.translation, true);
-  }
 };
 
 export default initI18n;

--- a/packages/account/src/i18n/init.ts
+++ b/packages/account/src/i18n/init.ts
@@ -1,16 +1,19 @@
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
-import { getI18nResource } from '@ac/i18n/utils';
-
 i18next.use(initReactI18next);
 
-const initI18n = async (initialLanguage?: string) => {
-  const { resources, lng } = await getI18nResource(initialLanguage);
+/**
+ * Initialize i18next without fetching phrase bundles.
+ * Remote phrases are loaded once in PageContextProvider via changeLanguage().
+ */
+const initI18n = async () => {
+  if (i18next.isInitialized) {
+    return;
+  }
 
   await i18next.init({
-    resources,
-    lng,
+    resources: {},
     fallbackLng: 'en',
     interpolation: {
       escapeValue: false,

--- a/packages/account/src/i18n/utils.phrases.test.ts
+++ b/packages/account/src/i18n/utils.phrases.test.ts
@@ -1,0 +1,91 @@
+import type { LocalePhrase } from '@logto/phrases-experience';
+import { type DeepPartial } from '@silverhand/essentials';
+import i18next from 'i18next';
+
+import { getPhrases as getPhrasesApi } from '@ac/apis/phrases';
+import { getUiLocales } from '@ac/utils/account-center-route';
+
+import { changeLanguage, getI18nResource } from './utils';
+
+jest.mock('@ac/apis/phrases', () => ({
+  getPhrases: jest.fn(),
+}));
+
+jest.mock('@ac/utils/account-center-route', () => ({
+  getUiLocales: jest.fn(),
+}));
+
+const getPhrasesApiMock = jest.mocked(getPhrasesApi);
+const getUiLocalesMock = jest.mocked(getUiLocales);
+
+const customLanguageTag = 'vi-VN';
+const customConfirmLabel = 'custom-vi-confirm';
+
+const mockRemotePhrases: DeepPartial<LocalePhrase> = {
+  translation: {
+    action: {
+      confirm: customConfirmLabel,
+    },
+  },
+};
+
+const createPhrasesResponse = (
+  lng: string,
+  phrases: DeepPartial<LocalePhrase> = mockRemotePhrases
+) => ({
+  json: async () => phrases as LocalePhrase,
+  headers: {
+    get: (name: string) => (name.toLowerCase() === 'content-language' ? lng : null),
+  },
+});
+
+describe('account center phrase loading', () => {
+  beforeEach(() => {
+    getUiLocalesMock.mockImplementation((): string | undefined => undefined);
+    getPhrasesApiMock.mockResolvedValue(
+      createPhrasesResponse(customLanguageTag) as Awaited<ReturnType<typeof getPhrasesApi>>
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('getI18nResource uses Content-Language and returned phrase bundle', async () => {
+    const { resources, lng } = await getI18nResource(customLanguageTag);
+
+    expect(lng).toBe(customLanguageTag);
+    expect(resources[customLanguageTag]).toMatchObject(mockRemotePhrases);
+    expect(getPhrasesApiMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        language: customLanguageTag,
+      })
+    );
+  });
+
+  it('changeLanguage registers remote bundles and switches i18next language', async () => {
+    const addResourceBundleSpy = jest.spyOn(i18next, 'addResourceBundle');
+    const changeLanguageSpy = jest.spyOn(i18next, 'changeLanguage');
+
+    await changeLanguage(customLanguageTag);
+
+    expect(addResourceBundleSpy).toHaveBeenCalledWith(
+      customLanguageTag,
+      'translation',
+      mockRemotePhrases.translation
+    );
+    expect(changeLanguageSpy).toHaveBeenCalledWith(customLanguageTag);
+
+    addResourceBundleSpy.mockRestore();
+    changeLanguageSpy.mockRestore();
+  });
+
+  it('getI18nResource falls back to built-in English when phrase loading fails', async () => {
+    getPhrasesApiMock.mockRejectedValueOnce(new Error('network error'));
+
+    const { resources, lng } = await getI18nResource(customLanguageTag);
+
+    expect(lng).toBe('en');
+    expect(resources.en).toBeDefined();
+  });
+});

--- a/packages/account/src/i18n/utils.test.ts
+++ b/packages/account/src/i18n/utils.test.ts
@@ -1,21 +1,9 @@
-import { getPreferredLanguage, resolveLanguage, resolveUiLocalesLanguage } from './utils';
+import { getPreferredLanguage } from './utils';
 
 describe('i18n utils', () => {
   afterEach(() => {
     localStorage.clear();
     jest.restoreAllMocks();
-  });
-
-  it('resolveLanguage returns the best supported built-in language', () => {
-    expect(resolveLanguage('pl')).toBe('pl-PL');
-    expect(resolveLanguage('zh-HK')).toBe('zh-HK');
-    expect(resolveLanguage('xx')).toBeUndefined();
-  });
-
-  it('resolveUiLocalesLanguage returns the first supported locale with fallback support', () => {
-    expect(resolveUiLocalesLanguage('xx pl fr')).toBe('pl-PL');
-    expect(resolveUiLocalesLanguage('zh-HK zh')).toBe('zh-HK');
-    expect(resolveUiLocalesLanguage('xx yy')).toBeUndefined();
   });
 
   it('getPreferredLanguage returns raw ui_locales for server-side resolution', () => {
@@ -53,7 +41,7 @@ describe('i18n utils', () => {
     ).toBe('vi-VN');
   });
 
-  it('getPreferredLanguage uses the shared SIE language source when auto detecting', () => {
+  it('getPreferredLanguage does not pin lng when auto-detect is enabled', () => {
     jest.spyOn(navigator, 'languages', 'get').mockReturnValue(['fr']);
     jest.spyOn(navigator, 'language', 'get').mockReturnValue('fr');
 
@@ -67,6 +55,6 @@ describe('i18n utils', () => {
           fallbackLanguage: 'fr',
         },
       })
-    ).toBe('en');
+    ).toBeUndefined();
   });
 });

--- a/packages/account/src/i18n/utils.test.ts
+++ b/packages/account/src/i18n/utils.test.ts
@@ -18,7 +18,19 @@ describe('i18n utils', () => {
     expect(resolveUiLocalesLanguage('xx yy')).toBeUndefined();
   });
 
-  it('getPreferredLanguage respects ui_locales fallback before language settings', () => {
+  it('getPreferredLanguage returns raw ui_locales for server-side resolution', () => {
+    expect(
+      getPreferredLanguage({
+        uiLocales: 'vi-VN',
+        languageSettings: {
+          autoDetect: false,
+          fallbackLanguage: 'fr',
+        },
+      })
+    ).toBe('vi-VN');
+  });
+
+  it('getPreferredLanguage respects ui_locales before language settings', () => {
     expect(
       getPreferredLanguage({
         uiLocales: 'xx pl',
@@ -27,7 +39,18 @@ describe('i18n utils', () => {
           fallbackLanguage: 'fr',
         },
       })
-    ).toBe('pl-PL');
+    ).toBe('xx pl');
+  });
+
+  it('getPreferredLanguage uses fallback language when auto-detect is disabled', () => {
+    expect(
+      getPreferredLanguage({
+        languageSettings: {
+          autoDetect: false,
+          fallbackLanguage: 'vi-VN',
+        },
+      })
+    ).toBe('vi-VN');
   });
 
   it('getPreferredLanguage uses the shared SIE language source when auto detecting', () => {

--- a/packages/account/src/i18n/utils.ts
+++ b/packages/account/src/i18n/utils.ts
@@ -1,8 +1,16 @@
 import { matchSupportedLanguageTag } from '@logto/language-kit';
-import { builtInLanguages, type BuiltInLanguageTag } from '@logto/phrases-experience';
+import resource, {
+  builtInLanguages,
+  type BuiltInLanguageTag,
+  type LocalePhrase,
+} from '@logto/phrases-experience';
 import type { LanguageInfo } from '@logto/schemas';
+import type { Resource } from 'i18next';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+
+import { getPhrases as getPhrasesApi } from '@ac/apis/phrases';
+import { getUiLocales } from '@ac/utils/account-center-route';
 
 const storageKey = 'i18nextLogtoUiLng';
 
@@ -47,7 +55,7 @@ const detectLanguages = () => {
 
 export const detectLanguage = (languageSettings?: LanguageInfo) => {
   if (languageSettings?.autoDetect === false) {
-    return resolveLanguage(languageSettings.fallbackLanguage) ?? 'en';
+    return languageSettings.fallbackLanguage;
   }
 
   return matchSupportedLanguageTag(detectLanguages(), builtInLanguages).match ?? 'en';
@@ -59,8 +67,59 @@ export const getPreferredLanguage = ({
 }: {
   languageSettings?: LanguageInfo;
   uiLocales?: string;
-}) => resolveUiLocalesLanguage(uiLocales) ?? detectLanguage(languageSettings);
+}) => {
+  const normalizedUiLocales = uiLocales?.trim();
+
+  if (normalizedUiLocales) {
+    return normalizedUiLocales;
+  }
+
+  return detectLanguage(languageSettings);
+};
+
+const getPhrases = async (language?: string) => {
+  const uiLocales = getUiLocales();
+  const preferredLanguage = language ?? uiLocales;
+  const detectedLanguage = detectLanguage();
+  const response = await getPhrasesApi({
+    localLanguage: Array.isArray(detectedLanguage) ? detectedLanguage.join(' ') : detectedLanguage,
+    language: preferredLanguage,
+  });
+
+  const remotePhrases = await response.json<LocalePhrase>();
+  const lng = response.headers.get('Content-Language');
+
+  if (!lng) {
+    throw new Error('lng not found');
+  }
+
+  return { phrases: remotePhrases, lng };
+};
+
+export const getI18nResource = async (
+  language?: string
+): Promise<{ resources: Resource; lng: string }> => {
+  try {
+    const { phrases, lng } = await getPhrases(language);
+
+    return {
+      resources: { [lng]: phrases },
+      lng,
+    };
+  } catch {
+    return {
+      resources: { en: resource.en },
+      lng: 'en',
+    };
+  }
+};
 
 export const changeLanguage = async (language: string) => {
-  await i18next.changeLanguage(resolveLanguage(language) ?? 'en');
+  const { resources, lng } = await getI18nResource(language);
+
+  for (const [namespace, resource] of Object.entries(resources[lng] ?? {})) {
+    i18next.addResourceBundle(lng, namespace, resource);
+  }
+
+  await i18next.changeLanguage(lng);
 };

--- a/packages/account/src/i18n/utils.ts
+++ b/packages/account/src/i18n/utils.ts
@@ -1,9 +1,4 @@
-import { matchSupportedLanguageTag } from '@logto/language-kit';
-import resource, {
-  builtInLanguages,
-  type BuiltInLanguageTag,
-  type LocalePhrase,
-} from '@logto/phrases-experience';
+import resource, { type LocalePhrase } from '@logto/phrases-experience';
 import type { LanguageInfo } from '@logto/schemas';
 import type { Resource } from 'i18next';
 import i18next from 'i18next';
@@ -14,27 +9,11 @@ import { getUiLocales } from '@ac/utils/account-center-route';
 
 const storageKey = 'i18nextLogtoUiLng';
 
-export const resolveLanguage = (language?: string): BuiltInLanguageTag | undefined =>
-  language
-    ? builtInLanguages.find(
-        (tag): tag is BuiltInLanguageTag =>
-          tag === matchSupportedLanguageTag([language], builtInLanguages).match
-      )
-    : undefined;
-
-export const resolveUiLocalesLanguage = (uiLocales?: string) => {
-  if (!uiLocales) {
-    return;
+export const detectLanguage = (languageSettings?: LanguageInfo) => {
+  if (languageSettings?.autoDetect === false) {
+    return languageSettings.fallbackLanguage;
   }
 
-  return uiLocales
-    .trim()
-    .split(/\s+/)
-    .map((language) => resolveLanguage(language))
-    .find(Boolean);
-};
-
-const detectLanguages = () => {
   const languageDetector = new LanguageDetector();
   languageDetector.init(
     { languageUtils: {} },
@@ -44,21 +23,7 @@ const detectLanguages = () => {
     }
   );
 
-  const detected = languageDetector.detect();
-
-  if (Array.isArray(detected)) {
-    return detected;
-  }
-
-  return detected ? [detected] : [];
-};
-
-export const detectLanguage = (languageSettings?: LanguageInfo) => {
-  if (languageSettings?.autoDetect === false) {
-    return languageSettings.fallbackLanguage;
-  }
-
-  return matchSupportedLanguageTag(detectLanguages(), builtInLanguages).match ?? 'en';
+  return languageDetector.detect();
 };
 
 export const getPreferredLanguage = ({
@@ -67,14 +32,18 @@ export const getPreferredLanguage = ({
 }: {
   languageSettings?: LanguageInfo;
   uiLocales?: string;
-}) => {
+}): string | undefined => {
   const normalizedUiLocales = uiLocales?.trim();
 
   if (normalizedUiLocales) {
     return normalizedUiLocales;
   }
 
-  return detectLanguage(languageSettings);
+  if (languageSettings?.autoDetect === false) {
+    return languageSettings.fallbackLanguage;
+  }
+
+  return undefined;
 };
 
 const getPhrases = async (language?: string) => {
@@ -114,7 +83,7 @@ export const getI18nResource = async (
   }
 };
 
-export const changeLanguage = async (language: string) => {
+export const changeLanguage = async (language?: string) => {
   const { resources, lng } = await getI18nResource(language);
 
   for (const [namespace, resource] of Object.entries(resources[lng] ?? {})) {

--- a/packages/integration-tests/src/tests/api/well-known.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.test.ts
@@ -9,13 +9,16 @@ import { HTTPError } from 'ky';
 
 import { fullnameData } from '#src/__mocks__/profile-fields-mock.js';
 import api, { adminTenantApi, authedAdminApi } from '#src/api/api.js';
+import { createOrUpdateCustomPhrase, deleteCustomPhrase } from '#src/api/custom-phrase.js';
 import {
   createCustomProfileField,
   deleteCustomProfileFieldByName,
+  getSignInExperience,
   updateSignInExperience,
 } from '#src/api/index.js';
 import { createSsoConnector, deleteSsoConnectorById } from '#src/api/sso-connector.js';
 import { newOidcSsoConnectorPayload } from '#src/constants.js';
+import { setLanguage } from '#src/helpers/sign-in-experience.js';
 import { generateSsoConnectorName } from '#src/utils.js';
 
 describe('.well-known api', () => {
@@ -72,6 +75,49 @@ describe('.well-known api', () => {
       .get('.well-known/phrases?lng=en')
       .json<{ translation: Translation }>();
     expect(updated.translation.list).toHaveProperty('and', and);
+  });
+
+  describe('manual language phrases', () => {
+    const manualLanguageTag = 'vi-VN';
+    const customConfirmLabel = 'integration-test-vi-VN-confirm';
+
+    it('should resolve manual language from lng query and fallback language settings', async () => {
+      const { languageInfo: originalLanguageInfo } = await getSignInExperience();
+
+      try {
+        await createOrUpdateCustomPhrase(manualLanguageTag, {
+          action: { confirm: customConfirmLabel },
+        });
+        await setLanguage(manualLanguageTag, false);
+
+        const explicitLanguageResponse = await api.get(
+          `.well-known/phrases?lng=${manualLanguageTag}`
+        );
+        expect(explicitLanguageResponse.headers.get('content-language')).toBe(manualLanguageTag);
+
+        const explicitLanguagePhrases = await explicitLanguageResponse.json<{
+          translation: Translation;
+        }>();
+        expect(explicitLanguagePhrases.translation).toMatchObject({
+          action: { confirm: customConfirmLabel },
+        });
+
+        const fallbackLanguageResponse = await api.get('.well-known/phrases');
+        expect(fallbackLanguageResponse.headers.get('content-language')).toBe(manualLanguageTag);
+
+        const fallbackLanguagePhrases = await fallbackLanguageResponse.json<{
+          translation: Translation;
+        }>();
+        expect(fallbackLanguagePhrases.translation).toMatchObject({
+          action: { confirm: customConfirmLabel },
+        });
+      } finally {
+        await deleteCustomPhrase(manualLanguageTag).catch(() => {
+          // Ignore cleanup errors when the phrase was never created.
+        });
+        await updateSignInExperience({ languageInfo: originalLanguageInfo });
+      }
+    });
   });
 
   describe('sso connectors in sign-in experience', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Account Center resolved `ui_locales` and fallback language settings against built-in languages only. Manually added locales (for example `vi-VN`) were dropped before phrase bundles were loaded, so customized Account Center strings never appeared even when sign-in pages worked.

This change aligns Account Center i18n with the experience app: phrase bundles are fetched from `GET /api/.well-known/phrases`, the resolved language comes from the `Content-Language` response header, and custom translations are applied via `addResourceBundle`.

Fixes #8640

## Testing

- Unit tests
- Integration tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f79dda2-5c97-49c9-b2b4-1db96fd395c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f79dda2-5c97-49c9-b2b4-1db96fd395c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

