### PR TITLE
feat(core): add application access evaluator

### DIFF
--- a/packages/core/src/libraries/application-access-control.test.ts
+++ b/packages/core/src/libraries/application-access-control.test.ts
@@ -1,0 +1,223 @@
+import {
+  createDefaultApplicationAccessControl,
+  type Application,
+  type ApplicationAccessControl,
+} from '@logto/schemas';
+
+import { mockApplication } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { MockQueries } from '#src/test-utils/tenant.js';
+
+import { createApplicationAccessControlLibrary } from './application-access-control.js';
+
+const { jest } = import.meta;
+
+const userId = 'user-id';
+const applicationId = 'application-id';
+const enabledApplication: Application = {
+  ...mockApplication,
+  id: applicationId,
+  appLevelAccessControlEnabled: true,
+};
+const disabledApplication: Application = {
+  ...enabledApplication,
+  appLevelAccessControlEnabled: false,
+};
+
+const buildAccessControl = (
+  patch: Partial<ApplicationAccessControl> = {}
+): ApplicationAccessControl => ({
+  ...createDefaultApplicationAccessControl(),
+  ...patch,
+});
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+const findApplicationById = jest.fn(async () => enabledApplication);
+const findApplicationAccessControl = jest.fn(async () => createDefaultApplicationAccessControl());
+const hasUserRole = jest.fn(async () => false);
+const getExistingOrganizationIds = jest.fn(async (): Promise<string[]> => []);
+const hasUserOrganizationRole = jest.fn(async () => false);
+
+const createLibrary = () => {
+  const queries = new MockQueries({
+    applications: { findApplicationById },
+    applicationAccessControl: { findApplicationAccessControl },
+    usersRoles: { hasUserRole },
+  });
+
+  jest
+    .spyOn(queries.organizations.relations.users, 'getExistingOrganizationIds')
+    .mockImplementation(getExistingOrganizationIds);
+  jest
+    .spyOn(queries.organizations.relations.usersRoles, 'hasUserOrganizationRole')
+    .mockImplementation(hasUserOrganizationRole);
+
+  return createApplicationAccessControlLibrary(queries);
+};
+
+const setDevFeaturesEnabled = (value: boolean) => {
+  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', value);
+};
+
+beforeEach(() => {
+  setDevFeaturesEnabled(true);
+  findApplicationById.mockResolvedValue(enabledApplication);
+  findApplicationAccessControl.mockResolvedValue(createDefaultApplicationAccessControl());
+  hasUserRole.mockResolvedValue(false);
+  getExistingOrganizationIds.mockResolvedValue([]);
+  hasUserOrganizationRole.mockResolvedValue(false);
+});
+
+afterEach(() => {
+  setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  jest.clearAllMocks();
+});
+
+describe('assertUserHasApplicationAccess()', () => {
+  it('allows without querying the application when dev features are disabled', async () => {
+    setDevFeaturesEnabled(false);
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).resolves.not.toThrow();
+
+    expect(findApplicationById).not.toHaveBeenCalled();
+    expect(findApplicationAccessControl).not.toHaveBeenCalled();
+  });
+
+  it('allows without querying rule tables when app-level access control is disabled', async () => {
+    findApplicationById.mockResolvedValueOnce(disabledApplication);
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).resolves.not.toThrow();
+
+    expect(findApplicationById).toHaveBeenCalledWith(applicationId);
+    expect(findApplicationAccessControl).not.toHaveBeenCalled();
+    expect(hasUserRole).not.toHaveBeenCalled();
+    expect(getExistingOrganizationIds).not.toHaveBeenCalled();
+    expect(hasUserOrganizationRole).not.toHaveBeenCalled();
+  });
+
+  it('denies access without revealing missing applications', async () => {
+    findApplicationById.mockRejectedValueOnce(
+      new RequestError({
+        code: 'entity.not_exists_with_id',
+        status: 404,
+        name: 'applications',
+        id: applicationId,
+      })
+    );
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
+  });
+
+  it('allows direct selected user', async () => {
+    findApplicationAccessControl.mockResolvedValueOnce(buildAccessControl({ userIds: [userId] }));
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).resolves.not.toThrow();
+
+    expect(hasUserRole).not.toHaveBeenCalled();
+    expect(getExistingOrganizationIds).not.toHaveBeenCalled();
+    expect(hasUserOrganizationRole).not.toHaveBeenCalled();
+  });
+
+  it('allows selected user role membership', async () => {
+    findApplicationAccessControl.mockResolvedValueOnce(
+      buildAccessControl({ userRoleIds: ['role-id'] })
+    );
+    hasUserRole.mockResolvedValueOnce(true);
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).resolves.not.toThrow();
+
+    expect(hasUserRole).toHaveBeenCalledWith(userId, ['role-id']);
+    expect(getExistingOrganizationIds).not.toHaveBeenCalled();
+    expect(hasUserOrganizationRole).not.toHaveBeenCalled();
+  });
+
+  it('allows selected organization membership', async () => {
+    findApplicationAccessControl.mockResolvedValueOnce(
+      buildAccessControl({ organizationIds: ['organization-id'] })
+    );
+    getExistingOrganizationIds.mockResolvedValueOnce(['organization-id']);
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).resolves.not.toThrow();
+
+    expect(getExistingOrganizationIds).toHaveBeenCalledWith(userId, ['organization-id']);
+    expect(hasUserOrganizationRole).not.toHaveBeenCalled();
+  });
+
+  it('allows selected organization-role assignment in the selected organization', async () => {
+    findApplicationAccessControl.mockResolvedValueOnce(
+      buildAccessControl({
+        organizationRoleRules: [
+          { organizationId: 'organization-id', organizationRoleIds: ['organization-role-id'] },
+        ],
+      })
+    );
+    hasUserOrganizationRole.mockResolvedValueOnce(true);
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).resolves.not.toThrow();
+
+    expect(hasUserOrganizationRole).toHaveBeenCalledWith(userId, [
+      { organizationId: 'organization-id', organizationRoleId: 'organization-role-id' },
+    ]);
+  });
+
+  it('denies organization membership when that organization is not selected', async () => {
+    findApplicationAccessControl.mockResolvedValueOnce(
+      buildAccessControl({ organizationIds: ['selected-organization-id'] })
+    );
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
+
+    expect(getExistingOrganizationIds).toHaveBeenCalledWith(userId, ['selected-organization-id']);
+  });
+
+  it('denies selected organization role when it belongs to a different organization', async () => {
+    findApplicationAccessControl.mockResolvedValueOnce(
+      buildAccessControl({
+        organizationRoleRules: [
+          { organizationId: 'selected-organization-id', organizationRoleIds: ['role-id'] },
+        ],
+      })
+    );
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
+
+    expect(hasUserOrganizationRole).toHaveBeenCalledWith(userId, [
+      { organizationId: 'selected-organization-id', organizationRoleId: 'role-id' },
+    ]);
+  });
+
+  it('denies enabled config with no matching rules', async () => {
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
+  });
+
+  it('delegates empty rule arrays to guarded query helpers', async () => {
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
+    ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
+
+    expect(hasUserRole).toHaveBeenCalledWith(userId, []);
+    expect(getExistingOrganizationIds).toHaveBeenCalledWith(userId, []);
+    expect(hasUserOrganizationRole).toHaveBeenCalledWith(userId, []);
+  });
+});

--- a/packages/core/src/libraries/application-access-control.ts
+++ b/packages/core/src/libraries/application-access-control.ts
@@ -1,0 +1,82 @@
+import type { ApplicationAccessControl } from '@logto/schemas';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import type Queries from '#src/tenants/Queries.js';
+
+const buildOrganizationRoleRuleMatches = ({
+  organizationRoleRules,
+}: ApplicationAccessControl): Array<{ organizationId: string; organizationRoleId: string }> =>
+  organizationRoleRules.flatMap(({ organizationId, organizationRoleIds }) =>
+    organizationRoleIds.map((organizationRoleId) => ({ organizationId, organizationRoleId }))
+  );
+
+const isApplicationNotFoundError = (error: unknown) =>
+  error instanceof RequestError && error.code === 'entity.not_exists_with_id';
+
+export const createApplicationAccessControlLibrary = (queries: Queries) => {
+  const {
+    applications: { findApplicationById },
+    applicationAccessControl: { findApplicationAccessControl },
+    usersRoles: { hasUserRole },
+    organizations: {
+      relations: { users: organizationUserRelations, usersRoles: organizationUserRoleRelations },
+    },
+  } = queries;
+
+  const assertUserHasApplicationAccess = async (applicationId: string, userId: string) => {
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    const { appLevelAccessControlEnabled } = await findApplicationById(applicationId).catch(
+      (error: unknown) => {
+        if (isApplicationNotFoundError(error)) {
+          throw new RequestError('oidc.access_denied');
+        }
+
+        throw error;
+      }
+    );
+
+    if (!appLevelAccessControlEnabled) {
+      return;
+    }
+
+    const accessControl = await findApplicationAccessControl(applicationId);
+
+    if (accessControl.userIds.includes(userId)) {
+      return;
+    }
+
+    if (await hasUserRole(userId, accessControl.userRoleIds)) {
+      return;
+    }
+
+    const organizationIds = await organizationUserRelations.getExistingOrganizationIds(
+      userId,
+      accessControl.organizationIds
+    );
+
+    if (organizationIds.length > 0) {
+      return;
+    }
+
+    const organizationRoleRuleMatches = buildOrganizationRoleRuleMatches(accessControl);
+
+    if (
+      await organizationUserRoleRelations.hasUserOrganizationRole(
+        userId,
+        organizationRoleRuleMatches
+      )
+    ) {
+      return;
+    }
+
+    throw new RequestError('oidc.access_denied');
+  };
+
+  return {
+    assertUserHasApplicationAccess,
+  };
+};

--- a/packages/core/src/queries/organization/user-role-relations.ts
+++ b/packages/core/src/queries/organization/user-role-relations.ts
@@ -16,6 +16,11 @@ import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 import RelationQueries from '#src/utils/RelationQueries.js';
 import { conditionalSql, convertToIdentifiers } from '#src/utils/sql.js';
 
+type OrganizationRoleRuleMatch = {
+  organizationId: string;
+  organizationRoleId: string;
+};
+
 export class UserRoleRelationQueries extends RelationQueries<
   [typeof Organizations, typeof OrganizationRoles, typeof Users]
 > {
@@ -72,6 +77,30 @@ export class UserRoleRelationQueries extends RelationQueries<
       where ${fields.userId} = ${userId}
       and ${resources.fields.indicator} = ${resourceIndicator}
       ${conditionalSql(organizationId, (value) => sql`and ${fields.organizationId} = ${value}`)}
+    `);
+  }
+
+  async hasUserOrganizationRole(
+    userId: string,
+    organizationRoleRuleMatches: readonly OrganizationRoleRuleMatch[]
+  ): Promise<boolean> {
+    if (organizationRoleRuleMatches.length === 0) {
+      return false;
+    }
+
+    const { fields } = convertToIdentifiers(OrganizationRoleUserRelations, true);
+
+    return this.pool.exists(sql`
+      select 1
+      from ${this.table}
+      where ${fields.userId} = ${userId}
+        and (${fields.organizationId}, ${fields.organizationRoleId}) in (${sql.join(
+          organizationRoleRuleMatches.map(
+            ({ organizationId, organizationRoleId }) =>
+              sql`(${organizationId}, ${organizationRoleId})`
+          ),
+          sql`, `
+        )})
     `);
   }
 

--- a/packages/core/src/queries/users-roles.ts
+++ b/packages/core/src/queries/users-roles.ts
@@ -34,6 +34,19 @@ export const createUsersRolesQueries = (pool: CommonQueryMethods) => {
       where ${fields.userId}=${userId}
     `);
 
+  const hasUserRole = async (userId: string, roleIds: readonly string[]): Promise<boolean> => {
+    if (roleIds.length === 0) {
+      return false;
+    }
+
+    return pool.exists(sql`
+      select 1
+      from ${table}
+      where ${fields.userId} = ${userId}
+        and ${fields.roleId} = any(${sql.array(roleIds, 'varchar')})
+    `);
+  };
+
   const findUsersRolesByRoleId = async (roleId: string, limit?: number) =>
     pool.any<UsersRole>(sql`
       select ${sql.join(Object.values(fields), sql`,`)}
@@ -95,6 +108,7 @@ export const createUsersRolesQueries = (pool: CommonQueryMethods) => {
     countUsersRolesByRoleIds,
     findFirstUsersRolesByRoleIdAndUserIds,
     findUsersRolesByUserId,
+    hasUserRole,
     findUsersRolesByRoleId,
     findUsersRolesByRoleIds,
     insertUsersRoles,

--- a/packages/core/src/routes/applications/application-access-control.test.ts
+++ b/packages/core/src/routes/applications/application-access-control.test.ts
@@ -73,9 +73,12 @@ describe('application access-control route', () => {
     const applicationRequest = createApplicationRequest();
 
     const patch = { appLevelAccessControlEnabled: true };
+    findApplicationAccessControl.mockResolvedValueOnce(buildAccessControl());
+
     const response = await applicationRequest.patch('/applications/foo').send(patch);
 
     expect(response.status).toEqual(200);
+    expect(findApplicationAccessControl).toHaveBeenCalledWith('foo');
     expect(updateApplicationById).toHaveBeenCalledWith('foo', patch, 'replace');
     expect(response.body).toMatchObject(patch);
 
@@ -86,6 +89,17 @@ describe('application access-control route', () => {
       .send(patch);
 
     expect(disabledResponse.status).toEqual(400);
+    expect(updateApplicationById).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /applications/:applicationId should reject enabling app-level access control with empty rules', async () => {
+    const applicationRequest = createApplicationRequest();
+
+    const response = await applicationRequest
+      .patch('/applications/foo')
+      .send({ appLevelAccessControlEnabled: true });
+
+    expect(response.status).toEqual(422);
     expect(updateApplicationById).not.toHaveBeenCalled();
   });
 
@@ -152,6 +166,21 @@ describe('application access-control route', () => {
         organizationRoleRules: [{ organizationId: 'organization-2', organizationRoleIds: [] }],
       })
     );
+
+    expect(response.status).toEqual(422);
+    expect(replaceApplicationAccessControl).not.toHaveBeenCalled();
+  });
+
+  it('PUT /applications/:applicationId/access-control should reject empty rules when app-level access control is enabled', async () => {
+    const applicationRequest = createApplicationRequest();
+    findApplicationById.mockResolvedValueOnce({
+      ...mockApplication,
+      appLevelAccessControlEnabled: true,
+    });
+
+    const response = await applicationRequest
+      .put('/applications/foo/access-control')
+      .send(createDefaultApplicationAccessControl());
 
     expect(response.status).toEqual(422);
     expect(replaceApplicationAccessControl).not.toHaveBeenCalled();

--- a/packages/core/src/routes/applications/application-access-control.ts
+++ b/packages/core/src/routes/applications/application-access-control.ts
@@ -9,6 +9,8 @@ import assertThat from '#src/utils/assert-that.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
+import { assertApplicationAccessControlHasRules } from './application-access-control/utils.js';
+
 // Keep this OpenAPI-friendly guard in sync with the canonical guard below. The canonical guard
 // uses transforms for dedupe/merge/limits, which do not round-trip cleanly through OpenAPI output.
 const applicationAccessControlOpenApiGuard = z.object({
@@ -99,7 +101,11 @@ export default function applicationAccessControlRoutes<T extends ManagementApiRo
       );
 
       assertNonEmptyOrganizationRoleRules(accessControl);
-      await findApplicationById(applicationId);
+      const { appLevelAccessControlEnabled } = await findApplicationById(applicationId);
+
+      if (appLevelAccessControlEnabled) {
+        assertApplicationAccessControlHasRules(accessControl);
+      }
 
       await replaceApplicationAccessControl(applicationId, accessControl);
 

--- a/packages/core/src/routes/applications/application-access-control/utils.ts
+++ b/packages/core/src/routes/applications/application-access-control/utils.ts
@@ -1,0 +1,27 @@
+import type { ApplicationAccessControl } from '@logto/schemas';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import assertThat from '#src/utils/assert-that.js';
+
+const hasApplicationAccessControlRules = ({
+  userIds,
+  userRoleIds,
+  organizationIds,
+  organizationRoleRules,
+}: ApplicationAccessControl) =>
+  userIds.length > 0 ||
+  userRoleIds.length > 0 ||
+  organizationIds.length > 0 ||
+  organizationRoleRules.some(({ organizationRoleIds }) => organizationRoleIds.length > 0);
+
+export const assertApplicationAccessControlHasRules = (accessControl: ApplicationAccessControl) => {
+  assertThat(
+    hasApplicationAccessControlRules(accessControl),
+    new RequestError({
+      code: 'request.invalid_input',
+      status: 422,
+      details:
+        'Application access control must include at least one rule before it can be enabled.',
+    })
+  );
+};

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -27,6 +27,7 @@ import { parseSearchParamsForSearch } from '#src/utils/search.js';
 import { captureEvent } from '../../utils/posthog.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
+import { assertApplicationAccessControlHasRules } from './application-access-control/utils.js';
 import applicationAccessControlRoutes from './application-access-control.js';
 import applicationCustomDataRoutes from './application-custom-data.js';
 import { generateInternalSecret } from './application-secret.js';
@@ -329,6 +330,12 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
 
       if (pendingUpdateApplication.type === ApplicationType.SAML) {
         throw new RequestError('application.saml.use_saml_app_api');
+      }
+
+      if (rest.appLevelAccessControlEnabled === true) {
+        assertApplicationAccessControlHasRules(
+          await queries.applicationAccessControl.findApplicationAccessControl(id)
+        );
       }
 
       assertThirdPartyApplicationTokenExchangeDisabled(

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -1,3 +1,4 @@
+import { createApplicationAccessControlLibrary } from '#src/libraries/application-access-control.js';
 import { createApplicationLibrary } from '#src/libraries/application.js';
 import { type CloudConnectionLibrary } from '#src/libraries/cloud-connection.js';
 import type { ConnectorLibrary } from '#src/libraries/connector.js';
@@ -41,6 +42,7 @@ export default class Libraries {
   );
 
   passcodes = createPasscodeLibrary(this.queries, this.connectors);
+  applicationAccessControl = createApplicationAccessControlLibrary(this.queries);
   applications = createApplicationLibrary(this.queries);
   verificationStatuses = createVerificationStatusLibrary(this.queries);
   samlApplications = createSamlApplicationsLibrary(this.queries);


### PR DESCRIPTION
## Summary
Add the core app-level access evaluator for LOG-13485. The evaluator checks whether a user can access an application through direct user, user role, organization membership, or organization role rules, and denies unmatched enabled configurations with `oidc.access_denied`.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
