### PR TITLE
fix(core): widen arbitrary JSON object types in openapi document

### DIFF
--- a/.changeset/fix-openapi-arbitrary-object-types.md
+++ b/.changeset/fix-openapi-arbitrary-object-types.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+declare `additionalProperties: true` on arbitrary JSON object schemas in the OpenAPI document. Generated TypeScript clients (e.g. `@logto/api`) now type fields such as `customData` as `{ [key: string]: unknown }` instead of `Record<string, never>`, which previously forbade every property at compile time

--- a/packages/core/src/utils/zod.test.ts
+++ b/packages/core/src/utils/zod.test.ts
@@ -27,6 +27,7 @@ describe('zodTypeToSwagger', () => {
     expect(zodTypeToSwagger(jsonObjectGuard)).toEqual({
       type: 'object',
       description: 'arbitrary',
+      additionalProperties: true,
     });
   });
 
@@ -152,6 +153,14 @@ describe('zodTypeToSwagger', () => {
 
   it('preprocess type', () => {
     expect(zodTypeToSwagger(preprocess(String, string()))).toEqual({ type: 'string' });
+  });
+
+  it('refinement type', () => {
+    expect(zodTypeToSwagger(string().refine(() => true))).toEqual({
+      type: 'object',
+      description: 'Validator function',
+      additionalProperties: true,
+    });
   });
 
   it('nullable type', () => {

--- a/packages/core/src/utils/zod.ts
+++ b/packages/core/src/utils/zod.ts
@@ -152,6 +152,7 @@ export const zodTypeToSwagger = (
     return {
       type: 'object',
       description: 'arbitrary',
+      additionalProperties: true,
     };
   }
 
@@ -162,6 +163,7 @@ export const zodTypeToSwagger = (
         {
           type: 'object',
           description: 'arbitrary JSON object',
+          additionalProperties: true,
         },
         {
           type: 'array',
@@ -178,6 +180,7 @@ export const zodTypeToSwagger = (
               {
                 type: 'object',
                 description: 'arbitrary JSON object',
+                additionalProperties: true,
               },
             ],
           },
@@ -329,6 +332,7 @@ export const zodTypeToSwagger = (
     return {
       type: 'object',
       description: 'Validator function',
+      additionalProperties: true,
     };
   }
 

--- a/packages/integration-tests/src/tests/api/well-known.openapi.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.openapi.test.ts
@@ -20,4 +20,23 @@ describe('.well-known openapi.json endpoints', () => {
     expect(result.errors).toEqual([]);
     await expect(SwaggerParser.default.validate(json)).resolves.not.toThrow();
   });
+
+  // Arbitrary JSON object fields must declare `additionalProperties` so that
+  // openapi-typescript emits `{ [k: string]: unknown }` instead of
+  // `Record<string, never>`, which would forbid all properties at the type level.
+  it('emits arbitrary-object fields as open objects', async () => {
+    const response = await adminTenantApi.get('.well-known/management.openapi.json');
+    const json = await response.json<OpenAPIV3.Document>();
+
+    const requestBody = json.paths['/api/organizations']?.post?.requestBody as
+      | OpenAPIV3.RequestBodyObject
+      | undefined;
+    const bodySchema = requestBody?.content['application/json']?.schema as
+      | OpenAPIV3.SchemaObject
+      | undefined;
+    const customData = bodySchema?.properties?.customData as OpenAPIV3.SchemaObject | undefined;
+
+    expect(customData?.type).toBe('object');
+    expect(customData?.additionalProperties).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #8043.

Arbitrary-JSON-object fields in the management OpenAPI document (e.g. `customData` on Organizations, Users, Applications) were emitted as `{ type: "object", description: "arbitrary" }` with no `additionalProperties`. `openapi-typescript` interprets that strictly as `Record<string, never>`, so the generated `@logto/api` types forbade every property at compile time — `customData: { foo: 1 }` failed to type-check even though the server accepted it.

### What changed

- [packages/core/src/utils/zod.ts](packages/core/src/utils/zod.ts) — `zodTypeToSwagger` now emits `additionalProperties: true` for every arbitrary-object schema it produces:
  - the `jsonObjectGuard` identity branch,
  - both nested arbitrary-object sub-schemas inside the `jsonGuard` `oneOf`,
  - the `ZodEffects` refinement fallback (`{ type: "object", description: "Validator function" }`).
- The `ZodEffects` preprocess/transform recursion behavior is unchanged, and the refinement fallback still emits `type: "object"` — only `additionalProperties: true` was added. Conservative scope: no behavior change for refined schemas beyond unblocking codegen.

### Expected result

- OpenAPI document: arbitrary-object schemas now carry `additionalProperties: true`. Still valid OpenAPI 3.0.1 and 3.1, and empty `{}` continues to validate (no `required` set).
- Generated TypeScript clients: fields like `Organization.customData` now type as `{ [key: string]: unknown }` instead of `Record<string, never>`. Strictly a type widening — `{}` still type-checks; populated objects now type-check where they previously didn't.
- No runtime change. The underlying Zod guard (`z.record(jsonGuard)`) already accepted any JSON object.

### Reviewer notes

- The fix deliberately does **not** unify `ZodEffects` refinement with preprocess/transform (which would have made `z.string().refine(...)` emit `{ type: "string" }` instead of an opaque object). That would correctly type `oidcClientMetadata.redirectUris` as `string[]` instead of `{ [k: string]: unknown }[]`, but it changes swagger output more broadly than this fix's scope. Tracked as a possible follow-up.
- An identical duplicate `ZodRecord` branch exists in `zodTypeToSwagger` (pre-existing, unrelated to this PR) — flagged for a separate cleanup.

## Testing

Unit tests, integration tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments