### PR TITLE
feat(schemas): add Cloudflare email service config

### DIFF
--- a/packages/schemas/src/types/system.ts
+++ b/packages/schemas/src/types/system.ts
@@ -83,6 +83,7 @@ export const storageProviderGuard: Readonly<{
 // Email service provider
 export enum EmailServiceProvider {
   SendGrid = 'SendGrid',
+  Cloudflare = 'Cloudflare',
 }
 
 export const sendgridEmailServiceConfigGuard = z.object({
@@ -95,8 +96,19 @@ export const sendgridEmailServiceConfigGuard = z.object({
 
 export type SendgridEmailServiceConfig = z.infer<typeof sendgridEmailServiceConfigGuard>;
 
+export const cloudflareEmailServiceConfigGuard = z.object({
+  provider: z.literal(EmailServiceProvider.Cloudflare),
+  apiKey: z.string(),
+  accountId: z.string(),
+  fromName: z.string(),
+  fromEmail: z.string(),
+});
+
+export type CloudflareEmailServiceConfig = z.infer<typeof cloudflareEmailServiceConfigGuard>;
+
 export const emailServiceConfigGuard = z.discriminatedUnion('provider', [
   sendgridEmailServiceConfigGuard,
+  cloudflareEmailServiceConfigGuard,
 ]);
 
 export type EmailServiceConfig = z.infer<typeof emailServiceConfigGuard>;


### PR DESCRIPTION
## Summary

- Add `EmailServiceProvider.Cloudflare`.
- Add `cloudflareEmailServiceConfigGuard` with `provider`, `apiKey`, `accountId`, `fromName`, and `fromEmail`.
- Extend `emailServiceConfigGuard` to accept both SendGrid and Cloudflare provider configs.

## Notes

- This keeps the existing `emailServiceProvider` system key and only extends its provider-discriminated schema.
- Existing SendGrid config shape remains unchanged.
- The cloud runtime provider implementation is stacked separately in logto-io/cloud#1888.

## Validation

- `pnpm --dir packages/schemas build`
- `pnpm --dir packages/schemas exec eslint --ext .ts src/types/system.ts`
- pre-commit lint-staged ran `eslint --cache --fix` and `tsc -p tsconfig.json --noEmit` for `packages/schemas`