### PR TITLE
fix(connector): allow SMTP login auth without user/pass

### DIFF
--- a/.changeset/fix-smtp-auth-empty-credentials.md
+++ b/.changeset/fix-smtp-auth-empty-credentials.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-smtp": patch
+---
+
+allow SMTP connector `auth` to omit `user` and `pass` so relays that authorize by source (e.g. IP/VLAN) can be configured without forging credentials

--- a/packages/connectors/connector-smtp/src/index.test.ts
+++ b/packages/connectors/connector-smtp/src/index.test.ts
@@ -150,6 +150,12 @@ describe('Test config guard', () => {
     expect(result.success && result.data).toMatchObject(expect.objectContaining(mockedConfig));
   });
 
+  it('config with login auth missing user/pass (e.g. IP-authorized SMTP relay)', () => {
+    const testConfig = { ...mockedConfig, auth: { type: 'login' as const } };
+    const result = smtpConfigGuard.safeParse(testConfig);
+    expect(result.success && result.data).toMatchObject(expect.objectContaining(testConfig));
+  });
+
   it('config with debugging and security options', () => {
     const testConfig = {
       ...mockedConfig,

--- a/packages/connectors/connector-smtp/src/index.ts
+++ b/packages/connectors/connector-smtp/src/index.ts
@@ -75,7 +75,8 @@ const sendMessage =
       )
     );
 
-    const configOptions: SMTPTransport.Options = config;
+    // eslint-disable-next-line no-restricted-syntax -- nodemailer's `AuthenticationTypeLogin` types `user`/`pass` as required strings, but at runtime it treats them as optional (skipping auth when absent). Our schema widens these to support relays that authorize by source.
+    const configOptions = config as SMTPTransport.Options;
     const transporter = nodemailer.createTransport(configOptions);
     const mailOptions = buildMailOptions(config, template, payload, to);
 

--- a/packages/connectors/connector-smtp/src/types.ts
+++ b/packages/connectors/connector-smtp/src/types.ts
@@ -26,11 +26,23 @@ const templateGuard = z.object({
  * Auth Options
  * See https://nodemailer.com/smtp/#authentication and https://nodemailer.com/smtp/oauth2/.
  */
-const loginAuthGuard = z.object({
-  user: z.string(),
-  pass: z.string(),
-  type: z.enum(['login', 'Login', 'LOGIN']).optional(),
-});
+/**
+ * `user` and `pass` are optional so that SMTP relays which authorize by source
+ * (e.g. IP/VLAN) — and therefore don't take credentials — still validate after
+ * the route layer's `cleanDeep` strips empty-string values from the config.
+ * Nodemailer treats absent `user`/`pass` as "skip auth".
+ *
+ * `.strict()` is required: with both fields optional this guard would otherwise
+ * swallow oauth2 auth payloads in the `authGuard` union (which only differ by
+ * their extra keys), silently stripping `privateKey` / `clientId` / etc.
+ */
+const loginAuthGuard = z
+  .object({
+    user: z.string().optional(),
+    pass: z.string().optional(),
+    type: z.enum(['login', 'Login', 'LOGIN']).optional(),
+  })
+  .strict();
 
 const oauth2AuthWithKeyGuard = z.object({
   type: z.enum(['oauth2', 'OAuth2', 'OAUTH2']).optional(),


### PR DESCRIPTION
## Summary
Closes #6754.

### Context
SMTP relays that authorize by source (IP/VLAN) — and don't take credentials — can't be configured because the connector route calls `cleanDeep` on the config before persisting, which strips empty-string `user`/`pass` from `auth`. The resulting `{ "type": "login" }` then fails the connector's zod guard on subsequent reads, the UI loses the fields, and the connector stops working.

### What changed
- `packages/connectors/connector-smtp/src/types.ts` — made `user` and `pass` optional on `loginAuthGuard`, and added `.strict()` so the now-looser shape doesn't silently swallow oauth2 payloads in the `authGuard` union (zod would otherwise match login first and drop the oauth2-only keys).
- `packages/connectors/connector-smtp/src/index.ts` — type-assert at the nodemailer boundary. Nodemailer's `AuthenticationTypeLogin` types `user`/`pass` as required strings, but at runtime treats them as optional (skipping auth when absent). Bypass is documented inline.
- `packages/connectors/connector-smtp/src/index.test.ts` — added one test covering the post-`cleanDeep` shape (`auth: { type: 'login' }`).
- `.changeset/fix-smtp-auth-empty-credentials.md` — patch bump for `@logto/connector-smtp`.

### Expected result
- Existing SMTP configs with real `user`/`pass` continue to validate and work unchanged (optional widens, doesn't break).
- New SMTP configs without credentials now validate after the route's `cleanDeep` pass, and nodemailer skips authentication as it already does for the standalone case shown in #6754.
- The `cleanDeep` round-trip dropping empty-string `user`/`pass` from the UI form is unchanged — it's now harmless rather than fatal.

### Reviewer notes
- `.strict()` is the minimal disambiguation for the union here. A `z.discriminatedUnion('type', …)` would be cleaner long-term but would require making `type` non-optional on all three variants, which is a breaking change to stored configs. Happy to revisit as a follow-up.
- The route-layer `cleanDeep` is left alone — it's shared across all connectors, so changing its empty-string behavior has a much larger blast radius than warranted here.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments