### PR TITLE
fix(core): return updated protected app metadata

### DIFF
--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -271,6 +271,11 @@ describe('application route', () => {
     });
 
     expect(response.status).toEqual(200);
+    expect(response.body.protectedAppMetadata).toEqual({
+      ...existingProtectedAppMetadata,
+      origin,
+      additionalScopes,
+    });
     expect(syncAppConfigsToRemote).toHaveBeenCalledWith('foo');
     expect(updateApplicationById).toHaveBeenNthCalledWith(1, 'foo', {
       protectedAppMetadata: {

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -387,7 +387,11 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
         }
       }
 
-      if (protectedAppMetadata) {
+      const updatedProtectedApplication = await (async () => {
+        if (!protectedAppMetadata) {
+          return;
+        }
+
         const { type, protectedAppMetadata: originProtectedAppMetadata } = pendingUpdateApplication;
         assertThat(type === ApplicationType.Protected, 'application.protected_application_only');
         assertThat(
@@ -397,7 +401,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
             status: 422,
           })
         );
-        await queries.applications.updateApplicationById(id, {
+        const updatedApplication = await queries.applications.updateApplicationById(id, {
           protectedAppMetadata: {
             ...originProtectedAppMetadata,
             ...protectedAppMetadata,
@@ -412,12 +416,13 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
           });
           throw error;
         }
-      }
+        return updatedApplication;
+      })();
 
       const updatedApplication =
         Object.keys(rest).length > 0
           ? await queries.applications.updateApplicationById(id, rest, 'replace')
-          : pendingUpdateApplication;
+          : (updatedProtectedApplication ?? pendingUpdateApplication);
 
       ctx.body = updatedApplication;
 


### PR DESCRIPTION
## Summary
Fix `PATCH /applications/:id` so protected app metadata-only updates return the updated application instead of the stale pre-update application.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
