### PR TITLE
feat(connector): support Aliyun DM regions

### DIFF
--- a/.changeset/support-aliyun-dm-region.md
+++ b/.changeset/support-aliyun-dm-region.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-aliyun-dm": minor
+---
+
+support configuring Direct Mail region for Aliyun DM connector

--- a/packages/connectors/connector-aliyun-dm/README.md
+++ b/packages/connectors/connector-aliyun-dm/README.md
@@ -55,6 +55,7 @@ After finishing setup, there are two different ways to test:
 2. Go to the "Sender Addresses" (发信地址) or "Email Tags" (邮件标签) tab you just visited from the [DM admin console page](https://dm.console.aliyun.com/), you can find _Sender Address_ or _Email Tag_ easily.
 3. Fill out the Aliyun DM Connector settings:
     - Fill out the `accessKeyId` and `accessKeySecret` fields with access key pairs you've got from step 1.
+    - Fill out the `regionId` field with the Direct Mail region where your sender address is configured. The default value is `cn-hangzhou`.
     - Fill out the `accountName` and `fromAlias` field with "Sender Address" and "Email Tag" which were found in step 2. All templates will share this signature name. (You can leave `fromAlias` blank as it is OPTIONAL.)
     - You can add multiple DM connector templates for different cases. Here is an example of adding a single template:
         - Fill out the `subject` field, which will work as title of the sending email.
@@ -73,6 +74,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 |-----------------|-------------------|
 | accessKeyId     | string            |
 | accessKeySecret | string            |
+| regionId        | string (OPTIONAL) |
 | accountName     | string            |
 | fromAlias       | string (OPTIONAL) |
 | templates       | Template[]        |
@@ -119,6 +121,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 2. 从 [邮件服务管理控制台](https://dm.console.aliyun.com/) 的侧边栏，分别进入「发信地址」和「邮件标签」。这里你可以找到之前创建的 _发信地址_ 和 _邮件标签_。
 3. 完成阿里云邮件服务连接器的设置：
     - 用你在步骤 1 中拿到的一对「AccessKey ID」和「AccessKey Secret」来分别填入 `accessKeyId` 和 `accessKeySecret`。
+    - 用发信地址所在的邮件推送地域填写 `regionId`。默认值为 `cn-hangzhou`。
     - 用步骤 2 中的 _发信地址_ 和 _邮件标签_ 填写 `accountName` 和 `fromAlias`。（`fromAlias` 可以不填写，它是 **可选的**。）
     - 你可以添加多个邮件服务模板以应对不同的用户场景。这里展示填写单个模板的例子：
       - 在 `subject` 栏填写发送邮件的 _标题_。
@@ -137,6 +140,7 @@ That's it. Don't forget to [Enable connector in sign-in experience](https://docs
 |-----------------|-------------------|
 | accessKeyId     | string            |
 | accessKeySecret | string            |
+| regionId        | string (OPTIONAL) |
 | accountName     | string            |
 | fromAlias       | string (OPTIONAL) |
 | templates       | Template[]        |

--- a/packages/connectors/connector-aliyun-dm/src/constant.ts
+++ b/packages/connectors/connector-aliyun-dm/src/constant.ts
@@ -1,7 +1,43 @@
 import type { ConnectorMetadata } from '@logto/connector-kit';
 import { ConnectorConfigFormItemType } from '@logto/connector-kit';
 
-export const endpoint = 'https://dm.aliyuncs.com/';
+export const defaultRegionId = 'cn-hangzhou';
+
+export const regionIds = [
+  'cn-hangzhou',
+  'ap-southeast-1',
+  'ap-southeast-2',
+  'eu-central-1',
+  'us-east-1',
+] as const;
+
+export type RegionId = (typeof regionIds)[number];
+
+export const regionConfigs: Record<RegionId, { title: string; endpoint: string }> = Object.freeze({
+  'cn-hangzhou': {
+    title: 'China (Hangzhou)',
+    endpoint: 'https://dm.aliyuncs.com/',
+  },
+  'ap-southeast-1': {
+    title: 'Singapore',
+    endpoint: 'https://dm.ap-southeast-1.aliyuncs.com/',
+  },
+  'ap-southeast-2': {
+    title: 'United States (formerly Sydney)',
+    endpoint: 'https://dm.ap-southeast-2.aliyuncs.com/',
+  },
+  'eu-central-1': {
+    title: 'Germany (Frankfurt)',
+    endpoint: 'https://dm.eu-central-1.aliyuncs.com/',
+  },
+  'us-east-1': {
+    title: 'US (Virginia)',
+    endpoint: 'https://dm.us-east-1.aliyuncs.com/',
+  },
+});
+
+export const getEndpoint = (regionId: RegionId = defaultRegionId) =>
+  regionConfigs[regionId].endpoint;
 
 export const staticConfigs = {
   Format: 'json',
@@ -43,6 +79,18 @@ export const defaultMetadata: ConnectorMetadata = {
       type: ConnectorConfigFormItemType.Text,
       required: true,
       placeholder: '<access-key-secret>',
+    },
+    {
+      key: 'regionId',
+      label: 'Region',
+      type: ConnectorConfigFormItemType.Select,
+      required: false,
+      defaultValue: defaultRegionId,
+      selectItems: regionIds.map((value) => ({
+        value,
+        title: regionConfigs[value].title,
+      })),
+      description: 'Select the Direct Mail region where the sender address is configured.',
     },
     {
       key: 'accountName',

--- a/packages/connectors/connector-aliyun-dm/src/index.test.ts
+++ b/packages/connectors/connector-aliyun-dm/src/index.test.ts
@@ -3,6 +3,10 @@ import { TemplateType } from '@logto/connector-kit';
 import { mockedConfigWithAllRequiredTemplates, mockGenericI18nEmailTemplate } from './mock.js';
 
 const getConfig = vi.fn().mockResolvedValue(mockedConfigWithAllRequiredTemplates);
+const getConfigWithSingaporeRegion = vi.fn().mockResolvedValue({
+  ...mockedConfigWithAllRequiredTemplates,
+  regionId: 'ap-southeast-1',
+});
 
 const singleSendMail = vi.fn(() => ({
   body: JSON.stringify({ EnvId: 'env-id', RequestId: 'request-id' }),
@@ -33,6 +37,21 @@ describe('sendMessage()', () => {
       expect.objectContaining({
         HtmlBody: 'Your sign-in code is 1234, 1234 is your code',
         Subject: 'Sign-in code 1234',
+      }),
+      expect.anything()
+    );
+  });
+
+  it('should call singleSendMail() with configured region', async () => {
+    const connector = await createConnector({ getConfig: getConfigWithSingaporeRegion });
+    await connector.sendMessage({
+      to: 'to@email.com',
+      type: TemplateType.SignIn,
+      payload: { code: '1234' },
+    });
+    expect(singleSendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        RegionId: 'ap-southeast-1',
       }),
       expect.anything()
     );

--- a/packages/connectors/connector-aliyun-dm/src/index.ts
+++ b/packages/connectors/connector-aliyun-dm/src/index.ts
@@ -18,7 +18,7 @@ import {
   getConfigTemplateByType,
 } from '@logto/connector-kit';
 
-import { defaultMetadata } from './constant.js';
+import { defaultMetadata, defaultRegionId } from './constant.js';
 import { singleSendMail } from './single-send-mail.js';
 import {
   aliyunDmConfigGuard,
@@ -35,7 +35,13 @@ const sendMessage =
     const { to, type, payload } = data;
     const config = inputConfig ?? (await getConfig(defaultMetadata.id));
     validateConfig(config, aliyunDmConfigGuard);
-    const { accessKeyId, accessKeySecret, accountName, fromAlias } = config;
+    const {
+      accessKeyId,
+      accessKeySecret,
+      accountName,
+      fromAlias,
+      regionId = defaultRegionId,
+    } = config;
 
     const customTemplate = await trySafe(async () => getI18nEmailTemplate?.(type, payload.locale));
 
@@ -53,6 +59,7 @@ const sendMessage =
       const httpResponse = await singleSendMail(
         {
           AccessKeyId: accessKeyId,
+          RegionId: regionId,
           AccountName: accountName,
           ReplyToAddress: 'false',
           AddressType: '1',

--- a/packages/connectors/connector-aliyun-dm/src/mock.ts
+++ b/packages/connectors/connector-aliyun-dm/src/mock.ts
@@ -7,7 +7,7 @@ export const mockedParameters = {
   AddressType: '1',
   Format: 'XML',
   HtmlBody: '4',
-  RegionId: 'cn-hangzhou',
+  RegionId: 'cn-hangzhou' as const,
   ReplyToAddress: 'true',
   SignatureMethod: 'HMAC-SHA1',
   SignatureVersion: '1.0',

--- a/packages/connectors/connector-aliyun-dm/src/single-send-mail.test.ts
+++ b/packages/connectors/connector-aliyun-dm/src/single-send-mail.test.ts
@@ -7,6 +7,10 @@ vi.mock('./utils.js', () => ({
 const { singleSendMail } = await import('./single-send-mail.js');
 
 describe('singleSendMail', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should call request with action SingleSendMail', async () => {
     await singleSendMail(
       {
@@ -25,6 +29,29 @@ describe('singleSendMail', () => {
     expect(calledData).not.toBeUndefined();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const payload = calledData?.[1];
+    expect(calledData?.[0]).toBe('https://dm.aliyuncs.com/');
     expect(payload).toHaveProperty('Action', 'SingleSendMail');
+    expect(payload).toHaveProperty('RegionId', 'cn-hangzhou');
+  });
+
+  it('should call request with the endpoint for the specified region', async () => {
+    await singleSendMail(
+      {
+        AccessKeyId: '<access-key-id>',
+        AccountName: 'noreply@example.com',
+        AddressType: '1',
+        FromAlias: 'CompanyName',
+        HtmlBody: 'test from logto',
+        RegionId: 'ap-southeast-1',
+        ReplyToAddress: 'false',
+        Subject: 'test',
+        ToAddress: 'user@example.com',
+      },
+      '<access-key-secret>'
+    );
+    const calledData = request.mock.calls[0];
+
+    expect(calledData?.[0]).toBe('https://dm.ap-southeast-1.aliyuncs.com/');
+    expect(calledData?.[1]).toHaveProperty('RegionId', 'ap-southeast-1');
   });
 });

--- a/packages/connectors/connector-aliyun-dm/src/single-send-mail.ts
+++ b/packages/connectors/connector-aliyun-dm/src/single-send-mail.ts
@@ -1,4 +1,4 @@
-import { endpoint, staticConfigs } from './constant.js';
+import { defaultRegionId, getEndpoint, staticConfigs } from './constant.js';
 import type { PublicParameters, SingleSendMail } from './types.js';
 import { request } from './utils.js';
 
@@ -9,9 +9,11 @@ export const singleSendMail = async (
   parameters: PublicParameters & SingleSendMail,
   accessKeySecret: string
 ) => {
+  const { RegionId = defaultRegionId, ...restParameters } = parameters;
+
   return request(
-    endpoint,
-    { Action: 'SingleSendMail', ...staticConfigs, ...parameters },
+    getEndpoint(RegionId),
+    { Action: 'SingleSendMail', ...staticConfigs, ...restParameters, RegionId },
     accessKeySecret
   );
 };

--- a/packages/connectors/connector-aliyun-dm/src/types.test.ts
+++ b/packages/connectors/connector-aliyun-dm/src/types.test.ts
@@ -11,4 +11,20 @@ describe('aliyunDmConfigGuard', () => {
     const result = aliyunDmConfigGuard.safeParse(mockedConfigWithAllRequiredTemplates);
     expect(result.success).toEqual(true);
   });
+
+  it('passes with supported region', () => {
+    const result = aliyunDmConfigGuard.safeParse({
+      ...mockedConfigWithAllRequiredTemplates,
+      regionId: 'ap-southeast-1',
+    });
+    expect(result.success).toEqual(true);
+  });
+
+  it('throws with unsupported region', () => {
+    const result = aliyunDmConfigGuard.safeParse({
+      ...mockedConfigWithAllRequiredTemplates,
+      regionId: 'cn-shanghai',
+    });
+    expect(result.success).toEqual(false);
+  });
 });

--- a/packages/connectors/connector-aliyun-dm/src/types.ts
+++ b/packages/connectors/connector-aliyun-dm/src/types.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { type RegionId, regionIds } from './constant.js';
+
 export const sendEmailResponseGuard = z.object({
   EnvId: z.string(),
   RequestId: z.string(),
@@ -22,6 +24,7 @@ const templateGuard = z.object({
 export const aliyunDmConfigGuard = z.object({
   accessKeyId: z.string(),
   accessKeySecret: z.string(),
+  regionId: z.enum(regionIds).optional(),
   accountName: z.string(),
   fromAlias: z.string().optional(),
   templates: z.array(templateGuard).refine(
@@ -60,7 +63,7 @@ export type SingleSendMail = {
 export type PublicParameters = {
   AccessKeyId: string;
   Format?: string; // 'json' or 'xml', default: 'json'
-  RegionId?: string; // 'cn-hangzhou' | 'ap-southeast-1' | 'ap-southeast-2'
+  RegionId?: RegionId;
   Signature?: string;
   SignatureMethod?: string;
   SignatureNonce?: string;


### PR DESCRIPTION
## Summary

- Add `regionId` configuration for the Aliyun Direct Mail connector.
- Route `SingleSendMail` requests to the endpoint for the configured Direct Mail region.
- Keep existing configurations backward compatible by defaulting to `cn-hangzhou`.

## Root cause

Aliyun Direct Mail sender addresses are region-scoped. The connector previously always called the Hangzhou endpoint, so sender addresses created in regions such as Singapore could not be found.

## Testing

Unit tests