### PR TITLE
ci(workflows): forward alteration repository for community PRs

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -77,12 +77,13 @@ jobs:
       STATUS_API_KEY: test-status-api-key
 
     steps:
-      - uses: logto-io/actions-run-logto-integration-tests@v4.0.1
+      - uses: logto-io/actions-run-logto-integration-tests@v4.1.0
         with:
           branch: ${{ github.base_ref }}
           logto-artifact: alteration-integration-test-${{ github.sha }}
           test-target: ${{ matrix.target }}
           db-alteration-target: ${{ github.head_ref }}
+          db-alteration-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           pnpm-version: 10
           node-version: ^22.14.0
 


### PR DESCRIPTION
## Summary

- Bump \`logto-io/actions-run-logto-integration-tests\` from \`v4.0.1\` → \`v4.1.0\`.
- Pass the PR head repo (the fork, for community PRs) via the new \`db-alteration-repository\` input.

## Why

The \`alteration-compatibility-integration-test\` workflow fails for every PR opened from a fork — the inner \`actions/checkout\` in \`actions-run-db-alteration-steps\` defaults to \`github.repository\` (= \`logto-io/logto\`), so it tries to fetch the contributor's branch from the base repo, where it doesn't exist:

\`\`\`
[command]/usr/bin/git -c protocol.version=2 fetch ... +refs/heads/<head-ref>*:refs/remotes/origin/<head-ref>*
The process '/usr/bin/git' failed with exit code 1
\`\`\`

Forwarding \`github.event.pull_request.head.repo.full_name\` to the inner checkout fixes this. \`GITHUB_TOKEN\` on \`pull_request\` events already has read access to the head fork.

## Depends on

- [ ] logto-io/actions-run-db-alteration-steps#3 — must release as \`v1.1.0\`.
- [ ] logto-io/actions-run-logto-integration-tests#26 — must release as \`v4.1.0\` (which pins \`actions-run-db-alteration-steps@v1.1.0\` and forwards the new input).

## Safety

The new value flows into \`actions/checkout\`'s \`repository:\` input — a structured action input, not a shell command — so this isn't a workflow-injection vector. \`github.event.pull_request.head.repo.full_name\` is GitHub-controlled (canonical \`owner/repo\` string), not contributor-controlled.

## Test plan

- [ ] Same-repo push to master: \`alteration-compatibility-integration-test\` still passes
- [ ] Same-repo PR with alteration changes: still passes
- [ ] Community PR (fork) with alteration changes: now passes instead of erroring at fetch