### PR TITLE
fix(core): allow local MinIO HTTP URLs in dev CSP img-src

### DIFF
--- a/.changeset/local-minio-csp-img-src.md
+++ b/.changeset/local-minio-csp-img-src.md
@@ -1,5 +1,0 @@
----
-"@logto/core": patch
----
-
-allow local MinIO HTTP origins in development CSP `img-src` for Experience, Account Center, and Console so user-asset previews work when storage uses `http://localhost:9000` or `http://127.0.0.1:9000`

--- a/.changeset/local-minio-csp-img-src.md
+++ b/.changeset/local-minio-csp-img-src.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+allow local MinIO HTTP origins in development CSP `img-src` for Experience, Account Center, and Console so user-asset previews work when storage uses `http://localhost:9000` or `http://127.0.0.1:9000`

--- a/packages/core/src/middleware/koa-security-headers.test.ts
+++ b/packages/core/src/middleware/koa-security-headers.test.ts
@@ -82,6 +82,19 @@ describe('koaSecurityHeaders() middleware — experience CSP', () => {
     expect(connectSource).not.toContain(customScriptSource);
   });
 
+  it('allows local MinIO HTTP origins in experience img-src during development', async () => {
+    const run = koaExperienceSecurityHeaders('default', createQueries());
+    const ctx = createMockContext({ method: 'GET', url: '/sign-in' });
+
+    await run(ctx, koaNoop);
+
+    const imageSource = getCspDirective(ctx, 'img-src');
+
+    expect(imageSource).toContain('https:');
+    expect(imageSource).toContain('http://localhost:9000');
+    expect(imageSource).toContain('http://127.0.0.1:9000');
+  });
+
   it('does not add Custom UI CSP sources when Custom UI assets are not configured', async () => {
     const run = koaExperienceSecurityHeaders(
       'default',

--- a/packages/core/src/middleware/koa-security-headers.ts
+++ b/packages/core/src/middleware/koa-security-headers.ts
@@ -70,6 +70,11 @@ const createSecurityHeaderSettings = (tenantId: string): SecurityHeaderSettings 
         'http://localhost:5173', // From local website
         'http://localhost:5174', // From local blog
       ];
+  /** Allow HTTP avatar URLs from local S3-compatible storage (e.g. MinIO) in dev. */
+  const developmentUserAssetImageSources = isProduction
+    ? []
+    : ['http://localhost:9000', 'http://127.0.0.1:9000'];
+  const userAssetImageSources = ["'self'", 'data:', 'https:', ...developmentUserAssetImageSources];
   const logtoOrigin = 'https://*.logto.io';
   /** Google Sign-In (GSI) origin for Google One Tap. */
   const gsiOrigin = 'https://accounts.google.com/gsi/';
@@ -161,7 +166,7 @@ const createSecurityHeaderSettings = (tenantId: string): SecurityHeaderSettings 
         useDefaults: true,
         directives: {
           'upgrade-insecure-requests': null,
-          imgSrc: ["'self'", 'data:', 'https:'],
+          imgSrc: userAssetImageSources,
           scriptSrc: appendCustomSources(experienceScriptSource, customUiCsp.scriptSrc),
           scriptSrcAttr: ["'unsafe-inline'"],
           connectSrc: appendCustomSources(experienceConnectSource, customUiCsp.connectSrc),
@@ -187,7 +192,7 @@ const createSecurityHeaderSettings = (tenantId: string): SecurityHeaderSettings 
       useDefaults: true,
       directives: {
         'upgrade-insecure-requests': null,
-        imgSrc: ["'self'", 'data:', 'https:'],
+        imgSrc: userAssetImageSources,
         scriptSrc: [
           "'self'",
           // Some of our users may use the Cloudflare Web Analytics service. We need to allow it to load its scripts.
@@ -209,7 +214,7 @@ const createSecurityHeaderSettings = (tenantId: string): SecurityHeaderSettings 
       useDefaults: true,
       directives: {
         'upgrade-insecure-requests': null,
-        imgSrc: ["'self'", 'data:', 'https:'],
+        imgSrc: userAssetImageSources,
         // Allow "unsafe-eval" and "unsafe-inline" for debugging purpose in non-production environment
         scriptSrc: [
           "'self'",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extracts the dev-only CSP change from #8884 so local MinIO user-asset previews work without waiting on the avatar upload feature PR.

When `storageProvider` points at local MinIO (`http://localhost:9000` or `http://127.0.0.1:9000`), uploaded avatar and other user-asset URLs are served over HTTP. Experience, Account Center, and Console CSP `img-src` previously allowed only `https:`, so previews were blocked in the browser.

This PR adds `http://localhost:9000` and `http://127.0.0.1:9000` to `img-src` for those apps when **not** in production. Production behavior is unchanged.

Related: logto-io/logto#8884

## Testing

Unit tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f53db9d1-841c-4ff1-8b00-196e91f86271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f53db9d1-841c-4ff1-8b00-196e91f86271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

