### PR TITLE
fix(connector): sync package logo files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  main-generated-files:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node and pnpm
+        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        with:
+          pnpm-version: 10
+          node-version: ^22.14.0
+
+      - name: Sync connector presets
+        run: pnpm run pnpm:devPreinstall
+
+      - name: Check connector generated files
+        run: |
+          if ! git diff --exit-code -- packages/connectors; then
+            echo "Connector package presets are out of sync. Run 'pnpm run pnpm:devPreinstall' and commit the changes."
+            exit 1
+          fi
+
   main-build:
     runs-on: ubuntu-latest
 

--- a/packages/connectors/README.md
+++ b/packages/connectors/README.md
@@ -9,6 +9,7 @@ Since all connectors have a same pattern for `package.json`, here we leverage se
 - The `"pnpm:devPreinstall"` script in the project root executes `templates/sync-preset.js` that:
   - Check every connectors's `package.json` to see if there's any unexpected keys
   - Sync `templates/package.json` by REPLACING every template key (except dependency keys) in the current `package.json` with the value from the template `package.json`
+  - Sync connector logo files in `package.json` with the actual `logo.*` and `logo-dark.*` files in each connector directory
   - Copies all config files to every connector directory
 - The hook in `.pnpmfile.cjs` of the project root merges dependency fields for every connector
   - Also we can update arbitrary fields in this hook, we still need to keep non-dependency fields in the connector's `package.json` since the hook only takes affect during `pnpm i`.

--- a/packages/connectors/connector-alipay-native/package.json
+++ b/packages/connectors/connector-alipay-native/package.json
@@ -36,8 +36,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-alipay-web/package.json
+++ b/packages/connectors/connector-alipay-web/package.json
@@ -35,8 +35,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-aliyun-dm/package.json
+++ b/packages/connectors/connector-aliyun-dm/package.json
@@ -17,8 +17,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-aliyun-sms-mas/package.json
+++ b/packages/connectors/connector-aliyun-sms-mas/package.json
@@ -17,8 +17,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-aliyun-sms/package.json
+++ b/packages/connectors/connector-aliyun-sms/package.json
@@ -17,8 +17,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-azuread/package.json
+++ b/packages/connectors/connector-azuread/package.json
@@ -19,8 +19,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-dingtalk-web/package.json
+++ b/packages/connectors/connector-dingtalk-web/package.json
@@ -35,8 +35,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-discord/package.json
+++ b/packages/connectors/connector-discord/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-facebook/package.json
+++ b/packages/connectors/connector-facebook/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-feishu-web/package.json
+++ b/packages/connectors/connector-feishu-web/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-gatewayapi-sms/package.json
+++ b/packages/connectors/connector-gatewayapi-sms/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-gitlab/package.json
+++ b/packages/connectors/connector-gitlab/package.json
@@ -21,8 +21,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-google/package.json
+++ b/packages/connectors/connector-google/package.json
@@ -19,8 +19,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-huggingface/package.json
+++ b/packages/connectors/connector-huggingface/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-kakao/package.json
+++ b/packages/connectors/connector-kakao/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-kook/package.json
+++ b/packages/connectors/connector-kook/package.json
@@ -10,8 +10,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-linkedin/package.json
+++ b/packages/connectors/connector-linkedin/package.json
@@ -19,8 +19,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-logto-social-demo/package.json
+++ b/packages/connectors/connector-logto-social-demo/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-mailgun/package.json
+++ b/packages/connectors/connector-mailgun/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.png"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-mailjunky/package.json
+++ b/packages/connectors/connector-mailjunky/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-mock-email-alternative/package.json
+++ b/packages/connectors/connector-mock-email-alternative/package.json
@@ -30,8 +30,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "engines": {
     "node": "^22.14.0"

--- a/packages/connectors/connector-mock-email/package.json
+++ b/packages/connectors/connector-mock-email/package.json
@@ -30,8 +30,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "engines": {
     "node": "^22.14.0"

--- a/packages/connectors/connector-mock-sms/package.json
+++ b/packages/connectors/connector-mock-sms/package.json
@@ -30,8 +30,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "engines": {
     "node": "^22.14.0"

--- a/packages/connectors/connector-mock-social/package.json
+++ b/packages/connectors/connector-mock-social/package.json
@@ -30,8 +30,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "engines": {
     "node": "^22.14.0"

--- a/packages/connectors/connector-naver/package.json
+++ b/packages/connectors/connector-naver/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-oauth2/package.json
+++ b/packages/connectors/connector-oauth2/package.json
@@ -21,8 +21,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-oidc/package.json
+++ b/packages/connectors/connector-oidc/package.json
@@ -21,8 +21,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-postmark/package.json
+++ b/packages/connectors/connector-postmark/package.json
@@ -32,8 +32,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-qq/package.json
+++ b/packages/connectors/connector-qq/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-saml/package.json
+++ b/packages/connectors/connector-saml/package.json
@@ -20,8 +20,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-sendgrid-email/package.json
+++ b/packages/connectors/connector-sendgrid-email/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-slack/package.json
+++ b/packages/connectors/connector-slack/package.json
@@ -19,8 +19,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-smsaero/package.json
+++ b/packages/connectors/connector-smsaero/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-tencent-sms/package.json
+++ b/packages/connectors/connector-tencent-sms/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-twilio-sms/package.json
+++ b/packages/connectors/connector-twilio-sms/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-vonage-sms/package.json
+++ b/packages/connectors/connector-vonage-sms/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-wechat-native/package.json
+++ b/packages/connectors/connector-wechat-native/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-wechat-web/package.json
+++ b/packages/connectors/connector-wechat-web/package.json
@@ -18,8 +18,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-wecom/package.json
+++ b/packages/connectors/connector-wecom/package.json
@@ -19,8 +19,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-whatsapp/package.json
+++ b/packages/connectors/connector-whatsapp/package.json
@@ -17,8 +17,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-xiaomi/package.json
+++ b/packages/connectors/connector-xiaomi/package.json
@@ -17,8 +17,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/connector-yunpian-sms/package.json
+++ b/packages/connectors/connector-yunpian-sms/package.json
@@ -17,8 +17,7 @@
   "files": [
     "lib",
     "docs",
-    "logo.svg",
-    "logo-dark.svg"
+    "logo.svg"
   ],
   "scripts": {
     "precommit": "lint-staged",

--- a/packages/connectors/templates/sync-preset.js
+++ b/packages/connectors/templates/sync-preset.js
@@ -5,6 +5,19 @@ import path from 'node:path';
 
 const isDependencyKey = (key) => key.toLowerCase().endsWith('dependencies');
 const allowedCustomKeys = Object.freeze(['name', 'version', 'description', 'author']);
+const logoFileRegex = /^logo(?:-dark)?\.(?:svg|png|webp|jpe?g)$/;
+const logoFileOrder = Object.freeze([
+  'logo.svg',
+  'logo.png',
+  'logo.webp',
+  'logo.jpg',
+  'logo.jpeg',
+  'logo-dark.svg',
+  'logo-dark.png',
+  'logo-dark.webp',
+  'logo-dark.jpg',
+  'logo-dark.jpeg',
+]);
 
 // Assuming execution context `packages/connectors`
 const templateJson = Object.fromEntries(
@@ -22,6 +35,22 @@ const templateKeys = Object.keys(templateJson);
  */
 const scriptExceptions = { 'connector-oauth2': ['prepack', 'build', 'build:test'] };
 
+const getLogoFiles = async (packageDirectory) => {
+  const files = await fs.readdir(packageDirectory);
+
+  return files
+    .filter((file) => logoFileRegex.test(file))
+    .toSorted(
+      (fileA, fileB) =>
+        logoFileOrder.indexOf(fileA) - logoFileOrder.indexOf(fileB) || fileA.localeCompare(fileB)
+    );
+};
+
+const getPackageFiles = async (packageDirectory) => [
+  ...templateJson.files.filter((file) => !logoFileRegex.test(file)),
+  ...(await getLogoFiles(packageDirectory)),
+];
+
 const sync = async () => {
   const packagesDirectory = './';
   const packages = await fs.readdir(packagesDirectory);
@@ -30,7 +59,8 @@ const sync = async () => {
     packages
       .filter((packageName) => packageName.startsWith('connector-'))
       .map(async (packageName) => {
-        const packageJsonPath = path.join(packagesDirectory, packageName, 'package.json');
+        const packageDirectory = path.join(packagesDirectory, packageName);
+        const packageJsonPath = path.join(packageDirectory, 'package.json');
 
         // Sync package.json
         const current = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
@@ -61,6 +91,7 @@ const sync = async () => {
             {
               ...current,
               ...templateJson,
+              files: await getPackageFiles(packageDirectory),
               scripts: { ...templateJson.scripts, ...scriptOverrides },
             },
             undefined,


### PR DESCRIPTION
## Summary
Sync connector package `files` entries with the actual logo assets in each connector directory. This keeps connectors without dark logos, such as SMSBao, from getting a generated `logo-dark.svg` entry during preset sync, and fixes existing package file lists that referenced missing logo assets.

Add a generated-files CI check for connector presets so PRs fail before merge when `pnpm:devPreinstall` would update connector package files.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments