### PR TITLE
fix(core): make POST /api/applications/:id/roles idempotent

### DIFF
--- a/.changeset/idempotent-application-roles.md
+++ b/.changeset/idempotent-application-roles.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": minor
+---
+
+Make `POST /api/applications/:applicationId/roles` idempotent: role IDs already attached to the application are silently ignored instead of causing the request to fail with `422 application.role_exists`. The response is now `201` with body `{ roleIds, addedRoleIds }`, matching the response shape of `POST /api/users/:userId/roles`.
+
+Closes #8900.

--- a/packages/core/src/routes/applications/application-role.openapi.json
+++ b/packages/core/src/routes/applications/application-role.openapi.json
@@ -26,11 +26,25 @@
         },
         "responses": {
           "201": {
-            "description": "The API resource roles have been assigned to the application successfully."
+            "description": "The API resource roles have been assigned to the application successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "roleIds": {
+                      "description": "An array of API resource role IDs requested for assignment."
+                    },
+                    "addedRoleIds": {
+                      "description": "An array of API resource role IDs newly assigned to the application. Role IDs already attached to the application are silently ignored and not present in this array."
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Assign API resource roles to application",
-        "description": "Assign API resource roles to the specified application. The API resource roles will be added to the existing API resource roles."
+        "description": "Assign API resource roles to the specified application. The API resource roles will be added to the existing API resource roles. Role IDs that are already assigned to the application are silently ignored."
       },
       "put": {
         "requestBody": {

--- a/packages/core/src/routes/applications/application-role.test.ts
+++ b/packages/core/src/routes/applications/application-role.test.ts
@@ -72,6 +72,25 @@ describe('application role routes', () => {
     ]);
   });
 
+  it('POST /applications/:applicationId/roles deduplicates duplicates in the request body', async () => {
+    findApplicationsRolesByApplicationId.mockResolvedValueOnce([]);
+    findRolesByRoleIds.mockResolvedValueOnce([]);
+    insertApplicationsRoles.mockClear();
+    const response = await applicationRoleRequester
+      .post(`/applications/${mockM2mApplication.id}/roles`)
+      .send({
+        roleIds: [mockAdminApplicationRole.id, mockAdminApplicationRole.id],
+      });
+    expect(response.status).toEqual(201);
+    expect(response.body).toEqual({
+      roleIds: [mockAdminApplicationRole.id, mockAdminApplicationRole.id],
+      addedRoleIds: [mockAdminApplicationRole.id],
+    });
+    expect(insertApplicationsRoles).toHaveBeenCalledWith([
+      { id: mockId, applicationId: mockM2mApplication.id, roleId: mockAdminApplicationRole.id },
+    ]);
+  });
+
   it('POST /applications/:applicationId/roles silently ignores already-assigned roles', async () => {
     findApplicationsRolesByApplicationId.mockResolvedValueOnce([mockApplicationRole]);
     findRolesByRoleIds.mockResolvedValueOnce([]);

--- a/packages/core/src/routes/applications/application-role.test.ts
+++ b/packages/core/src/routes/applications/application-role.test.ts
@@ -63,9 +63,30 @@ describe('application role routes', () => {
         roleIds: [mockAdminApplicationRole.id],
       });
     expect(response.status).toEqual(201);
+    expect(response.body).toEqual({
+      roleIds: [mockAdminApplicationRole.id],
+      addedRoleIds: [mockAdminApplicationRole.id],
+    });
     expect(insertApplicationsRoles).toHaveBeenCalledWith([
       { id: mockId, applicationId: mockM2mApplication.id, roleId: mockAdminApplicationRole.id },
     ]);
+  });
+
+  it('POST /applications/:applicationId/roles silently ignores already-assigned roles', async () => {
+    findApplicationsRolesByApplicationId.mockResolvedValueOnce([mockApplicationRole]);
+    findRolesByRoleIds.mockResolvedValueOnce([]);
+    insertApplicationsRoles.mockClear();
+    const response = await applicationRoleRequester
+      .post(`/applications/${mockM2mApplication.id}/roles`)
+      .send({
+        roleIds: [mockApplicationRole.roleId],
+      });
+    expect(response.status).toEqual(201);
+    expect(response.body).toEqual({
+      roleIds: [mockApplicationRole.roleId],
+      addedRoleIds: [],
+    });
+    expect(insertApplicationsRoles).not.toHaveBeenCalled();
   });
 
   it('PUT /applications/:applicationId/roles', async () => {

--- a/packages/core/src/routes/applications/application-role.ts
+++ b/packages/core/src/routes/applications/application-role.ts
@@ -83,6 +83,10 @@ export default function applicationRoleRoutes<T extends ManagementApiRouter>(
     koaGuard({
       params: object({ applicationId: string() }),
       body: object({ roleIds: string().min(1).array() }),
+      response: object({
+        roleIds: string().min(1).array(),
+        addedRoleIds: string().min(1).array(),
+      }),
       status: [201, 404, 422],
     }),
     async (ctx, next) => {
@@ -100,18 +104,12 @@ export default function applicationRoleRoutes<T extends ManagementApiRouter>(
         })
       );
       const applicationRoles = await findApplicationsRolesByApplicationId(applicationId);
+      const existingRoleIds = new Set(applicationRoles.map(({ roleId }) => roleId));
+      const roleIdsToAdd = roleIds.filter((id) => !existingRoleIds.has(id)); // ignore existing roles.
 
-      const roles = await findRolesByRoleIds(roleIds);
+      const roles = await findRolesByRoleIds(roleIdsToAdd);
 
       for (const role of roles) {
-        assertThat(
-          !applicationRoles.some(({ roleId: _roleId }) => _roleId === role.id),
-          new RequestError({
-            code: 'application.role_exists',
-            status: 422,
-            roleId: role.id,
-          })
-        );
         assertThat(
           role.type === RoleType.MachineToMachine,
           new RequestError({
@@ -121,10 +119,14 @@ export default function applicationRoleRoutes<T extends ManagementApiRouter>(
         );
       }
 
-      await Promise.all(roleIds.map(async (roleId) => findRoleById(roleId)));
-      await insertApplicationsRoles(
-        roleIds.map((roleId) => ({ id: generateStandardId(), applicationId, roleId }))
-      );
+      if (roleIdsToAdd.length > 0) {
+        await Promise.all(roleIdsToAdd.map(async (roleId) => findRoleById(roleId)));
+        await insertApplicationsRoles(
+          roleIdsToAdd.map((roleId) => ({ id: generateStandardId(), applicationId, roleId }))
+        );
+      }
+
+      ctx.body = { roleIds, addedRoleIds: roleIdsToAdd };
       ctx.status = 201;
 
       return next();

--- a/packages/core/src/routes/applications/application-role.ts
+++ b/packages/core/src/routes/applications/application-role.ts
@@ -105,7 +105,9 @@ export default function applicationRoleRoutes<T extends ManagementApiRouter>(
       );
       const applicationRoles = await findApplicationsRolesByApplicationId(applicationId);
       const existingRoleIds = new Set(applicationRoles.map(({ roleId }) => roleId));
-      const roleIdsToAdd = roleIds.filter((id) => !existingRoleIds.has(id)); // ignore existing roles.
+      // Deduplicate the input and drop role IDs already attached to the application.
+      // The `(application_id, role_id)` unique constraint would otherwise reject the bulk insert.
+      const roleIdsToAdd = [...new Set(roleIds)].filter((id) => !existingRoleIds.has(id));
 
       const roles = await findRolesByRoleIds(roleIdsToAdd);
 

--- a/packages/integration-tests/src/api/application.ts
+++ b/packages/integration-tests/src/api/application.ts
@@ -86,9 +86,11 @@ export const getApplicationRoles = async (applicationId: string, keyword?: strin
 };
 
 export const assignRolesToApplication = async (applicationId: string, roleIds: string[]) =>
-  authedAdminApi.post(`applications/${applicationId}/roles`, {
-    json: { roleIds },
-  });
+  authedAdminApi
+    .post(`applications/${applicationId}/roles`, {
+      json: { roleIds },
+    })
+    .json<{ roleIds: string[]; addedRoleIds: string[] }>();
 
 export const putRolesToApplication = async (applicationId: string, roleIds: string[]) =>
   authedAdminApi.put(`applications/${applicationId}/roles`, {

--- a/packages/integration-tests/src/tests/api/application/application.roles.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application.roles.test.ts
@@ -61,16 +61,19 @@ describe('admin console application management (roles)', () => {
     expect(rolesWithSearchParams.find(({ id }) => id === role2.id)).toBeUndefined();
   });
 
-  it('should fail when assign duplicated role to app', async () => {
+  it('should silently ignore already-assigned roles on re-assign', async () => {
     const applicationType = ApplicationType.MachineToMachine;
     const application = await createApplication(generateStandardId(), applicationType);
     const role = await createRole({ type: RoleType.MachineToMachine });
 
-    await assignRolesToApplication(application.id, [role.id]);
-    await expectRejects(assignRolesToApplication(application.id, [role.id]), {
-      code: 'application.role_exists',
-      status: 422,
-    });
+    const firstResponse = await assignRolesToApplication(application.id, [role.id]);
+    expect(firstResponse).toEqual({ roleIds: [role.id], addedRoleIds: [role.id] });
+
+    const secondResponse = await assignRolesToApplication(application.id, [role.id]);
+    expect(secondResponse).toEqual({ roleIds: [role.id], addedRoleIds: [] });
+
+    const roles = await getApplicationRoles(application.id);
+    expect(roles).toHaveLength(1);
   });
 
   it('should fail when assign role to non-m2m app', async () => {


### PR DESCRIPTION
## Summary
Align `POST /api/applications/:applicationId/roles` with `POST /api/users/:userId/roles` so that re-assigning an already-attached role is idempotent instead of failing with `422 application.role_exists`.

- Role IDs already attached to the application are silently filtered out before insert (matches the lenient behaviour introduced for users in #4382).
- The 201 response now carries `{ roleIds, addedRoleIds }`, matching the user endpoint's response shape (#8192). Clients learn what changed via `addedRoleIds.length`.
- Updated the integration test that previously pinned the strict 422 to assert the new lenient contract.

Closes #8900.

## Testing
- Updated unit test in `application-role.test.ts` covers both the fresh-assign and the re-assign (`addedRoleIds: []`) cases.
- Updated integration test in `application.roles.test.ts` runs the full re-assign flow and asserts the application's role count stays at 1.

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
