### PR TITLE
fix(core): fail fast on disconnected Redis cache client

### DIFF
--- a/packages/core/src/caches/index.test.ts
+++ b/packages/core/src/caches/index.test.ts
@@ -10,6 +10,8 @@ const mockFunction = jest.fn();
 
 mockEsm('redis', () => ({
   createClient: () => ({
+    // Standalone clients report readiness via `isReady`; default to ready so commands run.
+    isReady: true,
     set: mockFunction,
     get: mockFunction,
     del: mockFunction,
@@ -19,6 +21,8 @@ mockEsm('redis', () => ({
     on: mockFunction,
   }),
   createCluster: () => ({
+    // The cluster client only exposes `isOpen`; default to open so commands run.
+    isOpen: true,
     set: mockFunction,
     get: mockFunction,
     del: mockFunction,
@@ -105,6 +109,27 @@ describe('RedisCache', () => {
       expect(mockFunction).toBeCalledTimes(6);
       stub.restore();
     }
+  });
+
+  it('should short-circuit get and set when the client is not ready, but still issue delete', async () => {
+    jest.clearAllMocks();
+    const cache = new RedisCache('redis://url');
+    // Simulate a down or reconnecting socket so the readiness guard kicks in.
+    Sinon.stub(cache.client!, 'isReady').value(false);
+    // Independent stubs per command — the shared `mockFunction` can't tell which method ran.
+    const getStub = Sinon.stub(cache.client!, 'get');
+    const setStub = Sinon.stub(cache.client!, 'set');
+    const deleteStub = Sinon.stub(cache.client!, 'del');
+
+    await expect(cache.get('foo')).resolves.toBeUndefined();
+    await cache.set('foo', 'bar');
+    await cache.delete('foo');
+
+    // `get`/`set` short-circuit without touching Redis; `delete` is exempt so its command still runs
+    // (and flushes on reconnect).
+    expect(getStub.called).toBe(false);
+    expect(setStub.called).toBe(false);
+    expect(deleteStub.calledOnce).toBe(true);
   });
 
   it('should fail fast when cache read hangs for more than 1 second', async () => {

--- a/packages/core/src/caches/index.ts
+++ b/packages/core/src/caches/index.ts
@@ -56,7 +56,31 @@ const raceWithTimeout = async <T>(
 abstract class RedisCacheBase implements CacheStore {
   readonly client?: RedisClientType | RedisClusterType;
 
+  /**
+   * Whether the client is connected and ready to accept commands. When it isn't (no client, or
+   * the socket is down/reconnecting), `get` and `set` short-circuit to a miss instead of issuing
+   * a command and paying the full {@link raceWithTimeout} deadline on every call — which is what
+   * piles up into request latency, and ultimately upstream 499s, during a Redis outage. `delete`
+   * is deliberately exempt so invalidations are not silently dropped (see its comment below).
+   *
+   * Standalone clients expose `isReady` (connected and past handshake); the cluster client only
+   * exposes `isOpen`, so fall back to that.
+   */
+  protected get isClientReady(): boolean {
+    const { client } = this;
+
+    if (!client) {
+      return false;
+    }
+
+    return 'isReady' in client ? client.isReady : client.isOpen;
+  }
+
   async set(key: string, value: string, expire: number = 30 * 60) {
+    if (!this.isClientReady) {
+      return;
+    }
+
     await raceWithTimeout(
       'SET',
       key,
@@ -66,11 +90,18 @@ abstract class RedisCacheBase implements CacheStore {
   }
 
   async get(key: string): Promise<Optional<string>> {
+    if (!this.isClientReady) {
+      return;
+    }
+
     return conditional(
       await raceWithTimeout('GET', key, this.client?.get(key), redisCacheReadTimeout)
     );
   }
 
+  // Unlike `get`/`set`, `delete` is not gated on `isClientReady`: a dropped invalidation could
+  // serve stale data until TTL, so let it queue and flush once the connection recovers. It stays
+  // bounded by `raceWithTimeout` and never blocks a request beyond the write deadline.
   async delete(key: string) {
     await raceWithTimeout('DEL', key, this.client?.del(key), redisCacheWriteTimeout);
   }
@@ -139,9 +170,12 @@ export class RedisCache extends RedisCacheBase {
       this.client = createClient({
         url: conditional(!yes(redisUrl) && redisUrl),
         socket: this.getSocketOptions(trySafe(() => new URL(redisUrl))),
-        // Azure redis has a 10 minutes idle timeout
+        // Keep the connection warm with a frequent heartbeat. The interval must stay below the
+        // shortest idle timeout on the network path: load balancers, NAT, and firewalls commonly
+        // drop idle TCP at 4-5 min, well under Azure Redis' 10 min. A silently dropped socket
+        // otherwise surfaces later as `read ETIMEDOUT`.
         // @see https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout
-        pingInterval: 8 * 60 * 1000, // 8 minutes
+        pingInterval: 60 * 1000, // 1 minute
       });
 
       this.client.on('error', (error) => {


### PR DESCRIPTION
## Summary
When the Redis socket is down or reconnecting, node-redis still accepts commands, so every cache `get`/`set` was issued and waited out the full `raceWithTimeout` deadline (1s read / 5s write) before degrading to a miss. During a Redis outage that per-op latency piled up across the hot path (`/.well-known/*`) and surfaced as upstream 499s correlated with `read ETIMEDOUT` events.

### What changed
- Added an `isClientReady` getter and a fast-fail guard in `get`/`set` so they short-circuit to a miss instantly when the client is not ready, rather than paying the timeout on every call. Standalone clients expose `isReady` (false during reconnect); the cluster client only exposes `isOpen`, so the getter narrows on that.
- `delete` is intentionally left unguarded: a dropped invalidation could serve stale data until TTL, so it keeps queuing and flushes once the connection recovers. It stays bounded by `raceWithTimeout`.
- Shortened `pingInterval` from 8 min to 1 min. The heartbeat must stay below the shortest idle timeout on the network path — load balancers, NAT, and firewalls commonly drop idle TCP at 4-5 min, well under Azure Redis' 10 min — otherwise a silently dropped socket resurfaces later as `read ETIMEDOUT`.

### Expected result
- Happy path is unchanged: when Redis is healthy, `isReady`/`isOpen` is true and commands run as before.
- During a Redis outage or reconnect, reads/writes degrade to a miss with no added latency instead of stacking 1s–5s timeouts per request — removing the latency tail that drove the 499 spikes.
- Connections are kept warm, reducing the frequency of `read ETIMEDOUT` itself.

### Reviewer notes
- Both changes apply to the standalone client. The cluster client uses `isOpen` (which stays true through reconnects) and does not receive `pingInterval`, so cluster deployments see limited benefit — a cluster-targeted keepalive/readiness gate is a possible follow-up.
- Reconnect blips that the offline queue previously absorbed as eventual hits now fall through to the DB; this is the intended trade (bounded latency over DB load) and is bounded per-key by the in-process memoize cache.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments