### PR TITLE
test(account): add success page and route restore tests

### DIFF
--- a/packages/account/src/pages/UpdateSuccess/index.test.tsx
+++ b/packages/account/src/pages/UpdateSuccess/index.test.tsx
@@ -1,0 +1,169 @@
+import { SignInIdentifier } from '@logto/schemas';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { Route, Routes, useLocation } from 'react-router-dom';
+
+import renderWithPageContext from '@ac/__mocks__/RenderWithPageContext';
+import { accountStorage } from '@ac/utils/session-storage';
+
+import UpdateSuccess from '.';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@ac/components/ErrorPage', () => {
+  const MockErrorPage = ({
+    titleKey,
+    messageKey,
+    action,
+  }: {
+    readonly titleKey?: string;
+    readonly messageKey?: string;
+    readonly action?: { readonly titleKey: string; readonly onClick: () => void };
+  }) => (
+    <div>
+      <div data-testid="title">{titleKey}</div>
+      <div data-testid="message">{messageKey}</div>
+      {action && (
+        <button data-testid="action" onClick={action.onClick}>
+          {action.titleKey}
+        </button>
+      )}
+    </div>
+  );
+  return MockErrorPage;
+});
+
+const LocationSpy = () => {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
+describe('UpdateSuccess', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.clearAllMocks();
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        origin: 'http://localhost',
+        assign: jest.fn(),
+      },
+    });
+  });
+
+  describe('success page text per identifier type', () => {
+    it.each([
+      [SignInIdentifier.Email, 'account_center.update_success.email'],
+      [SignInIdentifier.Phone, 'account_center.update_success.phone'],
+      [SignInIdentifier.Username, 'account_center.update_success.username'],
+      ['password' as const, 'account_center.update_success.password'],
+      ['totp' as const, 'account_center.update_success.totp'],
+      ['totp_replaced' as const, 'account_center.update_success.totp_replaced'],
+      ['backup_code' as const, 'account_center.update_success.backup_code'],
+      ['passkey' as const, 'account_center.update_success.passkey'],
+      ['social' as const, 'account_center.update_success.default'],
+    ])('shows correct text for identifier type %s', (identifierType, expectedPrefix) => {
+      renderWithPageContext(<UpdateSuccess identifierType={identifierType} />, {
+        initialEntries: ['/success'],
+      });
+
+      expect(screen.getByTestId('title').textContent).toBe(`${expectedPrefix}.title`);
+      expect(screen.getByTestId('message').textContent).toBe(`${expectedPrefix}.description`);
+    });
+
+    it('shows default text when identifierType is undefined', () => {
+      renderWithPageContext(<UpdateSuccess />, {
+        initialEntries: ['/success'],
+      });
+
+      expect(screen.getByTestId('title').textContent).toBe(
+        'account_center.update_success.default.title'
+      );
+      expect(screen.getByTestId('message').textContent).toBe(
+        'account_center.update_success.default.description'
+      );
+    });
+  });
+
+  describe('pending return navigates back correctly', () => {
+    it('shows done button and navigates on click for social type with pending return', () => {
+      accountStorage.pendingReturn.set('https://external.example.com/dashboard');
+      accountStorage.showSuccess.set(true);
+
+      renderWithPageContext(<UpdateSuccess identifierType="social" />, {
+        initialEntries: ['/success'],
+      });
+
+      const actionButton = screen.getByTestId('action');
+      expect(actionButton).toBeTruthy();
+
+      fireEvent.click(actionButton);
+
+      expect(window.location.assign).toHaveBeenCalledWith('https://external.example.com/dashboard');
+    });
+
+    it('shows done button and navigates on click when showSuccess is true', () => {
+      accountStorage.pendingReturn.set('https://external.example.com/return');
+      accountStorage.showSuccess.set(true);
+
+      renderWithPageContext(<UpdateSuccess identifierType="password" />, {
+        initialEntries: ['/success'],
+      });
+
+      const actionButton = screen.getByTestId('action');
+      expect(actionButton).toBeTruthy();
+
+      fireEvent.click(actionButton);
+
+      expect(window.location.assign).toHaveBeenCalledWith('https://external.example.com/return');
+    });
+
+    it('auto-redirects without showing done button when showSuccess is false', async () => {
+      accountStorage.pendingReturn.set('https://external.example.com/auto');
+
+      renderWithPageContext(<UpdateSuccess identifierType="password" />, {
+        initialEntries: ['/success'],
+      });
+
+      await waitFor(() => {
+        expect(window.location.assign).toHaveBeenCalledWith('https://external.example.com/auto');
+      });
+    });
+  });
+
+  describe('internal route restore', () => {
+    it('navigates internally when pending return is a same-origin account center URL', () => {
+      accountStorage.pendingReturn.set('http://localhost/account/security');
+
+      renderWithPageContext(
+        <Routes>
+          <Route path="/success" element={<UpdateSuccess identifierType="password" />} />
+          <Route path="/security" element={<LocationSpy />} />
+        </Routes>,
+        {
+          initialEntries: ['/success'],
+        }
+      );
+
+      expect(mockNavigate).toHaveBeenCalledWith('/security', { replace: true });
+      expect(window.location.assign).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fallback navigation', () => {
+    it('shows no done button when there is no pending return', () => {
+      renderWithPageContext(<UpdateSuccess identifierType="password" />, {
+        initialEntries: ['/success'],
+      });
+
+      expect(screen.queryByTestId('action')).toBeNull();
+      expect(window.location.assign).not.toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/account/src/utils/account-center-route.test.ts
+++ b/packages/account/src/utils/account-center-route.test.ts
@@ -1,0 +1,136 @@
+import {
+  handleAccountCenterRoute,
+  setRouteRestore,
+  getPendingReturn,
+} from './account-center-route';
+import { accountStorage } from './session-storage';
+
+const setLocation = (pathname: string, search = '', origin = 'http://localhost') => {
+  // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      pathname,
+      search,
+      hash: '',
+      origin,
+    },
+  });
+};
+
+const mockReplaceState = jest.fn();
+
+describe('account-center-route', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    jest.clearAllMocks();
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    window.history.replaceState = mockReplaceState;
+  });
+
+  describe('handleAccountCenterRoute – route restore', () => {
+    it('restores a stored known route when landing on the base path', () => {
+      accountStorage.routeRestore.set('/account/security');
+      setLocation('/account');
+
+      handleAccountCenterRoute();
+
+      expect(mockReplaceState).toHaveBeenCalledWith({}, '', '/account/security');
+    });
+
+    it('clears the stored route after restoration (one-time use)', () => {
+      accountStorage.routeRestore.set('/account/security');
+      setLocation('/account');
+
+      handleAccountCenterRoute();
+
+      expect(accountStorage.routeRestore.get()).toBeUndefined();
+    });
+
+    it('does not restore when landing on a non-base path', () => {
+      accountStorage.routeRestore.set('/account/security');
+      setLocation('/account/email');
+
+      handleAccountCenterRoute();
+
+      expect(mockReplaceState).not.toHaveBeenCalled();
+    });
+
+    it('does not restore when no route is stored', () => {
+      setLocation('/account');
+
+      handleAccountCenterRoute();
+
+      expect(mockReplaceState).not.toHaveBeenCalled();
+    });
+
+    it('skips handling when search contains ?code= (auth callback)', () => {
+      accountStorage.routeRestore.set('/account/security');
+      setLocation('/account', '?code=abc123');
+
+      handleAccountCenterRoute();
+
+      expect(mockReplaceState).not.toHaveBeenCalled();
+    });
+
+    it('skips handling when search contains ?error= (auth error)', () => {
+      accountStorage.routeRestore.set('/account/security');
+      setLocation('/account', '?error=login_required');
+
+      handleAccountCenterRoute();
+
+      expect(mockReplaceState).not.toHaveBeenCalled();
+    });
+
+    it('parses and stores the redirect query parameter as pending return', () => {
+      setLocation('/account/email', '?redirect=https%3A%2F%2Fexample.com%2Fdashboard');
+
+      handleAccountCenterRoute();
+
+      expect(getPendingReturn()).toBe('https://example.com/dashboard');
+    });
+
+    it('stores show_success flag from query parameters', () => {
+      setLocation('/account/email', '?redirect=https%3A%2F%2Fexample.com&show_success=1');
+
+      handleAccountCenterRoute();
+
+      expect(accountStorage.showSuccess.get()).toBe(true);
+    });
+
+    it('ignores invalid redirect URLs', () => {
+      setLocation('/account/email', '?redirect=not-a-valid-url');
+
+      handleAccountCenterRoute();
+
+      expect(getPendingReturn()).toBeUndefined();
+    });
+  });
+
+  describe('setRouteRestore', () => {
+    it('stores known routes', () => {
+      setRouteRestore('/account/security');
+      expect(accountStorage.routeRestore.get()).toBe('/account/security');
+    });
+
+    it('stores email route', () => {
+      setRouteRestore('/account/email');
+      expect(accountStorage.routeRestore.get()).toBe('/account/email');
+    });
+
+    it('stores password route', () => {
+      setRouteRestore('/account/password');
+      expect(accountStorage.routeRestore.get()).toBe('/account/password');
+    });
+
+    it('does not store unknown routes', () => {
+      setRouteRestore('/account/unknown-page');
+      expect(accountStorage.routeRestore.get()).toBeUndefined();
+    });
+
+    it('does not store routes outside account center', () => {
+      setRouteRestore('/admin/dashboard');
+      expect(accountStorage.routeRestore.get()).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add integration tests for the `UpdateSuccess` page and the `account-center-route` utility, covering the four test cases from LOG-13389:

- **Success page text per identifier type**: Verifies correct title/message translation keys for all supported identifier types (email, phone, username, password, totp, totp_replaced, backup_code, passkey, social) and the undefined/default fallback.
- **Pending return navigates back correctly**: Tests that the "Done" button appears and navigates to the pending return URL for social type and when `showSuccess` is set, and auto-redirects when `showSuccess` is not set.
- **Internal route restore is parsed correctly**: Verifies that same-origin account center URLs are navigated internally via `react-router` instead of `window.location.assign`.
- **Fallback navigation**: Confirms no action button or navigation occurs when no pending return URL exists.

Additional `account-center-route` tests cover:
- `handleAccountCenterRoute` route restoration from session storage on the base path
- One-time-use clearing of stored routes
- Skipping restoration during auth callbacks (`?code=` / `?error=`)
- Redirect and `show_success` query parameter parsing
- `setRouteRestore` known-route filtering

## Review & Testing Checklist for Human

- [ ] Verify test cases match expected behavior for each identifier type mapping in `translationMap`
- [ ] Confirm `handleAccountCenterRoute` tests cover the auth callback skip conditions

### Notes

Resolves [LOG-13389](https://linear.app/silverhand/issue/LOG-13389/add-success-page-and-route-restore-tests)

### Testing

Integration tests

Link to Devin session: https://app.devin.ai/sessions/f86aeaa3cb8c4a1b9e89ca2dd5122e48
Requested by: @wangsijie

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only new test files; no runtime or API changes.
> 
> **Overview**
> Adds **test-only** coverage for account center post-update success UX and route bootstrapping (LOG-13389)—no production behavior changes.
> 
> **`UpdateSuccess`** tests mock `ErrorPage` and assert per-`identifierType` i18n keys (including default when undefined), pending-return flows (`showSuccess` vs auto-redirect via `window.location.assign`), same-origin internal navigation via `react-router` `navigate`, and the no-pending-return idle case.
> 
> **`account-center-route`** tests exercise `handleAccountCenterRoute` (base-path restore via `history.replaceState`, one-time session clear, skip on `?code=` / `?error=`, `redirect` / `show_success` query parsing, invalid redirect rejection) and `setRouteRestore` allowlisting for known account routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1e178e488be70f41a778f7bbeb9c61c6f7d5a71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->