### PR TITLE
feat(account): add avatar upload field to profile page

### DIFF
--- a/packages/account/src/apis/account.ts
+++ b/packages/account/src/apis/account.ts
@@ -51,6 +51,12 @@ export const updateName = async (accessToken: string, payload: { name: Nullable<
   });
 };
 
+export const updateAvatar = async (accessToken: string, payload: { avatar: Nullable<string> }) => {
+  await createAuthenticatedKy(accessToken).patch('/api/my-account', {
+    json: payload,
+  });
+};
+
 export const updateProfile = async (accessToken: string, payload: UserProfile) => {
   await createAuthenticatedKy(accessToken).patch('/api/my-account/profile', {
     json: payload,

--- a/packages/account/src/apis/avatar.ts
+++ b/packages/account/src/apis/avatar.ts
@@ -1,0 +1,19 @@
+import type { UserAssets } from '@logto/schemas';
+
+import { createAuthenticatedKy } from './base-ky';
+
+export const uploadAccountAvatar = async (
+  accessToken: string,
+  file: File,
+  options?: { signal?: AbortSignal }
+) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  return createAuthenticatedKy(accessToken)
+    .post('/api/my-account/user-assets/avatar', {
+      body: formData,
+      signal: options?.signal,
+    })
+    .json<UserAssets>();
+};

--- a/packages/account/src/components/AvatarUploadField/index.module.scss
+++ b/packages/account/src/components/AvatarUploadField/index.module.scss
@@ -1,81 +1,16 @@
 @use '@experience/shared/scss/underscore' as _;
 
-$avatar-size: _.unit(10);
-
-.container {
+.valueContent {
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
-  gap: _.unit(4);
-  padding: _.unit(5) _.unit(6);
-}
-
-.avatarSlot {
-  flex-shrink: 0;
-  width: $avatar-size;
-  height: $avatar-size;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.avatar {
-  width: $avatar-size;
-  height: $avatar-size;
-  border-radius: _.unit(2);
-  object-fit: cover;
-  object-position: center;
+  gap: _.unit(1);
 }
 
 .placeholder {
-  width: $avatar-size;
-  height: $avatar-size;
-  border-radius: _.unit(2);
-}
-
-.controls {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: _.unit(1.5);
-  min-width: 0;
-  min-height: $avatar-size;
-  justify-content: center;
-}
-
-.buttonRow {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: _.unit(3);
-}
-
-.uploadButton {
-  cursor: pointer;
-  font: var(--font-label-2);
-  color: var(--color-type-link);
-  background: none;
-  border: none;
-  padding: 0;
-  white-space: nowrap;
-
-  &:hover {
-    text-decoration: underline;
-  }
-
-  &:disabled {
-    cursor: not-allowed;
-    opacity: 50%;
-  }
-}
-
-.removeButton {
-  cursor: pointer;
-  font: var(--font-label-2);
-  color: var(--color-danger-default);
-  background: none;
-  border: none;
-  padding: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
 }
 
 .hint,
@@ -96,14 +31,7 @@ $avatar-size: _.unit(10);
 }
 
 .loadingIcon {
-  width: _.unit(6);
-  height: _.unit(6);
+  width: 32px;
+  height: 32px;
   color: var(--color-brand-default);
-}
-
-:global(body.mobile) {
-  .container {
-    padding: _.unit(4);
-    gap: _.unit(3);
-  }
 }

--- a/packages/account/src/components/AvatarUploadField/index.module.scss
+++ b/packages/account/src/components/AvatarUploadField/index.module.scss
@@ -1,0 +1,109 @@
+@use '@experience/shared/scss/underscore' as _;
+
+$avatar-size: _.unit(10);
+
+.container {
+  display: flex;
+  align-items: flex-start;
+  gap: _.unit(4);
+  padding: _.unit(5) _.unit(6);
+}
+
+.avatarSlot {
+  flex-shrink: 0;
+  width: $avatar-size;
+  height: $avatar-size;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.avatar {
+  width: $avatar-size;
+  height: $avatar-size;
+  border-radius: _.unit(2);
+  object-fit: cover;
+  object-position: center;
+}
+
+.placeholder {
+  width: $avatar-size;
+  height: $avatar-size;
+  border-radius: _.unit(2);
+}
+
+.controls {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: _.unit(1.5);
+  min-width: 0;
+  min-height: $avatar-size;
+  justify-content: center;
+}
+
+.buttonRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: _.unit(3);
+}
+
+.uploadButton {
+  cursor: pointer;
+  font: var(--font-label-2);
+  color: var(--color-type-link);
+  background: none;
+  border: none;
+  padding: 0;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 50%;
+  }
+}
+
+.removeButton {
+  cursor: pointer;
+  font: var(--font-label-2);
+  color: var(--color-danger-default);
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.hint,
+.errorText {
+  font: var(--font-body-3);
+}
+
+.hint {
+  color: var(--color-type-secondary);
+}
+
+.errorText {
+  color: var(--color-danger-default);
+}
+
+.hiddenInput {
+  display: none;
+}
+
+.loadingIcon {
+  width: _.unit(6);
+  height: _.unit(6);
+  color: var(--color-brand-default);
+}
+
+:global(body.mobile) {
+  .container {
+    padding: _.unit(4);
+    gap: _.unit(3);
+  }
+}

--- a/packages/account/src/components/AvatarUploadField/index.module.scss
+++ b/packages/account/src/components/AvatarUploadField/index.module.scss
@@ -13,16 +13,8 @@
   border-radius: 8px;
 }
 
-.hint,
 .errorText {
   font: var(--font-body-3);
-}
-
-.hint {
-  color: var(--color-type-secondary);
-}
-
-.errorText {
   color: var(--color-danger-default);
 }
 

--- a/packages/account/src/components/AvatarUploadField/index.tsx
+++ b/packages/account/src/components/AvatarUploadField/index.tsx
@@ -15,7 +15,9 @@ import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { uploadAccountAvatar } from '@ac/apis/avatar';
+import { layoutClassNames } from '@ac/constants/layout';
 
+import profileStyles from '../../pages/Profile/index.module.scss';
 import styles from './index.module.scss';
 
 const isAbortError = (error: unknown) =>
@@ -23,11 +25,12 @@ const isAbortError = (error: unknown) =>
 
 type Props = {
   readonly className?: string;
+  readonly label: string;
   readonly value?: string;
   readonly onChange: (value: string) => void;
 };
 
-const AvatarUploadField = ({ className, value = '', onChange }: Props) => {
+const AvatarUploadField = ({ className, label, value = '', onChange }: Props) => {
   const { t } = useTranslation();
   const { t: tAvatar } = useTranslation(undefined, { keyPrefix: 'profile.avatar_upload' });
   const { getAccessToken } = useLogto();
@@ -132,58 +135,57 @@ const AvatarUploadField = ({ className, value = '', onChange }: Props) => {
     [getAccessToken, handleUploadError, onChange, resetFileInput, tAvatar]
   );
 
-  const handleRemove = useCallback(() => {
-    setUploadError(undefined);
-    onChange('');
-  }, [onChange]);
+  const actionLabel = isUploading
+    ? tAvatar('uploading')
+    : value
+      ? t('account_center.security.change')
+      : tAvatar('upload');
 
-  const showRemove = Boolean(value) && !isUploading;
-  const showHint = !uploadError && !isUploading;
+  const showHint = !uploadError && !isUploading && !value;
 
   return (
-    <div className={classNames(styles.container, className)}>
-      <div className={styles.avatarSlot}>
-        {isUploading ? (
-          <div className={styles.loadingIcon}>
-            <RotatingRingIcon />
-          </div>
-        ) : value ? (
-          <img className={styles.avatar} src={value} alt="avatar" referrerPolicy="no-referrer" />
-        ) : (
-          <UserAvatar className={styles.placeholder} />
-        )}
-      </div>
-      <div className={styles.controls}>
-        <div className={styles.buttonRow}>
+    <div className={classNames(profileStyles.row, layoutClassNames.row, className)}>
+      <div className={profileStyles.topLine}>
+        <div className={profileStyles.name}>{label}</div>
+        <div className={profileStyles.actions}>
           <button
             type="button"
-            className={styles.uploadButton}
+            className={profileStyles.changeButton}
             disabled={isUploading}
             onClick={openFilePicker}
           >
-            {isUploading
-              ? tAvatar('uploading')
-              : value
-                ? t('account_center.security.change')
-                : tAvatar('upload')}
+            {actionLabel}
           </button>
-          {showRemove && (
-            <button type="button" className={styles.removeButton} onClick={handleRemove}>
-              {tAvatar('remove')}
-            </button>
+        </div>
+      </div>
+      <div className={profileStyles.value}>
+        <div className={styles.valueContent}>
+          {isUploading ? (
+            <div className={styles.loadingIcon}>
+              <RotatingRingIcon />
+            </div>
+          ) : value ? (
+            <img
+              className={profileStyles.avatar}
+              src={value}
+              alt="avatar"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <UserAvatar className={styles.placeholder} />
+          )}
+          {uploadError ? (
+            <span className={styles.errorText} role="alert">
+              {uploadError}
+            </span>
+          ) : (
+            showHint && (
+              <span className={styles.hint}>
+                {tAvatar('hint', { limit: formatFileSizeLimit(maxUploadFileSize) })}
+              </span>
+            )
           )}
         </div>
-        {uploadError ? (
-          <span className={styles.errorText} role="alert">
-            {uploadError}
-          </span>
-        ) : (
-          showHint && (
-            <span className={styles.hint}>
-              {tAvatar('hint', { limit: formatFileSizeLimit(maxUploadFileSize) })}
-            </span>
-          )
-        )}
       </div>
       <input
         key={fileInputKey}

--- a/packages/account/src/components/AvatarUploadField/index.tsx
+++ b/packages/account/src/components/AvatarUploadField/index.tsx
@@ -1,5 +1,3 @@
-import { uploadAccountAvatar } from '@ac/apis/avatar';
-import { layoutClassNames } from '@ac/constants/layout';
 import UserAvatar from '@experience/assets/icons/default-user-avatar.svg?react';
 import RotatingRingIcon from '@experience/shared/components/Button/RotatingRingIcon';
 import {
@@ -15,6 +13,9 @@ import classNames from 'classnames';
 import { HTTPError } from 'ky';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+
+import { uploadAccountAvatar } from '@ac/apis/avatar';
+import { layoutClassNames } from '@ac/constants/layout';
 
 import profileStyles from '../../pages/Profile/index.module.scss';
 

--- a/packages/account/src/components/AvatarUploadField/index.tsx
+++ b/packages/account/src/components/AvatarUploadField/index.tsx
@@ -28,7 +28,7 @@ type Props = {
   readonly className?: string;
   readonly label: string;
   readonly value?: string;
-  readonly onChange: (value: string) => void;
+  readonly onChange: (value: string) => void | Promise<void>;
 };
 
 const AvatarUploadField = ({ className, label, value = '', onChange }: Props) => {
@@ -96,7 +96,7 @@ const AvatarUploadField = ({ className, label, value = '', onChange }: Props) =>
       }
 
       if (validationError === 'file_type') {
-        setUploadError(tAvatar('error_file_type', { extensions: String(avatarFileExtensions) }));
+        setUploadError(tAvatar('error_file_type', { extensions: avatarFileExtensions }));
         resetFileInput();
         return;
       }
@@ -119,7 +119,7 @@ const AvatarUploadField = ({ className, label, value = '', onChange }: Props) =>
         const { url } = await uploadAccountAvatar(accessToken, file, {
           signal: abortController.signal,
         });
-        onChange(url);
+        await onChange(url);
       } catch (error: unknown) {
         if (isAbortError(error) || abortController.signal.aborted) {
           return;

--- a/packages/account/src/components/AvatarUploadField/index.tsx
+++ b/packages/account/src/components/AvatarUploadField/index.tsx
@@ -1,0 +1,201 @@
+import UserAvatar from '@experience/assets/icons/default-user-avatar.svg?react';
+import RotatingRingIcon from '@experience/shared/components/Button/RotatingRingIcon';
+import {
+  avatarFileAccept,
+  avatarFileExtensions,
+  formatFileSizeLimit,
+  getAvatarUploadErrorMessage,
+  validateAvatarFile,
+} from '@experience/utils/avatar-upload';
+import { useLogto } from '@logto/react';
+import { maxUploadFileSize, type RequestErrorBody } from '@logto/schemas';
+import classNames from 'classnames';
+import { HTTPError } from 'ky';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { uploadAccountAvatar } from '@ac/apis/avatar';
+
+import styles from './index.module.scss';
+
+const isAbortError = (error: unknown) =>
+  (error instanceof DOMException || error instanceof Error) && error.name === 'AbortError';
+
+type Props = {
+  readonly className?: string;
+  readonly value?: string;
+  readonly onChange: (value: string) => void;
+};
+
+const AvatarUploadField = ({ className, value = '', onChange }: Props) => {
+  const { t } = useTranslation();
+  const { t: tAvatar } = useTranslation(undefined, { keyPrefix: 'profile.avatar_upload' });
+  const { getAccessToken } = useLogto();
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const abortControllerRef = useRef<AbortController>();
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string>();
+  const [fileInputKey, setFileInputKey] = useState(0);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  const openFilePicker = useCallback(() => {
+    if (isUploading) {
+      return;
+    }
+
+    inputRef.current?.click();
+  }, [isUploading]);
+
+  const resetFileInput = useCallback(() => {
+    setFileInputKey((key) => key + 1);
+  }, []);
+
+  const handleUploadError = useCallback(
+    async (error: unknown) => {
+      if (error instanceof HTTPError) {
+        try {
+          const errorBody = await error.response.json<RequestErrorBody>();
+          setUploadError(getAvatarUploadErrorMessage(errorBody, tAvatar));
+          return;
+        } catch {
+          // Fall through to generic error message.
+        }
+      }
+
+      setUploadError(tAvatar('error_upload'));
+    },
+    [tAvatar]
+  );
+
+  const handleFileChange = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+
+      if (!file) {
+        return;
+      }
+
+      const validationError = validateAvatarFile(file);
+
+      if (validationError === 'file_size_exceeded') {
+        setUploadError(
+          tAvatar('error_file_size', { limit: formatFileSizeLimit(maxUploadFileSize) })
+        );
+        resetFileInput();
+        return;
+      }
+
+      if (validationError === 'file_type') {
+        setUploadError(tAvatar('error_file_type', { extensions: String(avatarFileExtensions) }));
+        resetFileInput();
+        return;
+      }
+
+      abortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      abortControllerRef.current = abortController;
+
+      setUploadError(undefined);
+      setIsUploading(true);
+
+      try {
+        const accessToken = await getAccessToken();
+
+        if (!accessToken) {
+          throw new Error('Session expired');
+        }
+
+        const { url } = await uploadAccountAvatar(accessToken, file, {
+          signal: abortController.signal,
+        });
+        onChange(url);
+      } catch (error: unknown) {
+        if (isAbortError(error) || abortController.signal.aborted) {
+          return;
+        }
+
+        await handleUploadError(error);
+      } finally {
+        if (!abortController.signal.aborted) {
+          setIsUploading(false);
+          setFileInputKey((key) => key + 1);
+        }
+      }
+    },
+    [getAccessToken, handleUploadError, onChange, resetFileInput, tAvatar]
+  );
+
+  const handleRemove = useCallback(() => {
+    setUploadError(undefined);
+    onChange('');
+  }, [onChange]);
+
+  const showRemove = Boolean(value) && !isUploading;
+  const showHint = !uploadError && !isUploading;
+
+  return (
+    <div className={classNames(styles.container, className)}>
+      <div className={styles.avatarSlot}>
+        {isUploading ? (
+          <div className={styles.loadingIcon}>
+            <RotatingRingIcon />
+          </div>
+        ) : value ? (
+          <img className={styles.avatar} src={value} alt="avatar" referrerPolicy="no-referrer" />
+        ) : (
+          <UserAvatar className={styles.placeholder} />
+        )}
+      </div>
+      <div className={styles.controls}>
+        <div className={styles.buttonRow}>
+          <button
+            type="button"
+            className={styles.uploadButton}
+            disabled={isUploading}
+            onClick={openFilePicker}
+          >
+            {isUploading
+              ? tAvatar('uploading')
+              : value
+                ? t('account_center.security.change')
+                : tAvatar('upload')}
+          </button>
+          {showRemove && (
+            <button type="button" className={styles.removeButton} onClick={handleRemove}>
+              {tAvatar('remove')}
+            </button>
+          )}
+        </div>
+        {uploadError ? (
+          <span className={styles.errorText} role="alert">
+            {uploadError}
+          </span>
+        ) : (
+          showHint && (
+            <span className={styles.hint}>
+              {tAvatar('hint', { limit: formatFileSizeLimit(maxUploadFileSize) })}
+            </span>
+          )
+        )}
+      </div>
+      <input
+        key={fileInputKey}
+        ref={inputRef}
+        id={inputId}
+        className={styles.hiddenInput}
+        type="file"
+        accept={avatarFileAccept}
+        onChange={handleFileChange}
+      />
+    </div>
+  );
+};
+
+export default AvatarUploadField;

--- a/packages/account/src/components/AvatarUploadField/index.tsx
+++ b/packages/account/src/components/AvatarUploadField/index.tsx
@@ -1,3 +1,5 @@
+import { uploadAccountAvatar } from '@ac/apis/avatar';
+import { layoutClassNames } from '@ac/constants/layout';
 import UserAvatar from '@experience/assets/icons/default-user-avatar.svg?react';
 import RotatingRingIcon from '@experience/shared/components/Button/RotatingRingIcon';
 import {
@@ -13,9 +15,6 @@ import classNames from 'classnames';
 import { HTTPError } from 'ky';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-
-import { uploadAccountAvatar } from '@ac/apis/avatar';
-import { layoutClassNames } from '@ac/constants/layout';
 
 import profileStyles from '../../pages/Profile/index.module.scss';
 
@@ -145,7 +144,9 @@ const AvatarUploadField = ({ className, label, value = '', onChange }: Props) =>
   return (
     <div className={classNames(profileStyles.row, layoutClassNames.row, className)}>
       <div className={profileStyles.topLine}>
-        <div className={profileStyles.name}>{label}</div>
+        <label className={profileStyles.name} htmlFor={inputId}>
+          {label}
+        </label>
         <div className={profileStyles.actions}>
           <button
             type="button"
@@ -167,7 +168,7 @@ const AvatarUploadField = ({ className, label, value = '', onChange }: Props) =>
             <img
               className={profileStyles.avatar}
               src={value}
-              alt="avatar"
+              alt={label}
               referrerPolicy="no-referrer"
             />
           ) : (

--- a/packages/account/src/components/AvatarUploadField/index.tsx
+++ b/packages/account/src/components/AvatarUploadField/index.tsx
@@ -142,8 +142,6 @@ const AvatarUploadField = ({ className, label, value = '', onChange }: Props) =>
       ? t('account_center.security.change')
       : tAvatar('upload');
 
-  const showHint = !uploadError && !isUploading && !value;
-
   return (
     <div className={classNames(profileStyles.row, layoutClassNames.row, className)}>
       <div className={profileStyles.topLine}>
@@ -175,16 +173,10 @@ const AvatarUploadField = ({ className, label, value = '', onChange }: Props) =>
           ) : (
             <UserAvatar className={styles.placeholder} />
           )}
-          {uploadError ? (
+          {uploadError && (
             <span className={styles.errorText} role="alert">
               {uploadError}
             </span>
-          ) : (
-            showHint && (
-              <span className={styles.hint}>
-                {tAvatar('hint', { limit: formatFileSizeLimit(maxUploadFileSize) })}
-              </span>
-            )
           )}
         </div>
       </div>

--- a/packages/account/src/components/AvatarUploadField/index.tsx
+++ b/packages/account/src/components/AvatarUploadField/index.tsx
@@ -1,3 +1,5 @@
+import { uploadAccountAvatar } from '@ac/apis/avatar';
+import { layoutClassNames } from '@ac/constants/layout';
 import UserAvatar from '@experience/assets/icons/default-user-avatar.svg?react';
 import RotatingRingIcon from '@experience/shared/components/Button/RotatingRingIcon';
 import {
@@ -14,10 +16,8 @@ import { HTTPError } from 'ky';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { uploadAccountAvatar } from '@ac/apis/avatar';
-import { layoutClassNames } from '@ac/constants/layout';
-
 import profileStyles from '../../pages/Profile/index.module.scss';
+
 import styles from './index.module.scss';
 
 const isAbortError = (error: unknown) =>

--- a/packages/account/src/pages/Profile/index.test.tsx
+++ b/packages/account/src/pages/Profile/index.test.tsx
@@ -321,6 +321,13 @@ describe('<Profile />', () => {
     expect(queryMissingAvatarAltText('avatar')).toBeNull();
   });
 
+  it('shows only change action for avatar when an image is set', () => {
+    const { queryByText } = renderProfile();
+
+    expect(queryByText('profile.avatar_upload.remove')).toBeNull();
+    expect(queryByText('profile.avatar_upload.upload')).toBeNull();
+  });
+
   it('renders avatar image in read-only mode with label and not_set placeholder', () => {
     const { queryByAltText, unmount } = renderProfile({
       accountCenterSettings: {

--- a/packages/account/src/pages/Profile/index.test.tsx
+++ b/packages/account/src/pages/Profile/index.test.tsx
@@ -18,6 +18,7 @@ import renderWithPageContext, {
 } from '@ac/__mocks__/RenderWithPageContext';
 
 import { updateAvatar, updateCustomData, updateName, updateProfile } from '../../apis/account';
+import { uploadAccountAvatar } from '../../apis/avatar';
 
 import Profile from '.';
 
@@ -326,6 +327,26 @@ describe('<Profile />', () => {
 
     expect(queryByText('profile.avatar_upload.remove')).toBeNull();
     expect(queryByText('profile.avatar_upload.upload')).toBeNull();
+  });
+
+  it('uploads avatar and persists URL via updateAvatar', async () => {
+    const refreshUserInfo = jest.fn().mockResolvedValue(undefined);
+    const setToast = jest.fn();
+    const mockUrl = 'https://example.com/new-avatar.png';
+    jest.mocked(uploadAccountAvatar).mockResolvedValueOnce({ url: mockUrl });
+
+    const { container } = renderProfile({ refreshUserInfo, setToast });
+    const fileInput = container.querySelector('input[type="file"]')!;
+    const file = new File(['avatar'], 'avatar.png', { type: 'image/png' });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(uploadAccountAvatar).toHaveBeenCalledWith('access-token', file, expect.any(Object));
+    });
+    await waitFor(() => {
+      expect(updateAvatar).toHaveBeenCalledWith('access-token', { avatar: mockUrl });
+    });
   });
 
   it('renders avatar image in read-only mode with label and not_set placeholder', () => {

--- a/packages/account/src/pages/Profile/index.test.tsx
+++ b/packages/account/src/pages/Profile/index.test.tsx
@@ -17,7 +17,7 @@ import renderWithPageContext, {
   mockUserInfo,
 } from '@ac/__mocks__/RenderWithPageContext';
 
-import { updateCustomData, updateName, updateProfile } from '../../apis/account';
+import { updateAvatar, updateCustomData, updateName, updateProfile } from '../../apis/account';
 
 import Profile from '.';
 
@@ -30,9 +30,14 @@ jest.mock('@logto/react', () => ({
 }));
 
 jest.mock('../../apis/account', () => ({
+  updateAvatar: jest.fn(),
   updateCustomData: jest.fn(),
   updateName: jest.fn(),
   updateProfile: jest.fn(),
+}));
+
+jest.mock('../../apis/avatar', () => ({
+  uploadAccountAvatar: jest.fn(),
 }));
 
 type ProfileRenderOptions = {
@@ -210,6 +215,7 @@ describe('<Profile />', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockGetAccessToken.mockResolvedValue('access-token');
+    jest.mocked(updateAvatar).mockResolvedValue(undefined);
     jest.mocked(updateCustomData).mockResolvedValue(undefined);
     jest.mocked(updateName).mockResolvedValue(undefined);
     jest.mocked(updateProfile).mockResolvedValue(undefined);
@@ -224,8 +230,7 @@ describe('<Profile />', () => {
     expect(queryByText('name')).not.toBeNull();
     expect(queryByText('Alex')).not.toBeNull();
 
-    expect(queryByText('avatar')).not.toBeNull();
-    expect(queryByAltText('Alex')).not.toBeNull();
+    expect(queryByAltText('avatar')).not.toBeNull();
 
     expect(queryByText('birthdate')).not.toBeNull();
     expect(queryByText('2023-08-20')).not.toBeNull();
@@ -233,7 +238,7 @@ describe('<Profile />', () => {
     expect(queryByText('Favorite color')).not.toBeNull();
     expect(queryByText('Red')).not.toBeNull();
 
-    expect(queryAllByText('account_center.security.change')).toHaveLength(3);
+    expect(queryAllByText('account_center.security.change')).toHaveLength(4);
   });
 
   it('renders read-only profile fields in display-only state', () => {
@@ -300,8 +305,30 @@ describe('<Profile />', () => {
     expect(queryByText('account_center.security.change')).toBeNull();
   });
 
-  it('renders avatar image when available and not_set placeholder when missing', () => {
+  it('renders avatar image when available and upload placeholder when missing (edit mode)', () => {
     const { queryByAltText, unmount } = renderProfile();
+
+    expect(queryByAltText('avatar')).not.toBeNull();
+
+    unmount();
+
+    const { queryByAltText: queryMissingAvatarAltText } = renderProfile({
+      userInfo: {
+        avatar: null,
+      },
+    });
+
+    expect(queryMissingAvatarAltText('avatar')).toBeNull();
+  });
+
+  it('renders avatar image in read-only mode with label and not_set placeholder', () => {
+    const { queryByAltText, unmount } = renderProfile({
+      accountCenterSettings: {
+        fields: {
+          avatar: AccountCenterControlValue.ReadOnly,
+        },
+      },
+    });
 
     expect(queryByAltText('Alex')).not.toBeNull();
 
@@ -309,6 +336,11 @@ describe('<Profile />', () => {
 
     const { queryByAltText: queryMissingAvatarAltText, queryByText: queryMissingAvatarText } =
       renderProfile({
+        accountCenterSettings: {
+          fields: {
+            avatar: AccountCenterControlValue.ReadOnly,
+          },
+        },
         userInfo: {
           avatar: null,
         },
@@ -410,7 +442,7 @@ describe('<Profile />', () => {
   it('updates custom data fields without dropping existing custom data', async () => {
     const { getByText, queryAllByText } = renderProfile();
 
-    fireEvent.click(queryAllByText('account_center.security.change')[2]!);
+    fireEvent.click(queryAllByText('account_center.security.change')[3]!);
     fireEvent.click(document.querySelector('input[name="favoriteColor"]')!);
     fireEvent.click(getByText('Blue'));
     fireEvent.click(getByText('action.save'));
@@ -504,7 +536,7 @@ describe('<Profile />', () => {
   it('edits birthdate with segmented date inputs', async () => {
     const { getByText, queryAllByText } = renderProfile();
 
-    fireEvent.click(queryAllByText('account_center.security.change')[1]!);
+    fireEvent.click(queryAllByText('account_center.security.change')[2]!);
 
     const [yearInput, monthInput, dayInput] = document.querySelectorAll(
       'input[inputmode="numeric"]'
@@ -595,7 +627,7 @@ describe('<Profile />', () => {
   it('shows a validation error for invalid birthdate input', async () => {
     const { getByText, queryAllByText } = renderProfile();
 
-    fireEvent.click(queryAllByText('account_center.security.change')[1]!);
+    fireEvent.click(queryAllByText('account_center.security.change')[2]!);
 
     const [yearInput, monthInput, dayInput] = document.querySelectorAll(
       'input[inputmode="numeric"]'

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -124,6 +124,7 @@ const Profile = () => {
                     return (
                       <AvatarUploadField
                         key={name}
+                        label={label}
                         value={userInfo?.avatar ?? ''}
                         onChange={handleAvatarChange}
                       />

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -4,9 +4,13 @@ import { useCallback, useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
+import { updateAvatar } from '@ac/apis/account';
 import AccountPageHeader from '@ac/components/AccountPageHeader';
+import AvatarUploadField from '@ac/components/AvatarUploadField';
 import PageFooter from '@ac/components/PageFooter';
 import { layoutClassNames } from '@ac/constants/layout';
+import useApi from '@ac/hooks/use-api';
+import useErrorHandler from '@ac/hooks/use-error-handler';
 
 import homeStyles from '../Home/index.module.scss';
 
@@ -79,6 +83,24 @@ const Profile = () => {
     userInfo,
   ]);
 
+  const updateAvatarRequest = useApi(updateAvatar);
+  const handleError = useErrorHandler();
+
+  const handleAvatarChange = useCallback(
+    async (avatarUrl: string) => {
+      const [error] = await updateAvatarRequest({ avatar: avatarUrl || null });
+
+      if (error) {
+        await handleError(error);
+        return;
+      }
+
+      await refreshUserInfo();
+      setToast(t('account_center.update_success.default.description'));
+    },
+    [handleError, refreshUserInfo, setToast, t, updateAvatarRequest]
+  );
+
   const handleUpdated = useCallback(async () => {
     await refreshUserInfo();
     setToast(t('account_center.update_success.default.description'));
@@ -97,6 +119,16 @@ const Profile = () => {
               <div className={classNames(styles.card, layoutClassNames.card)}>
                 {fieldRows.map((fieldRow) => {
                   const { name, label, value, controlValue } = fieldRow;
+
+                  if (name === 'avatar' && controlValue === AccountCenterControlValue.Edit) {
+                    return (
+                      <AvatarUploadField
+                        key={name}
+                        value={userInfo?.avatar ?? ''}
+                        onChange={handleAvatarChange}
+                      />
+                    );
+                  }
 
                   return (
                     <div key={name} className={classNames(styles.row, layoutClassNames.row)}>

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -1,8 +1,3 @@
-import { AccountCenterControlValue, type CustomProfileField } from '@logto/schemas';
-import classNames from 'classnames';
-import { useCallback, useContext, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import { updateAvatar } from '@ac/apis/account';
 import AccountPageHeader from '@ac/components/AccountPageHeader';
@@ -11,6 +6,10 @@ import PageFooter from '@ac/components/PageFooter';
 import { layoutClassNames } from '@ac/constants/layout';
 import useApi from '@ac/hooks/use-api';
 import useErrorHandler from '@ac/hooks/use-error-handler';
+import { AccountCenterControlValue, type CustomProfileField } from '@logto/schemas';
+import classNames from 'classnames';
+import { useCallback, useContext, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import homeStyles from '../Home/index.module.scss';
 
@@ -88,7 +87,7 @@ const Profile = () => {
 
   const handleAvatarChange = useCallback(
     async (avatarUrl: string) => {
-      const [error] = await updateAvatarRequest({ avatar: avatarUrl || null });
+      const [error] = await updateAvatarRequest({ avatar: avatarUrl });
 
       if (error) {
         await handleError(error);

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -1,3 +1,8 @@
+import { AccountCenterControlValue, type CustomProfileField } from '@logto/schemas';
+import classNames from 'classnames';
+import { useCallback, useContext, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import { updateAvatar } from '@ac/apis/account';
 import AccountPageHeader from '@ac/components/AccountPageHeader';
@@ -6,10 +11,6 @@ import PageFooter from '@ac/components/PageFooter';
 import { layoutClassNames } from '@ac/constants/layout';
 import useApi from '@ac/hooks/use-api';
 import useErrorHandler from '@ac/hooks/use-error-handler';
-import { AccountCenterControlValue, type CustomProfileField } from '@logto/schemas';
-import classNames from 'classnames';
-import { useCallback, useContext, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import homeStyles from '../Home/index.module.scss';
 


### PR DESCRIPTION
## Summary

Add avatar upload functionality to the Account Center profile page. When the avatar field is configured as `Edit` in account center settings, users can upload or change their avatar directly from the profile page.

Changes:
- New `AvatarUploadField` component in the account package with file upload, preview, loading state, and error handling
- New `uploadAccountAvatar` API function targeting `POST /api/my-account/user-assets/avatar`
- New `updateAvatar` API function using `PATCH /api/my-account` to persist avatar URL changes
- Profile page integration: renders `AvatarUploadField` for avatar when editable, falls back to read-only display otherwise
- Reuses validation utilities (`validateAvatarFile`, `getAvatarUploadErrorMessage`, etc.) and UI assets from the experience package
- Accessible label wired to file input via `htmlFor`; localized `alt` text on avatar image

### Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/cced3ec4fd77409f913c244303f2d894
Requested by: @wangsijie