### PR TITLE
fix(experience): validate preview postMessage comes from parent frame

### DIFF
--- a/packages/console/src/components/SignInExperiencePreview/index.tsx
+++ b/packages/console/src/components/SignInExperiencePreview/index.tsx
@@ -1,5 +1,10 @@
 import type { LanguageTag } from '@logto/language-kit';
-import { Theme, ConnectorType, ForgotPasswordMethod } from '@logto/schemas';
+import {
+  Theme,
+  ConnectorType,
+  ForgotPasswordMethod,
+  signInExperiencePreviewMessageSender,
+} from '@logto/schemas';
 import type { ConnectorMetadata, ConnectorResponse } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
@@ -119,7 +124,7 @@ function SignInExperiencePreview({
     }
 
     previewRef.current?.contentWindow?.postMessage(
-      { sender: 'ac_preview', config: configForUiPage },
+      { sender: signInExperiencePreviewMessageSender, config: configForUiPage },
       endpoint?.origin ?? ''
     );
   }, [endpoint?.origin, configForUiPage, customPhrases]);

--- a/packages/experience/src/Providers/SettingsProvider/use-preview.ts
+++ b/packages/experience/src/Providers/SettingsProvider/use-preview.ts
@@ -5,6 +5,7 @@ import PageContext from '@/Providers/PageContextProvider/PageContext';
 import initI18n from '@/i18n/init';
 import { changeLanguage } from '@/i18n/utils';
 import type { PreviewConfig, SignInExperienceResponse } from '@/types';
+import { isTrustedPreviewMessage } from '@/utils/preview-message';
 import { filterPreviewSocialConnectors } from '@/utils/social-connectors';
 
 const usePreview = () => {
@@ -15,16 +16,17 @@ const usePreview = () => {
   useEffect(() => {
     // Listen to the message from the ancestor window
     const previewMessageHandler = async (event: MessageEvent) => {
-      // #event.data should be guarded at the provider's side
-      if (event.data.sender === 'ac_preview') {
-        // eslint-disable-next-line no-restricted-syntax
-        const previewConfig = event.data.config as PreviewConfig;
+      if (!isTrustedPreviewMessage(event)) {
+        return;
+      }
+
+      // eslint-disable-next-line no-restricted-syntax
+      const previewConfig = event.data.config as PreviewConfig;
 
         // Wait for i18n to be initialized
-        await initI18n(previewConfig.language);
+      await initI18n(previewConfig.language);
 
-        setPreviewConfig(previewConfig);
-      }
+      setPreviewConfig(previewConfig);
     };
 
     window.addEventListener('message', previewMessageHandler);

--- a/packages/experience/src/Providers/SettingsProvider/use-preview.ts
+++ b/packages/experience/src/Providers/SettingsProvider/use-preview.ts
@@ -23,7 +23,7 @@ const usePreview = () => {
       // eslint-disable-next-line no-restricted-syntax
       const previewConfig = event.data.config as PreviewConfig;
 
-        // Wait for i18n to be initialized
+      // Wait for i18n to be initialized
       await initI18n(previewConfig.language);
 
       setPreviewConfig(previewConfig);

--- a/packages/experience/src/utils/preview-message.test.ts
+++ b/packages/experience/src/utils/preview-message.test.ts
@@ -1,73 +1,71 @@
-import { isTrustedPreviewMessage, previewMessageSender } from './preview-message';
+import { signInExperiencePreviewMessageSender } from '@logto/schemas';
+
+import { isTrustedPreviewMessage } from './preview-message';
+
+const parentWindow = { id: 'parent' } as unknown as Window;
+const otherWindow = { id: 'other' } as unknown as Window;
+const selfWindow = { id: 'self' } as unknown as Window;
 
 const createMessageEvent = (
   data: unknown,
-  options?: { source?: MessageEventSource | null; origin?: string }
-): MessageEvent =>
-  ({
-    data,
-    source: options?.source ?? null,
-    origin: options?.origin ?? 'https://console.example.com',
-  }) as MessageEvent;
+  source: MessageEvent['source'] = null
+): Pick<MessageEvent, 'data' | 'source'> => ({
+  data,
+  source,
+});
 
 describe('isTrustedPreviewMessage', () => {
-  const originalParent = window.parent;
-
-  afterEach(() => {
-    Object.defineProperty(window, 'parent', {
-      configurable: true,
-      value: originalParent,
-    });
-  });
-
   it('accepts a message from the direct parent frame', () => {
-    const parent = {} as Window;
-    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
-
     expect(
       isTrustedPreviewMessage(
-        createMessageEvent({ sender: previewMessageSender, config: {} }, { source: parent })
+        createMessageEvent(
+          { sender: signInExperiencePreviewMessageSender, config: {} },
+          parentWindow
+        ),
+        { parent: parentWindow, self: selfWindow }
       )
     ).toBe(true);
   });
 
   it('rejects messages when not embedded in a parent frame', () => {
-    Object.defineProperty(window, 'parent', { configurable: true, value: window });
-
     expect(
       isTrustedPreviewMessage(
-        createMessageEvent({ sender: previewMessageSender, config: {} }, { source: window })
+        createMessageEvent(
+          { sender: signInExperiencePreviewMessageSender, config: {} },
+          selfWindow
+        ),
+        { parent: selfWindow, self: selfWindow }
       )
     ).toBe(false);
   });
 
   it('rejects messages from a non-parent window', () => {
-    const parent = {} as Window;
-    const otherWindow = {} as Window;
-    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
-
     expect(
       isTrustedPreviewMessage(
-        createMessageEvent({ sender: previewMessageSender, config: {} }, { source: otherWindow })
+        createMessageEvent(
+          { sender: signInExperiencePreviewMessageSender, config: {} },
+          otherWindow
+        ),
+        { parent: parentWindow, self: selfWindow }
       )
     ).toBe(false);
   });
 
   it('rejects messages with an unexpected sender', () => {
-    const parent = {} as Window;
-    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
-
     expect(
-      isTrustedPreviewMessage(
-        createMessageEvent({ sender: 'other', config: {} }, { source: parent })
-      )
+      isTrustedPreviewMessage(createMessageEvent({ sender: 'other', config: {} }, parentWindow), {
+        parent: parentWindow,
+        self: selfWindow,
+      })
     ).toBe(false);
   });
 
   it('rejects non-object message data', () => {
-    const parent = {} as Window;
-    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
-
-    expect(isTrustedPreviewMessage(createMessageEvent('1', { source: parent }))).toBe(false);
+    expect(
+      isTrustedPreviewMessage(createMessageEvent('1', parentWindow), {
+        parent: parentWindow,
+        self: selfWindow,
+      })
+    ).toBe(false);
   });
 });

--- a/packages/experience/src/utils/preview-message.test.ts
+++ b/packages/experience/src/utils/preview-message.test.ts
@@ -1,0 +1,73 @@
+import { isTrustedPreviewMessage, previewMessageSender } from './preview-message';
+
+const createMessageEvent = (
+  data: unknown,
+  options?: { source?: MessageEventSource | null; origin?: string }
+): MessageEvent =>
+  ({
+    data,
+    source: options?.source ?? null,
+    origin: options?.origin ?? 'https://console.example.com',
+  }) as MessageEvent;
+
+describe('isTrustedPreviewMessage', () => {
+  const originalParent = window.parent;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      value: originalParent,
+    });
+  });
+
+  it('accepts a message from the direct parent frame', () => {
+    const parent = {} as Window;
+    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
+
+    expect(
+      isTrustedPreviewMessage(
+        createMessageEvent({ sender: previewMessageSender, config: {} }, { source: parent })
+      )
+    ).toBe(true);
+  });
+
+  it('rejects messages when not embedded in a parent frame', () => {
+    Object.defineProperty(window, 'parent', { configurable: true, value: window });
+
+    expect(
+      isTrustedPreviewMessage(
+        createMessageEvent({ sender: previewMessageSender, config: {} }, { source: window })
+      )
+    ).toBe(false);
+  });
+
+  it('rejects messages from a non-parent window', () => {
+    const parent = {} as Window;
+    const otherWindow = {} as Window;
+    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
+
+    expect(
+      isTrustedPreviewMessage(
+        createMessageEvent({ sender: previewMessageSender, config: {} }, { source: otherWindow })
+      )
+    ).toBe(false);
+  });
+
+  it('rejects messages with an unexpected sender', () => {
+    const parent = {} as Window;
+    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
+
+    expect(
+      isTrustedPreviewMessage(
+        createMessageEvent({ sender: 'other', config: {} }, { source: parent })
+      )
+    ).toBe(false);
+  });
+
+  it('rejects non-object message data', () => {
+    const parent = {} as Window;
+    Object.defineProperty(window, 'parent', { configurable: true, value: parent });
+
+    expect(isTrustedPreviewMessage(createMessageEvent('1', { source: parent }))).toBe(false);
+  });
+});

--- a/packages/experience/src/utils/preview-message.ts
+++ b/packages/experience/src/utils/preview-message.ts
@@ -1,0 +1,28 @@
+import { isObject } from '@silverhand/essentials';
+
+export const previewMessageSender = 'ac_preview';
+
+/**
+ * Validates a `postMessage` event for sign-in experience live preview.
+ *
+ * Preview config is sent from the admin Console iframe parent. Console and Experience
+ * run on different origins (e.g. admin :3002 vs tenant :3001), so checking
+ * `event.origin === window.location.origin` would reject legitimate messages.
+ *
+ * Instead, require the message to come from the direct parent frame. That matches how
+ * {@link SignInExperiencePreview} embeds Experience, and blocks cross-origin windows that
+ * only hold a reference (e.g. via `window.open`) because their `event.source` is not
+ * `window.parent`. Embedding by non-admin origins is already restricted by CSP
+ * `frame-ancestors` on the Experience app.
+ */
+export const isTrustedPreviewMessage = (event: MessageEvent): boolean => {
+  if (!isObject(event.data) || event.data.sender !== previewMessageSender) {
+    return false;
+  }
+
+  if (window.parent === window) {
+    return false;
+  }
+
+  return event.source === window.parent;
+};

--- a/packages/experience/src/utils/preview-message.ts
+++ b/packages/experience/src/utils/preview-message.ts
@@ -1,6 +1,17 @@
+import { signInExperiencePreviewMessageSender } from '@logto/schemas';
 import { isObject } from '@silverhand/essentials';
 
-export const previewMessageSender = 'ac_preview';
+type PreviewMessageEvent = Pick<MessageEvent, 'data' | 'source'>;
+
+type PreviewMessageContext = {
+  parent: Window;
+  self: Window;
+};
+
+const defaultContext = (): PreviewMessageContext => ({
+  parent: window.parent,
+  self: window,
+});
 
 /**
  * Validates a `postMessage` event for sign-in experience live preview.
@@ -15,14 +26,23 @@ export const previewMessageSender = 'ac_preview';
  * `window.parent`. Embedding by non-admin origins is already restricted by CSP
  * `frame-ancestors` on the Experience app.
  */
-export const isTrustedPreviewMessage = (event: MessageEvent): boolean => {
-  if (!isObject(event.data) || event.data.sender !== previewMessageSender) {
+export const isTrustedPreviewMessage = (
+  event: PreviewMessageEvent,
+  context: PreviewMessageContext = defaultContext()
+): boolean => {
+  if (
+    !isObject(event.data) ||
+    !('sender' in event.data) ||
+    event.data.sender !== signInExperiencePreviewMessageSender
+  ) {
     return false;
   }
 
-  if (window.parent === window) {
+  const { parent, self } = context;
+
+  if (parent === self) {
     return false;
   }
 
-  return event.source === window.parent;
+  return event.source === parent;
 };

--- a/packages/schemas/src/consts/experience.ts
+++ b/packages/schemas/src/consts/experience.ts
@@ -14,3 +14,6 @@ const routes = Object.freeze({
 export const experience = Object.freeze({
   routes,
 } as const);
+
+/** `postMessage` sender tag from admin Console sign-in experience live preview. */
+export const signInExperiencePreviewMessageSender = 'ac_preview' as const;

--- a/packages/schemas/src/consts/experience.ts
+++ b/packages/schemas/src/consts/experience.ts
@@ -16,4 +16,4 @@ export const experience = Object.freeze({
 } as const);
 
 /** `postMessage` sender tag from admin Console sign-in experience live preview. */
-export const signInExperiencePreviewMessageSender = 'ac_preview' as const;
+export const signInExperiencePreviewMessageSender = 'ac_preview';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #8902.

The sign-in experience preview listener accepted any `postMessage` with `sender: 'ac_preview'` without verifying who sent it. This change only applies preview config when the message comes from the direct parent frame (the admin Console iframe).

## Why not `event.origin === window.location.origin`?

Console and Experience run on different origins in normal deployments (e.g. admin `localhost:3002` vs tenant `localhost:3001`). The origin check suggested in the issue would reject legitimate preview updates and break the Console live preview.

## Approach

- Require `event.source === window.parent` and that the page is embedded (`window.parent !== window`).
- Blocks cross-origin windows that only hold a reference (e.g. via `window.open`), since their `event.source` is not the parent frame.
- Non-admin embedding is already limited by Experience CSP `frame-ancestors` (admin origins + `'self'`).

## Testing

Unit tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf07393b-2bf0-46e6-ba42-1a411a6ce6b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf07393b-2bf0-46e6-ba42-1a411a6ce6b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

