### PR TITLE
docs: add Cursor Cloud setup caveats to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,8 @@ Skills live under [.agents/skills/](.agents/skills/) ([Agent Skills](https://age
 
 ### Key caveats
 
+- If Core exits with `Undeployed database alterations found`, run `pnpm cli db alteration deploy next` (with `DB_URL` set), then restart `pnpm start:dev`.
+- If `pnpm install` fails in `sync-preset.js` with `ENOENT` for a `connector-*` `package.json`, remove that orphan directory under `packages/connectors/` (it is not in git) and re-run install.
 - `rsync` must be installed (needed by `@logto/core` for `copy:apidocs`). Install with `sudo apt-get install -y rsync` if missing.
 - Connector load errors at startup are expected in dev mode — connectors are not built by default (`pnpm start:dev` excludes them).
 - `@logto/core` unit tests require `pnpm build:test` in `packages/core` before running `pnpm test:only`, because Jest reads from `./build` (the tsup dev bundle doesn't include test files).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents two non-obvious setup issues encountered when bringing up the Logto dev stack in Cursor Cloud:

- Deploy pending DB alterations before starting Core when the database is behind the checkout
- Remove orphan `connector-*` directories that block `pnpm install` via `sync-preset.js`

## Testing

N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d4870b6-8092-4ea0-9842-2c69967bde5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d4870b6-8092-4ea0-9842-2c69967bde5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

