### PR TITLE
fix(core): avoid statement timeout in capped log count query

### DIFF
--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -30,8 +30,9 @@ type LogCondition = {
 
 /**
  * Bounds the rows counted to avoid a full `count(*)` traversal on tenants with
- * very large `logs` tables. The inner subquery walks `logs__created_at_id`
- * newest-first and stops at `LOGS_COUNT_CAP + 1` matches, sharply reducing the
+ * very large `logs` tables. The inner subquery is capped at `LOGS_COUNT_CAP + 1`
+ * rows via `LIMIT`, so the outer `count(*)` never scans beyond that; a result
+ * exceeding `LOGS_COUNT_CAP` is then reported as capped. This sharply reduces the
  * chance of hitting `statement_timeout`.
  */
 const LOGS_COUNT_CAP = 10_000;
@@ -91,16 +92,12 @@ export const createLogQueries = (pool: CommonQueryMethods) => {
     }
 
     const cappedLimit = LOGS_COUNT_CAP + 1;
-    // `order by created_at desc` lets Postgres use `logs__created_at_id` so
-    // `LIMIT` acts as a true scan boundary even when the residual filter is
-    // sparse. Matches the order `findLogs` returns rows in.
     const { count } = await pool.one<{ count: string }>(sql`
       select count(*)
       from (
         select 1
         from ${table}
         ${buildLogConditionSql(condition)}
-        order by ${fields.createdAt} desc
         limit ${cappedLimit}
       ) s
     `);


### PR DESCRIPTION
## Summary

Reverts the `order by created_at desc` added to the capped `countLogs` subquery in #8816, which was the cause of a recurring `StatementTimeoutError` on `GET /api/logs` for requests like `?enableCap=true&userId=...&start_time=...`.

### Root cause
The capped count query forced `order by created_at desc`, which pins Postgres to the `logs__created_at_id` index `(tenant_id, created_at, id)`. For a **sparse** residual filter — e.g. a specific `userId`, which almost never has 10,000+ audit logs — the `LIMIT 10001` boundary is never reached. The planner walks the entire `created_at > start_time` window row-by-row checking `payload->>'userId'`, scanning potentially millions of rows, and hits `statement_timeout`. The ideal index for this shape, `logs__user_id` on `(tenant_id, payload->>'userId')`, can't be used because it doesn't provide `created_at` order.

### What changed
- Dropped `order by created_at desc` from the capped subquery in `packages/core/src/queries/log.ts`. Chronological order is irrelevant to a count whose only job is "exact count, or 10,000+". Without the forced ordering the planner uses `logs__user_id` to seek directly to the (few) matching rows, while `LIMIT` still bounds the dense, unfiltered listing case.

### Expected result
- Sparse `userId` filter → `logs__user_id` seek → fast, exact count.
- Dense `userId` / broad listing → `LIMIT 10001` still bounds the scan → fast, capped.
- Header signaling (`total-number`, `total-number-is-capped`) is unchanged. Existing route and integration tests for the capped path continue to pass without modification.

## Testing
Tested locally

## Checklist
- [ ] \`.changeset\`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments