### PR TITLE
feat(toolkit,schemas,core): add per-tenant username policy guard and SIE column

### DIFF
--- a/.changeset/username-policy-core-kit.md
+++ b/.changeset/username-policy-core-kit.md
@@ -1,0 +1,5 @@
+---
+"@logto/core-kit": minor
+---
+
+add a shared username policy type, Zod guard, and default value

--- a/packages/account/src/__mocks__/RenderWithPageContext/index.tsx
+++ b/packages/account/src/__mocks__/RenderWithPageContext/index.tsx
@@ -7,6 +7,7 @@ import {
   SignInIdentifier,
   SignInMode,
   Theme,
+  defaultUsernamePolicy,
   type AccountCenter,
   type UserProfileResponse,
 } from '@logto/schemas';
@@ -125,6 +126,7 @@ export const mockSignInExperienceSettings = {
   isDevelopmentTenant: false,
   signUpProfileFields: null,
   passwordExpiration: {},
+  usernamePolicy: defaultUsernamePolicy,
 } satisfies SignInExperienceResponse;
 
 export const mockUserInfo = {

--- a/packages/console/src/pages/SignInExperience/PageContent/utils/parser.test.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/utils/parser.test.ts
@@ -5,6 +5,7 @@ import {
   MfaPolicy,
   SignInIdentifier,
   SignInMode,
+  defaultUsernamePolicy,
   type SignInExperience,
 } from '@logto/schemas';
 
@@ -55,6 +56,7 @@ const mockSignInExperience: SignInExperience = {
   passwordExpiration: {
     enabled: false,
   },
+  usernamePolicy: defaultUsernamePolicy,
   mfa: {
     policy: MfaPolicy.Mandatory,
     factors: [MfaFactor.TOTP],

--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -6,7 +6,13 @@ import type {
   SignUp,
   SignIn,
 } from '@logto/schemas';
-import { SignInMode, SignInIdentifier, MfaPolicy, AgreeToTermsPolicy } from '@logto/schemas';
+import {
+  SignInMode,
+  SignInIdentifier,
+  MfaPolicy,
+  AgreeToTermsPolicy,
+  defaultUsernamePolicy,
+} from '@logto/schemas';
 
 export const mockColor: Color = {
   primaryColor: '#000',
@@ -121,4 +127,5 @@ export const mockSignInExperience: SignInExperience = {
     allowAutofill: false,
   },
   signUpProfileFields: null,
+  usernamePolicy: defaultUsernamePolicy,
 };

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -45,12 +45,13 @@ describe('sign-in-experience query', () => {
     forgotPasswordMethods: JSON.stringify(mockSignInExperience.forgotPasswordMethods),
     passkeySignIn: JSON.stringify(mockSignInExperience.passkeySignIn),
     signUpProfileFields: JSON.stringify(mockSignInExperience.signUpProfileFields),
+    usernamePolicy: JSON.stringify(mockSignInExperience.usernamePolicy),
   };
 
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "tenant_id", "id", "color", "branding", "hide_logto_branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "custom_ui_csp", "password_policy", "mfa", "adaptive_mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy", "email_blocklist_policy", "forgot_password_methods", "passkey_sign_in", "sign_up_profile_fields", "password_expiration"
+      select "tenant_id", "id", "color", "branding", "hide_logto_branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "custom_ui_csp", "password_policy", "mfa", "adaptive_mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy", "email_blocklist_policy", "forgot_password_methods", "passkey_sign_in", "sign_up_profile_fields", "password_expiration", "username_policy"
       from "sign_in_experiences"
       where "id"=$1
     `;

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -112,6 +112,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
           emailBlocklistPolicy,
           signUpProfileFields,
           customUiCsp,
+          usernamePolicy,
           ...rest
         },
       } = ctx.guard;
@@ -381,6 +382,8 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
             passwordExpiration &&
             currentPasswordExpiration && { passwordExpiration: currentPasswordExpiration }
         ),
+        // Username policy is gated until the feature ships: ignore writes when the flag is off.
+        ...conditional(EnvSet.values.isDevFeaturesEnabled && usernamePolicy && { usernamePolicy }),
       };
 
       ctx.body = await updateDefaultSignInExperience(payload);

--- a/packages/experience/src/__mocks__/logto.tsx
+++ b/packages/experience/src/__mocks__/logto.tsx
@@ -6,6 +6,7 @@ import {
   MfaPolicy,
   SignInIdentifier,
   SignInMode,
+  defaultUsernamePolicy,
 } from '@logto/schemas';
 
 import type { SignInExperienceResponse } from '@/types';
@@ -129,6 +130,7 @@ export const mockSignInExperience: SignInExperience = {
   hideLogtoBranding: false,
   passkeySignIn: {},
   signUpProfileFields: null,
+  usernamePolicy: defaultUsernamePolicy,
 };
 
 export const mockSignInExperienceSettings: SignInExperienceResponse = {
@@ -178,6 +180,7 @@ export const mockSignInExperienceSettings: SignInExperienceResponse = {
   emailBlocklistPolicy: {},
   passkeySignIn: {},
   signUpProfileFields: null,
+  usernamePolicy: defaultUsernamePolicy,
 };
 
 const usernameSettings = {

--- a/packages/schemas/alterations/next-1780381219-add-username-policy.ts
+++ b/packages/schemas/alterations/next-1780381219-add-username-policy.ts
@@ -1,0 +1,41 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  // `create index concurrently` cannot run in a transaction; the runner wraps up/down in one.
+  beforeUp: async (pool) => {
+    await pool.query(sql`
+      create index concurrently users__tenant_lower_username
+        on users (tenant_id, lower(username))
+        where username is not null;
+    `);
+  },
+  up: async (pool) => {
+    // The default must be inlined: DDL cannot use bound parameters.
+    await pool.query(sql`
+      alter table sign_in_experiences
+        add column username_policy jsonb not null default '{
+          "caseSensitive": true,
+          "minLength": 1,
+          "maxLength": 128,
+          "allowedChars": {
+            "lowercase": true,
+            "uppercase": true,
+            "numbers": true,
+            "underscore": true
+          }
+        }'::jsonb;
+    `);
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`drop index concurrently users__tenant_lower_username;`);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences drop column username_policy;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
@@ -143,6 +143,10 @@ export const signInGuard = z.object({
 
 export type SignIn = z.infer<typeof signInGuard>;
 
+// The username policy is owned by @logto/core-kit (like passwordPolicyGuard) so core, experience,
+// and console share one source of truth; re-exported here for the `@use UsernamePolicy` column.
+export { defaultUsernamePolicy, usernamePolicyGuard, type UsernamePolicy } from '@logto/core-kit';
+
 export type SocialSignIn = {
   /**
    * If account linking should be performed when a user signs in with a social identity that is new

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -37,5 +37,16 @@ create table sign_in_experiences (
   /** Nullable by design: null keeps legacy full-catalog behavior and [] collects no custom profile fields. */
   sign_up_profile_fields jsonb /* @use SignUpProfileFields */,
   password_expiration jsonb /* @use PasswordExpirationPolicy */ not null default '{}'::jsonb,
+  username_policy jsonb /* @use UsernamePolicy */ not null default ('{
+    "caseSensitive": true,
+    "minLength": 1,
+    "maxLength": 128,
+    "allowedChars": {
+      "lowercase": true,
+      "uppercase": true,
+      "numbers": true,
+      "underscore": true
+    }
+  }'::jsonb),
   primary key (tenant_id, id)
 );

--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -46,6 +46,11 @@ create index users__name
 create index users_mfa_verifications_gin
   on users using gin (mfa_verifications jsonb_path_ops);
 
+/* Supports case-insensitive username lookups and case-flip conflict detection. */
+create index users__tenant_lower_username
+  on users (tenant_id, lower(username))
+  where username is not null;
+
 create trigger set_updated_at
   before update on users
   for each row

--- a/packages/toolkit/core-kit/src/index.ts
+++ b/packages/toolkit/core-kit/src/index.ts
@@ -5,3 +5,4 @@ export * from './openid.js';
 export * from './models/index.js';
 export * from './http.js';
 export * from './password-policy.js';
+export * from './username-policy.js';

--- a/packages/toolkit/core-kit/src/username-policy.test.ts
+++ b/packages/toolkit/core-kit/src/username-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultUsernamePolicy, usernamePolicyGuard } from './username-policy.js';
+
+describe('usernamePolicyGuard', () => {
+  it('accepts the default policy', () => {
+    expect(usernamePolicyGuard.safeParse(defaultUsernamePolicy).success).toBe(true);
+  });
+
+  it('rejects minLength > maxLength', () => {
+    const result = usernamePolicyGuard.safeParse({
+      ...defaultUsernamePolicy,
+      minLength: 10,
+      maxLength: 3,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a numbers-only policy (no valid leading char)', () => {
+    const result = usernamePolicyGuard.safeParse({
+      ...defaultUsernamePolicy,
+      allowedChars: { lowercase: false, uppercase: false, numbers: true, underscore: false },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts underscore as the only leading char class', () => {
+    const result = usernamePolicyGuard.safeParse({
+      ...defaultUsernamePolicy,
+      allowedChars: { lowercase: false, uppercase: false, numbers: true, underscore: true },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects out-of-range length', () => {
+    expect(usernamePolicyGuard.safeParse({ ...defaultUsernamePolicy, minLength: 0 }).success).toBe(
+      false
+    );
+    expect(
+      usernamePolicyGuard.safeParse({ ...defaultUsernamePolicy, maxLength: 129 }).success
+    ).toBe(false);
+  });
+});

--- a/packages/toolkit/core-kit/src/username-policy.ts
+++ b/packages/toolkit/core-kit/src/username-policy.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+/** Per-tenant username policy: case sensitivity, length bounds, and allowed character classes. */
+export type UsernamePolicy = {
+  caseSensitive: boolean;
+  /** Integer in [1, 128], inclusive. */
+  minLength: number;
+  /** Integer in [1, 128], inclusive. Must be >= minLength. */
+  maxLength: number;
+  /** At least one of lowercase, uppercase, or underscore must be enabled (see usernamePolicyGuard). */
+  allowedChars: {
+    lowercase: boolean;
+    uppercase: boolean;
+    numbers: boolean;
+    underscore: boolean;
+  };
+};
+
+export const usernamePolicyGuard = z
+  .object({
+    caseSensitive: z.boolean(),
+    minLength: z.number().int().min(1).max(128),
+    maxLength: z.number().int().min(1).max(128),
+    allowedChars: z.object({
+      lowercase: z.boolean(),
+      uppercase: z.boolean(),
+      numbers: z.boolean(),
+      underscore: z.boolean(),
+    }),
+  })
+  .refine((policy) => policy.minLength <= policy.maxLength, {
+    message: 'Minimum length cannot exceed maximum length.',
+    path: ['maxLength'],
+  })
+  // Messages are full sentences on purpose: koaGuard returns them verbatim in the 400 response,
+  // so a Management API caller posting an invalid policy reads exactly why.
+  .refine(
+    (policy) =>
+      policy.allowedChars.lowercase ||
+      policy.allowedChars.uppercase ||
+      policy.allowedChars.underscore,
+    {
+      message:
+        'At least one of lowercase, uppercase, or underscore must be enabled. Usernames cannot start with a number, so numbers alone are not allowed.',
+      path: ['allowedChars'],
+    }
+  ) satisfies z.ZodType<UsernamePolicy>;
+
+/**
+ * Mirrors current username behavior so the policy is a no-op when unset: `usernameRegEx` charset
+ * (all classes), length 1-128 (`z.string().min(1)` + `users.username varchar(128)`), case-sensitive
+ * (the `CASE_SENSITIVE_USERNAME` env default).
+ */
+export const defaultUsernamePolicy: UsernamePolicy = Object.freeze({
+  caseSensitive: true,
+  minLength: 1,
+  maxLength: 128,
+  allowedChars: Object.freeze({
+    lowercase: true,
+    uppercase: true,
+    numbers: true,
+    underscore: true,
+  }),
+});


### PR DESCRIPTION
## Summary
Foundation (phase 1) for per-tenant username policy. Relates to LOG-13523.

### What changed
- **`@logto/core-kit`**: new `UsernamePolicy` type, `usernamePolicyGuard`, and `defaultUsernamePolicy` — the shared source of truth for username rules, consumed by core, experience, and console (mirrors `passwordPolicy`).
- **`@logto/schemas`**: add the `username_policy` JSONB column to `sign_in_experiences` (re-exporting the type/guard from core-kit), plus a functional index `users (tenant_id, lower(username)) where username is not null`. A new alteration applies both — the concurrent index in `beforeUp`/`beforeDown` (outside the transaction), the column in `up`/`down`.
- **`@logto/core`**: `PATCH /sign-in-exp` ignores `usernamePolicy` updates unless `isDevFeaturesEnabled` (mirrors the `passwordExpiration` gate).

### Expected result
No behavior change in production: the column lands at a default that mirrors today's behavior (case-sensitive, length 1–128, all character classes), nothing reads it at runtime yet, and the write path is dev-gated. Existing rows and new tenants keep the same effective username rules as before.

### Reviewer notes
- The changeset is scoped to `@logto/core-kit` only — its new exports ship independently of the gated app feature, so there is no `@logto/core` changeset.
- The SIE column default is wrapped in parentheses (`default ('{…}'::jsonb)`) so the schema generator's comma-splitter doesn't break on the JSON object.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
