### PR TITLE
feat(toolkit): add shared username policy validator

### DIFF
--- a/.changeset/username-policy-validator.md
+++ b/.changeset/username-policy-validator.md
@@ -1,0 +1,5 @@
+---
+"@logto/core-kit": minor
+---
+
+add a shared username policy validator

--- a/packages/toolkit/core-kit/src/username-policy.test.ts
+++ b/packages/toolkit/core-kit/src/username-policy.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from 'vitest';
 
-import { defaultUsernamePolicy, usernamePolicyGuard } from './username-policy.js';
+import {
+  defaultUsernamePolicy,
+  usernamePolicyGuard,
+  validateUsernameAgainstPolicy,
+  validateUsernameHardFloor,
+  type UsernamePolicy,
+} from './username-policy.js';
+
+const lowercaseOnly: UsernamePolicy = {
+  caseSensitive: true,
+  minLength: 4,
+  maxLength: 8,
+  allowedChars: { lowercase: true, uppercase: false, numbers: false, underscore: false },
+};
+
+const uppercaseOnly: UsernamePolicy = {
+  caseSensitive: true,
+  minLength: 4,
+  maxLength: 8,
+  allowedChars: { lowercase: false, uppercase: true, numbers: false, underscore: false },
+};
 
 describe('usernamePolicyGuard', () => {
   it('accepts the default policy', () => {
@@ -39,5 +59,62 @@ describe('usernamePolicyGuard', () => {
     expect(
       usernamePolicyGuard.safeParse({ ...defaultUsernamePolicy, maxLength: 129 }).success
     ).toBe(false);
+  });
+});
+
+describe('validateUsernameHardFloor', () => {
+  it('returns "required" for an empty string', () => {
+    expect(validateUsernameHardFloor('')).toBe('required');
+  });
+  it('returns "starts_with_number" for a leading digit', () => {
+    expect(validateUsernameHardFloor('1abc')).toBe('starts_with_number');
+  });
+  it('returns "invalid_charset_hard" for an unsupported character', () => {
+    expect(validateUsernameHardFloor('ab c')).toBe('invalid_charset_hard');
+  });
+  it('returns undefined for a valid username', () => {
+    expect(validateUsernameHardFloor('abc')).toBeUndefined();
+  });
+});
+
+describe('validateUsernameAgainstPolicy (default policy)', () => {
+  it('accepts a lowercase username', () => {
+    expect(validateUsernameAgainstPolicy('abc', defaultUsernamePolicy)).toBeUndefined();
+  });
+  it('accepts a mixed-case username with digits and underscore', () => {
+    expect(validateUsernameAgainstPolicy('AbC_123', defaultUsernamePolicy)).toBeUndefined();
+  });
+  it('applies the hard floor before policy checks', () => {
+    expect(validateUsernameAgainstPolicy('1abc', defaultUsernamePolicy)).toBe('starts_with_number');
+  });
+});
+
+describe('validateUsernameAgainstPolicy (lowercase-only, length 4-8)', () => {
+  it('rejects too short', () => {
+    expect(validateUsernameAgainstPolicy('abc', lowercaseOnly)).toBe('too_short');
+  });
+  it('rejects too long', () => {
+    expect(validateUsernameAgainstPolicy('abcdefghi', lowercaseOnly)).toBe('too_long');
+  });
+  it('rejects an uppercase letter', () => {
+    expect(validateUsernameAgainstPolicy('abcD', lowercaseOnly)).toBe('uppercase_not_allowed');
+  });
+  it('rejects a digit', () => {
+    expect(validateUsernameAgainstPolicy('abc1', lowercaseOnly)).toBe('numbers_not_allowed');
+  });
+  it('rejects an underscore', () => {
+    expect(validateUsernameAgainstPolicy('ab_c', lowercaseOnly)).toBe('underscore_not_allowed');
+  });
+  it('accepts a lowercase username within bounds', () => {
+    expect(validateUsernameAgainstPolicy('abcd', lowercaseOnly)).toBeUndefined();
+  });
+});
+
+describe('validateUsernameAgainstPolicy (uppercase-only, length 4-8)', () => {
+  it('rejects a lowercase letter', () => {
+    expect(validateUsernameAgainstPolicy('ABCd', uppercaseOnly)).toBe('lowercase_not_allowed');
+  });
+  it('accepts an uppercase username within bounds', () => {
+    expect(validateUsernameAgainstPolicy('ABCD', uppercaseOnly)).toBeUndefined();
   });
 });

--- a/packages/toolkit/core-kit/src/username-policy.ts
+++ b/packages/toolkit/core-kit/src/username-policy.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { usernameRegEx } from './regex.js';
+
 /** Per-tenant username policy: case sensitivity, length bounds, and allowed character classes. */
 export type UsernamePolicy = {
   caseSensitive: boolean;
@@ -62,3 +64,68 @@ export const defaultUsernamePolicy: UsernamePolicy = Object.freeze({
     underscore: true,
   }),
 });
+
+export type UsernameViolation =
+  | 'required'
+  | 'starts_with_number'
+  | 'invalid_charset_hard'
+  | 'too_short'
+  | 'too_long'
+  | 'uppercase_not_allowed'
+  | 'lowercase_not_allowed'
+  | 'numbers_not_allowed'
+  | 'underscore_not_allowed';
+
+/**
+ * The always-on baseline, independent of any per-tenant policy: non-empty, no leading digit, and
+ * matching the existing `usernameRegEx` charset. Applies to admin writes too.
+ */
+export const validateUsernameHardFloor = (username: string): UsernameViolation | undefined => {
+  if (username.length === 0) {
+    return 'required';
+  }
+  if (/^\d/.test(username)) {
+    return 'starts_with_number';
+  }
+  if (!usernameRegEx.test(username)) {
+    return 'invalid_charset_hard';
+  }
+};
+
+const checkAllowedChars = (
+  username: string,
+  allowedChars: UsernamePolicy['allowedChars']
+): UsernameViolation | undefined => {
+  if (!allowedChars.uppercase && /[A-Z]/.test(username)) {
+    return 'uppercase_not_allowed';
+  }
+  if (!allowedChars.lowercase && /[a-z]/.test(username)) {
+    return 'lowercase_not_allowed';
+  }
+  if (!allowedChars.numbers && /\d/.test(username)) {
+    return 'numbers_not_allowed';
+  }
+  if (!allowedChars.underscore && username.includes('_')) {
+    return 'underscore_not_allowed';
+  }
+};
+
+/** Returns the first violation against the hard floor then the per-tenant policy, or undefined. */
+export const validateUsernameAgainstPolicy = (
+  username: string,
+  policy: UsernamePolicy
+): UsernameViolation | undefined => {
+  const hardFloor = validateUsernameHardFloor(username);
+  if (hardFloor) {
+    return hardFloor;
+  }
+
+  if (username.length < policy.minLength) {
+    return 'too_short';
+  }
+  if (username.length > policy.maxLength) {
+    return 'too_long';
+  }
+
+  return checkAllowedChars(username, policy.allowedChars);
+};


### PR DESCRIPTION
## Summary
Add a shared, pure username-policy validator to `@logto/core-kit`, alongside the type/guard added in P1. Relates to LOG-13524. Stacked on #8932 (P1) — review/merge that first.

`validateUsernameHardFloor` enforces the always-on baseline (non-empty, no leading digit, `usernameRegEx` charset); `validateUsernameAgainstPolicy` runs the hard floor first, then the per-tenant length and character-class checks. Both are browser-safe and side-effect-free, to be consumed by core, experience, and console in later phases. No callers yet.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
