### PR TITLE
fix(account): hide divider when tenant logo is not configured

### DIFF
--- a/packages/account/src/components/PageHeader/index.tsx
+++ b/packages/account/src/components/PageHeader/index.tsx
@@ -23,8 +23,12 @@ const PageHeader = () => {
   return (
     <header className={classNames(styles.header, layoutClassNames.pageHeader)}>
       <div className={styles.left}>
-        {logoUrl && <img className={styles.logo} src={logoUrl} alt="logo" />}
-        <div className={styles.divider} />
+        {logoUrl && (
+          <>
+            <img className={styles.logo} src={logoUrl} alt="logo" />
+            <div className={styles.divider} />
+          </>
+        )}
         <span className={styles.appName}>{t('account_center.page.title')}</span>
       </div>
     </header>


### PR DESCRIPTION
## Summary

In the account center `PageHeader`, the divider separator was rendered unconditionally while the logo `<img>` was conditional on `logoUrl`. When a tenant has no logo configured, this left a stray divider with nothing to its left.

Fix: wrap both the `<img>` and `.divider` in the same `logoUrl &&` guard so they render/hide together.

## Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/073593b742d9432f9bd7c95bacb2950b
Requested by: @wangsijie