### PR TITLE
fix(account): add empty placeholder on profile page when no fields configured

### DIFF
--- a/packages/account/src/pages/Profile/index.module.scss
+++ b/packages/account/src/pages/Profile/index.module.scss
@@ -80,6 +80,11 @@
   }
 }
 
+.empty {
+  flex: 1;
+  min-height: 200px;
+}
+
 :global(body.mobile) {
   .row {
     display: flex;

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -111,7 +111,7 @@ const Profile = () => {
           descriptionKey="account_center.page.profile_description"
         />
         <div className={classNames(homeStyles.content, layoutClassNames.pageContent)}>
-          {fieldRows.length > 0 && (
+          {fieldRows.length > 0 ? (
             <div className={classNames(styles.section, layoutClassNames.section)}>
               <div className={classNames(styles.card, layoutClassNames.card)}>
                 {fieldRows.map((fieldRow) => {
@@ -154,6 +154,8 @@ const Profile = () => {
                 })}
               </div>
             </div>
+          ) : (
+            <div className={styles.empty} />
           )}
         </div>
         <PageFooter />


### PR DESCRIPTION
## Summary

When no profile fields are configured in the account center, the header and footer stack together with no spacing. This adds an empty placeholder `div.empty` (with `flex: 1` + `min-height: 200px`) that renders via a ternary instead of the `&&` guard, ensuring visual separation between header and footer.

### Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/517ef712c7ed4029ab07aa78ea0c0a04
Requested by: @wangsijie