### PR TITLE
fix: correct 'the the' typo in JWT customizer comments

### DIFF
--- a/packages/console/scripts/custom-jwt-customizer-type-definition.ts
+++ b/packages/console/scripts/custom-jwt-customizer-type-definition.ts
@@ -12,7 +12,7 @@ import { CustomJwtApiContext } from '@logto/schemas';
  */
 export const jwtCustomizerApiContextTypeDefinition = `type CustomJwtApiContext = {
   /**
-   * Reject the the current token request.
+   * Reject the current token request.
    *
    * @remarks
    * This function will reject the current token request and throw

--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -277,7 +277,7 @@ export type CustomJwtErrorBody = z.infer<typeof customJwtErrorBodyGuard>;
 
 export type CustomJwtApiContext = {
   /**
-   * Reject the the current token request.
+   * Reject the current token request.
    *
    * @remarks
    * By calling this function, the current token request will be rejected,


### PR DESCRIPTION
## Summary
Fixed a typo in code comments in two files. The word "the" was duplicated ("the the") in a JSDoc comment describing the JWT customizer behavior.

Files changed:
- `packages/schemas/src/types/logto-config/jwt-customizer.ts`
- `packages/console/scripts/custom-jwt-customizer-type-definition.ts`

## Testing
No functional changes — this is a comment-only typo fix. No tests needed.

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments