### PR TITLE
refactor(core,shared): resolve username case-sensitivity per tenant

### DIFF
--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -49,6 +49,7 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
     oidcModelInstances: { revokeInstanceByUserId },
     userSsoIdentities,
     oidcSessionExtensions,
+    signInExperiences: { getUsernameCaseSensitive },
   } = queries;
 
   const generateUserId = async (retries = 500) =>
@@ -128,7 +129,7 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
       throw new RequestError({ code: 'user.phone_already_in_use', status: 422 });
     }
 
-    if (username && (await hasUser(username, excludeUserId))) {
+    if (username && (await hasUser(username, await getUsernameCaseSensitive(), excludeUserId))) {
       throw new RequestError({ code: 'user.username_already_in_use', status: 422 });
     }
 

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -1,6 +1,7 @@
 import { createMockPool, createMockQueryResult } from '@silverhand/slonik';
 
 import { mockSignInExperience } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import { MockWellKnownCache } from '#src/test-utils/tenant.js';
 import type { QueryType } from '#src/utils/test-utils.js';
 import { expectSqlAssert } from '#src/utils/test-utils.js';
@@ -88,4 +89,39 @@ describe('sign-in-experience query', () => {
 
     await expect(updateDefaultSignInExperience({ termsOfUseUrl })).resolves.toEqual(databaseValue);
   });
+});
+
+describe('getUsernameCaseSensitive', () => {
+  const originalIsCaseSensitiveUsername = EnvSet.values.isCaseSensitiveUsername;
+
+  afterEach(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- restore env override after each case
+    (EnvSet.values as { isCaseSensitiveUsername: boolean }).isCaseSensitiveUsername =
+      originalIsCaseSensitiveUsername;
+  });
+
+  it.each([
+    [true, true, true],
+    [true, false, false],
+    [false, true, false],
+    [false, false, false],
+  ])(
+    'policy caseSensitive=%s AND env=%s resolves to %s',
+    async (policyCaseSensitive, envCaseSensitive, expected) => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- toggle the legacy env var for this case
+      (EnvSet.values as { isCaseSensitiveUsername: boolean }).isCaseSensitiveUsername =
+        envCaseSensitive;
+      // Fresh instance so the memoized findDefaultSignInExperience isn't shared across cases.
+      const { getUsernameCaseSensitive } = createSignInExperienceQueries(
+        pool,
+        new MockWellKnownCache()
+      );
+      mockQuery.mockImplementationOnce(async () =>
+        // @ts-expect-error -- the mock returns a pre-parsed SIE row; createMockQueryResult's primitive row type can't express the jsonb object the resolver reads
+        createMockQueryResult([{ usernamePolicy: { caseSensitive: policyCaseSensitive } }])
+      );
+
+      expect(await getUsernameCaseSensitive()).toBe(expected);
+    }
+  );
 });

--- a/packages/core/src/queries/sign-in-experience.ts
+++ b/packages/core/src/queries/sign-in-experience.ts
@@ -5,6 +5,7 @@ import type { CommonQueryMethods } from '@silverhand/slonik';
 import { type WellKnownCache } from '#src/caches/well-known.js';
 import { buildFindEntityByIdWithPool } from '#src/database/find-entity-by-id.js';
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
+import { EnvSet } from '#src/env-set/index.js';
 
 const id = 'default';
 
@@ -26,8 +27,19 @@ export const createSignInExperienceQueries = (
     ['sie']
   );
 
+  /**
+   * Effective username case-sensitivity: the per-tenant policy AND-combined with the legacy
+   * `CASE_SENSITIVE_USERNAME` env var — case-insensitive if either is false.
+   * See {@link EnvSet.values.isCaseSensitiveUsername}.
+   */
+  const getUsernameCaseSensitive = async () => {
+    const { usernamePolicy } = await findDefaultSignInExperience();
+    return usernamePolicy.caseSensitive && EnvSet.values.isCaseSensitiveUsername;
+  };
+
   return {
     updateDefaultSignInExperience,
     findDefaultSignInExperience,
+    getUsernameCaseSensitive,
   };
 };

--- a/packages/core/src/queries/user.test.ts
+++ b/packages/core/src/queries/user.test.ts
@@ -1,9 +1,7 @@
 import { MfaFactor, Users } from '@logto/schemas';
 import { createMockPool, createMockQueryResult, sql } from '@silverhand/slonik';
-import Sinon from 'sinon';
 
 import { mockUser } from '#src/__mocks__/index.js';
-import { EnvSet } from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 import type { QueryType } from '#src/utils/test-utils.js';
@@ -36,17 +34,7 @@ const {
   deleteUserIdentity,
 } = createUserQueries(pool);
 
-const stubIsCaseSensitiveUsername = (isCaseSensitiveUsername: boolean) =>
-  Sinon.stub(EnvSet, 'values').value({
-    ...EnvSet.values,
-    isCaseSensitiveUsername,
-  });
-
 describe('user query', () => {
-  beforeEach(() => {
-    stubIsCaseSensitiveUsername(true);
-  });
-
   const { table, fields } = convertToIdentifiers(Users);
   const databaseValue = {
     ...mockUser,
@@ -71,11 +59,10 @@ describe('user query', () => {
       return createMockQueryResult([databaseValue]);
     });
 
-    await expect(findUserByUsername(mockUser.username!)).resolves.toEqual(databaseValue);
+    await expect(findUserByUsername(mockUser.username!, true)).resolves.toEqual(databaseValue);
   });
 
   it('findUserByUsername (case insensitive)', async () => {
-    stubIsCaseSensitiveUsername(false);
     const expectSql = sql`
       select ${sql.join(Object.values(fields), sql`,`)}
       from ${table}
@@ -89,7 +76,7 @@ describe('user query', () => {
       return createMockQueryResult([databaseValue]);
     });
 
-    await expect(findUserByUsername(mockUser.username!)).resolves.toEqual(databaseValue);
+    await expect(findUserByUsername(mockUser.username!, false)).resolves.toEqual(databaseValue);
   });
 
   it('findUserByEmail', async () => {
@@ -234,11 +221,10 @@ describe('user query', () => {
       return createMockQueryResult([{ exists: true }]);
     });
 
-    await expect(hasUser(mockUser.username!)).resolves.toEqual(true);
+    await expect(hasUser(mockUser.username!, true)).resolves.toEqual(true);
   });
 
   it('hasUser (case insensitive)', async () => {
-    stubIsCaseSensitiveUsername(false);
     const expectSql = sql`
       SELECT EXISTS(
         select ${fields.id}
@@ -254,7 +240,7 @@ describe('user query', () => {
       return createMockQueryResult([{ exists: true }]);
     });
 
-    await expect(hasUser(mockUser.username!)).resolves.toEqual(true);
+    await expect(hasUser(mockUser.username!, false)).resolves.toEqual(true);
   });
 
   it('hasUserWithId', async () => {

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -7,7 +7,6 @@ import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
 
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
-import { EnvSet } from '#src/env-set/index.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import type { Search } from '#src/utils/search.js';
 import { buildConditionsFromSearch } from '#src/utils/search.js';
@@ -65,12 +64,12 @@ export const userSearchKeys = Object.freeze([
 export const userSearchFields = Object.freeze(Object.values(pick(Users.fields, ...userSearchKeys)));
 
 export const createUserQueries = (pool: CommonQueryMethods) => {
-  const findUserByUsername = async (username: string) =>
+  const findUserByUsername = async (username: string, caseSensitive: boolean) =>
     pool.maybeOne<User>(sql`
       select ${sql.join(Object.values(fields), sql`,`)}
       from ${table}
       ${
-        EnvSet.values.isCaseSensitiveUsername
+        caseSensitive
           ? sql`where ${fields.username}=${username}`
           : sql`where lower(${fields.username})=lower(${username})`
       }
@@ -174,12 +173,12 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
       `
     );
 
-  const hasUser = async (username: string, excludeUserId?: string) =>
+  const hasUser = async (username: string, caseSensitive: boolean, excludeUserId?: string) =>
     pool.exists(sql`
       select ${fields.id}
       from ${table}
       ${
-        EnvSet.values.isCaseSensitiveUsername
+        caseSensitive
           ? sql`where ${fields.username}=${username}`
           : sql`where lower(${fields.username})=lower(${username})`
       }

--- a/packages/core/src/routes/admin-user/basics.ts
+++ b/packages/core/src/routes/admin-user/basics.ts
@@ -253,7 +253,8 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
       assertThat(!passwordDigest || passwordAlgorithm, 'user.password_algorithm_required');
 
       assertThat(
-        !username || !(await hasUser(username)),
+        !username ||
+          !(await hasUser(username, await queries.signInExperiences.getUsernameCaseSensitive())),
         new RequestError({
           code: 'user.username_already_in_use',
           status: 422,

--- a/packages/core/src/routes/experience/classes/libraries/profile-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/profile-validator.ts
@@ -36,7 +36,7 @@ export class ProfileValidator {
 
     if (username) {
       assertThat(
-        !(await hasUser(username)),
+        !(await hasUser(username, await this.queries.signInExperiences.getUsernameCaseSensitive())),
         new RequestError({
           code: 'user.username_already_in_use',
           status: 422,

--- a/packages/core/src/routes/experience/classes/utils.ts
+++ b/packages/core/src/routes/experience/classes/utils.ts
@@ -13,21 +13,22 @@ import type Queries from '#src/tenants/Queries.js';
 import type { InteractionProfile } from '../types.js';
 
 export const findUserByIdentifier = async (
-  userQuery: Queries['users'],
+  queries: Queries,
   { type, value }: VerificationIdentifier
 ) => {
+  const { users, signInExperiences } = queries;
   switch (type) {
     case SignInIdentifier.Username: {
-      return userQuery.findUserByUsername(value);
+      return users.findUserByUsername(value, await signInExperiences.getUsernameCaseSensitive());
     }
     case SignInIdentifier.Email: {
-      return userQuery.findUserByEmail(value);
+      return users.findUserByEmail(value);
     }
     case SignInIdentifier.Phone: {
-      return userQuery.findUserByNormalizedPhone(value);
+      return users.findUserByNormalizedPhone(value);
     }
     case AdditionalIdentifier.UserId: {
-      return userQuery.findUserById(value);
+      return users.findUserById(value);
     }
   }
 };

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -150,7 +150,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
       new RequestError({ code: 'session.verification_failed', status: 400 })
     );
 
-    const user = await findUserByIdentifier(this.queries.users, this.identifier);
+    const user = await findUserByIdentifier(this.queries, this.identifier);
 
     assertThat(
       user,

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -91,7 +91,7 @@ export class OneTimeTokenVerification
       new RequestError({ code: 'session.verification_failed', status: 400 })
     );
 
-    const user = await findUserByIdentifier(this.queries.users, this.identifier);
+    const user = await findUserByIdentifier(this.queries, this.identifier);
 
     assertThat(
       user,

--- a/packages/core/src/routes/experience/classes/verifications/password-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/password-verification.ts
@@ -72,7 +72,7 @@ export class PasswordVerification
    * @throws RequestError with 422 status if the user is not found or the password is incorrect.
    */
   async verify(password: string): Promise<User> {
-    const user = await findUserByIdentifier(this.queries.users, this.identifier);
+    const user = await findUserByIdentifier(this.queries, this.identifier);
 
     // Throws an 422 error if the user is not found or the password is incorrect
     const verifiedUser = await this.libraries.users.verifyUserPassword(user, password);
@@ -93,7 +93,7 @@ export class PasswordVerification
       new RequestError({ code: 'session.verification_failed', status: 400 })
     );
 
-    const user = await findUserByIdentifier(this.queries.users, this.identifier);
+    const user = await findUserByIdentifier(this.queries, this.identifier);
 
     assertThat(
       user,

--- a/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
@@ -303,7 +303,7 @@ export default function webAuthnVerificationRoute<T extends ExperienceInteractio
       const { identifier } = ctx.guard.body;
 
       // Look up user by identifier to get their WebAuthn credentials
-      const user = await findUserByIdentifier(queries.users, identifier);
+      const user = await findUserByIdentifier(queries, identifier);
 
       const { mfaVerifications = [] } = user ?? {};
       const { hostname } = ctx.URL;

--- a/packages/core/src/routes/interaction/utils/find-user-by-identifier.test.ts
+++ b/packages/core/src/routes/interaction/utils/find-user-by-identifier.test.ts
@@ -26,7 +26,18 @@ const findUserByIdentifier = await pickDefault(import('./find-user-by-identifier
 describe('findUserByIdentifier', () => {
   it('username', async () => {
     await findUserByIdentifier(tenantContext, { username: 'foo' });
-    expect(queries.findUserByUsername).toBeCalledWith('foo');
+    expect(queries.findUserByUsername).toBeCalledWith('foo', true);
+  });
+
+  it('username (case insensitive) forwards the resolved value', async () => {
+    const caseInsensitiveTenant = new MockTenant(
+      undefined,
+      { users: queries, signInExperiences: { getUsernameCaseSensitive: async () => false } },
+      { getLogtoConnectorById }
+    );
+    queries.findUserByUsername.mockClear();
+    await findUserByIdentifier(caseInsensitiveTenant, { username: 'foo' });
+    expect(queries.findUserByUsername).toBeCalledWith('foo', false);
   });
 
   it('email', async () => {

--- a/packages/core/src/routes/interaction/utils/find-user-by-identifier.ts
+++ b/packages/core/src/routes/interaction/utils/find-user-by-identifier.ts
@@ -21,7 +21,10 @@ export default async function findUserByIdentifier(
   const { getLogtoConnectorById } = connectors;
 
   if ('username' in identity) {
-    return findUserByUsername(identity.username);
+    return findUserByUsername(
+      identity.username,
+      await queries.signInExperiences.getUsernameCaseSensitive()
+    );
   }
 
   if ('email' in identity) {

--- a/packages/core/src/routes/interaction/verifications/profile-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/profile-verification.ts
@@ -67,7 +67,7 @@ const verifyProfileNotRegisteredByOtherUserAccount = async (
 
   if (username) {
     assertThat(
-      !(await hasUser(username)),
+      !(await hasUser(username, await queries.signInExperiences.getUsernameCaseSensitive())),
       new RequestError({
         code: 'user.username_already_in_use',
         status: 422,

--- a/packages/core/src/test-utils/tenant.ts
+++ b/packages/core/src/test-utils/tenant.ts
@@ -36,6 +36,14 @@ export class MockQueries extends Queries {
       wellKnownCache
     );
 
+    // The real `getUsernameCaseSensitive` closes over the real `findDefaultSignInExperience`, which
+    // the per-key merge below cannot swap, so it would hit the empty mock pool. Default it to a
+    // working stub (case-sensitive — the prod default); tests needing case-insensitive override it.
+    this.signInExperiences = {
+      ...this.signInExperiences,
+      getUsernameCaseSensitive: async () => true,
+    };
+
     if (!queriesOverride) {
       return;
     }

--- a/packages/integration-tests/src/tests/api/account.username-case.test.ts
+++ b/packages/integration-tests/src/tests/api/account.username-case.test.ts
@@ -1,0 +1,74 @@
+import { defaultUsernamePolicy } from '@logto/core-kit';
+
+import { enableAllAccountCenterFields } from '#src/api/account-center.js';
+import { deleteUser, updateSignInExperience } from '#src/api/index.js';
+import { updateUser } from '#src/api/my-account.js';
+import { createVerificationRecordByPassword } from '#src/api/verification-record.js';
+import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
+import { createDefaultTenantUserWithPassword, signInAndGetUserApi } from '#src/helpers/profile.js';
+import {
+  defaultSignInSignUpConfigs,
+  enableAllPasswordSignInMethods,
+} from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateUsername } from '#src/utils.js';
+
+// Restore a known baseline so this suite does not leak its sign-in or username-policy changes.
+const resetSignInExperience = async () =>
+  updateSignInExperience({ ...defaultSignInSignUpConfigs, usernamePolicy: defaultUsernamePolicy });
+
+describe('account API username case sensitivity', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await enableAllAccountCenterFields();
+  });
+
+  afterAll(async () => {
+    await resetSignInExperience();
+  });
+
+  it('should allow updating to a username that differs only by case from another user', async () => {
+    const base = generateUsername();
+    const other = await createUserByAdmin({ username: base.toLowerCase() });
+    const { user, username, password } = await createDefaultTenantUserWithPassword();
+    const api = await signInAndGetUserApi(username, password);
+    const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+    const response = await updateUser(api, { username: base.toUpperCase() }, verificationRecordId);
+
+    expect(response).toMatchObject({ username: base.toUpperCase() });
+    await deleteUser(other.id);
+    await deleteUser(user.id);
+  });
+});
+
+// Gated to dev features: the sign-in experience write path drops `usernamePolicy` unless dev
+// features are enabled, so case-insensitivity can only be configured (and exercised) here.
+devFeatureTest.describe('account API username case sensitivity (case-insensitive policy)', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await enableAllAccountCenterFields();
+    await updateSignInExperience({
+      usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
+    });
+  });
+
+  afterAll(async () => {
+    await resetSignInExperience();
+  });
+
+  it('should reject updating to a username that differs only by case from another user', async () => {
+    const base = generateUsername();
+    const other = await createUserByAdmin({ username: base.toLowerCase() });
+    const { user, username, password } = await createDefaultTenantUserWithPassword();
+    const api = await signInAndGetUserApi(username, password);
+    const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+    await expectRejects(updateUser(api, { username: base.toUpperCase() }, verificationRecordId), {
+      code: 'user.username_already_in_use',
+      status: 422,
+    });
+
+    await deleteUser(other.id);
+    await deleteUser(user.id);
+  });
+});

--- a/packages/integration-tests/src/tests/api/admin-user.username-case.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.username-case.test.ts
@@ -1,7 +1,7 @@
 import { defaultUsernamePolicy } from '@logto/core-kit';
 import { type User } from '@logto/schemas';
 
-import { authedAdminApi, deleteUser, updateSignInExperience } from '#src/api/index.js';
+import { authedAdminApi, deleteUser, updateSignInExperience, updateUser } from '#src/api/index.js';
 import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
 import { devFeatureTest, generateUsername } from '#src/utils.js';
 
@@ -38,6 +38,16 @@ describe('admin console user management (username case sensitive)', () => {
     await deleteUser(user.id);
     await deleteUser(user2.id);
   });
+
+  it('should allow updating a username that differs only by case', async () => {
+    const base = generateUsername();
+    const user = await createUserByAdmin({ username: base.toLowerCase() });
+    const user2 = await createUserByAdmin();
+    const updated = await updateUser(user2.id, { username: base.toUpperCase() });
+    expect(updated).toHaveProperty('username', base.toUpperCase());
+    await deleteUser(user.id);
+    await deleteUser(user2.id);
+  });
 });
 
 // Gated to dev features: the sign-in experience write path drops `usernamePolicy` unless dev
@@ -71,6 +81,21 @@ devFeatureTest.describe(
         status: 422,
       });
       await deleteUser(user.id);
+    });
+
+    it('should reject updating a username to differ only by case when case-insensitive', async () => {
+      await updateSignInExperience({
+        usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
+      });
+      const base = generateUsername();
+      const user = await createUserByAdmin({ username: base.toLowerCase() });
+      const user2 = await createUserByAdmin();
+      await expectRejects(updateUser(user2.id, { username: base.toUpperCase() }), {
+        code: 'user.username_already_in_use',
+        status: 422,
+      });
+      await deleteUser(user.id);
+      await deleteUser(user2.id);
     });
   }
 );

--- a/packages/integration-tests/src/tests/api/admin-user.username-case.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.username-case.test.ts
@@ -1,8 +1,9 @@
+import { defaultUsernamePolicy } from '@logto/core-kit';
 import { type User } from '@logto/schemas';
 
-import { authedAdminApi, deleteUser } from '#src/api/index.js';
+import { authedAdminApi, deleteUser, updateSignInExperience } from '#src/api/index.js';
 import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
-import { generateUsername } from '#src/utils.js';
+import { devFeatureTest, generateUsername } from '#src/utils.js';
 
 const getUsers = async <T>(
   init: string[][] | Record<string, string> | URLSearchParams
@@ -38,3 +39,38 @@ describe('admin console user management (username case sensitive)', () => {
     await deleteUser(user2.id);
   });
 });
+
+// Gated to dev features: the sign-in experience write path drops `usernamePolicy` unless dev
+// features are enabled, so the policy can only be configured (and exercised) here.
+devFeatureTest.describe(
+  'admin console user management (configurable username case sensitivity)',
+  () => {
+    const username = generateUsername();
+
+    afterAll(async () => {
+      await updateSignInExperience({ usernamePolicy: defaultUsernamePolicy });
+    });
+
+    it('should keep usernames case-sensitive when the policy enables it', async () => {
+      await updateSignInExperience({
+        usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: true },
+      });
+      const user = await createUserByAdmin({ username: username.toLowerCase() });
+      const user2 = await createUserByAdmin({ username: username.toUpperCase() });
+      await deleteUser(user.id);
+      await deleteUser(user2.id);
+    });
+
+    it('should reject a username that differs only by case when the policy is case-insensitive', async () => {
+      await updateSignInExperience({
+        usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
+      });
+      const user = await createUserByAdmin({ username: username.toLowerCase() });
+      await expectRejects(createUserByAdmin({ username: username.toUpperCase() }), {
+        code: 'user.username_already_in_use',
+        status: 422,
+      });
+      await deleteUser(user.id);
+    });
+  }
+);

--- a/packages/integration-tests/src/tests/api/experience-api/username-case.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/username-case.test.ts
@@ -1,0 +1,133 @@
+import { defaultUsernamePolicy } from '@logto/core-kit';
+import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
+
+import { deleteUser, updateSignInExperience } from '#src/api/index.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import {
+  registerNewUserUsernamePassword,
+  signInWithPassword,
+} from '#src/helpers/experience/index.js';
+import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
+import {
+  defaultSignInSignUpConfigs,
+  resetMfaSettings,
+  resetPasswordPolicy,
+} from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateUsername, generatePassword } from '#src/utils.js';
+
+const password = generatePassword();
+
+// Username + password sign-up and sign-in, with the password policy relaxed so the generated
+// password always passes, and MFA left non-blocking.
+const enableUsernameAuth = async () => {
+  await updateSignInExperience({ ...defaultSignInSignUpConfigs, passwordPolicy: {} });
+  await resetMfaSettings();
+};
+
+// Restore a known baseline so this suite does not leak its sign-up/sign-in, password-policy, or
+// username-policy changes into later test files.
+const resetSignInExperience = async () => {
+  await updateSignInExperience({
+    ...defaultSignInSignUpConfigs,
+    usernamePolicy: defaultUsernamePolicy,
+  });
+  await resetPasswordPolicy();
+};
+
+describe('experience API username case sensitivity', () => {
+  beforeAll(async () => {
+    await enableUsernameAuth();
+  });
+
+  afterAll(async () => {
+    await resetSignInExperience();
+  });
+
+  it('registration: allows usernames that differ only by case', async () => {
+    const base = generateUsername();
+    const lowerId = await registerNewUserUsernamePassword(base.toLowerCase(), password);
+    const upperId = await registerNewUserUsernamePassword(base.toUpperCase(), password);
+    await deleteUser(lowerId);
+    await deleteUser(upperId);
+  });
+
+  it('sign-in: a username that differs only by case does not match (invalid credentials)', async () => {
+    const base = generateUsername();
+    const user = await createUserByAdmin({ username: base.toLowerCase(), password });
+
+    await expectRejects(
+      signInWithPassword({
+        identifier: { type: SignInIdentifier.Username, value: base.toUpperCase() },
+        password,
+      }),
+      { code: 'session.invalid_credentials', status: 422 }
+    );
+
+    await deleteUser(user.id);
+  });
+
+  it('profile update: allows staging a username that differs only by case', async () => {
+    const base = generateUsername();
+    const other = await createUserByAdmin({ username: base.toLowerCase() });
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
+
+    await client.updateProfile({ type: SignInIdentifier.Username, value: base.toUpperCase() });
+
+    await deleteUser(other.id);
+  });
+});
+
+// Gated to dev features: the sign-in experience write path drops `usernamePolicy` unless dev
+// features are enabled, so case-insensitivity can only be configured (and exercised) here.
+devFeatureTest.describe(
+  'experience API username case sensitivity (case-insensitive policy)',
+  () => {
+    beforeAll(async () => {
+      await enableUsernameAuth();
+      await updateSignInExperience({
+        usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
+      });
+    });
+
+    afterAll(async () => {
+      await resetSignInExperience();
+    });
+
+    it('registration: rejects a username that differs only by case', async () => {
+      const base = generateUsername();
+      const lowerId = await registerNewUserUsernamePassword(base.toLowerCase(), password);
+
+      await expectRejects(registerNewUserUsernamePassword(base.toUpperCase(), password), {
+        code: 'user.username_already_in_use',
+        status: 422,
+      });
+
+      await deleteUser(lowerId);
+    });
+
+    it('sign-in: a username that differs only by case matches the existing user', async () => {
+      const base = generateUsername();
+      const user = await createUserByAdmin({ username: base.toLowerCase(), password });
+
+      await signInWithPassword({
+        identifier: { type: SignInIdentifier.Username, value: base.toUpperCase() },
+        password,
+      });
+
+      await deleteUser(user.id);
+    });
+
+    it('profile update: rejects staging a username that differs only by case', async () => {
+      const base = generateUsername();
+      const other = await createUserByAdmin({ username: base.toLowerCase() });
+      const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
+
+      await expectRejects(
+        client.updateProfile({ type: SignInIdentifier.Username, value: base.toUpperCase() }),
+        { code: 'user.username_already_in_use', status: 422 }
+      );
+
+      await deleteUser(other.id);
+    });
+  }
+);

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -190,7 +190,13 @@ export default class GlobalValues {
    */
   public readonly databaseStatementTimeout = parseTimeoutEnv(getEnv('DATABASE_STATEMENT_TIMEOUT'));
 
-  /** Global switch for enabling/disabling case-sensitive usernames. */
+  /**
+   * Global switch for enabling/disabling case-sensitive usernames.
+   *
+   * @deprecated Superseded by per-tenant `signInExperience.usernamePolicy.caseSensitive`.
+   * AND-combined as a runtime override: `false` forces case-insensitive for every tenant.
+   * Slated for removal in the next major.
+   */
   public readonly isCaseSensitiveUsername = yes(getEnv('CASE_SENSITIVE_USERNAME', 'true'));
 
   /**
@@ -273,6 +279,14 @@ export default class GlobalValues {
           '- The Admin Console may display incorrect user endpoints on multiple pages, such as guide, config, etc.' +
           ' This issue is caused by the native URL constructor new URL(), which overrides the base pathname.\n\n' +
           '****** END LOGTO WARNING ******\n'
+      );
+    }
+
+    if (process.env.CASE_SENSITIVE_USERNAME !== undefined && !this.isCaseSensitiveUsername) {
+      console.warn(
+        '[deprecated] CASE_SENSITIVE_USERNAME=false overrides every tenant to case-insensitive' +
+          ' username matching, ignoring the per-tenant username policy. Configure case sensitivity' +
+          ' per-tenant via Sign-in experience > Username policy, then remove this env var.'
       );
     }
   }


### PR DESCRIPTION
## Summary
Make username case-sensitivity per-tenant. Relates to LOG-13525. Stacked on #8933 (P2) — review/merge that first.

Replaces the two global `EnvSet.values.isCaseSensitiveUsername` reads in `queries/user.ts` with an explicit `caseSensitive` parameter on `findUserByUsername` and `hasUser`. Adds a `getUsernameCaseSensitive()` resolver on the SIE query layer that ANDs the per-tenant `usernamePolicy.caseSensitive` with the legacy env var (case-insensitive if either is false); all six call sites resolve through it. The env var is marked `@deprecated` (now a runtime override) with a boot warning when it is set to `false`.

The resolver is a boolean AND, so usernames are treated case-sensitively only when **both** inputs opt in; any `false` makes lookups case-insensitive:

| SIE `usernamePolicy.caseSensitive` | env `isCaseSensitiveUsername` | result | behavior |
| --- | --- | --- | --- |
| `true` | `true` | `true` | case-sensitive |
| `true` | `false` | `false` | case-insensitive |
| `false` | `true` | `false` | case-insensitive |
| `false` | `false` | `false` | case-insensitive |

### Expected result
No behavior change: the SIE column defaults to `caseSensitive: true` and no write path sets it yet, so the effective value equals the legacy env var. Once tenants can configure it (later phases) case-sensitivity becomes per-tenant; `CASE_SENSITIVE_USERNAME=false` still forces case-insensitive globally until removed.

### Reviewer notes
- The resolver lives on the SIE *query* object (not the library) because callers like `ProfileValidator` and the experience `findUserByIdentifier` hold `queries`, not `libraries`. The well-known cache guard-parses reads with the full SIE guard (now requiring `usernamePolicy`), so a stale pre-migration cache entry can't reach the resolver as a missing-field object.
- One `@ts-expect-error` in `sign-in-experience.test.ts`: `createMockQueryResult`'s primitive row type can't express the jsonb policy object the resolver reads.
- Integration coverage for username case-sensitivity spans every write path, each with a case-sensitive default test and a dev-feature-gated case-insensitive variant: management API create + update (`admin-user.username-case.test.ts`), account API update (`account.username-case.test.ts`), and the experience API registration, sign-in, and profile-update flows (`experience-api/username-case.test.ts`). Case-insensitive blocks set `usernamePolicy.caseSensitive: false` via the SIE; each suite resets the sign-in experience in `afterAll`. Dev-gated because the SIE write path strips `usernamePolicy` unless dev features are on; API tests run serially so the global flips are isolated.

## Testing
Unit tests, integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments



