### PR TITLE
chore(phrases): sync admin-console security i18n keys

### DIFF
--- a/packages/phrases/src/locales/ar/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/security.ts
@@ -20,6 +20,9 @@ const security = {
     enable_captcha: 'تفعيل CAPTCHA',
     enable_captcha_description:
       'تفعيل التحقق CAPTCHA لعمليات التسجيل وتسجيل الدخول واستعادة كلمة المرور.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'إعداد CAPTCHA',

--- a/packages/phrases/src/locales/de/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'CAPTCHA aktivieren',
     enable_captcha_description:
       'Aktivieren Sie die CAPTCHA-Verifizierung für Anmelde-, Anmelde- und Passwortwiederherstellungsabläufe.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'CAPTCHA einrichten',

--- a/packages/phrases/src/locales/es/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'Habilitar CAPTCHA',
     enable_captcha_description:
       'Habilita la verificación CAPTCHA para los procesos de registro, inicio de sesión y recuperación de contraseña.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'Configurar CAPTCHA',

--- a/packages/phrases/src/locales/fr/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'Activer CAPTCHA',
     enable_captcha_description:
       "Activer la vérification CAPTCHA pour les processus d'inscription, de connexion et de récupération de mot de passe.",
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'Configurer CAPTCHA',

--- a/packages/phrases/src/locales/it/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'Abilita CAPTCHA',
     enable_captcha_description:
       'Abilita la verifica CAPTCHA per i flussi di registrazione, accesso e recupero password.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'Configura CAPTCHA',

--- a/packages/phrases/src/locales/ja/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'CAPTCHA を有効化',
     enable_captcha_description:
       'サインアップ、サインイン、パスワード回復フローに CAPTCHA 検証を有効にします。',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'CAPTCHA をセットアップ',

--- a/packages/phrases/src/locales/ko/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'CAPTCHA 활성화',
     enable_captcha_description:
       '회원가입, 로그인, 비밀번호 복구 흐름에 대해 CAPTCHA 검증을 활성화합니다.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'CAPTCHA 설정',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'Włącz CAPTCHA',
     enable_captcha_description:
       'Włącz weryfikację CAPTCHA dla rejestracji, logowania i odzyskiwania hasła.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'Skonfiguruj CAPTCHA',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'Ativar CAPTCHA',
     enable_captcha_description:
       'Ativar verificação CAPTCHA para fluxos de cadastro, login e recuperação de senha.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'Configurar CAPTCHA',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'Ativar CAPTCHA',
     enable_captcha_description:
       'Ativar verificação CAPTCHA para fluxos de inscrição, entrada e recuperação de senha.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'Configurar CAPTCHA',

--- a/packages/phrases/src/locales/ru/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'Включить CAPTCHA',
     enable_captcha_description:
       'Включите проверку CAPTCHA для регистрации, входа в систему и восстановления пароля.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'Настройка CAPTCHA',

--- a/packages/phrases/src/locales/th/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: 'เปิดใช้งาน CAPTCHA',
     enable_captcha_description:
       'เปิดใช้งานการตรวจสอบ CAPTCHA สำหรับขั้นตอนการสมัครสมาชิก การเข้าสู่ระบบ และการกู้คืนรหัสผ่าน',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: 'ตั้งค่า CAPTCHA',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/security.ts
@@ -21,6 +21,9 @@ const security = {
     enable_captcha: "CAPTCHA'yı Etkinleştir",
     enable_captcha_description:
       'Kayıt olma, giriş yapma ve şifre kurtarma işlemleri için CAPTCHA doğrulamasını etkinleştirin.',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: "CAPTCHA'yı ayarla",

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/security.ts
@@ -19,6 +19,9 @@ const security = {
     settings: '设置',
     enable_captcha: '启用验证码',
     enable_captcha_description: '为注册、登录和密码恢复流程启用验证码验证。',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: '设置验证码',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
@@ -210,9 +210,9 @@ const sign_in_exp = {
       account_center_description:
         '将用户路由到账户中心，以管理电子邮件、手机号、用户名、密码、MFA 和关联账号等安全设置。',
       flows_title: '集成开箱即用的安全设置流程',
+      single_task_flows_title: '集成开箱即用的单一任务流程',
       flows_description:
         '将你的域名与路由组合以形成账户设置 URL（例如 https://auth.foo.com/account/email）。可选择添加 `redirect=` 以在成功更新后将用户返回到你的应用，添加 `show_success=true` 以保持成功页面可见，添加 `ui_locales=` 以覆盖默认语言，或添加 `identifier=` 以预填标识符输入字段。',
-      single_task_flows_title: '集成开箱即用的单一任务流程',
       single_task_flows_description:
         '直接将用户路由到特定流程（例如，邮箱绑定）。可选择添加 `redirect=` 以在成功更新后将用户返回到你的应用，添加 `show_success=true` 以保持成功页面可见，添加 `ui_locales=` 以覆盖默认语言，或添加 `identifier=` 以预填标识符输入字段。',
       tooltips: {

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/security.ts
@@ -19,6 +19,9 @@ const security = {
     settings: '設定',
     enable_captcha: '啟用 CAPTCHA',
     enable_captcha_description: '啟用註冊、登入和密碼恢復流程的 CAPTCHA 驗證。',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: '設定 CAPTCHA',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/security.ts
@@ -19,6 +19,9 @@ const security = {
     settings: '設定',
     enable_captcha: '啟用 CAPTCHA',
     enable_captcha_description: '啟用註冊、登入和密碼恢復流程的 CAPTCHA 驗證。',
+    /** UNTRANSLATED */
+    custom_ui_captcha_notice:
+      'You are using Bring your UI. Additional configuration is required to enable CAPTCHA in your custom UI. <a>View setup guide</a>.',
   },
   create_captcha: {
     setup_captcha: '設定 CAPTCHA',


### PR DESCRIPTION
## Summary
The i18n keys for `translation/admin-console/security.ts` (and `zh-cn`'s `sign-in-exp/index.ts`) had drifted: the English baseline had keys that were missing or differently ordered in the other 16 locales. This was surfaced because running `logto-translate sync-keys --skip-core-check -t all` modified those files as a side effect.

This PR runs that sync and commits only the resulting `admin-console/security.ts` / `sign-in-exp/index.ts` changes — restructuring each locale to match the English source. Newly-added non-English keys carry the `/** UNTRANSLATED */` marker with English placeholder values; CI's translation step fills them in later.

Pure i18n-structure cleanup — no behavior change, no changeset needed.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments