### PR TITLE
feat(core,phrases): add username case-sensitivity conflict-detection api

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -66,6 +66,7 @@ export const createSignInExperienceLibrary = (
     applicationSignInExperiences: { safeFindSignInExperienceByApplicationId },
     captchaProviders: { findCaptchaProvider },
     customProfileFields: { findAllCustomProfileFields },
+    users: { findUsernameCaseConflicts, countUsernameCaseConflicts },
     organizations,
   } = queries;
 
@@ -340,10 +341,24 @@ export const createSignInExperienceLibrary = (
     };
   };
 
+  /**
+   * Username case-sensitivity conflicts: groups of usernames that would clash if the tenant
+   * switched to a case-insensitive policy. Returns the total group count plus a capped sample,
+   * powering the diagnostic GET endpoint and the PATCH `/sign-in-exp` 409 guard.
+   */
+  const findCaseConflicts = async (limit: number) => {
+    const [totalConflicts, samples] = await Promise.all([
+      countUsernameCaseConflicts(),
+      findUsernameCaseConflicts(limit),
+    ]);
+    return { totalConflicts, samples };
+  };
+
   return {
     validateLanguageInfo,
     removeUnavailableSocialConnectorTargets,
     getFullSignInExperience,
     findCaptchaPublicConfig,
+    findCaseConflicts,
   };
 };

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -185,6 +185,35 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
       ${conditionalSql(excludeUserId, (id) => sql`and ${fields.id}<>${id}`)}
     `);
 
+  /**
+   * Groups of usernames that collide once compared case-insensitively (i.e. would clash under a
+   * case-insensitive policy). Each row is one `lower(username)` value shared by more than one user,
+   * with the colliding user ids. Ordered oldest-group-first and capped by `limit` for sampling.
+   */
+  const findUsernameCaseConflicts = async (limit: number) =>
+    pool.any<{ usernameLower: string; userIds: string[] }>(sql`
+      select lower(${fields.username}) as "usernameLower",
+             array_agg(${fields.id}) as "userIds"
+      from ${table}
+      where ${fields.username} is not null
+      group by lower(${fields.username})
+      having count(*) > 1
+      order by min(${fields.createdAt})
+      limit ${limit}
+    `);
+
+  /** Total number of case-insensitive username collision groups (see {@link findUsernameCaseConflicts}). */
+  const countUsernameCaseConflicts = async () =>
+    pool.oneFirst<number>(sql`
+      select count(*)::int from (
+        select 1
+        from ${table}
+        where ${fields.username} is not null
+        group by lower(${fields.username})
+        having count(*) > 1
+      ) as conflicts
+    `);
+
   const hasUserWithId = async (id: string) =>
     pool.exists(sql`
       select ${fields.id}
@@ -443,6 +472,8 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
     findUserByWebAuthnCredential,
     findUserByIdentity,
     hasUser,
+    findUsernameCaseConflicts,
+    countUsernameCaseConflicts,
     hasUserWithId,
     hasUserWithEmail,
     hasUserWithPhone,

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { defaultUsernamePolicy } from '@logto/core-kit';
 import {
   ForgotPasswordMethod,
   MfaFactor,
@@ -998,6 +999,86 @@ describe('PATCH /sign-in-exp customUiCsp', () => {
         },
       })
     ).resolves.toMatchObject({ status: 400 });
+  });
+});
+
+describe('PATCH /sign-in-exp username policy', () => {
+  const findCaseConflicts = jest.fn();
+
+  const buildRequester = (currentCaseSensitive = true) =>
+    createRequester({
+      authedRoutes: signInExperiencesRoutes,
+      tenantContext: new MockTenant(
+        undefined,
+        {
+          signInExperiences: {
+            updateDefaultSignInExperience: async (
+              data: Partial<CreateSignInExperience>
+            ): Promise<SignInExperience> => ({ ...mockSignInExperience, ...data }),
+            findDefaultSignInExperience: jest.fn().mockResolvedValue({
+              ...mockSignInExperience,
+              usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: currentCaseSensitive },
+            }),
+          },
+          customPhrases: { findAllCustomLanguageTags: async () => [] },
+        },
+        { getLogtoConnectors: jest.fn().mockResolvedValue([]) },
+        { signInExperiences: { validateLanguageInfo: jest.fn(), findCaseConflicts } }
+      ),
+    });
+
+  beforeEach(() => {
+    // The `usernamePolicy` body field (and therefore the 409 guard) is only honored with dev features on.
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet without reloading mocked modules.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+  });
+
+  afterEach(() => {
+    findCaseConflicts.mockReset();
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+      originalIsDevFeaturesEnabled;
+  });
+
+  it('returns 409 when flipping to case-insensitive while conflicts exist', async () => {
+    findCaseConflicts.mockResolvedValueOnce({
+      totalConflicts: 1,
+      samples: [{ usernameLower: 'foo', userIds: ['u1', 'u2'] }],
+    });
+
+    const response = await buildRequester()
+      .patch('/sign-in-exp')
+      .send({ usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false } });
+
+    expect(response.status).toBe(409);
+    expect(findCaseConflicts).toHaveBeenCalled();
+  });
+
+  it('updates successfully when flipping to case-insensitive without conflicts', async () => {
+    findCaseConflicts.mockResolvedValueOnce({ totalConflicts: 0, samples: [] });
+
+    const response = await buildRequester()
+      .patch('/sign-in-exp')
+      .send({ usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false } });
+
+    expect(response.status).toBe(200);
+    expect(findCaseConflicts).toHaveBeenCalled();
+  });
+
+  it('skips the conflict check when the policy is already case-insensitive', async () => {
+    // The tenant is already case-insensitive (no case-sensitive -> case-insensitive transition), so
+    // the guard must not run the scan even though conflicts would be reported.
+    findCaseConflicts.mockResolvedValueOnce({
+      totalConflicts: 3,
+      samples: [{ usernameLower: 'foo', userIds: ['u1', 'u2'] }],
+    });
+
+    const response = await buildRequester(false)
+      .patch('/sign-in-exp')
+      .send({ usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false } });
+
+    expect(response.status).toBe(200);
+    expect(findCaseConflicts).not.toHaveBeenCalled();
   });
 });
 /* eslint-enable max-lines */

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -32,6 +32,7 @@ import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
 import customUiAssetsRoutes from './custom-ui-assets/index.js';
 import { hasCustomUiCspSources, normalizeCustomUiCsp } from './custom-ui-csp.js';
+import usernamePolicyRoutes from './username-policy.js';
 
 const isMfaEnabled = (mfa: Optional<SignInExperience['mfa']>): boolean =>
   Boolean(mfa?.factors && mfa.factors.length > 0);
@@ -53,7 +54,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
   const { findUserById } = queries.users;
   const { normalizeProfileFields } = libraries.customProfileFields;
   const {
-    signInExperiences: { validateLanguageInfo },
+    signInExperiences: { validateLanguageInfo, findCaseConflicts },
     quota,
   } = libraries;
   const { getLogtoConnectors } = connectors;
@@ -101,7 +102,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         )
         .partial(),
       response: signInExperienceResponseGuard,
-      status: [200, 400, 404, 422, 403],
+      status: [200, 400, 404, 422, 403, 409],
     }),
     // eslint-disable-next-line complexity
     async (ctx, next) => {
@@ -152,6 +153,29 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         getLogtoConnectors(),
         findDefaultSignInExperience(),
       ]);
+
+      // Flipping usernames to case-insensitive would merge accounts that differ only by case, so
+      // reject the flip while such conflicts exist. Only the actual case-sensitive ->
+      // case-insensitive transition needs checking: a tenant that is already case-insensitive
+      // cannot have accumulated case conflicts (uniqueness was enforced case-insensitively), so we
+      // skip the (potentially expensive) scan otherwise. The `usernamePolicy` write is itself
+      // dev-gated, so this guard is too.
+      if (
+        EnvSet.values.isDevFeaturesEnabled &&
+        usernamePolicy?.caseSensitive === false &&
+        currentSettings.usernamePolicy.caseSensitive
+      ) {
+        const { totalConflicts, samples } = await findCaseConflicts(20);
+        if (totalConflicts > 0) {
+          throw new RequestError(
+            {
+              code: 'sign_in_experiences.username_policy_case_conflicts_exist',
+              status: 409,
+            },
+            { totalConflicts, samples }
+          );
+        }
+      }
 
       // Remove unavailable connectors
       const filteredSocialSignInConnectorTargets = socialSignInConnectorTargets?.filter((target) =>
@@ -452,5 +476,11 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
   );
 
   customUiAssetsRoutes(...args);
+
+  // Username policy conflict-detection API is gated until the feature ships, so the endpoint is
+  // absent (not just hidden) when dev features are off — keeping prod and its OpenAPI doc clean.
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    usernamePolicyRoutes(...args);
+  }
 }
 /* eslint-enable max-lines */

--- a/packages/core/src/routes/sign-in-experience/username-policy.openapi.json
+++ b/packages/core/src/routes/sign-in-experience/username-policy.openapi.json
@@ -1,0 +1,16 @@
+{
+  "paths": {
+    "/api/sign-in-exp/username-policy/case-sensitivity-conflicts": {
+      "get": {
+        "tags": ["Dev feature"],
+        "summary": "Get username case-sensitivity conflicts",
+        "description": "List groups of usernames that collide when compared case-insensitively (i.e. usernames that would clash if the tenant switched to a case-insensitive username policy), with the total group count and a capped sample. Useful for surfacing conflicts before disabling case sensitivity.",
+        "responses": {
+          "200": {
+            "description": "The total number of case-insensitive username collision groups and a sample of them."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/sign-in-experience/username-policy.test.ts
+++ b/packages/core/src/routes/sign-in-experience/username-policy.test.ts
@@ -1,0 +1,61 @@
+import { createMockUtils, pickDefault } from '@logto/shared/esm';
+
+import { MockTenant } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+const { mockEsmWithActual } = createMockUtils(jest);
+
+const findCaseConflicts = jest.fn();
+
+// The conflict-detection route is only registered when dev features are enabled, so mock EnvSet
+// with the flag on before importing the routes.
+await mockEsmWithActual('#src/env-set/index.js', () => ({
+  EnvSet: {
+    values: {
+      isDevFeaturesEnabled: true,
+      isCloud: false,
+      isProduction: false,
+      isUnitTest: true,
+    },
+  },
+}));
+
+const signInExperiencesRoutes = await pickDefault(import('./index.js'));
+
+describe('GET /sign-in-exp/username-policy/case-sensitivity-conflicts', () => {
+  const requester = createRequester({
+    authedRoutes: signInExperiencesRoutes,
+    tenantContext: new MockTenant(undefined, undefined, undefined, {
+      signInExperiences: { findCaseConflicts },
+    }),
+  });
+
+  afterEach(() => {
+    findCaseConflicts.mockReset();
+  });
+
+  it('returns the conflict count and samples', async () => {
+    findCaseConflicts.mockResolvedValueOnce({
+      totalConflicts: 2,
+      samples: [{ usernameLower: 'foo', userIds: ['u1', 'u2'] }],
+    });
+
+    const response = await requester.get('/sign-in-exp/username-policy/case-sensitivity-conflicts');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      totalConflicts: 2,
+      samples: [{ usernameLower: 'foo', userIds: ['u1', 'u2'] }],
+    });
+    expect(findCaseConflicts).toHaveBeenCalledWith(20);
+  });
+
+  it('forwards the limit query to the library', async () => {
+    findCaseConflicts.mockResolvedValueOnce({ totalConflicts: 0, samples: [] });
+
+    await requester.get('/sign-in-exp/username-policy/case-sensitivity-conflicts?limit=5');
+
+    expect(findCaseConflicts).toHaveBeenCalledWith(5);
+  });
+});

--- a/packages/core/src/routes/sign-in-experience/username-policy.ts
+++ b/packages/core/src/routes/sign-in-experience/username-policy.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+import koaGuard from '#src/middleware/koa-guard.js';
+
+import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
+
+export default function usernamePolicyRoutes<T extends ManagementApiRouter>(
+  ...[router, { libraries }]: RouterInitArgs<T>
+) {
+  const { findCaseConflicts } = libraries.signInExperiences;
+
+  /**
+   * Diagnostic endpoint for the console: reports usernames that would collide under a
+   * case-insensitive policy, so an operator can resolve them before flipping `caseSensitive` off
+   * (a flip that would otherwise be rejected with 409 on PATCH `/sign-in-exp`).
+   */
+  router.get(
+    '/sign-in-exp/username-policy/case-sensitivity-conflicts',
+    koaGuard({
+      query: z.object({ limit: z.coerce.number().int().min(1).max(100).default(20) }),
+      response: z.object({
+        totalConflicts: z.number().int().min(0),
+        samples: z.object({ usernameLower: z.string(), userIds: z.string().array() }).array(),
+      }),
+      status: [200],
+    }),
+    async (ctx, next) => {
+      const { limit } = ctx.guard.query;
+      ctx.body = await findCaseConflicts(limit);
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -31,6 +31,8 @@ const devFeatureCustomRoutes: Readonly<RouteDictionary> = Object.freeze({
   'get /configs/oidc/session': 'GetOidcSessionConfig',
   'patch /configs/oidc/session': 'UpdateOidcSessionConfig',
   'patch /users/:userId/password/expiration': 'UpdateUserPasswordExpiration',
+  'get /sign-in-exp/username-policy/case-sensitivity-conflicts':
+    'GetUsernameCaseSensitivityConflicts',
 });
 
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({

--- a/packages/integration-tests/src/api/sign-in-experience.ts
+++ b/packages/integration-tests/src/api/sign-in-experience.ts
@@ -15,3 +15,18 @@ export const updateSignInExperience = async (
       json: signInExperience,
     })
     .json<SignInExperience>();
+
+export type UsernameCaseSensitivityConflicts = {
+  totalConflicts: number;
+  samples: Array<{ usernameLower: string; userIds: string[] }>;
+};
+
+export const getUsernameCaseSensitivityConflicts = async (
+  limit = 20,
+  api: KyInstance = authedAdminApi
+) =>
+  api
+    .get('sign-in-exp/username-policy/case-sensitivity-conflicts', {
+      searchParams: { limit },
+    })
+    .json<UsernameCaseSensitivityConflicts>();

--- a/packages/integration-tests/src/tests/api/sign-in-experience.username-policy.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.username-policy.test.ts
@@ -1,0 +1,59 @@
+import { defaultUsernamePolicy } from '@logto/core-kit';
+
+import {
+  deleteUser,
+  getUsernameCaseSensitivityConflicts,
+  updateSignInExperience,
+} from '#src/api/index.js';
+import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
+import { devFeatureTest, generateUsername } from '#src/utils.js';
+
+// Dev-gated: the conflict-detection endpoint is only registered when dev features are enabled.
+devFeatureTest.describe('GET /sign-in-exp/username-policy/case-sensitivity-conflicts', () => {
+  it('reports usernames that collide case-insensitively', async () => {
+    const base = generateUsername();
+    const { totalConflicts: before } = await getUsernameCaseSensitivityConflicts(100);
+
+    // Created under the default case-sensitive policy, so both coexist while colliding on lower().
+    const lower = await createUserByAdmin({ username: base.toLowerCase() });
+    const upper = await createUserByAdmin({ username: base.toUpperCase() });
+
+    const after = await getUsernameCaseSensitivityConflicts(100);
+    expect(after.totalConflicts).toBe(before + 1);
+    const sample = after.samples.find(({ usernameLower }) => usernameLower === base.toLowerCase());
+    expect(sample?.userIds).toEqual(expect.arrayContaining([lower.id, upper.id]));
+
+    await deleteUser(lower.id);
+    await deleteUser(upper.id);
+
+    const { totalConflicts: restored } = await getUsernameCaseSensitivityConflicts(100);
+    expect(restored).toBe(before);
+  });
+});
+
+// Dev-gated: the PATCH `usernamePolicy` body field and the 409 guard only activate under dev
+// features (the write path strips `usernamePolicy` otherwise).
+devFeatureTest.describe('PATCH /sign-in-exp case-sensitivity conflict guard', () => {
+  afterAll(async () => {
+    await updateSignInExperience({ usernamePolicy: defaultUsernamePolicy });
+  });
+
+  it('rejects flipping to case-insensitive while conflicts exist with 409', async () => {
+    await updateSignInExperience({
+      usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: true },
+    });
+    const base = generateUsername();
+    const lower = await createUserByAdmin({ username: base.toLowerCase() });
+    const upper = await createUserByAdmin({ username: base.toUpperCase() });
+
+    await expectRejects(
+      updateSignInExperience({
+        usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
+      }),
+      { code: 'sign_in_experiences.username_policy_case_conflicts_exist', status: 409 }
+    );
+
+    await deleteUser(lower.id);
+    await deleteUser(upper.id);
+  });
+});

--- a/packages/phrases/src/locales/ar/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/ar/errors/sign-in-experiences.ts
@@ -42,6 +42,9 @@ const sign_in_experiences = {
     'سياسة انتهاء صلاحية كلمة المرور غير مفعلة. قم بتفعيلها في إعدادات تجربة تسجيل الدخول قبل إنهاء صلاحية كلمات المرور.',
   password_expiration_invalid_period_days:
     'عند تفعيل انتهاء صلاحية كلمة المرور، يجب أن تكون reminderPeriodDays أقل من validPeriodDays.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/de/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/de/errors/sign-in-experiences.ts
@@ -46,6 +46,9 @@ const sign_in_experiences = {
     'Die Passwort-Ablaufrichtlinie ist nicht aktiviert. Aktivieren Sie diese in den Einstellungen für das Anmeldeerlebnis, bevor Sie Passwörter ablaufen lassen.',
   password_expiration_invalid_period_days:
     'Wenn die Passwortablaufregel aktiviert ist, muss reminderPeriodDays kleiner als validPeriodDays sein.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
@@ -42,6 +42,8 @@ const sign_in_experiences = {
     'Password expiration policy is not enabled. Enable it in the sign-in experience settings before expiring passwords.',
   password_expiration_invalid_period_days:
     'Reminder period days must be less than valid period days when password expiration is enabled.',
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/es/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/es/errors/sign-in-experiences.ts
@@ -45,6 +45,9 @@ const sign_in_experiences = {
     'La política de expiración de contraseña no está habilitada. Habilítela en la configuración de la experiencia de inicio de sesión antes de que las contraseñas expiren.',
   password_expiration_invalid_period_days:
     'Cuando la expiración de contraseña está habilitada, reminderPeriodDays debe ser menor que validPeriodDays.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/fr/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/fr/errors/sign-in-experiences.ts
@@ -47,6 +47,9 @@ const sign_in_experiences = {
     "La politique d'expiration du mot de passe n'est pas activée. Activez-la dans les paramètres de l'expérience de connexion avant de faire expirer les mots de passe.",
   password_expiration_invalid_period_days:
     'Lorsque l’expiration du mot de passe est activée, reminderPeriodDays doit être inférieur à validPeriodDays.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/it/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/it/errors/sign-in-experiences.ts
@@ -45,6 +45,9 @@ const sign_in_experiences = {
     "La politica di scadenza della password non è abilitata. Abilitala nelle impostazioni dell'esperienza di accesso prima di far scadere le password.",
   password_expiration_invalid_period_days:
     'Quando la scadenza della password è abilitata, reminderPeriodDays deve essere minore di validPeriodDays.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/ja/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/ja/errors/sign-in-experiences.ts
@@ -45,6 +45,9 @@ const sign_in_experiences = {
     'パスワードの有効期限ポリシーが有効になっていません。パスワードを期限切れにする前に、サインイン体験の設定で有効にしてください。',
   password_expiration_invalid_period_days:
     'パスワード有効期限が有効な場合、reminderPeriodDays は validPeriodDays より小さくする必要があります。',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/ko/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/ko/errors/sign-in-experiences.ts
@@ -42,6 +42,9 @@ const sign_in_experiences = {
     '비밀번호 만료 정책이 활성화되지 않았습니다. 비밀번호를 만료시키기 전에 로그인 경험 설정에서 이를 활성화하세요.',
   password_expiration_invalid_period_days:
     '비밀번호 만료가 활성화된 경우 reminderPeriodDays는 validPeriodDays보다 작아야 합니다.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/pl-pl/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/sign-in-experiences.ts
@@ -44,6 +44,9 @@ const sign_in_experiences = {
     'Polityka wygasania haseł nie jest włączona. Włącz ją w ustawieniach logowania przed wygaszeniem haseł.',
   password_expiration_invalid_period_days:
     'Gdy wygaśnięcie hasła jest włączone, reminderPeriodDays musi być mniejsze niż validPeriodDays.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/pt-br/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/pt-br/errors/sign-in-experiences.ts
@@ -45,6 +45,9 @@ const sign_in_experiences = {
     'A política de expiração de senha não está ativada. Ative-a nas configurações de experiência de login antes de expirar senhas.',
   password_expiration_invalid_period_days:
     'Quando a expiração de senha estiver habilitada, reminderPeriodDays deve ser menor que validPeriodDays.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/pt-pt/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/sign-in-experiences.ts
@@ -45,6 +45,9 @@ const sign_in_experiences = {
     'A política de expiração de palavra-passe não está ativada. Ative-a nas definições de experiência de início de sessão antes de expirar palavras-passe.',
   password_expiration_invalid_period_days:
     'Quando a expiração de palavra-passe estiver ativada, reminderPeriodDays deve ser inferior a validPeriodDays.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/ru/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/ru/errors/sign-in-experiences.ts
@@ -46,6 +46,9 @@ const sign_in_experiences = {
     'Политика истечения срока действия пароля не включена. Включите ее в настройках входа в систему перед истечением срока действия паролей.',
   password_expiration_invalid_period_days:
     'Когда включено истечение срока действия пароля, reminderPeriodDays должен быть меньше validPeriodDays.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/th/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/th/errors/sign-in-experiences.ts
@@ -44,6 +44,9 @@ const sign_in_experiences = {
     'นโยบายการหมดอายุของรหัสผ่านไม่ได้เปิดใช้งาน โปรดเปิดใช้งานในการตั้งค่าประสบการณ์การลงชื่อเข้าใช้ก่อนที่จะกำหนดวันหมดอายุของรหัสผ่าน',
   password_expiration_invalid_period_days:
     'เมื่อเปิดใช้การหมดอายุรหัสผ่าน reminderPeriodDays ต้องน้อยกว่า validPeriodDays',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/tr-tr/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/sign-in-experiences.ts
@@ -44,6 +44,9 @@ const sign_in_experiences = {
     'Parola sona erme politikası etkinleştirilmemiş. Parolaların süresini doldurmadan önce oturum açma deneyimi ayarlarından etkinleştirin.',
   password_expiration_invalid_period_days:
     'Parola süresi dolma politikası etkin olduğunda, reminderPeriodDays değeri validPeriodDays değerinden küçük olmalıdır.',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/zh-cn/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/sign-in-experiences.ts
@@ -34,6 +34,9 @@ const sign_in_experiences = {
   password_expiration_not_enabled: '密码过期策略未启用。在过期密码前，请在登录体验设置中启用它。',
   password_expiration_invalid_period_days:
     '启用密码过期策略时，reminderPeriodDays 必须小于 validPeriodDays。',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/zh-hk/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/sign-in-experiences.ts
@@ -36,6 +36,9 @@ const sign_in_experiences = {
   password_expiration_not_enabled: '密碼過期策略未啟用。在過期密碼前，請在登錄體驗設置中啟用它。',
   password_expiration_invalid_period_days:
     '啟用密碼到期策略時，reminderPeriodDays 必須小於 validPeriodDays。',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);

--- a/packages/phrases/src/locales/zh-tw/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/sign-in-experiences.ts
@@ -35,6 +35,9 @@ const sign_in_experiences = {
   password_expiration_not_enabled: '密碼過期策略未啟用。在過期密碼前，請在登錄體驗設置中啟用它。',
   password_expiration_invalid_period_days:
     '啟用密碼到期策略時，reminderPeriodDays 必須小於 validPeriodDays。',
+  /** UNTRANSLATED */
+  username_policy_case_conflicts_exist:
+    'Cannot switch to case-insensitive usernames while usernames that differ only by case exist. Resolve the conflicts and try again.',
 };
 
 export default Object.freeze(sign_in_experiences);


### PR DESCRIPTION
## Summary
Adds a username case-sensitivity conflict-detection query and Management API. Relates to LOG-13526. Stacked on #8939 (P3) — review/merge that first.

### What changed
- `queries/user.ts` — `findUsernameCaseConflicts(limit)` (groups of `lower(username)` shared by more than one user, with their ids) and `countUsernameCaseConflicts()`.
- `libraries/sign-in-experience` — `findCaseConflicts(limit)` → `{ totalConflicts, samples }`.
- New **`GET /api/sign-in-exp/username-policy/case-sensitivity-conflicts?limit=20`** — read-only diagnostic, ungated.
- **`PATCH /api/sign-in-exp`** — returns **409** when the body sets `usernamePolicy.caseSensitive: false` while case-insensitive collisions exist. Gated behind `isDevFeaturesEnabled` (only reachable when the dev-gated `usernamePolicy` body field is accepted).
- New error phrase `sign_in_experiences.username_policy_case_conflicts_exist` across all locales.

### Expected result
- No prod behavior change: the 409 guard and the `usernamePolicy` body field are dev-gated; with the flag off the field is stripped as before. The GET endpoint is additive and read-only.
- With the flag on, an operator can list case-insensitive username collisions and is blocked from flipping a tenant to case-insensitive while they exist.

### Reviewer notes
- The conflict query has no explicit `tenant_id` filter, consistent with the tenant-scoped pool used by the sibling `hasUser` / `findUserByUsername` queries; it is supported by the P1 functional index `(tenant_id, lower(username))`.
- `array_agg(id)` order is unspecified and not relied upon (the response is an unordered array).
- The GET endpoint is intentionally ungated (read-only diagnostic); the console form in a later phase consumes it.

## Testing
Unit tests, integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
