### PR TITLE
feat(core,phrases,toolkit): enforce username policy on writes behind dev flag

### DIFF
--- a/packages/core/src/routes-me/user.ts
+++ b/packages/core/src/routes-me/user.ts
@@ -3,6 +3,7 @@ import { userInfoSelectFields, jsonObjectGuard } from '@logto/schemas';
 import { condArray, conditional, pick } from '@silverhand/essentials';
 import { literal, object, string } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayloadFromPassword } from '#src/libraries/user.utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -10,6 +11,7 @@ import assertThat from '#src/utils/assert-that.js';
 
 import type { RouterInitArgs } from '../routes/types.js';
 import { checkPasswordPolicyForUser } from '../utils/password.js';
+import { assertUsernameAllowed } from '../utils/user.js';
 
 import type { AuthedMeRouter } from './types.js';
 
@@ -59,10 +61,17 @@ export default function userRoutes<T extends AuthedMeRouter>(
       const user = await findUserById(userId);
       assertThat(!user.isSuspended, new RequestError({ code: 'user.suspended', status: 401 }));
 
-      const { primaryEmail } = body;
+      const { primaryEmail, username } = body;
       if (primaryEmail) {
         // Check if user has verified email within 10 minutes.
         await checkVerificationStatus(userId, primaryEmail);
+      }
+
+      // Per-tenant policy enforcement is gated until the feature ships; the regex guard above is the
+      // always-on hard floor, so prod behavior is unchanged when the flag is off.
+      if (username !== undefined && EnvSet.values.isDevFeaturesEnabled) {
+        const { usernamePolicy } = await findDefaultSignInExperience();
+        assertUsernameAllowed(usernamePolicy, username);
       }
 
       await checkIdentifierCollision(body, userId);

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -11,11 +11,12 @@ import {
 import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayloadFromPassword } from '#src/libraries/user.utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
-import { assertUserHasRemainingIdentifier } from '#src/utils/user.js';
+import { assertUserHasRemainingIdentifier, assertUsernameAllowed } from '#src/utils/user.js';
 
 import { PasswordValidator } from '../experience/classes/libraries/password-validator.js';
 import type { UserRouter, RouterInitArgs } from '../types.js';
@@ -113,6 +114,12 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
           ]);
           assertUserHasRemainingIdentifier(user, { username: null }, ssoIdentities.length);
         } else {
+          // Per-tenant policy enforcement is gated until the feature ships; the regex guard above
+          // is the always-on hard floor, so prod behavior is unchanged when the flag is off.
+          if (EnvSet.values.isDevFeaturesEnabled) {
+            const { usernamePolicy } = await findDefaultSignInExperience();
+            assertUsernameAllowed(usernamePolicy, username);
+          }
           await checkIdentifierCollision({ username }, userId);
         }
       }

--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -242,6 +242,12 @@ export class SignInExperienceValidator {
     return passwordPolicy;
   }
 
+  public async getUsernamePolicy() {
+    const { usernamePolicy } = await this.getSignInExperienceData();
+
+    return usernamePolicy;
+  }
+
   public async getPasswordExpirationPolicy() {
     const { passwordExpiration } = await this.getSignInExperienceData();
 

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -7,11 +7,13 @@ import {
 } from '@logto/schemas';
 import { pick, trySafe } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
+import { assertUsernameAllowed } from '#src/utils/user.js';
 
 import type {
   SanitizedInteractionProfile,
@@ -153,6 +155,17 @@ export class Profile {
 
     if (user) {
       this.profileValidator.guardProfileNotExistInCurrentUserAccount(user, profile);
+    }
+
+    // Per-tenant username policy enforcement is gated until the feature ships. The hard-floor regex
+    // on each entry route stays on regardless, so prod behavior is unchanged when the flag is off.
+    // Runs before the uniqueness check so a format/policy violation is reported ahead of
+    // "username already in use", matching the account and /me routes.
+    if (EnvSet.values.isDevFeaturesEnabled && profile.username) {
+      assertUsernameAllowed(
+        await this.signInExperienceValidator.getUsernamePolicy(),
+        profile.username
+      );
     }
 
     await this.profileValidator.guardProfileUniquenessAcrossUsers(profile);

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -1080,5 +1080,21 @@ describe('PATCH /sign-in-exp username policy', () => {
     expect(response.status).toBe(200);
     expect(findCaseConflicts).not.toHaveBeenCalled();
   });
+
+  it('rejects a numbers-only username policy', async () => {
+    const response = await buildRequester()
+      .patch('/sign-in-exp')
+      .send({
+        usernamePolicy: {
+          ...defaultUsernamePolicy,
+          allowedChars: { lowercase: false, uppercase: false, numbers: true, underscore: false },
+        },
+      });
+
+    // The `usernamePolicyGuard` refine rejects this at koaGuard (400). The exact human-readable
+    // message is asserted in core-kit's `username-policy.test.ts`; the test requester here does not
+    // mount the error handler that serializes the refine message into the response body.
+    expect(response.status).toBe(400);
+  });
 });
 /* eslint-enable max-lines */

--- a/packages/core/src/utils/user.ts
+++ b/packages/core/src/utils/user.ts
@@ -1,3 +1,4 @@
+import { type UsernamePolicy, validateUsernameAgainstPolicy } from '@logto/core-kit';
 import {
   MfaFactor,
   Users,
@@ -14,6 +15,18 @@ import { type z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
+
+/**
+ * Enforce the tenant's username policy on a write. Throws `user.username_<violation>` (422) on the
+ * first violation. The hard floor (non-empty, no leading digit, allowed charset) always applies;
+ * length and character-class rules come from the per-tenant policy.
+ */
+export const assertUsernameAllowed = (policy: UsernamePolicy, username: string): void => {
+  const violation = validateUsernameAgainstPolicy(username, policy);
+  if (violation) {
+    throw new RequestError({ code: `user.username_${violation}`, status: 422 });
+  }
+};
 
 export const adminUserProfileResponseGuard = userProfileResponseGuard.extend({
   passwordDigest: Users.guard.shape.passwordEncrypted.optional(),

--- a/packages/integration-tests/src/tests/api/account.username-policy.test.ts
+++ b/packages/integration-tests/src/tests/api/account.username-policy.test.ts
@@ -1,0 +1,49 @@
+import { defaultUsernamePolicy } from '@logto/core-kit';
+
+import { enableAllAccountCenterFields } from '#src/api/account-center.js';
+import { deleteUser, updateSignInExperience } from '#src/api/index.js';
+import { updateUser } from '#src/api/my-account.js';
+import { createVerificationRecordByPassword } from '#src/api/verification-record.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { createDefaultTenantUserWithPassword, signInAndGetUserApi } from '#src/helpers/profile.js';
+import {
+  defaultSignInSignUpConfigs,
+  enableAllPasswordSignInMethods,
+} from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateUsername } from '#src/utils.js';
+
+const uppercaseUsername = () => `A${generateUsername()}`;
+
+const uppercaseDisabledPolicy = {
+  ...defaultUsernamePolicy,
+  allowedChars: { lowercase: true, uppercase: false, numbers: true, underscore: true },
+};
+
+// Dev-gated: policy enforcement only activates under dev features.
+devFeatureTest.describe('account API username policy enforcement', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await enableAllAccountCenterFields();
+    await updateSignInExperience({ usernamePolicy: uppercaseDisabledPolicy });
+  });
+
+  afterAll(async () => {
+    await updateSignInExperience({
+      ...defaultSignInSignUpConfigs,
+      usernamePolicy: defaultUsernamePolicy,
+    });
+  });
+
+  it('rejects updating to a username that violates the policy', async () => {
+    const { user, username, password } = await createDefaultTenantUserWithPassword();
+    const api = await signInAndGetUserApi(username, password);
+    const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+    await expectRejects(updateUser(api, { username: uppercaseUsername() }, verificationRecordId), {
+      code: 'user.username_uppercase_not_allowed',
+      status: 422,
+    });
+
+    await deleteUser(user.id);
+  });
+});

--- a/packages/integration-tests/src/tests/api/experience-api/username-policy.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/username-policy.test.ts
@@ -1,0 +1,58 @@
+import { defaultUsernamePolicy } from '@logto/core-kit';
+import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
+
+import { updateSignInExperience } from '#src/api/index.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import { registerNewUserUsernamePassword } from '#src/helpers/experience/index.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  defaultSignInSignUpConfigs,
+  resetMfaSettings,
+  resetPasswordPolicy,
+} from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateUsername, generatePassword } from '#src/utils.js';
+
+const password = generatePassword();
+
+// Unique (so the uniqueness check passes) but contains an uppercase letter, which the policy below
+// forbids — so it trips the policy guard, not the collision check.
+const uppercaseUsername = () => `A${generateUsername()}`;
+
+const uppercaseDisabledPolicy = {
+  ...defaultUsernamePolicy,
+  allowedChars: { lowercase: true, uppercase: false, numbers: true, underscore: true },
+};
+
+// Dev-gated: policy enforcement only activates under dev features, and the policy can only be
+// written to the sign-in experience when dev features are enabled.
+devFeatureTest.describe('experience API username policy enforcement', () => {
+  beforeAll(async () => {
+    await updateSignInExperience({ ...defaultSignInSignUpConfigs, passwordPolicy: {} });
+    await resetMfaSettings();
+    await updateSignInExperience({ usernamePolicy: uppercaseDisabledPolicy });
+  });
+
+  afterAll(async () => {
+    await updateSignInExperience({
+      ...defaultSignInSignUpConfigs,
+      usernamePolicy: defaultUsernamePolicy,
+    });
+    await resetPasswordPolicy();
+  });
+
+  it('registration rejects a username that violates the policy', async () => {
+    await expectRejects(registerNewUserUsernamePassword(uppercaseUsername(), password), {
+      code: 'user.username_uppercase_not_allowed',
+      status: 422,
+    });
+  });
+
+  it('profile update rejects a username that violates the policy', async () => {
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
+
+    await expectRejects(
+      client.updateProfile({ type: SignInIdentifier.Username, value: uppercaseUsername() }),
+      { code: 'user.username_uppercase_not_allowed', status: 422 }
+    );
+  });
+});

--- a/packages/phrases/src/locales/ar/errors/user.ts
+++ b/packages/phrases/src/locales/ar/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'اسم المستخدم هذا مستخدم بالفعل.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'هذا البريد الإلكتروني مرتبط بحساب موجود بالفعل.',
   phone_already_in_use: 'هذا الرقم الهاتفي مرتبط بحساب موجود بالفعل.',
   invalid_email: 'عنوان البريد الإلكتروني غير صالح.',

--- a/packages/phrases/src/locales/de/errors/user.ts
+++ b/packages/phrases/src/locales/de/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'Dieser Benutzername wird bereits verwendet.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'Diese E-Mail-Adresse ist mit einem vorhandenen Konto verknüpft.',
   phone_already_in_use: 'Diese Telefonnummer ist mit einem vorhandenen Konto verknüpft.',
   invalid_email: 'Ungültige E-Mail.',

--- a/packages/phrases/src/locales/en/errors/user.ts
+++ b/packages/phrases/src/locales/en/errors/user.ts
@@ -1,5 +1,13 @@
 const user = {
   username_already_in_use: 'This username is already in use.',
+  username_starts_with_number: 'Username cannot start with a number.',
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  username_too_short: 'Username is too short.',
+  username_too_long: 'Username is too long.',
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'This email is associated with an existing account.',
   phone_already_in_use: 'This phone number is associated with an existing account.',
   invalid_email: 'Invalid email address.',

--- a/packages/phrases/src/locales/es/errors/user.ts
+++ b/packages/phrases/src/locales/es/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'Este nombre de usuario ya está en uso.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'Este correo electrónico está asociado a una cuenta existente.',
   phone_already_in_use: 'Este número de teléfono está asociado a una cuenta existente.',
   invalid_email: 'Dirección de correo electrónico inválida.',

--- a/packages/phrases/src/locales/fr/errors/user.ts
+++ b/packages/phrases/src/locales/fr/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: "Ce nom d'utilisateur est déjà utilisé.",
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'Cet e-mail est associé à un compte existant.',
   phone_already_in_use: 'Ce numéro de téléphone est associé à un compte existant.',
   invalid_email: 'Addresse email incorrecte.',

--- a/packages/phrases/src/locales/it/errors/user.ts
+++ b/packages/phrases/src/locales/it/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'Questo nome utente è già in uso.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'Questa email è associata ad un account esistente.',
   phone_already_in_use: 'Questo numero di telefono è associato ad un account esistente.',
   invalid_email: 'Indirizzo email non valido.',

--- a/packages/phrases/src/locales/ja/errors/user.ts
+++ b/packages/phrases/src/locales/ja/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'このユーザー名はすでに使用されています。',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'このメールアドレスは既に別のアカウントに関連付けされています。',
   phone_already_in_use: 'この電話番号は既に別のアカウントに関連付けされています。',
   invalid_email: '無効なメールアドレスです。',

--- a/packages/phrases/src/locales/ko/errors/user.ts
+++ b/packages/phrases/src/locales/ko/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: '이 사용자 이름은 다른 사람이 이미 사용 중이에요.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: '이 이메일은 다른 계정에서 이미 사용 중이에요.',
   phone_already_in_use: '이 휴대전화번호는 다른 계정에서 이미 사용 중이에요.',
   invalid_email: '유효하지 않은 이메일이에요.',

--- a/packages/phrases/src/locales/pl-pl/errors/user.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'Nazwa użytkownika jest już zajęta.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'Ten email jest już powiązany z istniejącym kontem.',
   phone_already_in_use: 'Ten numer telefonu jest już powiązany z istniejącym kontem.',
   invalid_email: 'Nieprawidłowy adres email.',

--- a/packages/phrases/src/locales/pt-br/errors/user.ts
+++ b/packages/phrases/src/locales/pt-br/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'Este nome de usuário já está em uso.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'Este e-mail está associado a uma conta existente.',
   phone_already_in_use: 'Este número de telefone está associado a uma conta existente.',
   invalid_email: 'Endereço de e-mail inválido.',

--- a/packages/phrases/src/locales/pt-pt/errors/user.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'Este nome de utilizador já está em uso.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'Este email já está associado a uma conta existente.',
   phone_already_in_use: 'Este número de telefone já está associado a uma conta existente.',
   invalid_email: 'Endereço de email inválido.',

--- a/packages/phrases/src/locales/ru/errors/user.ts
+++ b/packages/phrases/src/locales/ru/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'Это имя пользователя уже используется.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'Этот адрес электронной почты связан с существующей учетной записью.',
   phone_already_in_use: 'Этот номер телефона связан с существующей учетной записью.',
   invalid_email: 'Некорректный адрес электронной почты.',

--- a/packages/phrases/src/locales/th/errors/user.ts
+++ b/packages/phrases/src/locales/th/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'ชื่อผู้ใช้นี้ถูกใช้ไปแล้ว',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'อีเมลนี้ถูกเชื่อมโยงกับบัญชีที่มีอยู่แล้ว',
   phone_already_in_use: 'เบอร์โทรศัพท์นี้ถูกเชื่อมโยงกับบัญชีที่มีอยู่แล้ว',
   invalid_email: 'ที่อยู่อีเมลไม่ถูกต้อง',

--- a/packages/phrases/src/locales/tr-tr/errors/user.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: 'Bu kullanıcı adı zaten kullanımda.',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: 'Bu e-posta mevcut bir hesapla ilişkilendirilmiştir.',
   phone_already_in_use: 'Bu telefon numarası mevcut bir hesapla ilişkilendirilmiştir.',
   invalid_email: 'Geçersiz e-posta adresi.',

--- a/packages/phrases/src/locales/zh-cn/errors/user.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: '该用户名已被使用。',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: '该邮箱地址已被使用。',
   phone_already_in_use: '该手机号码已被使用。',
   invalid_email: '邮箱地址不正确。',

--- a/packages/phrases/src/locales/zh-hk/errors/user.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: '該使用者名稱已被使用。',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: '該電子郵件地址已被使用。',
   phone_already_in_use: '該手機號碼已被使用。',
   invalid_email: '電子郵件地址不正確。',

--- a/packages/phrases/src/locales/zh-tw/errors/user.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/user.ts
@@ -1,5 +1,21 @@
 const user = {
   username_already_in_use: '該用戶名已被使用。',
+  /** UNTRANSLATED */
+  username_starts_with_number: 'Username cannot start with a number.',
+  /** UNTRANSLATED */
+  username_invalid_charset_hard: 'Username can only contain letters, numbers, and underscores.',
+  /** UNTRANSLATED */
+  username_too_short: 'Username is too short.',
+  /** UNTRANSLATED */
+  username_too_long: 'Username is too long.',
+  /** UNTRANSLATED */
+  username_uppercase_not_allowed: 'Username cannot contain uppercase letters.',
+  /** UNTRANSLATED */
+  username_lowercase_not_allowed: 'Username cannot contain lowercase letters.',
+  /** UNTRANSLATED */
+  username_numbers_not_allowed: 'Username cannot contain numbers.',
+  /** UNTRANSLATED */
+  username_underscore_not_allowed: 'Username cannot contain underscores.',
   email_already_in_use: '該電子郵件地址已被使用。',
   phone_already_in_use: '該手機號碼已被使用。',
   invalid_email: '電子郵件地址不正確。',

--- a/packages/toolkit/core-kit/src/username-policy.test.ts
+++ b/packages/toolkit/core-kit/src/username-policy.test.ts
@@ -42,6 +42,11 @@ describe('usernamePolicyGuard', () => {
       allowedChars: { lowercase: false, uppercase: false, numbers: true, underscore: false },
     });
     expect(result.success).toBe(false);
+    // Lock the human-readable acknowledgement so the "numbers-only not allowed" message can't
+    // silently regress (koaGuard surfaces it verbatim on the Management API).
+    expect(result.success ? undefined : result.error.issues[0]?.message).toContain(
+      'numbers alone are not allowed'
+    );
   });
 
   it('accepts underscore as the only leading char class', () => {


### PR DESCRIPTION
## Summary
Enforces the per-tenant username policy at every end-user / experience username-write surface, gated behind `isDevFeaturesEnabled`. Relates to LOG-13552. Stacked on #8941 (P4) — review/merge that first.

### What changed
- `utils/user.ts` — `assertUsernameAllowed(policy, username)` throws `user.username_<violation>` (422) on the first policy violation.
- `routes/account/index.ts` (PATCH /account) and `routes-me/user.ts` (PATCH /me) — keep the `.regex(usernameRegEx)` hard-floor guard; add a gated `assertUsernameAllowed` against the tenant policy, before the uniqueness check.
- `routes/experience/classes/profile.ts` — enforce (gated) in the `setProfileWithValidation` chokepoint, before the uniqueness check; covers `POST /experience/profile` and the new-password-identity registration flow.
- `routes/experience/classes/libraries/sign-in-experience-validator.ts` — `getUsernamePolicy()` (mirrors `getPasswordPolicy()`).
- `packages/phrases/**/errors/user.ts` — 8 `username_*` violation keys across all locales (`required` reuses the existing key).
- Locks the numbers-only refine message in core-kit's guard test.

### Expected result
- No prod behavior change: enforcement is gated; with the flag off the regex hard floor is unchanged. With the flag on, a policy violation returns `422 user.username_<violation>`; the hard-floor regex still returns `400 guard.invalid_input` for charset / leading-digit.
- Admin (`POST`/`PATCH /users`) and the legacy interaction API are intentionally NOT enforced (hard-floor regex only) — support/migration surface and deprecated path respectively.

### Reviewer notes
- Error precedence is policy-before-uniqueness at all three surfaces, so a format/policy violation is reported ahead of "username already in use".
- Account/`me` integration enforcement runs in CI's seeded stack (the self-service sign-in flow needs the demo-app OIDC grant); the experience enforcement tests run anywhere.

## Testing
Unit tests, integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
