### PR TITLE
feat(core): mirror user.username into preferred_username claim when unset

### DIFF
--- a/packages/core/src/oidc/scope.test.ts
+++ b/packages/core/src/oidc/scope.test.ts
@@ -1,4 +1,10 @@
-import { getAcceptedUserClaims } from './scope.js';
+import { type UserClaim } from '@logto/core-kit';
+import { type User } from '@logto/schemas';
+
+import { mockUser } from '#src/__mocks__/user.js';
+import { EnvSet } from '#src/env-set/index.js';
+
+import { getAcceptedUserClaims, getUserClaimsData } from './scope.js';
 
 const use = {
   idToken: 'id_token',
@@ -139,5 +145,57 @@ describe('OIDC getUserClaims()', () => {
         rejected: [],
       })
     ).toEqual(profileExpectation);
+  });
+});
+
+describe('OIDC getUserClaimsData() preferred_username', () => {
+  // Unused for the `preferred_username` claim, but required by the function signature.
+  const userLibrary = {} as unknown as Parameters<typeof getUserClaimsData>[2];
+  const organizationQueries = {} as unknown as Parameters<typeof getUserClaimsData>[3];
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  const getPreferredUsername = async (user: User): Promise<unknown> => {
+    const claims: UserClaim[] = ['preferred_username'];
+    const data = await getUserClaimsData(user, claims, userLibrary, organizationQueries);
+    return data.find(([claim]) => claim === 'preferred_username')?.[1];
+  };
+
+  afterAll(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  describe('when dev features are enabled', () => {
+    beforeAll(() => {
+      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+    });
+
+    it('falls back to username when profile.preferredUsername is unset', async () => {
+      await expect(getPreferredUsername(mockUser)).resolves.toBe(mockUser.username);
+    });
+
+    it('uses profile.preferredUsername when set', async () => {
+      const user = { ...mockUser, profile: { preferredUsername: 'alice_the_great' } };
+      await expect(getPreferredUsername(user)).resolves.toBe('alice_the_great');
+    });
+
+    it('returns undefined when both username and profile.preferredUsername are unset', async () => {
+      const user = { ...mockUser, username: null };
+      await expect(getPreferredUsername(user)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('when dev features are disabled', () => {
+    beforeAll(() => {
+      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    });
+
+    it('does not fall back to username (preserves prior behavior)', async () => {
+      await expect(getPreferredUsername(mockUser)).resolves.toBeUndefined();
+    });
+
+    it('still uses an explicit profile.preferredUsername', async () => {
+      const user = { ...mockUser, profile: { preferredUsername: 'alice_the_great' } };
+      await expect(getPreferredUsername(user)).resolves.toBe('alice_the_great');
+    });
   });
 });

--- a/packages/core/src/oidc/scope.ts
+++ b/packages/core/src/oidc/scope.ts
@@ -12,6 +12,7 @@ import { cond, pick } from '@silverhand/essentials';
 import { snakeCase } from 'snake-case';
 import { type SnakeCaseKeys } from 'snakecase-keys';
 
+import { EnvSet } from '#src/env-set/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -62,6 +63,23 @@ const claimToUserProfileKey: Readonly<Record<UserProfileClaimSnakeCase, keyof Us
 
 const isUserProfileClaim = (claim: string): claim is UserProfileClaimSnakeCase =>
   userProfileKeys.some((key) => snakeCase(key) === claim);
+
+/**
+ * Resolve the standard `preferred_username` claim. Falls back to `user.username` when the user has
+ * no explicit `profile.preferredUsername`, so standards-compliant clients (e.g. Gitea, Forgejo,
+ * Mealie) receive a usable value out of the box. The explicit profile value always wins. Falls back
+ * to `undefined` (not `null`) to keep it stripped from tokens, matching the other profile claims.
+ * Gated until the feature ships.
+ */
+const getPreferredUsername = (user: User): string | undefined => {
+  const explicit = user.profile.preferredUsername;
+
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    return explicit ?? user.username ?? undefined;
+  }
+
+  return explicit ?? undefined;
+};
 
 /**
  * Get user claims data according to the claims.
@@ -124,6 +142,9 @@ export const getUserClaimsData = async (
             claim,
             ssoIdentities.map(({ issuer, identityId, detail }) => ({ issuer, identityId, detail })),
           ];
+        }
+        case 'preferred_username': {
+          return [claim, getPreferredUsername(user)];
         }
         default: {
           if (isUserProfileClaim(claim)) {


### PR DESCRIPTION
## Summary

Closes #6410, closes #6971. Linear: [LOG-9765](https://linear.app/silverhand/issue/LOG-9765).

Some standards-compliant clients (Gitea, Forgejo, Mealie) rely on the OIDC standard `preferred_username` claim. Today Logto only populates it from `profile.preferredUsername`, so a user who never set one gets `preferred_username: undefined` even when they have a `username`.

This makes `preferred_username` fall back to `user.username` when no explicit `profile.preferredUsername` is set. An explicit profile value always wins; when both are unset the claim stays `undefined` (stripped from tokens, matching the other profile claims).

### What changed
- `packages/core/src/oidc/scope.ts` — added a `getPreferredUsername(user)` helper and a dedicated `preferred_username` case in `getUserClaimsData`'s per-claim switch that returns `profile.preferredUsername ?? user.username ?? undefined`. Extracted to a helper to keep the dispatch switch within its complexity budget. Gated behind `isDevFeaturesEnabled`; flag-off preserves the prior behavior exactly (`profile.preferredUsername ?? undefined`).
- `packages/core/src/oidc/scope.test.ts` — added `getUserClaimsData()` coverage: fallback to username when unset, explicit value wins, both-unset → `undefined`, plus the flag-off path (no fallback, explicit still honored).

### Expected result
- **Prod (flag off): no change.** `preferred_username` resolves exactly as before.
- **Flag on (lit up in P9):** clients calling `/oidc/me` or receiving ID tokens with the `profile` scope see `preferred_username` populated from `user.username` whenever `profile.preferredUsername` is unset.

This is the part-6 PR of the username-policy series and is fully independent of P1–P5.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments