### PR TITLE
fix: bug bash fixes for account center and console UI

### DIFF
--- a/packages/account/src/App.module.scss
+++ b/packages/account/src/App.module.scss
@@ -129,6 +129,13 @@
     padding-bottom: _.unit(7);
   }
 
+  @media only screen and (max-width: 1060px) {
+    .withSidebar {
+      display: flex;
+      justify-content: center;
+    }
+  }
+
   @media only screen and (max-width: 800px) {
     .main:not(.cardMain) {
       width: auto;

--- a/packages/account/src/components/Sidebar/index.module.scss
+++ b/packages/account/src/components/Sidebar/index.module.scss
@@ -41,6 +41,14 @@
   flex-shrink: 0;
 }
 
+:global(body.desktop) {
+  @media only screen and (max-width: 1060px) {
+    .sidebar {
+      display: none;
+    }
+  }
+}
+
 :global(body.mobile) {
   .sidebar {
     display: none;

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.module.scss
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.module.scss
@@ -62,6 +62,11 @@
     background: inherit;
     color: var(--color-type-primary);
     font: var(--font-body-2);
+    opacity: 0%;
+
+    &.active {
+      opacity: 100%;
+    }
 
     &::placeholder {
       color: var(--color-type-secondary);
@@ -72,6 +77,11 @@
 .separator {
   color: var(--color-line-border);
   font: var(--font-body-2);
+  opacity: 0%;
+
+  &.active {
+    opacity: 100%;
+  }
 }
 
 .description,

--- a/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal/DateField.tsx
@@ -107,6 +107,7 @@ const DateField = ({
         {formatConfig.parts.map((part, index) => (
           <div key={`${name}-${part}`} className={styles.part}>
             <input
+              className={classNames((isFocused || valueString) && styles.active)}
               name={`${name}.${part}`}
               aria-label={`${label} ${part}`}
               value={dateParts[index] ?? ''}
@@ -131,7 +132,14 @@ const DateField = ({
               }}
             />
             {index < formatConfig.parts.length - 1 && (
-              <span className={styles.separator}>{formatConfig.separator}</span>
+              <span
+                className={classNames(
+                  styles.separator,
+                  (isFocused || valueString) && styles.active
+                )}
+              >
+                {formatConfig.separator}
+              </span>
             )}
           </div>
         ))}

--- a/packages/account/src/pages/Security/MfaSection/index.module.scss
+++ b/packages/account/src/pages/Security/MfaSection/index.module.scss
@@ -144,7 +144,7 @@
 }
 
 .notification {
-  margin: 0;
+  margin: _.unit(1) 0 0;
 }
 
 .toggleRow {

--- a/packages/console/src/ds-components/Tip/Tooltip/index.tsx
+++ b/packages/console/src/ds-components/Tip/Tooltip/index.tsx
@@ -83,9 +83,7 @@ function Tooltip({
     const dom = anchorRef.current;
 
     const enterHandler = () => {
-      if (!isVisible) {
-        setIsVisible(true);
-      }
+      setIsVisible(true);
     };
 
     const leaveHandler = () => {
@@ -103,7 +101,7 @@ function Tooltip({
       dom.removeEventListener('focusin', enterHandler);
       dom.removeEventListener('focusout', leaveHandler);
     };
-  }, [anchorRef, isVisible, isKeepOpen]);
+  }, [anchorRef, isKeepOpen]);
 
   useEffect(() => {
     if (!isVisible) {

--- a/packages/experience/src/components/InputFields/SelectField/index.module.scss
+++ b/packages/experience/src/components/InputFields/SelectField/index.module.scss
@@ -10,12 +10,6 @@
     cursor: pointer;
     position: relative;
 
-    input {
-      text-overflow: ellipsis;
-      padding-inline-end: _.unit(8);
-      cursor: pointer;
-    }
-
     .arrow {
       position: absolute;
       inset-inline-end: _.unit(2);
@@ -38,6 +32,12 @@
         transform: translateY(-50%) rotate(180deg);
       }
     }
+  }
+
+  .select .inputWrapper input {
+    text-overflow: ellipsis;
+    padding-inline-end: _.unit(8);
+    cursor: pointer;
   }
 
   .description,

--- a/packages/experience/src/components/InputFields/SelectField/index.tsx
+++ b/packages/experience/src/components/InputFields/SelectField/index.tsx
@@ -94,6 +94,7 @@ const SelectField = ({
       <div ref={ref} className={styles.select}>
         <InputField
           readOnly
+          className={styles.inputWrapper}
           name={name}
           label={label}
           placeholder={placeholder}


### PR DESCRIPTION
## Summary

Batch fix for 5 bug bash issues from the prebuilt user profile page project:

**LOG-13553/LOG-13567 — DateField label/placeholder overlap (account center)**
Date input parts and separators start with `opacity: 0%` and gain `.active` class when `isFocused || valueString` is truthy, matching the experience-package DateField pattern.

**LOG-13568 — SelectField `padding-inline-end` overridden by InputField shorthand**
InputField's `padding: 0 _.unit(4)` shorthand could win over SelectField's `padding-inline-end: _.unit(8)` due to equal specificity. Fixed by adding an `.inputWrapper` className to the InputField rendered by SelectField, giving the override selector `.selectContainer .select .inputWrapper input` → specificity (0,3,0,1) vs InputField's (0,2,0,1).

**LOG-13558 — MFA section inline notification lacks top margin**
Changed `.notification { margin: 0 }` → `margin: _.unit(1) 0 0` to add spacing above the notification banner.

**LOG-13566 — Sidebar/content overlap on narrow desktop**
Added `@media (max-width: 1060px)` to switch `.withSidebar` from grid to flex-center and hide the sidebar.

**LOG-13564 — Console tooltip flashes on disabled field hover**
Removed `isVisible` from the Tooltip `useEffect` dependency array. The stale `if (!isVisible)` guard was forcing event listener teardown/re-add on every visibility toggle; `setIsVisible(true)` is idempotent so the guard is unnecessary.

### Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/caba4a1cd2f54c35a18899b2c28dca71
Requested by: @wangsijie