### PR TITLE
perf(core): optimize app access control on OIDC paths

### DIFF
--- a/packages/core/src/include.d/oidc-provider/index.d.ts
+++ b/packages/core/src/include.d/oidc-provider/index.d.ts
@@ -1,7 +1,9 @@
 import type { CustomClientMetadata } from '@logto/schemas';
 
 declare module 'oidc-provider' {
-  export interface AllClientMetadata extends CustomClientMetadata {}
+  export interface AllClientMetadata extends CustomClientMetadata {
+    appLevelAccessControlEnabled?: boolean;
+  }
 
   export interface Configuration {
     allowWildcardRedirectUris?: boolean;

--- a/packages/core/src/libraries/application-access-control.test.ts
+++ b/packages/core/src/libraries/application-access-control.test.ts
@@ -1,9 +1,4 @@
-import {
-  accountCenterApplicationId,
-  createDefaultApplicationAccessControl,
-  type Application,
-  type ApplicationAccessControl,
-} from '@logto/schemas';
+import { accountCenterApplicationId, type Application } from '@logto/schemas';
 
 import { mockApplication } from '#src/__mocks__/index.js';
 import { EnvSet } from '#src/env-set/index.js';
@@ -26,33 +21,15 @@ const disabledApplication: Application = {
   appLevelAccessControlEnabled: false,
 };
 
-const buildAccessControl = (
-  patch: Partial<ApplicationAccessControl> = {}
-): ApplicationAccessControl => ({
-  ...createDefaultApplicationAccessControl(),
-  ...patch,
-});
-
 const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 const findApplicationById = jest.fn(async () => enabledApplication);
-const findApplicationAccessControl = jest.fn(async () => createDefaultApplicationAccessControl());
-const hasUserRole = jest.fn(async () => false);
-const getExistingOrganizationIds = jest.fn(async (): Promise<string[]> => []);
-const hasUserOrganizationRole = jest.fn(async () => false);
+const hasUserApplicationAccess = jest.fn(async () => false);
 
 const createLibrary = () => {
   const queries = new MockQueries({
     applications: { findApplicationById },
-    applicationAccessControl: { findApplicationAccessControl },
-    usersRoles: { hasUserRole },
+    applicationAccessControl: { hasUserApplicationAccess },
   });
-
-  jest
-    .spyOn(queries.organizations.relations.users, 'getExistingOrganizationIds')
-    .mockImplementation(getExistingOrganizationIds);
-  jest
-    .spyOn(queries.organizations.relations.usersRoles, 'hasUserOrganizationRole')
-    .mockImplementation(hasUserOrganizationRole);
 
   return createApplicationAccessControlLibrary(queries);
 };
@@ -64,10 +41,7 @@ const setDevFeaturesEnabled = (value: boolean) => {
 beforeEach(() => {
   setDevFeaturesEnabled(true);
   findApplicationById.mockResolvedValue(enabledApplication);
-  findApplicationAccessControl.mockResolvedValue(createDefaultApplicationAccessControl());
-  hasUserRole.mockResolvedValue(false);
-  getExistingOrganizationIds.mockResolvedValue([]);
-  hasUserOrganizationRole.mockResolvedValue(false);
+  hasUserApplicationAccess.mockResolvedValue(false);
 });
 
 afterEach(() => {
@@ -84,7 +58,7 @@ describe('assertUserHasApplicationAccess()', () => {
     ).resolves.not.toThrow();
 
     expect(findApplicationById).not.toHaveBeenCalled();
-    expect(findApplicationAccessControl).not.toHaveBeenCalled();
+    expect(hasUserApplicationAccess).not.toHaveBeenCalled();
   });
 
   it('allows built-in applications without querying the application', async () => {
@@ -93,7 +67,7 @@ describe('assertUserHasApplicationAccess()', () => {
     ).resolves.not.toThrow();
 
     expect(findApplicationById).not.toHaveBeenCalled();
-    expect(findApplicationAccessControl).not.toHaveBeenCalled();
+    expect(hasUserApplicationAccess).not.toHaveBeenCalled();
   });
 
   it('allows without querying rule tables when app-level access control is disabled', async () => {
@@ -104,10 +78,27 @@ describe('assertUserHasApplicationAccess()', () => {
     ).resolves.not.toThrow();
 
     expect(findApplicationById).toHaveBeenCalledWith(applicationId);
-    expect(findApplicationAccessControl).not.toHaveBeenCalled();
-    expect(hasUserRole).not.toHaveBeenCalled();
-    expect(getExistingOrganizationIds).not.toHaveBeenCalled();
-    expect(hasUserOrganizationRole).not.toHaveBeenCalled();
+    expect(hasUserApplicationAccess).not.toHaveBeenCalled();
+  });
+
+  it('allows disabled app-level access control from a request-local gate hint', async () => {
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId, false)
+    ).resolves.not.toThrow();
+
+    expect(findApplicationById).not.toHaveBeenCalled();
+    expect(hasUserApplicationAccess).not.toHaveBeenCalled();
+  });
+
+  it('uses request-local enabled gate hint without querying the application', async () => {
+    hasUserApplicationAccess.mockResolvedValueOnce(true);
+
+    await expect(
+      createLibrary().assertUserHasApplicationAccess(applicationId, userId, true)
+    ).resolves.not.toThrow();
+
+    expect(findApplicationById).not.toHaveBeenCalled();
+    expect(hasUserApplicationAccess).toHaveBeenCalledWith(applicationId, userId);
   });
 
   it('denies access without revealing missing applications', async () => {
@@ -125,109 +116,21 @@ describe('assertUserHasApplicationAccess()', () => {
     ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
   });
 
-  it('allows direct selected user', async () => {
-    findApplicationAccessControl.mockResolvedValueOnce(buildAccessControl({ userIds: [userId] }));
+  it('allows when the evaluator finds any matching access rule', async () => {
+    hasUserApplicationAccess.mockResolvedValueOnce(true);
 
     await expect(
       createLibrary().assertUserHasApplicationAccess(applicationId, userId)
     ).resolves.not.toThrow();
 
-    expect(hasUserRole).not.toHaveBeenCalled();
-    expect(getExistingOrganizationIds).not.toHaveBeenCalled();
-    expect(hasUserOrganizationRole).not.toHaveBeenCalled();
-  });
-
-  it('allows selected user role membership', async () => {
-    findApplicationAccessControl.mockResolvedValueOnce(
-      buildAccessControl({ userRoleIds: ['role-id'] })
-    );
-    hasUserRole.mockResolvedValueOnce(true);
-
-    await expect(
-      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
-    ).resolves.not.toThrow();
-
-    expect(hasUserRole).toHaveBeenCalledWith(userId, ['role-id']);
-    expect(getExistingOrganizationIds).not.toHaveBeenCalled();
-    expect(hasUserOrganizationRole).not.toHaveBeenCalled();
-  });
-
-  it('allows selected organization membership', async () => {
-    findApplicationAccessControl.mockResolvedValueOnce(
-      buildAccessControl({ organizationIds: ['organization-id'] })
-    );
-    getExistingOrganizationIds.mockResolvedValueOnce(['organization-id']);
-
-    await expect(
-      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
-    ).resolves.not.toThrow();
-
-    expect(getExistingOrganizationIds).toHaveBeenCalledWith(userId, ['organization-id']);
-    expect(hasUserOrganizationRole).not.toHaveBeenCalled();
-  });
-
-  it('allows selected organization-role assignment in the selected organization', async () => {
-    findApplicationAccessControl.mockResolvedValueOnce(
-      buildAccessControl({
-        organizationRoleRules: [
-          { organizationId: 'organization-id', organizationRoleIds: ['organization-role-id'] },
-        ],
-      })
-    );
-    hasUserOrganizationRole.mockResolvedValueOnce(true);
-
-    await expect(
-      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
-    ).resolves.not.toThrow();
-
-    expect(hasUserOrganizationRole).toHaveBeenCalledWith(userId, [
-      { organizationId: 'organization-id', organizationRoleId: 'organization-role-id' },
-    ]);
-  });
-
-  it('denies organization membership when that organization is not selected', async () => {
-    findApplicationAccessControl.mockResolvedValueOnce(
-      buildAccessControl({ organizationIds: ['selected-organization-id'] })
-    );
-
-    await expect(
-      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
-    ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
-
-    expect(getExistingOrganizationIds).toHaveBeenCalledWith(userId, ['selected-organization-id']);
-  });
-
-  it('denies selected organization role when it belongs to a different organization', async () => {
-    findApplicationAccessControl.mockResolvedValueOnce(
-      buildAccessControl({
-        organizationRoleRules: [
-          { organizationId: 'selected-organization-id', organizationRoleIds: ['role-id'] },
-        ],
-      })
-    );
-
-    await expect(
-      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
-    ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
-
-    expect(hasUserOrganizationRole).toHaveBeenCalledWith(userId, [
-      { organizationId: 'selected-organization-id', organizationRoleId: 'role-id' },
-    ]);
+    expect(hasUserApplicationAccess).toHaveBeenCalledWith(applicationId, userId);
   });
 
   it('denies enabled config with no matching rules', async () => {
     await expect(
       createLibrary().assertUserHasApplicationAccess(applicationId, userId)
     ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
-  });
 
-  it('delegates empty rule arrays to guarded query helpers', async () => {
-    await expect(
-      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
-    ).rejects.toMatchObject(new RequestError('oidc.access_denied'));
-
-    expect(hasUserRole).toHaveBeenCalledWith(userId, []);
-    expect(getExistingOrganizationIds).toHaveBeenCalledWith(userId, []);
-    expect(hasUserOrganizationRole).toHaveBeenCalledWith(userId, []);
+    expect(hasUserApplicationAccess).toHaveBeenCalledWith(applicationId, userId);
   });
 });

--- a/packages/core/src/libraries/application-access-control.ts
+++ b/packages/core/src/libraries/application-access-control.ts
@@ -1,15 +1,8 @@
-import { isBuiltInApplicationId, type ApplicationAccessControl } from '@logto/schemas';
+import { isBuiltInApplicationId } from '@logto/schemas';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
-
-const buildOrganizationRoleRuleMatches = ({
-  organizationRoleRules,
-}: ApplicationAccessControl): Array<{ organizationId: string; organizationRoleId: string }> =>
-  organizationRoleRules.flatMap(({ organizationId, organizationRoleIds }) =>
-    organizationRoleIds.map((organizationRoleId) => ({ organizationId, organizationRoleId }))
-  );
 
 const isApplicationNotFoundError = (error: unknown) =>
   error instanceof RequestError && error.code === 'entity.not_exists_with_id';
@@ -17,59 +10,35 @@ const isApplicationNotFoundError = (error: unknown) =>
 export const createApplicationAccessControlLibrary = (queries: Queries) => {
   const {
     applications: { findApplicationById },
-    applicationAccessControl: { findApplicationAccessControl },
-    usersRoles: { hasUserRole },
-    organizations: {
-      relations: { users: organizationUserRelations, usersRoles: organizationUserRoleRelations },
-    },
+    applicationAccessControl: { hasUserApplicationAccess },
   } = queries;
 
-  const assertUserHasApplicationAccess = async (applicationId: string, userId: string) => {
+  const assertUserHasApplicationAccess = async (
+    applicationId: string,
+    userId: string,
+    appLevelAccessControlEnabled?: boolean
+  ) => {
     if (!EnvSet.values.isDevFeaturesEnabled || isBuiltInApplicationId(applicationId)) {
       return;
     }
 
-    const { appLevelAccessControlEnabled } = await findApplicationById(applicationId).catch(
-      (error: unknown) => {
-        if (isApplicationNotFoundError(error)) {
-          throw new RequestError('oidc.access_denied');
-        }
+    const isEnabled =
+      appLevelAccessControlEnabled ??
+      (await findApplicationById(applicationId)
+        .then(({ appLevelAccessControlEnabled }) => appLevelAccessControlEnabled)
+        .catch((error: unknown) => {
+          if (isApplicationNotFoundError(error)) {
+            throw new RequestError('oidc.access_denied');
+          }
 
-        throw error;
-      }
-    );
+          throw error;
+        }));
 
-    if (!appLevelAccessControlEnabled) {
+    if (!isEnabled) {
       return;
     }
 
-    const accessControl = await findApplicationAccessControl(applicationId);
-
-    if (accessControl.userIds.includes(userId)) {
-      return;
-    }
-
-    if (await hasUserRole(userId, accessControl.userRoleIds)) {
-      return;
-    }
-
-    const organizationIds = await organizationUserRelations.getExistingOrganizationIds(
-      userId,
-      accessControl.organizationIds
-    );
-
-    if (organizationIds.length > 0) {
-      return;
-    }
-
-    const organizationRoleRuleMatches = buildOrganizationRoleRuleMatches(accessControl);
-
-    if (
-      await organizationUserRoleRelations.hasUserOrganizationRole(
-        userId,
-        organizationRoleRuleMatches
-      )
-    ) {
+    if (await hasUserApplicationAccess(applicationId, userId)) {
       return;
     }
 

--- a/packages/core/src/libraries/application-access-control.ts
+++ b/packages/core/src/libraries/application-access-control.ts
@@ -13,6 +13,20 @@ export const createApplicationAccessControlLibrary = (queries: Queries) => {
     applicationAccessControl: { hasUserApplicationAccess },
   } = queries;
 
+  const findAppLevelAccessControlEnabled = async (applicationId: string) => {
+    try {
+      const { appLevelAccessControlEnabled } = await findApplicationById(applicationId);
+
+      return appLevelAccessControlEnabled;
+    } catch (error: unknown) {
+      if (isApplicationNotFoundError(error)) {
+        throw new RequestError('oidc.access_denied');
+      }
+
+      throw error;
+    }
+  };
+
   const assertUserHasApplicationAccess = async (
     applicationId: string,
     userId: string,
@@ -23,16 +37,7 @@ export const createApplicationAccessControlLibrary = (queries: Queries) => {
     }
 
     const isEnabled =
-      appLevelAccessControlEnabled ??
-      (await findApplicationById(applicationId)
-        .then(({ appLevelAccessControlEnabled }) => appLevelAccessControlEnabled)
-        .catch((error: unknown) => {
-          if (isApplicationNotFoundError(error)) {
-            throw new RequestError('oidc.access_denied');
-          }
-
-          throw error;
-        }));
+      appLevelAccessControlEnabled ?? (await findAppLevelAccessControlEnabled(applicationId));
 
     if (!isEnabled) {
       return;

--- a/packages/core/src/oidc/adapter.test.ts
+++ b/packages/core/src/oidc/adapter.test.ts
@@ -83,9 +83,31 @@ describe('postgres Adapter', () => {
       client_id,
       client_name,
       client_secret,
+      appLevelAccessControlEnabled: mockApplication.appLevelAccessControlEnabled,
       ...getConstantClientMetadata(mockEnvSet, type),
       ...snakecaseKeys(oidcClientMetadata),
       ...customClientMetadata,
+    });
+  });
+
+  it('includes app-level access-control gate in client metadata', async () => {
+    const adapter = postgresAdapter(
+      mockEnvSet,
+      new MockQueries({
+        applications: {
+          findApplicationById: jest.fn(
+            async (): Promise<Application> => ({
+              ...mockApplication,
+              appLevelAccessControlEnabled: true,
+            })
+          ),
+        },
+      }),
+      'Client'
+    );
+
+    await expect(adapter.find('foo')).resolves.toMatchObject({
+      appLevelAccessControlEnabled: true,
     });
   });
 

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -16,6 +16,7 @@ import { EnvSet } from '#src/env-set/index.js';
 import { getTenantUrls } from '#src/env-set/utils.js';
 import type Queries from '#src/tenants/Queries.js';
 
+import { appLevelAccessControlMetadataKey } from './application-access-control.js';
 import { getConstantClientMetadata } from './utils.js';
 
 /**
@@ -156,12 +157,14 @@ export default function postgresAdapter(
         type,
         oidcClientMetadata,
         customClientMetadata,
+        appLevelAccessControlEnabled,
       }: CreateApplication,
       clientScopes?: string[]
     ): AllClientMetadata => ({
       client_id,
       client_secret,
       client_name,
+      [appLevelAccessControlMetadataKey]: appLevelAccessControlEnabled,
       ...getConstantClientMetadata(envSet, type, customClientMetadata),
       ...transpileMetadata(client_id, snakecaseKeys(oidcClientMetadata)),
       // `node-oidc-provider` won't camelCase custom parameter keys, so we need to keep the keys camelCased

--- a/packages/core/src/oidc/application-access-control.ts
+++ b/packages/core/src/oidc/application-access-control.ts
@@ -3,6 +3,8 @@ import { errors, type InteractionResults } from 'oidc-provider';
 import RequestError from '#src/errors/RequestError/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 
+export const appLevelAccessControlMetadataKey = 'appLevelAccessControlEnabled';
+
 const appLevelAccessControlInteractionResultKey = 'appLevelAccessControl';
 
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
@@ -57,10 +59,15 @@ export const markAppLevelAccessControlCheckedForOidcContext = (
 export const assertUserHasApplicationAccessForOidc = async (
   applicationAccessControl: Libraries['applicationAccessControl'],
   applicationId: string,
-  userId: string
+  userId: string,
+  appLevelAccessControlEnabled?: boolean
 ) => {
   try {
-    await applicationAccessControl.assertUserHasApplicationAccess(applicationId, userId);
+    await applicationAccessControl.assertUserHasApplicationAccess(
+      applicationId,
+      userId,
+      appLevelAccessControlEnabled
+    );
   } catch (error: unknown) {
     if (error instanceof RequestError && error.code === 'oidc.access_denied') {
       throw new errors.AccessDenied(error.message);

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -40,12 +40,12 @@ type RefreshToken = InstanceType<KoaContextWithOIDC['oidc']['provider']['Refresh
 type Grant = InstanceType<KoaContextWithOIDC['oidc']['provider']['Grant']>;
 type Client = InstanceType<KoaContextWithOIDC['oidc']['provider']['Client']>;
 
-// @ts-expect-error
 const validClient: Client = {
   clientId,
   grantTypeAllowed: jest.fn().mockResolvedValue(true),
   clientAuthMethod: 'none',
-};
+  metadata: jest.fn(() => ({ client_id: clientId, appLevelAccessControlEnabled: false })),
+} as unknown as Client;
 
 const validRefreshToken: RefreshToken = {
   kind: 'RefreshToken',

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -163,7 +163,12 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx,
     throw new InvalidGrant('refresh token already used');
   }
 
-  await assertUserHasApplicationAccessForOidc(appAccess, client.clientId, account.accountId);
+  await assertUserHasApplicationAccessForOidc(
+    appAccess,
+    client.clientId,
+    account.accountId,
+    client.metadata().appLevelAccessControlEnabled
+  );
 
   const { organizationId } = await checkOrganizationAccess(ctx, queries, account);
 

--- a/packages/core/src/oidc/grants/token-exchange/index.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.test.ts
@@ -43,12 +43,12 @@ const accountId = 'some_account_id';
 
 type Client = InstanceType<KoaContextWithOIDC['oidc']['provider']['Client']>;
 
-// @ts-expect-error
 const validClient: Client = {
   clientId,
   grantTypeAllowed: jest.fn().mockResolvedValue(true),
   clientAuthMethod: 'none',
-};
+  metadata: jest.fn(() => ({ client_id: clientId, appLevelAccessControlEnabled: false })),
+} as unknown as Client;
 
 const createValidSubjectToken = (): SubjectToken => ({
   id: subjectTokenId,

--- a/packages/core/src/oidc/grants/token-exchange/index.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.ts
@@ -98,7 +98,12 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx,
 
   ctx.oidc.entity('Account', account);
 
-  await assertUserHasApplicationAccessForOidc(appAccess, client.clientId, account.accountId);
+  await assertUserHasApplicationAccessForOidc(
+    appAccess,
+    client.clientId,
+    account.accountId,
+    client.metadata().appLevelAccessControlEnabled
+  );
 
   // Pre-generate grant ID to avoid a separate DB write just to obtain it.
   // oidc-provider's BaseModel.save() skips ID generation when jti is already set.

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -11,6 +11,7 @@ import { createOidcContext } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
 import {
+  appLevelAccessControlMetadataKey,
   hasAppLevelAccessControlChecked,
   markAppLevelAccessControlChecked,
 } from './application-access-control.js';
@@ -101,6 +102,22 @@ describe('oidc provider init', () => {
 
     expect(() =>
       initOidc(id, mockEnvSet, queries, libraries, logtoConfigs, subscription)
+    ).not.toThrow();
+  });
+
+  it('should allow missing application access control client metadata', async () => {
+    const tenant = new MockTenant();
+    const provider = createProvider(tenant);
+    const configuration = instance(provider).configuration();
+    const ctx = createOidcContext({ provider });
+
+    expect(() =>
+      configuration.extraClientMetadata.validator(
+        ctx,
+        appLevelAccessControlMetadataKey,
+        undefined,
+        { client_id: clientId }
+      )
     ).not.toThrow();
   });
 

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -54,7 +54,10 @@ const createProvider = (tenant: MockTenant) =>
 
 const createTestClient = (): KoaContextWithOIDC['oidc']['client'] => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub for OIDC context testing
-  return { clientId } as KoaContextWithOIDC['oidc']['client'];
+  return {
+    clientId,
+    metadata: () => ({ appLevelAccessControlEnabled: true }),
+  } as KoaContextWithOIDC['oidc']['client'];
 };
 
 const mockGrantFound = (provider: KoaContextWithOIDC['oidc']['provider']) => {
@@ -205,7 +208,7 @@ describe('oidc provider init', () => {
     } as Partial<KoaContextWithOIDC['oidc']>);
 
     await expect(configuration.loadExistingGrant(ctx)).rejects.toThrow(errors.AccessDenied);
-    expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(clientId, accountId);
+    expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(clientId, accountId, true);
   });
 
   it('should check application access for consent prompt without existing marker when loading existing grant', async () => {
@@ -228,7 +231,7 @@ describe('oidc provider init', () => {
     } as Partial<KoaContextWithOIDC['oidc']>);
 
     await expect(configuration.loadExistingGrant(ctx)).resolves.toBeDefined();
-    expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(clientId, accountId);
+    expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(clientId, accountId, true);
     expect(findGrant).toHaveBeenCalledWith('grant_id');
   });
 
@@ -278,7 +281,7 @@ describe('oidc provider init', () => {
     } as Partial<KoaContextWithOIDC['oidc']>);
 
     await expect(configuration.loadExistingGrant(ctx)).resolves.toBeDefined();
-    expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(clientId, accountId);
+    expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(clientId, accountId, true);
     expect(hasAppLevelAccessControlChecked(ctx.oidc.result, clientId, accountId)).toBe(true);
     expect(findGrant).toHaveBeenCalledWith('grant_id');
   });

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -121,6 +121,19 @@ describe('oidc provider init', () => {
     ).not.toThrow();
   });
 
+  it('should reject invalid application access control client metadata', async () => {
+    const tenant = new MockTenant();
+    const provider = createProvider(tenant);
+    const configuration = instance(provider).configuration();
+    const ctx = createOidcContext({ provider });
+
+    expect(() =>
+      configuration.extraClientMetadata.validator(ctx, appLevelAccessControlMetadataKey, 'true', {
+        client_id: clientId,
+      })
+    ).toThrow(errors.InvalidClientMetadata);
+  });
+
   it('should reflect updated resource data on token exchange read path', async () => {
     const findResourceByIndicator = jest
       .fn()

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -46,6 +46,7 @@ import { type SubscriptionLibrary } from '../libraries/subscription.js';
 import koaTokenUsageGuard from '../middleware/koa-token-usage-guard.js';
 
 import {
+  appLevelAccessControlMetadataKey,
   assertUserHasApplicationAccessForOidc,
   hasAppLevelAccessControlChecked,
   markAppLevelAccessControlCheckedForOidcContext,
@@ -281,7 +282,8 @@ export default function initOidc(
         await assertUserHasApplicationAccessForOidc(
           libraries.applicationAccessControl,
           client.clientId,
-          account.accountId
+          account.accountId,
+          client.metadata().appLevelAccessControlEnabled
         );
         markAppLevelAccessControlCheckedForOidcContext(
           ctx.oidc,
@@ -324,8 +326,16 @@ export default function initOidc(
       };
     },
     extraClientMetadata: {
-      properties: Object.values(CustomClientMetadataKey),
+      properties: [...Object.values(CustomClientMetadataKey), appLevelAccessControlMetadataKey],
       validator: (_, key, value) => {
+        if (key === appLevelAccessControlMetadataKey) {
+          assert(
+            typeof value === 'boolean',
+            `${appLevelAccessControlMetadataKey} must be a boolean`
+          );
+          return;
+        }
+
         validateCustomClientMetadata(key, value);
       },
     },

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -329,6 +329,10 @@ export default function initOidc(
       properties: [...Object.values(CustomClientMetadataKey), appLevelAccessControlMetadataKey],
       validator: (_, key, value) => {
         if (key === appLevelAccessControlMetadataKey) {
+          if (value === undefined) {
+            return;
+          }
+
           assert(
             typeof value === 'boolean',
             `${appLevelAccessControlMetadataKey} must be a boolean`

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -333,10 +333,10 @@ export default function initOidc(
             return;
           }
 
-          assert(
-            typeof value === 'boolean',
-            `${appLevelAccessControlMetadataKey} must be a boolean`
-          );
+          if (typeof value !== 'boolean') {
+            throw new errors.InvalidClientMetadata(appLevelAccessControlMetadataKey);
+          }
+
           return;
         }
 

--- a/packages/core/src/queries/application-access-control.ts
+++ b/packages/core/src/queries/application-access-control.ts
@@ -6,6 +6,9 @@ import {
   ApplicationAccessControlOrganizationRelations,
   ApplicationAccessControlUserRelations,
   ApplicationAccessControlUserRoleRelations,
+  OrganizationRoleUserRelations,
+  OrganizationUserRelations,
+  UsersRoles,
 } from '@logto/schemas';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
@@ -19,6 +22,22 @@ const userRelations = convertToIdentifiers(ApplicationAccessControlUserRelations
 const userRoleRelations = convertToIdentifiers(ApplicationAccessControlUserRoleRelations);
 const organizationRelations = convertToIdentifiers(ApplicationAccessControlOrganizationRelations);
 const organizationRoleRelations = convertToIdentifiers(ApplicationAccessControlOrgRoleRelations);
+const lookupUserRelations = convertToIdentifiers(ApplicationAccessControlUserRelations, true);
+const lookupUserRoleRelations = convertToIdentifiers(
+  ApplicationAccessControlUserRoleRelations,
+  true
+);
+const lookupOrganizationRelations = convertToIdentifiers(
+  ApplicationAccessControlOrganizationRelations,
+  true
+);
+const lookupOrganizationRoleRelations = convertToIdentifiers(
+  ApplicationAccessControlOrgRoleRelations,
+  true
+);
+const usersRoles = convertToIdentifiers(UsersRoles, true);
+const organizationUserRelations = convertToIdentifiers(OrganizationUserRelations, true);
+const organizationRoleUserRelations = convertToIdentifiers(OrganizationRoleUserRelations, true);
 
 export const createApplicationAccessControlQueries = (pool: CommonQueryMethods) => {
   const findApplicationAccessControl = async (
@@ -71,6 +90,42 @@ export const createApplicationAccessControlQueries = (pool: CommonQueryMethods) 
 
     return applicationAccessControlGuard.parse(accessControl);
   };
+
+  const hasUserApplicationAccess = async (applicationId: string, userId: string) =>
+    pool.exists(sql`
+      select 1
+      where exists (
+        select 1
+        from ${lookupUserRelations.table}
+        where ${lookupUserRelations.fields.applicationId} = ${applicationId}
+          and ${lookupUserRelations.fields.userId} = ${userId}
+      ) or exists (
+        select 1
+        from ${lookupUserRoleRelations.table}
+        join ${usersRoles.table}
+          on ${usersRoles.fields.roleId} = ${lookupUserRoleRelations.fields.roleId}
+        where ${lookupUserRoleRelations.fields.applicationId} = ${applicationId}
+          and ${usersRoles.fields.userId} = ${userId}
+      ) or exists (
+        select 1
+        from ${lookupOrganizationRelations.table}
+        join ${organizationUserRelations.table}
+          on ${organizationUserRelations.fields.organizationId} =
+            ${lookupOrganizationRelations.fields.organizationId}
+        where ${lookupOrganizationRelations.fields.applicationId} = ${applicationId}
+          and ${organizationUserRelations.fields.userId} = ${userId}
+      ) or exists (
+        select 1
+        from ${lookupOrganizationRoleRelations.table}
+        join ${organizationRoleUserRelations.table}
+          on ${organizationRoleUserRelations.fields.organizationId} =
+              ${lookupOrganizationRoleRelations.fields.organizationId}
+            and ${organizationRoleUserRelations.fields.organizationRoleId} =
+              ${lookupOrganizationRoleRelations.fields.organizationRoleId}
+        where ${lookupOrganizationRoleRelations.fields.applicationId} = ${applicationId}
+          and ${organizationRoleUserRelations.fields.userId} = ${userId}
+      )
+    `);
 
   const replaceApplicationAccessControl = async (
     applicationId: string,
@@ -183,6 +238,7 @@ export const createApplicationAccessControlQueries = (pool: CommonQueryMethods) 
 
   return {
     findApplicationAccessControl,
+    hasUserApplicationAccess,
     replaceApplicationAccessControl,
   };
 };

--- a/packages/integration-tests/src/tests/api/application-access-control.test.ts
+++ b/packages/integration-tests/src/tests/api/application-access-control.test.ts
@@ -1,7 +1,9 @@
 import { ReservedScope } from '@logto/core-kit';
 import {
+  type ApplicationAccessControl,
   ApplicationType,
   createDefaultApplicationAccessControl,
+  RoleType,
   SignInIdentifier,
 } from '@logto/schemas';
 import { assert } from '@silverhand/essentials';
@@ -14,8 +16,10 @@ import {
   replaceApplicationAccessControl,
   updateApplication,
 } from '#src/api/application.js';
+import { assignUsersToRole, createRole, deleteRole } from '#src/api/role.js';
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
 import { initExperienceClient } from '#src/helpers/client.js';
+import { OrganizationApiTest } from '#src/helpers/organization.js';
 import {
   createDefaultTenantUserWithPassword,
   deleteDefaultTenantUser,
@@ -55,7 +59,106 @@ const signInAndGetRefreshToken = async ({
   return client.getRefreshToken();
 };
 
+const assertRefreshTokenExchangeAllowed = async (
+  configureAccessControl: (
+    applicationId: string,
+    userId: string
+  ) => Promise<ApplicationAccessControl>
+) => {
+  const { user, username, password } = await createDefaultTenantUserWithPassword();
+  const application = await createApplication(generateTestName(), ApplicationType.SPA, {
+    oidcClientMetadata: {
+      redirectUris: [demoAppRedirectUri],
+      postLogoutRedirectUris: [],
+    },
+    customClientMetadata: {
+      alwaysIssueRefreshToken: true,
+    },
+  });
+
+  try {
+    await replaceApplicationAccessControl(
+      application.id,
+      await configureAccessControl(application.id, user.id)
+    );
+    await updateApplication(application.id, { appLevelAccessControlEnabled: true });
+
+    const refreshToken = await signInAndGetRefreshToken({
+      appId: application.id,
+      username,
+      password,
+    });
+    assert(refreshToken, new Error('Refresh token should be issued'));
+
+    const response = await oidcApi.post('token', {
+      body: new URLSearchParams({
+        client_id: application.id,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      }),
+      throwHttpErrors: false,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toHaveProperty('access_token');
+  } finally {
+    await Promise.allSettled([deleteApplication(application.id), deleteDefaultTenantUser(user.id)]);
+  }
+};
+
 devFeatureTest.describe('application access control OIDC enforcement', () => {
+  it('allows refresh token exchange through each app access rule type', async () => {
+    const organizationApi = new OrganizationApiTest();
+    const userRole = await createRole({ type: RoleType.User });
+
+    try {
+      await assertRefreshTokenExchangeAllowed(async (_applicationId, userId) => ({
+        ...createDefaultApplicationAccessControl(),
+        userIds: [userId],
+      }));
+
+      await assertRefreshTokenExchangeAllowed(async (_applicationId, userId) => {
+        await assignUsersToRole([userId], userRole.id);
+
+        return {
+          ...createDefaultApplicationAccessControl(),
+          userRoleIds: [userRole.id],
+        };
+      });
+
+      await assertRefreshTokenExchangeAllowed(async (_applicationId, userId) => {
+        const organization = await organizationApi.create({ name: generateTestName() });
+        await organizationApi.addUsers(organization.id, [userId]);
+
+        return {
+          ...createDefaultApplicationAccessControl(),
+          organizationIds: [organization.id],
+        };
+      });
+
+      await assertRefreshTokenExchangeAllowed(async (_applicationId, userId) => {
+        const [organization, organizationRole] = await Promise.all([
+          organizationApi.create({ name: generateTestName() }),
+          organizationApi.roleApi.create({ name: generateTestName(), type: RoleType.User }),
+        ]);
+        await organizationApi.addUsers(organization.id, [userId]);
+        await organizationApi.addUserRoles(organization.id, userId, [organizationRole.id]);
+
+        return {
+          ...createDefaultApplicationAccessControl(),
+          organizationRoleRules: [
+            {
+              organizationId: organization.id,
+              organizationRoleIds: [organizationRole.id],
+            },
+          ],
+        };
+      });
+    } finally {
+      await Promise.allSettled([organizationApi.cleanUp(), deleteRole(userRole.id)]);
+    }
+  });
+
   it('denies refresh token exchange after app access is revoked', async () => {
     const [{ user, username, password }, allowedUser] = await Promise.all([
       createDefaultTenantUserWithPassword(),


### PR DESCRIPTION
## Summary

- Carry app-level access-control state through OIDC client metadata so hot OIDC paths can avoid unnecessary application reads when access control is disabled.
- Replace enabled-app access evaluation with a single EXISTS query across direct user, user role, organization, and organization-role rules.
- Add coverage for metadata propagation and access-rule evaluation on token flows.

## Testing

Unit tests
Integration tests
