### PR TITLE
fix(account): add loading spinner on save button in profile field modal

### DIFF
--- a/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
@@ -119,6 +119,7 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
     const initialFields = buildEditableFields(field, userInfo, t);
     setValues(Object.fromEntries(initialFields.map(({ name, value }) => [name, value])));
     setErrors({});
+    setIsSubmitting(false);
     // Only reset when switching fields; ignore background userInfo refreshes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [field?.name]);
@@ -138,25 +139,29 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
     }
 
     setIsSubmitting(true);
-    const [error] = await submitFieldUpdate({
-      field,
-      fields,
-      userInfo,
-      values,
-      updateNameRequest,
-      updateCustomDataRequest,
-      updateProfileRequest,
-    });
+    try {
+      const [error] = await submitFieldUpdate({
+        field,
+        fields,
+        userInfo,
+        values,
+        updateNameRequest,
+        updateCustomDataRequest,
+        updateProfileRequest,
+      });
 
-    if (error) {
-      setIsSubmitting(false);
+      if (error) {
+        await handleError(error);
+        return;
+      }
+
+      await onUpdated();
+      onClose();
+    } catch (error: unknown) {
       await handleError(error);
-      return;
+    } finally {
+      setIsSubmitting(false);
     }
-
-    await onUpdated();
-    setIsSubmitting(false);
-    onClose();
   }, [
     field,
     fields,

--- a/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
+++ b/packages/account/src/pages/Profile/EditProfileFieldModal.tsx
@@ -109,6 +109,7 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
 
   const [values, setValues] = useState<Record<string, EditableValue>>({});
   const [errors, setErrors] = useState<Record<string, string | undefined>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     if (!field) {
@@ -136,6 +137,7 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
       return;
     }
 
+    setIsSubmitting(true);
     const [error] = await submitFieldUpdate({
       field,
       fields,
@@ -147,11 +149,13 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
     });
 
     if (error) {
+      setIsSubmitting(false);
       await handleError(error);
       return;
     }
 
     await onUpdated();
+    setIsSubmitting(false);
     onClose();
   }, [
     field,
@@ -274,6 +278,7 @@ const EditProfileFieldModal = ({ field, userInfo, onClose, onUpdated }: Props) =
             <Button
               title="action.save"
               type="primary"
+              isLoading={isSubmitting}
               onClick={() => {
                 void handleSubmit();
               }}


### PR DESCRIPTION
## Summary

Add `isLoading` state to the Save button in `EditProfileFieldModal` so it shows the existing `RotatingRingIcon` spinner during submission. The `Button` component already supports `isLoading` with debounced spinner — this just wires a local `isSubmitting` state that's set `true` before `submitFieldUpdate` and reset on completion/error.

### Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/dc8949d24aa349b688b3165c53dba5b0
Requested by: @wangsijie