### PR TITLE
fix(account): align page content to top for consistent layout with/without sidebar

### DIFF
--- a/packages/account/src/App.module.scss
+++ b/packages/account/src/App.module.scss
@@ -19,6 +19,7 @@
   flex: 1;
   display: flex;
   justify-content: center;
+  align-items: flex-start;
 }
 
 .withSidebar {


### PR DESCRIPTION
## Summary

When the account center has only one full-page (no sidebar), `.container` defaults to `align-items: stretch`, causing `.main` to fill the full viewport height and pushing the footer far below the content. With 2+ pages (sidebar visible), `.withSidebar` uses grid with `align-items: start` so the footer stays close to content.

Fix: add `align-items: flex-start` to `.container` so the single-page layout matches the multi-page layout behavior.

### Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/328faf8559d94e16a60b3588d718115f
Requested by: @wangsijie