### PR TITLE
fix(experience): add z-index to AvatarCropModal overlay

### DIFF
--- a/packages/experience/src/components/AvatarCropModal/index.module.scss
+++ b/packages/experience/src/components/AvatarCropModal/index.module.scss
@@ -1,5 +1,9 @@
 @use '@/shared/scss/underscore' as _;
 
+.overlay {
+  z-index: 100;
+}
+
 .modal {
   position: absolute;
   width: 480px;

--- a/packages/experience/src/components/AvatarCropModal/index.tsx
+++ b/packages/experience/src/components/AvatarCropModal/index.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { useCallback, useRef, useState } from 'react';
 import Cropper from 'react-easy-crop';
 import 'react-easy-crop/react-easy-crop.css';
@@ -108,7 +109,7 @@ const AvatarCropModal = ({
       role="dialog"
       isOpen={Boolean(imageSource)}
       className={styles.modal}
-      overlayClassName={modalStyles.overlay}
+      overlayClassName={classNames(modalStyles.overlay, styles.overlay)}
       onAfterClose={resetState}
       onRequestClose={handleCancel}
     >


### PR DESCRIPTION
## Summary

The `AvatarCropModal` overlay was missing `z-index`, causing page content underneath (e.g. the "Nickname" label) to bleed through the modal backdrop in the account center.

Other modals (`ConfirmModal/AcModal`, `EditProfileFieldModal`) already set `z-index: 100` on their overlays. This PR aligns `AvatarCropModal` with that pattern:

- Added `.overlay { z-index: 100; }` to `AvatarCropModal/index.module.scss`
- Changed `overlayClassName` from `modalStyles.overlay` → `classNames(modalStyles.overlay, styles.overlay)`, matching the `AcModal` approach

### Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/0c044f8a47b24ed18dccae085683e7c7
Requested by: @wangsijie