### PR TITLE
fix(console): add spacing between localization hint and avatar notification

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.module.scss
@@ -1,5 +1,9 @@
 @use '@/scss/underscore' as _;
 
+.avatarNotification {
+  margin-top: _.unit(6);
+}
+
 .dropdownTitleWrapper {
   display: flex;
   align-items: center;

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldPartSubForm/index.tsx
@@ -152,7 +152,7 @@ function ProfileFieldPartSubForm({ index }: Props) {
       </FormField>
       {/* TODO: Replace placeholder avatar help text once Experience and Account Center avatar upload is implemented. */}
       {isAvatarField && (
-        <InlineNotification hasIcon variant="plain">
+        <InlineNotification hasIcon className={styles.avatarNotification} variant="plain">
           {t('sign_in_exp.custom_profile_fields.details.avatar_upload_description')}
         </InlineNotification>
       )}


### PR DESCRIPTION
## Summary

Add `margin-top: _.unit(6)` to the avatar `InlineNotification` in `ProfileFieldPartSubForm` so it matches the standard `FormField` spacing. Previously the notification sat directly below the "Need localization?" description with no gap.

Link to Devin session: https://app.devin.ai/sessions/3e43af95373841beb1068e11c2e395e7
Requested by: @wangsijie