### PR TITLE
feat(account): add session management to Security page

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -274,6 +274,7 @@ const App = () => (
           UserScope.Address,
           UserScope.Identities,
           UserScope.CustomData,
+          UserScope.Sessions,
         ],
       }}
     >

--- a/packages/account/src/apis/sessions.ts
+++ b/packages/account/src/apis/sessions.ts
@@ -1,0 +1,26 @@
+import type { GetAccountUserSessionsResponse } from '@logto/schemas';
+
+import { verificationRecordIdHeader } from './account';
+import { createAuthenticatedKy } from './base-ky';
+
+export const getSessions = async (
+  accessToken: string,
+  verificationRecordId: string
+): Promise<GetAccountUserSessionsResponse> => {
+  return createAuthenticatedKy(accessToken)
+    .get('/api/my-account/sessions', {
+      headers: { [verificationRecordIdHeader]: verificationRecordId },
+    })
+    .json<GetAccountUserSessionsResponse>();
+};
+
+export const revokeSession = async (
+  accessToken: string,
+  verificationRecordId: string,
+  sessionId: string
+): Promise<void> => {
+  await createAuthenticatedKy(accessToken).delete(`/api/my-account/sessions/${sessionId}`, {
+    headers: { [verificationRecordIdHeader]: verificationRecordId },
+    searchParams: { revokeGrantsTarget: 'all' },
+  });
+};

--- a/packages/account/src/pages/Security/SessionSection/index.module.scss
+++ b/packages/account/src/pages/Security/SessionSection/index.module.scss
@@ -18,11 +18,13 @@
   overflow: clip;
 }
 
-.sessionRow {
-  display: flex;
+.row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  column-gap: _.unit(4);
   align-items: center;
-  gap: _.unit(4);
-  padding: _.unit(4) _.unit(6);
+  padding: _.unit(4.5) _.unit(6);
+  min-height: 76px;
 
   &:not(:last-child) {
     border-bottom: 1px solid var(--color-line-divider);
@@ -30,22 +32,48 @@
 }
 
 .sessionInfo {
-  flex: 1;
-  min-width: 0;
+  grid-column: 1;
   display: flex;
   flex-direction: column;
   gap: _.unit(1);
+  min-width: 0;
 }
 
-.sessionHeader {
-  display: flex;
-  align-items: center;
-  gap: _.unit(2);
-}
-
-.sessionDevice {
+.deviceName {
   font: var(--font-label-2);
   color: var(--color-type-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta {
+  font: var(--font-body-3);
+  color: var(--color-type-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.actions {
+  grid-column: 2;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.actionButton {
+  font: var(--font-label-2);
+  color: var(--color-type-link);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: _.unit(0.5) 0;
+  white-space: nowrap;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .currentTag {
@@ -57,7 +85,7 @@
   background: rgba(78, 162, 84, 12%);
   font: var(--font-label-3);
   color: var(--color-type-primary);
-  flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .currentDot {
@@ -67,20 +95,14 @@
   background: var(--color-success-default);
 }
 
-.sessionMeta {
-  font: var(--font-body-3);
-  color: var(--color-type-secondary);
-}
-
 .revokeButton {
   font: var(--font-label-2);
-  color: var(--color-type-link);
+  color: var(--color-danger-default);
   cursor: pointer;
   background: none;
   border: none;
   padding: _.unit(0.5) 0;
   white-space: nowrap;
-  flex-shrink: 0;
 
   &:hover {
     text-decoration: underline;
@@ -94,19 +116,41 @@
   text-align: center;
 }
 
-:global(body.mobile) {
+@mixin mobile-layout {
   .sectionTitle {
     padding-left: 0;
   }
 
-  .sessionRow {
-    flex-direction: column;
-    align-items: stretch;
-    gap: _.unit(2);
+  .row {
+    min-height: 0;
+    gap: _.unit(2) _.unit(3);
     padding: _.unit(4);
   }
 
-  .revokeButton {
-    align-self: flex-end;
+  .actions {
+    grid-row: 1;
+    place-self: start end;
+  }
+
+  .deviceName {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .meta {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+}
+
+:global(body.mobile) {
+  @include mobile-layout;
+}
+
+:global(body.desktop) {
+  @media only screen and (max-width: 800px) {
+    @include mobile-layout;
   }
 }

--- a/packages/account/src/pages/Security/SessionSection/index.module.scss
+++ b/packages/account/src/pages/Security/SessionSection/index.module.scss
@@ -1,0 +1,112 @@
+@use '@experience/shared/scss/underscore' as _;
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1.5);
+}
+
+.sectionTitle {
+  padding-left: _.unit(1);
+  font: var(--font-label-2);
+  color: var(--color-type-primary);
+}
+
+.card {
+  background: var(--color-bg-body);
+  border-radius: 12px;
+  overflow: clip;
+}
+
+.sessionRow {
+  display: flex;
+  align-items: center;
+  gap: _.unit(4);
+  padding: _.unit(4) _.unit(6);
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--color-line-divider);
+  }
+}
+
+.sessionInfo {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1);
+}
+
+.sessionHeader {
+  display: flex;
+  align-items: center;
+  gap: _.unit(2);
+}
+
+.sessionDevice {
+  font: var(--font-label-2);
+  color: var(--color-type-primary);
+}
+
+.currentTag {
+  display: inline-flex;
+  align-items: center;
+  gap: _.unit(1);
+  padding: _.unit(0.5) _.unit(2);
+  border-radius: 14px;
+  background: rgba(78, 162, 84, 12%);
+  font: var(--font-label-3);
+  color: var(--color-type-primary);
+  flex-shrink: 0;
+}
+
+.currentDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-success-default);
+}
+
+.sessionMeta {
+  font: var(--font-body-3);
+  color: var(--color-type-secondary);
+}
+
+.revokeButton {
+  font: var(--font-label-2);
+  color: var(--color-type-link);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: _.unit(0.5) 0;
+  white-space: nowrap;
+  flex-shrink: 0;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.emptyState {
+  padding: _.unit(5) _.unit(6);
+  font: var(--font-body-2);
+  color: var(--color-type-secondary);
+  text-align: center;
+}
+
+:global(body.mobile) {
+  .sectionTitle {
+    padding-left: 0;
+  }
+
+  .sessionRow {
+    flex-direction: column;
+    align-items: stretch;
+    gap: _.unit(2);
+    padding: _.unit(4);
+  }
+
+  .revokeButton {
+    align-self: flex-end;
+  }
+}

--- a/packages/account/src/pages/Security/SessionSection/index.tsx
+++ b/packages/account/src/pages/Security/SessionSection/index.tsx
@@ -17,7 +17,7 @@ import useApi from '../../../hooks/use-api';
 import useErrorHandler from '../../../hooks/use-error-handler';
 
 import styles from './index.module.scss';
-import { formatSessionMeta, parseUserAgent } from './utils';
+import { getSessionDisplayInfo } from './utils';
 
 type AccountSession = GetAccountUserSessionsResponse['sessions'][number];
 
@@ -156,29 +156,28 @@ const SessionSection = () => {
           {hasLoaded ? (
             <>
               {currentSession && (
-                <SessionRow isCurrentLabel session={currentSession} isEditable={false} />
+                <SessionRow isCurrent session={currentSession} isEditable={false} />
               )}
-              {otherSessions.length > 0 ? (
-                otherSessions.map((session) => (
-                  <SessionRow
-                    key={session.payload.uid}
-                    session={session}
-                    isEditable={isEditable}
-                    onRevoke={() => {
-                      setRevokeTarget(session);
-                    }}
-                  />
-                ))
-              ) : (
+              {otherSessions.map((session) => (
+                <SessionRow
+                  key={session.payload.uid}
+                  session={session}
+                  isEditable={isEditable}
+                  onRevoke={() => {
+                    setRevokeTarget(session);
+                  }}
+                />
+              ))}
+              {otherSessions.length === 0 && !currentSession && (
                 <div className={styles.emptyState}>
                   {t('account_center.security.session_no_other')}
                 </div>
               )}
             </>
           ) : (
-            <div className={styles.sessionRow}>
+            <div className={classNames(styles.row, layoutClassNames.row)}>
               <div className={styles.sessionInfo}>
-                <button type="button" className={styles.revokeButton} onClick={handleViewSessions}>
+                <button type="button" className={styles.actionButton} onClick={handleViewSessions}>
                   {t('account_center.security.manage')}
                 </button>
               </div>
@@ -205,47 +204,57 @@ const SessionSection = () => {
   );
 };
 
+const formatTimestamp = (value?: number) => {
+  if (!value) {
+    return '-';
+  }
+
+  const timestamp = value < 1_000_000_000_000 ? value * 1000 : value;
+
+  return new Date(timestamp).toLocaleString();
+};
+
 type SessionRowProps = {
   readonly session: AccountSession;
   readonly isEditable: boolean;
-  readonly isCurrentLabel?: boolean;
+  readonly isCurrent?: boolean;
   readonly onRevoke?: () => void;
 };
 
-const SessionRow = ({ session, isEditable, isCurrentLabel, onRevoke }: SessionRowProps) => {
+const SessionRow = ({ session, isEditable, isCurrent, onRevoke }: SessionRowProps) => {
   const { t } = useTranslation();
 
-  const userAgent = session.lastSubmission?.signInContext?.userAgent;
-  const deviceLabel = parseUserAgent(userAgent);
-  const meta = formatSessionMeta(session);
-  const signedInDate = new Date(session.payload.loginTs * 1000).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
+  const { name, location, ip } = getSessionDisplayInfo(session);
+  const deviceName = name ?? '-';
+  const signedInAt = formatTimestamp(session.payload.loginTs);
+
+  const metaParts = [location, ip].filter(Boolean);
+  const metaText = metaParts.length > 0 ? metaParts.join(' · ') : undefined;
 
   return (
-    <div className={styles.sessionRow}>
+    <div className={classNames(styles.row, layoutClassNames.row)}>
       <div className={styles.sessionInfo}>
-        <div className={styles.sessionHeader}>
-          <span className={styles.sessionDevice}>{deviceLabel}</span>
-          {isCurrentLabel && (
-            <span className={styles.currentTag}>
-              <span className={styles.currentDot} />
-              {t('account_center.security.session_current')}
-            </span>
-          )}
-        </div>
-        {meta && <div className={styles.sessionMeta}>{meta}</div>}
-        <div className={styles.sessionMeta}>
-          {t('account_center.security.session_signed_in', { date: signedInDate })}
+        <div className={styles.deviceName}>{deviceName}</div>
+        {metaText && <div className={styles.meta}>{metaText}</div>}
+        <div className={styles.meta}>
+          {t('account_center.security.session_signed_in', { date: signedInAt })}
         </div>
       </div>
-      {isEditable && onRevoke && (
-        <button type="button" className={styles.revokeButton} onClick={onRevoke}>
-          {t('account_center.security.session_revoke')}
-        </button>
-      )}
+      <div className={styles.actions}>
+        {isCurrent ? (
+          <span className={styles.currentTag}>
+            <span className={styles.currentDot} />
+            {t('account_center.security.session_current')}
+          </span>
+        ) : (
+          isEditable &&
+          onRevoke && (
+            <button type="button" className={styles.revokeButton} onClick={onRevoke}>
+              {t('account_center.security.session_revoke')}
+            </button>
+          )
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/account/src/pages/Security/SessionSection/index.tsx
+++ b/packages/account/src/pages/Security/SessionSection/index.tsx
@@ -1,0 +1,253 @@
+import { AccountCenterControlValue, type GetAccountUserSessionsResponse } from '@logto/schemas';
+import classNames from 'classnames';
+import { useCallback, useContext, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import PageContext from '@ac/Providers/PageContextProvider/PageContext';
+import ConfirmModal from '@ac/components/ConfirmModal';
+import { layoutClassNames } from '@ac/constants/layout';
+import { verifiedActionRoute } from '@ac/constants/routes';
+import { getPendingReturn, setPendingReturn } from '@ac/utils/account-center-route';
+import { isEditableField } from '@ac/utils/security-page';
+import { sessionStorage } from '@ac/utils/session-storage';
+
+import { getSessions, revokeSession } from '../../../apis/sessions';
+import useApi from '../../../hooks/use-api';
+import useErrorHandler from '../../../hooks/use-error-handler';
+
+import styles from './index.module.scss';
+import { formatSessionMeta, parseUserAgent } from './utils';
+
+type AccountSession = GetAccountUserSessionsResponse['sessions'][number];
+
+const SessionSection = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { accountCenterSettings, verificationId, setVerificationId, setToast } =
+    useContext(PageContext);
+  const [sessions, setSessions] = useState<AccountSession[]>();
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [revokeTarget, setRevokeTarget] = useState<AccountSession>();
+  const handleError = useErrorHandler();
+
+  const getSessionsApi = useApi(getSessions, { silent: true });
+  const revokeSessionApi = useApi(revokeSession);
+
+  const sessionControl = accountCenterSettings?.fields.session;
+  const isVisible =
+    sessionControl !== undefined && sessionControl !== AccountCenterControlValue.Off;
+  const isEditable = isEditableField(sessionControl);
+
+  const fetchSessions = useCallback(
+    async (verifiedId: string) => {
+      setIsLoading(true);
+      const [error, result] = await getSessionsApi(verifiedId);
+      if (error) {
+        await handleError(error, {
+          'verification_record.permission_denied': async () => {
+            setVerificationId(undefined);
+            setToast(t('account_center.verification.verification_required'));
+          },
+        });
+      } else if (result) {
+        setSessions(result.sessions);
+      }
+      setHasLoaded(true);
+      setIsLoading(false);
+    },
+    [getSessionsApi, handleError, setToast, setVerificationId, t]
+  );
+
+  // Auto-fetch sessions once we have a verificationId
+  useEffect(() => {
+    if (!isVisible || hasLoaded || isLoading) {
+      return;
+    }
+
+    if (!verificationId) {
+      return;
+    }
+
+    void fetchSessions(verificationId);
+  }, [isVisible, verificationId, hasLoaded, isLoading, fetchSessions]);
+
+  // Handle pending verified action (coming back from verification page)
+  useEffect(() => {
+    if (!verificationId) {
+      return;
+    }
+
+    const pendingAction = sessionStorage.getPendingVerifiedAction();
+
+    if (pendingAction !== 'load-sessions') {
+      return;
+    }
+
+    sessionStorage.clearPendingVerifiedAction();
+    void fetchSessions(verificationId);
+  }, [verificationId, fetchSessions]);
+
+  const navigateTo = useCallback(
+    (route: string) => {
+      setPendingReturn(getPendingReturn() ?? window.location.href);
+      navigate(route);
+    },
+    [navigate]
+  );
+
+  const handleViewSessions = useCallback(() => {
+    if (verificationId) {
+      void fetchSessions(verificationId);
+      return;
+    }
+
+    sessionStorage.setPendingVerifiedAction('load-sessions');
+    navigateTo(verifiedActionRoute);
+  }, [verificationId, fetchSessions, navigateTo]);
+
+  const handleRevoke = useCallback(
+    async (session: AccountSession) => {
+      if (!verificationId) {
+        return;
+      }
+
+      const [error] = await revokeSessionApi(verificationId, session.payload.uid);
+      if (error) {
+        await handleError(error, {
+          'verification_record.permission_denied': async () => {
+            setVerificationId(undefined);
+            setToast(t('account_center.verification.verification_required'));
+          },
+        });
+        return;
+      }
+
+      setSessions((previous) =>
+        previous?.filter((item) => item.payload.uid !== session.payload.uid)
+      );
+    },
+    [verificationId, revokeSessionApi, handleError, setVerificationId, setToast, t]
+  );
+
+  const handleConfirmRevoke = useCallback(async () => {
+    if (!revokeTarget) {
+      return;
+    }
+    setRevokeTarget(undefined);
+    await handleRevoke(revokeTarget);
+  }, [revokeTarget, handleRevoke]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  const currentSession = sessions?.find((item) => item.isCurrent);
+  const otherSessions = sessions?.filter((item) => !item.isCurrent) ?? [];
+
+  return (
+    <>
+      <div className={classNames(styles.section, layoutClassNames.section)}>
+        <div className={classNames(styles.sectionTitle, layoutClassNames.sectionTitle)}>
+          {t('account_center.security.sessions')}
+        </div>
+        <div className={classNames(styles.card, layoutClassNames.card)}>
+          {hasLoaded ? (
+            <>
+              {currentSession && (
+                <SessionRow isCurrentLabel session={currentSession} isEditable={false} />
+              )}
+              {otherSessions.length > 0 ? (
+                otherSessions.map((session) => (
+                  <SessionRow
+                    key={session.payload.uid}
+                    session={session}
+                    isEditable={isEditable}
+                    onRevoke={() => {
+                      setRevokeTarget(session);
+                    }}
+                  />
+                ))
+              ) : (
+                <div className={styles.emptyState}>
+                  {t('account_center.security.session_no_other')}
+                </div>
+              )}
+            </>
+          ) : (
+            <div className={styles.sessionRow}>
+              <div className={styles.sessionInfo}>
+                <button type="button" className={styles.revokeButton} onClick={handleViewSessions}>
+                  {t('account_center.security.manage')}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+      <ConfirmModal
+        isOpen={Boolean(revokeTarget)}
+        title="account_center.security.session_revoke_confirmation_title"
+        confirmText="account_center.security.session_revoke"
+        confirmButtonType="danger"
+        cancelText="action.cancel"
+        onConfirm={() => {
+          void handleConfirmRevoke();
+        }}
+        onCancel={() => {
+          setRevokeTarget(undefined);
+        }}
+      >
+        {t('account_center.security.session_revoke_confirmation_description')}
+      </ConfirmModal>
+    </>
+  );
+};
+
+type SessionRowProps = {
+  readonly session: AccountSession;
+  readonly isEditable: boolean;
+  readonly isCurrentLabel?: boolean;
+  readonly onRevoke?: () => void;
+};
+
+const SessionRow = ({ session, isEditable, isCurrentLabel, onRevoke }: SessionRowProps) => {
+  const { t } = useTranslation();
+
+  const userAgent = session.lastSubmission?.signInContext?.userAgent;
+  const deviceLabel = parseUserAgent(userAgent);
+  const meta = formatSessionMeta(session);
+  const signedInDate = new Date(session.payload.loginTs * 1000).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return (
+    <div className={styles.sessionRow}>
+      <div className={styles.sessionInfo}>
+        <div className={styles.sessionHeader}>
+          <span className={styles.sessionDevice}>{deviceLabel}</span>
+          {isCurrentLabel && (
+            <span className={styles.currentTag}>
+              <span className={styles.currentDot} />
+              {t('account_center.security.session_current')}
+            </span>
+          )}
+        </div>
+        {meta && <div className={styles.sessionMeta}>{meta}</div>}
+        <div className={styles.sessionMeta}>
+          {t('account_center.security.session_signed_in', { date: signedInDate })}
+        </div>
+      </div>
+      {isEditable && onRevoke && (
+        <button type="button" className={styles.revokeButton} onClick={onRevoke}>
+          {t('account_center.security.session_revoke')}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default SessionSection;

--- a/packages/account/src/pages/Security/SessionSection/utils.ts
+++ b/packages/account/src/pages/Security/SessionSection/utils.ts
@@ -1,79 +1,84 @@
-import type { GetAccountUserSessionsResponse } from '@logto/schemas';
+import {
+  type GetAccountUserSessionsResponse,
+  userSessionSignInContextGuard,
+  type UserSessionSignInContext,
+} from '@logto/schemas';
+import { UAParser } from 'ua-parser-js';
 
 type AccountSession = GetAccountUserSessionsResponse['sessions'][number];
 
-/**
- * Parse a user-agent string into a human-readable device label (browser + OS).
- * Intentionally lightweight — no external dependency.
- */
-export const parseUserAgent = (ua?: string): string => {
-  if (!ua) {
-    return 'Unknown device';
-  }
-
-  const browser = detectBrowser(ua);
-  const os = detectOS(ua);
-
-  return [browser, os].filter(Boolean).join(' on ') || 'Unknown device';
+type ParsedUserAgentInfo = {
+  browserName?: string;
+  osName?: string;
+  deviceModel?: string;
 };
 
-const detectBrowser = (ua: string): string => {
-  const lower = ua.toLowerCase();
-  // Order matters: check more specific patterns first
-  if (lower.includes('edg/')) {
-    return 'Edge';
-  }
-  if (lower.includes('opr/') || lower.includes('opera')) {
-    return 'Opera';
-  }
-  if (lower.includes('chrome/') && !lower.includes('chromium')) {
-    return 'Chrome';
-  }
-  if (lower.includes('firefox/')) {
-    return 'Firefox';
-  }
-  if (lower.includes('safari/') && !lower.includes('chrome')) {
-    return 'Safari';
-  }
-  return '';
+export type SessionDisplayInfo = ParsedUserAgentInfo & {
+  name?: string;
+  location?: string;
+  ip?: string;
 };
 
-const detectOS = (ua: string): string => {
-  const lower = ua.toLowerCase();
-  if (lower.includes('windows')) {
-    return 'Windows';
+const getParsedUserAgentInfo = (userAgent?: string): ParsedUserAgentInfo => {
+  if (!userAgent) {
+    return {};
   }
-  if (lower.includes('macintosh') || lower.includes('mac os x')) {
-    return 'macOS';
-  }
-  if (lower.includes('android')) {
-    return 'Android';
-  }
-  if (lower.includes('iphone') || lower.includes('ipad') || lower.includes('ipod')) {
-    return 'iOS';
-  }
-  if (lower.includes('linux')) {
-    return 'Linux';
-  }
-  return '';
+
+  const { device, browser, os } = new UAParser(userAgent).getResult();
+  const deviceModel = [device.vendor, device.model].filter(Boolean).join(' ') || undefined;
+
+  return {
+    browserName: browser.name,
+    osName: os.name,
+    deviceModel,
+  };
 };
 
-/**
- * Build a location string from country/city fields.
- */
-export const formatLocation = (country?: string, city?: string): string | undefined => {
-  const parts = [city, country].filter(Boolean);
-  return parts.length > 0 ? parts.join(', ') : undefined;
+const formatSessionDeviceName = ({ userAgent }: UserSessionSignInContext) => {
+  const { browserName, osName, deviceModel } = getParsedUserAgentInfo(userAgent);
+
+  if (browserName && deviceModel) {
+    return `${browserName} on ${deviceModel}`;
+  }
+
+  if (browserName && osName) {
+    return `${browserName} on ${osName}`;
+  }
+
+  if (browserName) {
+    return browserName;
+  }
+
+  if (deviceModel) {
+    return deviceModel;
+  }
+
+  return osName;
 };
 
-/**
- * Build session meta text (IP + location).
- */
-export const formatSessionMeta = (session: AccountSession): string => {
-  const signInContext = session.lastSubmission?.signInContext;
-  const ip = signInContext?.ip;
-  const location = formatLocation(signInContext?.country, signInContext?.city);
+const formatSessionLocation = ({ country, city }: UserSessionSignInContext) => {
+  const location = [city, country].filter(Boolean).join(', ');
 
-  const parts = [ip, location].filter(Boolean);
-  return parts.join(' · ');
+  return location || undefined;
+};
+
+const normalizeSessionInfo = (signInContext: UserSessionSignInContext): SessionDisplayInfo => {
+  const { browserName, osName, deviceModel } = getParsedUserAgentInfo(signInContext.userAgent);
+
+  return {
+    name: formatSessionDeviceName(signInContext),
+    location: formatSessionLocation(signInContext),
+    ip: signInContext.ip,
+    browserName,
+    osName,
+    deviceModel,
+  };
+};
+
+export const getSessionDisplayInfo = (session: AccountSession): SessionDisplayInfo => {
+  const signInContextResult = userSessionSignInContextGuard.safeParse(
+    session.lastSubmission?.signInContext
+  );
+
+  return signInContextResult.success ? normalizeSessionInfo(signInContextResult.data) : {};
 };

--- a/packages/account/src/pages/Security/SessionSection/utils.ts
+++ b/packages/account/src/pages/Security/SessionSection/utils.ts
@@ -1,0 +1,79 @@
+import type { GetAccountUserSessionsResponse } from '@logto/schemas';
+
+type AccountSession = GetAccountUserSessionsResponse['sessions'][number];
+
+/**
+ * Parse a user-agent string into a human-readable device label (browser + OS).
+ * Intentionally lightweight — no external dependency.
+ */
+export const parseUserAgent = (ua?: string): string => {
+  if (!ua) {
+    return 'Unknown device';
+  }
+
+  const browser = detectBrowser(ua);
+  const os = detectOS(ua);
+
+  return [browser, os].filter(Boolean).join(' on ') || 'Unknown device';
+};
+
+const detectBrowser = (ua: string): string => {
+  const lower = ua.toLowerCase();
+  // Order matters: check more specific patterns first
+  if (lower.includes('edg/')) {
+    return 'Edge';
+  }
+  if (lower.includes('opr/') || lower.includes('opera')) {
+    return 'Opera';
+  }
+  if (lower.includes('chrome/') && !lower.includes('chromium')) {
+    return 'Chrome';
+  }
+  if (lower.includes('firefox/')) {
+    return 'Firefox';
+  }
+  if (lower.includes('safari/') && !lower.includes('chrome')) {
+    return 'Safari';
+  }
+  return '';
+};
+
+const detectOS = (ua: string): string => {
+  const lower = ua.toLowerCase();
+  if (lower.includes('windows')) {
+    return 'Windows';
+  }
+  if (lower.includes('macintosh') || lower.includes('mac os x')) {
+    return 'macOS';
+  }
+  if (lower.includes('android')) {
+    return 'Android';
+  }
+  if (lower.includes('iphone') || lower.includes('ipad') || lower.includes('ipod')) {
+    return 'iOS';
+  }
+  if (lower.includes('linux')) {
+    return 'Linux';
+  }
+  return '';
+};
+
+/**
+ * Build a location string from country/city fields.
+ */
+export const formatLocation = (country?: string, city?: string): string | undefined => {
+  const parts = [city, country].filter(Boolean);
+  return parts.length > 0 ? parts.join(', ') : undefined;
+};
+
+/**
+ * Build session meta text (IP + location).
+ */
+export const formatSessionMeta = (session: AccountSession): string => {
+  const signInContext = session.lastSubmission?.signInContext;
+  const ip = signInContext?.ip;
+  const location = formatLocation(signInContext?.country, signInContext?.city);
+
+  const parts = [ip, location].filter(Boolean);
+  return parts.join(' · ');
+};

--- a/packages/account/src/pages/Security/index.test.tsx
+++ b/packages/account/src/pages/Security/index.test.tsx
@@ -118,6 +118,7 @@ const renderSecurity = ({
             ...mockAccountCenterSettings.fields,
             social: AccountCenterControlValue.Off,
             mfa: AccountCenterControlValue.Off,
+            session: AccountCenterControlValue.Off,
             ...fields,
           },
           deleteAccountUrl: null,

--- a/packages/account/src/pages/Security/index.tsx
+++ b/packages/account/src/pages/Security/index.tsx
@@ -10,6 +10,7 @@ import DeleteAccountSection from './DeleteAccountSection';
 import EmailPhoneSection from './EmailPhoneSection';
 import MfaSection from './MfaSection';
 import PasswordSection from './PasswordSection';
+import SessionSection from './SessionSection';
 import SocialSection from './SocialSection';
 import UsernameSection from './UsernameSection';
 
@@ -26,6 +27,7 @@ const Security = () => {
         <PasswordSection />
         <SocialSection />
         <MfaSection />
+        <SessionSection />
         <DeleteAccountSection />
       </div>
       <PageFooter />

--- a/packages/account/src/pages/VerifiedAction/index.tsx
+++ b/packages/account/src/pages/VerifiedAction/index.tsx
@@ -53,6 +53,12 @@ const VerifiedAction = () => {
       case 'remove-social': {
         return accountCenterSettings.fields.social === AccountCenterControlValue.Edit;
       }
+      case 'load-sessions': {
+        return (
+          accountCenterSettings.fields.session !== undefined &&
+          accountCenterSettings.fields.session !== AccountCenterControlValue.Off
+        );
+      }
       default: {
         return false;
       }

--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -36,7 +36,7 @@ export const hasVisibleSecuritySection = (
     return false;
   }
 
-  const { username, email, phone, password, social, mfa } = accountCenterSettings.fields;
+  const { username, email, phone, password, social, mfa, session } = accountCenterSettings.fields;
   const hasDeleteAccountUrl = Boolean(accountCenterSettings.deleteAccountUrl?.trim());
 
   return (
@@ -44,6 +44,7 @@ export const hasVisibleSecuritySection = (
     isVisibleField(email) ||
     isVisibleField(phone) ||
     isVisibleField(password) ||
+    isVisibleField(session) ||
     hasDeleteAccountUrl ||
     hasVisibleSocialSection(social, experienceSettings) ||
     hasVisibleMfaSection(mfa, experienceSettings)

--- a/packages/account/src/utils/session-storage.ts
+++ b/packages/account/src/utils/session-storage.ts
@@ -89,6 +89,7 @@ const pendingVerifiedActions = Object.freeze([
   'remove-email',
   'remove-phone',
   'remove-social',
+  'load-sessions',
 ] as const);
 
 export type PendingVerifiedAction = (typeof pendingVerifiedActions)[number];

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -105,7 +105,6 @@ const account_center = {
       'لم تقم بإضافة طريقة تحقق ثانية. أضف طريقة واحدة على الأقل لتفعيل التحقق بخطوتين عند تسجيل الدخول.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -103,6 +103,15 @@ const account_center = {
     disable_2_step_verification: 'تعطيل',
     no_verification_method_warning:
       'لم تقم بإضافة طريقة تحقق ثانية. أضف طريقة واحدة على الأقل لتفعيل التحقق بخطوتين عند تسجيل الدخول.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'حذف الحساب',
     delete_your_account: 'احذف حسابك',
     delete_account: 'حذف الحساب',

--- a/packages/phrases-experience/src/locales/cs/account-center.ts
+++ b/packages/phrases-experience/src/locales/cs/account-center.ts
@@ -105,7 +105,6 @@ const account_center = {
       'Nepřidali jste druhou ověřovací metodu. Přidejte alespoň jednu pro povolení dvoufázového ověření při přihlášení.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/cs/account-center.ts
+++ b/packages/phrases-experience/src/locales/cs/account-center.ts
@@ -103,6 +103,15 @@ const account_center = {
     disable_2_step_verification: 'Vypnout',
     no_verification_method_warning:
       'Nepřidali jste druhou ověřovací metodu. Přidejte alespoň jednu pro povolení dvoufázového ověření při přihlášení.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Smazání účtu',
     delete_your_account: 'Smazat svůj účet',
     delete_account: 'Smazat účet',

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -110,6 +110,15 @@ const account_center = {
     disable_2_step_verification: 'Deaktivieren',
     no_verification_method_warning:
       'Sie haben keine zweite Verifizierungsmethode hinzugefügt. Fügen Sie mindestens eine hinzu, um die 2-Faktor-Verifizierung bei der Anmeldung zu aktivieren.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Kontolöschung',
     delete_your_account: 'Ihr Konto löschen',
     delete_account: 'Konto löschen',

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -112,7 +112,6 @@ const account_center = {
       'Sie haben keine zweite Verifizierungsmethode hinzugefügt. Fügen Sie mindestens eine hinzu, um die 2-Faktor-Verifizierung bei der Anmeldung zu aktivieren.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -100,6 +100,15 @@ const account_center = {
     disable_2_step_verification: 'Disable',
     no_verification_method_warning:
       "You haven't added a second verification method. Add at least one to enable 2-step verification at sign-in.",
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Account removal',
     delete_your_account: 'Delete your account',
     delete_account: 'Delete account',

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -102,7 +102,6 @@ const account_center = {
       "You haven't added a second verification method. Add at least one to enable 2-step verification at sign-in.",
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -107,6 +107,15 @@ const account_center = {
     disable_2_step_verification: 'Desactivar',
     no_verification_method_warning:
       'No has añadido un segundo método de verificación. Añade al menos uno para activar la verificación en dos pasos al iniciar sesión.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Eliminación de la cuenta',
     delete_your_account: 'Elimina tu cuenta',
     delete_account: 'Eliminar cuenta',

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -109,7 +109,6 @@ const account_center = {
       'No has añadido un segundo método de verificación. Añade al menos uno para activar la verificación en dos pasos al iniciar sesión.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -109,6 +109,15 @@ const account_center = {
     disable_2_step_verification: 'Désactiver',
     no_verification_method_warning:
       "Vous n'avez pas ajouté de deuxième méthode de vérification. Ajoutez-en au moins une pour activer la vérification en deux étapes lors de la connexion.",
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Suppression du compte',
     delete_your_account: 'Supprimez votre compte',
     delete_account: 'Supprimer le compte',

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -111,7 +111,6 @@ const account_center = {
       "Vous n'avez pas ajouté de deuxième méthode de vérification. Ajoutez-en au moins une pour activer la vérification en deux étapes lors de la connexion.",
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -110,7 +110,6 @@ const account_center = {
       "Non hai aggiunto un secondo metodo di verifica. Aggiungine almeno uno per attivare la verifica in due passaggi all'accesso.",
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -108,6 +108,15 @@ const account_center = {
     disable_2_step_verification: 'Disattiva',
     no_verification_method_warning:
       "Non hai aggiunto un secondo metodo di verifica. Aggiungine almeno uno per attivare la verifica in due passaggi all'accesso.",
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: "Eliminazione dell'account",
     delete_your_account: 'Elimina il tuo account',
     delete_account: "Elimina l'account",

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -105,7 +105,6 @@ const account_center = {
       '2つ目の認証方法が追加されていません。サインイン時の2段階認証を有効にするには、少なくとも1つ追加してください。',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -103,6 +103,15 @@ const account_center = {
     disable_2_step_verification: '無効にする',
     no_verification_method_warning:
       '2つ目の認証方法が追加されていません。サインイン時の2段階認証を有効にするには、少なくとも1つ追加してください。',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'アカウント削除',
     delete_your_account: 'アカウントを削除',
     delete_account: 'アカウントを削除',

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -102,6 +102,15 @@ const account_center = {
     disable_2_step_verification: '비활성화',
     no_verification_method_warning:
       '두 번째 인증 방법을 추가하지 않았습니다. 로그인 시 2단계 인증을 활성화하려면 최소 하나를 추가하세요.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: '계정 삭제',
     delete_your_account: '내 계정 삭제',
     delete_account: '계정 삭제',

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -104,7 +104,6 @@ const account_center = {
       '두 번째 인증 방법을 추가하지 않았습니다. 로그인 시 2단계 인증을 활성화하려면 최소 하나를 추가하세요.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -104,6 +104,15 @@ const account_center = {
     disable_2_step_verification: 'Wyłącz',
     no_verification_method_warning:
       'Nie dodałeś drugiej metody weryfikacji. Dodaj co najmniej jedną, aby włączyć weryfikację dwuetapową podczas logowania.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Usunięcie konta',
     delete_your_account: 'Usuń swoje konto',
     delete_account: 'Usuń konto',

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -106,7 +106,6 @@ const account_center = {
       'Nie dodałeś drugiej metody weryfikacji. Dodaj co najmniej jedną, aby włączyć weryfikację dwuetapową podczas logowania.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -106,6 +106,15 @@ const account_center = {
     disable_2_step_verification: 'Desativar',
     no_verification_method_warning:
       'Você não adicionou um segundo método de verificação. Adicione pelo menos um para ativar a verificação em duas etapas ao fazer login.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Exclusão da conta',
     delete_your_account: 'Excluir sua conta',
     delete_account: 'Excluir conta',

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -108,7 +108,6 @@ const account_center = {
       'Você não adicionou um segundo método de verificação. Adicione pelo menos um para ativar a verificação em duas etapas ao fazer login.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -107,6 +107,15 @@ const account_center = {
     disable_2_step_verification: 'Desativar',
     no_verification_method_warning:
       'Não adicionou um segundo método de verificação. Adicione pelo menos um para ativar a verificação em duas etapas ao iniciar sessão.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Eliminação da conta',
     delete_your_account: 'Elimine a sua conta',
     delete_account: 'Eliminar conta',

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -109,7 +109,6 @@ const account_center = {
       'Não adicionou um segundo método de verificação. Adicione pelo menos um para ativar a verificação em duas etapas ao iniciar sessão.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -105,7 +105,6 @@ const account_center = {
       'Вы не добавили второй способ верификации. Добавьте хотя бы один, чтобы включить двухэтапную верификацию при входе.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -103,6 +103,15 @@ const account_center = {
     disable_2_step_verification: 'Отключить',
     no_verification_method_warning:
       'Вы не добавили второй способ верификации. Добавьте хотя бы один, чтобы включить двухэтапную верификацию при входе.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Удаление аккаунта',
     delete_your_account: 'Удалите свой аккаунт',
     delete_account: 'Удалить аккаунт',

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -103,6 +103,15 @@ const account_center = {
     disable_2_step_verification: 'ปิด',
     no_verification_method_warning:
       'คุณยังไม่ได้เพิ่มวิธีการยืนยันตัวตนที่สอง เพิ่มอย่างน้อยหนึ่งวิธีเพื่อเปิดใช้งานการยืนยันตัวตนสองขั้นตอนเมื่อลงชื่อเข้าใช้',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'การลบบัญชี',
     delete_your_account: 'ลบบัญชีของคุณ',
     delete_account: 'ลบบัญชี',

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -105,7 +105,6 @@ const account_center = {
       'คุณยังไม่ได้เพิ่มวิธีการยืนยันตัวตนที่สอง เพิ่มอย่างน้อยหนึ่งวิธีเพื่อเปิดใช้งานการยืนยันตัวตนสองขั้นตอนเมื่อลงชื่อเข้าใช้',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -106,7 +106,6 @@ const account_center = {
       'İkinci bir doğrulama yöntemi eklemediniz. Oturum açarken 2 adımlı doğrulamayı etkinleştirmek için en az bir tane ekleyin.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -104,6 +104,15 @@ const account_center = {
     disable_2_step_verification: 'Devre dışı bırak',
     no_verification_method_warning:
       'İkinci bir doğrulama yöntemi eklemediniz. Oturum açarken 2 adımlı doğrulamayı etkinleştirmek için en az bir tane ekleyin.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Hesap silme',
     delete_your_account: 'Hesabını sil',
     delete_account: 'Hesabı sil',

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -107,7 +107,6 @@ const account_center = {
       'Ви не додали другий метод верифікації. Додайте принаймні один, щоб увімкнути двоетапну верифікацію при вході.',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -105,6 +105,15 @@ const account_center = {
     disable_2_step_verification: 'Вимкнути',
     no_verification_method_warning:
       'Ви не додали другий метод верифікації. Додайте принаймні один, щоб увімкнути двоетапну верифікацію при вході.',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: 'Видалення акаунта',
     delete_your_account: 'Видаліть свій акаунт',
     delete_account: 'Видалити акаунт',

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -103,7 +103,6 @@ const account_center = {
       '你尚未添加第二种验证方式。请至少添加一种以在登录时启用两步验证。',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -101,6 +101,15 @@ const account_center = {
     disable_2_step_verification: '关闭',
     no_verification_method_warning:
       '你尚未添加第二种验证方式。请至少添加一种以在登录时启用两步验证。',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: '账号删除',
     delete_your_account: '删除你的账号',
     delete_account: '删除账号',

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -101,6 +101,15 @@ const account_center = {
     disable_2_step_verification: '關閉',
     no_verification_method_warning:
       '你尚未添加第二種驗證方式。請至少添加一種以在登入時啟用兩步驗證。',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: '帳戶刪除',
     delete_your_account: '刪除你的帳戶',
     delete_account: '刪除帳戶',

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -103,7 +103,6 @@ const account_center = {
       '你尚未添加第二種驗證方式。請至少添加一種以在登入時啟用兩步驗證。',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -103,7 +103,6 @@ const account_center = {
       '你尚未新增第二種驗證方式。請至少新增一種以在登入時啟用兩步驟驗證。',
     sessions: 'Sessions',
     session_current: 'Current session',
-    session_other: 'Other session',
     session_signed_in: 'Signed in {{date}}',
     session_revoke: 'Sign out',
     session_revoke_confirmation_title: 'Sign out session',

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -101,6 +101,15 @@ const account_center = {
     disable_2_step_verification: '關閉',
     no_verification_method_warning:
       '你尚未新增第二種驗證方式。請至少新增一種以在登入時啟用兩步驟驗證。',
+    sessions: 'Sessions',
+    session_current: 'Current session',
+    session_other: 'Other session',
+    session_signed_in: 'Signed in {{date}}',
+    session_revoke: 'Sign out',
+    session_revoke_confirmation_title: 'Sign out session',
+    session_revoke_confirmation_description:
+      'This will sign out the session and revoke all associated access. Are you sure you want to continue?',
+    session_no_other: 'No other active sessions.',
     account_removal: '帳戶刪除',
     delete_your_account: '刪除你的帳戶',
     delete_account: '刪除帳戶',


### PR DESCRIPTION
## Summary

Add session management to the account center Security page (`packages/account`), letting end users view and revoke their active sessions.

### What's new
- `SessionSection` component gated by `accountCenter.fields.session` (Off / ReadOnly / Edit)
- Sessions API layer (`apis/sessions.ts`) calling `GET /api/my-account/sessions` and `DELETE /api/my-account/sessions/:sessionId` with `revokeGrantsTarget=all`
- Identity-verification flow via `VerifiedAction` (added `'load-sessions'` case to the permission switch)
- `UserScope.Sessions` added to the LogtoProvider scope list in `App.tsx`
- UA parsing uses `ua-parser-js` + `userSessionSignInContextGuard.safeParse()`, consistent with Console's `UserSessions` utils
- Grid-based row layout matching `SocialSection` pattern; responsive mobile mixin

### Session row displays
Device name (browser on OS/device) · location (city, country) · IP · sign-in timestamp · "Current session" badge · "Sign out" button (Edit mode only, non-current sessions)

### Testing
Tested locally

Link to Devin session: https://app.devin.ai/sessions/d135c0c480f6408da2d84b708b66b472
Requested by: @wangsijie