### PR TITLE
fix(console): use focus-visible for icon buttons

### DIFF
--- a/packages/console/src/ds-components/CopyToClipboard/index.tsx
+++ b/packages/console/src/ds-components/CopyToClipboard/index.tsx
@@ -72,10 +72,6 @@ function CopyToClipboard(
   }, []);
 
   const copy: MouseEventHandler<HTMLButtonElement> = async () => {
-    /**
-     * Note: should blur the copy icon button before the tooltip is shown, or it will remain focused after the tooltip is closed.
-     */
-    copyIconReference.current?.blur();
     setCopyState('copying');
     await navigator.clipboard.writeText(value);
     setCopyState('copied');

--- a/packages/console/src/ds-components/IconButton/index.module.scss
+++ b/packages/console/src/ds-components/IconButton/index.module.scss
@@ -30,8 +30,11 @@
     }
   }
 
-  &:active,
-  &:focus {
+  &:focus-visible {
+    outline: 3px solid var(--color-focused);
+  }
+
+  &:active {
     background: var(--color-pressed);
   }
 

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/ActionButton/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/MonacoCodeEditor/ActionButton/index.tsx
@@ -37,8 +37,6 @@ function ActionButton({
   });
 
   const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(async () => {
-    iconButtonRef.current?.blur();
-
     if (actionLoadingTip) {
       setTipContent(actionLoadingTip);
     }

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/PrebuiltUiUrlItem.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/PrebuiltUiUrlItem.tsx
@@ -32,7 +32,6 @@ function PrebuiltUiUrlItem({ path, tooltip, tenantEndpoint, isPreviewHidden }: P
   }, []);
 
   const handleCopy = async () => {
-    copyIconRef.current?.blur();
     setCopyState('copying');
     await navigator.clipboard.writeText(path);
     setCopyState('copied');


### PR DESCRIPTION
## Summary

Previously, there's an focus background issue with the `IconButton` component. A focus background color was applied to the icon even when the click event is done, and workarounds were introduced to avoid the unexpected background color.

<img width="95" height="61" alt="image" src="https://github.com/user-attachments/assets/a0a4b3b6-a00a-474f-96df-f66a33d119ab" />


Update Console `IconButton` to use `:focus-visible` for the keyboard focus ring while keeping the pressed background limited to the active click state.

Remove local `blur()` workarounds from copy and Monaco editor icon buttons now that mouse focus no longer leaves a persistent pressed background.

## Testing
Tested locally

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments