### PR TITLE
fix(console): adjust transfer source item spacing

### DIFF
--- a/packages/console/src/components/EntitiesTransfer/components/SourceEntityItem/index.module.scss
+++ b/packages/console/src/components/EntitiesTransfer/components/SourceEntityItem/index.module.scss
@@ -7,25 +7,11 @@
   cursor: pointer;
   user-select: none;
 
-  .icon {
-    width: 20px;
-    height: 20px;
-    border-radius: 6px;
-  }
-
-  .title {
-    flex: 1 1 0;
-    font: var(--font-body-2);
-    @include _.text-ellipsis;
-    margin-inline-start: _.unit(2);
-    max-width: fit-content;
-  }
-
-  .suspended {
-    margin-inline-start: _.unit(1);
-  }
-
   &:hover {
     background: var(--color-hover);
   }
+}
+
+.checkbox {
+  margin-inline-end: _.unit(2);
 }

--- a/packages/console/src/components/EntitiesTransfer/components/SourceEntityItem/index.tsx
+++ b/packages/console/src/components/EntitiesTransfer/components/SourceEntityItem/index.tsx
@@ -32,6 +32,7 @@ function SourceEntityItem<T extends Identifiable>({
       }}
     >
       <Checkbox
+        className={styles.checkbox}
         checked={isSelected}
         onChange={() => {
           onSelect();

--- a/packages/console/src/ds-components/DataTransferBox/SourceGroupItem/index.module.scss
+++ b/packages/console/src/ds-components/DataTransferBox/SourceGroupItem/index.module.scss
@@ -15,10 +15,6 @@
       cursor: pointer;
       overflow: hidden;
 
-      .caret {
-        margin-inline-end: _.unit(2);
-      }
-
       .name {
         font: var(--font-label-2);
         @include _.text-ellipsis;

--- a/packages/console/src/ds-components/DataTransferBox/SourceGroupItem/index.tsx
+++ b/packages/console/src/ds-components/DataTransferBox/SourceGroupItem/index.tsx
@@ -65,7 +65,7 @@ function SourceGroupItem<TEntry extends DataEntry>({
             setIsDataListHidden(!isDataListHidden);
           }}
         >
-          <IconButton size="medium" className={styles.caret}>
+          <IconButton size="medium">
             {isDataListHidden ? <CaretFolded /> : <CaretExpanded />}
           </IconButton>
           <div className={styles.name}>{groupName}</div>


### PR DESCRIPTION
## Summary
Fix source item spacing in transfer components by adding the intended gap after entity checkboxes and removing the extra caret margin from grouped data transfer rows.

## Testing
Tested locally

## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
