### PR TITLE
fix(experience): preserve history state on page refresh to prevent session loss

### DIFF
--- a/packages/experience/src/shared/utils/search-parameters.ts
+++ b/packages/experience/src/shared/utils/search-parameters.ts
@@ -46,5 +46,11 @@ export const handleSearchParametersData = () => {
 
   const conditionalParamString = condString(parameters.size > 0 && `?${parameters.toString()}`);
 
-  window.history.replaceState({}, '', window.location.pathname + conditionalParamString);
+  // Preserve the existing history state (e.g. React Router's location state) to avoid
+  // losing in-progress flow data (like Continue page's interactionEvent) on page refresh.
+  window.history.replaceState(
+    window.history.state,
+    '',
+    window.location.pathname + conditionalParamString
+  );
 };


### PR DESCRIPTION
## Summary

`handleSearchParametersData()` in `search-parameters.ts` calls `window.history.replaceState({}, '', ...)` at module load time (before React Router initializes). On page refresh this wipes the React Router location state that the Continue flow depends on (`{ interactionEvent }`), causing the profile collection page to immediately show "invalid_session" instead of letting the user resume.

Fix: pass `window.history.state` instead of `{}` to preserve existing state.

### Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/e768e29f8c7641f5b8b8dd5b621f7335
Requested by: @wangsijie