### PR TITLE
fix(schemas): set sign-up profile fields default

### DIFF
--- a/packages/schemas/alterations/next-1780643665-set-sign-up-profile-fields-default.ts
+++ b/packages/schemas/alterations/next-1780643665-set-sign-up-profile-fields-default.ts
@@ -1,0 +1,20 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        alter column sign_up_profile_fields set default '[]'::jsonb;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        alter column sign_up_profile_fields drop default;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/sign-in-experience.test.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.test.ts
@@ -28,9 +28,14 @@ describe('createAdminTenantSignInExperience', () => {
   });
 });
 
-describe('createDefaultSignInExperience (unchanged contract)', () => {
+describe('createDefaultSignInExperience', () => {
   it('still has a two-parameter signature and seeds an empty passwordPolicy', () => {
     const row = createDefaultSignInExperience('some-tenant-id', false);
     expect(row.passwordPolicy).toEqual({});
+  });
+
+  it('keeps legacy null signUpProfileFields for seeded default tenants', () => {
+    const row = createDefaultSignInExperience('some-tenant-id', false);
+    expect(row.signUpProfileFields).toBeNull();
   });
 });

--- a/packages/schemas/src/seeds/sign-in-experience.ts
+++ b/packages/schemas/src/seeds/sign-in-experience.ts
@@ -56,6 +56,7 @@ export const createDefaultSignInExperience = (
     customCss: null,
     customContent: {},
     customUiAssets: null,
+    signUpProfileFields: null,
     passwordPolicy: {},
     mfa: {
       factors: [],

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -34,8 +34,8 @@ create table sign_in_experiences (
   email_blocklist_policy jsonb /* @use EmailBlocklistPolicy */ not null default '{}'::jsonb,
   forgot_password_methods jsonb /* @use ForgotPasswordMethods */ default '[]'::jsonb,
   passkey_sign_in jsonb /* @use PasskeySignIn */ not null default '{}'::jsonb,
-  /** Nullable by design: null keeps legacy full-catalog behavior and [] collects no custom profile fields. */
-  sign_up_profile_fields jsonb /* @use SignUpProfileFields */,
+  /** Nullable by design: null keeps legacy full-catalog behavior, and new rows default to [] to collect no custom profile fields. */
+  sign_up_profile_fields jsonb /* @use SignUpProfileFields */ default '[]'::jsonb,
   password_expiration jsonb /* @use PasswordExpirationPolicy */ not null default '{}'::jsonb,
   username_policy jsonb /* @use UsernamePolicy */ not null default ('{
     "caseSensitive": true,


### PR DESCRIPTION
## Summary

- Set the DB default for new sign-in experience rows to `[]`.
- Keep seeded default/admin tenant rows as legacy `null` so existing full-catalog compatibility remains intact.
- Document and test the intentional `null` vs `[]` distinction.

## Testing

Unit tests