### PR TITLE
feat(console): show profile field key alongside label in account center

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/ProfileFieldItem.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/ProfileFieldItem.module.scss
@@ -23,6 +23,11 @@
   .draggableIcon {
     color: var(--color-text-secondary);
   }
+
+  .fieldKey {
+    color: var(--color-text-secondary);
+    font: var(--font-body-3);
+  }
 }
 
 .disabled {

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/ProfileFieldItem.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/ProfileFieldItem.tsx
@@ -17,12 +17,13 @@ const preventDisabledRowActivation = (event: KeyboardEvent<HTMLDivElement>) => {
 
 type Props = {
   readonly label: string;
+  readonly fieldKey?: string;
   readonly onDelete: () => void;
   readonly isDisabled?: boolean;
   readonly disabledHint?: ReactNode;
 };
 
-function ProfileFieldItem({ label, onDelete, isDisabled = false, disabledHint }: Props) {
+function ProfileFieldItem({ label, fieldKey, onDelete, isDisabled = false, disabledHint }: Props) {
   const shouldShowDisabledHint = isDisabled && Boolean(disabledHint);
   const fieldRow = (
     <div
@@ -34,6 +35,7 @@ function ProfileFieldItem({ label, onDelete, isDisabled = false, disabledHint }:
     >
       <Draggable className={styles.draggableIcon} />
       {label}
+      {fieldKey && <span className={styles.fieldKey}>{fieldKey}</span>}
     </div>
   );
 

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.module.scss
@@ -8,6 +8,12 @@
   min-width: 208px;
 }
 
+.dropdownFieldKey {
+  color: var(--color-text-secondary);
+  font: var(--font-body-3);
+  margin-left: _.unit(1);
+}
+
 .setUpHint {
   font: var(--font-body-2);
   color: var(--color-text-secondary);

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
@@ -133,6 +133,7 @@ function ProfileFieldsEditBox<
                   return (
                     <ProfileFieldItem
                       label={fieldLabelByName.get(fieldName) ?? fieldName}
+                      fieldKey={fieldName}
                       isDisabled={isDisabled}
                       disabledHint={disabledReason}
                       onDelete={() => {
@@ -168,6 +169,7 @@ function ProfileFieldsEditBox<
                 }}
               >
                 {label || getI18nLabel(fieldName)}
+                <span className={styles.dropdownFieldKey}>{fieldName}</span>
               </DropdownItem>
             );
           })}

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
@@ -168,8 +168,10 @@ function ProfileFieldsEditBox<
                   append({ name: fieldName } as never);
                 }}
               >
-                {label || getI18nLabel(fieldName)}
-                <span className={styles.dropdownFieldKey}>{fieldName}</span>
+                <span>
+                  {label || getI18nLabel(fieldName)}
+                  <span className={styles.dropdownFieldKey}>{fieldName}</span>
+                </span>
               </DropdownItem>
             );
           })}

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
@@ -19,6 +19,7 @@ import { DropdownItem } from '@/ds-components/Dropdown';
 import { type RequestError } from '@/hooks/use-api';
 
 import useI18nFieldLabel from '../../CollectUserProfile/use-i18n-field-label';
+import { isBuiltInCustomProfileFieldKey } from '../../CollectUserProfile/utils';
 
 import ProfileFieldItem from './ProfileFieldItem';
 import styles from './index.module.scss';
@@ -133,7 +134,11 @@ function ProfileFieldsEditBox<
                   return (
                     <ProfileFieldItem
                       label={fieldLabelByName.get(fieldName) ?? fieldName}
-                      fieldKey={fieldName}
+                      fieldKey={
+                        isBuiltInCustomProfileFieldKey(fieldName)
+                          ? fieldName
+                          : `customData.${fieldName}`
+                      }
                       isDisabled={isDisabled}
                       disabledHint={disabledReason}
                       onDelete={() => {
@@ -170,7 +175,11 @@ function ProfileFieldsEditBox<
               >
                 <span>
                   {label || getI18nLabel(fieldName)}
-                  <span className={styles.dropdownFieldKey}>{fieldName}</span>
+                  <span className={styles.dropdownFieldKey}>
+                    {isBuiltInCustomProfileFieldKey(fieldName)
+                      ? fieldName
+                      : `customData.${fieldName}`}
+                  </span>
                 </span>
               </DropdownItem>
             );


### PR DESCRIPTION
## Summary

Display the field key (e.g. `fullname`, `address`) next to the label in the "Profile fields for prebuilt account center" section on the account center settings page.

- `ProfileFieldItem`: added optional `fieldKey` prop, rendered as a secondary-color `<span>` after the label
- `ProfileFieldsEditBox`: passes `fieldName` as `fieldKey` to each `ProfileFieldItem` row, and appends a `<span className={styles.dropdownFieldKey}>` in each dropdown item

## Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/0e79720de4804a04aafd67bfff056d1d
Requested by: @wangsijie