### PR TITLE
feat(account): apply username policy to username edit validation

### DIFF
--- a/packages/account/src/pages/Username/index.test.tsx
+++ b/packages/account/src/pages/Username/index.test.tsx
@@ -1,4 +1,4 @@
-import { AccountCenterControlValue, type AccountCenter } from '@logto/schemas';
+import { AccountCenterControlValue, type AccountCenter, type UsernamePolicy } from '@logto/schemas';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { HTTPError, type NormalizedOptions } from 'ky';
 import { Route, Routes } from 'react-router-dom';
@@ -6,6 +6,7 @@ import { Route, Routes } from 'react-router-dom';
 import type { PageContextType } from '@ac/Providers/PageContextProvider/PageContext';
 import renderWithPageContext, {
   mockAccountCenterSettings,
+  mockSignInExperienceSettings,
 } from '@ac/__mocks__/RenderWithPageContext';
 
 import { updateUsername } from '../../apis/account';
@@ -24,7 +25,25 @@ jest.mock('../../apis/account', () => ({
   updateUsername: jest.fn(),
 }));
 
+// The policy gate is read per submit; control it per test (and sidestep `import.meta.env`). Default
+// off — matching production and the suite's original hard-floor-only behavior; the policy block
+// turns it on.
+const mockIsDevFeaturesEnabled = jest.fn(() => false);
+jest.mock('@ac/constants/env', () => ({
+  get isDevFeaturesEnabled() {
+    return mockIsDevFeaturesEnabled();
+  },
+}));
+
 jest.mock('@ac/components/VerificationMethodList', () => () => <div>Verification methods</div>);
+
+// Lowercase-only, length 4–8: violations here are policy-only (not caught by the hard floor).
+const restrictivePolicy: UsernamePolicy = {
+  caseSensitive: true,
+  minLength: 4,
+  maxLength: 8,
+  allowedChars: { lowercase: true, uppercase: false, numbers: false, underscore: false },
+};
 
 const createHttpError = (code: string, status: number) =>
   new HTTPError(
@@ -76,11 +95,19 @@ const renderUsername = ({ pageContext }: UsernameRenderOptions = {}) =>
     }
   );
 
+const renderWithPolicy = () =>
+  renderUsername({
+    pageContext: {
+      experienceSettings: { ...mockSignInExperienceSettings, usernamePolicy: restrictivePolicy },
+    },
+  });
+
 describe('<Username />', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     mockGetAccessToken.mockResolvedValue('access-token');
     jest.mocked(updateUsername).mockResolvedValue(undefined);
+    mockIsDevFeaturesEnabled.mockReturnValue(false);
   });
 
   it('shows an error page when username editing is disabled', () => {
@@ -198,6 +225,69 @@ describe('<Username />', () => {
     await waitFor(() => {
       expect(setVerificationId).toHaveBeenCalledWith(undefined);
       expect(setToast).toHaveBeenCalledWith('account_center.verification.verification_required');
+    });
+  });
+
+  describe('username policy', () => {
+    beforeEach(() => {
+      mockIsDevFeaturesEnabled.mockReturnValue(true);
+    });
+
+    it('blocks a too-short username with an inline policy error', async () => {
+      const { getByText, container } = renderWithPolicy();
+
+      const usernameInput = container.querySelector('input[name="username"]');
+      fireEvent.change(usernameInput!, { target: { value: 'abc' } });
+      fireEvent.click(getByText('action.save'));
+
+      await waitFor(() => {
+        expect(getByText('error.username_too_short')).toBeTruthy();
+      });
+      expect(updateUsername).not.toHaveBeenCalled();
+    });
+
+    it('blocks a username with a disallowed character class', async () => {
+      const { getByText, container } = renderWithPolicy();
+
+      const usernameInput = container.querySelector('input[name="username"]');
+      fireEvent.change(usernameInput!, { target: { value: 'abcD' } });
+      fireEvent.click(getByText('action.save'));
+
+      await waitFor(() => {
+        expect(getByText('error.username_uppercase_not_allowed')).toBeTruthy();
+      });
+      expect(updateUsername).not.toHaveBeenCalled();
+    });
+
+    it('submits a policy-compliant username', async () => {
+      const { getByText, container } = renderWithPolicy();
+
+      const usernameInput = container.querySelector('input[name="username"]');
+      fireEvent.change(usernameInput!, { target: { value: 'abcd' } });
+      fireEvent.click(getByText('action.save'));
+
+      await waitFor(() => {
+        expect(updateUsername).toHaveBeenCalledWith('access-token', 'verification-record-id', {
+          username: 'abcd',
+        });
+      });
+    });
+
+    it('does not block a policy-only violation when dev features are off', async () => {
+      mockIsDevFeaturesEnabled.mockReturnValue(false);
+      const { getByText, container } = renderWithPolicy();
+
+      // 'abc' is too short for the policy but passes the always-on hard floor, so with the gate off
+      // it submits unchanged — proving the policy is not enforced client-side in production.
+      const usernameInput = container.querySelector('input[name="username"]');
+      fireEvent.change(usernameInput!, { target: { value: 'abc' } });
+      fireEvent.click(getByText('action.save'));
+
+      await waitFor(() => {
+        expect(updateUsername).toHaveBeenCalledWith('access-token', 'verification-record-id', {
+          username: 'abc',
+        });
+      });
     });
   });
 });

--- a/packages/account/src/pages/Username/index.tsx
+++ b/packages/account/src/pages/Username/index.tsx
@@ -11,6 +11,7 @@ import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import { updateUsername } from '@ac/apis/account';
 import ErrorPage from '@ac/components/ErrorPage';
 import VerificationMethodList from '@ac/components/VerificationMethodList';
+import { isDevFeaturesEnabled } from '@ac/constants/env';
 import { usernameSuccessRoute } from '@ac/constants/routes';
 import useApi from '@ac/hooks/use-api';
 import useErrorHandler from '@ac/hooks/use-error-handler';
@@ -26,6 +27,7 @@ const Username = () => {
   const { loading } = useContext(LoadingContext);
   const {
     accountCenterSettings,
+    experienceSettings,
     refreshUserInfo,
     verificationId,
     setVerificationId,
@@ -79,7 +81,12 @@ const Username = () => {
       return;
     }
 
-    const validationError = validateUsername(username);
+    // Per-tenant policy enforcement is gated until the feature ships; without the flag the
+    // always-on hard floor is the only client-side check, matching production behavior.
+    const validationError = validateUsername(
+      username,
+      isDevFeaturesEnabled ? experienceSettings?.usernamePolicy : undefined
+    );
 
     if (validationError) {
       const message =


### PR DESCRIPTION
## Summary

Closes [LOG-13578](https://linear.app/silverhand/issue/LOG-13578) (P8.5).

The account center lets a signed-in user edit their username at `packages/account/src/pages/Username/index.tsx`, but it only ran the always-on hard floor (non-empty, no leading digit, valid charset) client-side — the per-tenant username policy (length, allowed character types) was not applied, unlike the experience app's sign-up / profile-completion flows (P7). Server-side enforcement already exists (`assertUsernameAllowed`), so this closes the matching **client UX-parity gap**.

### What changed
- `pages/Username/index.tsx`: read `experienceSettings?.usernamePolicy` from `PageContext` (already fetched, no new wiring) and pass it into the **shared** `validateUsername` helper, gated behind the account dev-feature flag: `validateUsername(username, isDevFeaturesEnabled ? experienceSettings?.usernamePolicy : undefined)`. This reuses the same single-source-of-truth validator the experience app uses (`@experience/shared/utils/validate-username`) and mirrors experience's `validateIdentifierField` gating pattern.
- `pages/Username/index.test.tsx`: added a `username policy` test block (too-short → inline error & no submit; disallowed char class → inline error & no submit; policy-compliant → submits).

### Reviewer notes
- **Gating uses account's own `isDevFeaturesEnabled`** (not experience's), by design: account's flag carries an account-specific localStorage override and gates account's other dev features. Reusing experience's `validateIdentifierField` directly would silently bind experience's flag (the `@/`→`@experience/` rewrite only applies to files under the experience src), so the one-line gate is intentional, justified divergence — not duplication.
- **No server-error-handler changes.** Account's `use-error-handler` already falls back to `setToast(message)` (the server's localized message) for unmapped codes — identical to how experience surfaces a missed-then-server-rejected policy violation (experience only maps `username_already_in_use` inline; policy codes toast). Adding bespoke inline mapping would *diverge* from experience.
- All `error.username_*` phrase keys already exist in the shared `@logto/phrases-experience` namespace (P7); confirmed present in the built `lib/`, with `fallbackLng: 'en'`.
- Flag-gated: no production behavior change (with the flag off, the call is byte-identical to the previous hard-floor-only validation).

## Testing

Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments