### PR TITLE
fix(core): avoid consuming one-time tokens in consent guard

### DIFF
--- a/.changeset/one-time-token-consent-guard.md
+++ b/.changeset/one-time-token-consent-guard.md
@@ -1,0 +1,6 @@
+---
+"@logto/core": patch
+"@logto/integration-tests": patch
+---
+
+fix one-time token consent handling for switch-account sign-in flows

--- a/packages/core/src/middleware/koa-consent-guard.test.ts
+++ b/packages/core/src/middleware/koa-consent-guard.test.ts
@@ -28,12 +28,13 @@ describe('koaConsentGuard middleware', () => {
     },
   });
   const provisionOrganizations = jest.fn();
+  const findUserById = jest.fn().mockResolvedValue({ primaryEmail: 'foo@example.com' });
 
   const mockTenant = new MockTenant(
     provider,
     {
       users: {
-        findUserById: jest.fn().mockResolvedValue({ primaryEmail: 'foo@example.com' }),
+        findUserById,
       },
     },
     undefined,
@@ -73,7 +74,7 @@ describe('koaConsentGuard middleware', () => {
   it('should not block if token or login_hint are not provided', async () => {
     const ctx = createContext({
       params: { one_time_token: '', login_hint: '' },
-      // @ts-expect-error
+      // @ts-expect-error -- Only accountId is needed by this middleware.
       session: { accountId: 'foo' },
     });
     const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
@@ -86,24 +87,25 @@ describe('koaConsentGuard middleware', () => {
   it('should redirect to switch account page if email does not match', async () => {
     const ctx = createContext({
       params: { one_time_token: 'abcdefg', login_hint: 'bar@example.com' },
-      // @ts-expect-error
+      // @ts-expect-error -- Only accountId is needed by this middleware.
       session: { accountId: 'bar' },
     });
     const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
 
     await guard(ctx, jest.fn());
+    expect(checkOneTimeToken).toHaveBeenCalledWith('abcdefg', 'bar@example.com');
     expect(ctx.redirect).toHaveBeenCalledWith(
       expect.stringContaining('switch-account?login_hint=bar%40example.com&one_time_token=abcdefg')
     );
   });
 
-  it('should provision user to organizations on consent, if a valid one-time token is provided and there are organizations in token context', async () => {
+  it('should redirect to one-time-token page if valid token matches the current session user', async () => {
     const ctx = createContext({
       params: { one_time_token: 'token_value', login_hint: 'foo@example.com' },
-      // @ts-expect-error
+      // @ts-expect-error -- Only accountId is needed by this middleware.
       session: { accountId: 'foo' },
     });
-    checkOneTimeToken.mockResolvedValue({
+    checkOneTimeToken.mockResolvedValueOnce({
       token: 'token_value',
       email: 'foo@example.com',
       status: OneTimeTokenStatus.Active,
@@ -115,33 +117,130 @@ describe('koaConsentGuard middleware', () => {
 
     await guard(ctx, next);
 
-    expect(provisionOrganizations).toHaveBeenCalledWith({
-      userId: 'foo',
-      organizationIds: ['org_id'],
-    });
-    expect(updateOneTimeTokenStatus).toHaveBeenCalledWith(
-      'token_value',
-      OneTimeTokenStatus.Consumed
+    expect(ctx.redirect).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'one-time-token?login_hint=foo%40example.com&one_time_token=token_value'
+      )
     );
-    expect(next).toHaveBeenCalled();
+    expect(provisionOrganizations).not.toHaveBeenCalled();
+    expect(updateOneTimeTokenStatus).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
   });
 
-  it('should call next middleware if validations pass', async () => {
+  it('should redirect to one-time-token page if the original prompt contains login', async () => {
     const ctx = createContext({
-      params: { one_time_token: 'token_value', login_hint: 'foo@example.com' },
-      // @ts-expect-error
+      params: {
+        one_time_token: 'token_value',
+        login_hint: 'bar@example.com',
+        prompt: 'login consent',
+      },
+      // @ts-expect-error -- Only accountId is needed by this middleware.
       session: { accountId: 'foo' },
     });
     const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
 
     await guard(ctx, next);
+
+    expect(ctx.redirect).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'one-time-token?login_hint=bar%40example.com&one_time_token=token_value'
+      )
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should call next middleware if token is consumed and session matches the token email', async () => {
+    const ctx = createContext({
+      params: { one_time_token: 'token_value', login_hint: 'foo@example.com' },
+      // @ts-expect-error -- Only accountId is needed by this middleware.
+      session: { accountId: 'foo' },
+    });
+    checkOneTimeToken.mockImplementationOnce(() => {
+      throw new RequestError('one_time_token.token_consumed');
+    });
+    const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
+
+    await guard(ctx, next);
+
     expect(next).toHaveBeenCalled();
+    expect(ctx.redirect).not.toHaveBeenCalled();
+  });
+
+  it('should call next middleware if token is consumed and last submitted login matches the token email', async () => {
+    const ctx = createContext({
+      params: { one_time_token: 'token_value', login_hint: 'bar@example.com' },
+      // @ts-expect-error -- Only accountId is needed by this middleware.
+      session: { accountId: 'foo' },
+      lastSubmission: {
+        login: {
+          accountId: 'bar',
+        },
+      },
+    });
+    findUserById
+      .mockResolvedValueOnce({ primaryEmail: 'foo@example.com' })
+      .mockResolvedValueOnce({ primaryEmail: 'bar@example.com' });
+    checkOneTimeToken.mockImplementationOnce(() => {
+      throw new RequestError('one_time_token.token_consumed');
+    });
+    const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
+
+    await guard(ctx, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(ctx.redirect).not.toHaveBeenCalled();
+  });
+
+  it('should not call next middleware if token is consumed but neither session nor last submitted login matches the token email', async () => {
+    const ctx = createContext({
+      params: { one_time_token: 'token_value', login_hint: 'bar@example.com' },
+      // @ts-expect-error -- Only accountId is needed by this middleware.
+      session: { accountId: 'foo' },
+    });
+    checkOneTimeToken.mockImplementationOnce(() => {
+      throw new RequestError('one_time_token.token_consumed');
+    });
+    const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
+
+    await guard(ctx, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(ctx.redirect).toHaveBeenCalledWith(
+      expect.stringContaining('one-time-token?errorMessage=The+token+has+been+consumed.')
+    );
+  });
+
+  it('should redirect to error if token is consumed and last submitted login lookup fails', async () => {
+    const ctx = createContext({
+      params: { one_time_token: 'token_value', login_hint: 'bar@example.com' },
+      // @ts-expect-error -- Only accountId is needed by this middleware.
+      session: { accountId: 'foo' },
+      lastSubmission: {
+        login: {
+          accountId: 'bar',
+        },
+      },
+    });
+    findUserById
+      .mockResolvedValueOnce({ primaryEmail: 'foo@example.com' })
+      .mockRejectedValueOnce(new Error('user not found'));
+    checkOneTimeToken.mockImplementationOnce(() => {
+      throw new RequestError('one_time_token.token_consumed');
+    });
+    const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
+
+    await guard(ctx, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(ctx.redirect).toHaveBeenCalledWith(
+      expect.stringContaining('one-time-token?errorMessage=The+token+has+been+consumed.')
+    );
   });
 
   it('should navigate to `/one-time-token` route with error message in URL params, if the one-time token is not valid', async () => {
     const ctx = createContext({
       params: { one_time_token: 'token_value', login_hint: 'foo@example.com' },
-      // @ts-expect-error
+      // @ts-expect-error -- Only accountId is needed by this middleware.
       session: { accountId: 'foo' },
     });
     checkOneTimeToken.mockImplementationOnce(() => {
@@ -151,7 +250,7 @@ describe('koaConsentGuard middleware', () => {
 
     await guard(ctx, next);
     expect(ctx.redirect).toHaveBeenCalledWith(
-      expect.stringContaining('one-time-token?errorMessage=The token is expired.')
+      expect.stringContaining('one-time-token?errorMessage=The+token+is+expired.')
     );
   });
 });

--- a/packages/core/src/middleware/koa-consent-guard.test.ts
+++ b/packages/core/src/middleware/koa-consent-guard.test.ts
@@ -1,4 +1,5 @@
 import { OneTimeTokenStatus } from '@logto/schemas';
+import { NotFoundError } from '@silverhand/slonik';
 import { Provider } from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -11,22 +12,24 @@ const { jest } = import.meta;
 
 describe('koaConsentGuard middleware', () => {
   const provider = new Provider('https://logto.test');
-
-  const checkOneTimeToken = jest.fn().mockResolvedValue({
+  const activeOneTimeToken = {
     token: 'token_value',
     email: 'foo@example.com',
     status: OneTimeTokenStatus.Active,
     context: {
       jitOrganizationIds: ['org_id'],
     },
-  });
-  const updateOneTimeTokenStatus = jest.fn().mockResolvedValue({
+  };
+  const consumedOneTimeToken = {
     token: 'token_value',
     status: OneTimeTokenStatus.Consumed,
     context: {
       jitOrganizationIds: ['org_id'],
     },
-  });
+  };
+
+  const checkOneTimeToken = jest.fn().mockResolvedValue(activeOneTimeToken);
+  const updateOneTimeTokenStatus = jest.fn().mockResolvedValue(consumedOneTimeToken);
   const provisionOrganizations = jest.fn();
   const findUserById = jest.fn().mockResolvedValue({ primaryEmail: 'foo@example.com' });
 
@@ -46,8 +49,14 @@ describe('koaConsentGuard middleware', () => {
 
   const next = jest.fn();
 
+  beforeEach(() => {
+    checkOneTimeToken.mockResolvedValue(activeOneTimeToken);
+    updateOneTimeTokenStatus.mockResolvedValue(consumedOneTimeToken);
+    findUserById.mockResolvedValue({ primaryEmail: 'foo@example.com' });
+  });
+
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.resetAllMocks();
   });
 
   const createContext = (
@@ -93,9 +102,27 @@ describe('koaConsentGuard middleware', () => {
     const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
 
     await guard(ctx, jest.fn());
-    expect(checkOneTimeToken).toHaveBeenCalledWith('abcdefg', 'bar@example.com');
+    expect(checkOneTimeToken).not.toHaveBeenCalled();
     expect(ctx.redirect).toHaveBeenCalledWith(
       expect.stringContaining('switch-account?login_hint=bar%40example.com&one_time_token=abcdefg')
+    );
+  });
+
+  it('should redirect to switch account page without checking token state if email does not match', async () => {
+    const ctx = createContext({
+      params: { one_time_token: 'token_value', login_hint: 'bar@example.com' },
+      // @ts-expect-error -- Only accountId is needed by this middleware.
+      session: { accountId: 'foo' },
+    });
+    const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
+
+    await guard(ctx, next);
+
+    expect(checkOneTimeToken).not.toHaveBeenCalled();
+    expect(ctx.redirect).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'switch-account?login_hint=bar%40example.com&one_time_token=token_value'
+      )
     );
   });
 
@@ -191,26 +218,26 @@ describe('koaConsentGuard middleware', () => {
     expect(ctx.redirect).not.toHaveBeenCalled();
   });
 
-  it('should not call next middleware if token is consumed but neither session nor last submitted login matches the token email', async () => {
+  it('should redirect to switch account page if token email does not match the session and no submitted login is found', async () => {
     const ctx = createContext({
       params: { one_time_token: 'token_value', login_hint: 'bar@example.com' },
       // @ts-expect-error -- Only accountId is needed by this middleware.
       session: { accountId: 'foo' },
-    });
-    checkOneTimeToken.mockImplementationOnce(() => {
-      throw new RequestError('one_time_token.token_consumed');
     });
     const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
 
     await guard(ctx, next);
 
     expect(next).not.toHaveBeenCalled();
+    expect(checkOneTimeToken).not.toHaveBeenCalled();
     expect(ctx.redirect).toHaveBeenCalledWith(
-      expect.stringContaining('one-time-token?errorMessage=The+token+has+been+consumed.')
+      expect.stringContaining(
+        'switch-account?login_hint=bar%40example.com&one_time_token=token_value'
+      )
     );
   });
 
-  it('should redirect to error if token is consumed and last submitted login lookup fails', async () => {
+  it('should redirect to switch account page if the last submitted login user is not found', async () => {
     const ctx = createContext({
       params: { one_time_token: 'token_value', login_hint: 'bar@example.com' },
       // @ts-expect-error -- Only accountId is needed by this middleware.
@@ -223,18 +250,40 @@ describe('koaConsentGuard middleware', () => {
     });
     findUserById
       .mockResolvedValueOnce({ primaryEmail: 'foo@example.com' })
-      .mockRejectedValueOnce(new Error('user not found'));
-    checkOneTimeToken.mockImplementationOnce(() => {
-      throw new RequestError('one_time_token.token_consumed');
-    });
+      .mockRejectedValueOnce(new NotFoundError());
     const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
 
     await guard(ctx, next);
 
     expect(next).not.toHaveBeenCalled();
+    expect(checkOneTimeToken).not.toHaveBeenCalled();
     expect(ctx.redirect).toHaveBeenCalledWith(
-      expect.stringContaining('one-time-token?errorMessage=The+token+has+been+consumed.')
+      expect.stringContaining(
+        'switch-account?login_hint=bar%40example.com&one_time_token=token_value'
+      )
     );
+  });
+
+  it('should throw if the last submitted login lookup fails unexpectedly', async () => {
+    const ctx = createContext({
+      params: { one_time_token: 'token_value', login_hint: 'bar@example.com' },
+      // @ts-expect-error -- Only accountId is needed by this middleware.
+      session: { accountId: 'foo' },
+      lastSubmission: {
+        login: {
+          accountId: 'bar',
+        },
+      },
+    });
+    const databaseError = new Error('database unavailable');
+    findUserById
+      .mockResolvedValueOnce({ primaryEmail: 'foo@example.com' })
+      .mockRejectedValueOnce(databaseError);
+    const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
+
+    await expect(guard(ctx, next)).rejects.toThrow(databaseError);
+
+    expect(checkOneTimeToken).not.toHaveBeenCalled();
   });
 
   it('should navigate to `/one-time-token` route with error message in URL params, if the one-time token is not valid', async () => {

--- a/packages/core/src/middleware/koa-consent-guard.ts
+++ b/packages/core/src/middleware/koa-consent-guard.ts
@@ -1,11 +1,74 @@
-import { experience, OneTimeTokenStatus } from '@logto/schemas';
+import { experience, ExtraParamsKey } from '@logto/schemas';
 import { type MiddlewareType } from 'koa';
+import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
+
+const buildOneTimeTokenUrl = (token: string, loginHint: string) => {
+  const searchParams = new URLSearchParams({
+    [ExtraParamsKey.LoginHint]: loginHint,
+    [ExtraParamsKey.OneTimeToken]: token,
+  });
+
+  return `${experience.routes.oneTimeToken}?${searchParams.toString()}`;
+};
+
+const buildOneTimeTokenErrorUrl = (message: string) => {
+  const searchParams = new URLSearchParams({ errorMessage: message });
+
+  return `${experience.routes.oneTimeToken}?${searchParams.toString()}`;
+};
+
+const hasLoginPrompt = (prompt: unknown) =>
+  typeof prompt === 'string' && prompt.split(' ').includes('login');
+
+const lastSubmittedLoginGuard = z.object({
+  login: z.object({
+    accountId: z.string(),
+  }),
+});
+
+const getLastSubmittedLoginAccountId = (lastSubmission: unknown) => {
+  const result = lastSubmittedLoginGuard.safeParse(lastSubmission);
+
+  if (!result.success) {
+    return;
+  }
+
+  return result.data.login.accountId;
+};
+
+const shouldContinueWithConsumedOneTimeToken = async ({
+  primaryEmail,
+  loginHint,
+  lastSubmission,
+  getPrimaryEmailByUserId,
+}: {
+  primaryEmail: string;
+  loginHint: string;
+  lastSubmission: unknown;
+  getPrimaryEmailByUserId: (userId: string) => Promise<string>;
+}) => {
+  if (primaryEmail === loginHint) {
+    return true;
+  }
+
+  const submittedAccountId = getLastSubmittedLoginAccountId(lastSubmission);
+
+  if (!submittedAccountId) {
+    return false;
+  }
+
+  try {
+    return (await getPrimaryEmailByUserId(submittedAccountId)) === loginHint;
+  } catch {
+    return false;
+  }
+};
 
 /**
  * Guard before allowing auto-consent.
@@ -18,7 +81,7 @@ export default function koaConsentGuard<
 >(libraries: Libraries, queries: Queries): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   return async (ctx, next) => {
     const {
-      params: { one_time_token: token, login_hint: loginHint },
+      params: { one_time_token: token, login_hint: loginHint, prompt },
       session,
     } = ctx.interactionDetails;
 
@@ -26,42 +89,47 @@ export default function koaConsentGuard<
 
     // Handle one-time token before auto-consent
     if (token && loginHint && typeof token === 'string' && typeof loginHint === 'string') {
-      const { primaryEmail } = await queries.users.findUserById(session.accountId);
+      const getPrimaryEmailByUserId = async (userId: string) => {
+        const { primaryEmail } = await queries.users.findUserById(userId);
 
-      assertThat(primaryEmail, 'user.email_not_exist');
+        assertThat(primaryEmail, 'user.email_not_exist');
 
-      if (primaryEmail !== loginHint) {
-        const searchParams = new URLSearchParams({ login_hint: loginHint, one_time_token: token });
-        ctx.redirect(`${experience.routes.switchAccount}?${searchParams.toString()}`);
-        return;
-      }
+        return primaryEmail;
+      };
+      const primaryEmail = await getPrimaryEmailByUserId(session.accountId);
 
       try {
         await libraries.oneTimeTokens.checkOneTimeToken(token, loginHint);
-        const {
-          context: { jitOrganizationIds },
-        } = await libraries.oneTimeTokens.updateOneTimeTokenStatus(
-          token,
-          OneTimeTokenStatus.Consumed
-        );
-
-        if (jitOrganizationIds) {
-          await libraries.users.provisionOrganizations({
-            userId: session.accountId,
-            organizationIds: jitOrganizationIds,
-          });
-        }
       } catch (error: unknown) {
         if (error instanceof RequestError) {
-          // Green light for token in consumed state
-          if (error.code === 'one_time_token.token_consumed') {
+          if (
+            error.code === 'one_time_token.token_consumed' &&
+            (await shouldContinueWithConsumedOneTimeToken({
+              primaryEmail,
+              loginHint,
+              lastSubmission: ctx.interactionDetails.lastSubmission,
+              getPrimaryEmailByUserId,
+            }))
+          ) {
             return next();
           }
-          ctx.redirect(`${experience.routes.oneTimeToken}?errorMessage=${error.message}`);
+          ctx.redirect(buildOneTimeTokenErrorUrl(error.message));
           return;
         }
         throw error;
       }
+
+      if (primaryEmail !== loginHint && !hasLoginPrompt(prompt)) {
+        const searchParams = new URLSearchParams({
+          [ExtraParamsKey.LoginHint]: loginHint,
+          [ExtraParamsKey.OneTimeToken]: token,
+        });
+        ctx.redirect(`${experience.routes.switchAccount}?${searchParams.toString()}`);
+        return;
+      }
+
+      ctx.redirect(buildOneTimeTokenUrl(token, loginHint));
+      return;
     }
 
     return next();

--- a/packages/core/src/middleware/koa-consent-guard.ts
+++ b/packages/core/src/middleware/koa-consent-guard.ts
@@ -1,4 +1,6 @@
+import { Prompt } from '@logto/js';
 import { experience, ExtraParamsKey } from '@logto/schemas';
+import { NotFoundError } from '@silverhand/slonik';
 import { type MiddlewareType } from 'koa';
 import { z } from 'zod';
 
@@ -8,13 +10,13 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-const buildOneTimeTokenUrl = (token: string, loginHint: string) => {
+const buildExperienceUrl = (route: string, token: string, loginHint: string) => {
   const searchParams = new URLSearchParams({
     [ExtraParamsKey.LoginHint]: loginHint,
     [ExtraParamsKey.OneTimeToken]: token,
   });
 
-  return `${experience.routes.oneTimeToken}?${searchParams.toString()}`;
+  return `${route}?${searchParams.toString()}`;
 };
 
 const buildOneTimeTokenErrorUrl = (message: string) => {
@@ -24,7 +26,23 @@ const buildOneTimeTokenErrorUrl = (message: string) => {
 };
 
 const hasLoginPrompt = (prompt: unknown) =>
-  typeof prompt === 'string' && prompt.split(' ').includes('login');
+  typeof prompt === 'string' && prompt.split(' ').includes(Prompt.Login);
+
+const getOneTimeTokenParams = ({
+  one_time_token: token,
+  login_hint: loginHint,
+  prompt,
+}: {
+  one_time_token?: unknown;
+  login_hint?: unknown;
+  prompt?: unknown;
+}) => {
+  if (!token || !loginHint || typeof token !== 'string' || typeof loginHint !== 'string') {
+    return;
+  }
+
+  return { token, loginHint, prompt };
+};
 
 const lastSubmittedLoginGuard = z.object({
   login: z.object({
@@ -42,21 +60,19 @@ const getLastSubmittedLoginAccountId = (lastSubmission: unknown) => {
   return result.data.login.accountId;
 };
 
-const shouldContinueWithConsumedOneTimeToken = async ({
-  primaryEmail,
+const isUserNotFoundOrEmailMissingError = (error: unknown) =>
+  error instanceof NotFoundError ||
+  (error instanceof RequestError && error.code === 'user.email_not_exist');
+
+const doesLastSubmittedLoginMatchLoginHint = async ({
   loginHint,
   lastSubmission,
   getPrimaryEmailByUserId,
 }: {
-  primaryEmail: string;
   loginHint: string;
   lastSubmission: unknown;
   getPrimaryEmailByUserId: (userId: string) => Promise<string>;
 }) => {
-  if (primaryEmail === loginHint) {
-    return true;
-  }
-
   const submittedAccountId = getLastSubmittedLoginAccountId(lastSubmission);
 
   if (!submittedAccountId) {
@@ -65,10 +81,24 @@ const shouldContinueWithConsumedOneTimeToken = async ({
 
   try {
     return (await getPrimaryEmailByUserId(submittedAccountId)) === loginHint;
-  } catch {
-    return false;
+  } catch (error: unknown) {
+    if (isUserNotFoundOrEmailMissingError(error)) {
+      return false;
+    }
+
+    throw error;
   }
 };
+
+const shouldContinueWithConsumedOneTimeToken = ({
+  primaryEmail,
+  loginHint,
+  hasMatchingLastSubmittedLogin,
+}: {
+  primaryEmail: string;
+  loginHint: string;
+  hasMatchingLastSubmittedLogin: boolean;
+}) => primaryEmail === loginHint || hasMatchingLastSubmittedLogin;
 
 /**
  * Guard before allowing auto-consent.
@@ -80,58 +110,56 @@ export default function koaConsentGuard<
   ResponseBodyT,
 >(libraries: Libraries, queries: Queries): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   return async (ctx, next) => {
-    const {
-      params: { one_time_token: token, login_hint: loginHint, prompt },
-      session,
-    } = ctx.interactionDetails;
+    const { params, session } = ctx.interactionDetails;
 
     assertThat(session, new RequestError({ code: 'session.not_found' }));
 
-    // Handle one-time token before auto-consent
-    if (token && loginHint && typeof token === 'string' && typeof loginHint === 'string') {
-      const getPrimaryEmailByUserId = async (userId: string) => {
-        const { primaryEmail } = await queries.users.findUserById(userId);
+    const oneTimeTokenParams = getOneTimeTokenParams(params);
 
-        assertThat(primaryEmail, 'user.email_not_exist');
+    if (!oneTimeTokenParams) {
+      return next();
+    }
 
-        return primaryEmail;
-      };
-      const primaryEmail = await getPrimaryEmailByUserId(session.accountId);
+    const { token, loginHint, prompt } = oneTimeTokenParams;
+    const getPrimaryEmailByUserId = async (userId: string) => {
+      const { primaryEmail } = await queries.users.findUserById(userId);
 
-      try {
-        await libraries.oneTimeTokens.checkOneTimeToken(token, loginHint);
-      } catch (error: unknown) {
-        if (error instanceof RequestError) {
-          if (
-            error.code === 'one_time_token.token_consumed' &&
-            (await shouldContinueWithConsumedOneTimeToken({
-              primaryEmail,
-              loginHint,
-              lastSubmission: ctx.interactionDetails.lastSubmission,
-              getPrimaryEmailByUserId,
-            }))
-          ) {
-            return next();
-          }
-          ctx.redirect(buildOneTimeTokenErrorUrl(error.message));
-          return;
-        }
-        throw error;
-      }
+      assertThat(primaryEmail, 'user.email_not_exist');
 
-      if (primaryEmail !== loginHint && !hasLoginPrompt(prompt)) {
-        const searchParams = new URLSearchParams({
-          [ExtraParamsKey.LoginHint]: loginHint,
-          [ExtraParamsKey.OneTimeToken]: token,
-        });
-        ctx.redirect(`${experience.routes.switchAccount}?${searchParams.toString()}`);
-        return;
-      }
+      return primaryEmail;
+    };
+    const primaryEmail = await getPrimaryEmailByUserId(session.accountId);
+    const hasMatchingLastSubmittedLogin = await doesLastSubmittedLoginMatchLoginHint({
+      loginHint,
+      lastSubmission: ctx.interactionDetails.lastSubmission,
+      getPrimaryEmailByUserId,
+    });
 
-      ctx.redirect(buildOneTimeTokenUrl(token, loginHint));
+    if (primaryEmail !== loginHint && !hasLoginPrompt(prompt) && !hasMatchingLastSubmittedLogin) {
+      ctx.redirect(buildExperienceUrl(experience.routes.switchAccount, token, loginHint));
       return;
     }
 
-    return next();
+    try {
+      await libraries.oneTimeTokens.checkOneTimeToken(token, loginHint);
+    } catch (error: unknown) {
+      if (error instanceof RequestError) {
+        if (
+          error.code === 'one_time_token.token_consumed' &&
+          shouldContinueWithConsumedOneTimeToken({
+            primaryEmail,
+            loginHint,
+            hasMatchingLastSubmittedLogin,
+          })
+        ) {
+          return next();
+        }
+        ctx.redirect(buildOneTimeTokenErrorUrl(error.message));
+        return;
+      }
+      throw error;
+    }
+
+    ctx.redirect(buildExperienceUrl(experience.routes.oneTimeToken, token, loginHint));
   };
 }

--- a/packages/integration-tests/src/client/callback-uri.ts
+++ b/packages/integration-tests/src/client/callback-uri.ts
@@ -1,0 +1,37 @@
+import { assert } from '@silverhand/essentials';
+
+const decodeHtmlAttribute = (value: string) =>
+  value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#34;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&#39;', "'")
+    .replaceAll('&amp;', '&');
+
+const getHtmlAttribute = (html: string, attribute: string) =>
+  new RegExp(`\\b${attribute}=(["'])(.*?)\\1`, 'i').exec(html)?.[2];
+
+export const getSubmittingCallbackUri = (html: string, redirectUri?: string) => {
+  const form = /<form\b[^>]*>/i.exec(html)?.[0];
+  assert(form, new Error('Missing callback form'));
+  const action = getHtmlAttribute(form, 'action');
+  assert(action, new Error('Missing callback form action'));
+  const actionUrl = new URL(decodeHtmlAttribute(action));
+  const callbackUrl = new URL(redirectUri ?? actionUrl);
+  const callbackParameters = new URLSearchParams([
+    ...callbackUrl.searchParams,
+    ...actionUrl.searchParams,
+  ]);
+
+  for (const [input] of html.matchAll(/<input\b[^>]*>/gi)) {
+    const name = getHtmlAttribute(input, 'name');
+    const value = getHtmlAttribute(input, 'value');
+
+    if (name && value) {
+      callbackParameters.set(decodeHtmlAttribute(name), decodeHtmlAttribute(value));
+    }
+  }
+  const search = callbackParameters.toString();
+
+  return `${callbackUrl.origin}${callbackUrl.pathname}${search && `?${search}`}${callbackUrl.hash}`;
+};

--- a/packages/integration-tests/src/client/callback-uri.ts
+++ b/packages/integration-tests/src/client/callback-uri.ts
@@ -11,7 +11,28 @@ const decodeHtmlAttribute = (value: string) =>
 const getHtmlAttribute = (html: string, attribute: string) =>
   new RegExp(`\\b${attribute}=(["'])(.*?)\\1`, 'i').exec(html)?.[2];
 
-export const getSubmittingCallbackUri = (html: string, redirectUri?: string) => {
+export const getSignInCallbackContext = (signInSession: unknown) => {
+  if (typeof signInSession !== 'object' || signInSession === null) {
+    return {};
+  }
+
+  return {
+    redirectUri:
+      'redirectUri' in signInSession && typeof signInSession.redirectUri === 'string'
+        ? signInSession.redirectUri
+        : undefined,
+    state:
+      'state' in signInSession && typeof signInSession.state === 'string'
+        ? signInSession.state
+        : undefined,
+  };
+};
+
+export const getSubmittingCallbackUri = (
+  html: string,
+  redirectUri?: string,
+  fallbackState?: string
+) => {
   const form = /<form\b[^>]*>/i.exec(html)?.[0];
   assert(form, new Error('Missing callback form'));
   const action = getHtmlAttribute(form, 'action');
@@ -30,6 +51,9 @@ export const getSubmittingCallbackUri = (html: string, redirectUri?: string) => 
     if (name && value) {
       callbackParameters.set(decodeHtmlAttribute(name), decodeHtmlAttribute(value));
     }
+  }
+  if (fallbackState && !callbackParameters.has('state')) {
+    callbackParameters.set('state', fallbackState);
   }
   const search = callbackParameters.toString();
 

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -47,8 +47,6 @@ export class ExperienceClient extends MockClient {
     });
 
     this.mergeRawCookies(response.headers.getSetCookie());
-
-    return response.json();
   }
 
   public override async submitInteraction(): Promise<RedirectResponse> {

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -11,11 +11,18 @@ import {
   type WebAuthnAuthenticationOptions,
   type WebAuthnVerificationPayload,
 } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
 
 import MockClient from '#src/client/index.js';
 
 import { experienceRoutes } from './const.js';
 import type { SanitizedInteractionStorageData, RedirectResponse } from './types.js';
+
+const isRedirectResponse = (data: unknown): data is RedirectResponse =>
+  typeof data === 'object' &&
+  data !== null &&
+  'redirectTo' in data &&
+  typeof data.redirectTo === 'string';
 
 export class ExperienceClient extends MockClient {
   public extraHeaders: Record<string, string> = {};
@@ -56,7 +63,16 @@ export class ExperienceClient extends MockClient {
 
     this.mergeRawCookies(response.headers.getSetCookie());
 
-    return response.json<RedirectResponse>();
+    const body = await response.text();
+
+    if (!body) {
+      return { redirectTo: '' };
+    }
+
+    const data: unknown = JSON.parse(body);
+    assert(isRedirectResponse(data), new Error('Invalid submit interaction response'));
+
+    return data;
   }
 
   public async verifyPassword(payload: PasswordVerificationPayload) {

--- a/packages/integration-tests/src/client/experience/index.ts
+++ b/packages/integration-tests/src/client/experience/index.ts
@@ -41,18 +41,24 @@ export class ExperienceClient extends MockClient {
   }
 
   public async initInteraction(payload: CreateExperienceApiPayload) {
-    return this.api
-      .put(experienceRoutes.prefix, {
-        headers: this.headers,
-        json: payload,
-      })
-      .json();
+    const response = await this.api.put(experienceRoutes.prefix, {
+      headers: this.headers,
+      json: payload,
+    });
+
+    this.mergeRawCookies(response.headers.getSetCookie());
+
+    return response.json();
   }
 
   public override async submitInteraction(): Promise<RedirectResponse> {
-    return this.api
-      .post(`${experienceRoutes.prefix}/submit`, { headers: this.headers })
-      .json<RedirectResponse>();
+    const response = await this.api.post(`${experienceRoutes.prefix}/submit`, {
+      headers: this.headers,
+    });
+
+    this.mergeRawCookies(response.headers.getSetCookie());
+
+    return response.json<RedirectResponse>();
   }
 
   public async verifyPassword(payload: PasswordVerificationPayload) {

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -1,5 +1,4 @@
-import type { LogtoConfig, SignInOptions } from '@logto/node';
-import LogtoClient from '@logto/node';
+import LogtoClient, { PersistKey, type LogtoConfig, type SignInOptions } from '@logto/node';
 import { demoAppApplicationId } from '@logto/schemas';
 import type { Nullable, Optional } from '@silverhand/essentials';
 import { assert } from '@silverhand/essentials';
@@ -68,16 +67,13 @@ const decodeHtmlAttribute = (value: string) =>
 const getHtmlAttribute = (html: string, attribute: string) =>
   new RegExp(`\\b${attribute}=(["'])(.*?)\\1`, 'i').exec(html)?.[2];
 
-const getSubmittingCallbackUri = (html: string) => {
+const getSubmittingCallbackUri = (html: string, redirectUri?: string) => {
   const form = /<form\b[^>]*>/i.exec(html)?.[0];
   assert(form, new Error('Missing callback form'));
-
   const action = getHtmlAttribute(form, 'action');
   assert(action, new Error('Missing callback form action'));
-
-  const callbackUrl = new URL(decodeHtmlAttribute(action));
-  const callbackParameters = new URLSearchParams();
-
+  const callbackUrl = new URL(redirectUri ?? decodeHtmlAttribute(action));
+  const callbackParameters = new URLSearchParams(callbackUrl.search);
   for (const [input] of html.matchAll(/<input\b[^>]*>/gi)) {
     const name = getHtmlAttribute(input, 'name');
     const value = getHtmlAttribute(input, 'value');
@@ -86,7 +82,6 @@ const getSubmittingCallbackUri = (html: string) => {
       callbackParameters.set(decodeHtmlAttribute(name), decodeHtmlAttribute(value));
     }
   }
-
   const search = callbackParameters.toString();
 
   return `${callbackUrl.origin}${callbackUrl.pathname}${search && `?${search}`}${callbackUrl.hash}`;
@@ -211,7 +206,17 @@ export default class MockClient {
 
     if (authResponse.status === 200) {
       const body = await authResponse.text();
-      const signInCallbackUri = getSubmittingCallbackUri(body);
+      const signInSession: unknown = JSON.parse(
+        (await this.storage.getItem(PersistKey.SignInSession)) ?? 'null'
+      );
+      const redirectUri =
+        typeof signInSession === 'object' &&
+        signInSession !== null &&
+        'redirectUri' in signInSession &&
+        typeof signInSession.redirectUri === 'string'
+          ? signInSession.redirectUri
+          : undefined;
+      const signInCallbackUri = getSubmittingCallbackUri(body, redirectUri);
 
       this.mergeRawCookies(authResponse.headers.getSetCookie());
       await this.logto.handleSignInCallback(signInCallbackUri);

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -6,7 +6,7 @@ import ky, { type KyInstance } from 'ky';
 
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
 
-import { getSubmittingCallbackUri } from './callback-uri.js';
+import { getSignInCallbackContext, getSubmittingCallbackUri } from './callback-uri.js';
 import { MemoryStorage } from './storage.js';
 
 export const defaultConfig = {
@@ -178,14 +178,12 @@ export default class MockClient {
       const signInSession: unknown = JSON.parse(
         (await this.storage.getItem(PersistKey.SignInSession)) ?? 'null'
       );
-      const redirectUri =
-        typeof signInSession === 'object' &&
-        signInSession !== null &&
-        'redirectUri' in signInSession &&
-        typeof signInSession.redirectUri === 'string'
-          ? signInSession.redirectUri
-          : undefined;
-      const signInCallbackUri = getSubmittingCallbackUri(await authResponse.text(), redirectUri);
+      const { redirectUri, state } = getSignInCallbackContext(signInSession);
+      const signInCallbackUri = getSubmittingCallbackUri(
+        await authResponse.text(),
+        redirectUri,
+        state
+      );
 
       this.mergeRawCookies(authResponse.headers.getSetCookie());
       await this.logto.handleSignInCallback(signInCallbackUri);

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -57,6 +57,41 @@ const isCookiePathMatched = (cookiePath: string, requestPath: string) =>
   requestPath === cookiePath ||
   requestPath.startsWith(cookiePath.endsWith('/') ? cookiePath : `${cookiePath}/`);
 
+const decodeHtmlAttribute = (value: string) =>
+  value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#34;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&#39;', "'")
+    .replaceAll('&amp;', '&');
+
+const getHtmlAttribute = (html: string, attribute: string) =>
+  new RegExp(`\\b${attribute}=(["'])(.*?)\\1`, 'i').exec(html)?.[2];
+
+const getSubmittingCallbackUri = (html: string) => {
+  const form = /<form\b[^>]*>/i.exec(html)?.[0];
+  assert(form, new Error('Missing callback form'));
+
+  const action = getHtmlAttribute(form, 'action');
+  assert(action, new Error('Missing callback form action'));
+
+  const callbackUrl = new URL(decodeHtmlAttribute(action));
+  const callbackParameters = new URLSearchParams();
+
+  for (const [input] of html.matchAll(/<input\b[^>]*>/gi)) {
+    const name = getHtmlAttribute(input, 'name');
+    const value = getHtmlAttribute(input, 'value');
+
+    if (name && value) {
+      callbackParameters.set(decodeHtmlAttribute(name), decodeHtmlAttribute(value));
+    }
+  }
+
+  const search = callbackParameters.toString();
+
+  return `${callbackUrl.origin}${callbackUrl.pathname}${search && `?${search}`}${callbackUrl.hash}`;
+};
+
 export default class MockClient {
   public rawCookies: string[] = [];
   protected readonly config: LogtoConfig;
@@ -173,6 +208,16 @@ export default class MockClient {
       throwHttpErrors: false,
     });
     const authResponseLocation = authResponse.headers.get('location');
+
+    if (authResponse.status === 200) {
+      const body = await authResponse.text();
+      const signInCallbackUri = getSubmittingCallbackUri(body);
+
+      this.mergeRawCookies(authResponse.headers.getSetCookie());
+      await this.logto.handleSignInCallback(signInCallbackUri);
+
+      return;
+    }
 
     // Note: Should redirect to logto consent page
     if (

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -14,6 +14,28 @@ export const defaultConfig = {
   appId: demoAppApplicationId,
   persistAccessToken: false,
 };
+
+const getCookieMergeKey = (cookie: string) => {
+  const [nameValue, ...attributes] = cookie.split(';').map((value) => value.trim());
+  const name = nameValue?.split('=')[0];
+
+  if (!name) {
+    return;
+  }
+
+  const scope = new Map<string, string | undefined>();
+
+  for (const attribute of attributes) {
+    const [key, value] = attribute.split('=');
+
+    if (key) {
+      scope.set(key.toLowerCase(), value);
+    }
+  }
+
+  return [name, scope.get('domain') ?? '', scope.get('path') ?? ''].join('|');
+};
+
 export default class MockClient {
   public rawCookies: string[] = [];
   protected readonly config: LogtoConfig;
@@ -208,12 +230,18 @@ export default class MockClient {
   }
 
   public mergeRawCookies(cookies: string[]) {
-    const cookieMap = new Map(
-      this.rawCookies.map((cookie) => [cookie.split(';')[0]?.split('=')[0], cookie])
-    );
+    const cookieMap = new Map<string, string>();
+
+    for (const cookie of this.rawCookies) {
+      const key = getCookieMergeKey(cookie);
+
+      if (key) {
+        cookieMap.set(key, cookie);
+      }
+    }
 
     for (const cookie of cookies) {
-      const key = cookie.split(';')[0]?.split('=')[0];
+      const key = getCookieMergeKey(cookie);
 
       if (key) {
         cookieMap.set(key, cookie);

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -6,6 +6,7 @@ import ky, { type KyInstance } from 'ky';
 
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
 
+import { getSubmittingCallbackUri } from './callback-uri.js';
 import { MemoryStorage } from './storage.js';
 
 export const defaultConfig = {
@@ -55,37 +56,6 @@ const isCookiePathMatched = (cookiePath: string, requestPath: string) =>
   cookiePath === '/' ||
   requestPath === cookiePath ||
   requestPath.startsWith(cookiePath.endsWith('/') ? cookiePath : `${cookiePath}/`);
-
-const decodeHtmlAttribute = (value: string) =>
-  value
-    .replaceAll('&quot;', '"')
-    .replaceAll('&#34;', '"')
-    .replaceAll('&apos;', "'")
-    .replaceAll('&#39;', "'")
-    .replaceAll('&amp;', '&');
-
-const getHtmlAttribute = (html: string, attribute: string) =>
-  new RegExp(`\\b${attribute}=(["'])(.*?)\\1`, 'i').exec(html)?.[2];
-
-const getSubmittingCallbackUri = (html: string, redirectUri?: string) => {
-  const form = /<form\b[^>]*>/i.exec(html)?.[0];
-  assert(form, new Error('Missing callback form'));
-  const action = getHtmlAttribute(form, 'action');
-  assert(action, new Error('Missing callback form action'));
-  const callbackUrl = new URL(redirectUri ?? decodeHtmlAttribute(action));
-  const callbackParameters = new URLSearchParams(callbackUrl.search);
-  for (const [input] of html.matchAll(/<input\b[^>]*>/gi)) {
-    const name = getHtmlAttribute(input, 'name');
-    const value = getHtmlAttribute(input, 'value');
-
-    if (name && value) {
-      callbackParameters.set(decodeHtmlAttribute(name), decodeHtmlAttribute(value));
-    }
-  }
-  const search = callbackParameters.toString();
-
-  return `${callbackUrl.origin}${callbackUrl.pathname}${search && `?${search}`}${callbackUrl.hash}`;
-};
 
 export default class MockClient {
   public rawCookies: string[] = [];
@@ -205,7 +175,6 @@ export default class MockClient {
     const authResponseLocation = authResponse.headers.get('location');
 
     if (authResponse.status === 200) {
-      const body = await authResponse.text();
       const signInSession: unknown = JSON.parse(
         (await this.storage.getItem(PersistKey.SignInSession)) ?? 'null'
       );
@@ -216,7 +185,7 @@ export default class MockClient {
         typeof signInSession.redirectUri === 'string'
           ? signInSession.redirectUri
           : undefined;
-      const signInCallbackUri = getSubmittingCallbackUri(body, redirectUri);
+      const signInCallbackUri = getSubmittingCallbackUri(await authResponse.text(), redirectUri);
 
       this.mergeRawCookies(authResponse.headers.getSetCookie());
       await this.logto.handleSignInCallback(signInCallbackUri);

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -38,6 +38,25 @@ const getCookieMergeKey = (cookie: string) => {
 
 const getCookieHeaderValue = (cookie: string) => cookie.split(';')[0]?.trim();
 
+const getCookiePath = (cookie: string) => {
+  const [, ...attributes] = cookie.split(';').map((value) => value.trim());
+
+  for (const attribute of attributes) {
+    const [key, value] = attribute.split('=');
+
+    if (key?.toLowerCase() === 'path') {
+      return value ?? '/';
+    }
+  }
+
+  return '/';
+};
+
+const isCookiePathMatched = (cookiePath: string, requestPath: string) =>
+  cookiePath === '/' ||
+  requestPath === cookiePath ||
+  requestPath.startsWith(cookiePath.endsWith('/') ? cookiePath : `${cookiePath}/`);
+
 export default class MockClient {
   public rawCookies: string[] = [];
   protected readonly config: LogtoConfig;
@@ -62,7 +81,16 @@ export default class MockClient {
 
   // TODO: Rename to sessionCookies or something accurate
   public get interactionCookie(): string {
-    return this.rawCookies
+    return this.getCookieHeader();
+  }
+
+  public getCookieHeader(pathname?: string): string {
+    const cookies = pathname
+      ? this.rawCookies.filter((cookie) => isCookiePathMatched(getCookiePath(cookie), pathname))
+      : this.rawCookies;
+
+    return cookies
+      .toSorted((cookieA, cookieB) => getCookiePath(cookieB).length - getCookiePath(cookieA).length)
       .map((cookie) => getCookieHeaderValue(cookie))
       .filter(Boolean)
       .join('; ');
@@ -139,7 +167,7 @@ export default class MockClient {
 
     const authResponse = await ky.get(redirectTo, {
       headers: {
-        cookie: this.interactionCookie,
+        cookie: this.getCookieHeader(new URL(redirectTo).pathname),
       },
       redirect: 'manual',
       throwHttpErrors: false,
@@ -174,7 +202,7 @@ export default class MockClient {
   public async manualConsent(redirectTo: string) {
     const authCodeResponse = await ky.get(redirectTo, {
       headers: {
-        cookie: this.interactionCookie,
+        cookie: this.getCookieHeader(new URL(redirectTo).pathname),
       },
       redirect: 'manual',
       throwHttpErrors: false,
@@ -283,7 +311,7 @@ export default class MockClient {
 
     const consentResponse = await ky.get(`${this.config.endpoint}/consent`, {
       headers: {
-        cookie: this.interactionCookie,
+        cookie: this.getCookieHeader('/consent'),
       },
       redirect: 'manual',
       throwHttpErrors: false,
@@ -298,7 +326,7 @@ export default class MockClient {
 
     const authCodeResponse = await ky.get(redirectTo, {
       headers: {
-        cookie: this.interactionCookie,
+        cookie: this.getCookieHeader(new URL(redirectTo).pathname),
       },
       redirect: 'manual',
       throwHttpErrors: false,

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -61,19 +61,8 @@ export default class MockClient {
     redirectUri = demoAppRedirectUri,
     options: Omit<SignInOptions, 'redirectUri'> = {}
   ) {
-    await this.logto.signIn({ redirectUri, ...options });
-
-    assert(this.navigateUrl, new Error('Unable to navigate to sign in uri'));
-    assert(
-      this.navigateUrl.startsWith(`${this.config.endpoint}/oidc/auth`),
-      new Error('Unable to navigate to sign in uri')
-    );
-
     // Mock SDK sign-in navigation
-    const response = await ky(this.navigateUrl, {
-      redirect: 'manual',
-      throwHttpErrors: false,
-    });
+    const response = await this.startAuthorization(redirectUri, options);
 
     // Note: should redirect to sign-in page
     assert(
@@ -87,6 +76,26 @@ export default class MockClient {
     // Get session cookie
     this.rawCookies = response.headers.getSetCookie();
     assert(this.interactionCookie, new Error('Get cookie from authorization endpoint failed'));
+  }
+
+  public async startAuthorization(
+    redirectUri = demoAppRedirectUri,
+    options: Omit<SignInOptions, 'redirectUri'> = {},
+    cookie?: string
+  ) {
+    await this.logto.signIn({ redirectUri, ...options });
+
+    assert(this.navigateUrl, new Error('Unable to navigate to sign in uri'));
+    assert(
+      this.navigateUrl.startsWith(`${this.config.endpoint}/oidc/auth`),
+      new Error('Unable to navigate to sign in uri')
+    );
+
+    return ky(this.navigateUrl, {
+      headers: cookie ? { cookie } : undefined,
+      redirect: 'manual',
+      throwHttpErrors: false,
+    });
   }
 
   /**
@@ -108,13 +117,21 @@ export default class MockClient {
       redirect: 'manual',
       throwHttpErrors: false,
     });
+    const authResponseLocation = authResponse.headers.get('location');
 
     // Note: Should redirect to logto consent page
-    assert(
-      authResponse.status === 303 &&
-        authResponse.headers.get('location') === `/consent?app_id=${this.config.appId}`,
-      new Error('Invoke auth before consent failed')
-    );
+    if (
+      authResponse.status !== 303 ||
+      authResponseLocation !== `/consent?app_id=${this.config.appId}`
+    ) {
+      const body = await authResponse.text();
+
+      throw new Error(
+        `Invoke auth before consent failed: ${authResponse.status} ${
+          authResponseLocation ?? ''
+        } ${body.slice(0, 200)}`
+      );
+    }
 
     this.rawCookies = authResponse.headers.getSetCookie();
 
@@ -190,6 +207,22 @@ export default class MockClient {
     this.rawCookies = cookies;
   }
 
+  public mergeRawCookies(cookies: string[]) {
+    const cookieMap = new Map(
+      this.rawCookies.map((cookie) => [cookie.split(';')[0]?.split('=')[0], cookie])
+    );
+
+    for (const cookie of cookies) {
+      const key = cookie.split(';')[0]?.split('=')[0];
+
+      if (key) {
+        cookieMap.set(key, cookie);
+      }
+    }
+
+    this.rawCookies = [...cookieMap.values()];
+  }
+
   public async send<Args extends unknown[], T>(
     api: (cookie: string, ...args: Args) => Promise<T>,
     ...payload: Args
@@ -242,6 +275,7 @@ export default class MockClient {
     assert(authCodeResponse.status === 303, new Error('Complete auth failed'));
     const signInCallbackUri = authCodeResponse.headers.get('location');
     assert(signInCallbackUri, new Error('Get sign in callback uri failed'));
+    this.mergeRawCookies(authCodeResponse.headers.getSetCookie());
 
     return signInCallbackUri;
   };

--- a/packages/integration-tests/src/client/index.ts
+++ b/packages/integration-tests/src/client/index.ts
@@ -36,6 +36,8 @@ const getCookieMergeKey = (cookie: string) => {
   return [name, scope.get('domain') ?? '', scope.get('path') ?? ''].join('|');
 };
 
+const getCookieHeaderValue = (cookie: string) => cookie.split(';')[0]?.trim();
+
 export default class MockClient {
   public rawCookies: string[] = [];
   protected readonly config: LogtoConfig;
@@ -60,7 +62,10 @@ export default class MockClient {
 
   // TODO: Rename to sessionCookies or something accurate
   public get interactionCookie(): string {
-    return this.rawCookies.join('; ');
+    return this.rawCookies
+      .map((cookie) => getCookieHeaderValue(cookie))
+      .filter(Boolean)
+      .join('; ');
   }
 
   public get parsedCookies(): Map<string, Optional<string>> {

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
@@ -71,7 +71,7 @@ const startOneTimeTokenAuthorization = async (
         [ExtraParamsKey.OneTimeToken]: token,
       },
     },
-    client.interactionCookie
+    client.getCookieHeader('/oidc/auth')
   );
 
   expect([302, 303]).toContain(response.status);
@@ -82,7 +82,7 @@ const startOneTimeTokenAuthorization = async (
 const getConsentRedirectLocation = async (client: ExperienceClient) => {
   const response = await ky.get(`${logtoUrl}/consent`, {
     headers: {
-      cookie: client.interactionCookie,
+      cookie: client.getCookieHeader('/consent'),
     },
     redirect: 'manual',
     throwHttpErrors: false,

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
@@ -200,6 +200,9 @@ describe('Sign-in interaction with one-time token', () => {
       password: true,
     });
     const client = await signInWithPassword(activeUserProfile);
+    const signInClient = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
     const oneTimeToken = await createOneTimeToken({
       email: userProfile.primaryEmail,
     });
@@ -216,12 +219,11 @@ describe('Sign-in interaction with one-time token', () => {
         status: OneTimeTokenStatus.Active,
       });
 
-      const redirectTo = await submitOneTimeTokenSignIn(
-        client,
+      const userId = await completeOneTimeTokenSignIn(
+        signInClient,
         userProfile.primaryEmail,
         oneTimeToken.token
       );
-      const userId = await processSession(client, redirectTo);
 
       expect(userId).toBe(user.id);
       await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
@@ -230,6 +232,7 @@ describe('Sign-in interaction with one-time token', () => {
     } finally {
       await Promise.allSettled([
         logoutClient(client),
+        logoutClient(signInClient),
         deleteUser(activeUser.id),
         deleteOneTimeTokenById(oneTimeToken.id),
       ]);

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
@@ -1,29 +1,123 @@
 import {
   CaptchaType,
+  ExtraParamsKey,
   InteractionEvent,
   OneTimeTokenStatus,
   SignInIdentifier,
   SignInMode,
 } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+import ky from 'ky';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { deleteCaptchaProvider, updateCaptchaProvider } from '#src/api/captcha-provider.js';
 import { updateSignInExperience } from '#src/api/index.js';
 import {
   createOneTimeToken,
+  getOneTimeTokenById,
   updateOneTimeTokenStatus,
   deleteOneTimeTokenById,
 } from '#src/api/one-time-token.js';
+import type { ExperienceClient } from '#src/client/experience/index.js';
+import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
 import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
 import { expectRejects } from '#src/helpers/index.js';
+import { OrganizationApiTest } from '#src/helpers/organization.js';
 import { generateNewUser } from '#src/helpers/user.js';
-import { waitFor } from '#src/utils.js';
+import { generateTestName, waitFor } from '#src/utils.js';
 
 const { user, userProfile } = await generateNewUser({
   username: true,
   primaryEmail: true,
   password: true,
 });
+
+const signInWithPassword = async ({
+  username,
+  password,
+}: {
+  username: string;
+  password: string;
+}) => {
+  const client = await initExperienceClient({
+    interactionEvent: InteractionEvent.SignIn,
+  });
+
+  const { verificationId } = await client.verifyPassword({
+    identifier: {
+      type: SignInIdentifier.Username,
+      value: username,
+    },
+    password,
+  });
+
+  await client.identifyUser({ verificationId });
+  const { redirectTo } = await client.submitInteraction();
+  await processSession(client, redirectTo);
+
+  return client;
+};
+
+const startOneTimeTokenAuthorization = async (
+  client: ExperienceClient,
+  email: string,
+  token: string
+) => {
+  const response = await client.startAuthorization(
+    demoAppRedirectUri,
+    {
+      extraParams: {
+        [ExtraParamsKey.LoginHint]: email,
+        [ExtraParamsKey.OneTimeToken]: token,
+      },
+    },
+    client.interactionCookie
+  );
+
+  expect([302, 303]).toContain(response.status);
+  expect(response.headers.get('location')).toBe('/consent?app_id=demo-app');
+  client.mergeRawCookies(response.headers.getSetCookie());
+};
+
+const getConsentRedirectLocation = async (client: ExperienceClient) => {
+  const response = await ky.get(`${logtoUrl}/consent`, {
+    headers: {
+      cookie: client.interactionCookie,
+    },
+    redirect: 'manual',
+    throwHttpErrors: false,
+  });
+
+  expect([302, 303]).toContain(response.status);
+  const location = response.headers.get('location');
+  assert(location, new Error('Missing consent redirect location'));
+
+  return location;
+};
+
+const submitOneTimeTokenSignIn = async (client: ExperienceClient, email: string, token: string) => {
+  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
+
+  const { verificationId } = await client.verifyOneTimeToken({
+    token,
+    identifier: { type: SignInIdentifier.Email, value: email },
+  });
+
+  await client.identifyUser({ verificationId });
+  const { redirectTo } = await client.submitInteraction();
+
+  return redirectTo;
+};
+
+const completeOneTimeTokenSignIn = async (
+  client: ExperienceClient,
+  email: string,
+  token: string
+) => {
+  const redirectTo = await submitOneTimeTokenSignIn(client, email, token);
+
+  return processSession(client, redirectTo);
+};
 
 describe('Sign-in interaction with one-time token', () => {
   beforeAll(async () => {
@@ -54,6 +148,99 @@ describe('Sign-in interaction with one-time token', () => {
 
     await logoutClient(client);
     await deleteOneTimeTokenById(oneTimeToken.id);
+  });
+
+  it('should accept organization invitation when the magic link matches the active session user', async () => {
+    const organizationApi = new OrganizationApiTest();
+    const client = await signInWithPassword(userProfile);
+    const organization = await organizationApi.create({ name: generateTestName() });
+    const oneTimeToken = await createOneTimeToken({
+      email: userProfile.primaryEmail,
+      context: {
+        jitOrganizationIds: [organization.id],
+      },
+    });
+
+    try {
+      await startOneTimeTokenAuthorization(client, userProfile.primaryEmail, oneTimeToken.token);
+
+      const location = await getConsentRedirectLocation(client);
+      expect(location).toContain(
+        `one-time-token?login_hint=${encodeURIComponent(userProfile.primaryEmail)}`
+      );
+      expect(location).toContain(`one_time_token=${oneTimeToken.token}`);
+
+      const userId = await completeOneTimeTokenSignIn(
+        client,
+        userProfile.primaryEmail,
+        oneTimeToken.token
+      );
+
+      expect(userId).toBe(user.id);
+
+      const organizations = await organizationApi.getUserOrganizations(user.id);
+      expect(organizations.some(({ id }) => id === organization.id)).toBe(true);
+      await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
+        status: OneTimeTokenStatus.Consumed,
+      });
+    } finally {
+      await Promise.allSettled([
+        logoutClient(client),
+        deleteOneTimeTokenById(oneTimeToken.id),
+        organizationApi.cleanUp(),
+      ]);
+    }
+  });
+
+  it('should complete switch-account magic link sign-in after token is consumed by the normal flow', async () => {
+    const { user: activeUser, userProfile: activeUserProfile } = await generateNewUser({
+      username: true,
+      primaryEmail: true,
+      password: true,
+    });
+    const client = await signInWithPassword(activeUserProfile);
+    const oneTimeToken = await createOneTimeToken({
+      email: userProfile.primaryEmail,
+    });
+
+    try {
+      await startOneTimeTokenAuthorization(client, userProfile.primaryEmail, oneTimeToken.token);
+
+      const location = await getConsentRedirectLocation(client);
+      expect(location).toContain(
+        `switch-account?login_hint=${encodeURIComponent(userProfile.primaryEmail)}`
+      );
+      expect(location).toContain(`one_time_token=${oneTimeToken.token}`);
+      await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
+        status: OneTimeTokenStatus.Active,
+      });
+
+      const tokenClient = await initExperienceClient({
+        interactionEvent: InteractionEvent.SignIn,
+      });
+
+      try {
+        const redirectTo = await submitOneTimeTokenSignIn(
+          tokenClient,
+          userProfile.primaryEmail,
+          oneTimeToken.token
+        );
+        const userId = await processSession(tokenClient, redirectTo);
+
+        expect(userId).toBe(user.id);
+        await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
+          status: OneTimeTokenStatus.Consumed,
+        });
+      } finally {
+        await logoutClient(tokenClient);
+      }
+    } finally {
+      await Promise.allSettled([
+        logoutClient(client),
+        deleteUser(activeUser.id),
+        deleteOneTimeTokenById(oneTimeToken.id),
+      ]);
+    }
   });
 
   it('should fail to sign-in with an invalid one-time token', async () => {

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
@@ -215,25 +215,17 @@ describe('Sign-in interaction with one-time token', () => {
         status: OneTimeTokenStatus.Active,
       });
 
-      const tokenClient = await initExperienceClient({
-        interactionEvent: InteractionEvent.SignIn,
+      const redirectTo = await submitOneTimeTokenSignIn(
+        client,
+        userProfile.primaryEmail,
+        oneTimeToken.token
+      );
+      const userId = await processSession(client, redirectTo);
+
+      expect(userId).toBe(user.id);
+      await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
+        status: OneTimeTokenStatus.Consumed,
       });
-
-      try {
-        const redirectTo = await submitOneTimeTokenSignIn(
-          tokenClient,
-          userProfile.primaryEmail,
-          oneTimeToken.token
-        );
-        const userId = await processSession(tokenClient, redirectTo);
-
-        expect(userId).toBe(user.id);
-        await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
-          status: OneTimeTokenStatus.Consumed,
-        });
-      } finally {
-        await logoutClient(tokenClient);
-      }
     } finally {
       await Promise.allSettled([
         logoutClient(client),

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
@@ -89,6 +89,7 @@ const getConsentRedirectLocation = async (client: ExperienceClient) => {
   });
 
   expect([302, 303]).toContain(response.status);
+  client.mergeRawCookies(response.headers.getSetCookie());
   const location = response.headers.get('location');
   assert(location, new Error('Missing consent redirect location'));
 


### PR DESCRIPTION
## Summary
Fix the consent guard for magic-link one-time-token flows so it no longer consumes tokens or provisions JIT organizations before the normal Experience one-time-token flow runs.

This preserves organization JIT provisioning for same-user active sessions, supports switch-account completion after the token is consumed by the normal flow, and keeps consumed-token auto-consent guarded by the submitted login identity.

Fixes #8956

## Testing
Unit tests
Integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
