### PR TITLE
feat(experience): show username policy requirements hint

### DIFF
--- a/packages/account/src/pages/Username/index.test.tsx
+++ b/packages/account/src/pages/Username/index.test.tsx
@@ -273,6 +273,23 @@ describe('<Username />', () => {
       });
     });
 
+    // The test i18n returns the key, so the rendered hint surfaces as its frame key.
+    it('shows the requirements hint for a restrictive policy', () => {
+      const { getByText } = renderWithPolicy();
+      expect(getByText('description.username_requirements')).toBeTruthy();
+    });
+
+    it('hides the requirements hint for the permissive default policy', () => {
+      const { queryByText } = renderUsername();
+      expect(queryByText('description.username_requirements')).toBeNull();
+    });
+
+    it('hides the requirements hint when dev features are off', () => {
+      mockIsDevFeaturesEnabled.mockReturnValue(false);
+      const { queryByText } = renderWithPolicy();
+      expect(queryByText('description.username_requirements')).toBeNull();
+    });
+
     it('does not block a policy-only violation when dev features are off', async () => {
       mockIsDevFeaturesEnabled.mockReturnValue(false);
       const { getByText, container } = renderWithPolicy();

--- a/packages/account/src/pages/Username/index.tsx
+++ b/packages/account/src/pages/Username/index.tsx
@@ -1,5 +1,6 @@
 import Button from '@experience/shared/components/Button';
 import SmartInputField from '@experience/shared/components/InputFields/SmartInputField';
+import { buildUsernamePolicyDescription } from '@experience/shared/utils/username-policy-description';
 import { validateUsername } from '@experience/shared/utils/validate-username';
 import { AccountCenterControlValue, SignInIdentifier } from '@logto/schemas';
 import { useContext, useEffect, useState, type FormEvent } from 'react';
@@ -142,6 +143,11 @@ const Username = () => {
           enabledTypes={[SignInIdentifier.Username]}
           errorMessage={usernameError}
           isDanger={Boolean(usernameError)}
+          description={
+            isDevFeaturesEnabled
+              ? buildUsernamePolicyDescription(experienceSettings?.usernamePolicy, t)
+              : undefined
+          }
           onChange={(inputValue) => {
             setPendingUsername(inputValue.value);
           }}

--- a/packages/experience/src/components/IdentifierRegisterForm/index.tsx
+++ b/packages/experience/src/components/IdentifierRegisterForm/index.tsx
@@ -1,4 +1,4 @@
-import { AgreeToTermsPolicy, type SignInIdentifier } from '@logto/schemas';
+import { AgreeToTermsPolicy, SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
 import { useCallback, useContext, useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -11,6 +11,7 @@ import { SmartInputField } from '@/components/InputFields';
 import CaptchaBox from '@/containers/CaptchaBox';
 import TermsAndPrivacyCheckbox from '@/containers/TermsAndPrivacyCheckbox';
 import usePrefilledIdentifier from '@/hooks/use-prefilled-identifier';
+import { useUsernamePolicyDescription } from '@/hooks/use-sie';
 import useSingleSignOnWatch from '@/hooks/use-single-sign-on-watch';
 import useTerms from '@/hooks/use-terms';
 import Button from '@/shared/components/Button';
@@ -41,6 +42,7 @@ const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) 
   const { setIdentifierInputValue } = useContext(UserInteractionContext);
   const { experienceSettings } = useContext(PageContext);
   const prefilledIdentifier = usePrefilledIdentifier({ enabledIdentifiers: signUpMethods });
+  const usernamePolicyDescription = useUsernamePolicyDescription();
 
   const {
     watch,
@@ -138,6 +140,9 @@ const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) 
             isDanger={!!errors.identifier || !!errorMessage}
             errorMessage={errors.identifier?.message}
             enabledTypes={signUpMethods}
+            description={
+              field.value.type === SignInIdentifier.Username ? usernamePolicyDescription : undefined
+            }
           />
         )}
       />

--- a/packages/experience/src/hooks/use-sie.ts
+++ b/packages/experience/src/hooks/use-sie.ts
@@ -11,8 +11,10 @@ import { useContext, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PageContext from '@/Providers/PageContextProvider/PageContext';
+import { isDevFeaturesEnabled } from '@/constants/env';
 // eslint-disable-next-line unused-imports/no-unused-imports -- type only import
 import type useRequiredProfileErrorHandler from '@/hooks/use-required-profile-error-handler';
+import { buildUsernamePolicyDescription } from '@/shared/utils/username-policy-description';
 import { type SignInExperienceResponse, type VerificationCodeIdentifier } from '@/types';
 
 type UseSieMethodsReturnType = {
@@ -174,6 +176,24 @@ export const usePasswordPolicy = () => {
     /** The localized description of the password policy. */
     requirementsDescription,
   };
+};
+
+/**
+ * The localized username policy requirements hint, or `undefined` when the policy is the permissive
+ * default (nothing to surface). Gated by the dev-feature flag until the feature ships. Mirrors
+ * {@link usePasswordPolicy}'s `requirementsDescription`.
+ */
+export const useUsernamePolicyDescription = () => {
+  const { t } = useTranslation();
+  const { experienceSettings } = useContext(PageContext);
+
+  return useMemo(
+    () =>
+      isDevFeaturesEnabled
+        ? buildUsernamePolicyDescription(experienceSettings?.usernamePolicy, t)
+        : undefined,
+    [experienceSettings?.usernamePolicy, t]
+  );
 };
 
 export const useForgotPasswordSettings = () => {

--- a/packages/experience/src/pages/Continue/IdentifierProfileForm/index.tsx
+++ b/packages/experience/src/pages/Continue/IdentifierProfileForm/index.tsx
@@ -1,3 +1,4 @@
+import { SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
 import { useCallback, useContext, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
@@ -5,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 
 import PageContext from '@/Providers/PageContextProvider/PageContext';
 import { SmartInputField } from '@/components/InputFields';
+import { useUsernamePolicyDescription } from '@/hooks/use-sie';
 import Button from '@/shared/components/Button';
 import ErrorMessage from '@/shared/components/ErrorMessage';
 import type {
@@ -42,6 +44,7 @@ const IdentifierProfileForm = ({
 }: Props) => {
   const { t } = useTranslation();
   const { experienceSettings } = useContext(PageContext);
+  const usernamePolicyDescription = useUsernamePolicyDescription();
   const {
     handleSubmit,
     control,
@@ -114,6 +117,9 @@ const IdentifierProfileForm = ({
             isDanger={!!errors.identifier || !!errorMessage}
             errorMessage={errors.identifier?.message}
             enabledTypes={enabledTypes}
+            description={
+              field.value.type === SignInIdentifier.Username ? usernamePolicyDescription : undefined
+            }
           />
         )}
       />

--- a/packages/experience/src/shared/components/InputFields/SmartInputField/index.tsx
+++ b/packages/experience/src/shared/components/InputFields/SmartInputField/index.tsx
@@ -24,6 +24,8 @@ type Props = Omit<HTMLProps<HTMLInputElement>, 'onChange' | 'prefix' | 'value'> 
   readonly enabledTypes?: IdentifierInputType[];
   readonly defaultValue?: string;
   readonly onChange?: (data: IdentifierInputValue) => void;
+  /** Helper text shown beneath the field. Forwarded to the underlying input field. */
+  readonly description?: Nullable<string>;
 };
 
 const AnimatedInputField = animated(InputField);

--- a/packages/experience/src/shared/utils/username-policy-description.test.ts
+++ b/packages/experience/src/shared/utils/username-policy-description.test.ts
@@ -1,0 +1,93 @@
+import { defaultUsernamePolicy } from '@logto/core-kit';
+import resource from '@logto/phrases-experience';
+import { type UsernamePolicy } from '@logto/schemas';
+import i18next, { type TFunction } from 'i18next';
+
+import { buildUsernamePolicyDescription } from './username-policy-description';
+
+/**
+ * A fake `t` that echoes keys and interpolation so the composition (which fragments and characters
+ * are included, in what order) is observable without a real i18next instance.
+ */
+const translate = ((key: string, options?: Record<string, unknown>) => {
+  switch (key) {
+    case 'description.username_requirement.length': {
+      return `len:${String(options?.min)}-${String(options?.max)}`;
+    }
+    case 'description.username_requirement.characters': {
+      return `chars:${(options?.characters as string[]).join(',')}`;
+    }
+    case 'description.username_requirements': {
+      return `req:${(options?.items as string[]).join('|')}`;
+    }
+    default: {
+      return key.replace('description.username_character.', '');
+    }
+  }
+}) as unknown as TFunction;
+
+const build = (policy?: UsernamePolicy) => buildUsernamePolicyDescription(policy, translate);
+
+describe('buildUsernamePolicyDescription', () => {
+  it('returns undefined when no policy is provided', () => {
+    expect(build()).toBeUndefined();
+  });
+
+  it('returns undefined for the permissive default policy', () => {
+    expect(build(defaultUsernamePolicy)).toBeUndefined();
+  });
+
+  it('describes only the length when only the length is restrictive', () => {
+    expect(build({ ...defaultUsernamePolicy, minLength: 4, maxLength: 8 })).toBe('req:len:4-8');
+  });
+
+  it('describes only the allowed characters when only the character set is restrictive', () => {
+    expect(
+      build({
+        ...defaultUsernamePolicy,
+        allowedChars: { lowercase: true, uppercase: false, numbers: false, underscore: false },
+      })
+    ).toBe('req:chars:lowercase');
+  });
+
+  it('describes both length and characters, listing only the allowed types in order', () => {
+    expect(
+      build({
+        ...defaultUsernamePolicy,
+        minLength: 4,
+        maxLength: 8,
+        allowedChars: { lowercase: true, uppercase: false, numbers: true, underscore: false },
+      })
+    ).toBe('req:len:4-8|chars:lowercase,number');
+  });
+
+  it('treats a tightened maximum length alone as restrictive', () => {
+    expect(build({ ...defaultUsernamePolicy, maxLength: 20 })).toBe('req:len:1-20');
+  });
+});
+
+describe('buildUsernamePolicyDescription with real phrases', () => {
+  beforeAll(async () => {
+    await i18next.init({
+      lng: 'en',
+      resources: { en: resource.en },
+      interpolation: { escapeValue: false },
+    });
+  });
+
+  it('composes a readable English sentence via the i18next list formatter', () => {
+    const description = buildUsernamePolicyDescription(
+      {
+        ...defaultUsernamePolicy,
+        minLength: 4,
+        maxLength: 8,
+        allowedChars: { lowercase: true, uppercase: false, numbers: true, underscore: false },
+      },
+      i18next.t.bind(i18next) as TFunction
+    );
+
+    expect(description).toBe(
+      'Username must be 4 to 8 characters and can only contain lowercase letters and numbers.'
+    );
+  });
+});

--- a/packages/experience/src/shared/utils/username-policy-description.ts
+++ b/packages/experience/src/shared/utils/username-policy-description.ts
@@ -1,0 +1,53 @@
+import { defaultUsernamePolicy } from '@logto/core-kit';
+import { type UsernamePolicy } from '@logto/schemas';
+import { condArray } from '@silverhand/essentials';
+import { type TFunction } from 'i18next';
+
+const characterTypes = [
+  ['uppercase', 'description.username_character.uppercase'],
+  ['lowercase', 'description.username_character.lowercase'],
+  ['numbers', 'description.username_character.number'],
+  ['underscore', 'description.username_character.underscore'],
+] as const;
+
+/**
+ * Build a localized requirements hint for the username field from the tenant policy, e.g.
+ * "Username must be 4 to 8 characters and contain only lowercase letters, numbers, and underscores."
+ *
+ * Returns `undefined` when the policy matches the permissive default (length and character types
+ * both unrestricted) — there is nothing worth surfacing. Mirrors the password policy's
+ * `requirementsDescription`.
+ */
+export const buildUsernamePolicyDescription = (
+  policy: UsernamePolicy | undefined,
+  translate: TFunction
+): string | undefined => {
+  if (!policy) {
+    return undefined;
+  }
+
+  const { minLength, maxLength, allowedChars } = policy;
+
+  const isLengthRestrictive =
+    minLength > defaultUsernamePolicy.minLength || maxLength < defaultUsernamePolicy.maxLength;
+  const isCharsRestrictive = characterTypes.some(([key]) => !allowedChars[key]);
+
+  if (!isLengthRestrictive && !isCharsRestrictive) {
+    return undefined;
+  }
+
+  const allowedCharacterNames = characterTypes
+    .filter(([key]) => allowedChars[key])
+    .map(([, phraseKey]) => translate(phraseKey));
+
+  const items = condArray(
+    isLengthRestrictive &&
+      translate('description.username_requirement.length', { min: minLength, max: maxLength }),
+    isCharsRestrictive &&
+      translate('description.username_requirement.characters', {
+        characters: allowedCharacterNames,
+      })
+  );
+
+  return translate('description.username_requirements', { items });
+};

--- a/packages/phrases-experience/src/locales/ar/description.ts
+++ b/packages/phrases-experience/src/locales/ar/description.ts
@@ -81,6 +81,17 @@ const description = {
     character_types_other:
       'يجب أن يحتوي على {{count}} أنواع على الأقل من الأحرف الكبيرة والصغيرة والأرقام والرموز',
   },
+  username_requirements: 'اسم المستخدم {{items, list}}.',
+  username_requirement: {
+    length: 'يجب أن يتكون من {{min}} إلى {{max}} حرفًا',
+    characters: 'لا يمكن أن يحتوي إلا على {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'الأحرف الكبيرة',
+    lowercase: 'الأحرف الصغيرة',
+    number: 'الأرقام',
+    underscore: 'الشرطات السفلية',
+  },
   use: 'استخدام',
   single_sign_on_email_form: 'أدخل عنوان بريدك الإلكتروني الخاص بالشركة',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/cs/description.ts
+++ b/packages/phrases-experience/src/locales/cs/description.ts
@@ -83,6 +83,17 @@ const description = {
     character_types_other:
       'musí obsahovat alespoň {{count}} typů velkých písmen, malých písmen, číslic a symbolů',
   },
+  username_requirements: 'Uživatelské jméno {{items, list}}.',
+  username_requirement: {
+    length: 'musí mít {{min}} až {{max}} znaků',
+    characters: 'může obsahovat pouze {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'velká písmena',
+    lowercase: 'malá písmena',
+    number: 'číslice',
+    underscore: 'podtržítka',
+  },
   use: 'Použít',
   single_sign_on_email_form: 'Zadej svou firemní e-mailovou adresu',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/de/description.ts
+++ b/packages/phrases-experience/src/locales/de/description.ts
@@ -86,6 +86,17 @@ const description = {
     character_types_other:
       'sollte mindestens {{count}} Kategorien der folgenden Zeichenarten enthalten: Großbuchstaben, Kleinbuchstaben, Zahlen und Symbole',
   },
+  username_requirements: 'Benutzername {{items, list}}.',
+  username_requirement: {
+    length: 'muss {{min}} bis {{max}} Zeichen lang sein',
+    characters: 'darf nur {{characters, list}} enthalten',
+  },
+  username_character: {
+    uppercase: 'Großbuchstaben',
+    lowercase: 'Kleinbuchstaben',
+    number: 'Zahlen',
+    underscore: 'Unterstriche',
+  },
   use: 'Verwenden',
   single_sign_on_email_form: 'Gib deine Unternehmens-E-Mail-Adresse ein.',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/en/description.ts
+++ b/packages/phrases-experience/src/locales/en/description.ts
@@ -84,6 +84,17 @@ const description = {
     character_types_other:
       'should contain at least {{count}} types of uppercase letters, lowercase letters, digits, and symbols',
   },
+  username_requirements: 'Username {{items, list}}.',
+  username_requirement: {
+    length: 'must be {{min}} to {{max}} characters',
+    characters: 'can only contain {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'uppercase letters',
+    lowercase: 'lowercase letters',
+    number: 'numbers',
+    underscore: 'underscores',
+  },
   use: 'Use',
   single_sign_on_email_form: 'Enter your enterprise email address',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/es/description.ts
+++ b/packages/phrases-experience/src/locales/es/description.ts
@@ -86,6 +86,17 @@ const description = {
     character_types_other:
       'debe contener al menos {{count}} tipos de letras mayúsculas, letras minúsculas, dígitos y símbolos',
   },
+  username_requirements: 'Nombre de usuario {{items, list}}.',
+  username_requirement: {
+    length: 'debe tener entre {{min}} y {{max}} caracteres',
+    characters: 'solo puede contener {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'letras mayúsculas',
+    lowercase: 'letras minúsculas',
+    number: 'números',
+    underscore: 'guiones bajos',
+  },
   use: 'Usar',
   single_sign_on_email_form: 'Ingrese su dirección de correo electrónico corporativo',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/fr/description.ts
+++ b/packages/phrases-experience/src/locales/fr/description.ts
@@ -86,6 +86,17 @@ const description = {
     character_types_other:
       'doit contenir au moins {{count}} types de lettres majuscules, lettres minuscules, chiffres et symboles',
   },
+  username_requirements: "Nom d'utilisateur {{items, list}}.",
+  username_requirement: {
+    length: 'doit comporter entre {{min}} et {{max}} caractères',
+    characters: 'ne peut contenir que {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'lettres majuscules',
+    lowercase: 'lettres minuscules',
+    number: 'chiffres',
+    underscore: 'traits de soulignement',
+  },
   use: 'Utiliser',
   single_sign_on_email_form: "Entrez votre adresse e-mail d'entreprise",
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/it/description.ts
+++ b/packages/phrases-experience/src/locales/it/description.ts
@@ -84,6 +84,17 @@ const description = {
     character_types_other:
       'dovrebbe contenere almeno {{count}} tipi di lettere maiuscole, lettere minuscole, numeri e simboli',
   },
+  username_requirements: 'Nome utente {{items, list}}.',
+  username_requirement: {
+    length: 'deve contenere da {{min}} a {{max}} caratteri',
+    characters: 'può contenere solo {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'lettere maiuscole',
+    lowercase: 'lettere minuscole',
+    number: 'numeri',
+    underscore: 'trattini bassi',
+  },
   use: 'Utilizzare',
   single_sign_on_email_form: 'Inserisci il tuo indirizzo email aziendale',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/ja/description.ts
+++ b/packages/phrases-experience/src/locales/ja/description.ts
@@ -81,6 +81,17 @@ const description = {
     character_types_many: '大文字、小文字、数字、記号のうち {{count}} 種類を含む必要があります',
     character_types_other: '大文字、小文字、数字、記号のうち {{count}} 種類を含む必要があります',
   },
+  username_requirements: 'ユーザー名は{{items, list}}。',
+  username_requirement: {
+    length: '{{min}}〜{{max}}文字である必要があります',
+    characters: '{{characters, list}}のみを使用できます',
+  },
+  username_character: {
+    uppercase: '大文字',
+    lowercase: '小文字',
+    number: '数字',
+    underscore: 'アンダースコア',
+  },
   use: '使用する',
   single_sign_on_email_form: '企業のメールアドレスを入力してください',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/ko/description.ts
+++ b/packages/phrases-experience/src/locales/ko/description.ts
@@ -75,6 +75,17 @@ const description = {
     character_types_many: '최소 {{count}} 종류의 대문자, 소문자, 숫자, 특수 기호를 포함해야 함',
     character_types_other: '최소 {{count}} 개의 대문자, 소문자, 숫자, 특수 기호를 포함해야 함',
   },
+  username_requirements: '사용자 이름 조건: {{items, list}}.',
+  username_requirement: {
+    length: '{{min}}~{{max}}자',
+    characters: '{{characters, list}}만 사용 가능',
+  },
+  username_character: {
+    uppercase: '대문자',
+    lowercase: '소문자',
+    number: '숫자',
+    underscore: '밑줄',
+  },
   use: '사용',
   single_sign_on_email_form: '기업 이메일 주소를 입력하세요',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/pl-pl/description.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/description.ts
@@ -85,6 +85,17 @@ const description = {
     character_types_other:
       'powinno zawierać co najmniej {{count}} rodzaje liter wielkich, małych liter, cyfr i symboli',
   },
+  username_requirements: 'Nazwa użytkownika {{items, list}}.',
+  username_requirement: {
+    length: 'musi mieć od {{min}} do {{max}} znaków',
+    characters: 'może zawierać tylko {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'wielkie litery',
+    lowercase: 'małe litery',
+    number: 'cyfry',
+    underscore: 'podkreślenia',
+  },
   use: 'Użyj',
   single_sign_on_email_form: 'Wpisz swój służbowy adres email',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/pt-br/description.ts
+++ b/packages/phrases-experience/src/locales/pt-br/description.ts
@@ -82,6 +82,17 @@ const description = {
     character_types_other:
       'deve conter pelo menos {{count}} tipos de letra maiúscula, letra minúscula, dígito e símbolo.',
   },
+  username_requirements: 'Nome de usuário {{items, list}}.',
+  username_requirement: {
+    length: 'deve ter de {{min}} a {{max}} caracteres',
+    characters: 'pode conter apenas {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'letras maiúsculas',
+    lowercase: 'letras minúsculas',
+    number: 'números',
+    underscore: 'sublinhados',
+  },
   use: 'Usar',
   single_sign_on_email_form: 'Insira o endereço de e-mail corporativo',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/pt-pt/description.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/description.ts
@@ -83,6 +83,17 @@ const description = {
     character_types_other:
       'deve conter pelo menos {{count}} tipos de letras maiúsculas, letras minúsculas, dígitos e símbolos',
   },
+  username_requirements: 'Nome de utilizador {{items, list}}.',
+  username_requirement: {
+    length: 'deve ter de {{min}} a {{max}} caracteres',
+    characters: 'pode conter apenas {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'letras maiúsculas',
+    lowercase: 'letras minúsculas',
+    number: 'números',
+    underscore: 'sublinhados',
+  },
   use: 'Usar',
   single_sign_on_email_form: 'Insira o endereço de email corporativo',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/ru/description.ts
+++ b/packages/phrases-experience/src/locales/ru/description.ts
@@ -86,6 +86,17 @@ const description = {
     character_types_other:
       'должен содержать по крайней мере {{count}} типа прописных букв, строчных букв, цифр и символов',
   },
+  username_requirements: 'Имя пользователя {{items, list}}.',
+  username_requirement: {
+    length: 'должно содержать от {{min}} до {{max}} символов',
+    characters: 'может содержать только {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'прописные буквы',
+    lowercase: 'строчные буквы',
+    number: 'цифры',
+    underscore: 'подчёркивания',
+  },
   use: 'Использовать',
   single_sign_on_email_form: 'Введите корпоративный адрес электронной почты',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/th/description.ts
+++ b/packages/phrases-experience/src/locales/th/description.ts
@@ -83,6 +83,17 @@ const description = {
     character_types_other:
       'ต้องมีอย่างน้อย {{count}} ประเภทในตัวพิมพ์ใหญ่ ตัวพิมพ์เล็ก ตัวเลข และสัญลักษณ์',
   },
+  username_requirements: 'ชื่อผู้ใช้{{items, list}}',
+  username_requirement: {
+    length: 'ต้องมี {{min}} ถึง {{max}} อักขระ',
+    characters: 'มีได้เฉพาะ {{characters, list}} เท่านั้น',
+  },
+  username_character: {
+    uppercase: 'ตัวพิมพ์ใหญ่',
+    lowercase: 'ตัวพิมพ์เล็ก',
+    number: 'ตัวเลข',
+    underscore: 'ขีดล่าง',
+  },
   use: 'ใช้',
   single_sign_on_email_form: 'กรอกอีเมลบริษัทของคุณ',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/tr-tr/description.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/description.ts
@@ -80,6 +80,17 @@ const description = {
     character_types_other:
       'en az {{count}} tane büyük harf, küçük harf, rakam ve sembol içermelidir',
   },
+  username_requirements: 'Kullanıcı adı {{items, list}}.',
+  username_requirement: {
+    length: '{{min}} ile {{max}} karakter arasında olmalıdır',
+    characters: 'yalnızca {{characters, list}} içerebilir',
+  },
+  username_character: {
+    uppercase: 'büyük harfler',
+    lowercase: 'küçük harfler',
+    number: 'rakamlar',
+    underscore: 'alt çizgiler',
+  },
   use: 'Kullan',
   single_sign_on_email_form: 'Kurumsal e-posta adresinizi girin',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/uk-ua/description.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/description.ts
@@ -86,6 +86,17 @@ const description = {
     character_types_other:
       'має містити щонайменше {{count}} типів символів: великі літери, малі літери, цифри та спеціальні символи',
   },
+  username_requirements: "Ім'я користувача {{items, list}}.",
+  username_requirement: {
+    length: 'має містити від {{min}} до {{max}} символів',
+    characters: 'може містити лише {{characters, list}}',
+  },
+  username_character: {
+    uppercase: 'великі літери',
+    lowercase: 'малі літери',
+    number: 'цифри',
+    underscore: 'підкреслення',
+  },
   use: 'Використовувати',
   single_sign_on_email_form: 'Введіть вашу корпоративну електронну адресу',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/zh-cn/description.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/description.ts
@@ -71,6 +71,17 @@ const description = {
     character_types_many: '至少应包含大写字母、小写字母、数字和符号中的 {{count}} 种',
     character_types_other: '至少应包含大写字母、小写字母、数字和符号中的 {{count}} 种',
   },
+  username_requirements: '用户名{{items, list}}。',
+  username_requirement: {
+    length: '必须为 {{min}} 到 {{max}} 个字符',
+    characters: '只能包含{{characters, list}}',
+  },
+  username_character: {
+    uppercase: '大写字母',
+    lowercase: '小写字母',
+    number: '数字',
+    underscore: '下划线',
+  },
   use: '使用',
   single_sign_on_email_form: '输入你的企业电子邮件地址',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/zh-hk/description.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/description.ts
@@ -71,6 +71,17 @@ const description = {
     character_types_many: '要求包含至少 {{count}} 類型的大寫字母，小寫字母，數字和符號',
     character_types_other: '要求包含至少 {{count}} 類型的大寫字母，小寫字母，數字和符號',
   },
+  username_requirements: '用戶名{{items, list}}。',
+  username_requirement: {
+    length: '必須為 {{min}} 至 {{max}} 個字元',
+    characters: '只能包含{{characters, list}}',
+  },
+  username_character: {
+    uppercase: '大寫字母',
+    lowercase: '小寫字母',
+    number: '數字',
+    underscore: '底線',
+  },
   use: '使用',
   single_sign_on_email_form: '輸入你的企業電子郵件地址',
   single_sign_on_connectors_list:

--- a/packages/phrases-experience/src/locales/zh-tw/description.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/description.ts
@@ -71,6 +71,17 @@ const description = {
     character_types_many: '需包含 {{count}} 類型的大寫字母、小寫字母、數字和符號',
     character_types_other: '需包含 {{count}} 類型的大寫字母、小寫字母、數字和符號',
   },
+  username_requirements: '使用者名稱{{items, list}}。',
+  username_requirement: {
+    length: '必須為 {{min}} 至 {{max}} 個字元',
+    characters: '只能包含{{characters, list}}',
+  },
+  username_character: {
+    uppercase: '大寫字母',
+    lowercase: '小寫字母',
+    number: '數字',
+    underscore: '底線',
+  },
   use: '使用',
   single_sign_on_email_form: '輸入你的企業電子郵件地址',
   single_sign_on_connectors_list:


### PR DESCRIPTION
## Summary

Closes [LOG-13581](https://linear.app/silverhand/issue/LOG-13581) (P8.6).

Today the username field validates against the per-tenant policy (P7 experience, P8.5 account) but the **enabled policy is never shown** — validation only surfaces the first violation, and only after submit. This adds proactive disclosure: a localized requirements hint beneath the username field, so users learn the rules before failing validation.

### What changed
- **Shared formatter** `buildUsernamePolicyDescription(policy, t)` (`experience/src/shared/utils/username-policy-description.ts`): composes a sentence via the i18next `list` formatter (e.g. _"Username must be 4 to 8 characters and can only contain lowercase letters and numbers."_). Returns `undefined` for the permissive default policy — the hint shows **only when the policy is more restrictive than the default**.
- **`SmartInputField`** gains a generic `description` passthrough prop (forwarded to the existing `InputField` helper-text slot). No policy/business logic in the widget.
- **`useUsernamePolicyDescription()` hook** (`hooks/use-sie.ts`) wraps the formatter + dev-flag gate + `PageContext`, mirroring `usePasswordPolicy().requirementsDescription`. The two experience call sites (`IdentifierRegisterForm`, `Continue/IdentifierProfileForm`) use it and apply a per-render `field.value.type === Username` gate, so multi-type sign-up fields only show it while username is the active type.
- **Account** `Username` page wires the hint inline (separate app/dev-flag, single-type → always shown when restrictive).
- **i18n**: new `description.username_requirements` / `username_requirement.{length,characters}` / `username_character.{uppercase,lowercase,number,underscore}` keys in en + 18 hand-translated locales.

### Reviewer notes
- The hint is **dev-flag gated** (each app uses its own `isDevFeaturesEnabled`); no production behavior change. In prod the policy is the default, so the formatter returns `undefined` regardless.
- Mirrors the existing `password_requirements` pattern (frame + `{{items, list}}` + fragment keys); the `list` formatter is an i18next built-in already used by the password hint in both apps.
- Korean uses a label-style frame (noun-phrase fragments) to keep the list-join grammatical, matching ko's own `password_requirements` structure.

## Testing

Unit tests

## Checklist
- [ ] \`.changeset\`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments