### PR TITLE
refactor(console): cap app access rule entity fetching

### DIFF
--- a/packages/console/src/hooks/use-batch-entity-details-fetch.test.ts
+++ b/packages/console/src/hooks/use-batch-entity-details-fetch.test.ts
@@ -1,0 +1,149 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import useApi from './use-api';
+import useBatchEntityDetailsFetch from './use-batch-entity-details-fetch';
+
+jest.mock('./use-api', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+type TestEntity = {
+  id: string;
+  name: string;
+};
+
+const mockedUseApi = jest.mocked(useApi);
+
+const createApi = () => ({
+  get: jest.fn((pathname: string) => ({
+    json: async () => {
+      const id = pathname.split('/').at(-1) ?? '';
+
+      return { id, name: `entity-${id}` };
+    },
+  })),
+});
+
+const createDeferredEntity = (id: string) => {
+  // eslint-disable-next-line @silverhand/fp/no-let -- Tests need a controlled resolver.
+  let resolveDeferredEntity: (entity: TestEntity) => void;
+  const promise = new Promise<TestEntity>((resolve) => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Tests need a controlled resolver.
+    resolveDeferredEntity = resolve;
+  });
+
+  return {
+    promise,
+    resolve: () => {
+      resolveDeferredEntity({ id, name: `entity-${id}` });
+    },
+  };
+};
+
+describe('useBatchEntityDetailsFetch', () => {
+  it('keeps the input order', async () => {
+    const api = createApi();
+    mockedUseApi.mockReturnValue(api as unknown as ReturnType<typeof useApi>);
+    const { result } = renderHook(() => useBatchEntityDetailsFetch());
+
+    const entities = await result.current<TestEntity>('api/entities', ['1', '2', '3']);
+
+    expect(entities).toEqual([
+      { id: '1', name: 'entity-1' },
+      { id: '2', name: 'entity-2' },
+      { id: '3', name: 'entity-3' },
+    ]);
+    expect(api.get).toHaveBeenCalledWith('api/entities/1');
+    expect(api.get).toHaveBeenCalledWith('api/entities/2');
+    expect(api.get).toHaveBeenCalledWith('api/entities/3');
+  });
+
+  it('respects the concurrency limit', async () => {
+    const pendingEntities = new Map<string, ReturnType<typeof createDeferredEntity>>();
+    const api = {
+      get: jest.fn((pathname: string) => {
+        const id = pathname.split('/').at(-1) ?? '';
+        const deferredEntity = createDeferredEntity(id);
+        pendingEntities.set(id, deferredEntity);
+
+        return {
+          json: async () => deferredEntity.promise,
+        };
+      }),
+    };
+    mockedUseApi.mockReturnValue(api as unknown as ReturnType<typeof useApi>);
+    const { result } = renderHook(() => useBatchEntityDetailsFetch(2.5));
+
+    const fetchPromise = result.current<TestEntity>('api/entities', ['1', '2', '3', '4', '5']);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledTimes(2);
+    });
+    pendingEntities.get('1')?.resolve();
+    pendingEntities.get('2')?.resolve();
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledTimes(4);
+    });
+    pendingEntities.get('3')?.resolve();
+    pendingEntities.get('4')?.resolve();
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledTimes(5);
+    });
+    pendingEntities.get('5')?.resolve();
+
+    await expect(fetchPromise).resolves.toEqual([
+      { id: '1', name: 'entity-1' },
+      { id: '2', name: 'entity-2' },
+      { id: '3', name: 'entity-3' },
+      { id: '4', name: 'entity-4' },
+      { id: '5', name: 'entity-5' },
+    ]);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY])(
+    'falls back to default concurrency for %p',
+    async (concurrency) => {
+      const api = createApi();
+      mockedUseApi.mockReturnValue(api as unknown as ReturnType<typeof useApi>);
+      const { result } = renderHook(() => useBatchEntityDetailsFetch(concurrency));
+
+      const entities = await result.current<TestEntity>('api/entities', ['1', '2', '3']);
+
+      expect(entities).toEqual([
+        { id: '1', name: 'entity-1' },
+        { id: '2', name: 'entity-2' },
+        { id: '3', name: 'entity-3' },
+      ]);
+      expect(api.get).toHaveBeenCalledTimes(3);
+    }
+  );
+
+  it('stops remaining batches when a batch request fails', async () => {
+    const api = {
+      get: jest.fn((pathname: string) => ({
+        json: async () => {
+          const id = pathname.split('/').at(-1) ?? '';
+
+          if (id === '2') {
+            throw new Error('Failed to fetch entity.');
+          }
+
+          return { id, name: `entity-${id}` };
+        },
+      })),
+    };
+    mockedUseApi.mockReturnValue(api as unknown as ReturnType<typeof useApi>);
+    const { result } = renderHook(() => useBatchEntityDetailsFetch(2));
+
+    await expect(result.current<TestEntity>('api/entities', ['1', '2', '3'])).rejects.toThrow(
+      'Failed to fetch entity.'
+    );
+
+    expect(api.get).toHaveBeenCalledWith('api/entities/1');
+    expect(api.get).toHaveBeenCalledWith('api/entities/2');
+    expect(api.get).not.toHaveBeenCalledWith('api/entities/3');
+  });
+});

--- a/packages/console/src/hooks/use-batch-entity-details-fetch.ts
+++ b/packages/console/src/hooks/use-batch-entity-details-fetch.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+
+import useApi from './use-api';
+
+const maxEntityDetailFetchConcurrency = 5;
+
+const normalizeConcurrency = (concurrency: number) =>
+  Number.isFinite(concurrency)
+    ? Math.max(1, Math.floor(concurrency))
+    : maxEntityDetailFetchConcurrency;
+
+/**
+ * Returns a typed entity-detail fetcher that loads `{pathname}/{id}` resources in bounded batches.
+ *
+ * The returned fetcher preserves the input ID order, runs requests in each batch in parallel, and
+ * keeps the previous fail-fast behavior: if any entity request rejects, the whole fetch rejects and
+ * remaining batches are not started.
+ */
+const useBatchEntityDetailsFetch = (concurrency = maxEntityDetailFetchConcurrency) => {
+  const api = useApi();
+
+  return useCallback(
+    async <TEntity>(pathname: string, ids: string[]) => {
+      const normalizedConcurrency = normalizeConcurrency(concurrency);
+      const entityIdBatches = Array.from(
+        { length: Math.ceil(ids.length / normalizedConcurrency) },
+        (_, index) => ids.slice(index * normalizedConcurrency, (index + 1) * normalizedConcurrency)
+      );
+
+      // Run batches sequentially so large rule lists do not create an unbounded request burst.
+      const entityBatches = await entityIdBatches.reduce<Promise<TEntity[][]>>(
+        async (previousBatches, entityIdBatch) => [
+          ...(await previousBatches),
+          // Keep each batch parallel and fail-fast, matching the previous Promise.all behavior.
+          await Promise.all(
+            entityIdBatch.map(async (id) => api.get(`${pathname}/${id}`).json<TEntity>())
+          ),
+        ],
+        Promise.resolve([])
+      );
+
+      return entityBatches.flat();
+    },
+    [api, concurrency]
+  );
+};
+
+export default useBatchEntityDetailsFetch;

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/use-rule-entities.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/use-rule-entities.ts
@@ -12,6 +12,7 @@ import { useCallback, useMemo } from 'react';
 import useSWR from 'swr';
 
 import useApi, { type RequestError } from '@/hooks/use-api';
+import useBatchEntityDetailsFetch from '@/hooks/use-batch-entity-details-fetch';
 import { buildUrl } from '@/utils/url';
 
 import {
@@ -21,12 +22,12 @@ import {
 } from './utils';
 
 const useEntitiesByIds = <TEntity>(key: string, pathname: string, ids: string[] | undefined) => {
-  const api = useApi();
+  const fetchBatchEntityDetails = useBatchEntityDetailsFetch();
 
   const fetchEntitiesByIds = useCallback(
     async ([, entityIds]: readonly [string, string[]]) =>
-      Promise.all(entityIds.map(async (id) => api.get(`${pathname}/${id}`).json<TEntity>())),
-    [api, pathname]
+      fetchBatchEntityDetails<TEntity>(pathname, entityIds),
+    [fetchBatchEntityDetails, pathname]
   );
 
   return useSWR<TEntity[], RequestError>(


### PR DESCRIPTION
## Summary
Cap app access rule entity detail fetching so large rule lists no longer fire all entity detail requests at once.

This adds a small batched helper for app access control entity detail requests while preserving the existing response order and fail-fast behavior.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
