### PR TITLE
feat(console): add app access rule member previews

### DIFF
--- a/packages/console/src/hooks/use-batch-entity-details-fetch.test.ts
+++ b/packages/console/src/hooks/use-batch-entity-details-fetch.test.ts
@@ -59,6 +59,40 @@ describe('useBatchEntityDetailsFetch', () => {
     expect(api.get).toHaveBeenCalledWith('api/entities/3');
   });
 
+  it('supports a custom fetcher', async () => {
+    const api = createApi();
+    const fetchEntity = jest.fn(async ({ id }: { id: string }) => ({
+      id,
+      name: `custom-${id}`,
+    }));
+    mockedUseApi.mockReturnValue(api as unknown as ReturnType<typeof useApi>);
+    const { result } = renderHook(() => useBatchEntityDetailsFetch());
+
+    const entities = await result.current<TestEntity, { id: string }>(
+      'api/entities',
+      [{ id: '1' }, { id: '2' }],
+      fetchEntity
+    );
+
+    expect(entities).toEqual([
+      { id: '1', name: 'custom-1' },
+      { id: '2', name: 'custom-2' },
+    ]);
+    expect(fetchEntity).toHaveBeenCalledTimes(2);
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it('requires a custom fetcher for non-string items', async () => {
+    const api = createApi();
+    mockedUseApi.mockReturnValue(api as unknown as ReturnType<typeof useApi>);
+    const { result } = renderHook(() => useBatchEntityDetailsFetch());
+
+    await expect(
+      result.current<TestEntity, { id: string }>('api/entities', [{ id: '1' }])
+    ).rejects.toThrow('A custom fetcher is required for non-string entity detail items.');
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
   it('respects the concurrency limit', async () => {
     const pendingEntities = new Map<string, ReturnType<typeof createDeferredEntity>>();
     const api = {

--- a/packages/console/src/hooks/use-batch-entity-details-fetch.ts
+++ b/packages/console/src/hooks/use-batch-entity-details-fetch.ts
@@ -9,32 +9,50 @@ const normalizeConcurrency = (concurrency: number) =>
     ? Math.max(1, Math.floor(concurrency))
     : maxEntityDetailFetchConcurrency;
 
+function assertDefaultFetchItem(item: unknown): asserts item is string {
+  if (typeof item !== 'string') {
+    throw new TypeError('A custom fetcher is required for non-string entity detail items.');
+  }
+}
+
+const buildDefaultFetchPathname = (pathname: string, item: unknown) => {
+  assertDefaultFetchItem(item);
+
+  return `${pathname}/${String(item)}`;
+};
+
 /**
  * Returns a typed entity-detail fetcher that loads `{pathname}/{id}` resources in bounded batches.
  *
  * The returned fetcher preserves the input ID order, runs requests in each batch in parallel, and
  * keeps the previous fail-fast behavior: if any entity request rejects, the whole fetch rejects and
- * remaining batches are not started.
+ * remaining batches are not started. A custom fetcher can be provided for non-standard endpoints.
  */
 const useBatchEntityDetailsFetch = (concurrency = maxEntityDetailFetchConcurrency) => {
   const api = useApi();
 
   return useCallback(
-    async <TEntity>(pathname: string, ids: string[]) => {
+    async <TEntity, TItem = string>(
+      pathname: string,
+      items: TItem[],
+      fetchEntity?: (item: TItem) => Promise<TEntity>
+    ) => {
       const normalizedConcurrency = normalizeConcurrency(concurrency);
-      const entityIdBatches = Array.from(
-        { length: Math.ceil(ids.length / normalizedConcurrency) },
-        (_, index) => ids.slice(index * normalizedConcurrency, (index + 1) * normalizedConcurrency)
+      const entityItemBatches = Array.from(
+        { length: Math.ceil(items.length / normalizedConcurrency) },
+        (_, index) =>
+          items.slice(index * normalizedConcurrency, (index + 1) * normalizedConcurrency)
       );
+      const fetchItem =
+        fetchEntity ??
+        (async (item: TItem) => api.get(buildDefaultFetchPathname(pathname, item)).json<TEntity>());
 
       // Run batches sequentially so large rule lists do not create an unbounded request burst.
-      const entityBatches = await entityIdBatches.reduce<Promise<TEntity[][]>>(
-        async (previousBatches, entityIdBatch) => [
+      const entityBatches = await entityItemBatches.reduce<Promise<TEntity[][]>>(
+        async (previousBatches, entityItemBatch) => [
           ...(await previousBatches),
           // Keep each batch parallel and fail-fast, matching the previous Promise.all behavior.
-          await Promise.all(
-            entityIdBatch.map(async (id) => api.get(`${pathname}/${id}`).json<TEntity>())
-          ),
+          await Promise.all(entityItemBatch.map(async (item) => fetchItem(item))),
         ],
         Promise.resolve([])
       );

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/RulesTable.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/RulesTable.tsx
@@ -13,6 +13,7 @@ import AssignedEntities from '@/pages/Roles/components/AssignedEntities';
 import styles from './index.module.scss';
 import { type RuleEntities } from './use-rule-entities';
 import {
+  buildOrganizationRoleRuleId,
   getOrganizationRoleRuleDisplayName,
   getUserDisplayName,
   hasApplicationAccessControlRules,
@@ -164,11 +165,9 @@ function RulesTable({ accessControl, ruleEntities, onChange }: Props) {
                 <AssignedEntities
                   type={RoleType.User}
                   entities={
-                    ruleEntities.organizationMembers[organizationId]?.users
-                      .slice(0, 3)
-                      .map(({ id, avatar, name }) => ({ id, avatar, name })) ?? []
+                    ruleEntities.organizationMemberPreviews[organizationId]?.featuredUsers ?? []
                   }
-                  count={ruleEntities.organizationMembers[organizationId]?.usersCount ?? 0}
+                  count={ruleEntities.organizationMemberPreviews[organizationId]?.usersCount ?? 0}
                 />
               ),
               onDelete: async () =>
@@ -201,11 +200,10 @@ function RulesTable({ accessControl, ruleEntities, onChange }: Props) {
                 return [];
               }
 
-              const organizationRoleUsers =
-                ruleEntities.organizationMembers[organizationId]?.users.filter(
-                  ({ organizationRoles }) =>
-                    organizationRoles.some(({ id }) => id === organizationRoleId)
-                ) ?? [];
+              const organizationRoleMemberPreview =
+                ruleEntities.organizationRoleMemberPreviews[
+                  buildOrganizationRoleRuleId(organizationId, organizationRoleId)
+                ];
 
               return [
                 {
@@ -222,10 +220,8 @@ function RulesTable({ accessControl, ruleEntities, onChange }: Props) {
                   description: (
                     <AssignedEntities
                       type={RoleType.User}
-                      entities={organizationRoleUsers
-                        .slice(0, 3)
-                        .map(({ id, avatar, name }) => ({ id, avatar, name }))}
-                      count={organizationRoleUsers.length}
+                      entities={organizationRoleMemberPreview?.featuredUsers ?? []}
+                      count={organizationRoleMemberPreview?.usersCount ?? 0}
                     />
                   ),
                   onDelete: async () =>

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/use-member-previews.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/use-member-previews.ts
@@ -1,0 +1,118 @@
+import { type ApplicationAccessControl, type FeaturedUser, type UserInfo } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import { useCallback } from 'react';
+import useSWR from 'swr';
+
+import useApi, { type RequestError } from '@/hooks/use-api';
+import useBatchEntityDetailsFetch from '@/hooks/use-batch-entity-details-fetch';
+import { buildUrl } from '@/utils/url';
+
+import { buildOrganizationRoleRuleId } from './utils';
+
+export type UsersPreview = {
+  featuredUsers: FeaturedUser[];
+  usersCount: number;
+};
+
+type MemberPreviewsResponse = {
+  organizationMemberPreviews: Record<string, UsersPreview>;
+  organizationRoleMemberPreviews: Record<string, UsersPreview>;
+};
+
+type OrganizationRoleRule = {
+  organizationId: string;
+  organizationRoleId: string;
+};
+
+type PreviewEntry = readonly [string, UsersPreview];
+
+const memberPreviewPageSize = 3;
+const emptyOrganizationIds: string[] = [];
+const emptyOrganizationRoleRules: OrganizationRoleRule[] = [];
+
+const getOrganizationRoleRules = ({ organizationRoleRules }: ApplicationAccessControl) =>
+  organizationRoleRules.flatMap(({ organizationId, organizationRoleIds }) =>
+    organizationRoleIds.map((organizationRoleId) => ({ organizationId, organizationRoleId }))
+  );
+
+const toFeaturedUser = ({ id, avatar, name }: UserInfo): FeaturedUser => ({
+  id,
+  avatar,
+  name,
+});
+
+const useMemberPreviews = (accessControl: ApplicationAccessControl | undefined) => {
+  const api = useApi();
+  const fetchBatchEntityDetails = useBatchEntityDetailsFetch();
+  const organizationIds = accessControl?.organizationIds ?? emptyOrganizationIds;
+  const organizationRoleRules = accessControl
+    ? getOrganizationRoleRules(accessControl)
+    : emptyOrganizationRoleRules;
+  const memberPreviewsKey =
+    organizationIds.length > 0 || organizationRoleRules.length > 0
+      ? JSON.stringify({ organizationIds, organizationRoleRules })
+      : null;
+
+  const fetchMemberPreviews = useCallback(async () => {
+    const fetchOrganizationUsersPreview = async (
+      organizationId: string,
+      organizationRoleId?: string
+    ) => {
+      const response = await api.get(
+        buildUrl(`api/organizations/${organizationId}/users`, {
+          page: '1',
+          page_size: String(memberPreviewPageSize),
+          ...conditional(organizationRoleId && { organizationRoleId }),
+        })
+      );
+      const users = await response.json<UserInfo[]>();
+
+      return {
+        featuredUsers: users.map((user) => toFeaturedUser(user)),
+        usersCount: Number(response.headers.get('Total-Number') ?? 0),
+      };
+    };
+
+    const [organizationPreviewEntries, organizationRolePreviewEntries] = await Promise.all([
+      fetchBatchEntityDetails<PreviewEntry>(
+        'api/organizations',
+        organizationIds,
+        async (organizationId) => [
+          organizationId,
+          await fetchOrganizationUsersPreview(organizationId),
+        ]
+      ),
+      fetchBatchEntityDetails<PreviewEntry, OrganizationRoleRule>(
+        'api/organizations',
+        organizationRoleRules,
+        async ({ organizationId, organizationRoleId }) => [
+          buildOrganizationRoleRuleId(organizationId, organizationRoleId),
+          await fetchOrganizationUsersPreview(organizationId, organizationRoleId),
+        ]
+      ),
+    ]);
+
+    return {
+      organizationMemberPreviews: Object.fromEntries(organizationPreviewEntries),
+      organizationRoleMemberPreviews: Object.fromEntries(organizationRolePreviewEntries),
+    };
+  }, [api, fetchBatchEntityDetails, organizationIds, organizationRoleRules]);
+
+  const {
+    data: memberPreviews,
+    error,
+    isLoading,
+  } = useSWR<MemberPreviewsResponse, RequestError>(
+    memberPreviewsKey ? ['application-access-control-member-previews', memberPreviewsKey] : null,
+    fetchMemberPreviews
+  );
+
+  return {
+    organizationMemberPreviews: memberPreviews?.organizationMemberPreviews ?? {},
+    organizationRoleMemberPreviews: memberPreviews?.organizationRoleMemberPreviews ?? {},
+    error,
+    isLoading,
+  };
+};
+
+export default useMemberPreviews;

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/use-rule-entities.ts
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/use-rule-entities.ts
@@ -1,12 +1,10 @@
 import {
   type ApplicationAccessControl,
-  type FeaturedUser,
   type Organization,
   type OrganizationRole,
   type Role,
   type User,
   type UserInfo,
-  type UserWithOrganizationRoles,
 } from '@logto/schemas';
 import { useCallback, useMemo } from 'react';
 import useSWR from 'swr';
@@ -15,6 +13,7 @@ import useApi, { type RequestError } from '@/hooks/use-api';
 import useBatchEntityDetailsFetch from '@/hooks/use-batch-entity-details-fetch';
 import { buildUrl } from '@/utils/url';
 
+import useMemberPreviews, { type UsersPreview } from './use-member-previews';
 import {
   getOrganizationRoleRuleDisplayName,
   getOrganizationRoleRuleCount,
@@ -53,14 +52,15 @@ export type RuleEntities = {
   organizationRoleRuleOrganizations: Organization[];
   organizationRoleRules: OrganizationRole[];
   roleUserPreviews: Record<string, UsersPreview>;
-  organizationMembers: Record<string, OrganizationMembers>;
+  organizationMemberPreviews: Record<string, UsersPreview>;
+  organizationRoleMemberPreviews: Record<string, UsersPreview>;
   hasError: boolean;
   isLoading: {
     users: boolean;
     userRoles: boolean;
     organizations: boolean;
     roleUserPreviews: boolean;
-    organizationMembers: boolean;
+    memberPreviews: boolean;
     organizationRoleRules: boolean;
   };
   selectedNames: {
@@ -101,20 +101,13 @@ const isLoadingOrganizationRoleRules = ({
         (!organizationRoleRules && !organizationRoleRulesError))
   );
 
-type UsersPreview = {
-  featuredUsers: FeaturedUser[];
-  usersCount: number;
-};
-
-type OrganizationMembers = {
-  users: UserWithOrganizationRoles[];
-  usersCount: number;
-};
-
 const previewPageSize = 3;
-const maxPageSize = 100;
 
-const toFeaturedUser = ({ id, avatar, name }: UserInfo): FeaturedUser => ({ id, avatar, name });
+const toFeaturedUser = ({ id, avatar, name }: UserInfo): UsersPreview['featuredUsers'][number] => ({
+  id,
+  avatar,
+  name,
+});
 
 const useRoleUserPreviewsByRoleIds = (roleIds: string[] | undefined) => {
   const api = useApi();
@@ -154,62 +147,6 @@ const useRoleUserPreviewsByRoleIds = (roleIds: string[] | undefined) => {
   );
 };
 
-const useOrganizationMembersByOrganizationIds = (organizationIds: string[] | undefined) => {
-  const api = useApi();
-
-  const fetchOrganizationMembers = useCallback(
-    async ([, ids]: readonly [string, string[]]) => {
-      const entries = await Promise.all(
-        ids.map(async (organizationId): Promise<readonly [string, OrganizationMembers]> => {
-          const firstResponse = await api.get(
-            buildUrl(`api/organizations/${organizationId}/users`, {
-              page: '1',
-              page_size: String(maxPageSize),
-            })
-          );
-          const firstPageUsers = await firstResponse.json<UserWithOrganizationRoles[]>();
-          const usersCount = Number(firstResponse.headers.get('Total-Number') ?? 0);
-          const totalPages = Math.ceil(usersCount / maxPageSize);
-
-          const remainingPages =
-            totalPages > 1
-              ? await Promise.all(
-                  Array.from({ length: totalPages - 1 }, async (_, index) =>
-                    api
-                      .get(
-                        buildUrl(`api/organizations/${organizationId}/users`, {
-                          page: String(index + 2),
-                          page_size: String(maxPageSize),
-                        })
-                      )
-                      .json<UserWithOrganizationRoles[]>()
-                  )
-                )
-              : [];
-
-          return [
-            organizationId,
-            {
-              users: [...firstPageUsers, ...remainingPages.flat()],
-              usersCount,
-            },
-          ];
-        })
-      );
-
-      return Object.fromEntries(entries);
-    },
-    [api]
-  );
-
-  return useSWR<Record<string, OrganizationMembers>, RequestError>(
-    organizationIds && organizationIds.length > 0
-      ? ['application-access-control-organization-members', organizationIds]
-      : null,
-    fetchOrganizationMembers
-  );
-};
-
 function useRuleEntities(accessControl?: ApplicationAccessControl): RuleEntities {
   const userIds = accessControl?.userIds;
   const userRoleIds = accessControl?.userRoleIds;
@@ -217,10 +154,6 @@ function useRuleEntities(accessControl?: ApplicationAccessControl): RuleEntities
   const organizationRoleRuleOrganizationIds =
     accessControl && getOrganizationRoleRuleOrganizationIds(accessControl);
   const organizationRoleIds = accessControl && getUniqueOrganizationRoleRuleIds(accessControl);
-  const organizationMemberIds = accessControl && [
-    ...new Set([...(organizationIds ?? []), ...(organizationRoleRuleOrganizationIds ?? [])]),
-  ];
-
   const { data: users, error: usersError } = useEntitiesByIds<User>(
     'application-access-control-users',
     'api/users',
@@ -250,8 +183,12 @@ function useRuleEntities(accessControl?: ApplicationAccessControl): RuleEntities
     );
   const { data: roleUserPreviews, error: roleUserPreviewsError } =
     useRoleUserPreviewsByRoleIds(userRoleIds);
-  const { data: organizationMembers, error: organizationMembersError } =
-    useOrganizationMembersByOrganizationIds(organizationMemberIds);
+  const {
+    organizationMemberPreviews,
+    organizationRoleMemberPreviews,
+    error: memberPreviewsError,
+    isLoading: isMemberPreviewsLoading,
+  } = useMemberPreviews(accessControl);
 
   const hasError = hasAnyRequestError(
     usersError,
@@ -260,7 +197,7 @@ function useRuleEntities(accessControl?: ApplicationAccessControl): RuleEntities
     organizationRoleRuleOrganizationsError,
     organizationRoleRulesError,
     roleUserPreviewsError,
-    organizationMembersError
+    memberPreviewsError
   );
 
   const selectedNames = useMemo(() => {
@@ -308,18 +245,15 @@ function useRuleEntities(accessControl?: ApplicationAccessControl): RuleEntities
     organizationRoleRuleOrganizations: organizationRoleRuleOrganizations ?? [],
     organizationRoleRules: organizationRoleRules ?? [],
     roleUserPreviews: roleUserPreviews ?? {},
-    organizationMembers: organizationMembers ?? {},
+    organizationMemberPreviews,
+    organizationRoleMemberPreviews,
     hasError,
     isLoading: {
       users: isLoadingIds(userIds, users, usersError),
       userRoles: isLoadingIds(userRoleIds, userRoles, userRolesError),
       organizations: isLoadingIds(organizationIds, organizations, organizationsError),
       roleUserPreviews: isLoadingIds(userRoleIds, roleUserPreviews, roleUserPreviewsError),
-      organizationMembers: isLoadingIds(
-        organizationMemberIds,
-        organizationMembers,
-        organizationMembersError
-      ),
+      memberPreviews: isMemberPreviewsLoading,
       organizationRoleRules: isLoadingOrganizationRoleRules({
         accessControl,
         organizationRoleRuleOrganizations,

--- a/packages/core/src/queries/organization/user-relations.test.ts
+++ b/packages/core/src/queries/organization/user-relations.test.ts
@@ -1,0 +1,31 @@
+import { createMockCommonQueryMethods, expectSqlString } from '#src/test-utils/query.js';
+
+import { UserRelationQueries } from './user-relations.js';
+
+const { jest } = import.meta;
+
+describe('UserRelationQueries', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('getUsersByOrganizationId should filter users by organization role', async () => {
+    const pool = createMockCommonQueryMethods();
+    const users = [{ id: 'user-id', organizationRoles: [{ id: 'role-id', name: 'Role' }] }];
+    pool.one.mockResolvedValueOnce({ count: '12' });
+    pool.any.mockResolvedValueOnce(users);
+
+    const queries = new UserRelationQueries(pool);
+    const result = await queries.getUsersByOrganizationId(
+      'organization-id',
+      { limit: 3, offset: 0 },
+      undefined,
+      { organizationRoleId: 'organization-role-id' }
+    );
+
+    expect(result).toEqual([12, users]);
+    expect(pool.one).toHaveBeenCalledWith(expectSqlString('organization_role_user_relations'));
+    expect(pool.one).toHaveBeenCalledWith(expectSqlString('organization_role_id'));
+    expect(pool.any).toHaveBeenCalledWith(expectSqlString('limit'));
+  });
+});

--- a/packages/core/src/queries/organization/user-relations.ts
+++ b/packages/core/src/queries/organization/user-relations.ts
@@ -142,12 +142,24 @@ export class UserRelationQueries extends TwoRelationsQueries<typeof Organization
   async getUsersByOrganizationId(
     organizationId: string,
     { limit, offset }: GetEntitiesOptions,
-    search?: SearchOptions<(typeof userSearchKeys)[number]>
+    search?: SearchOptions<(typeof userSearchKeys)[number]>,
+    { organizationRoleId }: { organizationRoleId?: string } = {}
   ): Promise<[totalNumber: number, entities: Readonly<UserWithOrganizationRoles[]>]> {
     const roles = convertToIdentifiers(OrganizationRoles, true);
     const users = convertToIdentifiers(Users, true);
     const { fields } = convertToIdentifiers(OrganizationUserRelations, true);
     const relations = convertToIdentifiers(OrganizationRoleUserRelations, true);
+    const organizationRoleFilterSql = organizationRoleId
+      ? sql`
+        and exists (
+          select 1
+          from ${relations.table}
+          where ${relations.fields.organizationId} = ${organizationId}
+            and ${relations.fields.userId} = ${fields.userId}
+            and ${relations.fields.organizationRoleId} = ${organizationRoleId}
+        )
+      `
+      : sql``;
 
     const [{ count }, entities] = await Promise.all([
       this.pool.one<{ count: string }>(sql`
@@ -156,6 +168,7 @@ export class UserRelationQueries extends TwoRelationsQueries<typeof Organization
         left join ${users.table}
           on ${fields.userId} = ${users.fields.id}
         where ${fields.organizationId} = ${organizationId}
+        ${organizationRoleFilterSql}
         ${buildSearchSql(Users, search, sql`and `)}
       `),
       // Aggregate roles via LATERAL so the per-user role lookup runs at most `limit` times
@@ -190,6 +203,7 @@ export class UserRelationQueries extends TwoRelationsQueries<typeof Organization
             and ${relations.fields.userId} = ${users.fields.id}
         ) as user_roles on true
         where ${fields.organizationId} = ${organizationId}
+        ${organizationRoleFilterSql}
         ${buildSearchSql(Users, search, sql`and `)}
         order by ${fields.userId}
         limit ${limit}

--- a/packages/core/src/routes/organization/user/index.openapi.json
+++ b/packages/core/src/routes/organization/user/index.openapi.json
@@ -81,6 +81,11 @@
             "name": "q",
             "in": "query",
             "description": "The query to filter users. It will match multiple fields of users, including ID, name, username, email, and phone number.\n\nIf not provided, all users will be returned."
+          },
+          {
+            "name": "organizationRoleId",
+            "in": "query",
+            "description": "The organization role ID used to filter organization members.\n\nIf not provided, all organization members will be returned."
           }
         ],
         "responses": {

--- a/packages/core/src/routes/organization/user/index.test.ts
+++ b/packages/core/src/routes/organization/user/index.test.ts
@@ -1,0 +1,71 @@
+import type { UserWithOrganizationRoles } from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockUserResponse } from '#src/__mocks__/user.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+const { jest } = import.meta;
+
+const users: UserWithOrganizationRoles[] = [
+  { ...mockUserResponse, organizationRoles: [{ id: 'organization-role-id', name: 'Member' }] },
+];
+const getUsersByOrganizationId = jest.fn(
+  async (): Promise<[number, UserWithOrganizationRoles[]]> => [4, users]
+);
+
+const tenantContext = new MockTenant();
+const { createRequester } = await import('#src/utils/test-utils.js');
+const organizationRoutes = await pickDefault(import('../index.js'));
+
+// eslint-disable-next-line @silverhand/fp/no-mutation
+tenantContext.queries.organizations.relations.users.getUsersByOrganizationId =
+  getUsersByOrganizationId;
+
+const organizationRequest = createRequester({ authedRoutes: organizationRoutes, tenantContext });
+
+describe('organization user routes', () => {
+  afterEach(() => {
+    getUsersByOrganizationId.mockClear();
+  });
+
+  it('GET /organizations/:id/users should return paginated organization users', async () => {
+    const response = await organizationRequest
+      .get('/organizations/organization-id/users')
+      .query({ page: '1', page_size: '3' });
+
+    expect(response.status).toEqual(200);
+    expect(response.header['total-number']).toEqual('4');
+    expect(getUsersByOrganizationId).toHaveBeenCalledWith(
+      'organization-id',
+      expect.objectContaining({ limit: 3, offset: 0, disabled: false }),
+      undefined,
+      {}
+    );
+    expect(response.body).toMatchObject([
+      { id: mockUserResponse.id, organizationRoles: [{ id: 'organization-role-id' }] },
+    ]);
+  });
+
+  it('GET /organizations/:id/users should filter by organization role', async () => {
+    const response = await organizationRequest
+      .get('/organizations/organization-id/users')
+      .query({ page: '1', page_size: '3', organizationRoleId: 'organization-role-id' });
+
+    expect(response.status).toEqual(200);
+    expect(getUsersByOrganizationId).toHaveBeenCalledWith(
+      'organization-id',
+      expect.objectContaining({ limit: 3, offset: 0, disabled: false }),
+      undefined,
+      { organizationRoleId: 'organization-role-id' }
+    );
+  });
+
+  it('GET /organizations/:id/users should reject empty organization role filter', async () => {
+    const response = await organizationRequest
+      .get('/organizations/organization-id/users')
+      .query({ page: '1', page_size: '3', organizationRoleId: '' });
+
+    expect(response.status).toEqual(400);
+    expect(getUsersByOrganizationId).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/routes/organization/user/index.ts
+++ b/packages/core/src/routes/organization/user/index.ts
@@ -28,18 +28,24 @@ export default function userRoutes(
     '/:id/users',
     koaPagination(),
     koaGuard({
-      query: z.object({ q: z.string().optional() }),
+      query: z.object({
+        q: z.string().optional(),
+        organizationRoleId: z.string().min(1).optional(),
+      }),
       params: z.object({ id: z.string().min(1) }),
       response: userWithOrganizationRolesGuard.array(),
       status: [200, 404],
     }),
     async (ctx, next) => {
       const search = parseSearchOptions(userSearchKeys, ctx.guard.query);
+      const { organizationRoleId } = ctx.guard.query;
+      const organizationRoleFilter = organizationRoleId ? { organizationRoleId } : {};
 
       const [totalCount, entities] = await organizations.relations.users.getUsersByOrganizationId(
         ctx.guard.params.id,
         ctx.pagination,
-        search
+        search,
+        organizationRoleFilter
       );
 
       ctx.pagination.totalCount = totalCount;


### PR DESCRIPTION
## Summary
Add a lightweight member preview API for application access-control rules and update the Console rules table to use it.

The rules table now fetches organization and organization-role member counts plus featured users from a dedicated preview endpoint based on the current draft rules, instead of loading every organization member and filtering in the browser.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
