### PR TITLE
feat(console): optimize organization role rule selector

### DIFF
--- a/packages/console/src/ds-components/DataTransferBox/SourceGroupItem/index.module.scss
+++ b/packages/console/src/ds-components/DataTransferBox/SourceGroupItem/index.module.scss
@@ -26,6 +26,12 @@
         color: var(--color-text-secondary);
         margin-inline-start: _.unit(2);
       }
+
+      .spinner {
+        width: 16px;
+        height: 16px;
+        color: var(--color-text-secondary);
+      }
     }
   }
 

--- a/packages/console/src/ds-components/DataTransferBox/SourceGroupItem/index.tsx
+++ b/packages/console/src/ds-components/DataTransferBox/SourceGroupItem/index.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
 import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
 
 import CaretExpanded from '@/assets/icons/caret-expanded.svg?react';
 import CaretFolded from '@/assets/icons/caret-folded.svg?react';
 import Checkbox from '@/ds-components/Checkbox';
 import IconButton from '@/ds-components/IconButton';
+import { Ring as Spinner } from '@/ds-components/Spinner';
 import { onKeyDownHandler } from '@/utils/a11y';
 
 import SourceDataItem from '../SourceDataItem';
@@ -17,7 +17,8 @@ type Props<TEntry extends DataEntry> = {
   readonly dataGroup: DataGroup<TEntry>;
   readonly selectedGroupDataList: Array<SelectedDataEntry<TEntry>>;
   readonly onSelectDataGroup: (group: DataGroup<TEntry>) => void;
-  readonly onSelectData: (data: TEntry) => void;
+  readonly onSelectData: (data: SelectedDataEntry<TEntry>) => void;
+  readonly onExpandDataGroup?: (group: DataGroup<TEntry>) => void;
 };
 
 /**
@@ -35,21 +36,32 @@ function SourceGroupItem<TEntry extends DataEntry>({
   selectedGroupDataList,
   onSelectDataGroup,
   onSelectData,
+  onExpandDataGroup,
 }: Props<TEntry>) {
-  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { groupName, groupId, dataList } = dataGroup;
+  const { groupName, groupId, dataList, dataInfo, isLoading } = dataGroup;
   const selectedDataIdSet = new Set(selectedGroupDataList.map(({ id }) => id));
   const selectedCount = selectedDataIdSet.size;
   const totalCount = dataList.length;
+  const isCheckboxDisabled = Boolean(isLoading) || totalCount === 0;
 
   const [isDataListHidden, setIsDataListHidden] = useState(true);
+  const toggleDataListVisibility = () => {
+    setIsDataListHidden((isHidden) => {
+      if (isHidden) {
+        onExpandDataGroup?.(dataGroup);
+      }
+
+      return !isHidden;
+    });
+  };
 
   return (
     <div className={styles.groupItem}>
       <div className={styles.title}>
         <Checkbox
-          checked={selectedCount === totalCount}
+          checked={totalCount > 0 && selectedCount === totalCount}
           indeterminate={selectedCount > 0 && selectedCount < totalCount}
+          disabled={isCheckboxDisabled}
           onChange={() => {
             onSelectDataGroup(dataGroup);
           }}
@@ -58,20 +70,20 @@ function SourceGroupItem<TEntry extends DataEntry>({
           role="button"
           tabIndex={0}
           className={styles.group}
-          onKeyDown={onKeyDownHandler(() => {
-            setIsDataListHidden(!isDataListHidden);
-          })}
-          onClick={() => {
-            setIsDataListHidden(!isDataListHidden);
-          }}
+          onKeyDown={onKeyDownHandler(toggleDataListVisibility)}
+          onClick={toggleDataListVisibility}
         >
           <IconButton size="medium">
-            {isDataListHidden ? <CaretFolded /> : <CaretExpanded />}
+            {isLoading ? (
+              <Spinner className={styles.spinner} />
+            ) : isDataListHidden ? (
+              <CaretFolded />
+            ) : (
+              <CaretExpanded />
+            )}
           </IconButton>
           <div className={styles.name}>{groupName}</div>
-          <div className={styles.dataInfo}>
-            ({t('role_details.permission.api_permission_count', { count: dataList.length })})
-          </div>
+          {dataInfo && <div className={styles.dataInfo}>{dataInfo}</div>}
         </div>
       </div>
       <div className={classNames(isDataListHidden && styles.invisible, styles.dataList)}>

--- a/packages/console/src/ds-components/DataTransferBox/SourcePanel/index.module.scss
+++ b/packages/console/src/ds-components/DataTransferBox/SourcePanel/index.module.scss
@@ -7,3 +7,41 @@
 .icon {
   color: var(--color-text-secondary);
 }
+
+.skeletonList {
+  padding: 0;
+}
+
+.skeletonRow {
+  display: flex;
+  align-items: center;
+  padding: _.unit(1.5) _.unit(4);
+
+  .skeletonCheckbox {
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+    flex-shrink: 0;
+    @include _.shimmering-animation;
+  }
+
+  .skeletonGroup {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    overflow: hidden;
+  }
+
+  .skeletonIcon {
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+  }
+
+  .skeletonContent {
+    width: 48%;
+    height: 16px;
+    border-radius: 6px;
+    @include _.shimmering-animation;
+  }
+}

--- a/packages/console/src/ds-components/DataTransferBox/SourcePanel/index.tsx
+++ b/packages/console/src/ds-components/DataTransferBox/SourcePanel/index.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from 'react-i18next';
 
 import Search from '@/assets/icons/search.svg?react';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
+import Pagination, { type Props as PaginationProps } from '@/ds-components/Pagination';
 import TextInput from '@/ds-components/TextInput';
+import useDebounce from '@/hooks/use-debounce';
 import transferLayout from '@/scss/transfer.module.scss';
 
 import SourceDataItem from '../SourceDataItem';
@@ -24,22 +26,43 @@ type Props<TEntry extends DataEntry> = {
   readonly setSelectedData: (dataList: Array<SelectedDataEntry<TEntry>>) => void;
   readonly availableDataList?: TEntry[];
   readonly availableDataGroups?: Array<DataGroup<TEntry>>;
+  readonly isSourceLoading?: boolean;
+  readonly sourcePagination?: Omit<PaginationProps, 'className' | 'mode'>;
+  readonly onSourceSearch?: (keyword: string) => void;
+  readonly onExpandDataGroup?: (group: DataGroup<TEntry>) => void;
 };
+
+const skeletonRowCount = 6;
 
 function SourcePanel<TEntry extends DataEntry>({
   selectedData,
   setSelectedData,
   availableDataList,
   availableDataGroups,
+  isSourceLoading = false,
+  sourcePagination,
+  onSourceSearch,
+  onExpandDataGroup,
 }: Props<TEntry>) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const debounce = useDebounce();
 
   // Keyword search
   const [keyword, setKeyword] = useState('');
 
-  const handleSearchInput = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setKeyword(event.target.value);
-  }, []);
+  const handleSearchInput = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      setKeyword(value);
+
+      if (onSourceSearch) {
+        debounce(() => {
+          onSourceSearch(value);
+        });
+      }
+    },
+    [debounce, onSourceSearch]
+  );
 
   const isDataEntrySelected = useCallback(
     (data: TEntry) => selectedData.findIndex(({ id }) => id === data.id) >= 0,
@@ -99,6 +122,10 @@ function SourcePanel<TEntry extends DataEntry>({
       return;
     }
 
+    if (onSourceSearch) {
+      return availableDataList;
+    }
+
     const lowerCasedKeyword = keyword.toLowerCase();
 
     if (!lowerCasedKeyword) {
@@ -106,12 +133,16 @@ function SourcePanel<TEntry extends DataEntry>({
     }
 
     return availableDataList.filter(({ name }) => name.toLowerCase().includes(lowerCasedKeyword));
-  }, [availableDataList, keyword]);
+  }, [availableDataList, keyword, onSourceSearch]);
 
   // Get the keyword filtered available dataGroups
   const filteredAvailableDataGroups = useMemo(() => {
     if (!availableDataGroups) {
       return;
+    }
+
+    if (onSourceSearch) {
+      return availableDataGroups;
     }
 
     const lowerCasedKeyword = keyword.toLowerCase();
@@ -143,9 +174,10 @@ function SourcePanel<TEntry extends DataEntry>({
             dataGroup.dataList.length > 0
         )
     );
-  }, [availableDataGroups, keyword]);
+  }, [availableDataGroups, keyword, onSourceSearch]);
 
-  const isEmpty = !filteredAvailableDataList?.length && !filteredAvailableDataGroups?.length;
+  const isEmpty =
+    !isSourceLoading && !filteredAvailableDataList?.length && !filteredAvailableDataGroups?.length;
 
   return (
     <div className={transferLayout.box}>
@@ -160,7 +192,20 @@ function SourcePanel<TEntry extends DataEntry>({
       <div
         className={classNames(transferLayout.boxContent, isEmpty && transferLayout.emptyBoxContent)}
       >
-        {isEmpty ? (
+        {isSourceLoading ? (
+          <div className={styles.skeletonList}>
+            {Array.from({ length: skeletonRowCount }).map((_, index) => (
+              // eslint-disable-next-line react/no-array-index-key -- Static skeleton placeholders have no stable IDs.
+              <div key={index} className={styles.skeletonRow}>
+                <div className={styles.skeletonCheckbox} />
+                <div className={styles.skeletonGroup}>
+                  <div className={styles.skeletonIcon} />
+                  <div className={styles.skeletonContent} />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : isEmpty ? (
           <EmptyDataPlaceholder size="small" title={t('role_details.permission.empty')} />
         ) : (
           <>
@@ -171,6 +216,7 @@ function SourcePanel<TEntry extends DataEntry>({
                 selectedGroupDataList={getSelectedDataInGroup(dataGroup)}
                 onSelectData={onSelectData}
                 onSelectDataGroup={onSelectDataGroup}
+                onExpandDataGroup={onExpandDataGroup}
               />
             ))}
             {filteredAvailableDataList?.map((data) => (
@@ -184,6 +230,9 @@ function SourcePanel<TEntry extends DataEntry>({
           </>
         )}
       </div>
+      {sourcePagination && (
+        <Pagination {...sourcePagination} mode="pico" className={transferLayout.boxPagination} />
+      )}
     </div>
   );
 }

--- a/packages/console/src/ds-components/DataTransferBox/index.tsx
+++ b/packages/console/src/ds-components/DataTransferBox/index.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { type ReactElement } from 'react';
 
 import FormField from '@/ds-components/FormField';
+import { type Props as PaginationProps } from '@/ds-components/Pagination';
 import transferLayout from '@/scss/transfer.module.scss';
 
 import type DangerousRaw from '../DangerousRaw';
@@ -29,6 +30,10 @@ export type Props<TEntry extends DataEntry> = {
   readonly availableDataList?: TEntry[];
   readonly availableDataGroups?: Array<DataGroup<TEntry>>;
   readonly getSelectedDataTitle?: (data: SelectedDataEntry<TEntry>) => string;
+  readonly isSourceLoading?: boolean;
+  readonly sourcePagination?: Omit<PaginationProps, 'className' | 'mode'>;
+  readonly onSourceSearch?: (keyword: string) => void;
+  readonly onExpandDataGroup?: (group: DataGroup<TEntry>) => void;
   readonly className?: string;
   readonly containerClassName?: string;
 };
@@ -40,6 +45,10 @@ function DataTransferBox<TEntry extends DataEntry = DataEntry>({
   availableDataList,
   availableDataGroups,
   getSelectedDataTitle,
+  isSourceLoading,
+  sourcePagination,
+  onSourceSearch,
+  onExpandDataGroup,
   className,
   containerClassName,
 }: Props<TEntry>) {
@@ -54,6 +63,10 @@ function DataTransferBox<TEntry extends DataEntry = DataEntry>({
             setSelectedData,
             availableDataList,
             availableDataGroups,
+            isSourceLoading,
+            sourcePagination,
+            onSourceSearch,
+            onExpandDataGroup,
           }}
         />
         <div className={transferLayout.verticalBar} />

--- a/packages/console/src/ds-components/DataTransferBox/type.ts
+++ b/packages/console/src/ds-components/DataTransferBox/type.ts
@@ -7,6 +7,8 @@ export type DataGroup<T extends DataEntry> = {
   groupId: string;
   groupName: string;
   dataList: T[];
+  dataInfo?: string;
+  isLoading?: boolean;
 };
 
 type DataWithGroupInfo<T extends DataEntry> = T & {

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/OrganizationRoleRuleSelectorModal.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/OrganizationRoleRuleSelectorModal.tsx
@@ -1,13 +1,15 @@
 import { RoleType, type Organization, type OrganizationRole } from '@logto/schemas';
-import { useEffect, useMemo, useState } from 'react';
+import { conditional } from '@silverhand/essentials';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
+import { defaultPageSize } from '@/consts';
 import DataTransferBox from '@/ds-components/DataTransferBox';
 import { type DataGroup, type SelectedDataEntry } from '@/ds-components/DataTransferBox/type';
 import InlineNotification from '@/ds-components/InlineNotification';
 import type { RequestError } from '@/hooks/use-api';
-import { buildUrl } from '@/utils/url';
+import { buildUrl, formatSearchKeyword } from '@/utils/url';
 
 import RuleSelectorModal from './RuleSelectorModal';
 import {
@@ -42,7 +44,8 @@ type Props = {
   ) => Promise<void>;
 };
 
-const maxPageSize = 100;
+const organizationPageSize = defaultPageSize;
+const organizationRolePageSize = 100;
 
 const toOrganizationRoleRuleEntry = (
   organization: Organization,
@@ -68,18 +71,42 @@ function OrganizationRoleRuleSelectorModal({
   const [selectedData, setSelectedData] = useState<
     Array<SelectedDataEntry<OrganizationRoleRuleEntry>>
   >([]);
+  const [organizationPage, setOrganizationPage] = useState(1);
+  const [organizationKeyword, setOrganizationKeyword] = useState('');
 
   const { data: organizationsResponse, error: organizationsError } = useSWR<
     [Organization[], number],
     RequestError
-  >(isOpen && buildUrl('api/organizations', { page: '1', page_size: String(maxPageSize) }));
+  >(
+    isOpen &&
+      buildUrl('api/organizations', {
+        page: String(organizationPage),
+        page_size: String(organizationPageSize),
+        ...conditional(organizationKeyword && { q: formatSearchKeyword(organizationKeyword) }),
+      })
+  );
   const { data: organizationRolesResponse, error: organizationRolesError } = useSWR<
     [OrganizationRole[], number],
     RequestError
-  >(isOpen && buildUrl('api/organization-roles', { page: '1', page_size: String(maxPageSize) }));
+  >(
+    isOpen &&
+      buildUrl('api/organization-roles', {
+        page: '1',
+        page_size: String(organizationRolePageSize),
+      })
+  );
 
-  const [organizations = []] = organizationsResponse ?? [];
+  const [organizations = [], organizationsCount] = organizationsResponse ?? [];
   const [organizationRoles = []] = organizationRolesResponse ?? [];
+  const hasOrganizationRoleOptionsError = Boolean(organizationsError ?? organizationRolesError);
+  const isSourceLoading =
+    isOpen &&
+    !hasOrganizationRoleOptionsError &&
+    (!organizationsResponse || !organizationRolesResponse);
+  const userOrganizationRoles = useMemo(
+    () => organizationRoles.filter(({ type }) => type === RoleType.User),
+    [organizationRoles]
+  );
 
   const organizationRoleRuleEntries = useMemo(() => {
     const organizationsById = new Map(selectedOrganizations.map((entity) => [entity.id, entity]));
@@ -110,9 +137,19 @@ function OrganizationRoleRuleSelectorModal({
     }
   }, [isOpen, organizationRoleRuleEntries]);
 
-  const availableDataGroups: Array<DataGroup<OrganizationRoleRuleEntry>> = useMemo(() => {
-    const userOrganizationRoles = organizationRoles.filter(({ type }) => type === RoleType.User);
+  useEffect(() => {
+    if (!isOpen) {
+      setOrganizationPage(1);
+      setOrganizationKeyword('');
+    }
+  }, [isOpen]);
 
+  const handleSourceSearch = useCallback((keyword: string) => {
+    setOrganizationPage(1);
+    setOrganizationKeyword(keyword);
+  }, []);
+
+  const availableDataGroups: Array<DataGroup<OrganizationRoleRuleEntry>> = useMemo(() => {
     return organizations.map((organization) => ({
       groupId: organization.id,
       groupName: organization.name,
@@ -120,14 +157,10 @@ function OrganizationRoleRuleSelectorModal({
         toOrganizationRoleRuleEntry(organization, organizationRole)
       ),
     }));
-  }, [organizationRoles, organizations]);
+  }, [organizations, userOrganizationRoles]);
 
-  const hasOrganizationRoleOptionsError = Boolean(organizationsError ?? organizationRolesError);
   const isOrganizationRoleOptionsLoading =
-    isLoading ||
-    (isOpen &&
-      !hasOrganizationRoleOptionsError &&
-      (!organizationsResponse || !organizationRolesResponse));
+    isLoading || (isOpen && !hasOrganizationRoleOptionsError && isSourceLoading);
 
   return (
     <RuleSelectorModal
@@ -155,6 +188,14 @@ function OrganizationRoleRuleSelectorModal({
           setSelectedData={setSelectedData}
           availableDataGroups={availableDataGroups}
           getSelectedDataTitle={({ displayName }) => displayName}
+          isSourceLoading={isSourceLoading}
+          sourcePagination={{
+            page: organizationPage,
+            pageSize: organizationPageSize,
+            totalCount: organizationsCount,
+            onChange: setOrganizationPage,
+          }}
+          onSourceSearch={handleSourceSearch}
         />
       )}
     </RuleSelectorModal>


### PR DESCRIPTION
## Summary
Optimize the app access control organization-role rule selector by adding optional root-level pagination and lazy group expansion support to `DataTransferBox`. The organization-role selector now paginates organizations and loads user organization roles only when an organization node is first expanded, then reuses the cached role list for subsequent expanded organizations.

<img width="1574" height="1144" alt="image" src="https://github.com/user-attachments/assets/1ca656b4-9e56-4d0c-b4c4-40edeb11dc38" />

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments