### PR TITLE
fix(console): keep username policy save button active during conflict check

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/UsernamePolicy/UsernamePolicyModal/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/UsernamePolicy/UsernamePolicyModal/index.tsx
@@ -77,13 +77,11 @@ function UsernamePolicyModal({ policy, onClose }: Props) {
   );
   const hasConflicts = Boolean(conflicts && conflicts.totalConflicts > 0);
 
+  // `isCheckingConflicts` intentionally does not disable Save: keeping the button active avoids a
+  // flicker when the operator toggles case sensitivity on an already-dirty form. The save click
+  // handler below swallows clicks while the probe is in flight instead.
   const isSaveDisabled =
-    !isDirty ||
-    hasNoValidLeadingChar ||
-    !isLengthValid ||
-    hasConflicts ||
-    isCheckingConflicts ||
-    isSubmitting;
+    !isDirty || hasNoValidLeadingChar || !isLengthValid || hasConflicts || isSubmitting;
 
   const onSubmit = handleSubmit(
     trySubmitSafe(async (formData) => {
@@ -97,6 +95,15 @@ function UsernamePolicyModal({ policy, onClose }: Props) {
       onClose();
     })
   );
+
+  const onSaveClick = () => {
+    // Gate before react-hook-form so an ignored click can't flash `isSubmitting`.
+    if (isCheckingConflicts) {
+      return;
+    }
+
+    void onSubmit();
+  };
 
   return (
     <ReactModal
@@ -117,7 +124,7 @@ function UsernamePolicyModal({ policy, onClose }: Props) {
             htmlType="submit"
             disabled={isSaveDisabled}
             isLoading={isSubmitting}
-            onClick={onSubmit}
+            onClick={onSaveClick}
           />
         }
         onClose={onClose}

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/UsernamePolicy/use-conflict-detection.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/UsernamePolicy/use-conflict-detection.ts
@@ -12,8 +12,8 @@ const conflictsEndpoint = 'api/sign-in-exp/username-policy/case-sensitivity-conf
 
 /**
  * Reads username case-sensitivity conflicts, debounced by 300 ms, while `enabled` (the operator is
- * switching the policy to case-insensitive). Surfacing them lets the modal block the save before
- * the server rejects the PATCH with a 409.
+ * switching the policy to case-insensitive). Surfacing them lets the modal warn about conflicts and
+ * guard the save before the server rejects the PATCH with a 409.
  */
 const useConflictDetection = (enabled: boolean) => {
   const [debouncedEnabled, setDebouncedEnabled] = useState(false);
@@ -33,17 +33,19 @@ const useConflictDetection = (enabled: boolean) => {
     };
   }, [enabled]);
 
-  const { data, error, isLoading } = useSWR<CaseConflicts, RequestError>(
+  const { data, error, isValidating } = useSWR<CaseConflicts, RequestError>(
     debouncedEnabled && conflictsEndpoint
   );
 
   return {
-    conflicts: debouncedEnabled ? data : undefined,
-    // Block from the moment the operator switches to case-insensitive until a settled answer
-    // arrives — including the pre-debounce window, so Save can't be clicked before the probe runs.
-    // On error we stop blocking and fall back to the server-side 409 guard instead of leaving Save
-    // stuck disabled forever.
-    isChecking: enabled && !error && (!debouncedEnabled || isLoading || !data),
+    // SWR retains the last `data` when a revalidation fails; hide it on error so stale conflicts
+    // can't keep Save disabled while the probe itself is broken.
+    conflicts: debouncedEnabled && !error ? data : undefined,
+    // True from the moment the operator switches to case-insensitive until the probe settles
+    // (pre-debounce window included). `isValidating` rather than `isLoading`, so a cached entry
+    // mid-revalidation still gates the save instead of letting it through on stale results. On
+    // error we stop gating and fall back to the server-side 409 guard.
+    isChecking: enabled && !error && (!debouncedEnabled || isValidating || !data),
   };
 };
 


### PR DESCRIPTION
## Summary

Closes LOG-13594. In the username policy modal, toggling the **Case-sensitive** switch on an already-dirty form made the **Save changes** button briefly go disabled, then active again.

Cause: the default policy is case-sensitive, so turning the switch off triggers `useConflictDetection`, and its `isCheckingConflicts` (debounce + fetch window) was part of `isSaveDisabled` — disabling the button for a few hundred ms even though the form is dirty and valid.

Fix (keep the button active, guard the action instead):
- Removed `isCheckingConflicts` from `isSaveDisabled`, so the Save button stays visually active while the conflict probe runs (no flicker).
- The submit handler now ignores clicks while `isCheckingConflicts` is true, so a switch to case-insensitive can never be submitted before the conflict result settles — the server-side 409 guard remains the backstop.
- Save is still disabled when conflicts are **confirmed** (`hasConflicts`), alongside the existing inline conflict notification.

## Testing

Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
