### PR TITLE
fix(console): center username length separator on the input boxes

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/UsernamePolicy/UsernamePolicyModal/index.module.scss
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/UsernamePolicy/UsernamePolicyModal/index.module.scss
@@ -18,10 +18,19 @@
   color: var(--color-text-secondary);
 }
 
+.separatorColumn {
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1);
+}
+
 .separator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* Match the input box height so the dash centers on the input, not the label + input column. */
+  height: 36px;
   color: var(--color-text-secondary);
-  /* Align the dash with the inputs, accounting for the label row above each field. */
-  padding-top: _.unit(6);
 }
 
 .allowedChars {

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/UsernamePolicy/UsernamePolicyModal/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/UsernamePolicy/UsernamePolicyModal/index.tsx
@@ -158,7 +158,13 @@ function UsernamePolicyModal({ policy, onClose }: Props) {
                   )}
                 />
               </div>
-              <span className={styles.separator}>–</span>
+              <div className={styles.separatorColumn}>
+                {/* Empty label keeps the dash on the same baseline as the inputs below the labels. */}
+                <span aria-hidden className={styles.lengthLabel}>
+                  &nbsp;
+                </span>
+                <span className={styles.separator}>–</span>
+              </div>
               <div className={styles.lengthField}>
                 <span className={styles.lengthLabel}>{t('length.maximum')}</span>
                 <Controller


### PR DESCRIPTION
## Summary

Closes LOG-13592. In the username policy modal, the `–` separator between the **Minimum** and **Maximum** length inputs sat too high — it was offset with a hardcoded `padding-top` that centered it against the whole label + input column instead of the input box.

Fix: give the separator its own column with an empty (aria-hidden) label spacer that occupies the same height as the real labels, then size the dash box to the input height (36px) and center the dash in it. The dash now lines up with the vertical center of the input boxes, independent of the label height and of the min field's validation error.

## Testing

Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
