### PR TITLE
fix(account): mock Vite env in App tests

### DIFF
--- a/packages/account/src/App.test.tsx
+++ b/packages/account/src/App.test.tsx
@@ -6,6 +6,11 @@ import renderWithPageContext, {
   mockAccountCenterSettings,
 } from './__mocks__/RenderWithPageContext';
 
+jest.mock('./constants/env', () => ({
+  __esModule: true,
+  isDevFeaturesEnabled: false,
+}));
+
 // Note: jest.requireActual('@logto/react') can't be used here, as it pulls in
 // @logto/client → @logto/js, which fails to resolve under the monorepo's
 // pnpm/jest module layout. Prompt/ReservedScope/UserScope are OIDC/OAuth


### PR DESCRIPTION
## Summary

- Restores the account App test mock for the Vite env module.
- Prevents Jest from evaluating `import.meta.env` while loading account routes.

## Root cause

A recent test cleanup removed the env module mock, which let `App.test.tsx` import the real Vite env module through the username route graph. Jest does not provide Vite's `import.meta.env`, so the suite failed during parsing.

## Testing

Unit tests
