### PR TITLE
feat(console): add SAML app access control rules tab

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/index.tsx
@@ -31,7 +31,7 @@ import { areApplicationAccessControlsEqual, hasApplicationAccessControlRules } f
 type Props = {
   readonly application: ApplicationResponse;
   readonly isActive: boolean;
-  readonly onApplicationUpdated: () => void;
+  readonly onApplicationUpdated: (application?: ApplicationResponse) => void | Promise<void>;
 };
 
 type ApplicationAccessControlForm = {
@@ -133,12 +133,12 @@ function ApplicationAccessControl({ application, isActive, onApplicationUpdated 
       }
 
       if (shouldUpdateEnabled) {
-        await api
+        const updatedApplication = await api
           .patch(`api/applications/${id}`, {
             json: { appLevelAccessControlEnabled },
           })
           .json<ApplicationResponse>();
-        onApplicationUpdated();
+        await onApplicationUpdated(updatedApplication);
       }
 
       reset({

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
@@ -47,7 +47,7 @@ type Props = {
   readonly data: ApplicationResponse;
   readonly secrets: ApplicationSecretRow[];
   readonly oidcConfig: SnakeCaseOidcConfig;
-  readonly onApplicationUpdated: () => void;
+  readonly onApplicationUpdated: (application?: ApplicationResponse) => void | Promise<void>;
 };
 
 function ApplicationDetailsContent({ data, secrets, oidcConfig, onApplicationUpdated }: Props) {
@@ -95,7 +95,7 @@ function ApplicationDetailsContent({ data, secrets, oidcConfig, onApplicationUpd
         .json<ApplicationResponse>();
 
       reset(applicationFormDataParser.fromResponse(updatedData));
-      onApplicationUpdated();
+      await onApplicationUpdated(updatedData);
       toast.success(t('general.saved'));
     })
   );
@@ -115,7 +115,7 @@ function ApplicationDetailsContent({ data, secrets, oidcConfig, onApplicationUpd
 
   const onCloseDrawer = () => {
     // The guide drawer may have updated the application data
-    onApplicationUpdated();
+    void onApplicationUpdated();
     setIsReadmeOpen(false);
   };
 

--- a/packages/console/src/pages/ApplicationDetails/SamlApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/SamlApplicationDetailsContent/index.tsx
@@ -15,6 +15,7 @@ import DetailsPageHeader from '@/components/DetailsPage/DetailsPageHeader';
 import Skeleton from '@/components/FormCard/Skeleton';
 import RequestDataError from '@/components/RequestDataError';
 import { ApplicationDetailsTabs } from '@/consts';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import DeleteConfirmModal from '@/ds-components/DeleteConfirmModal';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import TabWrapper from '@/ds-components/TabWrapper';
@@ -22,6 +23,7 @@ import useApi, { type RequestError } from '@/hooks/use-api';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 import { applicationTypeI18nKey } from '@/types/applications';
 
+import ApplicationAccessControl from '../ApplicationDetailsContent/ApplicationAccessControl';
 import Branding from '../components/Branding';
 
 import AttributeMapping from './AttributeMapping';
@@ -37,9 +39,10 @@ export const isSamlApplication = (data: ApplicationResponse): data is SamlApplic
 
 type Props = {
   readonly data: SamlApplication;
+  readonly onApplicationUpdated: (application?: ApplicationResponse) => void | Promise<void>;
 };
 
-function SamlApplicationDetailsContent({ data }: Props) {
+function SamlApplicationDetailsContent({ data, onApplicationUpdated }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { tab } = useParams();
   const { navigate } = useTenantPathname();
@@ -57,6 +60,7 @@ function SamlApplicationDetailsContent({ data }: Props) {
   const api = useApi();
 
   const isLoading = !samlApplicationData && !samlApplicationError;
+  const hasRules = isDevFeaturesEnabled;
 
   const onDelete = useCallback(async () => {
     setIsDeleting(true);
@@ -137,6 +141,11 @@ function SamlApplicationDetailsContent({ data }: Props) {
         <TabNavItem href={`/applications/${data.id}/${ApplicationDetailsTabs.Branding}`}>
           {t('application_details.branding.name')}
         </TabNavItem>
+        {hasRules && (
+          <TabNavItem href={`/applications/${data.id}/${ApplicationDetailsTabs.Rules}`}>
+            {t('application_details.access_control.name')}
+          </TabNavItem>
+        )}
       </TabNav>
       <TabWrapper
         isActive={tab === ApplicationDetailsTabs.Settings}
@@ -165,6 +174,15 @@ function SamlApplicationDetailsContent({ data }: Props) {
         {/* isActive is needed to support conditional render UnsavedChangesAlertModal */}
         <Branding application={data} isActive={tab === ApplicationDetailsTabs.Branding} />
       </TabWrapper>
+      {hasRules && (
+        <TabWrapper isActive={tab === ApplicationDetailsTabs.Rules} className={styles.tabContainer}>
+          <ApplicationAccessControl
+            application={data}
+            isActive={tab === ApplicationDetailsTabs.Rules}
+            onApplicationUpdated={onApplicationUpdated}
+          />
+        </TabWrapper>
+      )}
     </>
   );
 }

--- a/packages/console/src/pages/ApplicationDetails/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/index.tsx
@@ -1,4 +1,5 @@
 import { type ApplicationResponse, type SnakeCaseOidcConfig } from '@logto/schemas';
+import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
@@ -24,6 +25,18 @@ function ApplicationDetails() {
   );
   const secrets = useSWR<ApplicationSecretRow[], RequestError>(`api/applications/${id}/secrets`);
   const oidcConfig = useSWR<SnakeCaseOidcConfig, RequestError>(openIdProviderConfigPath);
+
+  const handleApplicationUpdated = useCallback(
+    async (application?: ApplicationResponse) => {
+      if (application) {
+        await mutate(application, { revalidate: false });
+        return;
+      }
+
+      await mutate();
+    },
+    [mutate]
+  );
 
   const isLoading =
     (!data && !error) ||
@@ -65,13 +78,16 @@ function ApplicationDetails() {
         oidcConfig.data &&
         secrets.data &&
         (isSamlApplication(data) ? (
-          <SamlApplicationDetailsContent data={data} />
+          <SamlApplicationDetailsContent
+            data={data}
+            onApplicationUpdated={handleApplicationUpdated}
+          />
         ) : (
           <ApplicationDetailsContent
             data={data}
             oidcConfig={oidcConfig.data}
             secrets={secrets.data}
-            onApplicationUpdated={mutate}
+            onApplicationUpdated={handleApplicationUpdated}
           />
         ))}
     </DetailsPage>


### PR DESCRIPTION
## Summary
Add the app-level access control Rules tab to SAML application details and reuse the existing access control configuration UI.

Update the application details parent to accept updated application data from child saves and write it back into the SWR cache.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments