### PR TITLE
fix(experience): show username policy hint on initial render

### DIFF
--- a/packages/experience/src/components/IdentifierRegisterForm/index.test.tsx
+++ b/packages/experience/src/components/IdentifierRegisterForm/index.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- exhaustive matrix of sign-up methods, SSO, and username policy cases */
 import {
   SignInIdentifier,
   experience,
@@ -233,6 +234,44 @@ describe('<IdentifierRegisterForm />', () => {
     });
     await waitFor(() => {
       expect(queryByText('error.username_too_short')).toBeNull();
+    });
+  });
+
+  describe('username policy hint', () => {
+    const restrictivePolicy: UsernamePolicy = {
+      caseSensitive: true,
+      minLength: 4,
+      maxLength: 8,
+      allowedChars: { lowercase: true, uppercase: false, numbers: false, underscore: false },
+    };
+
+    test('shows on initial render for username-only sign-up', () => {
+      const { queryByText } = renderForm([SignInIdentifier.Username], [], restrictivePolicy);
+      expect(queryByText('description.username_requirements')).not.toBeNull();
+    });
+
+    test('hidden for the permissive default policy', () => {
+      const { queryByText } = renderForm([SignInIdentifier.Username]);
+      expect(queryByText('description.username_requirements')).toBeNull();
+    });
+
+    test('in a multi-identifier form, appears only once the input is detected as a username', async () => {
+      const { queryByText, container } = renderForm(
+        [SignInIdentifier.Username, SignInIdentifier.Email],
+        [],
+        restrictivePolicy
+      );
+      expect(queryByText('description.username_requirements')).toBeNull();
+
+      const identifierInput = container.querySelector('input[name=identifier]');
+      assert(identifierInput, new Error('identifier input not found'));
+
+      act(() => {
+        fireEvent.change(identifierInput, { target: { value: 'abc' } });
+      });
+      await waitFor(() => {
+        expect(queryByText('description.username_requirements')).not.toBeNull();
+      });
     });
   });
 
@@ -496,3 +535,4 @@ describe('<IdentifierRegisterForm />', () => {
     });
   });
 });
+/* eslint-enable max-lines */

--- a/packages/experience/src/components/IdentifierRegisterForm/index.tsx
+++ b/packages/experience/src/components/IdentifierRegisterForm/index.tsx
@@ -44,6 +44,12 @@ const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) 
   const prefilledIdentifier = usePrefilledIdentifier({ enabledIdentifiers: signUpMethods });
   const usernamePolicyDescription = useUsernamePolicyDescription();
 
+  /**
+   * The form value's identifier type stays undefined until it is detected from user input, so
+   * for a single-method form fall back to that method to show the policy hint on initial render.
+   */
+  const fallbackIdentifierType = signUpMethods.length === 1 ? signUpMethods[0] : undefined;
+
   const {
     watch,
     handleSubmit,
@@ -141,7 +147,9 @@ const IdentifierRegisterForm = ({ className, autoFocus, signUpMethods }: Props) 
             errorMessage={errors.identifier?.message}
             enabledTypes={signUpMethods}
             description={
-              field.value.type === SignInIdentifier.Username ? usernamePolicyDescription : undefined
+              (field.value.type ?? fallbackIdentifierType) === SignInIdentifier.Username
+                ? usernamePolicyDescription
+                : undefined
             }
           />
         )}


### PR DESCRIPTION
## Summary
Fixes BB-4.1 (LOG-13598): on the register page, the username policy requirements hint (P8.6) only appeared after the user started typing, instead of on initial render.

The hint was gated on `field.value.type === SignInIdentifier.Username`, but the form's default identifier value has no `type` until one is detected from user input. `SmartInputField` does detect the type on mount and propagates it via `field.onChange`, but that effect fires before the react-hook-form `Controller` subscribes to value changes, so the initial render-prop value stays stale.

Fix: when the form has a single sign-up method, fall back to that method as the identifier type for the hint gate, so a username-only form shows the hint immediately. Multi-identifier forms keep the existing behavior — the hint appears once the input is detected as a username — since a username hint under a field that may receive an email or phone would be noise.

The Continue page (`SetUsername`) and account center are unaffected: they already show the hint from the first render.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments