### PR TITLE
feat: release per-tenant username policy and preferred_username mirror

### DIFF
--- a/.changeset/username-policy-client.md
+++ b/.changeset/username-policy-client.md
@@ -1,0 +1,9 @@
+---
+"@logto/experience": minor
+"@logto/account": minor
+"@logto/phrases-experience": minor
+---
+
+apply the tenant username policy in sign-in experience and account center username forms
+
+Usernames entered during sign-up, profile fulfillment, and account center editing are validated against the tenant username policy with localized inline errors. The dedicated username pages (continue flow and account center) state the policy requirements in their page description, and the sign-up identifier form surfaces the full requirements sentence when an entered username violates the policy.

--- a/.changeset/username-policy-console.md
+++ b/.changeset/username-policy-console.md
@@ -1,0 +1,8 @@
+---
+"@logto/console": minor
+"@logto/phrases": minor
+---
+
+add username policy management to the sign-in experience advanced options
+
+Operators can configure the tenant username policy — case sensitivity, length bounds, and allowed character types — from Console → Sign-in experience → Sign-up and sign-in → Advanced options. Switching to case-insensitive proactively detects existing usernames that differ only by case and blocks the save until the conflicts are resolved.

--- a/.changeset/username-policy-core.md
+++ b/.changeset/username-policy-core.md
@@ -1,0 +1,15 @@
+---
+"@logto/core": minor
+"@logto/schemas": minor
+"@logto/shared": patch
+---
+
+add per-tenant username policy enforcement and mirror preferred_username from username by default
+
+The sign-in experience now stores a per-tenant username policy (case sensitivity, length bounds, and allowed character types) that is enforced on end-user username writes: experience sign-up and profile fulfillment, the account API, and `/me`. Admin (Management API) writes keep the always-on baseline rules only.
+
+Switching usernames to case-insensitive is guarded: `PATCH /api/sign-in-exp` is rejected with a 409 while usernames that differ only by case exist, and the new `GET /api/sign-in-exp/username-policy/case-sensitivity-conflicts` endpoint reports such conflicts.
+
+For deployments using the legacy `CASE_SENSITIVE_USERNAME` environment variable: the effective case sensitivity is the per-tenant policy AND-combined with the env var, so usernames are treated case-insensitively if either is false. Existing `CASE_SENSITIVE_USERNAME=false` setups keep their behavior — the env var acts as a runtime override that forces case-insensitive handling for every tenant, and the per-tenant policy cannot re-enable case sensitivity while it is set. The env var is deprecated and slated for removal in the next major; migrate by unsetting it and configuring `usernamePolicy.caseSensitive` per tenant instead.
+
+The OIDC `preferred_username` claim now falls back to the user's `username` when `profile.preferredUsername` is unset, so standards-compliant clients receive a usable value out of the box.

--- a/packages/account/src/pages/Username/index.test.tsx
+++ b/packages/account/src/pages/Username/index.test.tsx
@@ -25,16 +25,6 @@ jest.mock('../../apis/account', () => ({
   updateUsername: jest.fn(),
 }));
 
-// The policy gate is read per submit; control it per test (and sidestep `import.meta.env`). Default
-// off — matching production and the suite's original hard-floor-only behavior; the policy block
-// turns it on.
-const mockIsDevFeaturesEnabled = jest.fn(() => false);
-jest.mock('@ac/constants/env', () => ({
-  get isDevFeaturesEnabled() {
-    return mockIsDevFeaturesEnabled();
-  },
-}));
-
 jest.mock('@ac/components/VerificationMethodList', () => () => <div>Verification methods</div>);
 
 // Lowercase-only, length 4–8: violations here are policy-only (not caught by the hard floor).
@@ -107,7 +97,6 @@ describe('<Username />', () => {
     jest.resetAllMocks();
     mockGetAccessToken.mockResolvedValue('access-token');
     jest.mocked(updateUsername).mockResolvedValue(undefined);
-    mockIsDevFeaturesEnabled.mockReturnValue(false);
   });
 
   it('shows an error page when username editing is disabled', () => {
@@ -229,10 +218,6 @@ describe('<Username />', () => {
   });
 
   describe('username policy', () => {
-    beforeEach(() => {
-      mockIsDevFeaturesEnabled.mockReturnValue(true);
-    });
-
     it('blocks a too-short username with an inline policy error', async () => {
       const { getByText, container } = renderWithPolicy();
 
@@ -284,30 +269,6 @@ describe('<Username />', () => {
       const { getByText, queryByText } = renderUsername();
       expect(getByText('account_center.username.description')).toBeTruthy();
       expect(queryByText('account_center.username.policy_description')).toBeNull();
-    });
-
-    it('keeps the static page description when dev features are off', () => {
-      mockIsDevFeaturesEnabled.mockReturnValue(false);
-      const { getByText, queryByText } = renderWithPolicy();
-      expect(getByText('account_center.username.description')).toBeTruthy();
-      expect(queryByText('account_center.username.policy_description')).toBeNull();
-    });
-
-    it('does not block a policy-only violation when dev features are off', async () => {
-      mockIsDevFeaturesEnabled.mockReturnValue(false);
-      const { getByText, container } = renderWithPolicy();
-
-      // 'abc' is too short for the policy but passes the always-on hard floor, so with the gate off
-      // it submits unchanged — proving the policy is not enforced client-side in production.
-      const usernameInput = container.querySelector('input[name="username"]');
-      fireEvent.change(usernameInput!, { target: { value: 'abc' } });
-      fireEvent.click(getByText('action.save'));
-
-      await waitFor(() => {
-        expect(updateUsername).toHaveBeenCalledWith('access-token', 'verification-record-id', {
-          username: 'abc',
-        });
-      });
     });
   });
 });

--- a/packages/account/src/pages/Username/index.tsx
+++ b/packages/account/src/pages/Username/index.tsx
@@ -12,7 +12,6 @@ import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import { updateUsername } from '@ac/apis/account';
 import ErrorPage from '@ac/components/ErrorPage';
 import VerificationMethodList from '@ac/components/VerificationMethodList';
-import { isDevFeaturesEnabled } from '@ac/constants/env';
 import { usernameSuccessRoute } from '@ac/constants/routes';
 import useApi from '@ac/hooks/use-api';
 import useErrorHandler from '@ac/hooks/use-error-handler';
@@ -59,10 +58,7 @@ const Username = () => {
    * tenant policy is restrictive, so the page never contradicts the enforced policy.
    */
   const usernamePolicyDescription = useMemo(
-    () =>
-      isDevFeaturesEnabled
-        ? buildUsernamePolicyDescription(experienceSettings?.usernamePolicy, t)
-        : undefined,
+    () => buildUsernamePolicyDescription(experienceSettings?.usernamePolicy, t),
     [experienceSettings?.usernamePolicy, t]
   );
 
@@ -94,12 +90,7 @@ const Username = () => {
       return;
     }
 
-    // Per-tenant policy enforcement is gated until the feature ships; without the flag the
-    // always-on hard floor is the only client-side check, matching production behavior.
-    const validationError = validateUsername(
-      username,
-      isDevFeaturesEnabled ? experienceSettings?.usernamePolicy : undefined
-    );
+    const validationError = validateUsername(username, experienceSettings?.usernamePolicy);
 
     if (validationError) {
       const message =

--- a/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/AdvancedOptions/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/SignUpAndSignIn/AdvancedOptions/index.tsx
@@ -2,7 +2,6 @@ import { type SignInExperience } from '@logto/schemas';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 import Card from '@/ds-components/Card';
 import FormField from '@/ds-components/FormField';
 import Switch from '@/ds-components/Switch';
@@ -67,7 +66,7 @@ function AdvancedOptions({ signInExperience }: Props) {
           placeholder="https://"
         />
       </FormField>
-      {isDevFeaturesEnabled && <UsernamePolicy signInExperience={signInExperience} />}
+      <UsernamePolicy signInExperience={signInExperience} />
     </Card>
   );
 }

--- a/packages/core/src/oidc/scope.test.ts
+++ b/packages/core/src/oidc/scope.test.ts
@@ -2,7 +2,6 @@ import { type UserClaim } from '@logto/core-kit';
 import { type User } from '@logto/schemas';
 
 import { mockUser } from '#src/__mocks__/user.js';
-import { EnvSet } from '#src/env-set/index.js';
 
 import { getAcceptedUserClaims, getUserClaimsData } from './scope.js';
 
@@ -152,7 +151,6 @@ describe('OIDC getUserClaimsData() preferred_username', () => {
   // Unused for the `preferred_username` claim, but required by the function signature.
   const userLibrary = {} as unknown as Parameters<typeof getUserClaimsData>[2];
   const organizationQueries = {} as unknown as Parameters<typeof getUserClaimsData>[3];
-  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 
   const getPreferredUsername = async (user: User): Promise<unknown> => {
     const claims: UserClaim[] = ['preferred_username'];
@@ -160,42 +158,17 @@ describe('OIDC getUserClaimsData() preferred_username', () => {
     return data.find(([claim]) => claim === 'preferred_username')?.[1];
   };
 
-  afterAll(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  it('falls back to username when profile.preferredUsername is unset', async () => {
+    await expect(getPreferredUsername(mockUser)).resolves.toBe(mockUser.username);
   });
 
-  describe('when dev features are enabled', () => {
-    beforeAll(() => {
-      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
-    });
-
-    it('falls back to username when profile.preferredUsername is unset', async () => {
-      await expect(getPreferredUsername(mockUser)).resolves.toBe(mockUser.username);
-    });
-
-    it('uses profile.preferredUsername when set', async () => {
-      const user = { ...mockUser, profile: { preferredUsername: 'alice_the_great' } };
-      await expect(getPreferredUsername(user)).resolves.toBe('alice_the_great');
-    });
-
-    it('returns undefined when both username and profile.preferredUsername are unset', async () => {
-      const user = { ...mockUser, username: null };
-      await expect(getPreferredUsername(user)).resolves.toBeUndefined();
-    });
+  it('uses profile.preferredUsername when set', async () => {
+    const user = { ...mockUser, profile: { preferredUsername: 'alice_the_great' } };
+    await expect(getPreferredUsername(user)).resolves.toBe('alice_the_great');
   });
 
-  describe('when dev features are disabled', () => {
-    beforeAll(() => {
-      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
-    });
-
-    it('does not fall back to username (preserves prior behavior)', async () => {
-      await expect(getPreferredUsername(mockUser)).resolves.toBeUndefined();
-    });
-
-    it('still uses an explicit profile.preferredUsername', async () => {
-      const user = { ...mockUser, profile: { preferredUsername: 'alice_the_great' } };
-      await expect(getPreferredUsername(user)).resolves.toBe('alice_the_great');
-    });
+  it('returns undefined when both username and profile.preferredUsername are unset', async () => {
+    const user = { ...mockUser, username: null };
+    await expect(getPreferredUsername(user)).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/oidc/scope.ts
+++ b/packages/core/src/oidc/scope.ts
@@ -12,7 +12,6 @@ import { cond, pick } from '@silverhand/essentials';
 import { snakeCase } from 'snake-case';
 import { type SnakeCaseKeys } from 'snakecase-keys';
 
-import { EnvSet } from '#src/env-set/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -69,17 +68,9 @@ const isUserProfileClaim = (claim: string): claim is UserProfileClaimSnakeCase =
  * no explicit `profile.preferredUsername`, so standards-compliant clients (e.g. Gitea, Forgejo,
  * Mealie) receive a usable value out of the box. The explicit profile value always wins. Falls back
  * to `undefined` (not `null`) to keep it stripped from tokens, matching the other profile claims.
- * Gated until the feature ships.
  */
-const getPreferredUsername = (user: User): string | undefined => {
-  const explicit = user.profile.preferredUsername;
-
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    return explicit ?? user.username ?? undefined;
-  }
-
-  return explicit ?? undefined;
-};
+const getPreferredUsername = (user: User): string | undefined =>
+  user.profile.preferredUsername ?? user.username ?? undefined;
 
 /**
  * Get user claims data according to the claims.

--- a/packages/core/src/routes-me/user.ts
+++ b/packages/core/src/routes-me/user.ts
@@ -3,7 +3,6 @@ import { userInfoSelectFields, jsonObjectGuard } from '@logto/schemas';
 import { condArray, conditional, pick } from '@silverhand/essentials';
 import { literal, object, string } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayloadFromPassword } from '#src/libraries/user.utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -67,9 +66,7 @@ export default function userRoutes<T extends AuthedMeRouter>(
         await checkVerificationStatus(userId, primaryEmail);
       }
 
-      // Per-tenant policy enforcement is gated until the feature ships; the regex guard above is the
-      // always-on hard floor, so prod behavior is unchanged when the flag is off.
-      if (username !== undefined && EnvSet.values.isDevFeaturesEnabled) {
+      if (username !== undefined) {
         const { usernamePolicy } = await findDefaultSignInExperience();
         assertUsernameAllowed(usernamePolicy, username);
       }

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -11,7 +11,6 @@ import {
 import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayloadFromPassword } from '#src/libraries/user.utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -114,12 +113,8 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
           ]);
           assertUserHasRemainingIdentifier(user, { username: null }, ssoIdentities.length);
         } else {
-          // Per-tenant policy enforcement is gated until the feature ships; the regex guard above
-          // is the always-on hard floor, so prod behavior is unchanged when the flag is off.
-          if (EnvSet.values.isDevFeaturesEnabled) {
-            const { usernamePolicy } = await findDefaultSignInExperience();
-            assertUsernameAllowed(usernamePolicy, username);
-          }
+          const { usernamePolicy } = await findDefaultSignInExperience();
+          assertUsernameAllowed(usernamePolicy, username);
           await checkIdentifierCollision({ username }, userId);
         }
       }

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -7,7 +7,6 @@ import {
 } from '@logto/schemas';
 import { pick, trySafe } from '@silverhand/essentials';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
 import type Libraries from '#src/tenants/Libraries.js';
@@ -157,11 +156,9 @@ export class Profile {
       this.profileValidator.guardProfileNotExistInCurrentUserAccount(user, profile);
     }
 
-    // Per-tenant username policy enforcement is gated until the feature ships. The hard-floor regex
-    // on each entry route stays on regardless, so prod behavior is unchanged when the flag is off.
     // Runs before the uniqueness check so a format/policy violation is reported ahead of
     // "username already in use", matching the account and /me routes.
-    if (EnvSet.values.isDevFeaturesEnabled && profile.username) {
+    if (profile.username) {
       assertUsernameAllowed(
         await this.signInExperienceValidator.getUsernamePolicy(),
         profile.username

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -1086,17 +1086,8 @@ describe('PATCH /sign-in-exp username policy', () => {
       ),
     });
 
-  beforeEach(() => {
-    // The `usernamePolicy` body field (and therefore the 409 guard) is only honored with dev features on.
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet without reloading mocked modules.
-    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-  });
-
   afterEach(() => {
     findCaseConflicts.mockReset();
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
-    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
-      originalIsDevFeaturesEnabled;
   });
 
   it('returns 409 when flipping to case-insensitive while conflicts exist', async () => {

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -162,13 +162,8 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
       // reject the flip while such conflicts exist. Only the actual case-sensitive ->
       // case-insensitive transition needs checking: a tenant that is already case-insensitive
       // cannot have accumulated case conflicts (uniqueness was enforced case-insensitively), so we
-      // skip the (potentially expensive) scan otherwise. The `usernamePolicy` write is itself
-      // dev-gated, so this guard is too.
-      if (
-        EnvSet.values.isDevFeaturesEnabled &&
-        usernamePolicy?.caseSensitive === false &&
-        currentSettings.usernamePolicy.caseSensitive
-      ) {
+      // skip the (potentially expensive) scan otherwise.
+      if (usernamePolicy?.caseSensitive === false && currentSettings.usernamePolicy.caseSensitive) {
         const { totalConflicts, samples } = await findCaseConflicts(20);
         if (totalConflicts > 0) {
           throw new RequestError(
@@ -423,8 +418,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
             passwordExpiration &&
             passwordExpirationToPersist && { passwordExpiration: passwordExpirationToPersist }
         ),
-        // Username policy is gated until the feature ships: ignore writes when the flag is off.
-        ...conditional(EnvSet.values.isDevFeaturesEnabled && usernamePolicy && { usernamePolicy }),
+        ...conditional(usernamePolicy && { usernamePolicy }),
         // Verification code policy is gated until the feature ships.
         ...conditional(
           EnvSet.values.isDevFeaturesEnabled && verificationCodePolicy && { verificationCodePolicy }
@@ -498,10 +492,6 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
 
   customUiAssetsRoutes(...args);
 
-  // Username policy conflict-detection API is gated until the feature ships, so the endpoint is
-  // absent (not just hidden) when dev features are off — keeping prod and its OpenAPI doc clean.
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    usernamePolicyRoutes(...args);
-  }
+  usernamePolicyRoutes(...args);
 }
 /* eslint-enable max-lines */

--- a/packages/core/src/routes/sign-in-experience/username-policy.openapi.json
+++ b/packages/core/src/routes/sign-in-experience/username-policy.openapi.json
@@ -2,7 +2,6 @@
   "paths": {
     "/api/sign-in-exp/username-policy/case-sensitivity-conflicts": {
       "get": {
-        "tags": ["Dev feature"],
         "summary": "Get username case-sensitivity conflicts",
         "description": "List groups of usernames that collide when compared case-insensitively (i.e. usernames that would clash if the tenant switched to a case-insensitive username policy), with the total group count and a capped sample. Useful for surfacing conflicts before disabling case sensitivity.",
         "responses": {

--- a/packages/core/src/routes/sign-in-experience/username-policy.test.ts
+++ b/packages/core/src/routes/sign-in-experience/username-policy.test.ts
@@ -1,25 +1,11 @@
-import { createMockUtils, pickDefault } from '@logto/shared/esm';
+import { pickDefault } from '@logto/shared/esm';
 
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
 const { jest } = import.meta;
-const { mockEsmWithActual } = createMockUtils(jest);
 
 const findCaseConflicts = jest.fn();
-
-// The conflict-detection route is only registered when dev features are enabled, so mock EnvSet
-// with the flag on before importing the routes.
-await mockEsmWithActual('#src/env-set/index.js', () => ({
-  EnvSet: {
-    values: {
-      isDevFeaturesEnabled: true,
-      isCloud: false,
-      isProduction: false,
-      isUnitTest: true,
-    },
-  },
-}));
 
 const signInExperiencesRoutes = await pickDefault(import('./index.js'));
 

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -31,8 +31,6 @@ const devFeatureCustomRoutes: Readonly<RouteDictionary> = Object.freeze({
   'get /configs/oidc/session': 'GetOidcSessionConfig',
   'patch /configs/oidc/session': 'UpdateOidcSessionConfig',
   'patch /users/:userId/password/expiration': 'UpdateUserPasswordExpiration',
-  'get /sign-in-exp/username-policy/case-sensitivity-conflicts':
-    'GetUsernameCaseSensitivityConflicts',
 });
 
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
@@ -91,6 +89,9 @@ export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   'get /.well-known/sign-in-exp': 'GetSignInExperienceConfig',
   // Custom UI assets
   'post /sign-in-exp/default/custom-ui-assets': 'UploadCustomUiAssets',
+  // Username policy
+  'get /sign-in-exp/username-policy/case-sensitivity-conflicts':
+    'GetUsernameCaseSensitivityConflicts',
   // One-time tokens
   'post /one-time-tokens': 'AddOneTimeTokens',
   'post /one-time-tokens/verify': 'VerifyOneTimeToken',

--- a/packages/experience/src/components/IdentifierRegisterForm/index.test.tsx
+++ b/packages/experience/src/components/IdentifierRegisterForm/index.test.tsx
@@ -199,8 +199,7 @@ describe('<IdentifierRegisterForm />', () => {
   });
 
   describe('username policy violations', () => {
-    // Dev features are on under jest (NODE_ENV=test), so the per-tenant policy is enforced. This
-    // verifies the policy flows from the SIE context through the form into the validator. The test
+    // Verifies the policy flows from the SIE context through the form into the validator. The test
     // i18n returns the key, so the requirements sentence surfaces as its frame key.
     const restrictivePolicy: UsernamePolicy = {
       caseSensitive: true,

--- a/packages/experience/src/hooks/use-sie.ts
+++ b/packages/experience/src/hooks/use-sie.ts
@@ -11,7 +11,6 @@ import { useContext, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PageContext from '@/Providers/PageContextProvider/PageContext';
-import { isDevFeaturesEnabled } from '@/constants/env';
 // eslint-disable-next-line unused-imports/no-unused-imports -- type only import
 import type useRequiredProfileErrorHandler from '@/hooks/use-required-profile-error-handler';
 import { buildUsernamePolicyDescription } from '@/shared/utils/username-policy-description';
@@ -180,18 +179,14 @@ export const usePasswordPolicy = () => {
 
 /**
  * The localized username policy requirements hint, or `undefined` when the policy is the permissive
- * default (nothing to surface). Gated by the dev-feature flag until the feature ships. Mirrors
- * {@link usePasswordPolicy}'s `requirementsDescription`.
+ * default (nothing to surface). Mirrors {@link usePasswordPolicy}'s `requirementsDescription`.
  */
 export const useUsernamePolicyDescription = () => {
   const { t } = useTranslation();
   const { experienceSettings } = useContext(PageContext);
 
   return useMemo(
-    () =>
-      isDevFeaturesEnabled
-        ? buildUsernamePolicyDescription(experienceSettings?.usernamePolicy, t)
-        : undefined,
+    () => buildUsernamePolicyDescription(experienceSettings?.usernamePolicy, t),
     [experienceSettings?.usernamePolicy, t]
   );
 };

--- a/packages/experience/src/utils/form.test.ts
+++ b/packages/experience/src/utils/form.test.ts
@@ -1,5 +1,7 @@
 import { SignInIdentifier, type UsernamePolicy } from '@logto/schemas';
 
+import { validateIdentifierField } from './form';
+
 const restrictivePolicy: UsernamePolicy = {
   caseSensitive: true,
   minLength: 4,
@@ -7,113 +9,66 @@ const restrictivePolicy: UsernamePolicy = {
   allowedChars: { lowercase: true, uppercase: false, numbers: false, underscore: false },
 };
 
-/**
- * Re-import `validateIdentifierField` with the dev-feature flag forced on or off. The flag is a
- * build-time constant read at call time inside the validator, so the module must be reloaded to
- * pick up a different value.
- */
-const loadValidateIdentifierField = async (isDevFeaturesEnabled: boolean) => {
-  jest.resetModules();
-  jest.doMock('@/constants/env', () => ({ isDevFeaturesEnabled }));
-  const { validateIdentifierField } = await import('./form');
-  return validateIdentifierField;
-};
+describe('validateIdentifierField username policy', () => {
+  it('enforces the full per-tenant policy with the proper error for each violation', () => {
+    // The hard floor still runs first.
+    expect(validateIdentifierField(SignInIdentifier.Username, '', restrictivePolicy)).toBe(
+      'username_required'
+    );
+    expect(validateIdentifierField(SignInIdentifier.Username, '1abc', restrictivePolicy)).toBe(
+      'username_should_not_start_with_number'
+    );
+    expect(validateIdentifierField(SignInIdentifier.Username, 'ab c', restrictivePolicy)).toBe(
+      'username_invalid_charset'
+    );
 
-describe('validateIdentifierField username policy gating', () => {
-  afterEach(() => {
-    jest.resetModules();
+    // Length violations carry the bound as interpolation data.
+    expect(validateIdentifierField(SignInIdentifier.Username, 'abc', restrictivePolicy)).toEqual({
+      code: 'username_too_short',
+      data: { min: 4 },
+    });
+    expect(
+      validateIdentifierField(SignInIdentifier.Username, 'abcdefghi', restrictivePolicy)
+    ).toEqual({ code: 'username_too_long', data: { max: 8 } });
+
+    // Disallowed character classes.
+    expect(validateIdentifierField(SignInIdentifier.Username, 'abcD', restrictivePolicy)).toBe(
+      'username_uppercase_not_allowed'
+    );
+    expect(validateIdentifierField(SignInIdentifier.Username, 'abc1', restrictivePolicy)).toBe(
+      'username_numbers_not_allowed'
+    );
+    expect(validateIdentifierField(SignInIdentifier.Username, 'ab_c', restrictivePolicy)).toBe(
+      'username_underscore_not_allowed'
+    );
+    // `lowercase_not_allowed` needs a policy that disallows lowercase.
+    const uppercaseOnly: UsernamePolicy = {
+      ...restrictivePolicy,
+      allowedChars: { lowercase: false, uppercase: true, numbers: false, underscore: false },
+    };
+    expect(validateIdentifierField(SignInIdentifier.Username, 'ABCd', uppercaseOnly)).toBe(
+      'username_lowercase_not_allowed'
+    );
+
+    // A username satisfying the policy passes.
+    expect(
+      validateIdentifierField(SignInIdentifier.Username, 'abcd', restrictivePolicy)
+    ).toBeUndefined();
   });
 
-  describe('when dev features are off', () => {
-    it('applies only the hard floor and ignores the per-tenant policy', async () => {
-      const validateIdentifierField = await loadValidateIdentifierField(false);
-
-      // Hard-floor violations are still reported (unchanged from the original code).
-      expect(validateIdentifierField(SignInIdentifier.Username, '', restrictivePolicy)).toBe(
-        'username_required'
-      );
-      expect(validateIdentifierField(SignInIdentifier.Username, '1abc', restrictivePolicy)).toBe(
-        'username_should_not_start_with_number'
-      );
-      expect(validateIdentifierField(SignInIdentifier.Username, 'ab c', restrictivePolicy)).toBe(
-        'username_invalid_charset'
-      );
-
-      // Policy-only violations are NOT reported — behavior is identical to the original hard-floor
-      // validation even though a restrictive policy is supplied.
-      expect(
-        validateIdentifierField(SignInIdentifier.Username, 'ab', restrictivePolicy)
-      ).toBeUndefined();
-      expect(
-        validateIdentifierField(SignInIdentifier.Username, 'abcdefghijk', restrictivePolicy)
-      ).toBeUndefined();
-      expect(
-        validateIdentifierField(SignInIdentifier.Username, 'abcD', restrictivePolicy)
-      ).toBeUndefined();
-      expect(
-        validateIdentifierField(SignInIdentifier.Username, 'ab_c', restrictivePolicy)
-      ).toBeUndefined();
-    });
+  it('applies only the hard floor when no policy is provided', () => {
+    expect(validateIdentifierField(SignInIdentifier.Username, '1abc')).toBe(
+      'username_should_not_start_with_number'
+    );
+    expect(validateIdentifierField(SignInIdentifier.Username, 'ab')).toBeUndefined();
   });
 
-  describe('when dev features are on', () => {
-    it('enforces the full per-tenant policy with the proper error for each violation', async () => {
-      const validateIdentifierField = await loadValidateIdentifierField(true);
-
-      // The hard floor still runs first.
-      expect(validateIdentifierField(SignInIdentifier.Username, '', restrictivePolicy)).toBe(
-        'username_required'
-      );
-      expect(validateIdentifierField(SignInIdentifier.Username, '1abc', restrictivePolicy)).toBe(
-        'username_should_not_start_with_number'
-      );
-      expect(validateIdentifierField(SignInIdentifier.Username, 'ab c', restrictivePolicy)).toBe(
-        'username_invalid_charset'
-      );
-
-      // Length violations carry the bound as interpolation data.
-      expect(validateIdentifierField(SignInIdentifier.Username, 'abc', restrictivePolicy)).toEqual({
-        code: 'username_too_short',
-        data: { min: 4 },
-      });
-      expect(
-        validateIdentifierField(SignInIdentifier.Username, 'abcdefghi', restrictivePolicy)
-      ).toEqual({ code: 'username_too_long', data: { max: 8 } });
-
-      // Disallowed character classes.
-      expect(validateIdentifierField(SignInIdentifier.Username, 'abcD', restrictivePolicy)).toBe(
-        'username_uppercase_not_allowed'
-      );
-      expect(validateIdentifierField(SignInIdentifier.Username, 'abc1', restrictivePolicy)).toBe(
-        'username_numbers_not_allowed'
-      );
-      expect(validateIdentifierField(SignInIdentifier.Username, 'ab_c', restrictivePolicy)).toBe(
-        'username_underscore_not_allowed'
-      );
-      // `lowercase_not_allowed` needs a policy that disallows lowercase.
-      const uppercaseOnly: UsernamePolicy = {
-        ...restrictivePolicy,
-        allowedChars: { lowercase: false, uppercase: true, numbers: false, underscore: false },
-      };
-      expect(validateIdentifierField(SignInIdentifier.Username, 'ABCd', uppercaseOnly)).toBe(
-        'username_lowercase_not_allowed'
-      );
-
-      // A username satisfying the policy passes.
-      expect(
-        validateIdentifierField(SignInIdentifier.Username, 'abcd', restrictivePolicy)
-      ).toBeUndefined();
-    });
-
-    it('does not apply the username policy to email or phone identifiers', async () => {
-      const validateIdentifierField = await loadValidateIdentifierField(true);
-
-      expect(
-        validateIdentifierField(SignInIdentifier.Email, 'foo@logto.io', restrictivePolicy)
-      ).toBeUndefined();
-      expect(validateIdentifierField(SignInIdentifier.Email, 'invalid', restrictivePolicy)).toBe(
-        'invalid_email'
-      );
-    });
+  it('does not apply the username policy to email or phone identifiers', () => {
+    expect(
+      validateIdentifierField(SignInIdentifier.Email, 'foo@logto.io', restrictivePolicy)
+    ).toBeUndefined();
+    expect(validateIdentifierField(SignInIdentifier.Email, 'invalid', restrictivePolicy)).toBe(
+      'invalid_email'
+    );
   });
 });

--- a/packages/experience/src/utils/form.ts
+++ b/packages/experience/src/utils/form.ts
@@ -5,7 +5,6 @@ import i18next from 'i18next';
 import type { TFuncKey } from 'i18next';
 import { ParseError } from 'libphonenumber-js/mobile';
 
-import { isDevFeaturesEnabled } from '@/constants/env';
 import type { ErrorType } from '@/shared/components/ErrorMessage';
 import type { IdentifierInputType } from '@/shared/components/InputFields/SmartInputField';
 import { validateUsername } from '@/shared/utils/validate-username';
@@ -42,9 +41,7 @@ export const validateIdentifierField = (
 ) => {
   switch (type) {
     case SignInIdentifier.Username: {
-      // Per-tenant policy enforcement is gated until the feature ships; without the flag the
-      // always-on hard floor is the only client-side check, matching production behavior.
-      return validateUsername(value, isDevFeaturesEnabled ? usernamePolicy : undefined);
+      return validateUsername(value, usernamePolicy);
     }
 
     case SignInIdentifier.Email: {

--- a/packages/integration-tests/src/tests/api/account.username-case.test.ts
+++ b/packages/integration-tests/src/tests/api/account.username-case.test.ts
@@ -10,7 +10,7 @@ import {
   defaultSignInSignUpConfigs,
   enableAllPasswordSignInMethods,
 } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateUsername } from '#src/utils.js';
+import { generateUsername } from '#src/utils.js';
 
 // Restore a known baseline so this suite does not leak its sign-in or username-policy changes.
 const resetSignInExperience = async () =>
@@ -41,9 +41,7 @@ describe('account API username case sensitivity', () => {
   });
 });
 
-// Gated to dev features: the sign-in experience write path drops `usernamePolicy` unless dev
-// features are enabled, so case-insensitivity can only be configured (and exercised) here.
-devFeatureTest.describe('account API username case sensitivity (case-insensitive policy)', () => {
+describe('account API username case sensitivity (case-insensitive policy)', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
     await enableAllAccountCenterFields();

--- a/packages/integration-tests/src/tests/api/account.username-policy.test.ts
+++ b/packages/integration-tests/src/tests/api/account.username-policy.test.ts
@@ -10,7 +10,7 @@ import {
   defaultSignInSignUpConfigs,
   enableAllPasswordSignInMethods,
 } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateUsername } from '#src/utils.js';
+import { generateUsername } from '#src/utils.js';
 
 const uppercaseUsername = () => `A${generateUsername()}`;
 
@@ -19,8 +19,7 @@ const uppercaseDisabledPolicy = {
   allowedChars: { lowercase: true, uppercase: false, numbers: true, underscore: true },
 };
 
-// Dev-gated: policy enforcement only activates under dev features.
-devFeatureTest.describe('account API username policy enforcement', () => {
+describe('account API username policy enforcement', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
     await enableAllAccountCenterFields();

--- a/packages/integration-tests/src/tests/api/admin-user.username-case.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.username-case.test.ts
@@ -3,7 +3,7 @@ import { type User } from '@logto/schemas';
 
 import { authedAdminApi, deleteUser, updateSignInExperience, updateUser } from '#src/api/index.js';
 import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
-import { devFeatureTest, generateUsername } from '#src/utils.js';
+import { generateUsername } from '#src/utils.js';
 
 const getUsers = async <T>(
   init: string[][] | Record<string, string> | URLSearchParams
@@ -50,52 +50,57 @@ describe('admin console user management (username case sensitive)', () => {
   });
 });
 
-// Gated to dev features: the sign-in experience write path drops `usernamePolicy` unless dev
-// features are enabled, so the policy can only be configured (and exercised) here.
-devFeatureTest.describe(
-  'admin console user management (configurable username case sensitivity)',
-  () => {
-    const username = generateUsername();
+describe('admin console user management (configurable username case sensitivity)', () => {
+  const username = generateUsername();
 
-    afterAll(async () => {
-      await updateSignInExperience({ usernamePolicy: defaultUsernamePolicy });
-    });
+  afterAll(async () => {
+    await updateSignInExperience({ usernamePolicy: defaultUsernamePolicy });
+  });
 
-    it('should keep usernames case-sensitive when the policy enables it', async () => {
-      await updateSignInExperience({
-        usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: true },
-      });
-      const user = await createUserByAdmin({ username: username.toLowerCase() });
-      const user2 = await createUserByAdmin({ username: username.toUpperCase() });
-      await deleteUser(user.id);
-      await deleteUser(user2.id);
+  it('should keep usernames case-sensitive when the policy enables it', async () => {
+    await updateSignInExperience({
+      usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: true },
     });
+    const user = await createUserByAdmin({ username: username.toLowerCase() });
+    const user2 = await createUserByAdmin({ username: username.toUpperCase() });
+    await deleteUser(user.id);
+    await deleteUser(user2.id);
+  });
 
-    it('should reject a username that differs only by case when the policy is case-insensitive', async () => {
-      await updateSignInExperience({
-        usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
-      });
-      const user = await createUserByAdmin({ username: username.toLowerCase() });
-      await expectRejects(createUserByAdmin({ username: username.toUpperCase() }), {
-        code: 'user.username_already_in_use',
-        status: 422,
-      });
-      await deleteUser(user.id);
+  it('should reject a username that differs only by case when the policy is case-insensitive', async () => {
+    await updateSignInExperience({
+      usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
     });
+    const user = await createUserByAdmin({ username: username.toLowerCase() });
+    await expectRejects(createUserByAdmin({ username: username.toUpperCase() }), {
+      code: 'user.username_already_in_use',
+      status: 422,
+    });
+    await deleteUser(user.id);
+  });
 
-    it('should reject updating a username to differ only by case when case-insensitive', async () => {
-      await updateSignInExperience({
-        usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
-      });
-      const base = generateUsername();
-      const user = await createUserByAdmin({ username: base.toLowerCase() });
-      const user2 = await createUserByAdmin();
-      await expectRejects(updateUser(user2.id, { username: base.toUpperCase() }), {
-        code: 'user.username_already_in_use',
-        status: 422,
-      });
-      await deleteUser(user.id);
-      await deleteUser(user2.id);
+  it('should reject updating a username to differ only by case when case-insensitive', async () => {
+    await updateSignInExperience({
+      usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
     });
-  }
-);
+    const base = generateUsername();
+    const user = await createUserByAdmin({ username: base.toLowerCase() });
+    const user2 = await createUserByAdmin();
+    await expectRejects(updateUser(user2.id, { username: base.toUpperCase() }), {
+      code: 'user.username_already_in_use',
+      status: 422,
+    });
+    await deleteUser(user.id);
+    await deleteUser(user2.id);
+  });
+
+  it('should bypass the policy length limits when creating a user via the admin API', async () => {
+    // Admin writes are hard-floor-only by design: a username shorter than the policy minimum is
+    // accepted here, while end-user write paths reject it.
+    await updateSignInExperience({
+      usernamePolicy: { ...defaultUsernamePolicy, minLength: 64 },
+    });
+    const user = await createUserByAdmin({ username: generateUsername() });
+    await deleteUser(user.id);
+  });
+});

--- a/packages/integration-tests/src/tests/api/experience-api/username-case.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/username-case.test.ts
@@ -13,7 +13,7 @@ import {
   resetMfaSettings,
   resetPasswordPolicy,
 } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateUsername, generatePassword } from '#src/utils.js';
+import { generateUsername, generatePassword } from '#src/utils.js';
 
 const password = generatePassword();
 
@@ -77,57 +77,52 @@ describe('experience API username case sensitivity', () => {
   });
 });
 
-// Gated to dev features: the sign-in experience write path drops `usernamePolicy` unless dev
-// features are enabled, so case-insensitivity can only be configured (and exercised) here.
-devFeatureTest.describe(
-  'experience API username case sensitivity (case-insensitive policy)',
-  () => {
-    beforeAll(async () => {
-      await enableUsernameAuth();
-      await updateSignInExperience({
-        usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
-      });
+describe('experience API username case sensitivity (case-insensitive policy)', () => {
+  beforeAll(async () => {
+    await enableUsernameAuth();
+    await updateSignInExperience({
+      usernamePolicy: { ...defaultUsernamePolicy, caseSensitive: false },
+    });
+  });
+
+  afterAll(async () => {
+    await resetSignInExperience();
+  });
+
+  it('registration: rejects a username that differs only by case', async () => {
+    const base = generateUsername();
+    const lowerId = await registerNewUserUsernamePassword(base.toLowerCase(), password);
+
+    await expectRejects(registerNewUserUsernamePassword(base.toUpperCase(), password), {
+      code: 'user.username_already_in_use',
+      status: 422,
     });
 
-    afterAll(async () => {
-      await resetSignInExperience();
+    await deleteUser(lowerId);
+  });
+
+  it('sign-in: a username that differs only by case matches the existing user', async () => {
+    const base = generateUsername();
+    const user = await createUserByAdmin({ username: base.toLowerCase(), password });
+
+    await signInWithPassword({
+      identifier: { type: SignInIdentifier.Username, value: base.toUpperCase() },
+      password,
     });
 
-    it('registration: rejects a username that differs only by case', async () => {
-      const base = generateUsername();
-      const lowerId = await registerNewUserUsernamePassword(base.toLowerCase(), password);
+    await deleteUser(user.id);
+  });
 
-      await expectRejects(registerNewUserUsernamePassword(base.toUpperCase(), password), {
-        code: 'user.username_already_in_use',
-        status: 422,
-      });
+  it('profile update: rejects staging a username that differs only by case', async () => {
+    const base = generateUsername();
+    const other = await createUserByAdmin({ username: base.toLowerCase() });
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
 
-      await deleteUser(lowerId);
-    });
+    await expectRejects(
+      client.updateProfile({ type: SignInIdentifier.Username, value: base.toUpperCase() }),
+      { code: 'user.username_already_in_use', status: 422 }
+    );
 
-    it('sign-in: a username that differs only by case matches the existing user', async () => {
-      const base = generateUsername();
-      const user = await createUserByAdmin({ username: base.toLowerCase(), password });
-
-      await signInWithPassword({
-        identifier: { type: SignInIdentifier.Username, value: base.toUpperCase() },
-        password,
-      });
-
-      await deleteUser(user.id);
-    });
-
-    it('profile update: rejects staging a username that differs only by case', async () => {
-      const base = generateUsername();
-      const other = await createUserByAdmin({ username: base.toLowerCase() });
-      const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
-
-      await expectRejects(
-        client.updateProfile({ type: SignInIdentifier.Username, value: base.toUpperCase() }),
-        { code: 'user.username_already_in_use', status: 422 }
-      );
-
-      await deleteUser(other.id);
-    });
-  }
-);
+    await deleteUser(other.id);
+  });
+});

--- a/packages/integration-tests/src/tests/api/experience-api/username-policy.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/username-policy.test.ts
@@ -10,7 +10,7 @@ import {
   resetMfaSettings,
   resetPasswordPolicy,
 } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateUsername, generatePassword } from '#src/utils.js';
+import { generateUsername, generatePassword } from '#src/utils.js';
 
 const password = generatePassword();
 
@@ -23,9 +23,7 @@ const uppercaseDisabledPolicy = {
   allowedChars: { lowercase: true, uppercase: false, numbers: true, underscore: true },
 };
 
-// Dev-gated: policy enforcement only activates under dev features, and the policy can only be
-// written to the sign-in experience when dev features are enabled.
-devFeatureTest.describe('experience API username policy enforcement', () => {
+describe('experience API username policy enforcement', () => {
   beforeAll(async () => {
     await updateSignInExperience({ ...defaultSignInSignUpConfigs, passwordPolicy: {} });
     await resetMfaSettings();

--- a/packages/integration-tests/src/tests/api/oidc/id-token.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/id-token.test.ts
@@ -1,7 +1,7 @@
 import { Prompt } from '@logto/node';
 import { demoAppApplicationId } from '@logto/schemas';
 
-import { assignRolesToUser, putRolesToUser } from '#src/api/index.js';
+import { assignRolesToUser, putRolesToUser, updateUser } from '#src/api/index.js';
 import { createRole } from '#src/api/role.js';
 import { demoAppRedirectUri } from '#src/constants.js';
 import { initExperienceClient, processSession } from '#src/helpers/client.js';
@@ -91,5 +91,15 @@ describe('OpenID Connect ID token', () => {
 
     expect(organizationRoles).toHaveLength(1);
     expect(organizationRoles).toContainEqual(`${org1.id}:${role.name}`);
+  });
+
+  it('should mirror `preferred_username` from the username when `profile.preferredUsername` is unset', async () => {
+    await fetchIdToken(['profile'], { preferred_username: username });
+  });
+
+  // Mutates the shared user's profile, so it runs last.
+  it('should prefer an explicit `profile.preferredUsername` over the mirrored username', async () => {
+    await updateUser(userId, { profile: { preferredUsername: `${username}_preferred` } });
+    await fetchIdToken(['profile'], { preferred_username: `${username}_preferred` });
   });
 });

--- a/packages/integration-tests/src/tests/api/sign-in-experience.username-policy.test.ts
+++ b/packages/integration-tests/src/tests/api/sign-in-experience.username-policy.test.ts
@@ -6,10 +6,9 @@ import {
   updateSignInExperience,
 } from '#src/api/index.js';
 import { createUserByAdmin, expectRejects } from '#src/helpers/index.js';
-import { devFeatureTest, generateUsername } from '#src/utils.js';
+import { generateUsername } from '#src/utils.js';
 
-// Dev-gated: the conflict-detection endpoint is only registered when dev features are enabled.
-devFeatureTest.describe('GET /sign-in-exp/username-policy/case-sensitivity-conflicts', () => {
+describe('GET /sign-in-exp/username-policy/case-sensitivity-conflicts', () => {
   it('reports usernames that collide case-insensitively', async () => {
     const base = generateUsername();
     const { totalConflicts: before } = await getUsernameCaseSensitivityConflicts(100);
@@ -31,9 +30,7 @@ devFeatureTest.describe('GET /sign-in-exp/username-policy/case-sensitivity-confl
   });
 });
 
-// Dev-gated: the PATCH `usernamePolicy` body field and the 409 guard only activate under dev
-// features (the write path strips `usernamePolicy` otherwise).
-devFeatureTest.describe('PATCH /sign-in-exp case-sensitivity conflict guard', () => {
+describe('PATCH /sign-in-exp case-sensitivity conflict guard', () => {
   afterAll(async () => {
     await updateSignInExperience({ usernamePolicy: defaultUsernamePolicy });
   });

--- a/packages/integration-tests/src/tests/console/sign-in-experience/username-policy.test.ts
+++ b/packages/integration-tests/src/tests/console/sign-in-experience/username-policy.test.ts
@@ -11,7 +11,7 @@ import {
   goToAdminConsole,
   waitForToast,
 } from '#src/ui-helpers/index.js';
-import { appendPathname, devFeatureTest, expectNavigation, generateUsername } from '#src/utils.js';
+import { appendPathname, expectNavigation, generateUsername } from '#src/utils.js';
 
 await page.setViewport({ width: 1920, height: 1080 });
 
@@ -50,9 +50,7 @@ const setLengthInput = async (input: ElementHandle<HTMLInputElement>, value: str
   await input.type(value);
 };
 
-// The username policy card is gated behind `isDevFeaturesEnabled` in the console, so these tests
-// only run when dev features are on (matching when the card is rendered).
-devFeatureTest.describe('sign-in experience (username policy)', () => {
+describe('sign-in experience (username policy)', () => {
   beforeAll(async () => {
     await goToAdminConsole();
     await goToSignUpAndSignInTab();


### PR DESCRIPTION
## Summary
P9 of the username policy plan (LOG-13529): removes every dev-feature gate added across P1–P8.6, making the feature live in production builds.

Closes #6410, closes #6971.

### What changed

**Dev-feature gate removal (11 sites)**
- **core**: `usernamePolicy` PATCH body acceptance, the 409 case-sensitivity conflict guard, and the conflict-detection route registration in `routes/sign-in-experience/index.ts`; policy enforcement in `routes-me/user.ts`, `routes/account/index.ts`, and `routes/experience/classes/profile.ts`; the `preferred_username` mirror in `oidc/scope.ts`.
- **console**: `UsernamePolicy` field mount in Advanced options.
- **experience**: `validateIdentifierField` policy gate and `useUsernamePolicyDescription`.
- **account**: client validation and the policy-aware page description on the Username page.
- **OpenAPI**: removed the `Dev feature` tag from `username-policy.openapi.json` so the conflicts endpoint appears in the published API docs.

**Tests**
- New integration tests: ID-token `preferred_username` mirrors `username` when `profile.preferredUsername` is unset (and the explicit value wins); admin user create bypasses policy length limits (hard-floor-only by design).
- Flipped `devFeatureTest.describe` → `describe` in the 7 existing username-policy/-case integration test files so non-dev CI keeps the coverage.
- Removed flag-driven unit tests and flag plumbing (core `oidc/scope.test`, SIE route tests, experience `form.test` module-reload harness, account Username flag-off tests).

**Changesets** — three scoped entries:
- `username-policy-core.md`: `@logto/core`/`@logto/schemas` minor, `@logto/shared` patch (deprecation annotation only).
- `username-policy-console.md`: `@logto/console`/`@logto/phrases` minor.
- `username-policy-client.md`: `@logto/experience`/`@logto/account`/`@logto/phrases-experience` minor.
- `@logto/core-kit` is intentionally absent — already covered by the pending `username-policy-core-kit` and `username-policy-validator` changesets from P1/P2.

### Expected result
Production behavior changes (the public switch flip):
1. `preferred_username` falls back to `user.username` (resolves #6410, #6971).
2. The console username policy field under Advanced options becomes visible; the conflicts endpoint appears in API docs.
3. `PATCH /api/sign-in-exp` accepts `usernamePolicy`; end-user/experience/account-center username writes enforce it; policy-aware descriptions and errors show in the experience and account center UIs.

### Reviewer notes
- `grep -rn isDevFeaturesEnabled packages/{core,experience,console,account}/src` filtered by username/policy/preferredUsername returns 0 hits; remaining flags in touched files (password expiration, geo context) belong to other features and are untouched.
- Integration tests are written but require the running stack — relying on CI for `pnpm test:integration`.

## Testing
Unit tests, integration tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
