### PR TITLE
fix(core): reject null bytes in oidc request body

### DIFF
--- a/.changeset/reject-null-bytes-in-oidc-request-body.md
+++ b/.changeset/reject-null-bytes-in-oidc-request-body.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": patch
+---
+
+reject null bytes in OIDC request bodies and strip them from audit logs so malformed input returns a clean 400 instead of a 500
+
+A null byte (`U+0000`) in an `application/x-www-form-urlencoded` body sent to `/oidc/token` previously surfaced as a `500 Internal Server Error`. The actual cause was the audit log insert: PostgreSQL rejects null bytes in `jsonb` (error `22P05`), and because the insert runs in a `finally` block, that failure masked the original clean error. The OIDC body parser now rejects null bytes with a `400 invalid_request`, and audit log payloads are sanitized of null bytes before insert as defense in depth.
+
+Closes #8990.

--- a/packages/core/src/middleware/koa-audit-log.test.ts
+++ b/packages/core/src/middleware/koa-audit-log.test.ts
@@ -270,6 +270,37 @@ describe('koaAuditLog middleware', () => {
     });
   });
 
+  it('should strip null characters so the payload is safe to store as jsonb', async () => {
+    const ctx: TestContext = createTestContext({ 'user-agent': userAgent });
+    ctx.request.ip = ip;
+
+    const next = async () => {
+      const log = ctx.createLog(logKey);
+      const nul = String.fromCodePoint(0);
+      log.append({
+        params: {
+          grant_type: `authorization_code${nul}`,
+          nested: [`a${nul}b`],
+          [`field${nul}name`]: 'value',
+        },
+      });
+    };
+    await koaLog(queries)(ctx, next);
+
+    expect(insertLog).toBeCalledWith({
+      id: mockId,
+      key: logKey,
+      payload: {
+        params: { grant_type: 'authorization_code', nested: ['ab'], fieldname: 'value' },
+        key: logKey,
+        result: LogResult.Success,
+        ip,
+        userAgent,
+        userAgentParsed,
+      },
+    });
+  });
+
   describe('should insert an error log with the error message when next() throws an error', () => {
     it('should log with error message when next throws a normal Error', async () => {
       const ctx: TestContext = createTestContext({ 'user-agent': userAgent });

--- a/packages/core/src/middleware/koa-audit-log.ts
+++ b/packages/core/src/middleware/koa-audit-log.ts
@@ -31,6 +31,38 @@ const sanitise = (value: unknown): unknown => {
   return value;
 };
 
+/**
+ * Recursively strip null characters (U+0000) from every string in the value. PostgreSQL rejects
+ * null bytes in `jsonb` (error code `22P05`), so leaving them in would make `insertLog` throw. Since
+ * logs are inserted in a `finally` block, that throw would replace the original response with a 500.
+ */
+const nullCharacter = String.fromCodePoint(0);
+
+const stripFromString = (value: string): string =>
+  value.includes(nullCharacter) ? value.replaceAll(nullCharacter, '') : value;
+
+const stripNullCharacters = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    return stripFromString(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((element) => stripNullCharacters(element));
+  }
+
+  if (isRecord(value)) {
+    // Strip from keys as well: PostgreSQL rejects null bytes anywhere in `jsonb`, keys included.
+    return Object.fromEntries(
+      Object.entries(value).map(([key, element]) => [
+        stripFromString(key),
+        stripNullCharacters(element),
+      ])
+    );
+  }
+
+  return value;
+};
+
 const filterSensitiveData = (data: Record<string, unknown>): Record<string, unknown> => {
   return Object.fromEntries(
     Object.entries(data).map(([key, value]) => {
@@ -187,10 +219,12 @@ export default function koaAuditLog<StateT, ContextT extends IRouterParamContext
 
       await Promise.all(
         entries.map(async ({ payload }) => {
+          const fullPayload = { ...basePayload, ...payload };
           return insertLog({
             id: generateStandardId(),
             key: payload.key,
-            payload: { ...basePayload, ...payload },
+            // eslint-disable-next-line no-restricted-syntax -- structural identity transform preserves the payload shape
+            payload: stripNullCharacters(fullPayload) as typeof fullPayload,
           });
         })
       );

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -483,6 +483,7 @@ export default function initOidc(
   oidc.use(async (ctx, next) => {
     const jsonContentType = 'application/json';
     const formUrlEncodedContentType = 'application/x-www-form-urlencoded';
+    const nullByte = String.fromCodePoint(0);
 
     // Replicate the behavior of `oidc-provider` for parsing the request body
     if (ctx.req.readable) {
@@ -496,6 +497,13 @@ export default function initOidc(
         limit: '56kb',
         encoding: charset ?? 'utf8',
       });
+
+      // Reject null bytes: they are invalid in request bodies and, once parsed, a value can reach
+      // the `jsonb` audit log column, which PostgreSQL rejects (error `22P05`) and surfaces as a 500
+      // instead of a clean client error. `InvalidRequest` is rendered as a 400 by `koaOidcErrorHandler`.
+      if (body.includes(nullByte)) {
+        throw new errors.InvalidRequest('null bytes are not allowed in the request body');
+      }
 
       // WARNING: [Registration actions](https://github.com/panva/node-oidc-provider/blob/6a0bcbcd35ed3e6179e81f0ab97a45f5e4e58f48/lib/actions/registration.js#L4) are using
       // 'application/json' for body parsing. Update relatively when we enable that feature.

--- a/packages/integration-tests/src/tests/api/oidc/content-type-json.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/content-type-json.test.ts
@@ -75,6 +75,32 @@ describe('content-type: application/json compatibility', () => {
     );
   });
 
+  it('rejects a null byte in the request body with a 400 instead of a 500', async () => {
+    const nullByte = String.fromCodePoint(0);
+    await trySafe(
+      api
+        .post('token', {
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+          body: `grant_type=authorization_code${nullByte}&client_id=test&code=test`,
+        })
+        .json(),
+      async (error) => {
+        if (!(error instanceof HTTPError)) {
+          throw new TypeError('Error is not a HTTPError instance.');
+        }
+
+        // The null byte must be rejected cleanly, not surface as a 500.
+        expect(error.response.status).toBe(400);
+        expect(await error.response.json()).toHaveProperty(
+          'error_description',
+          'null bytes are not allowed in the request body'
+        );
+      }
+    );
+  });
+
   it('should be ok when `content-type` is json for GET requests', async () => {
     await expect(
       api.get('.well-known/openid-configuration', {


### PR DESCRIPTION
## Summary

Closes #8990.

A null byte (`U+0000`) in an `application/x-www-form-urlencoded` body sent to `/oidc/token` returned a `500 Internal Server Error` instead of a clean client error. The root cause was not oidc-provider: it throws a clean error, but the `grant.error` listener records the request `params` (including the null byte) in the audit log, and `koaAuditLog` inserts that payload in a `finally` block. PostgreSQL rejects null bytes in `jsonb` (error `22P05`), so the insert throws and \*replaces\* the original clean error, surfacing as a 500.

### What changed
- `oidc/init.ts`: the OIDC body parser now rejects a request body containing a null byte with `errors.InvalidRequest`, rendered as a `400 invalid_request` by `koaOidcErrorHandler`.
- `koa-audit-log.ts`: audit log payloads are stripped of null characters before `insertLog` (defense in depth — guarantees no logged value can turn a request into a 500, on any route).

### Expected result
- `POST /oidc/token` with a null byte in the body now returns `400 invalid_request` ("null bytes are not allowed in the request body") instead of `500`.
- Behavior is unchanged for well-formed requests.

## Testing
Unit tests, integration tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments