### PR TITLE
feat(experience,account): add CSS html[data-theme] selectors for theme flash fix

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -71,6 +71,7 @@ import { useAuthRedirect } from './use-auth-redirect';
 import { accountCenterBasePath, handleAccountCenterRoute } from './utils/account-center-route';
 import { hasVisibleSecuritySection, hasVisibleSessionsPage } from './utils/security-page';
 import '@experience/shared/scss/normalized.scss';
+import './scss/normalized.scss';
 
 handleAccountCenterRoute();
 void initI18n();

--- a/packages/account/src/scss/normalized.scss
+++ b/packages/account/src/scss/normalized.scss
@@ -1,13 +1,3 @@
-@use '@experience/shared/scss/colors' as colors;
-
-html[data-theme='light'] body {
-  @include colors.light;
-}
-
-html[data-theme='dark'] body {
-  @include colors.dark;
-}
-
 html[data-theme] body {
   background: var(--color-bg-float-base);
 }

--- a/packages/account/src/scss/normalized.scss
+++ b/packages/account/src/scss/normalized.scss
@@ -1,0 +1,13 @@
+@use '@experience/shared/scss/colors' as colors;
+
+html[data-theme='light'] body {
+  @include colors.light;
+}
+
+html[data-theme='dark'] body {
+  @include colors.dark;
+}
+
+html[data-theme] body {
+  background: var(--color-bg-float-base);
+}

--- a/packages/experience/src/shared/scss/normalized.scss
+++ b/packages/experience/src/shared/scss/normalized.scss
@@ -15,6 +15,18 @@ body {
   font: var(--font-body-2);
 }
 
+html[data-theme='light'] body {
+  @include colors.light;
+}
+
+html[data-theme='dark'] body {
+  @include colors.dark;
+}
+
+html[data-theme] body {
+  background: var(--color-bg-body);
+}
+
 * {
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;

--- a/packages/experience/src/shared/scss/normalized.scss
+++ b/packages/experience/src/shared/scss/normalized.scss
@@ -23,7 +23,7 @@ html[data-theme='dark'] body {
   @include colors.dark;
 }
 
-html[data-theme] body {
+html[data-theme] body:not(.desktop) {
   background: var(--color-bg-body);
 }
 


### PR DESCRIPTION
## Summary

Add parallel CSS selectors using `html[data-theme]` to apply color variables in both the experience and account packages. This provides a plain-attribute-based CSS path that a future inline blocking script (Layer 2) can leverage to set the theme before React hydrates, eliminating the flash of unstyled/wrong-theme content.

**Experience** (`normalized.scss`): `html[data-theme='light'] body` / `html[data-theme='dark'] body` include the `colors.light` / `colors.dark` mixins, plus `html[data-theme] body { background: var(--color-bg-body) }`.

**Account**: New `src/scss/normalized.scss` with the same `data-theme` selectors but using `var(--color-bg-float-base)` for background (matching the account center's body background). Imported in `App.tsx` after the experience normalized import so the account background override takes precedence.

The CSS is inert unless `data-theme` is set on `<html>`, which will be gated in Layer 2.

### Testing
N/A

Link to Devin session: https://app.devin.ai/sessions/9f831370071b4935a6e94db5108fa989
Requested by: @wangsijie