### PR TITLE
feat(experience,account): add inline blocking script for theme flash fix

### DIFF
--- a/packages/account/index.html
+++ b/packages/account/index.html
@@ -13,6 +13,8 @@
 
 <body>
   <script>
+    // Keep this blocking script in the HTML so the theme, platform class, and brand color
+    // are applied before React loads and the browser has a chance to paint the wrong UI.
     (function () {
       try {
         var ssr = window.logtoSsr;

--- a/packages/account/index.html
+++ b/packages/account/index.html
@@ -12,6 +12,31 @@
 </head>
 
 <body>
+  <script>
+    (function () {
+      try {
+        var ssr = window.logtoSsr;
+        var darkOk = typeof ssr === 'object' && ssr !== null
+          && ssr.signInExperience && ssr.signInExperience.data
+          && ssr.signInExperience.data.color.isDarkModeEnabled;
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = (darkOk && prefersDark) ? 'dark' : 'light';
+        document.documentElement.setAttribute('data-theme', theme);
+        document.body.classList.add(
+          /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop');
+        if (typeof ssr === 'object' && ssr !== null && ssr.signInExperience
+          && ssr.signInExperience.data && ssr.signInExperience.data.color) {
+          var color = ssr.signInExperience.data.color;
+          var primaryColor = theme === 'dark' && color.darkPrimaryColor
+            ? color.darkPrimaryColor
+            : color.primaryColor;
+          if (primaryColor) {
+            document.body.style.setProperty('--color-brand-default', primaryColor);
+          }
+        }
+      } catch (e) { /* noop */ }
+    })();
+  </script>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="app"></div>
   <script type="module">

--- a/packages/account/index.html
+++ b/packages/account/index.html
@@ -18,8 +18,11 @@
     (function () {
       var theme = 'light';
       document.documentElement.setAttribute('data-theme', theme);
-      document.body.classList.add(
-        /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop');
+      var isMobile = navigator.userAgentData
+        ? navigator.userAgentData.mobile
+        : /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+          || (/Macintosh/i.test(navigator.userAgent) && navigator.maxTouchPoints > 1);
+      document.body.classList.add(isMobile ? 'mobile' : 'desktop');
 
       try {
         var ssr = window.logtoSsr;

--- a/packages/account/index.html
+++ b/packages/account/index.html
@@ -16,16 +16,20 @@
     // Keep this blocking script in the HTML so the theme, platform class, and brand color
     // are applied before React loads and the browser has a chance to paint the wrong UI.
     (function () {
+      var theme = 'light';
+      document.documentElement.setAttribute('data-theme', theme);
+      document.body.classList.add(
+        /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop');
+
       try {
         var ssr = window.logtoSsr;
         var darkOk = typeof ssr === 'object' && ssr !== null
           && ssr.signInExperience && ssr.signInExperience.data
           && ssr.signInExperience.data.color.isDarkModeEnabled;
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        var theme = (darkOk && prefersDark) ? 'dark' : 'light';
+        var prefersDark = typeof window.matchMedia === 'function'
+          && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        theme = (darkOk && prefersDark) ? 'dark' : 'light';
         document.documentElement.setAttribute('data-theme', theme);
-        document.body.classList.add(
-          /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop');
         if (typeof ssr === 'object' && ssr !== null && ssr.signInExperience
           && ssr.signInExperience.data && ssr.signInExperience.data.color) {
           var color = ssr.signInExperience.data.color;

--- a/packages/account/src/Providers/PageContextProvider/index.tsx
+++ b/packages/account/src/Providers/PageContextProvider/index.tsx
@@ -1,7 +1,6 @@
 import { useLogto } from '@logto/react';
 import { Theme } from '@logto/schemas';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { isMobile } from 'react-device-detect';
 
 import { getAccountCenterSettings } from '@ac/apis/account-center';
 import { getSignInExperienceSettings } from '@ac/apis/sign-in-experience';
@@ -24,10 +23,21 @@ type Props = {
   readonly children: React.ReactNode;
 };
 
+const getInitialTheme = () => {
+  if (document.documentElement.dataset.theme === Theme.Dark) {
+    return Theme.Dark;
+  }
+
+  return Theme.Light;
+};
+
+const getInitialPlatform = (): PageContextType['platform'] =>
+  document.body.classList.contains('mobile') ? 'mobile' : 'web';
+
 const PageContextProvider = ({ children }: Props) => {
   const { isAuthenticated } = useLogto();
   const getUserInfoRequest = useApi(getUserInfo, { silent: true });
-  const [theme, setTheme] = useState(getThemeBySystemPreference);
+  const [theme, setTheme] = useState(getInitialTheme);
   const [toast, setToast] = useState('');
   const [experienceSettings, setExperienceSettings] =
     useState<PageContextType['experienceSettings']>(undefined);
@@ -199,7 +209,7 @@ const PageContextProvider = ({ children }: Props) => {
     };
   }, [experienceSettings]);
 
-  const platform = isMobile ? 'mobile' : 'web';
+  const platform = getInitialPlatform();
 
   const value = useMemo<PageContextType>(
     () => ({

--- a/packages/experience/index.html
+++ b/packages/experience/index.html
@@ -17,16 +17,20 @@
     // Keep this blocking script in the HTML so the theme, platform class, and brand color
     // are applied before React loads and the browser has a chance to paint the wrong UI.
     (function () {
+      var theme = 'light';
+      document.documentElement.setAttribute('data-theme', theme);
+      document.body.classList.add(
+        /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop');
+
       try {
         var ssr = window.logtoSsr;
         var darkOk = typeof ssr === 'object' && ssr !== null
           && ssr.signInExperience && ssr.signInExperience.data
           && ssr.signInExperience.data.color.isDarkModeEnabled;
-        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        var theme = (darkOk && prefersDark) ? 'dark' : 'light';
+        var prefersDark = typeof window.matchMedia === 'function'
+          && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        theme = (darkOk && prefersDark) ? 'dark' : 'light';
         document.documentElement.setAttribute('data-theme', theme);
-        document.body.classList.add(
-          /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop');
         if (typeof ssr === 'object' && ssr !== null && ssr.signInExperience
           && ssr.signInExperience.data && ssr.signInExperience.data.color) {
           var color = ssr.signInExperience.data.color;

--- a/packages/experience/index.html
+++ b/packages/experience/index.html
@@ -14,6 +14,8 @@
 
 <body>
   <script>
+    // Keep this blocking script in the HTML so the theme, platform class, and brand color
+    // are applied before React loads and the browser has a chance to paint the wrong UI.
     (function () {
       try {
         var ssr = window.logtoSsr;

--- a/packages/experience/index.html
+++ b/packages/experience/index.html
@@ -13,6 +13,31 @@
 </head>
 
 <body>
+  <script>
+    (function () {
+      try {
+        var ssr = window.logtoSsr;
+        var darkOk = typeof ssr === 'object' && ssr !== null
+          && ssr.signInExperience && ssr.signInExperience.data
+          && ssr.signInExperience.data.color.isDarkModeEnabled;
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = (darkOk && prefersDark) ? 'dark' : 'light';
+        document.documentElement.setAttribute('data-theme', theme);
+        document.body.classList.add(
+          /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop');
+        if (typeof ssr === 'object' && ssr !== null && ssr.signInExperience
+          && ssr.signInExperience.data && ssr.signInExperience.data.color) {
+          var color = ssr.signInExperience.data.color;
+          var primaryColor = theme === 'dark' && color.darkPrimaryColor
+            ? color.darkPrimaryColor
+            : color.primaryColor;
+          if (primaryColor) {
+            document.body.style.setProperty('--color-brand-default', primaryColor);
+          }
+        }
+      } catch (e) { /* noop */ }
+    })();
+  </script>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="app"></div>
   <script type="module" src="src/index.tsx"></script>

--- a/packages/experience/index.html
+++ b/packages/experience/index.html
@@ -19,8 +19,11 @@
     (function () {
       var theme = 'light';
       document.documentElement.setAttribute('data-theme', theme);
-      document.body.classList.add(
-        /Mobi|Android/i.test(navigator.userAgent) ? 'mobile' : 'desktop');
+      var isMobile = navigator.userAgentData
+        ? navigator.userAgentData.mobile
+        : /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent)
+          || (/Macintosh/i.test(navigator.userAgent) && navigator.maxTouchPoints > 1);
+      document.body.classList.add(isMobile ? 'mobile' : 'desktop');
 
       try {
         var ssr = window.logtoSsr;

--- a/packages/experience/src/Providers/PageContextProvider/index.tsx
+++ b/packages/experience/src/Providers/PageContextProvider/index.tsx
@@ -41,9 +41,7 @@ const PageContextProvider = ({ children, preset }: Props) => {
   const [toast, setToast] = useState(preset?.toast ?? '');
   const [theme, setTheme] = useState<Theme>(preset?.theme ?? getInitialTheme);
 
-  const [platform, setPlatform] = useState<Platform>(
-    preset?.platform ?? getInitialPlatform
-  );
+  const [platform, setPlatform] = useState<Platform>(preset?.platform ?? getInitialPlatform);
   const [termsAgreement, setTermsAgreement] = useState(preset?.termsAgreement ?? false);
   const [experienceSettings, setExperienceSettings] = useState<
     SignInExperienceResponse | undefined

--- a/packages/experience/src/Providers/PageContextProvider/index.tsx
+++ b/packages/experience/src/Providers/PageContextProvider/index.tsx
@@ -1,6 +1,5 @@
 import { Theme } from '@logto/schemas';
 import { useState, useMemo } from 'react';
-import { isMobile } from 'react-device-detect';
 import { useSearchParams } from 'react-router-dom';
 
 import type { SignInExperienceResponse, Platform } from '@/types';
@@ -24,15 +23,26 @@ type Props = {
   >;
 };
 
+const getInitialTheme = () => {
+  if (document.documentElement.dataset.theme === Theme.Dark) {
+    return Theme.Dark;
+  }
+
+  return Theme.Light;
+};
+
+const getInitialPlatform = (): Platform =>
+  document.body.classList.contains('mobile') ? 'mobile' : 'web';
+
 const PageContextProvider = ({ children, preset }: Props) => {
   const [searchParameters] = useSearchParams();
 
   const [loading, setLoading] = useState(preset?.loading ?? false);
   const [toast, setToast] = useState(preset?.toast ?? '');
-  const [theme, setTheme] = useState<Theme>(preset?.theme ?? Theme.Light);
+  const [theme, setTheme] = useState<Theme>(preset?.theme ?? getInitialTheme);
 
   const [platform, setPlatform] = useState<Platform>(
-    preset?.platform ?? (isMobile ? 'mobile' : 'web')
+    preset?.platform ?? getInitialPlatform
   );
   const [termsAgreement, setTermsAgreement] = useState(preset?.termsAgreement ?? false);
   const [experienceSettings, setExperienceSettings] = useState<


### PR DESCRIPTION
## Summary

Add a synchronous `<script>` immediately after `<body>` in both experience and account center `index.html` files. The script runs before first paint and:

1. Reads `window.logtoSsr` (SSR-injected data)
2. Determines the correct theme (`dark` if dark mode is enabled + system prefers dark, else `light`)
3. Sets `data-theme` attribute on `<html>` — which Layer 1's CSS consumes to apply colors instantly
4. Adds `mobile`/`desktop` class on `<body>` based on user agent
5. Injects brand primary color as `--color-brand-default` CSS variable if available

The script is wrapped in try/catch and gracefully degrades if SSR data is unavailable (falls back to light theme).

### Testing
N/A

Link to Devin session: https://app.devin.ai/sessions/f32fc80e8821496d974f7e12aaad929d
Requested by: @wangsijie