### PR TITLE
fix(account): fix useEffect theme bug causing unnecessary theme cycle

### DIFF
--- a/packages/account/src/Providers/PageContextProvider/index.tsx
+++ b/packages/account/src/Providers/PageContextProvider/index.tsx
@@ -6,6 +6,7 @@ import { isMobile } from 'react-device-detect';
 import { getAccountCenterSettings } from '@ac/apis/account-center';
 import { getSignInExperienceSettings } from '@ac/apis/sign-in-experience';
 import { getUserInfo } from '@ac/apis/user';
+import { isDevFeaturesEnabled } from '@ac/constants/env';
 import useApi from '@ac/hooks/use-api';
 import { changeLanguage, getPreferredLanguage } from '@ac/i18n/utils';
 import { getUiLocales } from '@ac/utils/account-center-route';
@@ -157,6 +158,30 @@ const PageContextProvider = ({ children }: Props) => {
   }, []);
 
   useEffect(() => {
+    if (isDevFeaturesEnabled) {
+      // Don't change theme while settings are loading; the initial state from
+      // getThemeBySystemPreference() is already correct.
+      if (!experienceSettings) {
+        return;
+      }
+
+      if (!experienceSettings.color.isDarkModeEnabled) {
+        setTheme(Theme.Light);
+        return;
+      }
+
+      const updateTheme = () => {
+        setTheme(getThemeBySystemPreference());
+      };
+
+      updateTheme();
+      const unsubscribe = subscribeToSystemTheme(updateTheme);
+
+      return () => {
+        unsubscribe();
+      };
+    }
+
     if (!experienceSettings?.color.isDarkModeEnabled) {
       setTheme(Theme.Light);
       return;


### PR DESCRIPTION
## Summary

Fix a React-level bug in account center's `PageContextProvider` that causes an unnecessary theme flash (dark → light → dark cycle).

The bug: when `experienceSettings` is `undefined` (during initial load), the existing `useEffect` treats `!experienceSettings?.color.isDarkModeEnabled` as truthy and forces `Theme.Light` — overriding the correct initial theme state that was already determined by `getThemeBySystemPreference()`.

The fix (gated): early-return when `experienceSettings` is `undefined` so the theme remains at the system-preferred value until settings actually load. Once loaded, apply the dark mode check normally.

```diff
 useEffect(() => {
+  if (!experienceSettings) {
+    return; // Don't override system preference while loading
+  }
+
   if (!experienceSettings.color.isDarkModeEnabled) {
     setTheme(Theme.Light);
     return;
   }
   // ...subscribe to system theme
 }, [experienceSettings]);
```

### Testing
N/A

Link to Devin session: https://app.devin.ai/sessions/f32fc80e8821496d974f7e12aaad929d
Requested by: @wangsijie