### PR TITLE
fix(connector): drop url regex lookbehind that crashes old safari

### DIFF
--- a/.changeset/url-regex-no-lookbehind.md
+++ b/.changeset/url-regex-no-lookbehind.md
@@ -1,0 +1,7 @@
+---
+"@logto/connector-kit": patch
+---
+
+fix a runtime crash on iOS 15 and older Safari when loading the experience or demo apps
+
+`urlRegEx` used a lookbehind assertion (`(?<![\w.])`), which Safari < 16.4 cannot parse. Because the regex is a top-level literal bundled into the experience app, loading the app threw `SyntaxError: Invalid regular expression: invalid group specifier name` before any code ran. The boundary now uses a `(?:^|[^\w.])` group, which is behaviorally equivalent for `.test()` and parses on all supported browsers.

--- a/packages/toolkit/connector-kit/src/types/passwordless.test.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.test.ts
@@ -30,6 +30,11 @@ describe('urlRegEx', () => {
     expect(urlRegEx.test('x.y')).toBe(true);
     expect(urlRegEx.test('a.b.c.com')).toBe(true);
   });
+
+  // Lookbehind is unsupported in Safari < 16.4 and throws at module load, breaking iOS 15 and older.
+  it('does not use a lookbehind assertion (breaks iOS 15 and older Safari)', () => {
+    expect(urlRegEx.source.includes('(?<')).toBe(false);
+  });
 });
 
 describe('emailServiceBrandingGuard companyInformation', () => {

--- a/packages/toolkit/connector-kit/src/types/passwordless.ts
+++ b/packages/toolkit/connector-kit/src/types/passwordless.ts
@@ -91,9 +91,14 @@ export const sendMessagePayloadGuard = z
   })
   .catchall(z.unknown()) satisfies z.ZodType<SendMessagePayload>;
 
-/** Matches URLs while ignoring standalone dotted abbreviations (e.g. p.s.a.). */
+/**
+ * Matches URLs while ignoring standalone dotted abbreviations (e.g. p.s.a.).
+ *
+ * The leading boundary uses `(?:^|[^\w.])` instead of a `(?<![\w.])` lookbehind, which Safari
+ * < 16.4 cannot parse (throws at module load on iOS 15 and older, where this regex is bundled).
+ */
 export const urlRegEx =
-  /(?<![\w.])(?![A-Za-z]\.[A-Za-z]\.(?=$|[^\w#%&()+./:=?@~-]))(?![A-Za-z](?:\.[A-Za-z]){2,}\.?(?=$|[^\w#%&()+./:=?@~-]))(https?:\/\/)?(?:www\.)?[\w#%+.:=@~-]{1,256}\.[\d()A-Za-z]{1,6}\b[\w#%&()+./:=?@~-]*/;
+  /(?:^|[^\w.])(?![A-Za-z]\.[A-Za-z]\.(?=$|[^\w#%&()+./:=?@~-]))(?![A-Za-z](?:\.[A-Za-z]){2,}\.?(?=$|[^\w#%&()+./:=?@~-]))(https?:\/\/)?(?:www\.)?[\w#%+.:=@~-]{1,256}\.[\d()A-Za-z]{1,6}\b[\w#%&()+./:=?@~-]*/;
 
 export const emailServiceBrandingGuard = z
   .object({


### PR DESCRIPTION
## Summary

Opening the experience or demo app on iOS 15 and older Safari threw `SyntaxError: Invalid regular expression: invalid group specifier name` at load, before any app code ran.

The cause is `urlRegEx` in `@logto/connector-kit` (`passwordless.ts`), introduced in #8747. Its leading boundary used a lookbehind assertion `(?<![\w.])`, which Safari < 16.4 cannot parse. The regex is a top-level module literal bundled into the experience app, so the parse failure crashed the whole bundle at load. (The error surfaced near zod frames only because zod guards live in the same module/chunk; zod itself uses lookahead, which old Safari supports.)

This replaces the lookbehind with an equivalent `(?:^|[^\w.])` group — "at start, or preceded by a separator" — which is behaviorally identical for the regex's only usage (`.test()`) and parses on all supported browsers. Verified identical results against the original across all existing test inputs plus extra edge cases. Added a regression test asserting the source contains no lookbehind.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments