### PR TITLE
fix(test): handle context destruction in expectNavigation

### DIFF
--- a/packages/integration-tests/src/utils.ts
+++ b/packages/integration-tests/src/utils.ts
@@ -84,18 +84,39 @@ export const appendPathname = (pathname: string, baseUrl: URL) =>
  * Run an action and simultaneously wait for navigation to complete. This is
  * useful for actions that trigger navigation, such as clicking a link or
  * submitting a form.
+ *
+ * When the action triggers a full-page navigation, the execution context may be destroyed
+ * before the action's Promise resolves (e.g., expect-puppeteer's `toClick` polls the DOM
+ * via `evaluateHandle`, and if the navigation fires mid-poll the context is gone). This is
+ * expected and harmless — the navigation itself is what we care about — so we catch these
+ * errors instead of letting them fail the test.
  */
 export const expectNavigation = async <T>(
   action: Promise<T>,
   page: Page = global.page
 ): Promise<T> => {
   const [_, result] = await Promise.all([
-    /**
-     * We should call `waitForNavigation` before the action or the `waitForNavigation` will encounter a timeout error randomly,
-     * since sometimes the action is too fast and the `waitForNavigation` is not called before the navigation is completed.
-     */
     page.waitForNavigation({ waitUntil: 'networkidle0' }),
-    action,
+    action.catch((error: unknown) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : typeof error === 'object' && error !== null && 'message' in error
+            ? String(error.message)
+            : String(error);
+      if (
+        message.includes('Execution context was destroyed') ||
+        message.includes('not available in detached frame') ||
+        message.includes('Navigating frame was detached') ||
+        message.includes('Argument should belong to the same JavaScript world') ||
+        message.includes('Attempted to use detached Frame') ||
+        message.includes('Cannot find context with specified id')
+      ) {
+        // eslint-disable-next-line no-restricted-syntax -- Return value unused; action context is destroyed.
+        return undefined as unknown as T;
+      }
+      throw error;
+    }),
   ]);
   return result;
 };


### PR DESCRIPTION
## Summary

Fix randomly-failing experience integration tests caused by a race condition in `expectNavigation`.

When `expectNavigation` wraps an action that triggers a full-page navigation (e.g. social sign-in redirect, form submit), expect-puppeteer's `toClick`/`toMatchElement` may still be polling the DOM via `evaluateHandle` when the navigation fires. The old execution context is destroyed mid-poll, producing errors like:

- `Execution context was destroyed`
- `Argument should belong to the same JavaScript world as target object`
- `Cannot find context with specified id`

These are expected and harmless — the navigation itself is what we care about — but the old code let them bubble up and fail the test.

The fix wraps the `action` promise with `.catch()` that recognizes these navigation-induced errors and suppresses them, while still re-throwing genuine failures.

```diff
-    action,
+    action.catch((error: unknown) => {
+      const message = /* extract from Error or error-like object */;
+      if (message.includes('Execution context was destroyed') || ...)
+        return undefined as unknown as T;  // navigation succeeded — suppress
+      throw error;  // real error — propagate
+    }),
```

Also handles a cross-realm issue where Puppeteer's `ProtocolError` does not pass `instanceof Error` in Jest context — the message is extracted from the error object directly instead.

### Testing

Tested locally


Link to Devin session: https://app.devin.ai/sessions/1562f1d2ba1d46398f482272b246592b
Requested by: @wangsijie