### PR TITLE
feat(experience): add sign-out action to access denied page

### DIFF
--- a/packages/experience/src/pages/Consent/index.test.tsx
+++ b/packages/experience/src/pages/Consent/index.test.tsx
@@ -6,6 +6,7 @@ import UserInteractionContextProvider from '@/Providers/UserInteractionContextPr
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { consent, getConsentInfo } from '@/apis/consent';
+import { searchKeys } from '@/shared/utils/search-parameters';
 
 import Consent from '.';
 
@@ -16,6 +17,8 @@ jest.mock('@/apis/consent', () => ({
 
 const mockedConsent = consent as jest.MockedFunction<typeof consent>;
 const mockedGetConsentInfo = getConsentInfo as jest.MockedFunction<typeof getConsentInfo>;
+const originalLocation = window.location;
+const assign = jest.fn();
 
 const consentInfo: ConsentInfoResponse = {
   application: {
@@ -68,9 +71,38 @@ const renderConsent = () =>
     </SettingsProvider>
   );
 
+const renderConsentWithSearchParams = () =>
+  renderWithPageContext(
+    <SettingsProvider>
+      <UserInteractionContextProvider>
+        <Consent />
+      </UserInteractionContextProvider>
+    </SettingsProvider>
+  );
+
 describe('Consent', () => {
+  beforeAll(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        assign,
+        origin: 'http://localhost',
+        search: `?${searchKeys.appId}=application_id`,
+      },
+    });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
   });
 
   it('renders generic access denied page when consent info is denied', async () => {
@@ -83,6 +115,7 @@ describe('Consent', () => {
     });
 
     expect(queryByText('error.application_access_denied')).not.toBeNull();
+    expect(queryByText('account_center.sessions.revoke_session')).not.toBeNull();
     expect(queryByText('action.authorize')).toBeNull();
     expect(queryByText('action.cancel')).toBeNull();
   });
@@ -104,7 +137,22 @@ describe('Consent', () => {
     });
 
     expect(queryByText('error.application_access_denied')).not.toBeNull();
+    expect(queryByText('account_center.sessions.revoke_session')).not.toBeNull();
     expect(queryByText('action.authorize')).toBeNull();
     expect(queryByText('action.cancel')).toBeNull();
+  });
+
+  it('signs out from the access denied page', async () => {
+    mockedGetConsentInfo.mockRejectedValueOnce(accessDeniedError());
+
+    const { getByText, queryByText } = renderConsentWithSearchParams();
+
+    await waitFor(() => {
+      expect(queryByText('account_center.sessions.revoke_session')).not.toBeNull();
+    });
+
+    fireEvent.click(getByText('account_center.sessions.revoke_session'));
+
+    expect(assign).toBeCalledWith('http://localhost/oidc/session/end?client_id=application_id');
   });
 });

--- a/packages/experience/src/pages/Consent/index.tsx
+++ b/packages/experience/src/pages/Consent/index.tsx
@@ -12,6 +12,7 @@ import useErrorHandler, { type ErrorHandlers } from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
 import ErrorPage from '@/pages/ErrorPage';
 import Button from '@/shared/components/Button';
+import { searchKeys } from '@/shared/utils/search-parameters';
 
 import OrganizationSelector, { type Organization } from './OrganizationSelector';
 import ScopesListCard from './ScopesListCard';
@@ -48,6 +49,19 @@ const Consent = () => {
     },
     [consentErrorHandlers, handleError]
   );
+
+  const signOut = useCallback(() => {
+    const applicationId =
+      new URLSearchParams(window.location.search).get(searchKeys.appId) ??
+      consentData?.application.id;
+    const signOutUrl = new URL('/oidc/session/end', window.location.origin);
+
+    if (applicationId) {
+      signOutUrl.searchParams.set('client_id', applicationId);
+    }
+
+    window.location.assign(signOutUrl.href);
+  }, [consentData?.application.id]);
 
   const consentHandler = useCallback(async () => {
     setIsConsentLoading(true);
@@ -94,6 +108,10 @@ const Consent = () => {
         isNavbarHidden
         title="error.access_denied"
         message="error.application_access_denied"
+        primaryAction={{
+          title: 'account_center.sessions.revoke_session',
+          onClick: signOut,
+        }}
       />
     );
   }

--- a/packages/experience/src/pages/ErrorPage/index.tsx
+++ b/packages/experience/src/pages/ErrorPage/index.tsx
@@ -1,12 +1,14 @@
 import { Theme } from '@logto/schemas';
 import type { TFuncKey } from 'i18next';
 import { useContext } from 'react';
+import { type To } from 'react-router-dom';
 
 import StaticPageLayout from '@/Layout/StaticPageLayout';
 import PageContext from '@/Providers/PageContextProvider/PageContext';
 import EmptyStateDark from '@/assets/icons/empty-state-dark.svg?react';
 import EmptyState from '@/assets/icons/empty-state.svg?react';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
+import Button from '@/shared/components/Button';
 import DynamicT from '@/shared/components/DynamicT';
 import NavBar from '@/shared/components/NavBar';
 import PageMeta from '@/shared/components/PageMeta';
@@ -19,6 +21,12 @@ type Props = {
   readonly message?: TFuncKey;
   readonly rawMessage?: string;
   readonly isNavbarHidden?: boolean;
+  readonly primaryAction?: {
+    readonly title: TFuncKey;
+    readonly to?: To;
+    readonly replace?: boolean;
+    readonly onClick?: () => void;
+  };
 };
 
 const ErrorPage = ({
@@ -26,6 +34,7 @@ const ErrorPage = ({
   message,
   rawMessage,
   isNavbarHidden,
+  primaryAction,
 }: Props) => {
   const { theme } = useContext(PageContext);
   const navigate = useNavigateWithPreservedSearchParams();
@@ -49,6 +58,22 @@ const ErrorPage = ({
         </div>
         {errorMessage && (
           <div className={styles.message}>{rawMessage ?? <DynamicT forKey={message} />}</div>
+        )}
+        {primaryAction && (
+          <Button
+            className={styles.backButton}
+            title={primaryAction.title}
+            onClick={() => {
+              if (primaryAction.onClick) {
+                primaryAction.onClick();
+                return;
+              }
+
+              if (primaryAction.to) {
+                navigate(primaryAction.to, { replace: primaryAction.replace });
+              }
+            }}
+          />
         )}
         <SupportInfo />
       </div>


### PR DESCRIPTION
## Summary
Add a primary action slot to the generic experience error page and use it on the consent access denied state.

Users who are denied app access can now sign out directly from the error page, clearing the current Logto session via the OIDC end-session endpoint before returning to sign-in.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments