### PR TITLE
fix(core): escape HTML attribute values in SAML auto-submit form

### DIFF
--- a/.changeset/escape-saml-auto-submit-form.md
+++ b/.changeset/escape-saml-auto-submit-form.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": patch
+---
+
+escape HTML attribute values in the SAML IdP auto-submit form
+
+When Logto acts as a SAML IdP, the auto-submit form posted to the SP's ACS interpolated `SAMLResponse`, `RelayState` and the action URL into HTML attributes without escaping. If a value contained a double quote, the browser truncated the attribute at that quote.
+
+This broke SPs that send a JSON string as `RelayState`: the SP received only `{` instead of the full value, losing the post-login context. The values are now HTML-escaped, so quotes and other markup characters round-trip intact (this also closes a reflected-markup injection vector in the interstitial page).

--- a/.changeset/escape-saml-auto-submit-form.md
+++ b/.changeset/escape-saml-auto-submit-form.md
@@ -7,3 +7,5 @@ escape HTML attribute values in the SAML IdP auto-submit form
 When Logto acts as a SAML IdP, the auto-submit form posted to the SP's ACS interpolated `SAMLResponse`, `RelayState` and the action URL into HTML attributes without escaping. If a value contained a double quote, the browser truncated the attribute at that quote.
 
 This broke SPs that send a JSON string as `RelayState`: the SP received only `{` instead of the full value, losing the post-login context. The values are now HTML-escaped, so quotes and other markup characters round-trip intact (this also closes a reflected-markup injection vector in the interstitial page).
+
+In addition, the form action URL is now restricted to the `http`/`https` schemes before rendering. Escaping the attribute value alone does not neutralize a scriptable scheme such as `javascript:`, which the browser would execute on submission, so such URLs are now rejected.

--- a/packages/core/src/saml-application/SamlApplication/utils.test.ts
+++ b/packages/core/src/saml-application/SamlApplication/utils.test.ts
@@ -151,4 +151,36 @@ describe('generateAutoSubmitForm', () => {
     expect(result).toContain('value="&lt;script&gt;alert(1)&lt;/script&gt;"');
     expect(result).toContain('value="&#39;&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"');
   });
+
+  it('should html-escape quotes and markup in the action URL', () => {
+    const actionUrl = `https://example.com/acs?redirect="><script>alert(1)</script>`;
+    const samlResponse = 'base64EncodedSamlResponse';
+
+    const result = generateAutoSubmitForm(actionUrl, samlResponse);
+
+    expect(result).not.toContain('"><script>');
+    expect(result).toContain(
+      'action="https://example.com/acs?redirect=&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"'
+    );
+  });
+
+  it('should reject action URLs with a non-http(s) scheme', () => {
+    const samlResponse = 'base64EncodedSamlResponse';
+
+    // eslint-disable-next-line no-script-url -- deliberately asserting a `javascript:` URL is rejected
+    expect(() => generateAutoSubmitForm('javascript:alert(1)', samlResponse)).toThrowError();
+    expect(() =>
+      generateAutoSubmitForm('data:text/html,<script>alert(1)</script>', samlResponse)
+    ).toThrowError();
+    expect(() => generateAutoSubmitForm('not-a-url', samlResponse)).toThrowError();
+  });
+
+  it('should allow http and https action URLs', () => {
+    const samlResponse = 'base64EncodedSamlResponse';
+
+    expect(() => generateAutoSubmitForm('http://example.com/acs', samlResponse)).not.toThrowError();
+    expect(() =>
+      generateAutoSubmitForm('https://example.com/acs', samlResponse)
+    ).not.toThrowError();
+  });
 });

--- a/packages/core/src/saml-application/SamlApplication/utils.test.ts
+++ b/packages/core/src/saml-application/SamlApplication/utils.test.ts
@@ -87,8 +87,8 @@ describe('generateAutoSubmitForm', () => {
 
     const result = generateAutoSubmitForm(actionUrl, samlResponse);
 
-    expect(result).toContain('action="https://example.com/acs?param=value&other=123"');
-    expect(result).toContain('value="response+with/special=characters&"');
+    expect(result).toContain('action="https://example.com/acs?param=value&amp;other=123"');
+    expect(result).toContain('value="response+with/special=characters&amp;"');
   });
 
   it('should include RelayState field when relayState is provided', () => {
@@ -119,6 +119,36 @@ describe('generateAutoSubmitForm', () => {
 
     const result = generateAutoSubmitForm(actionUrl, samlResponse, relayState);
 
-    expect(result).toContain(`<input type="hidden" name="RelayState" value="${relayState}" />`);
+    expect(result).toContain(
+      '<input type="hidden" name="RelayState" value="relay+state/with&amp;special=characters" />'
+    );
+  });
+
+  it('should html-escape double quotes in relayState so the attribute value is not truncated', () => {
+    // Some SPs (e.g. HubSpot membership SSO) send a JSON string as RelayState. Without
+    // escaping, the attribute value is cut off at the first inner double quote and the
+    // SP receives only `{`.
+    const actionUrl = 'https://example.com/acs';
+    const samlResponse = 'base64EncodedSamlResponse';
+    const relayState = '{"pageId":12345,"redirectUrl":"https://example.com/private"}';
+
+    const result = generateAutoSubmitForm(actionUrl, samlResponse, relayState);
+
+    expect(result).toContain(
+      '<input type="hidden" name="RelayState" value="{&quot;pageId&quot;:12345,&quot;redirectUrl&quot;:&quot;https://example.com/private&quot;}" />'
+    );
+  });
+
+  it('should html-escape markup characters in samlResponse and relayState', () => {
+    const actionUrl = 'https://example.com/acs';
+    const samlResponse = '<script>alert(1)</script>';
+    const relayState = `'"><img src=x onerror=alert(1)>`;
+
+    const result = generateAutoSubmitForm(actionUrl, samlResponse, relayState);
+
+    expect(result).not.toContain('<script>alert(1)</script>');
+    expect(result).not.toContain('<img');
+    expect(result).toContain('value="&lt;script&gt;alert(1)&lt;/script&gt;"');
+    expect(result).toContain('value="&#39;&quot;&gt;&lt;img src=x onerror=alert(1)&gt;"');
   });
 });

--- a/packages/core/src/saml-application/SamlApplication/utils.ts
+++ b/packages/core/src/saml-application/SamlApplication/utils.ts
@@ -54,6 +54,14 @@ export const buildSamlAssertionNameId = (
   });
 };
 
+const escapeHtmlAttributeValue = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+
 export const generateAutoSubmitForm = (
   actionUrl: string,
   samlResponse: string,
@@ -62,9 +70,17 @@ export const generateAutoSubmitForm = (
   return `
     <html>
       <body>
-        <form id="redirectForm" action="${actionUrl}" method="POST">
-          <input type="hidden" name="SAMLResponse" value="${samlResponse}" />
-          ${relayState ? `<input type="hidden" name="RelayState" value="${relayState}" />` : ''}
+        <form id="redirectForm" action="${escapeHtmlAttributeValue(actionUrl)}" method="POST">
+          <input type="hidden" name="SAMLResponse" value="${escapeHtmlAttributeValue(
+            samlResponse
+          )}" />
+          ${
+            relayState
+              ? `<input type="hidden" name="RelayState" value="${escapeHtmlAttributeValue(
+                  relayState
+                )}" />`
+              : ''
+          }
         </form>
         <script>
           window.onload = function() {

--- a/packages/core/src/saml-application/SamlApplication/utils.ts
+++ b/packages/core/src/saml-application/SamlApplication/utils.ts
@@ -62,11 +62,25 @@ const escapeHtmlAttributeValue = (value: string): string =>
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;');
 
+const safeActionUrlProtocols = Object.freeze(['http:', 'https:']);
+
+// HTML-escaping the action attribute prevents markup breakouts but not scriptable schemes
+// (e.g. `javascript:`), which the browser would execute on form submission.
+const isSafeActionUrl = (actionUrl: string): boolean => {
+  try {
+    return safeActionUrlProtocols.includes(new URL(actionUrl).protocol);
+  } catch {
+    return false;
+  }
+};
+
 export const generateAutoSubmitForm = (
   actionUrl: string,
   samlResponse: string,
   relayState?: string
 ): string => {
+  assertThat(isSafeActionUrl(actionUrl), 'application.saml.acs_url_scheme_not_supported', 400);
+
   return `
     <html>
       <body>

--- a/packages/phrases/src/locales/ar/errors/application.ts
+++ b/packages/phrases/src/locales/ar/errors/application.ts
@@ -32,6 +32,8 @@ const application = {
     reach_oss_limit:
       'لا يمكنك إنشاء المزيد من تطبيقات SAML لأن الحد الأقصى {{limit}} تم الوصول إليه.',
     acs_url_binding_not_supported: 'يدعم فقط التوزيع HTTP-POST لاستقبال إقرارات SAML.',
+    acs_url_scheme_not_supported:
+      'يتم دعم مخططي HTTP و HTTPS فقط لعنوان URL الخاص بخدمة استهلاك التأكيد (ACS).',
     can_not_delete_active_secret: 'لا يمكن حذف السر النشط.',
     no_active_secret: 'لم يتم العثور على سر نشط.',
     entity_id_required: 'معرف الكيان مطلوب لإنشاء بيانات وصفية.',

--- a/packages/phrases/src/locales/de/errors/application.ts
+++ b/packages/phrases/src/locales/de/errors/application.ts
@@ -35,6 +35,8 @@ const application = {
       'Du kannst keine weiteren SAML-Apps erstellen, da das Limit von {{limit}} erreicht wurde.',
     acs_url_binding_not_supported:
       'Nur HTTP-POST-Bindung wird für den Empfang von SAML-Aussagen unterstützt.',
+    acs_url_scheme_not_supported:
+      'Nur die HTTP- und HTTPS-Schemata werden für die Assertion Consumer Service-URL unterstützt.',
     can_not_delete_active_secret: 'Das aktive Geheimnis kann nicht gelöscht werden.',
     no_active_secret: 'Kein aktives Geheimnis gefunden.',
     entity_id_required: 'Entity ID ist erforderlich, um Metadaten zu generieren.',

--- a/packages/phrases/src/locales/en/errors/application.ts
+++ b/packages/phrases/src/locales/en/errors/application.ts
@@ -31,6 +31,8 @@ const application = {
     reach_oss_limit: 'You CAN NOT create more SAML apps since the limit of {{limit}} is hit.',
     acs_url_binding_not_supported:
       'Only HTTP-POST binding is supported for receiving SAML assertions.',
+    acs_url_scheme_not_supported:
+      'Only the HTTP and HTTPS schemes are supported for the Assertion Consumer Service URL.',
     can_not_delete_active_secret: 'Can not delete the active secret.',
     no_active_secret: 'No active secret found.',
     entity_id_required: 'Entity ID is required to generate metadata.',

--- a/packages/phrases/src/locales/es/errors/application.ts
+++ b/packages/phrases/src/locales/es/errors/application.ts
@@ -37,6 +37,8 @@ const application = {
       'NO PUEDES crear más aplicaciones SAML porque se ha alcanzado el límite de {{limit}}.',
     acs_url_binding_not_supported:
       'Solo se admite la vinculación HTTP-POST para recibir aserciones SAML.',
+    acs_url_scheme_not_supported:
+      'Solo se admiten los esquemas HTTP y HTTPS para la URL del Assertion Consumer Service.',
     can_not_delete_active_secret: 'No se puede eliminar el secreto activo.',
     no_active_secret: 'No se encontró un secreto activo.',
     entity_id_required: 'Se requiere un ID de entidad para generar metadatos.',

--- a/packages/phrases/src/locales/fr/errors/application.ts
+++ b/packages/phrases/src/locales/fr/errors/application.ts
@@ -38,6 +38,8 @@ const application = {
       "Vous NE POUVEZ PAS créer plus d'applications SAML car la limite de {{limit}} est atteinte.",
     acs_url_binding_not_supported:
       'Seul le binding HTTP-POST est pris en charge pour recevoir des assertions SAML.',
+    acs_url_scheme_not_supported:
+      'Seuls les schémas HTTP et HTTPS sont pris en charge pour l’URL de l’Assertion Consumer Service.',
     can_not_delete_active_secret: 'Impossible de supprimer le secret actif.',
     no_active_secret: 'Aucun secret actif trouvé.',
     entity_id_required: "L'identifiant de l'entité est requis pour générer les métadonnées.",

--- a/packages/phrases/src/locales/it/errors/application.ts
+++ b/packages/phrases/src/locales/it/errors/application.ts
@@ -36,6 +36,8 @@ const application = {
       'Non puoi creare più app SAML poiché è stato raggiunto il limite di {{limit}}.',
     acs_url_binding_not_supported:
       'Solo il binding HTTP-POST è supportato per ricevere assertion SAML.',
+    acs_url_scheme_not_supported:
+      'Solo gli schemi HTTP e HTTPS sono supportati per l’URL dell’Assertion Consumer Service.',
     can_not_delete_active_secret: 'Non è possibile eliminare il segreto attivo.',
     no_active_secret: 'Non è stato trovato alcun segreto attivo.',
     entity_id_required: 'È richiesto un Entity ID per generare i metadati.',

--- a/packages/phrases/src/locales/ja/errors/application.ts
+++ b/packages/phrases/src/locales/ja/errors/application.ts
@@ -33,6 +33,8 @@ const application = {
     reach_oss_limit: 'OSS の上限 {{limit}} に達したため、これ以上 SAML アプリを作成できません。',
     acs_url_binding_not_supported:
       'SAML アサーションを受信するには HTTP-POST バインディングのみがサポートされています。',
+    acs_url_scheme_not_supported:
+      'Assertion Consumer Service URL では HTTP および HTTPS スキームのみがサポートされています。',
     can_not_delete_active_secret: 'アクティブなシークレットを削除できません。',
     no_active_secret: 'アクティブなシークレットが見つかりません。',
     entity_id_required: 'メタデータを生成するには、エンティティ ID が必要です。',

--- a/packages/phrases/src/locales/ko/errors/application.ts
+++ b/packages/phrases/src/locales/ko/errors/application.ts
@@ -31,6 +31,8 @@ const application = {
     saml_application_only: '이 API 는 SAML 응용 프로그램에만 사용할 수 있습니다.',
     reach_oss_limit: '{{limit}} 개의 제한에 도달했기 때문에 더 이상 SAML 앱을 만들 수 없습니다.',
     acs_url_binding_not_supported: 'SAML 어설션을 받기 위해서는 HTTP-POST 바인딩만 지원됩니다.',
+    acs_url_scheme_not_supported:
+      'Assertion Consumer Service URL에는 HTTP 및 HTTPS 체계만 지원됩니다.',
     can_not_delete_active_secret: '활성 비밀을 삭제할 수 없습니다.',
     no_active_secret: '활성 비밀을 찾을 수 없습니다.',
     entity_id_required: '메타데이터 생성을 위해 엔터티 ID 가 필요합니다.',

--- a/packages/phrases/src/locales/pl-pl/errors/application.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/application.ts
@@ -32,6 +32,8 @@ const application = {
       'NIE możesz utworzyć więcej aplikacji SAML, ponieważ osiągnięto limit {{limit}}.',
     acs_url_binding_not_supported:
       'Obsługiwane jest tylko wiązanie HTTP-POST do odbierania asercji SAML.',
+    acs_url_scheme_not_supported:
+      'Dla adresu URL Assertion Consumer Service obsługiwane są tylko schematy HTTP i HTTPS.',
     can_not_delete_active_secret: 'Nie można usunąć aktywnego sekretu.',
     no_active_secret: 'Nie znaleziono aktywnego sekretu.',
     entity_id_required: 'Do wygenerowania metadanych wymagany jest identyfikator podmiotu.',

--- a/packages/phrases/src/locales/pt-br/errors/application.ts
+++ b/packages/phrases/src/locales/pt-br/errors/application.ts
@@ -35,6 +35,8 @@ const application = {
       'Você NÃO PODE criar mais aplicativos SAML, pois o limite de {{limit}} foi atingido.',
     acs_url_binding_not_supported:
       'Apenas a vinculação HTTP-POST é suportada para receber assertivas SAML.',
+    acs_url_scheme_not_supported:
+      'Apenas os esquemas HTTP e HTTPS são suportados para a URL do Assertion Consumer Service.',
     can_not_delete_active_secret: 'Não é possível excluir o segredo ativo.',
     no_active_secret: 'Nenhum segredo ativo encontrado.',
     entity_id_required: 'ID da entidade é necessário para gerar metadados.',

--- a/packages/phrases/src/locales/pt-pt/errors/application.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/application.ts
@@ -32,6 +32,8 @@ const application = {
     reach_oss_limit: 'NÃO PODE criar mais apps SAML, pois o limite de {{limit}} foi atingido.',
     acs_url_binding_not_supported:
       'Apenas a ligação HTTP-POST é suportada para receber assertivas SAML.',
+    acs_url_scheme_not_supported:
+      'Apenas os esquemas HTTP e HTTPS são suportados para o URL do Assertion Consumer Service.',
     can_not_delete_active_secret: 'Não é possível eliminar o segredo ativo.',
     no_active_secret: 'Nenhum segredo ativo encontrado.',
     entity_id_required: 'O ID da Entidade é necessário para gerar metadados.',

--- a/packages/phrases/src/locales/ru/errors/application.ts
+++ b/packages/phrases/src/locales/ru/errors/application.ts
@@ -34,6 +34,8 @@ const application = {
       'Вы не можете создать больше приложений SAML, так как достигнут лимит {{limit}}.',
     acs_url_binding_not_supported:
       'Только HTTP-POST привязка поддерживается для получения утверждений SAML.',
+    acs_url_scheme_not_supported:
+      'Для URL-адреса Assertion Consumer Service поддерживаются только схемы HTTP и HTTPS.',
     can_not_delete_active_secret: 'Невозможно удалить активный секрет.',
     no_active_secret: 'Активный секрет не найден.',
     entity_id_required: 'Для создания метаданных требуется идентификатор сущности.',

--- a/packages/phrases/src/locales/th/errors/application.ts
+++ b/packages/phrases/src/locales/th/errors/application.ts
@@ -30,6 +30,8 @@ const application = {
     reach_oss_limit: 'คุณไม่สามารถสร้าง SAML แอปเพิ่มเติมได้ เนื่องจากถึงขีดจำกัด {{limit}} แล้ว',
     acs_url_binding_not_supported:
       'รองรับเฉพาะ HTTP-POST binding สำหรับรับ SAML assertion เท่านั้น',
+    acs_url_scheme_not_supported:
+      'รองรับเฉพาะรูปแบบ HTTP และ HTTPS สำหรับ URL ของ Assertion Consumer Service เท่านั้น',
     can_not_delete_active_secret: 'ไม่สามารถลบ secret ที่ถูกใช้งานอยู่ได้',
     no_active_secret: 'ไม่พบ secret ที่ถูกใช้งานอยู่',
     entity_id_required: 'ต้องระบุ Entity ID เพื่อสร้าง metadata',

--- a/packages/phrases/src/locales/tr-tr/errors/application.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/application.ts
@@ -32,6 +32,8 @@ const application = {
       '{{limit}} sınırına ulaşıldığı için daha fazla SAML uygulaması oluşturamazsınız.',
     acs_url_binding_not_supported:
       'SAML iddialarını almak için sadece HTTP-POST bağlaması desteklenir.',
+    acs_url_scheme_not_supported:
+      'Assertion Consumer Service URL’si için yalnızca HTTP ve HTTPS şemaları desteklenir.',
     can_not_delete_active_secret: 'Aktif gizli anahtar silinemez.',
     no_active_secret: 'Aktif gizli anahtar bulunamadı.',
     entity_id_required: 'Meta verileri oluşturmak için Kimlik Varlığı gereklidir.',

--- a/packages/phrases/src/locales/zh-cn/errors/application.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/application.ts
@@ -27,6 +27,7 @@ const application = {
     saml_application_only: '该 API 仅适用于 SAML 应用。',
     reach_oss_limit: '你不能创建更多 SAML 应用，因为已达到 {{limit}} 的限制。',
     acs_url_binding_not_supported: '仅支持用于接收 SAML 断言的 HTTP-POST 绑定。',
+    acs_url_scheme_not_supported: '断言消费者服务（ACS）URL 仅支持 HTTP 和 HTTPS 协议。',
     can_not_delete_active_secret: '不能删除活动密钥。',
     no_active_secret: '未找到活动密钥。',
     entity_id_required: '生成元数据需要实体 ID。',

--- a/packages/phrases/src/locales/zh-hk/errors/application.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/application.ts
@@ -27,6 +27,7 @@ const application = {
     saml_application_only: '此 API 只適用於 SAML 應用程式。',
     reach_oss_limit: '你不能創建更多的 SAML 應用程式，因為已達到限制 {{limit}}。',
     acs_url_binding_not_supported: '只支持 HTTP-POST 綁定來接收 SAML 斷言。',
+    acs_url_scheme_not_supported: '斷言消費者服務（ACS）URL 僅支持 HTTP 和 HTTPS 協定。',
     can_not_delete_active_secret: '不能刪除活動密鑰。',
     no_active_secret: '未找到活動密鑰。',
     entity_id_required: '生成元數據需要實體 ID。',

--- a/packages/phrases/src/locales/zh-tw/errors/application.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/application.ts
@@ -27,6 +27,7 @@ const application = {
     saml_application_only: '該 API 僅適用於 SAML 應用程式。',
     reach_oss_limit: '由於已達到 {{limit}} 的限制，你無法創建更多的 SAML 應用程式。',
     acs_url_binding_not_supported: '僅支持使用 HTTP-POST 方式接收 SAML 聲明。',
+    acs_url_scheme_not_supported: '斷言消費者服務（ACS）URL 僅支援 HTTP 和 HTTPS 協定。',
     can_not_delete_active_secret: '無法刪除活躍的秘鑰。',
     no_active_secret: '找不到活躍的秘鑰。',
     entity_id_required: '需要提供實體 ID 來生成元數據。',


### PR DESCRIPTION
## Summary

When Logto acts as a SAML IdP, `generateAutoSubmitForm` builds an auto-submitting HTML form that POSTs the assertion to the SP's ACS. The `actionUrl`, `SAMLResponse` and `RelayState` values were interpolated into HTML attribute values **without escaping**.

If a value contains a double quote, the browser truncates the attribute at that quote. This breaks any SP that sends a JSON string as `RelayState` (e.g. HubSpot membership SSO): the value is cut off at the first inner `"`, so the SP receives only `{` and loses the post-login redirect context, failing verification.

`SAMLResponse` survives today only because it is base64 (no quotes), but it's interpolated the same unsafe way.

## What changed

- Added a small `escapeHtmlAttributeValue` helper and applied it to `actionUrl`, `samlResponse` and `relayState` in `generateAutoSubmitForm`.
- This also closes a reflected-markup injection vector in the interstitial page.

## Reproduction

A `RelayState` of `{"pageId":12345,"redirectUrl":"https://example.com/private"}` renders as:

```html
<input type="hidden" name="RelayState" value="{"pageId":12345,...}" />
```

The browser parses the attribute value as just `{`. After this change it renders escaped (`&quot;`) and round-trips back to the original JSON when the browser submits the form.

## Tests

- Updated the existing "escape special characters" expectations to reflect `&`-escaping.
- Added a test asserting a JSON `RelayState` is escaped and not truncated.
- Added a test asserting markup characters in `samlResponse`/`relayState` are escaped (no `<script>`/`<img>` reflected).