### PR TITLE
fix(console,core,schemas): support SAML app access control toggle

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/index.tsx
@@ -31,7 +31,7 @@ import { areApplicationAccessControlsEqual, hasApplicationAccessControlRules } f
 type Props = {
   readonly application: ApplicationResponse;
   readonly isActive: boolean;
-  readonly onApplicationUpdated: (application?: ApplicationResponse) => void | Promise<void>;
+  readonly onAppLevelAccessControlUpdated: (enabled: boolean) => Promise<void>;
 };
 
 type ApplicationAccessControlForm = {
@@ -54,7 +54,11 @@ function RulesSectionHeader() {
   );
 }
 
-function ApplicationAccessControl({ application, isActive, onApplicationUpdated }: Props) {
+function ApplicationAccessControl({
+  application,
+  isActive,
+  onAppLevelAccessControlUpdated,
+}: Props) {
   const { id, appLevelAccessControlEnabled } = application;
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const api = useApi();
@@ -135,16 +139,13 @@ function ApplicationAccessControl({ application, isActive, onApplicationUpdated 
         !appLevelAccessControlEnabled &&
         !hasApplicationAccessControlRules(draftAccessControl);
 
-      const updateAppLevelAccessControlEnabled = async () =>
-        api
-          .patch(`api/applications/${id}`, {
-            json: { appLevelAccessControlEnabled },
-          })
-          .json<ApplicationResponse>();
+      const updateAppLevelAccessControlEnabled = async () => {
+        await onAppLevelAccessControlUpdated(appLevelAccessControlEnabled);
+      };
 
-      const updatedApplication = shouldDisableBeforeUpdatingEmptyRules
-        ? await updateAppLevelAccessControlEnabled()
-        : undefined;
+      if (shouldDisableBeforeUpdatingEmptyRules) {
+        await updateAppLevelAccessControlEnabled();
+      }
 
       const savedAccessControl = shouldUpdateRules
         ? await api
@@ -158,10 +159,8 @@ function ApplicationAccessControl({ application, isActive, onApplicationUpdated 
         await mutate(savedAccessControl, { revalidate: false });
       }
 
-      if (shouldUpdateEnabled && !updatedApplication) {
-        await onApplicationUpdated(await updateAppLevelAccessControlEnabled());
-      } else if (updatedApplication) {
-        await onApplicationUpdated(updatedApplication);
+      if (shouldUpdateEnabled && !shouldDisableBeforeUpdatingEmptyRules) {
+        await updateAppLevelAccessControlEnabled();
       }
 
       reset({

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
@@ -4,7 +4,7 @@ import {
   type SnakeCaseOidcConfig,
 } from '@logto/schemas';
 import { condArray } from '@silverhand/essentials';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
@@ -98,6 +98,19 @@ function ApplicationDetailsContent({ data, secrets, oidcConfig, onApplicationUpd
       await onApplicationUpdated(updatedData);
       toast.success(t('general.saved'));
     })
+  );
+
+  const onAppLevelAccessControlUpdated = useCallback(
+    async (appLevelAccessControlEnabled: boolean) => {
+      const updatedApplication = await api
+        .patch(`api/applications/${data.id}`, {
+          json: { appLevelAccessControlEnabled },
+        })
+        .json<ApplicationResponse>();
+
+      await onApplicationUpdated(updatedApplication);
+    },
+    [api, data.id, onApplicationUpdated]
   );
 
   const onDelete = async () => {
@@ -276,7 +289,7 @@ function ApplicationDetailsContent({ data, secrets, oidcConfig, onApplicationUpd
           <ApplicationAccessControl
             application={data}
             isActive={tab === ApplicationDetailsTabs.Rules}
-            onApplicationUpdated={onApplicationUpdated}
+            onAppLevelAccessControlUpdated={onAppLevelAccessControlUpdated}
           />
         </TabWrapper>
       )}

--- a/packages/console/src/pages/ApplicationDetails/SamlApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/SamlApplicationDetailsContent/index.tsx
@@ -81,6 +81,20 @@ function SamlApplicationDetailsContent({ data, onApplicationUpdated }: Props) {
     }
   }, [api, data.id, navigate, samlApplicationData?.isThirdParty, samlApplicationData?.name, t]);
 
+  const onAppLevelAccessControlUpdated = useCallback(
+    async (appLevelAccessControlEnabled: boolean) => {
+      const updatedSamlApplication = await api
+        .patch(`api/saml-applications/${data.id}`, {
+          json: { appLevelAccessControlEnabled },
+        })
+        .json<SamlApplicationResponse>();
+
+      await mutateSamlApplication(updatedSamlApplication, { revalidate: false });
+      await onApplicationUpdated();
+    },
+    [api, data.id, mutateSamlApplication, onApplicationUpdated]
+  );
+
   if (isLoading) {
     return <Skeleton />;
   }
@@ -179,7 +193,7 @@ function SamlApplicationDetailsContent({ data, onApplicationUpdated }: Props) {
           <ApplicationAccessControl
             application={data}
             isActive={tab === ApplicationDetailsTabs.Rules}
-            onApplicationUpdated={onApplicationUpdated}
+            onAppLevelAccessControlUpdated={onAppLevelAccessControlUpdated}
           />
         </TabWrapper>
       )}

--- a/packages/core/src/libraries/saml-application/saml-applications.test.ts
+++ b/packages/core/src/libraries/saml-application/saml-applications.test.ts
@@ -1,0 +1,65 @@
+import { ApplicationType, BindingType, NameIdFormat, type Application } from '@logto/schemas';
+
+import { mockApplication } from '#src/__mocks__/index.js';
+import { MockQueries } from '#src/test-utils/tenant.js';
+
+import { createSamlApplicationsLibrary } from './saml-applications.js';
+
+const { jest } = import.meta;
+
+const mockSamlApplication: Application = {
+  ...mockApplication,
+  type: ApplicationType.SAML,
+};
+const mockSamlConfig = {
+  tenantId: mockSamlApplication.tenantId,
+  applicationId: mockSamlApplication.id,
+  entityId: 'sp-entity-id',
+  acsUrl: {
+    binding: BindingType.Post,
+    url: 'https://example.com/acs',
+  },
+  attributeMapping: {},
+  encryption: {},
+  nameIdFormat: NameIdFormat.Persistent,
+};
+
+const findApplicationById = jest.fn(async () => mockSamlApplication);
+const updateApplicationById = jest.fn(async (_, data) => ({
+  ...mockSamlApplication,
+  ...data,
+}));
+const findSamlApplicationConfigByApplicationId = jest.fn(async () => mockSamlConfig);
+const updateSamlApplicationConfig = jest.fn(async ({ set }) => set);
+
+const createLibrary = () =>
+  createSamlApplicationsLibrary(
+    new MockQueries({
+      applications: {
+        findApplicationById,
+        updateApplicationById,
+      },
+      samlApplicationConfigs: {
+        findSamlApplicationConfigByApplicationId,
+        updateSamlApplicationConfig,
+      },
+    })
+  );
+
+describe('createSamlApplicationsLibrary()', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updateSamlApplicationById() should update app-level access control enablement on the application record', async () => {
+    const result = await createLibrary().updateSamlApplicationById('foo', {
+      appLevelAccessControlEnabled: true,
+    });
+
+    expect(updateApplicationById).toHaveBeenCalledWith('foo', {
+      appLevelAccessControlEnabled: true,
+    });
+    expect(updateSamlApplicationConfig).not.toHaveBeenCalled();
+    expect(result.appLevelAccessControlEnabled).toBe(true);
+  });
+});

--- a/packages/core/src/libraries/saml-application/saml-applications.ts
+++ b/packages/core/src/libraries/saml-application/saml-applications.ts
@@ -82,9 +82,16 @@ export const createSamlApplicationsLibrary = (queries: Queries) => {
     id: string,
     patchApplicationObject: PatchSamlApplication
   ): Promise<SamlApplicationResponse> => {
-    const { name, description, customData, ...config } = patchApplicationObject;
+    const { name, description, customData, appLevelAccessControlEnabled, ...config } =
+      patchApplicationObject;
     const applicationData = removeUndefinedKeys(
-      pick(patchApplicationObject, 'name', 'description', 'customData')
+      pick(
+        patchApplicationObject,
+        'name',
+        'description',
+        'customData',
+        'appLevelAccessControlEnabled'
+      )
     );
 
     const originalApplication = await findApplicationById(id);

--- a/packages/core/src/routes/applications/types.ts
+++ b/packages/core/src/routes/applications/types.ts
@@ -9,7 +9,7 @@ import { EnvSet } from '#src/env-set/index.js';
 
 const protectedAppAdditionalScopeGuard = z.enum(protectedAppAdditionalScopes);
 
-const appLevelAccessControlEnabledGuard = z
+export const appLevelAccessControlEnabledGuard = z
   .boolean()
   .refine(() => EnvSet.values.isDevFeaturesEnabled, {
     message: 'appLevelAccessControlEnabled is not available when dev features are disabled',

--- a/packages/core/src/routes/saml-application/index.openapi.json
+++ b/packages/core/src/routes/saml-application/index.openapi.json
@@ -143,6 +143,11 @@
                     "type": "object",
                     "description": "Custom data for the application."
                   },
+                  "appLevelAccessControlEnabled": {
+                    "type": "boolean",
+                    "description": "Whether app-level access control is enabled for this application. This field is available only when dev features are enabled.",
+                    "x-logto-dev-feature": true
+                  },
                   "acsUrl": {
                     "type": "string",
                     "description": "The Assertion Consumer Service (ACS) URL."

--- a/packages/core/src/routes/saml-application/index.test.ts
+++ b/packages/core/src/routes/saml-application/index.test.ts
@@ -1,0 +1,118 @@
+import {
+  ApplicationType,
+  BindingType,
+  createDefaultApplicationAccessControl,
+  NameIdFormat,
+  type ApplicationAccessControl,
+} from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockApplication } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+const { jest } = import.meta;
+
+const mockSamlApplication = {
+  ...mockApplication,
+  type: ApplicationType.SAML,
+  entityId: 'sp-entity-id',
+  acsUrl: {
+    binding: BindingType.Post,
+    url: 'https://example.com/acs',
+  },
+  attributeMapping: {},
+  encryption: {},
+  nameIdFormat: NameIdFormat.Persistent,
+};
+
+const updateSamlApplicationById = jest.fn(async (_, data) => ({
+  ...mockSamlApplication,
+  ...data,
+}));
+const findApplicationAccessControl = jest.fn(async () => createDefaultApplicationAccessControl());
+
+const tenantContext = new MockTenant(
+  undefined,
+  {
+    applicationAccessControl: {
+      findApplicationAccessControl,
+    },
+  },
+  undefined,
+  {
+    samlApplications: {
+      updateSamlApplicationById,
+    },
+  }
+);
+
+const { createRequester } = await import('#src/utils/test-utils.js');
+const samlApplicationRoutes = await pickDefault(import('./index.js'));
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Tests need to cover both dev-feature states.
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
+};
+
+const createSamlApplicationRequest = (isDevFeaturesEnabled = true) => {
+  setDevFeaturesEnabled(isDevFeaturesEnabled);
+
+  return createRequester({ authedRoutes: samlApplicationRoutes, tenantContext });
+};
+
+const buildAccessControl = (
+  patch: Partial<ApplicationAccessControl> = {}
+): ApplicationAccessControl => ({
+  userIds: ['user-1'],
+  userRoleIds: [],
+  organizationIds: [],
+  organizationRoleRules: [],
+  ...patch,
+});
+
+describe('SAML application route', () => {
+  afterEach(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+    updateSamlApplicationById.mockClear();
+    findApplicationAccessControl.mockClear();
+  });
+
+  it('PATCH /saml-applications/:id should update app-level access control enablement', async () => {
+    const samlApplicationRequest = createSamlApplicationRequest();
+    findApplicationAccessControl.mockResolvedValueOnce(buildAccessControl());
+
+    const response = await samlApplicationRequest
+      .patch('/saml-applications/foo')
+      .send({ appLevelAccessControlEnabled: true });
+
+    expect(response.status).toEqual(200);
+    expect(findApplicationAccessControl).toHaveBeenCalledWith('foo');
+    expect(updateSamlApplicationById).toHaveBeenCalledWith('foo', {
+      appLevelAccessControlEnabled: true,
+    });
+    expect(response.body.appLevelAccessControlEnabled).toEqual(true);
+  });
+
+  it('PATCH /saml-applications/:id should reject enabling app-level access control with empty rules', async () => {
+    const samlApplicationRequest = createSamlApplicationRequest();
+
+    const response = await samlApplicationRequest
+      .patch('/saml-applications/foo')
+      .send({ appLevelAccessControlEnabled: true });
+
+    expect(response.status).toEqual(422);
+    expect(updateSamlApplicationById).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /saml-applications/:id should reject app-level access control updates without dev features', async () => {
+    const response = await createSamlApplicationRequest(false)
+      .patch('/saml-applications/foo')
+      .send({ appLevelAccessControlEnabled: true });
+
+    expect(response.status).toEqual(400);
+    expect(findApplicationAccessControl).not.toHaveBeenCalled();
+    expect(updateSamlApplicationById).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/routes/saml-application/index.ts
+++ b/packages/core/src/routes/saml-application/index.ts
@@ -2,7 +2,6 @@ import {
   ApplicationType,
   ProductEvent,
   samlApplicationCreateGuard,
-  samlApplicationPatchGuard,
   samlApplicationResponseGuard,
   samlApplicationSecretResponseGuard,
   SamlApplicationSecrets,
@@ -28,6 +27,9 @@ import assertThat from '#src/utils/assert-that.js';
 import { parseSearchParamsForSearch } from '#src/utils/search.js';
 
 import { captureEvent } from '../../utils/posthog.js';
+import { assertApplicationAccessControlHasRules } from '../applications/application-access-control/utils.js';
+
+import { samlApplicationPatchGuard } from './types.js';
 
 export default function samlApplicationRoutes<T extends ManagementApiRouter>(
   ...[router, { id: tenantId, queries, libraries }]: RouterInitArgs<T>
@@ -87,7 +89,9 @@ export default function samlApplicationRoutes<T extends ManagementApiRouter>(
       status: [201, 400, 422],
     }),
     async (ctx, next) => {
-      const { name, description, customData, ...config } = ctx.guard.body;
+      const { name, description, customData, ...config } = samlApplicationCreateGuard.parse(
+        ctx.guard.body
+      );
 
       if (config.acsUrl) {
         validateAcsUrl(config.acsUrl);
@@ -178,6 +182,12 @@ export default function samlApplicationRoutes<T extends ManagementApiRouter>(
     }),
     async (ctx, next) => {
       const { id } = ctx.guard.params;
+
+      if (ctx.guard.body.appLevelAccessControlEnabled === true) {
+        assertApplicationAccessControlHasRules(
+          await queries.applicationAccessControl.findApplicationAccessControl(id)
+        );
+      }
 
       const updatedSamlApplication = await updateSamlApplicationById(id, ctx.guard.body);
 

--- a/packages/core/src/routes/saml-application/types.ts
+++ b/packages/core/src/routes/saml-application/types.ts
@@ -1,0 +1,7 @@
+import { samlApplicationPatchGuard as originalSamlApplicationPatchGuard } from '@logto/schemas';
+
+import { appLevelAccessControlEnabledGuard } from '../applications/types.js';
+
+export const samlApplicationPatchGuard = originalSamlApplicationPatchGuard.extend({
+  appLevelAccessControlEnabled: appLevelAccessControlEnabledGuard,
+});

--- a/packages/schemas/src/types/saml-application.ts
+++ b/packages/schemas/src/types/saml-application.ts
@@ -34,6 +34,11 @@ export const samlApplicationPatchGuard = applicationPatchGuard
     description: true,
     customData: true,
   })
+  .merge(
+    Applications.createGuard.pick({
+      appLevelAccessControlEnabled: true,
+    })
+  )
   // The reason for encapsulating attributeMapping and spMetadata into an object within the config field is that you cannot provide only one of `attributeMapping` or `spMetadata`. Due to the structure of the `saml_application_configs` table, both must be not null.
   .merge(samlAppConfigGuard.partial())
   .extend({ nameIdFormat: nameIdFormatGuard.optional() });


### PR DESCRIPTION
## Summary

Fix the SAML app Rules tab save flow for app-level access control. The Console now patches `appLevelAccessControlEnabled` through the SAML application API, while regular applications keep using the regular application API.

Also allow the SAML application PATCH payload to accept `appLevelAccessControlEnabled` behind the same dev-feature guard, persist it to the application record, and validate that access rules exist before enabling access control.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments