### PR TITLE
fix(console): use skeleton for app access rules loading

### DIFF
--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/RulesTableSkeleton.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/RulesTableSkeleton.tsx
@@ -1,0 +1,139 @@
+import { type ApplicationAccessControl } from '@logto/schemas';
+import { Fragment } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import styles from './index.module.scss';
+import { hasApplicationAccessControlRules } from './utils';
+
+type RuleTableSkeletonGroup = {
+  key: string;
+  title: string;
+  description: string;
+  rowCount: number;
+  rowType: 'user' | 'assignedEntities';
+};
+
+type Props = {
+  readonly accessControl?: ApplicationAccessControl;
+};
+
+const getOrganizationRoleRuleCount = ({ organizationRoleRules }: ApplicationAccessControl) =>
+  organizationRoleRules.reduce(
+    (count, { organizationRoleIds }) => count + organizationRoleIds.length,
+    0
+  );
+
+function SkeletonAssignedEntities() {
+  return (
+    <div className={styles.ruleSkeletonAssignedEntities}>
+      <div className={styles.ruleSkeletonAvatars}>
+        <div className={styles.ruleSkeletonAvatar} />
+        <div className={styles.ruleSkeletonAvatar} />
+        <div className={styles.ruleSkeletonAvatar} />
+      </div>
+      <div className={styles.ruleSkeletonCount} />
+    </div>
+  );
+}
+
+function RulesTableSkeleton({ accessControl }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  if (accessControl && !hasApplicationAccessControlRules(accessControl)) {
+    return null;
+  }
+
+  const groups = accessControl
+    ? (
+        [
+          {
+            key: 'users',
+            title: t('application_details.access_control.rule_users'),
+            description: t('application_details.access_control.rule_table_user_id'),
+            rowCount: accessControl.userIds.length,
+            rowType: 'user',
+          },
+          {
+            key: 'userRoles',
+            title: t('application_details.access_control.rule_roles'),
+            description: t('application_details.access_control.rule_table_users'),
+            rowCount: accessControl.userRoleIds.length,
+            rowType: 'assignedEntities',
+          },
+          {
+            key: 'organizations',
+            title: t('application_details.access_control.rule_organizations'),
+            description: t('application_details.access_control.rule_table_members'),
+            rowCount: accessControl.organizationIds.length,
+            rowType: 'assignedEntities',
+          },
+          {
+            key: 'organizationRoles',
+            title: t('application_details.access_control.rule_organization_roles'),
+            description: t('application_details.access_control.rule_table_members'),
+            rowCount: getOrganizationRoleRuleCount(accessControl),
+            rowType: 'assignedEntities',
+          },
+        ] satisfies RuleTableSkeletonGroup[]
+      ).filter(({ rowCount }) => rowCount > 0)
+    : ([
+        {
+          key: 'placeholder',
+          title: '',
+          description: '',
+          rowCount: 3,
+          rowType: 'assignedEntities',
+        },
+      ] satisfies RuleTableSkeletonGroup[]);
+
+  return (
+    <table className={styles.rulesTable}>
+      <thead>
+        <tr>
+          <th>{t('application_details.access_control.rule_table_rules')}</th>
+          <th>{t('application_details.access_control.rule_table_description')}</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {groups.map(({ key, title, description, rowCount, rowType }) => (
+          <Fragment key={key}>
+            <tr className={styles.ruleGroupRow}>
+              <td>{accessControl ? title : <div className={styles.ruleSkeletonGroupTitle} />}</td>
+              <td>
+                {accessControl ? (
+                  description
+                ) : (
+                  <div className={styles.ruleSkeletonGroupDescription} />
+                )}
+              </td>
+              <td />
+            </tr>
+            {Array.from({ length: rowCount }, (_, index) => index + 1).map((rowNumber) => (
+              <tr key={`${key}-row-${rowNumber}`}>
+                <td>
+                  <div className={styles.ruleSkeletonName}>
+                    {rowType === 'user' && <div className={styles.ruleSkeletonUserAvatar} />}
+                    <div className={styles.ruleSkeletonTitle} />
+                  </div>
+                </td>
+                <td>
+                  {rowType === 'user' ? (
+                    <div className={styles.ruleSkeletonUserId} />
+                  ) : (
+                    <SkeletonAssignedEntities />
+                  )}
+                </td>
+                <td className={styles.ruleDelete}>
+                  <div className={styles.ruleSkeletonDelete} />
+                </td>
+              </tr>
+            ))}
+          </Fragment>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default RulesTableSkeleton;

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/index.module.scss
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/index.module.scss
@@ -20,13 +20,6 @@
   margin-block-start: _.unit(3);
 }
 
-.loading {
-  display: flex;
-  justify-content: center;
-  padding: _.unit(6) 0;
-  color: var(--color-primary-50);
-}
-
 .rulesSection {
   display: flex;
   flex-direction: column;
@@ -126,4 +119,87 @@
 
 .ruleDelete svg {
   color: var(--color-text-secondary);
+}
+
+.ruleSkeletonName {
+  display: flex;
+  align-items: center;
+}
+
+.ruleSkeletonUserAvatar {
+  width: 24px;
+  height: 24px;
+  margin-inline-end: _.unit(3);
+  flex-shrink: 0;
+  border-radius: 6px;
+  @include _.shimmering-animation;
+}
+
+.ruleSkeletonGroupTitle {
+  width: min(140px, 70%);
+  height: 16px;
+  border-radius: 6px;
+  @include _.shimmering-animation;
+}
+
+.ruleSkeletonGroupDescription {
+  width: min(160px, 70%);
+  height: 16px;
+  border-radius: 6px;
+  @include _.shimmering-animation;
+}
+
+.ruleSkeletonTitle {
+  width: min(220px, 70%);
+  height: 16px;
+  border-radius: 6px;
+  @include _.shimmering-animation;
+}
+
+.ruleSkeletonUserId {
+  width: min(260px, 80%);
+  height: 16px;
+  border-radius: 6px;
+  @include _.shimmering-animation;
+}
+
+.ruleSkeletonAssignedEntities {
+  display: flex;
+  align-items: center;
+  gap: _.unit(2);
+}
+
+.ruleSkeletonAvatars {
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+}
+
+.ruleSkeletonAvatar {
+  width: 24px;
+  height: 24px;
+  position: relative;
+  border: 2px solid var(--color-layer-1);
+  border-radius: 6px;
+  box-sizing: content-box;
+  @include _.shimmering-animation;
+
+  &:not(:last-child) {
+    margin-inline-start: _.unit(-2);
+  }
+}
+
+.ruleSkeletonCount {
+  width: 72px;
+  height: 16px;
+  border-radius: 6px;
+  @include _.shimmering-animation;
+}
+
+.ruleSkeletonDelete {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  @include _.shimmering-animation;
 }

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ApplicationAccessControl/index.tsx
@@ -15,7 +15,6 @@ import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { appLevelAccessControl } from '@/consts';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
-import { Ring } from '@/ds-components/Spinner';
 import Switch from '@/ds-components/Switch';
 import useApi, { type RequestError } from '@/hooks/use-api';
 import { trySubmitSafe } from '@/utils/form';
@@ -23,6 +22,7 @@ import { trySubmitSafe } from '@/utils/form';
 import AddRuleMenu from './AddRuleMenu';
 import RuleSelectorModals from './RuleSelectorModals';
 import RulesTable from './RulesTable';
+import RulesTableSkeleton from './RulesTableSkeleton';
 import styles from './index.module.scss';
 import { type RuleType } from './types';
 import useRuleEntities from './use-rule-entities';
@@ -38,6 +38,21 @@ type ApplicationAccessControlForm = {
   appLevelAccessControlEnabled: boolean;
   accessControl?: ApplicationAccessControlRules;
 };
+
+function RulesSectionHeader() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  return (
+    <div className={styles.rulesHeader}>
+      <div className={styles.rulesTitle}>
+        {t('application_details.access_control.custom_allow_rules')}
+      </div>
+      <div className={styles.rulesDescription}>
+        {t('application_details.access_control.custom_allow_rules_description')}
+      </div>
+    </div>
+  );
+}
 
 function ApplicationAccessControl({ application, isActive, onApplicationUpdated }: Props) {
   const { id, appLevelAccessControlEnabled } = application;
@@ -174,8 +189,9 @@ function ApplicationAccessControl({ application, isActive, onApplicationUpdated 
             )}
           />
           {isLoading && (
-            <div className={styles.loading}>
-              <Ring />
+            <div className={styles.rulesSection}>
+              <RulesSectionHeader />
+              <RulesTableSkeleton />
             </div>
           )}
           {error && (
@@ -192,19 +208,8 @@ function ApplicationAccessControl({ application, isActive, onApplicationUpdated 
           )}
           {draftAccessControl && (
             <div className={styles.rulesSection}>
-              <div className={styles.rulesHeader}>
-                <div className={styles.rulesTitle}>
-                  {t('application_details.access_control.custom_allow_rules')}
-                </div>
-                <div className={styles.rulesDescription}>
-                  {t('application_details.access_control.custom_allow_rules_description')}
-                </div>
-              </div>
-              {isRuleEntitiesLoading && (
-                <div className={styles.loading}>
-                  <Ring />
-                </div>
-              )}
+              <RulesSectionHeader />
+              {isRuleEntitiesLoading && <RulesTableSkeleton accessControl={draftAccessControl} />}
               {!isRuleEntitiesLoading && ruleEntities.hasError && (
                 <InlineNotification className={styles.notification} severity="error">
                   {t('application_details.access_control.load_error')}


### PR DESCRIPTION
## Summary
Use table-shaped skeleton placeholders for app-level access control rules while the access control payload and rule entity details are loading. This removes the intermediate centered spinner and keeps the rules area closer to its final layout.

## Testing
Tested locally

<img width="1466" height="640" alt="image" src="https://github.com/user-attachments/assets/8dbd58ca-1b04-4a8a-8302-ab73f71eaafd" />
<img width="1464" height="710" alt="image" src="https://github.com/user-attachments/assets/f781bd03-ceea-49a5-8b9c-423cd583eaf9" />

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments