### PR TITLE
fix(account): prompt reauth on unauthorized API errors

### DIFF
--- a/packages/account/src/Providers/AppBoundary/index.tsx
+++ b/packages/account/src/Providers/AppBoundary/index.tsx
@@ -1,6 +1,7 @@
 import useColorTheme from '@/Providers/AppBoundary/use-color-theme';
 import type { ReactElement } from 'react';
 
+import ReauthPromptProvider from '../ReauthPromptProvider';
 import ToastProvider from '../ToastProvider';
 
 import AppMeta from './AppMeta';
@@ -15,7 +16,9 @@ const AppBoundary = ({ children }: Props) => {
   return (
     <>
       <AppMeta />
-      <ToastProvider>{children}</ToastProvider>
+      <ToastProvider>
+        <ReauthPromptProvider>{children}</ReauthPromptProvider>
+      </ToastProvider>
     </>
   );
 };

--- a/packages/account/src/Providers/ReauthPromptProvider/ReauthPromptContext.tsx
+++ b/packages/account/src/Providers/ReauthPromptProvider/ReauthPromptContext.tsx
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+
+type ReauthPromptContextValue = {
+  requestReauthPrompt: () => void;
+};
+
+const ReauthPromptContext = createContext<ReauthPromptContextValue>({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  requestReauthPrompt: () => {},
+});
+
+export default ReauthPromptContext;

--- a/packages/account/src/Providers/ReauthPromptProvider/index.tsx
+++ b/packages/account/src/Providers/ReauthPromptProvider/index.tsx
@@ -1,0 +1,60 @@
+import DynamicT from '@experience/shared/components/DynamicT';
+import { useLogto } from '@logto/react';
+import type { ReactNode } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+
+import ConfirmModal from '@ac/components/ConfirmModal';
+import { accountCenterBasePath, setRouteRestore } from '@ac/utils/account-center-route';
+
+import ReauthPromptContext from './ReauthPromptContext';
+
+const redirectUri = `${window.location.origin}${accountCenterBasePath}`;
+
+type Props = {
+  readonly children: ReactNode;
+};
+
+const ReauthPromptProvider = ({ children }: Props) => {
+  const { signIn } = useLogto();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const requestReauthPrompt = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const closePrompt = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const confirmReauth = useCallback(() => {
+    closePrompt();
+    setRouteRestore(window.location.pathname);
+
+    void signIn({ redirectUri });
+  }, [closePrompt, signIn]);
+
+  const contextValue = useMemo(
+    () => ({
+      requestReauthPrompt,
+    }),
+    [requestReauthPrompt]
+  );
+
+  return (
+    <ReauthPromptContext.Provider value={contextValue}>
+      {children}
+      <ConfirmModal
+        isOpen={isOpen}
+        title="error.something_went_wrong"
+        confirmText="action.sign_in"
+        cancelText="action.cancel"
+        onConfirm={confirmReauth}
+        onCancel={closePrompt}
+      >
+        <DynamicT forKey="error.invalid_session" />
+      </ConfirmModal>
+    </ReauthPromptContext.Provider>
+  );
+};
+
+export default ReauthPromptProvider;

--- a/packages/account/src/hooks/use-error-handler.test.tsx
+++ b/packages/account/src/hooks/use-error-handler.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { HTTPError, type NormalizedOptions } from 'ky';
+
+import ReauthPromptProvider from '@ac/Providers/ReauthPromptProvider';
+import renderWithPageContext from '@ac/__mocks__/RenderWithPageContext';
+import { sessionStorage } from '@ac/utils/session-storage';
+
+import useErrorHandler, { type ErrorHandlers } from './use-error-handler';
+
+const mockSignIn = jest.fn();
+
+jest.mock('@logto/react', () => ({
+  useLogto: () => ({
+    signIn: mockSignIn,
+  }),
+}));
+
+const createHttpError = (code: string, status: number, message = code) =>
+  new HTTPError(
+    {
+      status,
+      json: async () => ({ code, message }),
+    } as Response,
+    {} as Request,
+    {} as NormalizedOptions
+  );
+
+const TestButton = ({
+  error,
+  errorHandlers,
+}: {
+  readonly error: unknown;
+  readonly errorHandlers?: ErrorHandlers;
+}) => {
+  const handleError = useErrorHandler();
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        void handleError(error, errorHandlers);
+      }}
+    >
+      Trigger error
+    </button>
+  );
+};
+
+const renderTestButton = (error: unknown, errorHandlers?: ErrorHandlers) =>
+  renderWithPageContext(
+    <ReauthPromptProvider>
+      <TestButton error={error} errorHandlers={errorHandlers} />
+    </ReauthPromptProvider>,
+    {
+      future: {
+        v7_relativeSplatPath: true,
+        v7_startTransition: true,
+      },
+    }
+  );
+
+describe('useErrorHandler', () => {
+  beforeEach(() => {
+    mockSignIn.mockResolvedValue(undefined);
+    window.history.replaceState({}, '', '/account/security');
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prompts the user to sign in again for auth.unauthorized 401 errors', async () => {
+    renderTestButton(createHttpError('auth.unauthorized', 401));
+
+    fireEvent.click(screen.getByText('Trigger error'));
+
+    await waitFor(() => {
+      expect(screen.getByText('error.invalid_session')).not.toBeNull();
+    });
+
+    fireEvent.click(screen.getByText('action.sign_in'));
+
+    await waitFor(() => {
+      expect(mockSignIn).toHaveBeenCalledWith({ redirectUri: 'http://localhost/account' });
+    });
+    expect(sessionStorage.getRouteRestore()).not.toBeUndefined();
+  });
+
+  it('prefers explicit error handlers over the default reauth prompt', async () => {
+    const handler = jest.fn();
+    renderTestButton(createHttpError('auth.unauthorized', 401), {
+      'auth.unauthorized': handler,
+    });
+
+    fireEvent.click(screen.getByText('Trigger error'));
+
+    await waitFor(() => {
+      expect(handler).toHaveBeenCalledWith({
+        code: 'auth.unauthorized',
+        message: 'auth.unauthorized',
+      });
+    });
+    expect(screen.queryByText('error.invalid_session')).toBeNull();
+    expect(mockSignIn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/account/src/hooks/use-error-handler.ts
+++ b/packages/account/src/hooks/use-error-handler.ts
@@ -4,6 +4,7 @@ import { useCallback, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
+import ReauthPromptContext from '@ac/Providers/ReauthPromptProvider/ReauthPromptContext';
 
 export type ErrorHandlers = {
   [code: string]: ((error: RequestErrorBody) => void | Promise<void>) | undefined;
@@ -14,6 +15,7 @@ export type ErrorHandlers = {
 const useErrorHandler = () => {
   const { t } = useTranslation();
   const { setToast } = useContext(PageContext);
+  const { requestReauthPrompt } = useContext(ReauthPromptContext);
 
   const handleError = useCallback(
     async (error: unknown, errorHandlers?: ErrorHandlers) => {
@@ -27,6 +29,8 @@ const useErrorHandler = () => {
 
           if (handler) {
             await handler(logtoError);
+          } else if (error.response.status === 401 && code === 'auth.unauthorized') {
+            requestReauthPrompt();
           } else {
             setToast(message);
           }
@@ -49,7 +53,7 @@ const useErrorHandler = () => {
       setToast(t('error.unknown'));
       console.error(error);
     },
-    [setToast, t]
+    [requestReauthPrompt, setToast, t]
   );
 
   return handleError;

--- a/packages/account/src/pages/Sessions/index.tsx
+++ b/packages/account/src/pages/Sessions/index.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { HTTPError } from 'ky';
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -180,14 +181,18 @@ const Sessions = () => {
         app.grantIds.map(async (grantId) => {
           const [error] = await revokeGrantApi(verificationId, grantId);
           if (error) {
-            throw new Error('revoke_failed');
+            throw error instanceof Error ? error : new Error('revoke_failed');
           }
         })
       );
 
-      const hasFailure = results.some((result) => result.status === 'rejected');
-      if (hasFailure) {
-        setToast(t('account_center.sessions.revoke_grant_failed'));
+      const failure = results.find((result) => result.status === 'rejected');
+      if (failure) {
+        if (failure.reason instanceof HTTPError) {
+          await handleError(failure.reason);
+        } else {
+          setToast(t('account_center.sessions.revoke_grant_failed'));
+        }
         setRemovingAppId(undefined);
         return;
       }
@@ -197,7 +202,7 @@ const Sessions = () => {
       );
       setRemovingAppId(undefined);
     },
-    [verificationId, revokeGrantApi, setToast, t]
+    [verificationId, revokeGrantApi, handleError, setToast, t]
   );
 
   const handleConfirmRevokeGrant = useCallback(async () => {

--- a/packages/account/src/utils/account-center-route.test.ts
+++ b/packages/account/src/utils/account-center-route.test.ts
@@ -123,6 +123,11 @@ describe('account-center-route', () => {
       expect(accountStorage.routeRestore.get()).toBe('/account/password');
     });
 
+    it('stores sessions route', () => {
+      setRouteRestore('/account/sessions');
+      expect(accountStorage.routeRestore.get()).toBe('/account/sessions');
+    });
+
     it('does not store unknown routes', () => {
       setRouteRestore('/account/unknown-page');
       expect(accountStorage.routeRestore.get()).toBeUndefined();

--- a/packages/account/src/utils/account-center-route.ts
+++ b/packages/account/src/utils/account-center-route.ts
@@ -20,6 +20,7 @@ import {
   passkeySuccessRoute,
   profileRoute,
   securityRoute,
+  sessionsRoute,
   verifiedActionRoute,
   socialRoutePrefix,
 } from '@ac/constants/routes';
@@ -58,6 +59,7 @@ const knownRoutePrefixes: readonly string[] = [
   passkeyManageRoute,
   passkeySuccessRoute,
   verifiedActionRoute,
+  sessionsRoute,
   socialRoutePrefix,
 ];
 


### PR DESCRIPTION
## Summary

Adds an Account Center reauthentication prompt for user-initiated API flows that fail with `auth.unauthorized` 401.

## Root cause

When Account Center adds a new required scope, users who are already signed in can still hold older access tokens. User-triggered API calls then fail with 401, and the existing error handling only showed the raw API error as a toast or page-level failure.

## Changes

- Add a shared Account Center reauth prompt provider that asks users to sign in again before redirecting.
- Route default `auth.unauthorized` 401 handling through that prompt while preserving explicit per-flow error handlers.
- Preserve original revoke-grant HTTP errors so the shared handler can detect unauthorized responses.
- Include the sessions route in Account Center route restore so users return to `/account/sessions` after reauth.

## Testing

- Unit tests
- Tested locally

## Local validation

Ran the local Logto dev stack and reproduced the missing-scope behavior through the real Account Center UI. To mimic an already-signed-in user with an older access token, I temporarily omitted the sessions scope locally, signed in to Account Center, opened `/account/sessions`, clicked **Manage**, completed password verification, and let the sessions API return `auth.unauthorized` 401. The modal below was captured from that real flow.

![Account Center reauth modal](https://gist.githubusercontent.com/wangsijie/b1b4d1b11031fdb20e7ad7d2534f227a/raw/f033751ebab26431ece9e83747e92d6dc7f72a53/logto-account-reauth-validation.svg)

Commands run locally:

```bash
pnpm --filter @logto/account test --runInBand
pnpm --filter @logto/account check
pnpm --filter @logto/account lint
```
