### PR TITLE
feat: release theme flash fix

### DIFF
--- a/.changeset/release-theme-flash-fix.md
+++ b/.changeset/release-theme-flash-fix.md
@@ -1,8 +1,8 @@
 ---
-"@logto/core": minor
-"@logto/schemas": minor
-"@logto/experience": minor
-"@logto/account": minor
+"@logto/core": patch
+"@logto/schemas": patch
+"@logto/experience": patch
+"@logto/account": patch
 ---
 
 prevent theme flash in sign-in experience and account center

--- a/.changeset/release-theme-flash-fix.md
+++ b/.changeset/release-theme-flash-fix.md
@@ -1,0 +1,10 @@
+---
+"@logto/core": minor
+"@logto/schemas": minor
+"@logto/experience": minor
+"@logto/account": minor
+---
+
+prevent theme flash in sign-in experience and account center
+
+Sign-in experience and account center now apply tenant theme, platform, and brand color before the app hydrates, reducing flashes of the wrong theme during initial page load.

--- a/packages/account/src/Providers/PageContextProvider/index.tsx
+++ b/packages/account/src/Providers/PageContextProvider/index.tsx
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { getAccountCenterSettings } from '@ac/apis/account-center';
 import { getSignInExperienceSettings } from '@ac/apis/sign-in-experience';
 import { getUserInfo } from '@ac/apis/user';
-import { isDevFeaturesEnabled } from '@ac/constants/env';
 import useApi from '@ac/hooks/use-api';
 import { changeLanguage, getPreferredLanguage } from '@ac/i18n/utils';
 import { getUiLocales } from '@ac/utils/account-center-route';
@@ -168,31 +167,11 @@ const PageContextProvider = ({ children }: Props) => {
   }, []);
 
   useEffect(() => {
-    if (isDevFeaturesEnabled) {
-      // Don't change theme while settings are loading; the initial state from
-      // getThemeBySystemPreference() is already correct.
-      if (!experienceSettings) {
-        return;
-      }
-
-      if (!experienceSettings.color.isDarkModeEnabled) {
-        setTheme(Theme.Light);
-        return;
-      }
-
-      const updateTheme = () => {
-        setTheme(getThemeBySystemPreference());
-      };
-
-      updateTheme();
-      const unsubscribe = subscribeToSystemTheme(updateTheme);
-
-      return () => {
-        unsubscribe();
-      };
+    if (!experienceSettings) {
+      return;
     }
 
-    if (!experienceSettings?.color.isDarkModeEnabled) {
+    if (!experienceSettings.color.isDarkModeEnabled) {
       setTheme(Theme.Light);
       return;
     }

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -77,6 +77,7 @@ const {
   validateLanguageInfo,
   removeUnavailableSocialConnectorTargets,
   getFullSignInExperience,
+  getAccountCenterSsrSignInExperience,
   findCaptchaPublicConfig,
 } = createSignInExperienceLibrary(
   'tenant_foo',
@@ -156,6 +157,21 @@ describe('remove unavailable social connector targets', () => {
     expect(updateDefaultSignInExperience).toBeCalledWith({
       socialSignInConnectorTargets: [socialTarget01, socialTarget02],
     });
+  });
+});
+
+describe('getAccountCenterSsrSignInExperience()', () => {
+  it('should return only sign-in experience color data', async () => {
+    findDefaultSignInExperience.mockResolvedValueOnce(mockSignInExperience);
+
+    await expect(getAccountCenterSsrSignInExperience()).resolves.toStrictEqual({
+      color: mockSignInExperience.color,
+    });
+    expect(findDefaultSignInExperience).toBeCalledTimes(1);
+    expect(getLogtoConnectors).not.toBeCalled();
+    expect(mockSsoConnectorLibrary.getAvailableSsoConnectors).not.toBeCalled();
+    expect(findCaptchaProvider).not.toBeCalled();
+    expect(findAllCustomProfileFields).not.toBeCalled();
   });
 });
 

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -1,6 +1,7 @@
 import { GoogleConnector } from '@logto/connector-kit';
 import { builtInLanguages } from '@logto/phrases-experience';
 import type {
+  AccountCenterSsrSignInExperience,
   ConnectorMetadata,
   ForgotPasswordMethods,
   FullSignInExperience,
@@ -341,6 +342,13 @@ export const createSignInExperienceLibrary = (
     };
   };
 
+  const getAccountCenterSsrSignInExperience =
+    async (): Promise<AccountCenterSsrSignInExperience> => {
+      const { color } = await findDefaultSignInExperience();
+
+      return { color };
+    };
+
   /**
    * Username case-sensitivity conflicts: groups of usernames that would clash if the tenant
    * switched to a case-insensitive policy. Returns the total group count plus a capped sample,
@@ -358,6 +366,7 @@ export const createSignInExperienceLibrary = (
     validateLanguageInfo,
     removeUnavailableSocialConnectorTargets,
     getFullSignInExperience,
+    getAccountCenterSsrSignInExperience,
     findCaptchaPublicConfig,
     findCaseConflicts,
   };

--- a/packages/core/src/middleware/koa-account-center-ssr.test.ts
+++ b/packages/core/src/middleware/koa-account-center-ssr.test.ts
@@ -79,7 +79,7 @@ describe('koaAccountCenterSsr()', () => {
     expect(ctx.body).not.toContain(accountCenterSsrPlaceholder);
     expect(ctx.body).toContain(
       `const logtoSsr=Object.freeze(${JSON.stringify({
-        signInExperience: { data: mockSignInExperience },
+        signInExperience: { data: mockAccountCenterSsrSignInExperience },
       })});`
     );
   });

--- a/packages/core/src/middleware/koa-account-center-ssr.test.ts
+++ b/packages/core/src/middleware/koa-account-center-ssr.test.ts
@@ -7,6 +7,7 @@ import koaAccountCenterSsr from './koa-account-center-ssr.js';
 const { jest } = import.meta;
 
 const accountCenterSsrPlaceholder = '"__LOGTO_ACCOUNT_CENTER_SSR__"';
+const mockAccountCenterSsrSignInExperience = { color: mockSignInExperience.color };
 
 describe('koaAccountCenterSsr()', () => {
   const baseCtx = Object.freeze({
@@ -15,7 +16,10 @@ describe('koaAccountCenterSsr()', () => {
   });
   const tenant = new MockTenant(undefined, undefined, undefined, {
     signInExperiences: {
-      getFullSignInExperience: jest.fn().mockResolvedValue(mockSignInExperience),
+      getAccountCenterSsrSignInExperience: jest
+        .fn()
+        .mockResolvedValue(mockAccountCenterSsrSignInExperience),
+      getFullSignInExperience: jest.fn(),
     },
   });
 
@@ -40,7 +44,7 @@ describe('koaAccountCenterSsr()', () => {
     expect(ctx.body).toBe('...');
   });
 
-  it('should prefetch sign-in experience data and inject it into the HTML response', async () => {
+  it('should prefetch sign-in experience color data and inject it into the HTML response', async () => {
     const ctx = {
       ...baseCtx,
       path: '/',
@@ -50,10 +54,14 @@ describe('koaAccountCenterSsr()', () => {
     };
     await koaAccountCenterSsr(tenant.libraries)(ctx, next);
     expect(next).toHaveBeenCalledTimes(1);
+    expect(
+      tenant.libraries.signInExperiences.getAccountCenterSsrSignInExperience
+    ).toHaveBeenCalledTimes(1);
+    expect(tenant.libraries.signInExperiences.getFullSignInExperience).not.toHaveBeenCalled();
     expect(ctx.body).not.toContain(accountCenterSsrPlaceholder);
     expect(ctx.body).toContain(
       `const logtoSsr=Object.freeze(${JSON.stringify({
-        signInExperience: { data: mockSignInExperience },
+        signInExperience: { data: mockAccountCenterSsrSignInExperience },
       })});`
     );
   });

--- a/packages/core/src/middleware/koa-account-center-ssr.ts
+++ b/packages/core/src/middleware/koa-account-center-ssr.ts
@@ -31,7 +31,7 @@ export default function koaAccountCenterSsr<StateT, ContextT extends WithI18nCon
     }
 
     const signInExperience = await trySafe(
-      libraries.signInExperiences.getFullSignInExperience({ locale: ctx.locale })
+      libraries.signInExperiences.getAccountCenterSsrSignInExperience()
     );
 
     if (!signInExperience) {

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -226,7 +226,7 @@ export default class Tenant implements TenantContext {
       mount(
         '/' + UserApps.AccountCenter,
         compose([
-          ...(EnvSet.values.isDevFeaturesEnabled ? [koaAccountCenterSsr(libraries)] : []),
+          koaAccountCenterSsr(libraries),
           koaSpaProxy({
             mountedApps,
             queries,

--- a/packages/schemas/src/types/ssr.ts
+++ b/packages/schemas/src/types/ssr.ts
@@ -1,5 +1,7 @@
 import { type LocalePhrase } from '@logto/phrases-experience';
 
+import { type SignInExperience } from '../db-entries/index.js';
+
 import { type FullSignInExperience } from './sign-in-experience.js';
 
 /**
@@ -22,9 +24,11 @@ export type SsrData = {
  * The server-side rendering data type for **account center**. Only sign-in experience color/theme
  * data is needed for theme flash prevention.
  */
+export type AccountCenterSsrSignInExperience = Pick<SignInExperience, 'color'>;
+
 export type AccountCenterSsrData = {
   signInExperience: {
-    data: FullSignInExperience;
+    data: AccountCenterSsrSignInExperience;
   };
 };
 


### PR DESCRIPTION
## Summary

- Prepare the theme flash prevention work from #8995, #8996, #8997, and #8998 for release.
- Always initialize Account Center SSR theme data before serving the Account Center SPA.
- Keep Account Center theme stable while settings load and add the release changeset.

## Testing

Tested locally