### PR TITLE
test(test): add UI tests to cover app access control console rules

### DIFF
--- a/packages/integration-tests/src/tests/console/applications/access-control.test.ts
+++ b/packages/integration-tests/src/tests/console/applications/access-control.test.ts
@@ -1,0 +1,341 @@
+import {
+  type ApplicationAccessControl,
+  ApplicationType,
+  createDefaultApplicationAccessControl,
+  RoleType,
+  type SamlApplicationResponse,
+} from '@logto/schemas';
+
+import { authedAdminApi } from '#src/api/api.js';
+import {
+  createApplication,
+  deleteApplication,
+  getApplication,
+  getApplications,
+  replaceApplicationAccessControl,
+  updateApplication,
+} from '#src/api/application.js';
+import { assignUsersToRole, createRole, deleteRole } from '#src/api/role.js';
+import {
+  deleteSamlApplication,
+  getSamlApplication,
+  updateSamlApplication,
+} from '#src/api/saml-application.js';
+import { logtoConsoleUrl as logtoConsoleUrlString } from '#src/constants.js';
+import { OrganizationApiTest } from '#src/helpers/organization.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+} from '#src/helpers/profile.js';
+import { expectToClickModalAction, goToAdminConsole } from '#src/ui-helpers/index.js';
+import { appendPathname, devFeatureTest, expectNavigation, generateTestName } from '#src/utils.js';
+
+await page.setViewport({ width: 1920, height: 1080 });
+
+const createOrReuseSamlApplication = async () => {
+  const response = await authedAdminApi.post('saml-applications', {
+    json: {
+      name: generateTestName(),
+      description: null,
+    },
+    throwHttpErrors: false,
+  });
+
+  if (response.ok) {
+    return {
+      application: await response.json<SamlApplicationResponse>(),
+      shouldDelete: true,
+    };
+  }
+
+  const error = await response.json<{ code?: string }>();
+  if (response.status === 403 && error.code === 'application.saml.reach_oss_limit') {
+    const [application] = await getApplications([ApplicationType.SAML]);
+
+    expect(application).toBeDefined();
+
+    return {
+      application: application!,
+      shouldDelete: false,
+    };
+  }
+
+  throw new Error(`Failed to create SAML application: ${response.status} ${error.code ?? ''}`);
+};
+
+const resetOrDeleteSamlApplication = async ({
+  application,
+  shouldDelete,
+}: Awaited<ReturnType<typeof createOrReuseSamlApplication>>) => {
+  if (shouldDelete) {
+    await deleteSamlApplication(application.id);
+    return;
+  }
+
+  await updateSamlApplication(application.id, { appLevelAccessControlEnabled: false });
+  await replaceApplicationAccessControl(application.id, createDefaultApplicationAccessControl());
+};
+
+const createAccessControlFixtures = async () => {
+  const organizationApi = new OrganizationApiTest();
+  const { user, username } = await createDefaultTenantUserWithPassword();
+  const userRole = await createRole({ name: generateTestName(), type: RoleType.User });
+  const [organization, organizationWithRole] = await Promise.all([
+    organizationApi.create({ name: generateTestName() }),
+    organizationApi.create({ name: generateTestName() }),
+  ]);
+  const organizationRole = await organizationApi.roleApi.create({
+    name: generateTestName(),
+    type: RoleType.User,
+  });
+
+  await Promise.all([
+    assignUsersToRole([user.id], userRole.id),
+    organizationApi.addUsers(organization.id, [user.id]),
+    organizationApi.addUsers(organizationWithRole.id, [user.id]),
+  ]);
+  await organizationApi.addUserRoles(organizationWithRole.id, user.id, [organizationRole.id]);
+
+  return {
+    accessControl: {
+      ...createDefaultApplicationAccessControl(),
+      userIds: [user.id],
+      userRoleIds: [userRole.id],
+      organizationIds: [organization.id],
+      organizationRoleRules: [
+        {
+          organizationId: organizationWithRole.id,
+          organizationRoleIds: [organizationRole.id],
+        },
+      ],
+    } satisfies ApplicationAccessControl,
+    tableDetails: {
+      username,
+      userId: user.id,
+      userRoleName: userRole.name,
+      organizationName: organization.name,
+      organizationRoleRuleName: `${organizationWithRole.name} - ${organizationRole.name}`,
+    },
+    cleanup: async () =>
+      Promise.allSettled([
+        deleteDefaultTenantUser(user.id),
+        deleteRole(userRole.id),
+        organizationApi.cleanUp(),
+      ]),
+  };
+};
+
+const expectAccessControlTableDetails = async ({
+  username,
+  userId,
+  userRoleName,
+  organizationName,
+  organizationRoleRuleName,
+}: Awaited<ReturnType<typeof createAccessControlFixtures>>['tableDetails']) => {
+  await expect(page).toMatchElement('table tbody tr td', { text: username });
+  await expect(page).toMatchElement('table tbody tr td', { text: userId });
+  await expect(page).toMatchElement('table tbody tr td', { text: userRoleName });
+  await expect(page).toMatchElement('table tbody tr td', { text: organizationName });
+  await expect(page).toMatchElement('table tbody tr td', { text: organizationRoleRuleName });
+};
+
+const clickRemoveRuleByText = async (text: string) =>
+  page.evaluate((targetText) => {
+    const row = [...document.querySelectorAll('table tbody tr')].find((element) =>
+      element.textContent?.includes(targetText)
+    );
+    const button = row?.querySelector<HTMLButtonElement>('button[aria-label=Remove]');
+
+    if (!button) {
+      throw new Error(`Remove button for rule "${targetText}" not found`);
+    }
+
+    button.click();
+  }, text);
+
+const expectRuleNotInTable = async (text: string) =>
+  page.waitForFunction(
+    (targetText) =>
+      [...document.querySelectorAll('table tbody tr')].every(
+        (element) => !element.textContent?.includes(targetText)
+      ),
+    {},
+    text
+  );
+
+devFeatureTest.describe('application access control Console', () => {
+  const logtoConsoleUrl = new URL(logtoConsoleUrlString);
+
+  beforeAll(async () => {
+    await goToAdminConsole();
+  });
+
+  it('renders rules tab and table details for enabled applications', async () => {
+    const accessControlFixtures = await createAccessControlFixtures();
+    const [application, machineToMachineApplication] = await Promise.all([
+      createApplication(generateTestName(), ApplicationType.SPA),
+      createApplication(generateTestName(), ApplicationType.MachineToMachine),
+    ]);
+
+    try {
+      await replaceApplicationAccessControl(application.id, accessControlFixtures.accessControl);
+      await updateApplication(application.id, { appLevelAccessControlEnabled: true });
+
+      await expectNavigation(
+        page.goto(
+          appendPathname(
+            `/console/applications/${machineToMachineApplication.id}/settings`,
+            logtoConsoleUrl
+          ).href
+        )
+      );
+      await expect(page).toMatchElement('nav a', { text: 'Settings' });
+
+      const machineToMachineRulesTabCount = await page.$$eval(
+        'nav a',
+        (links) => links.filter((link) => link.textContent?.trim() === 'Rules').length
+      );
+      expect(machineToMachineRulesTabCount).toBe(0);
+
+      await expectNavigation(
+        page.goto(
+          appendPathname(`/console/applications/${application.id}/rules`, logtoConsoleUrl).href
+        )
+      );
+
+      await expect(page).toMatchElement('nav a', { text: 'Rules' });
+      await expect(page).toMatchElement('div[class$=title]', {
+        text: 'Enable app-level access control',
+      });
+
+      await expectAccessControlTableDetails(accessControlFixtures.tableDetails);
+
+      await expect(getApplication(application.id)).resolves.toMatchObject({
+        appLevelAccessControlEnabled: true,
+      });
+    } finally {
+      await Promise.allSettled([
+        deleteApplication(application.id),
+        deleteApplication(machineToMachineApplication.id),
+        accessControlFixtures.cleanup(),
+      ]);
+    }
+  });
+
+  it('renders SAML rules tab and table details for enabled applications', async () => {
+    const samlApplicationFixtures = await createOrReuseSamlApplication();
+    const accessControlFixtures = await createAccessControlFixtures();
+    const { application: samlApplication } = samlApplicationFixtures;
+
+    try {
+      await replaceApplicationAccessControl(
+        samlApplication.id,
+        accessControlFixtures.accessControl
+      );
+      await updateSamlApplication(samlApplication.id, { appLevelAccessControlEnabled: true });
+
+      await expectNavigation(
+        page.goto(
+          appendPathname(`/console/applications/${samlApplication.id}/rules`, logtoConsoleUrl).href
+        )
+      );
+
+      await expect(page).toMatchElement('nav a', { text: 'Rules' });
+      await expect(page).toMatchElement('div[class$=title]', {
+        text: 'Enable app-level access control',
+      });
+
+      await expectAccessControlTableDetails(accessControlFixtures.tableDetails);
+
+      await expect(getSamlApplication(samlApplication.id)).resolves.toMatchObject({
+        appLevelAccessControlEnabled: true,
+      });
+    } finally {
+      await Promise.allSettled([
+        resetOrDeleteSamlApplication(samlApplicationFixtures),
+        accessControlFixtures.cleanup(),
+      ]);
+    }
+  });
+
+  it('removes user rules from the rules tab', async () => {
+    const [existingUser, { user, username }] = await Promise.all([
+      createDefaultTenantUserWithPassword(),
+      createDefaultTenantUserWithPassword(),
+    ]);
+    const application = await createApplication(generateTestName(), ApplicationType.SPA);
+
+    try {
+      await replaceApplicationAccessControl(application.id, {
+        ...createDefaultApplicationAccessControl(),
+        userIds: [existingUser.user.id, user.id],
+      });
+      await updateApplication(application.id, { appLevelAccessControlEnabled: true });
+
+      await expectNavigation(
+        page.goto(
+          appendPathname(`/console/applications/${application.id}/rules`, logtoConsoleUrl).href
+        )
+      );
+
+      await expect(page).toMatchElement('table tbody tr td', { text: existingUser.username });
+      await expect(page).toMatchElement('table tbody tr td', { text: username });
+
+      await clickRemoveRuleByText(existingUser.username);
+      await expectToClickModalAction(page, 'Remove');
+      await expectRuleNotInTable(existingUser.username);
+
+      await expect(getApplication(application.id)).resolves.toMatchObject({
+        appLevelAccessControlEnabled: true,
+      });
+      await expect(page).toMatchElement('table tbody tr td', { text: username });
+    } finally {
+      await Promise.allSettled([
+        deleteApplication(application.id),
+        deleteDefaultTenantUser(existingUser.user.id),
+        deleteDefaultTenantUser(user.id),
+      ]);
+    }
+  });
+
+  it('removes user rules from the SAML rules tab', async () => {
+    const [existingUser, { user, username }] = await Promise.all([
+      createDefaultTenantUserWithPassword(),
+      createDefaultTenantUserWithPassword(),
+    ]);
+    const samlApplicationFixtures = await createOrReuseSamlApplication();
+    const { application: samlApplication } = samlApplicationFixtures;
+
+    try {
+      await replaceApplicationAccessControl(samlApplication.id, {
+        ...createDefaultApplicationAccessControl(),
+        userIds: [existingUser.user.id, user.id],
+      });
+      await updateSamlApplication(samlApplication.id, { appLevelAccessControlEnabled: true });
+
+      await expectNavigation(
+        page.goto(
+          appendPathname(`/console/applications/${samlApplication.id}/rules`, logtoConsoleUrl).href
+        )
+      );
+
+      await expect(page).toMatchElement('table tbody tr td', { text: existingUser.username });
+      await expect(page).toMatchElement('table tbody tr td', { text: username });
+
+      await clickRemoveRuleByText(existingUser.username);
+      await expectToClickModalAction(page, 'Remove');
+      await expectRuleNotInTable(existingUser.username);
+
+      await expect(getSamlApplication(samlApplication.id)).resolves.toMatchObject({
+        appLevelAccessControlEnabled: true,
+      });
+      await expect(page).toMatchElement('table tbody tr td', { text: username });
+    } finally {
+      await Promise.allSettled([
+        resetOrDeleteSamlApplication(samlApplicationFixtures),
+        deleteDefaultTenantUser(existingUser.user.id),
+        deleteDefaultTenantUser(user.id),
+      ]);
+    }
+  });
+});

--- a/packages/integration-tests/src/tests/experience/application-access-control.test.ts
+++ b/packages/integration-tests/src/tests/experience/application-access-control.test.ts
@@ -1,0 +1,130 @@
+import {
+  AgreeToTermsPolicy,
+  ApplicationType,
+  createDefaultApplicationAccessControl,
+} from '@logto/schemas';
+
+import {
+  createApplication,
+  deleteApplication,
+  replaceApplicationAccessControl,
+  updateApplication,
+} from '#src/api/application.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { demoAppRedirectUri, demoAppUrl, logtoUrl } from '#src/constants.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+} from '#src/helpers/profile.js';
+import { setUsernamePasswordOnly } from '#src/helpers/sign-in-experience.js';
+import ExpectExperience from '#src/ui-helpers/expect-experience.js';
+import { devFeatureTest, generateTestName } from '#src/utils.js';
+
+const createAccessControlledSpaApplication = async (allowedUserId: string) => {
+  const application = await createApplication(generateTestName(), ApplicationType.SPA, {
+    oidcClientMetadata: {
+      redirectUris: [demoAppRedirectUri],
+      postLogoutRedirectUris: [demoAppRedirectUri],
+    },
+  });
+
+  await replaceApplicationAccessControl(application.id, {
+    ...createDefaultApplicationAccessControl(),
+    userIds: [allowedUserId],
+  });
+  await updateApplication(application.id, { appLevelAccessControlEnabled: true });
+
+  return application;
+};
+
+const buildDemoAppUrl = (applicationId: string) => {
+  const url = new URL(demoAppUrl);
+  url.searchParams.set('app_id', applicationId);
+
+  return url;
+};
+
+const signInFromExperience = async (
+  experience: ExpectExperience,
+  username: string,
+  password: string
+) => {
+  await experience.toFillForm(
+    {
+      identifier: username,
+      password,
+    },
+    { submit: true, shouldNavigate: false }
+  );
+};
+
+const clearExperienceCookies = async (experience: ExpectExperience) => {
+  const cookies = await Promise.all([
+    experience.page.cookies(logtoUrl),
+    experience.page.cookies(demoAppUrl.href),
+  ]);
+
+  await experience.page.deleteCookie(...cookies.flat());
+};
+
+devFeatureTest.describe('application access control experience', () => {
+  beforeAll(async () => {
+    await setUsernamePasswordOnly();
+    await updateSignInExperience({
+      termsOfUseUrl: null,
+      privacyPolicyUrl: null,
+      agreeToTermsPolicy: AgreeToTermsPolicy.Automatic,
+    });
+  });
+
+  it('allows users that match the app access rules to enter the app', async () => {
+    const { user, username, password } = await createDefaultTenantUserWithPassword();
+    const application = await createAccessControlledSpaApplication(user.id);
+    const experience = new ExpectExperience(await browser.newPage());
+
+    try {
+      await clearExperienceCookies(experience);
+      await experience.startWith(buildDemoAppUrl(application.id));
+      await signInFromExperience(experience, username, password);
+
+      await experience.page.waitForFunction(() => {
+        const url = new URL(window.location.href);
+
+        return url.pathname === '/demo-app' && url.searchParams.has('code');
+      });
+    } finally {
+      await Promise.allSettled([
+        experience.page.close(),
+        deleteApplication(application.id),
+        deleteDefaultTenantUser(user.id),
+      ]);
+    }
+  });
+
+  it('shows the generic access denied page when the signed-in user has no app access', async () => {
+    const [deniedUser, allowedUser] = await Promise.all([
+      createDefaultTenantUserWithPassword(),
+      createDefaultTenantUserWithPassword(),
+    ]);
+    const application = await createAccessControlledSpaApplication(allowedUser.user.id);
+    const experience = new ExpectExperience(await browser.newPage());
+
+    try {
+      await clearExperienceCookies(experience);
+      await experience.startWith(buildDemoAppUrl(application.id));
+      await signInFromExperience(experience, deniedUser.username, deniedUser.password);
+
+      await experience.page.waitForFunction(() =>
+        document.body.textContent?.toLowerCase().includes('access denied')
+      );
+      await experience.toMatchElement('body', { text: /sign out/i });
+    } finally {
+      await Promise.allSettled([
+        experience.page.close(),
+        deleteApplication(application.id),
+        deleteDefaultTenantUser(deniedUser.user.id),
+        deleteDefaultTenantUser(allowedUser.user.id),
+      ]);
+    }
+  });
+});

--- a/packages/integration-tests/src/ui-helpers/index.ts
+++ b/packages/integration-tests/src/ui-helpers/index.ts
@@ -25,12 +25,17 @@ export const goToAdminConsole = async () => {
   const logtoConsoleUrl = new URL(logtoConsoleUrlString);
   await expectNavigation(page.goto(logtoConsoleUrl.href));
 
-  if (page.url() === new URL('sign-in', logtoConsoleUrl).href) {
+  if (new URL(page.url()).pathname === '/sign-in') {
     await expect(page).toFillForm('form', {
       identifier: consoleUsername,
       password: consolePassword,
     });
-    await expectNavigation(expect(page).toClick('button[name=submit]'));
+    await expect(page).toClick('button[name=submit]');
+    await page.waitForFunction(
+      () =>
+        window.location.pathname.startsWith('/console') &&
+        window.location.pathname !== '/console/callback'
+    );
   }
 };
 


### PR DESCRIPTION
## Summary
Add broader UI integration coverage for app-level access control.

Console UI matrix covered in this PR:

| App / UI surface | User IDs | User roles | Organizations | Organization roles | Additional coverage |
| --- | --- | --- | --- | --- | --- |
| SPA application Rules tab | ✅ table rendering | ✅ table rendering | ✅ table rendering | ✅ table rendering | Rules tab is visible, enabled state is reflected, M2M app has no Rules tab |
| SPA application rule removal | ✅ remove confirmation + row update | N/A | N/A | N/A | Confirms the remove modal flow and keeps remaining user rule visible |
| SAML application Rules tab | ✅ table rendering | ✅ table rendering | ✅ table rendering | ✅ table rendering | Covers the SAML-specific details UI and SAML update API path |
| SAML application rule removal | ✅ remove confirmation + row update | N/A | N/A | N/A | Confirms the remove modal flow through the SAML Rules tab |

Experience UI matrix covered in this PR:

| App type | Rule type | Allowed user | Denied user |
| --- | --- | --- | --- |
| SPA | User IDs | ✅ reaches app callback with authorization code | ✅ sees generic access denied page with sign-out action |

## Testing
Integration tests

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments