### PR TITLE
feat: release app-level access control

### DIFF
--- a/.changeset/new-cobras-perform.md
+++ b/.changeset/new-cobras-perform.md
@@ -1,0 +1,22 @@
+---
+"@logto/console": minor
+"@logto/core": minor
+"@logto/experience": minor
+"@logto/phrases-experience": minor
+"@logto/phrases": minor
+"@logto/integration-tests": minor
+"@logto/schemas": minor
+---
+
+add app-level access control for applications
+
+Add a new application access control feature that allows administrators to restrict user access to applications. When enabled, users who do not have permission to access an application will see an access denied error message when they attempt to sign in or access the application. This feature can be configured in the Console Security settings.
+
+Supported custom control rules include:
+
+- User IDs
+- User roles
+- Organizations
+- Organization roles
+
+Refer to the documentation for more details: https://docs.logto.io/integrate-logto/app-level-access-control

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/index.tsx
@@ -18,7 +18,6 @@ import DetailsPageHeader from '@/components/DetailsPage/DetailsPageHeader';
 import Drawer from '@/components/Drawer';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { ApplicationDetailsTabs, logtoThirdPartyGuideLink, protectedApp } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import DeleteConfirmModal from '@/ds-components/DeleteConfirmModal';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import TabWrapper from '@/ds-components/TabWrapper';
@@ -78,7 +77,7 @@ function ApplicationDetailsContent({ data, secrets, oidcConfig, onApplicationUpd
     ApplicationType.Traditional,
     ApplicationType.Protected,
   ].includes(data.type);
-  const hasRules = isDevFeaturesEnabled && data.type !== ApplicationType.MachineToMachine;
+  const hasRules = data.type !== ApplicationType.MachineToMachine;
 
   const onSubmit = handleSubmit(
     trySubmitSafe(async (formData) => {

--- a/packages/console/src/pages/ApplicationDetails/SamlApplicationDetailsContent/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/SamlApplicationDetailsContent/index.tsx
@@ -15,7 +15,6 @@ import DetailsPageHeader from '@/components/DetailsPage/DetailsPageHeader';
 import Skeleton from '@/components/FormCard/Skeleton';
 import RequestDataError from '@/components/RequestDataError';
 import { ApplicationDetailsTabs } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import DeleteConfirmModal from '@/ds-components/DeleteConfirmModal';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import TabWrapper from '@/ds-components/TabWrapper';
@@ -60,7 +59,6 @@ function SamlApplicationDetailsContent({ data, onApplicationUpdated }: Props) {
   const api = useApi();
 
   const isLoading = !samlApplicationData && !samlApplicationError;
-  const hasRules = isDevFeaturesEnabled;
 
   const onDelete = useCallback(async () => {
     setIsDeleting(true);
@@ -155,11 +153,9 @@ function SamlApplicationDetailsContent({ data, onApplicationUpdated }: Props) {
         <TabNavItem href={`/applications/${data.id}/${ApplicationDetailsTabs.Branding}`}>
           {t('application_details.branding.name')}
         </TabNavItem>
-        {hasRules && (
-          <TabNavItem href={`/applications/${data.id}/${ApplicationDetailsTabs.Rules}`}>
-            {t('application_details.access_control.name')}
-          </TabNavItem>
-        )}
+        <TabNavItem href={`/applications/${data.id}/${ApplicationDetailsTabs.Rules}`}>
+          {t('application_details.access_control.name')}
+        </TabNavItem>
       </TabNav>
       <TabWrapper
         isActive={tab === ApplicationDetailsTabs.Settings}
@@ -188,15 +184,13 @@ function SamlApplicationDetailsContent({ data, onApplicationUpdated }: Props) {
         {/* isActive is needed to support conditional render UnsavedChangesAlertModal */}
         <Branding application={data} isActive={tab === ApplicationDetailsTabs.Branding} />
       </TabWrapper>
-      {hasRules && (
-        <TabWrapper isActive={tab === ApplicationDetailsTabs.Rules} className={styles.tabContainer}>
-          <ApplicationAccessControl
-            application={data}
-            isActive={tab === ApplicationDetailsTabs.Rules}
-            onAppLevelAccessControlUpdated={onAppLevelAccessControlUpdated}
-          />
-        </TabWrapper>
-      )}
+      <TabWrapper isActive={tab === ApplicationDetailsTabs.Rules} className={styles.tabContainer}>
+        <ApplicationAccessControl
+          application={data}
+          isActive={tab === ApplicationDetailsTabs.Rules}
+          onAppLevelAccessControlUpdated={onAppLevelAccessControlUpdated}
+        />
+      </TabWrapper>
     </>
   );
 }

--- a/packages/core/src/libraries/application-access-control.test.ts
+++ b/packages/core/src/libraries/application-access-control.test.ts
@@ -1,7 +1,6 @@
 import { accountCenterApplicationId, type Application } from '@logto/schemas';
 
 import { mockApplication } from '#src/__mocks__/index.js';
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
 
@@ -21,7 +20,6 @@ const disabledApplication: Application = {
   appLevelAccessControlEnabled: false,
 };
 
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 const findApplicationById = jest.fn(async () => enabledApplication);
 const hasUserApplicationAccess = jest.fn(async () => false);
 
@@ -34,33 +32,16 @@ const createLibrary = () => {
   return createApplicationAccessControlLibrary(queries);
 };
 
-const setDevFeaturesEnabled = (value: boolean) => {
-  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', value);
-};
-
 beforeEach(() => {
-  setDevFeaturesEnabled(true);
   findApplicationById.mockResolvedValue(enabledApplication);
   hasUserApplicationAccess.mockResolvedValue(false);
 });
 
 afterEach(() => {
-  setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
   jest.clearAllMocks();
 });
 
 describe('assertUserHasApplicationAccess()', () => {
-  it('allows without querying the application when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
-
-    await expect(
-      createLibrary().assertUserHasApplicationAccess(applicationId, userId)
-    ).resolves.not.toThrow();
-
-    expect(findApplicationById).not.toHaveBeenCalled();
-    expect(hasUserApplicationAccess).not.toHaveBeenCalled();
-  });
-
   it('allows built-in applications without querying the application', async () => {
     await expect(
       createLibrary().assertUserHasApplicationAccess(accountCenterApplicationId, userId)

--- a/packages/core/src/libraries/application-access-control.ts
+++ b/packages/core/src/libraries/application-access-control.ts
@@ -1,6 +1,5 @@
 import { isBuiltInApplicationId } from '@logto/schemas';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -32,7 +31,7 @@ export const createApplicationAccessControlLibrary = (queries: Queries) => {
     userId: string,
     appLevelAccessControlEnabled?: boolean
   ) => {
-    if (!EnvSet.values.isDevFeaturesEnabled || isBuiltInApplicationId(applicationId)) {
+    if (isBuiltInApplicationId(applicationId)) {
       return;
     }
 

--- a/packages/core/src/routes/applications/application-access-control.openapi.json
+++ b/packages/core/src/routes/applications/application-access-control.openapi.json
@@ -2,7 +2,6 @@
   "paths": {
     "/api/applications/{applicationId}/access-control": {
       "get": {
-        "tags": ["Dev feature"],
         "summary": "Get application access-control rules",
         "description": "Get the app-level access-control rule configuration for the specified application.",
         "responses": {
@@ -10,12 +9,11 @@
             "description": "The app-level access-control rule configuration."
           },
           "404": {
-            "description": "The application was not found, or app-level access control is unavailable."
+            "description": "The application was not found."
           }
         }
       },
       "put": {
-        "tags": ["Dev feature"],
         "summary": "Replace application access-control rules",
         "description": "Replace the app-level access-control rule configuration for the specified application.",
         "requestBody": {
@@ -52,7 +50,7 @@
             "description": "The app-level access-control rule configuration was replaced successfully."
           },
           "404": {
-            "description": "The application or referenced entities were not found, or app-level access control is unavailable."
+            "description": "The application or referenced entities were not found."
           },
           "422": {
             "description": "The access-control rule payload contains invalid role types or empty organization-role groups."

--- a/packages/core/src/routes/applications/application-access-control.test.ts
+++ b/packages/core/src/routes/applications/application-access-control.test.ts
@@ -7,7 +7,6 @@ import {
 import { pickDefault } from '@logto/shared/esm';
 
 import { mockApplication } from '#src/__mocks__/index.js';
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
@@ -36,17 +35,8 @@ const tenantContext = new MockTenant(undefined, {
 
 const { createRequester } = await import('#src/utils/test-utils.js');
 const applicationRoutes = await pickDefault(import('./application.js'));
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
-  // eslint-disable-next-line @silverhand/fp/no-mutation
-  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
-};
-
-const createApplicationRequest = (isDevFeaturesEnabled = true) => {
-  setDevFeaturesEnabled(isDevFeaturesEnabled);
-
-  return createRequester({ authedRoutes: applicationRoutes, tenantContext });
-};
+const createApplicationRequest = () =>
+  createRequester({ authedRoutes: applicationRoutes, tenantContext });
 
 const buildAccessControl = (
   patch: Partial<ApplicationAccessControl> = {}
@@ -62,14 +52,13 @@ const buildAccessControl = (
 
 describe('application access-control route', () => {
   afterEach(() => {
-    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
     findApplicationById.mockClear();
     updateApplicationById.mockClear();
     findApplicationAccessControl.mockClear();
     replaceApplicationAccessControl.mockClear();
   });
 
-  it('PATCH /applications/:applicationId should gate app-level access control enablement by dev features', async () => {
+  it('PATCH /applications/:applicationId should update app-level access control enablement', async () => {
     const applicationRequest = createApplicationRequest();
 
     const patch = { appLevelAccessControlEnabled: true };
@@ -81,15 +70,6 @@ describe('application access-control route', () => {
     expect(findApplicationAccessControl).toHaveBeenCalledWith('foo');
     expect(updateApplicationById).toHaveBeenCalledWith('foo', patch, 'replace');
     expect(response.body).toMatchObject(patch);
-
-    updateApplicationById.mockClear();
-
-    const disabledResponse = await createApplicationRequest(false)
-      .patch('/applications/foo')
-      .send(patch);
-
-    expect(disabledResponse.status).toEqual(400);
-    expect(updateApplicationById).not.toHaveBeenCalled();
   });
 
   it('PATCH /applications/:applicationId should reject enabling app-level access control with empty rules', async () => {
@@ -112,15 +92,6 @@ describe('application access-control route', () => {
     expect(findApplicationById).toHaveBeenCalledWith('foo');
     expect(findApplicationAccessControl).toHaveBeenCalledWith('foo');
     expect(response.body).toEqual(createDefaultApplicationAccessControl());
-  });
-
-  it('GET /applications/:applicationId/access-control should be unavailable without dev features', async () => {
-    const applicationRequest = createApplicationRequest(false);
-
-    const response = await applicationRequest.get('/applications/foo/access-control');
-
-    expect(response.status).toEqual(404);
-    expect(findApplicationAccessControl).not.toHaveBeenCalled();
   });
 
   it('PUT /applications/:applicationId/access-control should validate and replace deduplicated rules', async () => {
@@ -200,17 +171,6 @@ describe('application access-control route', () => {
     const response = await applicationRequest
       .put('/applications/foo/access-control')
       .send(buildAccessControl({ userIds: ['missing-user'] }));
-
-    expect(response.status).toEqual(404);
-    expect(replaceApplicationAccessControl).not.toHaveBeenCalled();
-  });
-
-  it('PUT /applications/:applicationId/access-control should be unavailable without dev features', async () => {
-    const applicationRequest = createApplicationRequest(false);
-
-    const response = await applicationRequest
-      .put('/applications/foo/access-control')
-      .send(buildAccessControl());
 
     expect(response.status).toEqual(404);
     expect(replaceApplicationAccessControl).not.toHaveBeenCalled();

--- a/packages/core/src/routes/applications/application-access-control.ts
+++ b/packages/core/src/routes/applications/application-access-control.ts
@@ -2,7 +2,6 @@ import { applicationAccessControlGuard, type ApplicationAccessControl } from '@l
 import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard, { parse } from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -56,15 +55,6 @@ export default function applicationAccessControlRoutes<T extends ManagementApiRo
 
   const pathname = '/applications/:applicationId/access-control';
   const params = z.object({ applicationId: z.string().min(1) });
-
-  router.use(pathname, koaGuard({ params }), async (_, next) => {
-    assertThat(
-      EnvSet.values.isDevFeaturesEnabled,
-      new RequestError({ code: 'entity.not_found', status: 404 })
-    );
-
-    return next();
-  });
 
   router.get(
     pathname,

--- a/packages/core/src/routes/applications/application.openapi.json
+++ b/packages/core/src/routes/applications/application.openapi.json
@@ -128,8 +128,7 @@
                   },
                   "appLevelAccessControlEnabled": {
                     "type": "boolean",
-                    "description": "Whether app-level access control is enabled for this application. This field is available only when dev features are enabled.",
-                    "x-logto-dev-feature": true
+                    "description": "Whether app-level access control is enabled for this application."
                   }
                 }
               }

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -16,7 +16,6 @@ import { generateStandardId, generateStandardSecret } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
 import { boolean, object, string, z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
@@ -484,8 +483,6 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
 
   applicationCustomDataRoutes(router, tenant);
 
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    applicationAccessControlRoutes(router, tenant);
-  }
+  applicationAccessControlRoutes(router, tenant);
 }
 /* eslint-enable max-lines */

--- a/packages/core/src/routes/applications/types.ts
+++ b/packages/core/src/routes/applications/types.ts
@@ -5,16 +5,9 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
-
 const protectedAppAdditionalScopeGuard = z.enum(protectedAppAdditionalScopes);
 
-export const appLevelAccessControlEnabledGuard = z
-  .boolean()
-  .refine(() => EnvSet.values.isDevFeaturesEnabled, {
-    message: 'appLevelAccessControlEnabled is not available when dev features are disabled',
-  })
-  .optional();
+export const appLevelAccessControlEnabledGuard = z.boolean().optional();
 
 export const applicationCreateGuard = originalApplicationCreateGuard
   .omit({

--- a/packages/core/src/routes/saml-application/index.openapi.json
+++ b/packages/core/src/routes/saml-application/index.openapi.json
@@ -145,8 +145,7 @@
                   },
                   "appLevelAccessControlEnabled": {
                     "type": "boolean",
-                    "description": "Whether app-level access control is enabled for this application. This field is available only when dev features are enabled.",
-                    "x-logto-dev-feature": true
+                    "description": "Whether app-level access control is enabled for this application."
                   },
                   "acsUrl": {
                     "type": "string",

--- a/packages/core/src/routes/saml-application/index.test.ts
+++ b/packages/core/src/routes/saml-application/index.test.ts
@@ -8,7 +8,6 @@ import {
 import { pickDefault } from '@logto/shared/esm';
 
 import { mockApplication } from '#src/__mocks__/index.js';
-import { EnvSet } from '#src/env-set/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
 const { jest } = import.meta;
@@ -49,18 +48,8 @@ const tenantContext = new MockTenant(
 
 const { createRequester } = await import('#src/utils/test-utils.js');
 const samlApplicationRoutes = await pickDefault(import('./index.js'));
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-
-const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
-  // eslint-disable-next-line @silverhand/fp/no-mutation -- Tests need to cover both dev-feature states.
-  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
-};
-
-const createSamlApplicationRequest = (isDevFeaturesEnabled = true) => {
-  setDevFeaturesEnabled(isDevFeaturesEnabled);
-
-  return createRequester({ authedRoutes: samlApplicationRoutes, tenantContext });
-};
+const createSamlApplicationRequest = () =>
+  createRequester({ authedRoutes: samlApplicationRoutes, tenantContext });
 
 const buildAccessControl = (
   patch: Partial<ApplicationAccessControl> = {}
@@ -74,7 +63,6 @@ const buildAccessControl = (
 
 describe('SAML application route', () => {
   afterEach(() => {
-    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
     updateSamlApplicationById.mockClear();
     findApplicationAccessControl.mockClear();
   });
@@ -103,16 +91,6 @@ describe('SAML application route', () => {
       .send({ appLevelAccessControlEnabled: true });
 
     expect(response.status).toEqual(422);
-    expect(updateSamlApplicationById).not.toHaveBeenCalled();
-  });
-
-  it('PATCH /saml-applications/:id should reject app-level access control updates without dev features', async () => {
-    const response = await createSamlApplicationRequest(false)
-      .patch('/saml-applications/foo')
-      .send({ appLevelAccessControlEnabled: true });
-
-    expect(response.status).toEqual(400);
-    expect(findApplicationAccessControl).not.toHaveBeenCalled();
     expect(updateSamlApplicationById).not.toHaveBeenCalled();
   });
 });

--- a/packages/integration-tests/src/tests/api/application-access-control.test.ts
+++ b/packages/integration-tests/src/tests/api/application-access-control.test.ts
@@ -29,7 +29,7 @@ import {
   createDefaultTenantUserWithPassword,
   deleteDefaultTenantUser,
 } from '#src/helpers/profile.js';
-import { devFeatureTest, generateTestName } from '#src/utils.js';
+import { generateTestName } from '#src/utils.js';
 
 const signInAndGetRefreshToken = async ({
   appId,
@@ -119,7 +119,7 @@ const assertRefreshTokenExchangeAllowed = async (
   }
 };
 
-devFeatureTest.describe('application access control OIDC enforcement', () => {
+describe('application access control OIDC enforcement', () => {
   it('allows refresh token exchange through each app access rule type', async () => {
     const organizationApi = new OrganizationApiTest();
     const userRole = await createRole({ type: RoleType.User });


### PR DESCRIPTION
## Summary
Make app-level access control generally available across Console application rules, Management API routes, OpenAPI docs, and OIDC enforcement.

Resolves #8173 #8196

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments