### PR TITLE
feat(account): release account center session management

### DIFF
--- a/.changeset/release-account-center-session-management.md
+++ b/.changeset/release-account-center-session-management.md
@@ -1,0 +1,8 @@
+---
+"@logto/account": minor
+"@logto/console": minor
+---
+
+add account center session management
+
+Users can now configure and use the account center Sessions page to review active sessions and connected third-party applications.

--- a/packages/account/src/pages/VerifiedAction/index.tsx
+++ b/packages/account/src/pages/VerifiedAction/index.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from 'react-router-dom';
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import ErrorPage from '@ac/components/ErrorPage';
 import VerificationMethodList from '@ac/components/VerificationMethodList';
-import { isDevFeaturesEnabled } from '@ac/constants/env';
 import { sessionStorage } from '@ac/utils/session-storage';
 import type { PendingVerifiedAction } from '@ac/utils/session-storage';
 
@@ -56,7 +55,6 @@ const VerifiedAction = () => {
       }
       case 'load-sessions': {
         return (
-          isDevFeaturesEnabled &&
           accountCenterSettings.fields.session !== undefined &&
           accountCenterSettings.fields.session !== AccountCenterControlValue.Off
         );

--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -2,8 +2,6 @@ import type { SignInExperienceResponse } from '@experience/shared/types';
 import type { AccountCenter, UserProfileResponse } from '@logto/schemas';
 import { AccountCenterControlValue } from '@logto/schemas';
 
-import { isDevFeaturesEnabled } from '@ac/constants/env';
-
 import { getAvailableSocialConnectors } from './social-connector.js';
 
 type SecurityPageSettings = Pick<AccountCenter, 'enabled' | 'fields' | 'deleteAccountUrl'>;
@@ -53,7 +51,7 @@ export const hasVisibleSecuritySection = (
 };
 
 export const hasVisibleSessionsPage = (accountCenterSettings?: SecurityPageSettings): boolean => {
-  if (!isDevFeaturesEnabled || !accountCenterSettings?.enabled) {
+  if (!accountCenterSettings?.enabled) {
     return false;
   }
 

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/IntegratePrebuiltUi/index.tsx
@@ -2,7 +2,6 @@ import { useContext } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { AppDataContext } from '@/contexts/AppDataProvider';
 import DynamicT from '@/ds-components/DynamicT';
 import FormField from '@/ds-components/FormField';
@@ -85,14 +84,10 @@ const accountCenterRoutes = [
     path: '/account/profile',
     tooltipKey: 'sign_in_exp.account_center.prebuilt_ui.tooltips.profile',
   },
-  ...(isDevFeaturesEnabled
-    ? ([
-        {
-          path: '/account/sessions',
-          tooltipKey: 'sign_in_exp.account_center.prebuilt_ui.tooltips.sessions',
-        },
-      ] as const)
-    : []),
+  {
+    path: '/account/sessions',
+    tooltipKey: 'sign_in_exp.account_center.prebuilt_ui.tooltips.sessions',
+  },
 ] as const satisfies ReadonlyArray<{ path: string; tooltipKey: string }>;
 
 type Props = {


### PR DESCRIPTION
## Summary

Make account center session management available through the configured Sessions page and include the Sessions route in Console's prebuilt Account Center UI integration list.

Add a changeset for the account and console packages.

## Testing
Tested locally
