### PR TITLE
fix(core): fix account API passkey permission and binding check

### DIFF
--- a/packages/core/src/routes/account/mfa-verifications.test.ts
+++ b/packages/core/src/routes/account/mfa-verifications.test.ts
@@ -6,7 +6,9 @@ import {
   mockSignInExperience,
   mockUser,
   mockUserTotpMfaVerification,
+  mockUserWebAuthnMfaVerification,
 } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
@@ -42,8 +44,11 @@ const mockedQueries = {
 } satisfies Partial2<Queries>;
 
 const { findUserById, updateUserById } = mockedQueries.users;
+const { findDefaultSignInExperience } = mockedQueries.signInExperiences;
 
 const accountMfaRoutes = await pickDefault(import('./mfa-verifications.js'));
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 
 describe('account mfa verification routes', () => {
   const tenantContext = new MockTenant(undefined, mockedQueries);
@@ -80,6 +85,9 @@ describe('account mfa verification routes', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+      originalIsDevFeaturesEnabled;
   });
 
   describe('PUT /api/my-account/mfa-verifications/totp', () => {
@@ -172,6 +180,286 @@ describe('account mfa verification routes', () => {
       expect(response.status).toBe(400);
       expect(mockValidateTotpToken).toHaveBeenCalledWith('new_totp_secret', 'bad-code');
       expect(updateUserById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/my-account/mfa-verifications passkey permission and binding', () => {
+    it('should allow WebAuthn binding when passkeySignIn.enabled is true (without MFA factor)', async () => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+
+      findDefaultSignInExperience.mockResolvedValueOnce({
+        ...mockSignInExperience,
+        mfa: { ...mockSignInExperience.mfa, factors: [] },
+        passkeySignIn: { enabled: true, showPasskeyButton: true, allowAutofill: false },
+      });
+
+      const response = await accountRequest.post('/my-account/mfa-verifications').send({
+        type: MfaFactor.WebAuthn,
+        newIdentifierVerificationRecordId: 'fake_record_id',
+      });
+
+      // Will fail at verification record lookup, but should pass binding check
+      expect(response.status).not.toBe(400);
+    });
+
+    it('should reject WebAuthn binding when both mfa.factors and passkeySignIn.enabled are off', async () => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+
+      findDefaultSignInExperience.mockResolvedValueOnce({
+        ...mockSignInExperience,
+        mfa: { ...mockSignInExperience.mfa, factors: [] },
+        passkeySignIn: { enabled: false, showPasskeyButton: false, allowAutofill: false },
+      });
+
+      const response = await accountRequest.post('/my-account/mfa-verifications').send({
+        type: MfaFactor.WebAuthn,
+        newIdentifierVerificationRecordId: 'fake_record_id',
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should use fields.passkey for WebAuthn permission when isDevFeaturesEnabled', async () => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+
+      const passkeyRequest = createRequester({
+        authedRoutes: [
+          (router) => {
+            router.use(async (ctx, next) => {
+              ctx.auth = {
+                ...ctx.auth,
+                id: mockUser.id,
+                identityVerified: true,
+                scopes: new Set([UserScope.Identities]),
+              };
+              ctx.accountCenter = {
+                enabled: true,
+                fields: {
+                  mfa: AccountCenterControlValue.Off,
+                  passkey: AccountCenterControlValue.Edit,
+                },
+              };
+              ctx.appendDataHookContext = jest.fn();
+              return next();
+            });
+          },
+          accountMfaRoutes as never,
+        ],
+        tenantContext,
+      });
+
+      findDefaultSignInExperience.mockResolvedValueOnce({
+        ...mockSignInExperience,
+        mfa: { ...mockSignInExperience.mfa, factors: [MfaFactor.WebAuthn] },
+      });
+
+      const response = await passkeyRequest.post('/my-account/mfa-verifications').send({
+        type: MfaFactor.WebAuthn,
+        newIdentifierVerificationRecordId: 'fake_record_id',
+      });
+
+      // Should pass permission check (passkey=Edit) even though mfa=Off
+      expect(response.status).not.toBe(400);
+    });
+
+    it('should fall back to fields.mfa for non-WebAuthn types even when isDevFeaturesEnabled', async () => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+
+      const response = await accountRequest.post('/my-account/mfa-verifications').send({
+        type: MfaFactor.TOTP,
+        secret: 'totp_secret',
+      });
+
+      // Uses fields.mfa which is Edit, so permission passes; TOTP is in factors
+      expect(response.status).toBe(204);
+    });
+  });
+
+  describe('PATCH /api/my-account/mfa-verifications/:id/name passkey permission', () => {
+    it('should use fields.passkey for permission when isDevFeaturesEnabled', async () => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+
+      const passkeyRequest = createRequester({
+        authedRoutes: [
+          (router) => {
+            router.use(async (ctx, next) => {
+              ctx.auth = {
+                ...ctx.auth,
+                id: mockUser.id,
+                identityVerified: true,
+                scopes: new Set([UserScope.Identities]),
+              };
+              ctx.accountCenter = {
+                enabled: true,
+                fields: {
+                  mfa: AccountCenterControlValue.Off,
+                  passkey: AccountCenterControlValue.Edit,
+                },
+              };
+              ctx.appendDataHookContext = jest.fn();
+              return next();
+            });
+          },
+          accountMfaRoutes as never,
+        ],
+        tenantContext,
+      });
+
+      findUserById.mockResolvedValueOnce({
+        ...mockUser,
+        mfaVerifications: [mockUserWebAuthnMfaVerification],
+      });
+
+      const response = await passkeyRequest
+        .patch(`/my-account/mfa-verifications/${mockUserWebAuthnMfaVerification.id}/name`)
+        .send({ name: 'new-name' });
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should reject when passkey field is not editable with isDevFeaturesEnabled', async () => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+
+      const passkeyRequest = createRequester({
+        authedRoutes: [
+          (router) => {
+            router.use(async (ctx, next) => {
+              ctx.auth = {
+                ...ctx.auth,
+                id: mockUser.id,
+                identityVerified: true,
+                scopes: new Set([UserScope.Identities]),
+              };
+              ctx.accountCenter = {
+                enabled: true,
+                fields: {
+                  mfa: AccountCenterControlValue.Edit,
+                  passkey: AccountCenterControlValue.ReadOnly,
+                },
+              };
+              ctx.appendDataHookContext = jest.fn();
+              return next();
+            });
+          },
+          accountMfaRoutes as never,
+        ],
+        tenantContext,
+      });
+
+      const response = await passkeyRequest
+        .patch(`/my-account/mfa-verifications/${mockUserWebAuthnMfaVerification.id}/name`)
+        .send({ name: 'new-name' });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('DELETE /api/my-account/mfa-verifications/:id passkey permission', () => {
+    it('should use fields.passkey for WebAuthn verification deletion when isDevFeaturesEnabled', async () => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+
+      const passkeyRequest = createRequester({
+        authedRoutes: [
+          (router) => {
+            router.use(async (ctx, next) => {
+              ctx.auth = {
+                ...ctx.auth,
+                id: mockUser.id,
+                identityVerified: true,
+                scopes: new Set([UserScope.Identities]),
+              };
+              ctx.accountCenter = {
+                enabled: true,
+                fields: {
+                  mfa: AccountCenterControlValue.Off,
+                  passkey: AccountCenterControlValue.Edit,
+                },
+              };
+              ctx.appendDataHookContext = jest.fn();
+              return next();
+            });
+          },
+          accountMfaRoutes as never,
+        ],
+        tenantContext,
+      });
+
+      findUserById.mockResolvedValueOnce({
+        ...mockUser,
+        mfaVerifications: [mockUserWebAuthnMfaVerification],
+      });
+
+      const response = await passkeyRequest.delete(
+        `/my-account/mfa-verifications/${mockUserWebAuthnMfaVerification.id}`
+      );
+
+      expect(response.status).toBe(204);
+    });
+
+    it('should use fields.mfa for non-WebAuthn verification deletion when isDevFeaturesEnabled', async () => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+
+      findUserById.mockResolvedValueOnce({
+        ...mockUser,
+        mfaVerifications: [mockUserTotpMfaVerification],
+      });
+
+      const response = await accountRequest.delete(
+        `/my-account/mfa-verifications/${mockUserTotpMfaVerification.id}`
+      );
+
+      // Fields.mfa = Edit, so should pass
+      expect(response.status).toBe(204);
+    });
+
+    it('should reject WebAuthn deletion when passkey field is not editable', async () => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+
+      const passkeyRequest = createRequester({
+        authedRoutes: [
+          (router) => {
+            router.use(async (ctx, next) => {
+              ctx.auth = {
+                ...ctx.auth,
+                id: mockUser.id,
+                identityVerified: true,
+                scopes: new Set([UserScope.Identities]),
+              };
+              ctx.accountCenter = {
+                enabled: true,
+                fields: {
+                  mfa: AccountCenterControlValue.Edit,
+                  passkey: AccountCenterControlValue.ReadOnly,
+                },
+              };
+              ctx.appendDataHookContext = jest.fn();
+              return next();
+            });
+          },
+          accountMfaRoutes as never,
+        ],
+        tenantContext,
+      });
+
+      findUserById.mockResolvedValueOnce({
+        ...mockUser,
+        mfaVerifications: [mockUserWebAuthnMfaVerification],
+      });
+
+      const response = await passkeyRequest.delete(
+        `/my-account/mfa-verifications/${mockUserWebAuthnMfaVerification.id}`
+      );
+
+      expect(response.status).toBe(400);
     });
   });
 });

--- a/packages/core/src/routes/account/mfa-verifications.test.ts
+++ b/packages/core/src/routes/account/mfa-verifications.test.ts
@@ -199,8 +199,10 @@ describe('account mfa verification routes', () => {
         newIdentifierVerificationRecordId: 'fake_record_id',
       });
 
-      // Will fail at verification record lookup, but should pass binding check
-      expect(response.status).not.toBe(400);
+      // Binding check passed — findDefaultSignInExperience was reached
+      expect(findDefaultSignInExperience).toHaveBeenCalled();
+      // Error is from verification record lookup, not binding check
+      expect(response.body).not.toHaveProperty('code', 'session.mfa.mfa_factor_not_enabled');
     });
 
     it('should reject WebAuthn binding when both mfa.factors and passkeySignIn.enabled are off', async () => {
@@ -219,6 +221,7 @@ describe('account mfa verification routes', () => {
       });
 
       expect(response.status).toBe(400);
+      expect(findDefaultSignInExperience).toHaveBeenCalled();
     });
 
     it('should use fields.passkey for WebAuthn permission when isDevFeaturesEnabled', async () => {
@@ -261,8 +264,10 @@ describe('account mfa verification routes', () => {
         newIdentifierVerificationRecordId: 'fake_record_id',
       });
 
-      // Should pass permission check (passkey=Edit) even though mfa=Off
-      expect(response.status).not.toBe(400);
+      // Permission check passed — findDefaultSignInExperience was reached
+      expect(findDefaultSignInExperience).toHaveBeenCalled();
+      // Error is from verification record lookup, not permission check
+      expect(response.body).not.toHaveProperty('code', 'account_center.field_not_editable');
     });
 
     it('should fall back to fields.mfa for non-WebAuthn types even when isDevFeaturesEnabled', async () => {

--- a/packages/core/src/routes/account/mfa-verifications.ts
+++ b/packages/core/src/routes/account/mfa-verifications.ts
@@ -9,6 +9,7 @@ import {
 import { generateStandardId } from '@logto/shared';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import {
   generateBackupCodes,
@@ -92,8 +93,13 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
       );
       const { fields } = ctx.accountCenter;
+      const isWebAuthn = ctx.guard.body.type === MfaFactor.WebAuthn;
+      const passkeyControl =
+        EnvSet.values.isDevFeaturesEnabled && isWebAuthn
+          ? (fields.passkey ?? fields.mfa)
+          : fields.mfa;
       assertThat(
-        fields.mfa === AccountCenterControlValue.Edit,
+        passkeyControl === AccountCenterControlValue.Edit,
         'account_center.field_not_editable'
       );
 
@@ -105,8 +111,12 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
       const user = await findUserById(userId);
 
       // Check sign in experience, if mfa factor is enabled
-      const { mfa } = await findDefaultSignInExperience();
-      assertThat(mfa.factors.includes(ctx.guard.body.type), 'session.mfa.mfa_factor_not_enabled');
+      const { mfa, passkeySignIn } = await findDefaultSignInExperience();
+      const isFactorEnabled =
+        EnvSet.values.isDevFeaturesEnabled && isWebAuthn
+          ? mfa.factors.includes(MfaFactor.WebAuthn) || passkeySignIn.enabled
+          : mfa.factors.includes(ctx.guard.body.type);
+      assertThat(isFactorEnabled, 'session.mfa.mfa_factor_not_enabled');
 
       switch (ctx.guard.body.type) {
         case MfaFactor.TOTP: {
@@ -390,8 +400,11 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
       );
       const { name } = ctx.guard.body;
       const { fields } = ctx.accountCenter;
+      const passkeyControl = EnvSet.values.isDevFeaturesEnabled
+        ? (fields.passkey ?? fields.mfa)
+        : fields.mfa;
       assertThat(
-        fields.mfa === AccountCenterControlValue.Edit,
+        passkeyControl === AccountCenterControlValue.Edit,
         'account_center.field_not_editable'
       );
 
@@ -438,11 +451,6 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         identityVerified,
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
       );
-      const { fields } = ctx.accountCenter;
-      assertThat(
-        fields.mfa === AccountCenterControlValue.Edit,
-        'account_center.field_not_editable'
-      );
       assertThat(
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
@@ -453,6 +461,17 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         (mfaVerification) => mfaVerification.id === ctx.guard.params.verificationId
       );
       assertThat(mfaVerification, 'verification_record.not_found');
+
+      const { fields } = ctx.accountCenter;
+      const isWebAuthnVerification = mfaVerification.type === MfaFactor.WebAuthn;
+      const deleteControl =
+        EnvSet.values.isDevFeaturesEnabled && isWebAuthnVerification
+          ? (fields.passkey ?? fields.mfa)
+          : fields.mfa;
+      assertThat(
+        deleteControl === AccountCenterControlValue.Edit,
+        'account_center.field_not_editable'
+      );
 
       const updatedUser = await updateUserById(userId, {
         mfaVerifications: user.mfaVerifications.filter(


### PR DESCRIPTION
## Summary

Fix passkey-related Account API operations to use `fields.passkey ?? fields.mfa` for permission checks (behind `isDevFeaturesEnabled`), and allow WebAuthn binding when `passkeySignIn.enabled = true`.

**Permission control** — passkey operations now resolve their permission via:
```ts
const passkeyControl = EnvSet.values.isDevFeaturesEnabled && isWebAuthn
  ? (fields.passkey ?? fields.mfa)
  : fields.mfa;
```

Affected routes:
- `POST /api/my-account/mfa-verifications` (type=WebAuthn)
- `PATCH /api/my-account/mfa-verifications/:id/name`
- `DELETE /api/my-account/mfa-verifications/:id` (WebAuthn type)

**Binding check** — WebAuthn binding is now allowed when `passkeySignIn.enabled = true`, even if `mfa.factors` does not include WebAuthn, aligning with the experience layer's `getMfaFactorsEnabledForBinding()`:
```ts
const isFactorEnabled = EnvSet.values.isDevFeaturesEnabled && isWebAuthn
  ? mfa.factors.includes(MfaFactor.WebAuthn) || passkeySignIn.enabled
  : mfa.factors.includes(ctx.guard.body.type);
```

When the flag is off, original `fields.mfa`-only behavior is preserved.

## Testing

Unit tests


Link to Devin session: https://app.devin.ai/sessions/b62d573eb526438085b1247af079e963
Requested by: @wangsijie