### PR TITLE
fix(console): hide account center MFA warning when passkey sign-in enabled

### DIFF
--- a/.changeset/account-center-mfa-warning-passkey.md
+++ b/.changeset/account-center-mfa-warning-passkey.md
@@ -1,0 +1,7 @@
+---
+"@logto/console": patch
+---
+
+hide the account center MFA warning when passkey sign-in is enabled
+
+In Sign-in experience → Account center, the multi-factor authentication field no longer shows the "No MFA factor set-up yet" warning when passkey sign-in is enabled, since passkey already provides a verification method for the account API.

--- a/.changeset/account-center-mfa-warning-passkey.md
+++ b/.changeset/account-center-mfa-warning-passkey.md
@@ -1,7 +1,0 @@
----
-"@logto/console": patch
----
-
-hide the account center MFA warning when passkey sign-in is enabled
-
-In Sign-in experience → Account center, the multi-factor authentication field no longer shows the "No MFA factor set-up yet" warning when passkey sign-in is enabled, since passkey already provides a verification method for the account API.

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/AccountCenterField.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/AccountCenterField.tsx
@@ -17,6 +17,7 @@ type Props = {
   readonly item: AccountCenterFieldItem;
   readonly value: AccountCenterControlValue;
   readonly isMfaEnabled: boolean;
+  readonly isPasskeySignInEnabled: boolean;
   readonly isGlobalDisabled: boolean;
   readonly onChange: (field: AccountCenterFieldKey, value?: AccountCenterControlValue) => void;
   readonly fieldOptions: Array<Option<AccountCenterControlValue>>;
@@ -39,6 +40,7 @@ function AccountCenterField({
   item,
   value,
   isMfaEnabled,
+  isPasskeySignInEnabled,
   // When Account Center is disabled, all fields should show "off" state but keep the current value
   // then when Account Center is enabled again, the fields will restore to previous values
   isGlobalDisabled,
@@ -59,7 +61,8 @@ function AccountCenterField({
     item.key === 'mfa' &&
     value !== AccountCenterControlValue.Off &&
     !isGlobalDisabled &&
-    !isMfaEnabled;
+    !isMfaEnabled &&
+    !isPasskeySignInEnabled;
 
   return (
     <div>

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -5,7 +5,6 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
 import PageMeta from '@/components/PageMeta';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import CodeEditor from '@/ds-components/CodeEditor';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
@@ -69,7 +68,7 @@ function AccountCenter({ isActive, data }: Props) {
 
   // When passkey sign-in is enabled, passkey can serve as a verification method, so the
   // "no MFA factor configured" warning on the MFA field is no longer relevant.
-  const isPasskeySignInEnabled = isDevFeaturesEnabled && Boolean(data.passkeySignIn.enabled);
+  const isPasskeySignInEnabled = Boolean(data.passkeySignIn.enabled);
 
   const handleToggle = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
 import PageMeta from '@/components/PageMeta';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import CodeEditor from '@/ds-components/CodeEditor';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
@@ -68,7 +69,7 @@ function AccountCenter({ isActive, data }: Props) {
 
   // When passkey sign-in is enabled, passkey can serve as a verification method, so the
   // "no MFA factor configured" warning on the MFA field is no longer relevant.
-  const isPasskeySignInEnabled = Boolean(data.passkeySignIn.enabled);
+  const isPasskeySignInEnabled = isDevFeaturesEnabled && Boolean(data.passkeySignIn.enabled);
 
   const handleToggle = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -5,6 +5,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
 import PageMeta from '@/components/PageMeta';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import CodeEditor from '@/ds-components/CodeEditor';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
@@ -65,6 +66,10 @@ function AccountCenter({ isActive, data }: Props) {
   const isMfaEnabled = useMemo(() => {
     return data.mfa.factors.length > 0;
   }, [data.mfa]);
+
+  // When passkey sign-in is enabled, passkey can serve as a verification method, so the
+  // "no MFA factor configured" warning on the MFA field is no longer relevant.
+  const isPasskeySignInEnabled = isDevFeaturesEnabled && Boolean(data.passkeySignIn.enabled);
 
   const handleToggle = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -184,6 +189,7 @@ function AccountCenter({ isActive, data }: Props) {
                       item={item}
                       value={fields[item.key]}
                       isMfaEnabled={isMfaEnabled}
+                      isPasskeySignInEnabled={isPasskeySignInEnabled}
                       isGlobalDisabled={!isAccountApiEnabled}
                       fieldOptions={fieldOptions}
                       onChange={handleFieldChange}


### PR DESCRIPTION
## Summary

The account center "Multi-factor authentication" field shows a `No MFA factor set-up yet` warning whenever the field is enabled but no MFA factors are configured (`mfa.factors.length === 0`). This is misleading when passkey sign-in is enabled, because passkey already provides a verification method for the account API — there is nothing missing to set up.

This PR suppresses that warning when passkey sign-in is enabled:

```ts
const isPasskeySignInEnabled = Boolean(data.passkeySignIn.enabled);

const shouldShowMfaWarning =
  item.key === 'mfa' &&
  value !== AccountCenterControlValue.Off &&
  !isGlobalDisabled &&
  !isMfaEnabled &&
  !isPasskeySignInEnabled; // new: skip the warning when passkey sign-in covers verification
```

`isPasskeySignInEnabled` is derived from the sign-in experience config (`data.passkeySignIn.enabled`) in `AccountCenter/index.tsx` and threaded down to `AccountCenterField`.

This is part **6b** of [LOG-13540](https://linear.app/silverhand/issue/LOG-13540/admin-console-passkey-field-configuration-warning-fix). Part **6a** (the `passkey` field control with Off / ReadOnly / Edit options) was already shipped in #8982, so no changes are needed there.

### Testing

Tested locally


Link to Devin session: https://app.devin.ai/sessions/2bc419b2a3f84528a2d6ba72ed522254
Requested by: @wangsijie