### PR TITLE
fix: inject account center SSR for deep links

### DIFF
--- a/packages/core/src/middleware/koa-account-center-ssr.test.ts
+++ b/packages/core/src/middleware/koa-account-center-ssr.test.ts
@@ -33,13 +33,6 @@ describe('koaAccountCenterSsr()', () => {
     expect(ctx.body).toBe(symbol);
   });
 
-  it('should call next() and do nothing if the request path is not an index path', async () => {
-    const ctx = { ...baseCtx, path: '/foo', body: '...' };
-    await koaAccountCenterSsr(tenant.libraries)(ctx, next);
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(ctx.body).toBe('...');
-  });
-
   it('should call next() and do nothing if the placeholder is not present', async () => {
     const ctx = { ...baseCtx, path: '/', body: '...' };
     await koaAccountCenterSsr(tenant.libraries)(ctx, next);
@@ -51,6 +44,24 @@ describe('koaAccountCenterSsr()', () => {
     const ctx = {
       ...baseCtx,
       path: '/',
+      body: `<script>
+        const logtoSsr=${accountCenterSsrPlaceholder};
+      </script>`,
+    };
+    await koaAccountCenterSsr(tenant.libraries)(ctx, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(ctx.body).not.toContain(accountCenterSsrPlaceholder);
+    expect(ctx.body).toContain(
+      `const logtoSsr=Object.freeze(${JSON.stringify({
+        signInExperience: { data: mockSignInExperience },
+      })});`
+    );
+  });
+
+  it('should inject SSR data for Account Center deep links', async () => {
+    const ctx = {
+      ...baseCtx,
+      path: '/profile',
       body: `<script>
         const logtoSsr=${accountCenterSsrPlaceholder};
       </script>`,

--- a/packages/core/src/middleware/koa-account-center-ssr.ts
+++ b/packages/core/src/middleware/koa-account-center-ssr.ts
@@ -5,7 +5,6 @@ import type { MiddlewareType } from 'koa';
 import type Libraries from '#src/tenants/Libraries.js';
 
 import { type WithI18nContext } from './koa-i18next.js';
-import { isIndexPath } from './koa-serve-static.js';
 
 /**
  * Placeholder for account center SSR data injection. The value should be kept in sync with
@@ -19,7 +18,6 @@ const accountCenterSsrPlaceholder = '"__LOGTO_ACCOUNT_CENTER_SSR__"';
  *
  * Conditions for injection:
  * - The response body should be a string after the middleware chain (calling `next()`).
- * - The request path should be an index path.
  * - The SSR placeholder string should be present in the response body.
  */
 export default function koaAccountCenterSsr<StateT, ContextT extends WithI18nContext>(
@@ -28,10 +26,7 @@ export default function koaAccountCenterSsr<StateT, ContextT extends WithI18nCon
   return async (ctx, next) => {
     await next();
 
-    if (
-      !(typeof ctx.body === 'string' && isIndexPath(ctx.path)) ||
-      !ctx.body.includes(accountCenterSsrPlaceholder)
-    ) {
+    if (typeof ctx.body !== 'string' || !ctx.body.includes(accountCenterSsrPlaceholder)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- Inject Account Center SSR data whenever the served HTML contains the Account Center SSR placeholder.
- Keep deep-linked Account Center routes such as `/account/profile` and `/account/security` from falling back to the default light theme before hydration.
- Add unit coverage for Account Center deep-link SSR injection.

## Testing

Unit tests