### PR TITLE
feat(schemas): add message rate limit policy and send actions

### DIFF
--- a/packages/core/src/sentinel/basic-sentinel.ts
+++ b/packages/core/src/sentinel/basic-sentinel.ts
@@ -70,8 +70,11 @@ export default class BasicSentinel extends Sentinel {
    * @throws {Error} If the action is not supported.
    */
   static assertAction(action: unknown): asserts action is SentinelActivityAction {
-    // eslint-disable-next-line no-restricted-syntax
-    if (!BasicSentinel.supportedActions.includes(action as SentinelActivityAction)) {
+    // `supportedActions` is a narrow tuple of the actions this sentinel handles; widen it so
+    // `includes` accepts any `SentinelActivityAction` (e.g. the send actions handled elsewhere).
+    const actionAllowlist: readonly SentinelActivityAction[] = BasicSentinel.supportedActions;
+    // eslint-disable-next-line no-restricted-syntax -- check membership against the allowlist
+    if (!actionAllowlist.includes(action as SentinelActivityAction)) {
       // Update to use the new error class later.
       throw new Error(`Unsupported action: ${String(action)}`);
     }

--- a/packages/schemas/src/consts/index.ts
+++ b/packages/schemas/src/consts/index.ts
@@ -6,6 +6,7 @@ export * from './tenant.js';
 export * from './subscriptions.js';
 export * from './experience.js';
 export * from './sentinel.js';
+export * from './message-rate-limit.js';
 export * from './verification-code.js';
 export * from './product-event.js';
 export * from './application.js';

--- a/packages/schemas/src/consts/message-rate-limit.test.ts
+++ b/packages/schemas/src/consts/message-rate-limit.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultMessageRateLimitPolicy,
+  messageRateLimitPolicyGuard,
+} from './message-rate-limit.js';
+
+describe('messageRateLimitPolicyGuard', () => {
+  it('parses a valid policy', () => {
+    expect(
+      messageRateLimitPolicyGuard.parse({ sendWindow: 3600, maxSendsPerRecipient: 5 })
+    ).toEqual({ sendWindow: 3600, maxSendsPerRecipient: 5 });
+  });
+
+  it('rejects a non-numeric value', () => {
+    expect(
+      messageRateLimitPolicyGuard.safeParse({ sendWindow: '3600', maxSendsPerRecipient: 5 }).success
+    ).toBe(false);
+  });
+
+  it.each([
+    { sendWindow: 0, maxSendsPerRecipient: 5 },
+    { sendWindow: 3600, maxSendsPerRecipient: 0 },
+    { sendWindow: 3600.5, maxSendsPerRecipient: 5 },
+  ])('rejects out-of-range or fractional values %o', (policy) => {
+    expect(messageRateLimitPolicyGuard.safeParse(policy).success).toBe(false);
+  });
+
+  it('accepts the default policy', () => {
+    expect(messageRateLimitPolicyGuard.parse(defaultMessageRateLimitPolicy)).toEqual(
+      defaultMessageRateLimitPolicy
+    );
+  });
+});

--- a/packages/schemas/src/consts/message-rate-limit.ts
+++ b/packages/schemas/src/consts/message-rate-limit.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+
+import { type ToZodObject } from '../utils/zod.js';
+
+/**
+ * System-level rate-limit policy for outbound messages (verification codes and
+ * other notifications) over email/SMS.
+ *
+ * This is intentionally separate from `SentinelPolicy`: the sentinel throttles
+ * *failed verification attempts* and is tenant-configurable (a paid security
+ * feature), whereas this throttles *successful sends* and is mandatory and
+ * system-level — it is not exposed for tenant editing.
+ *
+ * Note: a per-send cooldown is intentionally omitted here. The experience app
+ * already enforces a client-side resend cooldown, and the windowed per-recipient
+ * cap below bounds abuse for non-UI callers without risking a server/client
+ * cooldown mismatch that could reject a legitimate resend.
+ */
+export type MessageRateLimitPolicy = {
+  /** Rolling window, in seconds, over which the per-recipient cap is counted. */
+  sendWindow: number;
+  /** Maximum number of sends to the same recipient within `sendWindow`. */
+  maxSendsPerRecipient: number;
+};
+
+export const messageRateLimitPolicyGuard = z.object({
+  sendWindow: z.number().int().positive(),
+  maxSendsPerRecipient: z.number().int().positive(),
+}) satisfies ToZodObject<MessageRateLimitPolicy>;
+
+/**
+ * The default message rate limit policy. Applied to every tenant and not
+ * tenant-configurable.
+ *
+ * - `sendWindow`: 3600 seconds (1 hour)
+ * - `maxSendsPerRecipient`: 5 per window
+ */
+export const defaultMessageRateLimitPolicy = Object.freeze({
+  sendWindow: 3600,
+  maxSendsPerRecipient: 5,
+} satisfies MessageRateLimitPolicy);

--- a/packages/schemas/src/foundations/jsonb-types/sentinel.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sentinel.ts
@@ -42,6 +42,21 @@ export enum SentinelActivityAction {
    * The subject tries to pass a backup code MFA verification.
    */
   MfaBackupCode = 'MfaBackupCode',
+  /**
+   * A verification code is sent to the target (email/phone), e.g. sign-in,
+   * register, forgot-password, or identifier-binding codes.
+   *
+   * Used by the message rate limit to throttle sends, distinct from the
+   * failure-based lockout actions above.
+   */
+  VerificationCodeSend = 'VerificationCodeSend',
+  /**
+   * A non-verification-code message is sent to the target (email/phone),
+   * e.g. an organization invitation.
+   *
+   * Used by the message rate limit to throttle sends.
+   */
+  MessageSend = 'MessageSend',
 }
 export const sentinelActivityActionGuard = z.nativeEnum(SentinelActivityAction);
 


### PR DESCRIPTION
## Summary
First, foundational PR of the email send-rate-limit work (`MessageRateGuard` stack). Schemas only — nothing consumes these yet; the module and route wiring land in follow-up PRs. Refs LOG-13542.

- Adds `VerificationCodeSend` and `MessageSend` to `SentinelActivityAction`. These are additive `varchar` values (no DB alteration) and are isolated from the pooled failure-lockout actions, so they don't affect existing sentinel lockout counts.
- Adds `MessageRateLimitPolicy` type, `messageRateLimitPolicyGuard`, and `defaultMessageRateLimitPolicy` — a **system-level** send-rate-limit policy, deliberately kept separate from the tenant-editable `sentinelPolicy` (which is the paid identifier-lockout feature). Limits are not tenant-configurable.
- The policy carries a windowed per-recipient cap (`sendWindow` + `maxSendsPerRecipient`) and intentionally **no** server-side cooldown — the experience app already enforces a client-side resend cooldown, and the windowed cap bounds non-UI callers.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments