### PR TITLE
fix(account): show passkey row when only passkey sign-in is enabled

### DIFF
--- a/packages/account/src/pages/Security/MfaSection/index.passkey.test.tsx
+++ b/packages/account/src/pages/Security/MfaSection/index.passkey.test.tsx
@@ -1,0 +1,119 @@
+import {
+  AccountCenterControlValue,
+  MfaFactor,
+  MfaPolicy,
+  type UserMfaVerificationResponse,
+} from '@logto/schemas';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+
+import renderWithPageContext, {
+  mockAccountCenterSettings,
+  mockSignInExperienceSettings,
+} from '@ac/__mocks__/RenderWithPageContext';
+import { passkeyAddRoute, passkeyManageRoute, securityRoute } from '@ac/constants/routes';
+
+import { getMfaSettings, getMfaVerifications, updateMfaSettings } from '../../../apis/mfa';
+
+import MfaSection from '.';
+
+jest.mock('@ac/constants/env', () => ({
+  __esModule: true,
+  isDevFeaturesEnabled: true,
+}));
+
+const mockGetAccessToken = jest.fn().mockResolvedValue('access-token');
+
+jest.mock('@logto/react', () => ({
+  useLogto: () => ({
+    getAccessToken: mockGetAccessToken,
+  }),
+}));
+
+jest.mock('../../../apis/mfa', () => ({
+  getMfaSettings: jest.fn(),
+  getMfaVerifications: jest.fn(),
+  updateMfaSettings: jest.fn(),
+}));
+
+const mockGetMfaSettings = getMfaSettings as jest.MockedFunction<typeof getMfaSettings>;
+const mockGetMfaVerifications = getMfaVerifications as jest.MockedFunction<
+  typeof getMfaVerifications
+>;
+const mockUpdateMfaSettings = updateMfaSettings as jest.MockedFunction<typeof updateMfaSettings>;
+
+const renderMfaSection = (mfaVerifications: UserMfaVerificationResponse = []) => {
+  mockGetMfaVerifications.mockResolvedValue(mfaVerifications);
+
+  return renderWithPageContext(
+    <Routes>
+      <Route path={securityRoute} element={<MfaSection />} />
+      <Route path={passkeyAddRoute} element={<div>passkey add page</div>} />
+      <Route path={passkeyManageRoute} element={<div>passkey manage page</div>} />
+    </Routes>,
+    {
+      initialEntries: [securityRoute],
+      future: { v7_relativeSplatPath: true, v7_startTransition: true },
+    },
+    {
+      pageContext: {
+        accountCenterSettings: {
+          ...mockAccountCenterSettings,
+          fields: { ...mockAccountCenterSettings.fields, mfa: AccountCenterControlValue.Edit },
+        },
+        // Only passkey sign-in is enabled; no MFA factors are configured.
+        experienceSettings: {
+          ...mockSignInExperienceSettings,
+          mfa: { policy: MfaPolicy.UserControlled, factors: [] },
+          passkeySignIn: { enabled: true },
+        },
+      },
+    }
+  );
+};
+
+describe('<MfaSection /> with only passkey sign-in enabled', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockGetAccessToken.mockResolvedValue('access-token');
+    mockGetMfaSettings.mockResolvedValue({ skipMfaOnSignIn: true });
+    mockUpdateMfaSettings.mockResolvedValue({ skipMfaOnSignIn: true });
+    window.sessionStorage.clear();
+  });
+
+  it('shows the passkey row without WebAuthn in MFA factors and exposes the add flow', async () => {
+    const { getByText, queryByText } = renderMfaSection();
+
+    await waitFor(() => {
+      expect(queryByText('account_center.security.passkeys')).not.toBeNull();
+    });
+
+    // No MFA-only factors or two-step toggle should appear.
+    expect(queryByText('account_center.security.authenticator_app')).toBeNull();
+    expect(queryByText('account_center.security.backup_codes')).toBeNull();
+    expect(queryByText('account_center.security.no_verification_method_warning')).toBeNull();
+    expect(mockGetMfaSettings).not.toHaveBeenCalled();
+
+    fireEvent.click(getByText('account_center.security.add'));
+
+    expect(getByText('passkey add page')).not.toBeNull();
+  });
+
+  it('exposes the manage flow when a passkey is already configured', async () => {
+    const { getByText, queryByText } = renderMfaSection([
+      {
+        id: 'passkey-verification-id',
+        createdAt: '2026-05-13T00:00:00.000Z',
+        type: MfaFactor.WebAuthn,
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(queryByText('account_center.security.passkeys_count')).not.toBeNull();
+    });
+
+    fireEvent.click(getByText('account_center.security.manage'));
+
+    expect(getByText('passkey manage page')).not.toBeNull();
+  });
+});

--- a/packages/account/src/pages/Security/MfaSection/use-mfa-rows.ts
+++ b/packages/account/src/pages/Security/MfaSection/use-mfa-rows.ts
@@ -23,7 +23,11 @@ import {
   passkeyManageRoute,
   phoneRoute,
 } from '@ac/constants/routes';
-import { hasVisibleMfaSection, isEditableField } from '@ac/utils/security-page';
+import {
+  hasVisibleMfaSection,
+  isEditableField,
+  isPasskeySignInEnabled,
+} from '@ac/utils/security-page';
 
 const factorIcon = {
   [MfaFactor.TOTP]: TotpIcon,
@@ -71,7 +75,10 @@ const useMfaRows = (
     );
 
     const buildWebAuthnRow = (): Row[] => {
-      if (!enabledFactors.includes(MfaFactor.WebAuthn)) {
+      if (
+        !enabledFactors.includes(MfaFactor.WebAuthn) &&
+        !isPasskeySignInEnabled(experienceSettings)
+      ) {
         return [];
       }
       const isConfigured = webAuthnVerifications.length > 0;

--- a/packages/account/src/utils/security-page.passkey.test.ts
+++ b/packages/account/src/utils/security-page.passkey.test.ts
@@ -1,0 +1,33 @@
+import { AccountCenterControlValue, MfaPolicy } from '@logto/schemas';
+
+import { hasVisibleMfaSection, isPasskeySignInEnabled } from './security-page';
+
+jest.mock('@ac/constants/env', () => ({
+  __esModule: true,
+  isDevFeaturesEnabled: true,
+}));
+
+describe('security-page utils with passkey sign-in enabled', () => {
+  const experienceSettings = {
+    socialConnectors: [],
+    mfa: { factors: [], policy: MfaPolicy.UserControlled },
+    passkeySignIn: { enabled: true },
+  };
+
+  it('isPasskeySignInEnabled returns true when passkey sign-in is enabled', () => {
+    expect(isPasskeySignInEnabled(experienceSettings)).toBe(true);
+    expect(
+      isPasskeySignInEnabled({ ...experienceSettings, passkeySignIn: { enabled: false } })
+    ).toBe(false);
+    expect(isPasskeySignInEnabled({ ...experienceSettings, passkeySignIn: {} })).toBe(false);
+  });
+
+  it('hasVisibleMfaSection returns true when passkey sign-in is enabled without MFA factors', () => {
+    expect(hasVisibleMfaSection(AccountCenterControlValue.Edit, experienceSettings)).toBe(true);
+  });
+
+  it('hasVisibleMfaSection still requires a visible MFA control', () => {
+    expect(hasVisibleMfaSection(AccountCenterControlValue.Off, experienceSettings)).toBe(false);
+    expect(hasVisibleMfaSection(undefined, experienceSettings)).toBe(false);
+  });
+});

--- a/packages/account/src/utils/security-page.test.ts
+++ b/packages/account/src/utils/security-page.test.ts
@@ -1,11 +1,13 @@
-import { AccountCenterControlValue, ConnectorPlatform, MfaPolicy } from '@logto/schemas';
+import { AccountCenterControlValue, ConnectorPlatform, MfaFactor, MfaPolicy } from '@logto/schemas';
 
 import {
   canManageSocialIdentitiesWithoutVerification,
   canSetInitialPasswordWithoutVerification,
   isEditableField,
+  isPasskeySignInEnabled,
   canOpenPasswordEditFlow,
   hasAvailableSecurityVerificationMethod,
+  hasVisibleMfaSection,
   hasVisibleSecuritySection,
   hasVisibleSocialSection,
 } from './security-page';
@@ -106,6 +108,35 @@ describe('security-page utils', () => {
           },
         ],
         mfa: { factors: [], policy: MfaPolicy.UserControlled },
+      })
+    ).toBe(false);
+  });
+
+  it('hasVisibleMfaSection returns true when MFA factors are enabled', () => {
+    expect(
+      hasVisibleMfaSection(AccountCenterControlValue.Edit, {
+        socialConnectors: [],
+        mfa: { factors: [MfaFactor.TOTP], policy: MfaPolicy.UserControlled },
+      })
+    ).toBe(true);
+  });
+
+  it('hasVisibleMfaSection ignores passkey sign-in when dev features are disabled', () => {
+    expect(
+      hasVisibleMfaSection(AccountCenterControlValue.Edit, {
+        socialConnectors: [],
+        mfa: { factors: [], policy: MfaPolicy.UserControlled },
+        passkeySignIn: { enabled: true },
+      })
+    ).toBe(false);
+  });
+
+  it('isPasskeySignInEnabled returns false when dev features are disabled', () => {
+    expect(
+      isPasskeySignInEnabled({
+        socialConnectors: [],
+        mfa: { factors: [], policy: MfaPolicy.UserControlled },
+        passkeySignIn: { enabled: true },
       })
     ).toBe(false);
   });

--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -7,7 +7,8 @@ import { isDevFeaturesEnabled } from '@ac/constants/env';
 import { getAvailableSocialConnectors } from './social-connector.js';
 
 type SecurityPageSettings = Pick<AccountCenter, 'enabled' | 'fields' | 'deleteAccountUrl'>;
-type SecurityPageExperienceSettings = Pick<SignInExperienceResponse, 'socialConnectors' | 'mfa'>;
+type SecurityPageExperienceSettings = Pick<SignInExperienceResponse, 'socialConnectors' | 'mfa'> &
+  Partial<Pick<SignInExperienceResponse, 'passkeySignIn'>>;
 
 const isVisibleField = (value?: AccountCenterControlValue): boolean =>
   value !== undefined && value !== AccountCenterControlValue.Off;
@@ -25,10 +26,17 @@ export const hasVisibleSocialSection = (
   isVisibleField(socialControl) &&
   getAvailableSocialConnectors(experienceSettings?.socialConnectors ?? []).length > 0;
 
+export const isPasskeySignInEnabled = (
+  experienceSettings?: SecurityPageExperienceSettings
+): boolean => isDevFeaturesEnabled && Boolean(experienceSettings?.passkeySignIn?.enabled);
+
 export const hasVisibleMfaSection = (
   mfaControl: AccountCenterControlValue | undefined,
   experienceSettings?: SecurityPageExperienceSettings
-): boolean => isVisibleField(mfaControl) && (experienceSettings?.mfa.factors ?? []).length > 0;
+): boolean =>
+  isVisibleField(mfaControl) &&
+  ((experienceSettings?.mfa.factors ?? []).length > 0 ||
+    isPasskeySignInEnabled(experienceSettings));
 
 export const hasVisibleSecuritySection = (
   accountCenterSettings?: SecurityPageSettings,


### PR DESCRIPTION
## Summary

In the Account Center security page, the passkey UI only appeared when WebAuthn was configured as an MFA factor. When a tenant enables passwordless passkey sign-in (`passkeySignIn.enabled`) without adding WebAuthn to its MFA factors, the passkey row was hidden, so users could not add or manage passkeys even though the Account API (LOG-13536, #9021) already allows binding them in that case.

This makes the frontend visibility match the API: the passkey row is shown when WebAuthn is an MFA factor **or** passkey sign-in is enabled.

```ts
// security-page.ts
hasVisibleMfaSection = isVisibleField(mfaControl) &&
  (mfa.factors.length > 0 || isPasskeySignInEnabled(experienceSettings));

// use-mfa-rows.ts — buildWebAuthnRow()
if (!enabledFactors.includes(MfaFactor.WebAuthn) && !isPasskeySignInEnabled(experienceSettings)) {
  return [];
}
```

A new `isPasskeySignInEnabled(experienceSettings)` helper centralizes the check, and `SecurityPageExperienceSettings` now also reads `passkeySignIn`. `MfaSection` consumes this through the helpers, so the section becomes visible and the add/manage flows are reachable while the existing two-step verification toggle (which still requires real MFA factors) is unaffected.

## Testing

Unit tests


Link to Devin session: https://app.devin.ai/sessions/47642687d2f0416c98fd60c9b6dc83c3
Requested by: @wangsijie