### PR TITLE
feat(core): add sentinel-activities insert and count queries

### DIFF
--- a/packages/core/src/queries/sentinel-activities.test.ts
+++ b/packages/core/src/queries/sentinel-activities.test.ts
@@ -1,0 +1,83 @@
+import {
+  SentinelActivities,
+  SentinelActivityAction,
+  SentinelActivityTargetType,
+  SentinelActionResult,
+  SentinelDecision,
+} from '@logto/schemas';
+import { createMockPool, createMockQueryResult, sql } from '@silverhand/slonik';
+
+import { convertToIdentifiers } from '#src/utils/sql.js';
+import type { QueryType } from '#src/utils/test-utils.js';
+import { expectSqlAssert } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
+
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return mockQuery(sql, values);
+  },
+});
+
+const { createSentinelActivitiesQueries } = await import('./sentinel-activities.js');
+const { insertActivity, countActivities } = createSentinelActivitiesQueries(pool);
+
+describe('sentinel activities queries', () => {
+  const { table, fields } = convertToIdentifiers(SentinelActivities, true);
+
+  it('countActivities counts matching rows within the window', async () => {
+    const expectSql = sql`
+      select count(*)
+      from ${table}
+      where ${fields.targetType} = $1
+        and ${fields.targetHash} = $2
+        and ${fields.action} = $3
+        and ${fields.createdAt} > now() - make_interval(secs => $4)
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toEqual([
+        SentinelActivityTargetType.User,
+        'target-hash',
+        SentinelActivityAction.VerificationCodeSend,
+        3600,
+      ]);
+
+      // Slonik surfaces count(*) (a bigint) as a string in production; countActivities coerces it.
+      return createMockQueryResult([{ count: '2' }]);
+    });
+
+    await expect(
+      countActivities({
+        targetType: SentinelActivityTargetType.User,
+        targetHash: 'target-hash',
+        action: SentinelActivityAction.VerificationCodeSend,
+        windowSeconds: 3600,
+      })
+    ).resolves.toBe(2);
+  });
+
+  it('insertActivity inserts into the sentinel_activities table', async () => {
+    const activity = {
+      id: 'activity-id',
+      targetType: SentinelActivityTargetType.User,
+      targetHash: 'target-hash',
+      action: SentinelActivityAction.VerificationCodeSend,
+      actionResult: SentinelActionResult.Success,
+      payload: {},
+      decision: SentinelDecision.Allowed,
+      decisionExpiresAt: 123,
+    };
+
+    mockQuery.mockImplementationOnce(async (sql) => {
+      expect(sql).toMatch(/insert into "sentinel_activities"/i);
+
+      return createMockQueryResult([]);
+    });
+
+    await expect(insertActivity(activity)).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/queries/sentinel-activities.ts
+++ b/packages/core/src/queries/sentinel-activities.ts
@@ -1,19 +1,57 @@
 import {
   SentinelActivities,
   type SentinelActivity,
+  type SentinelActivityAction,
   type SentinelActivityTargetType,
 } from '@logto/schemas';
 import { type CommonQueryMethods, sql } from '@silverhand/slonik';
 
+import { buildInsertIntoWithPool } from '../database/insert-into.js';
 import { convertToIdentifiers } from '../utils/sql.js';
 
 const { table, fields } = convertToIdentifiers(SentinelActivities, true);
 
-/**
- * Delete all records in the `sentinel_activities` table that match the given target within 1 hour.
- * This should unblock the user if they are locked.
- */
+type CountActivitiesQuery = {
+  targetType: SentinelActivityTargetType;
+  targetHash: string;
+  action: SentinelActivityAction;
+  /** The rolling window, in seconds, to count activities within. */
+  windowSeconds: number;
+};
+
 export const createSentinelActivitiesQueries = (pool: CommonQueryMethods) => {
+  /**
+   * Insert a sentinel activity row. Reused by both the failure-based sentinel and the
+   * message rate guard — the table is a shared activity log.
+   */
+  const insertActivity = buildInsertIntoWithPool(pool)(SentinelActivities);
+
+  /**
+   * Count the activities matching the given target and action within the rolling window.
+   * Used by the message rate guard to evaluate the per-recipient send cap.
+   */
+  const countActivities = async ({
+    targetType,
+    targetHash,
+    action,
+    windowSeconds,
+  }: CountActivitiesQuery): Promise<number> =>
+    // Postgres returns count(*) as a bigint that Slonik surfaces as a string; coerce to a number.
+    Number(
+      await pool.oneFirst<string>(sql`
+        select count(*)
+        from ${table}
+        where ${fields.targetType} = ${targetType}
+          and ${fields.targetHash} = ${targetHash}
+          and ${fields.action} = ${action}
+          and ${fields.createdAt} > now() - make_interval(secs => ${windowSeconds})
+      `)
+    );
+
+  /**
+   * Delete all records in the `sentinel_activities` table that match the given target within
+   * 1 hour. This should unblock the user if they are locked.
+   */
   const deleteActivities = async (
     targetType: SentinelActivityTargetType,
     targetHashes: string[]
@@ -27,6 +65,8 @@ export const createSentinelActivitiesQueries = (pool: CommonQueryMethods) => {
   };
 
   return {
+    insertActivity,
+    countActivities,
     deleteActivities,
   };
 };


### PR DESCRIPTION
## Summary
Second PR of the MessageRateGuard stack (Refs LOG-13659), stacked on #9025. Adds storage primitives to the shared `sentinel_activities` query module for the (not-yet-wired) send-rate-limit module — no behavior change.

- `insertActivity` — `buildInsertIntoWithPool(pool)(SentinelActivities)`, returns `Promise<void>` (same as `BasicSentinel`). Lets the upcoming message rate guard record send rows without touching `BasicSentinel`.
- `countActivities({ targetType, targetHash, action, windowSeconds })` — counts `sentinel_activities` rows for a target+action within a rolling window via `now() - make_interval(secs => $n)`. Uses `count(*)::int` so the value is a real number (Postgres surfaces `count(*)` bigint as a string otherwise).
- `deleteActivities` is unchanged (JSDoc reflow only).

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments