### PR TITLE
feat(core): add message rate guard module

### DIFF
--- a/packages/core/src/sentinel/message-rate-guard.test.ts
+++ b/packages/core/src/sentinel/message-rate-guard.test.ts
@@ -1,0 +1,109 @@
+import {
+  SentinelActionResult,
+  SentinelActivityAction,
+  SentinelActivityTargetType,
+  SentinelDecision,
+  type MessageRateLimitPolicy,
+} from '@logto/schemas';
+
+const { jest } = import.meta;
+
+const { MessageRateGuard, withMessageRateGuard } = await import('./message-rate-guard.js');
+
+const policy: MessageRateLimitPolicy = { sendWindow: 60, maxSendsPerRecipient: 3 };
+const action = SentinelActivityAction.VerificationCodeSend;
+const recipient = 'recipient@example.com';
+
+const countActivities = jest.fn();
+const insertActivity = jest.fn();
+
+const buildGuard = () => new MessageRateGuard({ countActivities, insertActivity }, policy);
+
+beforeEach(() => {
+  countActivities.mockReset();
+  insertActivity.mockReset();
+});
+
+describe('MessageRateGuard', () => {
+  it('allows a send below the per-recipient cap', async () => {
+    countActivities.mockResolvedValueOnce(2);
+
+    await expect(buildGuard().guard(action, recipient)).resolves.toBeUndefined();
+    expect(countActivities).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetType: SentinelActivityTargetType.User,
+        action,
+        windowSeconds: 60,
+      })
+    );
+  });
+
+  it('rejects with 429 when the recipient is at the cap', async () => {
+    countActivities.mockResolvedValueOnce(3);
+
+    await expect(buildGuard().guard(action, recipient)).rejects.toMatchObject({
+      code: 'request.rate_limited',
+      status: 429,
+    });
+  });
+
+  it('records a successful send', async () => {
+    await buildGuard().record(action, recipient);
+
+    expect(insertActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetType: SentinelActivityTargetType.User,
+        action,
+        actionResult: SentinelActionResult.Success,
+        decision: SentinelDecision.Allowed,
+        payload: {},
+      })
+    );
+  });
+
+  it('fails open (does not throw) when the count query fails', async () => {
+    countActivities.mockRejectedValueOnce(new Error('db unavailable'));
+
+    await expect(buildGuard().guard(action, recipient)).resolves.toBeUndefined();
+  });
+
+  it('does not throw when recording the send fails', async () => {
+    insertActivity.mockRejectedValueOnce(new Error('db unavailable'));
+
+    await expect(buildGuard().record(action, recipient)).resolves.toBeUndefined();
+  });
+});
+
+describe('withMessageRateGuard', () => {
+  it('sends and records when under the cap', async () => {
+    countActivities.mockResolvedValueOnce(0);
+    const send = jest.fn().mockResolvedValueOnce('sent');
+
+    await expect(withMessageRateGuard(buildGuard(), { action, recipient }, send)).resolves.toBe(
+      'sent'
+    );
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(insertActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send when over the cap', async () => {
+    countActivities.mockResolvedValueOnce(3);
+    const send = jest.fn();
+
+    await expect(
+      withMessageRateGuard(buildGuard(), { action, recipient }, send)
+    ).rejects.toMatchObject({ status: 429 });
+    expect(send).not.toHaveBeenCalled();
+    expect(insertActivity).not.toHaveBeenCalled();
+  });
+
+  it('still sends when the rate-limit query fails (fails open)', async () => {
+    countActivities.mockRejectedValueOnce(new Error('db unavailable'));
+    const send = jest.fn().mockResolvedValueOnce('sent');
+
+    await expect(withMessageRateGuard(buildGuard(), { action, recipient }, send)).resolves.toBe(
+      'sent'
+    );
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/sentinel/message-rate-guard.ts
+++ b/packages/core/src/sentinel/message-rate-guard.ts
@@ -1,0 +1,96 @@
+import {
+  type MessageRateLimitPolicy,
+  type SentinelActivityAction,
+  SentinelActionResult,
+  SentinelActivityTargetType,
+  SentinelDecision,
+  defaultMessageRateLimitPolicy,
+} from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import { trySafe } from '@silverhand/essentials';
+import { sha256 } from 'hash-wasm';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { type createSentinelActivitiesQueries } from '#src/queries/sentinel-activities.js';
+
+type SentinelActivitiesQueries = ReturnType<typeof createSentinelActivitiesQueries>;
+
+type MessageRateGuardQueries = Pick<
+  SentinelActivitiesQueries,
+  'countActivities' | 'insertActivity'
+>;
+
+/**
+ * A mandatory, system-level rate limit on outbound messages (verification codes, organization
+ * invitations) keyed by recipient. Separate from the identifier {@link Sentinel} (which throttles
+ * failed verification attempts): this throttles *successful sends* to protect recipients from
+ * spam. Its limits come from {@link defaultMessageRateLimitPolicy}, not the tenant-editable
+ * `sentinelPolicy`, and are not tenant-configurable.
+ *
+ * Reuses the `sentinel_activities` table as the activity store via the shared queries.
+ */
+export class MessageRateGuard {
+  constructor(
+    private readonly queries: MessageRateGuardQueries,
+    private readonly policy: MessageRateLimitPolicy = defaultMessageRateLimitPolicy
+  ) {}
+
+  /**
+   * Throws a 429 {@link RequestError} if another send to `recipient` for `action` would exceed the
+   * per-recipient cap within the policy window. Call before performing the send.
+   */
+  async guard(action: SentinelActivityAction, recipient: string): Promise<void> {
+    const targetHash = await sha256(recipient);
+    // Fail open: this is a best-effort spam guard, not a hard dependency of the send flow. If the
+    // count query fails, `trySafe` returns `undefined` and we allow the send rather than block a
+    // legitimate user.
+    const count = await trySafe(
+      this.queries.countActivities({
+        targetType: SentinelActivityTargetType.User,
+        targetHash,
+        action,
+        windowSeconds: this.policy.sendWindow,
+      })
+    );
+
+    if (count !== undefined && count >= this.policy.maxSendsPerRecipient) {
+      throw new RequestError({ code: 'request.rate_limited', status: 429 });
+    }
+  }
+
+  /** Record a successful send so it counts toward the recipient's cap. */
+  async record(action: SentinelActivityAction, recipient: string): Promise<void> {
+    const targetHash = await sha256(recipient);
+    // Best-effort: a failure to record must not surface to the caller after the message was sent.
+    await trySafe(
+      this.queries.insertActivity({
+        id: generateStandardId(),
+        targetType: SentinelActivityTargetType.User,
+        targetHash,
+        action,
+        actionResult: SentinelActionResult.Success,
+        payload: {},
+        decision: SentinelDecision.Allowed,
+      })
+    );
+  }
+}
+
+/**
+ * Wraps a message send with the {@link MessageRateGuard}: rejects with a 429 before sending if the
+ * recipient is over the cap, performs the send, then records it.
+ *
+ * A failed `send()` is intentionally not recorded (failed sends don't count toward the cap). A
+ * `record()` failure after a successful send does not roll back the send.
+ */
+export const withMessageRateGuard = async <T>(
+  guard: MessageRateGuard,
+  { action, recipient }: { action: SentinelActivityAction; recipient: string },
+  send: () => Promise<T>
+): Promise<T> => {
+  await guard.guard(action, recipient);
+  const result = await send();
+  await guard.record(action, recipient);
+
+  return result;
+};

--- a/packages/phrases/src/locales/ar/errors/request.ts
+++ b/packages/phrases/src/locales/ar/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'حدث خطأ في الطلب.',
   range_not_satisfiable: 'النطاق غير قابل للتحقق.',
   feature_not_supported: 'هذه الميزة غير مدعومة في البيئة الحالية.',
+  rate_limited: 'طلبات كثيرة جدًا. يرجى المحاولة مرة أخرى لاحقًا.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/de/errors/request.ts
+++ b/packages/phrases/src/locales/de/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'Es ist ein Fehler bei der Anfrage aufgetreten.',
   range_not_satisfiable: 'Der Bereich ist nicht erfüllbar.',
   feature_not_supported: 'Diese Funktion wird in der aktuellen Umgebung nicht unterstützt.',
+  rate_limited: 'Zu viele Anfragen. Bitte versuchen Sie es später erneut.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/en/errors/request.ts
+++ b/packages/phrases/src/locales/en/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'Request error occurred.',
   range_not_satisfiable: 'Range not satisfiable.',
   feature_not_supported: 'This feature is not supported in the current environment.',
+  rate_limited: 'Too many requests. Please try again later.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/es/errors/request.ts
+++ b/packages/phrases/src/locales/es/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'Ocurrió un error en la solicitud.',
   range_not_satisfiable: 'El rango no es satisfactorio.',
   feature_not_supported: 'Esta función no es compatible con el entorno actual.',
+  rate_limited: 'Demasiadas solicitudes. Inténtalo de nuevo más tarde.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/fa-ir/errors/request.ts
+++ b/packages/phrases/src/locales/fa-ir/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'خطای درخواست رخ داد.',
   range_not_satisfiable: 'بازه قابل برآورده‌سازی نیست.',
   feature_not_supported: 'این ویژگی در محیط فعلی پشتیبانی نمی‌شود.',
+  rate_limited: 'درخواست‌های بیش از حد. لطفاً بعداً دوباره تلاش کنید.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/fr/errors/request.ts
+++ b/packages/phrases/src/locales/fr/errors/request.ts
@@ -4,6 +4,7 @@ const request = {
   range_not_satisfiable: 'Plage non satisfaisable.',
   feature_not_supported:
     "Cette fonctionnalité n'est pas prise en charge dans l'environnement actuel.",
+  rate_limited: 'Trop de requêtes. Veuillez réessayer plus tard.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/it/errors/request.ts
+++ b/packages/phrases/src/locales/it/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'Si è verificato un errore nella richiesta.',
   range_not_satisfiable: 'Intervallo non soddisfacente.',
   feature_not_supported: "Questa funzionalità non è supportata nell'ambiente attuale.",
+  rate_limited: 'Troppe richieste. Riprova più tardi.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/ja/errors/request.ts
+++ b/packages/phrases/src/locales/ja/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'リクエストエラーが発生しました。',
   range_not_satisfiable: '要求範囲が満たされません。',
   feature_not_supported: 'この機能は現在の環境ではサポートされていません。',
+  rate_limited: 'リクエストが多すぎます。しばらくしてからもう一度お試しください。',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/ko/errors/request.ts
+++ b/packages/phrases/src/locales/ko/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: '요청 중에 오류가 발생했어요.',
   range_not_satisfiable: '범위가 충족되지 않습니다.',
   feature_not_supported: '이 기능은 현재 환경에서 지원되지 않습니다.',
+  rate_limited: '요청이 너무 많습니다. 나중에 다시 시도해 주세요.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/pl-pl/errors/request.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'Wystąpił błąd żądania.',
   range_not_satisfiable: 'Zakres nie do zrealizowania.',
   feature_not_supported: 'Ta funkcja nie jest obsługiwana w bieżącym środowisku.',
+  rate_limited: 'Zbyt wiele żądań. Spróbuj ponownie później.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/pt-br/errors/request.ts
+++ b/packages/phrases/src/locales/pt-br/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'Ocorreu um erro no pedido.',
   range_not_satisfiable: 'Intervalo não satisfatório.',
   feature_not_supported: 'Este recurso não é suportado no ambiente atual.',
+  rate_limited: 'Muitas solicitações. Tente novamente mais tarde.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/pt-pt/errors/request.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'Ocorreu um erro no pedido.',
   range_not_satisfiable: 'Intervalo não satisfatório.',
   feature_not_supported: 'Esta funcionalidade não é suportada no ambiente atual.',
+  rate_limited: 'Demasiados pedidos. Tente novamente mais tarde.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/ru/errors/request.ts
+++ b/packages/phrases/src/locales/ru/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'Произошла ошибка запроса.',
   range_not_satisfiable: 'Диапазон не удовлетворен.',
   feature_not_supported: 'Эта функция не поддерживается в текущей среде.',
+  rate_limited: 'Слишком много запросов. Пожалуйста, повторите попытку позже.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/th/errors/request.ts
+++ b/packages/phrases/src/locales/th/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'เกิดข้อผิดพลาดในการร้องขอ',
   range_not_satisfiable: 'ช่วงข้อมูลไม่ตรงตามข้อกำหนด',
   feature_not_supported: 'ฟีเจอร์นี้ไม่รองรับในสภาพแวดล้อมปัจจุบัน',
+  rate_limited: 'มีคำขอมากเกินไป โปรดลองใหม่อีกครั้งในภายหลัง',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/tr-tr/errors/request.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: 'İstek hatası oluştu.',
   range_not_satisfiable: 'Aralık karşılanamıyor.',
   feature_not_supported: 'Bu özellik mevcut ortamda desteklenmiyor.',
+  rate_limited: 'Çok fazla istek. Lütfen daha sonra tekrar deneyin.',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/zh-cn/errors/request.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: '发生请求错误。',
   range_not_satisfiable: '范围不满足。',
   feature_not_supported: '当前环境不支持此功能。',
+  rate_limited: '请求过于频繁，请稍后再试。',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/zh-hk/errors/request.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: '發生請求錯誤。',
   range_not_satisfiable: '範圍不滿足。',
   feature_not_supported: '當前環境不支援此功能。',
+  rate_limited: '請求過於頻繁，請稍後再試。',
 };
 
 export default Object.freeze(request);

--- a/packages/phrases/src/locales/zh-tw/errors/request.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/request.ts
@@ -3,6 +3,7 @@ const request = {
   general: '發生請求錯誤。',
   range_not_satisfiable: '範圍不滿足。',
   feature_not_supported: '此功能在當前環境中不受支持。',
+  rate_limited: '請求過於頻繁，請稍後再試。',
 };
 
 export default Object.freeze(request);


### PR DESCRIPTION
## Summary
Third PR of the MessageRateGuard stack (Refs LOG-13661), stacked on #9028. Adds the standalone send-rate-limit module — **not wired to any route yet** (wiring + `isDevFeaturesEnabled` gating come in a later PR), so no behavior change.

- `MessageRateGuard` — `guard(action, recipient)` rejects with `request.rate_limited` (429) when a send to `recipient` for `action` would exceed the per-recipient cap within the policy window; `record(action, recipient)` logs a successful send. Reuses the `sentinel_activities` store via the shared queries; recipient hashed with sha256.
- `withMessageRateGuard(guard, { action, recipient }, send)` — cap-check → send → record. Records only successful sends.
- **Fails open:** the count/insert queries are wrapped in `trySafe`, so a rate-limit query failure never blocks the end-user send flow (this is a best-effort spam guard, not a hard dependency of sending).
- Limits come from `defaultMessageRateLimitPolicy` (system-level, not the tenant-editable `sentinelPolicy`).
- Recipient-only (per-IP deferred). All verification flows share one bucket (`VerificationCodeSend`); invitations use `MessageSend`.
- Adds the `request.rate_limited` phrase (the 429 error code), with translations for all locales.

## Testing
Unit tests

## Checklist
- [ ] \`.changeset\`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments