### PR TITLE
fix(core): coerce sentinel failed-attempt count to a number

### DIFF
--- a/.changeset/fix-sentinel-count-string.md
+++ b/.changeset/fix-sentinel-count-string.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+fix identifier-lockout sentinel misfiring because `count(*)` was treated as a string
+
+Postgres returns `count(*)` as a bigint that Slonik surfaces as a string. The sentinel added `1` to this value to decide whether to lock an identifier, so `'10' + 1` evaluated to `'101'` and the failed-attempt threshold (default 100) tripped far too early — roughly at 10 failed attempts. The count is now coerced to a number so the threshold is compared numerically.

--- a/packages/core/src/sentinel/basic-sentinel.test.ts
+++ b/packages/core/src/sentinel/basic-sentinel.test.ts
@@ -135,6 +135,18 @@ describe('BasicSentinel -> decide()', () => {
     const decision = await sentinel.decide(activity);
     expect(decision).toEqual([SentinelDecision.Blocked, mockedDefaultBlockedTime]);
   });
+
+  it('coerces the bigint count(*) string to a number instead of concatenating', async () => {
+    methods.maybeOne.mockResolvedValueOnce(null);
+    // Slonik surfaces count(*) (a bigint) as a string in production; the decision must coerce it.
+    methods.oneFirst.mockResolvedValueOnce('10');
+
+    const decision = await sentinel.decide(createMockActivityReport());
+
+    // 10 is well below the default max of 100, so it must be allowed. The pre-fix code computed
+    // '10' + 0 = '100' >= 100 and wrongly blocked.
+    expect(decision).toEqual([SentinelDecision.Allowed, mockedTime]);
+  });
 });
 
 describe('BasicSentinel -> action pools', () => {

--- a/packages/core/src/sentinel/basic-sentinel.ts
+++ b/packages/core/src/sentinel/basic-sentinel.ts
@@ -171,15 +171,19 @@ export default class BasicSentinel extends Sentinel {
     }
 
     const actionArray = BasicSentinel.getActionArray(query.action);
-    const failedAttempts = await this.pool.oneFirst<number>(sql`
-      select count(*) from ${table}
-      where ${fields.targetType} = ${query.targetType}
-        and ${fields.targetHash} = ${query.targetHash}
-        and ${fields.action} = any(${actionArray})
-        and ${fields.actionResult} = ${SentinelActionResult.Failed}
-        and ${fields.decision} != ${SentinelDecision.Blocked}
-        and ${fields.createdAt} > now() - interval '1 hour'
-    `);
+    // Postgres returns a bigint for count(*), which Slonik surfaces as a string. Convert it to a
+    // number so the threshold arithmetic below is numeric rather than string concatenation.
+    const failedAttempts = Number(
+      await this.pool.oneFirst<string>(sql`
+        select count(*) from ${table}
+        where ${fields.targetType} = ${query.targetType}
+          and ${fields.targetHash} = ${query.targetHash}
+          and ${fields.action} = any(${actionArray})
+          and ${fields.actionResult} = ${SentinelActionResult.Failed}
+          and ${fields.decision} != ${SentinelDecision.Blocked}
+          and ${fields.createdAt} > now() - interval '1 hour'
+      `)
+    );
 
     const { maxAttempts, lockoutDuration } = await this.getSentinelPolicy();
 


### PR DESCRIPTION
## Summary
Fixes the identifier-lockout sentinel tripping far below its configured threshold.

Postgres returns `count(*)` as a bigint that Slonik surfaces as a **string** (this repo configures no int8 type parser — see the comments in `database/row-count.ts`, `queries/log.ts`, `utils/RelationQueries.ts`). `BasicSentinel.decide()` then computed `failedAttempts + (failed ? 1 : 0) >= maxAttempts` on that value, so `'10' + 1` became `'101'`, and `'101' >= 100` blocked the identifier at roughly **10** failed attempts instead of the configured **100** (with erratic behavior across other counts). The count is now coerced with `Number()` before the comparison, matching the existing count handling in `row-count`/`log`/`roles`.

Not caught earlier because `basic-sentinel.test.ts` mocked the count as a JS number, masking the production string. Added a regression test that mocks `count(*)` as a string (as production returns it) and asserts the threshold stays numeric.

## Testing
Unit tests

## Checklist
- [x] \`.changeset\`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments