### PR TITLE
feat(core): rate-limit experience verification-code sends

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -23,6 +23,12 @@ async function resolveVoid(): Promise<void> {
 
 const { sendCode } = await import('./verification-code-helpers.js');
 
+// The message rate guard runs when dev features are enabled; provide a permissive activity store.
+const mockSentinelActivities = {
+  countActivities: jest.fn().mockResolvedValue(0),
+  insertActivity: jest.fn().mockImplementation(resolveVoid),
+};
+
 describe('sendCode parameter passing', () => {
   // To make a void callable function/method
   const mockSendVerificationCode = jest.fn().mockImplementation(resolveVoid);
@@ -47,6 +53,7 @@ describe('sendCode parameter passing', () => {
   };
 
   const mockQueries = {
+    sentinelActivities: mockSentinelActivities,
     users: {
       hasUserWithEmail: jest.fn().mockResolvedValue(true),
       hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(true),
@@ -92,6 +99,7 @@ describe('sendCode parameter passing', () => {
 
   it('should skip delivery for forgot-password with non-existing email user', async () => {
     const mockQueriesNoUser = {
+      sentinelActivities: mockSentinelActivities,
       users: {
         hasUserWithEmail: jest.fn().mockResolvedValue(false),
         hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
@@ -130,6 +138,7 @@ describe('sendCode parameter passing', () => {
 
   it('should not skip delivery for forgot-password with existing user', async () => {
     const mockQueriesWithUser = {
+      sentinelActivities: mockSentinelActivities,
       users: {
         hasUserWithEmail: jest.fn().mockResolvedValue(true),
         hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(true),
@@ -167,6 +176,7 @@ describe('sendCode parameter passing', () => {
 
   it('should not check user existence for non-ForgotPassword events', async () => {
     const mockQueriesTracking = {
+      sentinelActivities: mockSentinelActivities,
       users: {
         hasUserWithEmail: jest.fn().mockResolvedValue(false),
         hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
@@ -195,5 +205,31 @@ describe('sendCode parameter passing', () => {
       expect.any(Object),
       expect.objectContaining({ skipDelivery: false })
     );
+  });
+
+  it('rejects with 429 and does not send when the recipient is over the rate-limit cap', async () => {
+    // Default policy allows 5 sends per recipient per window; simulate the cap being reached.
+    mockSentinelActivities.countActivities.mockResolvedValueOnce(5);
+
+    const ctx = {
+      request: { ip: '127.0.0.1' },
+      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+      experienceInteraction: mockExperienceInteraction,
+      emailI18n: {},
+    };
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
+
+    await expect(
+      sendCode({
+        identifier: { type: SignInIdentifier.Email, value: 'spammed@example.com' },
+        interactionEvent: InteractionEvent.SignIn,
+        createVerificationRecord: () => mockCodeVerification,
+        libraries: libraries as unknown as Libraries,
+        queries: mockQueries,
+        ctx: ctx as unknown as ExperienceInteractionRouterContext,
+      })
+    ).rejects.toMatchObject({ code: 'request.rate_limited', status: 429 });
+
+    expect(mockSendVerificationCode).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -8,9 +8,11 @@ import {
 } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { type LogContext } from '#src/middleware/koa-audit-log.js';
+import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import { getLogtoCookie } from '#src/utils/cookie.js';
@@ -140,8 +142,17 @@ export const sendCode = async ({
         ...(ctx.request.ip && { ip: ctx.request.ip }),
       };
 
-  // Send verification code
-  await codeVerification.sendVerificationCode(payload, { skipDelivery });
+  // Send verification code. When delivery is skipped (forgot-password to an unknown user) nothing
+  // is sent, so the rate guard is bypassed.
+  const send = async () => codeVerification.sendVerificationCode(payload, { skipDelivery });
+
+  await (skipDelivery || !EnvSet.values.isDevFeaturesEnabled
+    ? send()
+    : withMessageRateGuard(
+        new MessageRateGuard(queries.sentinelActivities),
+        { action: SentinelActivityAction.VerificationCodeSend, recipient: identifier.value },
+        send
+      ));
 
   // Save state
   experienceInteraction.setVerificationRecord(codeVerification);

--- a/packages/core/src/routes/experience/verification-routes/verification-code.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.ts
@@ -41,8 +41,8 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
       response: z.object({
         verificationId: z.string(),
       }),
-      // 501: connector not found
-      status: [200, 400, 404, 422, 501],
+      // 429: rate limited; 501: connector not found
+      status: [200, 400, 404, 422, 429, 501],
     }),
     async (ctx, next) => {
       const { identifier, interactionEvent } = ctx.guard.body;
@@ -123,7 +123,8 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
       response: z.object({
         verificationId: z.string(),
       }),
-      status: [200, 400, 404, 501],
+      // 429: rate limited; 501: connector not found
+      status: [200, 400, 404, 429, 501],
     }),
     async (ctx, next) => {
       const { identifierType } = ctx.guard.body;

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/social-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/social-verification.test.ts
@@ -13,6 +13,7 @@ import {
   successfullyVerifySocialAuthorization,
 } from '#src/helpers/experience/social-verification.js';
 import { expectRejects } from '#src/helpers/index.js';
+import { generateEmail } from '#src/utils.js';
 
 describe('social verification', () => {
   const state = 'fake_state';
@@ -134,7 +135,9 @@ describe('social verification', () => {
       const { verificationId } = await client.sendVerificationCode({
         identifier: {
           type: SignInIdentifier.Email,
-          value: 'foo@logto.io',
+          // A fresh recipient avoids tripping the per-recipient message rate guard, which counts
+          // sends across the whole test run.
+          value: generateEmail(),
         },
         interactionEvent: InteractionEvent.SignIn,
       });

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code-rate-limit.test.ts
@@ -1,0 +1,70 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { defaultMessageRateLimitPolicy, InteractionEvent, SignInIdentifier } from '@logto/schemas';
+
+import { initExperienceClient } from '#src/helpers/client.js';
+import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connector.js';
+import { successfullySendVerificationCode } from '#src/helpers/experience/verification-code.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
+
+// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
+devFeatureTest.describe('Verification code send rate limit', () => {
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email]);
+    await setEmailConnector();
+  });
+
+  it('rejects with 429 once the per-recipient send cap within the window is exceeded', async () => {
+    // Use a fresh recipient so the count is not polluted by other tests sharing the activity store.
+    const identifier = { type: SignInIdentifier.Email, value: generateEmail() } as const;
+    const client = await initExperienceClient();
+
+    // Sends up to the cap all succeed. The guard counts by recipient, independent of session.
+    for (const _ of Array.from({ length: maxSendsPerRecipient })) {
+      // eslint-disable-next-line no-await-in-loop
+      await successfullySendVerificationCode(client, {
+        interactionEvent: InteractionEvent.SignIn,
+        identifier,
+      });
+    }
+
+    // The next send to the same recipient exceeds the cap and is rejected.
+    await expectRejects(
+      client.sendVerificationCode({
+        interactionEvent: InteractionEvent.SignIn,
+        identifier,
+      }),
+      { code: 'request.rate_limited', status: 429 }
+    );
+  });
+
+  it('counts the cap per recipient so a different recipient is unaffected', async () => {
+    const cappedIdentifier = { type: SignInIdentifier.Email, value: generateEmail() } as const;
+    const client = await initExperienceClient();
+
+    for (const _ of Array.from({ length: maxSendsPerRecipient })) {
+      // eslint-disable-next-line no-await-in-loop
+      await successfullySendVerificationCode(client, {
+        interactionEvent: InteractionEvent.SignIn,
+        identifier: cappedIdentifier,
+      });
+    }
+
+    await expectRejects(
+      client.sendVerificationCode({
+        interactionEvent: InteractionEvent.SignIn,
+        identifier: cappedIdentifier,
+      }),
+      { code: 'request.rate_limited', status: 429 }
+    );
+
+    // The same session sending to a different recipient still succeeds: the bucket is keyed by
+    // recipient, not by session.
+    await successfullySendVerificationCode(client, {
+      interactionEvent: InteractionEvent.SignIn,
+      identifier: { type: SignInIdentifier.Email, value: generateEmail() },
+    });
+  });
+});

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code.test.ts
@@ -1,10 +1,5 @@
 import { ConnectorType, TemplateType } from '@logto/connector-kit';
-import {
-  AlternativeSignUpIdentifier,
-  InteractionEvent,
-  SignInIdentifier,
-  type VerificationCodeIdentifier,
-} from '@logto/schemas';
+import { AlternativeSignUpIdentifier, InteractionEvent, SignInIdentifier } from '@logto/schemas';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -19,25 +14,26 @@ import {
   successfullyVerifyVerificationCode,
 } from '#src/helpers/experience/verification-code.js';
 import { createUserByAdmin, expectRejects, readConnectorMessage } from '#src/helpers/index.js';
-import { generateEmail, generatePassword, generateUsername } from '#src/utils.js';
+import { generateEmail, generatePassword, generatePhone, generateUsername } from '#src/utils.js';
 
 describe('Verification code verification APIs', () => {
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
   });
 
-  const identifiers: VerificationCodeIdentifier[] = [
-    {
-      type: SignInIdentifier.Email,
-      value: 'foo@logto.io',
-    },
-    {
-      type: SignInIdentifier.Phone,
-      value: '1234567890',
-    },
-  ];
+  const identifierTypes = [SignInIdentifier.Email, SignInIdentifier.Phone] as const;
 
-  describe.each(identifiers)('Verification code verification APIs for %p', ({ type, value }) => {
+  describe.each(identifierTypes)('Verification code verification APIs for %s', (type) => {
+    // The message rate guard counts verification-code sends per recipient across the whole run, so
+    // each test uses a fresh recipient to stay under the cap instead of sharing one address.
+    // eslint-disable-next-line @silverhand/fp/no-let -- reassigned per test in beforeEach
+    let value: string;
+
+    beforeEach(() => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- fresh recipient per test
+      value = type === SignInIdentifier.Email ? generateEmail() : generatePhone();
+    });
+
     it(`should throw an 501 error if the ${type} connector is not set`, async () => {
       const client = await initExperienceClient();
 


### PR DESCRIPTION
## Summary
Fourth PR of the MessageRateGuard stack (Refs LOG-13646), stacked on #9029. First **behavior-changing** slice — wires the guard into the experience verification-code send path, gated behind `isDevFeaturesEnabled` (no-op when off).

- In `sendCode` (`verification-code-helpers.ts`), the send is wrapped with `withMessageRateGuard` (action `VerificationCodeSend`, recipient = `identifier.value`), instantiating `MessageRateGuard` locally from `queries.sentinelActivities` (stateless — avoids a `TenantContext` ripple).
- **Bypassed when `skipDelivery` is true** (forgot-password to an unknown user — nothing is sent, and counting it would leak account existence).
- Covers regular **and** MFA code sends that flow through `sendCode` (shared `VerificationCodeSend` bucket).
- Fail-open: a rate-limit query failure never blocks the send (the guard wraps its queries in `trySafe`).

Remaining send paths (account/verification API, management `/verification-codes`, `/me`, org invitation, legacy interaction) are separate follow-up slices.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments