### PR TITLE
fix(account): import security page env guard

### DIFF
--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -2,6 +2,8 @@ import type { SignInExperienceResponse } from '@experience/shared/types';
 import type { AccountCenter, UserProfileResponse } from '@logto/schemas';
 import { AccountCenterControlValue } from '@logto/schemas';
 
+import { isDevFeaturesEnabled } from '@ac/constants/env';
+
 import { getAvailableSocialConnectors } from './social-connector.js';
 
 type SecurityPageSettings = Pick<AccountCenter, 'enabled' | 'fields' | 'deleteAccountUrl'>;


### PR DESCRIPTION
## Summary

- Add the missing account environment guard import used by security page passkey helpers.
- Resolve the undefined symbol that broke the account package checks on master.

## Testing

Unit tests
