### PR TITLE
feat(core): rate-limit account, management, and me verification-code sends

### DIFF
--- a/packages/core/src/routes-me/verification-code.ts
+++ b/packages/core/src/routes-me/verification-code.ts
@@ -1,9 +1,12 @@
 import { TemplateType } from '@logto/connector-kit';
 import { emailRegEx } from '@logto/core-kit';
+import { SentinelActivityAction } from '@logto/schemas';
 import { object, string } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type { RouterInitArgs } from '#src/routes/types.js';
+import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
 import RequestError from '../errors/RequestError/index.js';
 import assertThat from '../utils/assert-that.js';
@@ -17,6 +20,7 @@ export default function verificationCodeRoutes<T extends AuthedMeRouter>(
   const codeType = TemplateType.Generic;
   const {
     queries: {
+      sentinelActivities,
       users: { findUserById },
     },
     libraries: {
@@ -31,13 +35,28 @@ export default function verificationCodeRoutes<T extends AuthedMeRouter>(
       body: object({ email: string().regex(emailRegEx) }),
     }),
     async (ctx, next) => {
-      const code = await createPasscode(undefined, codeType, ctx.guard.body);
       const { uiLocales } = getLogtoCookie(ctx);
-      await sendPasscode(code, {
-        locale: ctx.locale,
-        ...(uiLocales && { uiLocales }),
-        ip: ctx.request.ip,
-      });
+      // Create the passcode inside `send` so a rate-limited request neither creates a passcode nor
+      // deletes the recipient's existing unconsumed one (createPasscode replaces prior codes).
+      const send = async () => {
+        const code = await createPasscode(undefined, codeType, ctx.guard.body);
+        return sendPasscode(code, {
+          locale: ctx.locale,
+          ...(uiLocales && { uiLocales }),
+          ip: ctx.request.ip,
+        });
+      };
+
+      await (EnvSet.values.isDevFeaturesEnabled
+        ? withMessageRateGuard(
+            new MessageRateGuard(sentinelActivities),
+            {
+              action: SentinelActivityAction.VerificationCodeSend,
+              recipient: ctx.guard.body.email,
+            },
+            send
+          )
+        : send());
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/verification-code.ts
+++ b/packages/core/src/routes/verification-code.ts
@@ -1,17 +1,20 @@
 import { TemplateType } from '@logto/connector-kit';
 import {
   requestVerificationCodePayloadGuard,
+  SentinelActivityAction,
   verifyVerificationCodePayloadGuard,
 } from '@logto/schemas';
 
+import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 
 const codeType = TemplateType.Generic;
 
 export default function verificationCodeRoutes<T extends ManagementApiRouter>(
-  ...[router, { libraries }]: RouterInitArgs<T>
+  ...[router, { libraries, queries }]: RouterInitArgs<T>
 ) {
   const {
     passcodes: { createPasscode, sendPasscode, verifyPasscode },
@@ -21,11 +24,24 @@ export default function verificationCodeRoutes<T extends ManagementApiRouter>(
     '/verification-codes',
     koaGuard({
       body: requestVerificationCodePayloadGuard,
-      status: [204, 400, 501],
+      status: [204, 400, 429, 501],
     }),
     async (ctx, next) => {
-      const code = await createPasscode(undefined, codeType, ctx.guard.body);
-      await sendPasscode(code, { ip: ctx.request.ip });
+      const recipient = 'email' in ctx.guard.body ? ctx.guard.body.email : ctx.guard.body.phone;
+      // Create the passcode inside `send` so a rate-limited request neither creates a passcode nor
+      // deletes the recipient's existing unconsumed one (createPasscode replaces prior codes).
+      const send = async () => {
+        const code = await createPasscode(undefined, codeType, ctx.guard.body);
+        return sendPasscode(code, { ip: ctx.request.ip });
+      };
+
+      await (EnvSet.values.isDevFeaturesEnabled
+        ? withMessageRateGuard(
+            new MessageRateGuard(queries.sentinelActivities),
+            { action: SentinelActivityAction.VerificationCodeSend, recipient },
+            send
+          )
+        : send());
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -12,7 +12,9 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
 import {
   buildVerificationRecordByIdAndType,
@@ -90,7 +92,7 @@ export default function verificationRoutes<T extends UserRouter>(
           .optional(),
       }),
       response: z.object({ verificationRecordId: z.string(), expiresAt: z.string() }),
-      status: [201, 501],
+      status: [201, 429, 501],
     }),
     async (ctx, next) => {
       const { id: userId, clientId: applicationId } = ctx.auth;
@@ -118,10 +120,19 @@ export default function verificationRoutes<T extends UserRouter>(
           ? await libraries.passcodes.buildVerificationCodeContext({ user, applicationId }, ctx)
           : undefined;
 
-      await codeVerification.sendVerificationCode({
-        ...ctx.emailI18n,
-        ...emailContextPayload,
-      });
+      const send = async () =>
+        codeVerification.sendVerificationCode({
+          ...ctx.emailI18n,
+          ...emailContextPayload,
+        });
+
+      await (EnvSet.values.isDevFeaturesEnabled
+        ? withMessageRateGuard(
+            new MessageRateGuard(queries.sentinelActivities),
+            { action: SentinelActivityAction.VerificationCodeSend, recipient: identifier.value },
+            send
+          )
+        : send());
 
       const { expiresAt } = await insertVerificationRecord(
         codeVerification,

--- a/packages/integration-tests/src/tests/api/account/verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/account/verification-code-rate-limit.test.ts
@@ -1,0 +1,55 @@
+import { UserScope } from '@logto/core-kit';
+import { defaultMessageRateLimitPolicy, SignInIdentifier } from '@logto/schemas';
+import { type KyInstance } from 'ky';
+
+import { enableAllAccountCenterFields } from '#src/api/account-center.js';
+import { authedAdminApi } from '#src/api/api.js';
+import { setEmailConnector } from '#src/helpers/connector.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+  signInAndGetUserApi,
+} from '#src/helpers/profile.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
+
+const sendAccountVerificationCode = async (api: KyInstance, email: string) =>
+  api.post('api/verifications/verification-code', {
+    json: { identifier: { type: SignInIdentifier.Email, value: email } },
+  });
+
+// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
+devFeatureTest.describe('Account verification code send rate limit', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await setEmailConnector(authedAdminApi);
+    await enableAllAccountCenterFields(authedAdminApi);
+  });
+
+  it('rejects with 429 once the per-recipient send cap within the window is exceeded', async () => {
+    const { user, username, password } = await createDefaultTenantUserWithPassword();
+    const api = await signInAndGetUserApi(username, password, {
+      scopes: [UserScope.Profile, UserScope.Email],
+    });
+    // Use a fresh recipient so the count is not polluted by other tests sharing the activity store.
+    const email = generateEmail();
+
+    try {
+      for (const _ of Array.from({ length: maxSendsPerRecipient })) {
+        // eslint-disable-next-line no-await-in-loop -- sequential sends required to reach the cap deterministically
+        const response = await sendAccountVerificationCode(api, email);
+        expect(response.status).toBe(201);
+      }
+
+      await expectRejects(sendAccountVerificationCode(api, email), {
+        code: 'request.rate_limited',
+        status: 429,
+      });
+    } finally {
+      await deleteDefaultTenantUser(user.id);
+    }
+  });
+});

--- a/packages/integration-tests/src/tests/api/me-verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/me-verification-code-rate-limit.test.ts
@@ -1,0 +1,49 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { defaultMessageRateLimitPolicy } from '@logto/schemas';
+import ky from 'ky';
+
+import { authedAdminTenantApi as api } from '#src/api/api.js';
+import { logtoConsoleUrl } from '#src/constants.js';
+import {
+  createUserWithAllRolesAndSignInToClient,
+  deleteUser,
+  resourceMe,
+} from '#src/helpers/admin-tenant.js';
+import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connector.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
+
+// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
+devFeatureTest.describe('Account center (/me) verification code send rate limit', () => {
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email], api);
+    await setEmailConnector(api);
+  });
+
+  afterAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email], api);
+  });
+
+  it('rejects with 429 once the per-recipient send cap within the window is exceeded', async () => {
+    const { id, client } = await createUserWithAllRolesAndSignInToClient();
+    const headers = { authorization: `Bearer ${await client.getAccessToken(resourceMe)}` };
+    // Use a fresh recipient so the count is not polluted by other tests sharing the activity store.
+    const email = generateEmail();
+    const sendCode = async () =>
+      ky.post(logtoConsoleUrl + '/me/verification-codes', { headers, json: { email } });
+
+    try {
+      for (const _ of Array.from({ length: maxSendsPerRecipient })) {
+        // eslint-disable-next-line no-await-in-loop -- sequential sends required to reach the cap deterministically
+        const response = await sendCode();
+        expect(response.status).toBe(204);
+      }
+
+      await expectRejects(sendCode(), { code: 'request.rate_limited', status: 429 });
+    } finally {
+      await deleteUser(id);
+    }
+  });
+});

--- a/packages/integration-tests/src/tests/api/verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/verification-code-rate-limit.test.ts
@@ -1,0 +1,53 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { defaultMessageRateLimitPolicy } from '@logto/schemas';
+
+import { requestVerificationCode } from '#src/api/verification-code.js';
+import {
+  clearConnectorsByTypes,
+  setEmailConnector,
+  setSmsConnector,
+} from '#src/helpers/connector.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { devFeatureTest, generateEmail, generatePhone } from '#src/utils.js';
+
+const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
+
+// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
+devFeatureTest.describe('Management verification code send rate limit', () => {
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+    await setEmailConnector();
+    await setSmsConnector();
+  });
+
+  it('rejects with 429 once the per-recipient email send cap within the window is exceeded', async () => {
+    // Use a fresh recipient so the count is not polluted by other tests sharing the activity store.
+    const email = generateEmail();
+
+    for (const _ of Array.from({ length: maxSendsPerRecipient })) {
+      // eslint-disable-next-line no-await-in-loop -- sequential sends required to reach the cap deterministically
+      const response = await requestVerificationCode({ email });
+      expect(response.status).toBe(204);
+    }
+
+    await expectRejects(requestVerificationCode({ email }), {
+      code: 'request.rate_limited',
+      status: 429,
+    });
+  });
+
+  it('rejects with 429 once the per-recipient phone send cap within the window is exceeded', async () => {
+    const phone = generatePhone();
+
+    for (const _ of Array.from({ length: maxSendsPerRecipient })) {
+      // eslint-disable-next-line no-await-in-loop -- sequential sends required to reach the cap deterministically
+      const response = await requestVerificationCode({ phone });
+      expect(response.status).toBe(204);
+    }
+
+    await expectRejects(requestVerificationCode({ phone }), {
+      code: 'request.rate_limited',
+      status: 429,
+    });
+  });
+});

--- a/packages/integration-tests/src/tests/api/verification-code.test.ts
+++ b/packages/integration-tests/src/tests/api/verification-code.test.ts
@@ -9,16 +9,28 @@ import {
 } from '#src/helpers/connector.js';
 import { expectRejects, readConnectorMessage, removeConnectorMessage } from '#src/helpers/index.js';
 import { enableAllVerificationCodeSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateEmail, generatePhone } from '#src/utils.js';
 
 describe('Generic verification code through management API', () => {
-  const mockEmail = 'foo@bar.com';
-  const mockPhone = '1234567890';
+  // The message rate guard counts verification-code sends per recipient across the whole run, so
+  // each test uses a fresh recipient to stay under the cap instead of sharing one address.
+  // eslint-disable-next-line @silverhand/fp/no-let -- reassigned per test in beforeEach
+  let mockEmail: string;
+  // eslint-disable-next-line @silverhand/fp/no-let -- reassigned per test in beforeEach
+  let mockPhone: string;
 
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
     await setEmailConnector();
     await setSmsConnector();
     await enableAllVerificationCodeSignInMethods();
+  });
+
+  beforeEach(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- fresh recipients per test
+    mockEmail = generateEmail();
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- fresh recipients per test
+    mockPhone = generatePhone();
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary
Refs LOG-13671. Wiring slice 2 of the message rate guard: applies the mandatory, system-level per-recipient send cap to the remaining route-handler verification-code send paths, behind `isDevFeaturesEnabled`. Stacked on #9031 (experience wiring), which carries the guard module.

### What changed
- **Account/Verification API** `POST /verifications/verification-code` ([routes/verification/index.ts](packages/core/src/routes/verification/index.ts)) — recipient = `identifier.value`.
- **Management** `POST /verification-codes` ([routes/verification-code.ts](packages/core/src/routes/verification-code.ts)) — recipient = the email/phone in the body; added `queries` to the router init destructure.
- **`POST /me/verification-codes`** ([routes-me/verification-code.ts](packages/core/src/routes-me/verification-code.ts)) — recipient = `ctx.guard.body.email`.

Each wraps the send with `withMessageRateGuard(new MessageRateGuard(queries.sentinelActivities), { action: VerificationCodeSend, recipient }, send)` and only when dev features are enabled; otherwise the original send runs unchanged. The management and account routes now declare `429` in their `koaGuard` `status` so the guard's rate-limited response isn't flagged as an unexpected status code (the `/me` route declares no `status`, so it's unaffected).

### Expected result
- Once a recipient exceeds the default cap (5 sends/recipient/hour) within the window, further sends to that recipient on these routes are rejected with `429 request.rate_limited`. Below the cap, behavior is unchanged.
- Management/M2M paths remain exempt from the per-IP dimension (deferred); the per-recipient cap applies.

### Reviewer notes
- Integration tests use fresh generated recipients so they don't accumulate against the shared `sentinel_activities` store across the run.
- Sibling PR #9031's experience send routes have the same `429`-not-in-`status` omission (currently only logged in production); I'll address that in #9031 separately.

## Testing
Integration tests

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments