### PR TITLE
feat(core): rate-limit organization invitation sends

### DIFF
--- a/packages/core/src/libraries/organization-invitation.ts
+++ b/packages/core/src/libraries/organization-invitation.ts
@@ -2,15 +2,18 @@ import { appInsights } from '@logto/app-insights/node';
 import { ConnectorType, type SendMessagePayload, TemplateType } from '@logto/connector-kit';
 import {
   OrganizationInvitationStatus,
+  SentinelActivityAction,
   type CreateOrganizationInvitation,
   type OrganizationInvitationEntity,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional, type Nullable, removeUndefinedKeys } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import OrganizationQueries from '#src/queries/organization/index.js';
 import { createUserQueries } from '#src/queries/user.js';
+import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 import type Queries from '#src/tenants/Queries.js';
 import {
   buildOrganizationContextInfo,
@@ -255,11 +258,20 @@ export class OrganizationInvitationLibrary {
     ip?: string
   ) {
     const emailConnector = await this.connector.getMessageConnector(ConnectorType.Email);
-    return emailConnector.sendMessage({
-      to,
-      type: TemplateType.OrganizationInvitation,
-      payload,
-      ...(ip && { ip }),
-    });
+    const send = async () =>
+      emailConnector.sendMessage({
+        to,
+        type: TemplateType.OrganizationInvitation,
+        payload,
+        ...(ip && { ip }),
+      });
+
+    return EnvSet.values.isDevFeaturesEnabled
+      ? withMessageRateGuard(
+          new MessageRateGuard(this.queries.sentinelActivities),
+          { action: SentinelActivityAction.MessageSend, recipient: to },
+          send
+        )
+      : send();
   }
 }

--- a/packages/core/src/routes/organization-invitation/index.ts
+++ b/packages/core/src/routes/organization-invitation/index.ts
@@ -67,7 +67,7 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
           messagePayload: sendMessagePayloadGuard.or(z.literal(false)).default(false),
         }),
       response: organizationInvitationEntityGuard,
-      status: [201, 400, 422, 501],
+      status: [201, 400, 422, 429, 501],
     }),
     async (ctx, next) => {
       const {
@@ -93,7 +93,7 @@ export default function organizationInvitationRoutes<T extends ManagementApiRout
     koaGuard({
       params: z.object({ id: z.string() }),
       body: sendMessagePayloadGuard,
-      status: [204],
+      status: [204, 429],
     }),
     async (ctx, next) => {
       const {

--- a/packages/integration-tests/src/tests/api/email-templates/organization-invitation.test.ts
+++ b/packages/integration-tests/src/tests/api/email-templates/organization-invitation.test.ts
@@ -34,13 +34,21 @@ describe('organization invitation API with i18n email templates', () => {
   const organizationApi = new OrganizationApiTest();
   const useApi = new UserApiTest();
 
-  const mockEmail = generateEmail();
+  // A fresh recipient per test keeps each invitee under the per-recipient message send rate limit,
+  // which counts sends across the whole run.
+  // eslint-disable-next-line @silverhand/fp/no-let -- reassigned per test in beforeEach
+  let mockEmail = generateEmail();
 
   beforeAll(async () => {
     await Promise.all([
       emailTemplatesApi.create([mockEnTemplate, mockDeTemplate, mockFrSignInTemplate]),
       setEmailConnector(),
     ]);
+  });
+
+  beforeEach(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- fresh recipient per test
+    mockEmail = generateEmail();
   });
 
   afterAll(async () => {

--- a/packages/integration-tests/src/tests/api/organization/organization-invitation.rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-invitation.rate-limit.test.ts
@@ -1,0 +1,46 @@
+import { defaultMessageRateLimitPolicy } from '@logto/schemas';
+
+import { authedAdminApi } from '#src/api/api.js';
+import { setEmailConnector } from '#src/helpers/connector.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { OrganizationApiTest, OrganizationInvitationApiTest } from '#src/helpers/organization.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
+
+const resendPayload = { link: 'https://example.com' };
+
+// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
+devFeatureTest.describe('organization invitation send rate limit', () => {
+  const invitationApi = new OrganizationInvitationApiTest();
+  const organizationApi = new OrganizationApiTest();
+
+  afterEach(async () => {
+    await Promise.all([organizationApi.cleanUp(), invitationApi.cleanUp()]);
+  });
+
+  it('rejects with 429 once the per-recipient send cap within the window is exceeded', async () => {
+    await setEmailConnector();
+    const organization = await organizationApi.create({ name: 'test' });
+    // Create a pending invitation without sending, then drive the sends through resend so they all
+    // target the same recipient. A fresh recipient keeps the count isolated from other tests.
+    const invitation = await invitationApi.create({
+      organizationId: organization.id,
+      invitee: generateEmail(),
+      expiresAt: Date.now() + 1_000_000,
+    });
+    // Use the raw endpoint so the success status is observable; the typed helper discards it.
+    const resend = async () =>
+      authedAdminApi.post(`organization-invitations/${invitation.id}/message`, {
+        json: resendPayload,
+      });
+
+    for (const _ of Array.from({ length: maxSendsPerRecipient })) {
+      // eslint-disable-next-line no-await-in-loop -- sequential sends required to reach the cap deterministically
+      const response = await resend();
+      expect(response.status).toBe(204);
+    }
+
+    await expectRejects(resend(), { code: 'request.rate_limited', status: 429 });
+  });
+});


### PR DESCRIPTION
## Summary
Refs LOG-13672. Wiring slice 3 of the message rate guard: applies the mandatory, system-level per-recipient send cap to organization-invitation emails, behind `isDevFeaturesEnabled`. Stacked on #9034.

### What changed
- [organization-invitation.ts](packages/core/src/libraries/organization-invitation.ts) — `sendEmail()` wraps `emailConnector.sendMessage(...)` with `withMessageRateGuard(new MessageRateGuard(this.queries.sentinelActivities), { action: MessageSend, recipient: to }, send)` when dev features are on; otherwise the original send runs unchanged. `sendEmail` is the single chokepoint for both create-with-`messagePayload` and the `/:id/message` resend, so one wrap covers both.
- [organization-invitation/index.ts](packages/core/src/routes/organization-invitation/index.ts) — declare `429` in the `koaGuard` `status` of the create (`POST /`) and resend (`POST /:id/message`) routes so the guard's rate-limited response isn't flagged as an unexpected status code.

### Expected result
- Once an invitee exceeds the default cap (5 sends/recipient/hour) within the window, further invitation sends/resends to that address are rejected with `429 request.rate_limited`. Below the cap, behavior is unchanged.
- Uses a **separate `MessageSend` bucket**, independent from verification-code sends (`VerificationCodeSend`).

### Reviewer notes
- The guard's count/record run on the main pool via `this.queries.sentinelActivities`, not the invitation transaction connection. On the create path a 429 throws before the send and rolls back the invitation insert (desired: no half-created invitation when rate-limited); both guard queries are fail-open.
- Integration test uses a fresh generated invitee and drives all sends through resend for deterministic, isolated bucket accounting.

## Testing
Integration tests

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments