### PR TITLE
feat(core):  rate-limit legacy interaction verification-code send

### DIFF
--- a/packages/core/src/routes/interaction/additional.test.ts
+++ b/packages/core/src/routes/interaction/additional.test.ts
@@ -95,6 +95,9 @@ const baseProviderMock = {
 };
 
 const findUserById = jest.fn().mockResolvedValue(mockUser);
+// The message rate guard runs when dev features are enabled; provide a permissive activity store.
+const countActivities = jest.fn().mockResolvedValue(0);
+const insertActivity = jest.fn();
 const tenantContext = new MockTenant(
   createMockProvider(jest.fn().mockResolvedValue(baseProviderMock)),
   {
@@ -103,6 +106,10 @@ const tenantContext = new MockTenant(
     },
     users: {
       findUserById,
+    },
+    sentinelActivities: {
+      countActivities,
+      insertActivity,
     },
   },
   {
@@ -163,6 +170,16 @@ describe('interaction routes', () => {
         tenantContext.libraries.passcodes
       );
       expect(response.status).toEqual(204);
+    });
+
+    it('should reject with 429 and not send when the recipient is over the rate-limit cap', async () => {
+      // Default policy allows 5 sends per recipient per window; simulate the cap being reached.
+      countActivities.mockResolvedValueOnce(5);
+
+      const response = await sessionRequest.post(path).send({ email: 'spammed@logto.io' });
+
+      expect(response.status).toEqual(429);
+      expect(sendVerificationCodeToIdentifier).not.toBeCalled();
     });
   });
 

--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -3,6 +3,7 @@ import {
   MfaFactor,
   type RequestVerificationCodePayload,
   requestVerificationCodePayloadGuard,
+  SentinelActivityAction,
   webAuthnAuthenticationOptionsGuard,
   webAuthnRegistrationOptionsGuard,
 } from '@logto/schemas';
@@ -13,6 +14,7 @@ import { authenticator } from 'otplib';
 import qrcode from 'qrcode';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { createSocialAuthorizationUrl } from '#src/libraries/verification-helpers/social-verification.js';
@@ -25,6 +27,7 @@ import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { type WithI18nContext } from '#src/middleware/koa-i18next.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { getLogtoCookie } from '#src/utils/cookie.js';
@@ -76,6 +79,7 @@ export default function additionalRoutes<T extends IRouterParamContext>(
     },
     queries: {
       users: { findUserById },
+      sentinelActivities,
     },
   } = tenant;
 
@@ -117,7 +121,8 @@ export default function additionalRoutes<T extends IRouterParamContext>(
     `${interactionPrefix}/${verificationPath}/verification-code`,
     koaGuard({
       body: requestVerificationCodePayloadGuard,
-      status: [204, 400, 404, 501],
+      // 429: rate limited; 501: connector not found
+      status: [204, 400, 404, 429, 501],
     }),
     async (ctx, next) => {
       const { interactionDetails, guard, createLog } = ctx;
@@ -127,19 +132,29 @@ export default function additionalRoutes<T extends IRouterParamContext>(
       const messageContext = await buildVerificationCodeTemplateContext(passcodes, ctx, guard.body);
       const { uiLocales } = getLogtoCookie(ctx);
 
-      await sendVerificationCodeToIdentifier(
-        {
-          event,
-          ...guard.body,
-          locale: ctx.locale,
-          ...(uiLocales && { uiLocales }),
-          messageContext,
-          ip: ctx.request.ip,
-        },
-        interactionDetails.jti,
-        createLog,
-        passcodes
-      );
+      const recipient = 'email' in guard.body ? guard.body.email : guard.body.phone;
+      const send = async () =>
+        sendVerificationCodeToIdentifier(
+          {
+            event,
+            ...guard.body,
+            locale: ctx.locale,
+            ...(uiLocales && { uiLocales }),
+            messageContext,
+            ip: ctx.request.ip,
+          },
+          interactionDetails.jti,
+          createLog,
+          passcodes
+        );
+
+      await (EnvSet.values.isDevFeaturesEnabled
+        ? withMessageRateGuard(
+            new MessageRateGuard(sentinelActivities),
+            { action: SentinelActivityAction.VerificationCodeSend, recipient },
+            send
+          )
+        : send());
 
       ctx.status = 204;
 


### PR DESCRIPTION
## Summary
Refs LOG-13673. Final wiring slice of the message rate guard: applies the mandatory per-recipient send cap to the **deprecated** legacy interaction passwordless send (`POST /interaction/verification/verification-code`), behind `isDevFeaturesEnabled`. Stacked on #9035.

### What changed
- [additional.ts](packages/core/src/routes/interaction/additional.ts) — wrap the `sendVerificationCodeToIdentifier` call with `withMessageRateGuard(new MessageRateGuard(queries.sentinelActivities), { action: VerificationCodeSend, recipient }, send)` when dev features are on; otherwise the original send runs unchanged. Recipient is the email/phone from the request body (`'email' in body ? body.email : body.phone`). Added `sentinelActivities` to the destructured tenant queries and `429` to the route's `koaGuard` status.

### Expected result
- Once a recipient exceeds the default cap (5 sends/recipient/hour) within the window on this legacy endpoint, further sends are rejected with `429 request.rate_limited`. Below the cap, behavior is unchanged.
- Shares the `VerificationCodeSend` bucket with the experience/account/me verification-code sends (a single per-recipient cap across all verification-code surfaces).

### Testing note (reviewer)
Covered by a **unit test** in `additional.test.ts` (429 over cap + no send), not an integration test: the legacy interaction API has no integration-test client and is slated for deprecation, so building one to exercise a soon-to-be-removed path would be disproportionate. This was an explicit decision; the other four send paths have integration coverage.

## Testing
Unit tests (`additional.test.ts`, 14 passing incl. the new 429 case)

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments