### PR TITLE
feat(schemas): add created_at index on sentinel_activities

### DIFF
--- a/packages/schemas/alterations/next-1781689400-add-sentinel-activities-created-at-index.ts
+++ b/packages/schemas/alterations/next-1781689400-add-sentinel-activities-created-at-index.ts
@@ -1,0 +1,25 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    await pool.query(sql`
+      create index concurrently if not exists sentinel_activities__created_at
+        on sentinel_activities (created_at);
+    `);
+  },
+  up: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently if exists sentinel_activities__created_at;
+    `);
+  },
+  down: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/sentinel_activities.sql
+++ b/packages/schemas/tables/sentinel_activities.sql
@@ -33,3 +33,7 @@ create index sentinel_activities__target_type_target_hash
 
 create index sentinel_activities__target_type_target_hash_action_action_result_decision
   on sentinel_activities (tenant_id, target_type, target_hash, action, action_result, decision);
+
+/** Supports the cross-tenant retention prune of stale activity rows by age. */
+create index sentinel_activities__created_at
+  on sentinel_activities (created_at);


### PR DESCRIPTION
## Summary
Refs LOG-13676 (follow-up from LOG-13660 / [cloud#1938](https://github.com/logto-io/cloud/pull/1938)).

Adds a `(created_at)` index on `sentinel_activities` to support the retention prune of stale rows. All three existing indexes are `tenant_id`-leading, so the prune's cross-tenant `created_at < cutoff` range scan + sort could not use an index.

- New alteration `next-1781689400-add-sentinel-activities-created-at-index.ts` creates the index `concurrently` (so it doesn't lock the table) with a matching `drop` on down.
- `tables/sentinel_activities.sql` updated to keep the table definition in sync for fresh installs.

A plain `(created_at)` index (not a partial one) because the prune deletes stale rows across **all** actions — both the message-send rows and the Sentinel failure-counting rows are dead weight beyond the decision window and were growing unbounded.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments