### PR TITLE
feat(console): handle unauthenticated invitation accept route

### DIFF
--- a/packages/connectors/connector-logto-email/package.json
+++ b/packages/connectors/connector-logto-email/package.json
@@ -53,7 +53,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-cbf0233",
+    "@logto/cloud": "0.2.5-31c9868",
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/ts-config": "6.0.0",
     "@types/node": "^22.14.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -30,7 +30,7 @@
     "@fontsource/roboto-mono": "^5.0.0",
     "@inkeep/cxkit-react": "^0.5.66",
     "@jest/types": "^29.5.0",
-    "@logto/cloud": "0.2.5-cbf0233",
+    "@logto/cloud": "0.2.5-31c9868",
     "@logto/connector-kit": "workspace:^",
     "@logto/core-kit": "workspace:^",
     "@logto/language-kit": "workspace:^",

--- a/packages/console/src/cloud/AppRoutes.tsx
+++ b/packages/console/src/cloud/AppRoutes.tsx
@@ -37,11 +37,11 @@ function AppRoutes() {
             path={GlobalAnonymousRoute.ExternalGoogleOneTapLanding}
             element={<ExternalGoogleOneTapLanding />}
           />
+          <Route
+            path={`${GlobalRoute.AcceptInvitation}/:invitationId`}
+            element={<AcceptInvitation />}
+          />
           <Route element={<ProtectedRoutes />}>
-            <Route
-              path={`${GlobalRoute.AcceptInvitation}/:invitationId`}
-              element={<AcceptInvitation />}
-            />
             <Route path={GlobalRoute.Profile + '/*'} element={<Profile />} />
             <Route path={GlobalRoute.HandleSocial} element={<HandleSocialCallback />} />
             <Route

--- a/packages/console/src/containers/ProtectedRoutes/index.tsx
+++ b/packages/console/src/containers/ProtectedRoutes/index.tsx
@@ -1,7 +1,7 @@
 import { useLogto } from '@logto/react';
-import { yes, conditional } from '@silverhand/essentials';
+import { conditional, yes } from '@silverhand/essentials';
 import { useContext, useEffect } from 'react';
-import { Outlet, useMatch, useSearchParams } from 'react-router-dom';
+import { Outlet, useSearchParams } from 'react-router-dom';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import AppLoading from '@/components/AppLoading';
@@ -35,16 +35,14 @@ export default function ProtectedRoutes() {
   const { isAuthenticated, isLoading, signIn } = useLogto();
   const { isInitComplete, resetTenants } = useContext(TenantsContext);
   const redirectUri = useRedirectUri();
-  const match = useMatch('/accept/:invitationId');
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       saveRedirect();
-      const isInvitationLink = Boolean(match?.pathname.startsWith('/accept/'));
-      const isSignUpMode = yes(searchParameters.get(searchKeys.signUp)) || isInvitationLink;
+      const isSignUpMode = yes(searchParameters.get(searchKeys.signUp));
       void signIn(redirectUri.href, conditional(isSignUpMode && 'signUp'));
     }
-  }, [redirectUri, isAuthenticated, isLoading, searchParameters, signIn, match?.pathname]);
+  }, [redirectUri, isAuthenticated, isLoading, searchParameters, signIn]);
 
   useEffect(() => {
     if (isAuthenticated && !isInitComplete) {

--- a/packages/console/src/pages/AcceptInvitation/index.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.tsx
@@ -1,40 +1,64 @@
 import { useLogto } from '@logto/react';
 import { OrganizationInvitationStatus, getTenantIdFromOrganizationId } from '@logto/schemas';
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type InvitationResponse } from '@/cloud/types/router';
 import AppError from '@/components/AppError';
 import AppLoading from '@/components/AppLoading';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import { type RequestError } from '@/hooks/use-api';
 import useRedirectUri from '@/hooks/use-redirect-uri';
 import { saveRedirect } from '@/utils/storage';
 
 import SwitchAccount from './SwitchAccount';
+import { buildInvitationAcceptUrl, buildInvitationAuthPath } from './utils';
 
 function AcceptInvitation() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const { signIn } = useLogto();
+  const { isAuthenticated, isLoading, signIn } = useLogto();
   const redirectUri = useRedirectUri();
   const { invitationId = '' } = useParams();
+  const [searchParameters] = useSearchParams();
+  const oneTimeToken = searchParameters.get('one_time_token');
   const cloudApi = useCloudApi();
   const { navigateTenant, resetTenants } = useContext(TenantsContext);
+  const hasStartedSignIn = useRef(false);
+  const authFormRef = useRef<HTMLFormElement>(null);
 
   // The request is only made when the user has signed-in and the invitation ID is available.
   // The response data is returned only when the current user matches the invitee email. Otherwise, it returns 404.
   const { data: invitation, error } = useSWR<InvitationResponse, RequestError>(
-    invitationId && `/api/invitations/${invitationId}`,
+    isAuthenticated && invitationId && `/api/invitations/${invitationId}`,
     async () => cloudApi.get('/api/invitations/:invitationId', { params: { invitationId } })
   );
 
   useEffect(() => {
-    if (!invitation) {
+    if (isLoading || isAuthenticated || !invitationId || hasStartedSignIn.current) {
       return;
     }
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- React ref guards against duplicate sign-in redirects
+    hasStartedSignIn.current = true;
+
+    if (!isDevFeaturesEnabled || !oneTimeToken) {
+      saveRedirect(buildInvitationAcceptUrl(invitationId));
+      void signIn(redirectUri.href, 'signUp');
+      return;
+    }
+
+    authFormRef.current?.requestSubmit();
+  }, [invitationId, isAuthenticated, isLoading, oneTimeToken, redirectUri, signIn]);
+
+  useEffect(() => {
+    if (!invitation || invitation.status !== OrganizationInvitationStatus.Pending) {
+      return;
+    }
+
     (async () => {
       const { id, organizationId } = invitation;
 
@@ -48,14 +72,36 @@ function AcceptInvitation() {
       resetTenants(data);
       navigateTenant(getTenantIdFromOrganizationId(organizationId));
     })();
-  }, [cloudApi, error, invitation, navigateTenant, resetTenants, t]);
+  }, [cloudApi, invitation, navigateTenant, resetTenants]);
+
+  if (!invitationId) {
+    return <AppError errorMessage={t('invitation.invitation_not_found')} />;
+  }
+
+  const invitationAuthForm = isDevFeaturesEnabled && oneTimeToken && (
+    <form
+      ref={authFormRef}
+      hidden
+      method="post"
+      action={buildInvitationAuthPath(invitationId, oneTimeToken)}
+    />
+  );
+
+  if (isLoading || !isAuthenticated) {
+    return (
+      <>
+        {invitationAuthForm}
+        <AppLoading />
+      </>
+    );
+  }
 
   // No invitation returned, indicating the current signed-in user is not the invitee.
   if (error?.status === 403) {
     return (
       <SwitchAccount
         onClickSwitch={() => {
-          saveRedirect();
+          saveRedirect(buildInvitationAcceptUrl(invitationId));
           void signIn(redirectUri.href);
         }}
       />

--- a/packages/console/src/pages/AcceptInvitation/utils.test.ts
+++ b/packages/console/src/pages/AcceptInvitation/utils.test.ts
@@ -1,0 +1,18 @@
+import { buildInvitationAcceptUrl, buildInvitationAuthPath } from './utils';
+
+describe('accept invitation utils', () => {
+  test('builds the accept invitation URL for the current Console origin', () => {
+    expect(buildInvitationAcceptUrl('invitation-id').href).toBe(
+      'http://localhost/accept/invitation-id'
+    );
+  });
+
+  test('builds the invitation auth endpoint path', () => {
+    expect(buildInvitationAuthPath('invitation-id', 'one-time-token')).toBe(
+      '/api/invitations/invitation-id/auth?one_time_token=one-time-token'
+    );
+    expect(buildInvitationAuthPath('invitation/id', 'one/time token')).toBe(
+      '/api/invitations/invitation%2Fid/auth?one_time_token=one%2Ftime+token'
+    );
+  });
+});

--- a/packages/console/src/pages/AcceptInvitation/utils.ts
+++ b/packages/console/src/pages/AcceptInvitation/utils.ts
@@ -1,0 +1,19 @@
+import { type anonymousRouter } from '@logto/cloud/routes';
+import { type RouterRoutes } from '@withtyped/client';
+
+const acceptInvitationRoute = '/accept';
+const invitationAuthRoute = '/api/invitations/:invitationId/auth' satisfies keyof RouterRoutes<
+  typeof anonymousRouter
+>['post'];
+
+export const buildInvitationAcceptUrl = (invitationId: string) =>
+  new URL(`${acceptInvitationRoute}/${invitationId}`, window.location.origin);
+
+export const buildInvitationAuthPath = (invitationId: string, oneTimeToken: string) => {
+  const searchParameters = new URLSearchParams({ one_time_token: oneTimeToken });
+
+  return `${invitationAuthRoute.replace(
+    ':invitationId',
+    encodeURIComponent(invitationId)
+  )}?${searchParameters.toString()}`;
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
     "zod": "3.24.3"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-cbf0233",
+    "@logto/cloud": "0.2.5-31c9868",
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/ts-config": "6.0.0",
     "@types/adm-zip": "^0.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1956,8 +1956,8 @@ importers:
         version: 3.24.3
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-cbf0233
-        version: 0.2.5-cbf0233(zod@3.24.3)
+        specifier: 0.2.5-31c9868
+        version: 0.2.5-31c9868(zod@3.24.3)
       '@silverhand/eslint-config':
         specifier: 6.0.1
         version: 6.0.1(eslint@8.57.0)(prettier@3.5.3)(typescript@5.5.3)
@@ -3771,8 +3771,8 @@ importers:
         specifier: ^29.5.0
         version: 29.6.3
       '@logto/cloud':
-        specifier: 0.2.5-cbf0233
-        version: 0.2.5-cbf0233(zod@3.24.3)
+        specifier: 0.2.5-31c9868
+        version: 0.2.5-31c9868(zod@3.24.3)
       '@logto/connector-kit':
         specifier: workspace:^
         version: link:../toolkit/connector-kit
@@ -4303,8 +4303,8 @@ importers:
         version: 3.24.3
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-cbf0233
-        version: 0.2.5-cbf0233(zod@3.24.3)
+        specifier: 0.2.5-31c9868
+        version: 0.2.5-31c9868(zod@3.24.3)
       '@silverhand/eslint-config':
         specifier: 6.0.1
         version: 6.0.1(eslint@8.57.0)(prettier@3.5.3)(typescript@5.5.3)
@@ -6574,8 +6574,8 @@ packages:
   '@logto/client@3.1.8':
     resolution: {integrity: sha512-f6NcPOV/K1IpPm4ccARWeYpQVMeN4mfikGg+5Qw1rcIPYPUpD5BmDsQbVTAnDepCMbC7syzRerZmbwL8S3UL+A==}
 
-  '@logto/cloud@0.2.5-cbf0233':
-    resolution: {integrity: sha512-u9927SAlxVTV4odr1k1UKAQHFiUNMurTGUBQ9wRqLOg6o93GR4NCEnbcbBUuiFonqwEF9o4IY7vGvdVPODyAUA==}
+  '@logto/cloud@0.2.5-31c9868':
+    resolution: {integrity: sha512-zjLFeCsZLejMdLV0TU/NRQ4epg0G8ZwykmHc2Ax6wBt6wOra5lGlNZHX+RvcC6B0U8mb9O7X5Qa9i8nfOWOz2w==}
     engines: {node: ^22.14.0}
 
   '@logto/js@5.1.0':
@@ -7620,131 +7620,157 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -8219,24 +8245,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.3.52':
     resolution: {integrity: sha512-GCxNjTAborAmv4VV1AMZLyejHLGgIzu13tvLUFqybtU4jFxVbE2ZK4ZnPCfDlWN+eBwyRWk1oNFR2hH+66vaUQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.3.52':
     resolution: {integrity: sha512-mrvDBSkLI3Mza2qcu3uzB5JGwMBYDb1++UQ1VB0RXf2AR21/cCper4P44IpfdeqFz9XyXq18Sh3gblICUCGvig==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.3.52':
     resolution: {integrity: sha512-r9RIvKUQv7yBkpXz+QxPAucdoj8ymBlgIm5rLE0b5VmU7dlKBnpAmRBYaITdH6IXhF0pwuG+FHAd5elBcrkIwA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.3.52':
     resolution: {integrity: sha512-YRtEr7tDo0Wes3M2ZhigF4erUjWBXeFP+O+iz6ELBBmPG7B7m/lrA21eiW9/90YGnzi0iNo46shK6PfXuPhP+Q==}
@@ -12447,24 +12477,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.25.1:
     resolution: {integrity: sha512-IhxVFJoTW8wq6yLvxdPvyHv4NjzcpN1B7gjxrY3uaykQNXPHNIpChLB52+wfH+yS58zm1PL4LemUp8u9Cfp6Bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.25.1:
     resolution: {integrity: sha512-RXIaru79KrREPEd6WLXfKfIp4QzoppZvD3x7vuTKkDA64PwTzKJ2jaC43RZHRt8BmyIkRRlmywNhTRMbmkPYpA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.25.1:
     resolution: {integrity: sha512-TdcNqFsAENEEFr8fJWg0Y4fZ/nwuqTRsIr7W7t2wmDUlA8eSXVepeeONYcb+gtTj1RaXn/WgNLB45SFkz+XBZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-x64-msvc@1.25.1:
     resolution: {integrity: sha512-9KZZkmmy9oGDSrnyHuxP6iMhbsgChUiu/NSgOx+U1I/wTngBStDf2i2aGRCHvFqj19HqqBEI4WuGVQBa2V6e0A==}
@@ -17840,9 +17874,9 @@ snapshots:
       camelcase-keys: 9.1.3
       jose: 5.9.6
 
-  '@logto/cloud@0.2.5-cbf0233(zod@3.24.3)':
+  '@logto/cloud@0.2.5-31c9868(zod@3.24.3)':
     dependencies:
-      '@silverhand/essentials': 2.9.2
+      '@silverhand/essentials': 2.9.3
       '@withtyped/server': 0.14.0(zod@3.24.3)
     transitivePeerDependencies:
       - zod
@@ -19133,7 +19167,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.5.3)
@@ -22662,7 +22696,7 @@ snapshots:
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -22730,7 +22764,7 @@ snapshots:
       eslint: 8.57.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5


### PR DESCRIPTION
## Summary
Update the Console invitation accept page so it can serve as the email entry point for unauthenticated users. The accept route now lives outside protected routes, submits invitation auth through the Cloud endpoint, and keeps the existing authenticated invitation validation and accept flow.

Depends on logto-io/cloud#1940 for the invitation auth API.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
