### PR TITLE
fix(core): normalize recipient before hashing in message rate guard

### DIFF
--- a/packages/core/src/sentinel/message-rate-guard.test.ts
+++ b/packages/core/src/sentinel/message-rate-guard.test.ts
@@ -67,6 +67,42 @@ describe('MessageRateGuard', () => {
     await expect(buildGuard().guard(action, recipient)).resolves.toBeUndefined();
   });
 
+  it('buckets email casing/whitespace variants together', async () => {
+    countActivities.mockResolvedValue(0);
+    const guard = buildGuard();
+
+    await guard.guard(action, '  Foo@Example.com ');
+    await guard.guard(action, 'foo@example.com');
+
+    expect(countActivities.mock.calls[0]?.[0].targetHash).toBe(
+      countActivities.mock.calls[1]?.[0].targetHash
+    );
+  });
+
+  it('buckets phone formatting variants together', async () => {
+    countActivities.mockResolvedValue(0);
+    const guard = buildGuard();
+
+    await guard.guard(action, '+1 (650) 253-0000');
+    await guard.guard(action, '16502530000');
+
+    expect(countActivities.mock.calls[0]?.[0].targetHash).toBe(
+      countActivities.mock.calls[1]?.[0].targetHash
+    );
+  });
+
+  it('hashes the normalized recipient on both guard and record', async () => {
+    countActivities.mockResolvedValue(0);
+    const guard = buildGuard();
+
+    await guard.guard(action, 'Foo@Example.com');
+    await guard.record(action, 'foo@example.com');
+
+    expect(insertActivity.mock.calls[0]?.[0].targetHash).toBe(
+      countActivities.mock.calls[0]?.[0].targetHash
+    );
+  });
+
   it('does not throw when recording the send fails', async () => {
     insertActivity.mockRejectedValueOnce(new Error('db unavailable'));
 

--- a/packages/core/src/sentinel/message-rate-guard.ts
+++ b/packages/core/src/sentinel/message-rate-guard.ts
@@ -6,7 +6,7 @@ import {
   SentinelDecision,
   defaultMessageRateLimitPolicy,
 } from '@logto/schemas';
-import { generateStandardId } from '@logto/shared';
+import { generateStandardId, parsePhoneNumber } from '@logto/shared';
 import { trySafe } from '@silverhand/essentials';
 import { sha256 } from 'hash-wasm';
 
@@ -19,6 +19,19 @@ type MessageRateGuardQueries = Pick<
   SentinelActivitiesQueries,
   'countActivities' | 'insertActivity'
 >;
+
+/**
+ * Canonicalizes a recipient so casing/formatting variants of the same address share one rate-limit
+ * bucket — otherwise the per-recipient cap is trivially bypassed by re-casing an email or
+ * reformatting a phone number. Emails are lower-cased; everything else is treated as a phone number
+ * and reduced to its E.164 digits (the form Logto stores), falling back to the trimmed input when
+ * it is not a valid number.
+ */
+const normalizeRecipient = (recipient: string): string => {
+  const trimmed = recipient.trim();
+  // Email is the only messaging recipient that contains `@`; anything else is a phone number.
+  return trimmed.includes('@') ? trimmed.toLowerCase() : parsePhoneNumber(trimmed);
+};
 
 /**
  * A mandatory, system-level rate limit on outbound messages (verification codes, organization
@@ -40,7 +53,7 @@ export class MessageRateGuard {
    * per-recipient cap within the policy window. Call before performing the send.
    */
   async guard(action: SentinelActivityAction, recipient: string): Promise<void> {
-    const targetHash = await sha256(recipient);
+    const targetHash = await sha256(normalizeRecipient(recipient));
     // Fail open: this is a best-effort spam guard, not a hard dependency of the send flow. If the
     // count query fails, `trySafe` returns `undefined` and we allow the send rather than block a
     // legitimate user.
@@ -63,7 +76,7 @@ export class MessageRateGuard {
 
   /** Record a successful send so it counts toward the recipient's cap. */
   async record(action: SentinelActivityAction, recipient: string): Promise<void> {
-    const targetHash = await sha256(recipient);
+    const targetHash = await sha256(normalizeRecipient(recipient));
     // Best-effort: a failure to record must not surface to the caller after the message was sent.
     await trySafe(
       this.queries.insertActivity({


### PR DESCRIPTION
## Summary

Closes [LOG-13682](https://linear.app/silverhand/issue/LOG-13682).

The per-recipient message rate guard hashed the **raw** recipient (`sha256(recipient)` in both `guard()` and `record()`), so casing/formatting variants of the same address fell into separate rate-limit buckets — `Foo@x.com` vs `foo@x.com`, or phone formatting variants like `+1 (650) 253-0000` vs `16502530000`. That makes the per-recipient cap trivially bypassable and also splits counts for benign re-casing. It's also inconsistent with the rest of the codebase, which already treats email case-insensitively (e.g. the invitation-accept check at `libraries/organization-invitation.ts`).

### What changed

- Added `normalizeRecipient` in `sentinel/message-rate-guard.ts`, applied once before `sha256` in both `guard()` and `record()`:
  - **Email** (the only `@`-bearing recipient): `trim().toLowerCase()`.
  - **Phone** (everything else): `parsePhoneNumber` from `@logto/shared` — the same helper Logto uses to canonicalize phone numbers to their E.164 digits for storage; falls back to the trimmed input when the number isn't valid.
- Normalizing inside the guard covers every wired send path with one change (experience #9031, account/management/`/me` #9034, org-invitation #9035) — no call-site changes needed.

### Notes

- Still behind `isDevFeaturesEnabled` — pre-GA cleanup, lands before the gate is removed (no changeset).
- Stacked on [#9044](https://github.com/logto-io/logto/pull/9044) (the `sentinel_activities` index); base will retarget to master once that merges.

## Testing

Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
