### PR TITLE
feat(schemas): loosen default message rate-limit to 10 per 10 minutes

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,4 +1,4 @@
-import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
+import { defaultMessageRateLimitPolicy, InteractionEvent, SignInIdentifier } from '@logto/schemas';
 
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -208,8 +208,10 @@ describe('sendCode parameter passing', () => {
   });
 
   it('rejects with 429 and does not send when the recipient is over the rate-limit cap', async () => {
-    // Default policy allows 5 sends per recipient per window; simulate the cap being reached.
-    mockSentinelActivities.countActivities.mockResolvedValueOnce(5);
+    // Simulate the per-recipient cap being reached for the default policy.
+    mockSentinelActivities.countActivities.mockResolvedValueOnce(
+      defaultMessageRateLimitPolicy.maxSendsPerRecipient
+    );
 
     const ctx = {
       request: { ip: '127.0.0.1' },

--- a/packages/schemas/src/consts/message-rate-limit.ts
+++ b/packages/schemas/src/consts/message-rate-limit.ts
@@ -32,10 +32,14 @@ export const messageRateLimitPolicyGuard = z.object({
  * The default message rate limit policy. Applied to every tenant and not
  * tenant-configurable.
  *
- * - `sendWindow`: 3600 seconds (1 hour)
- * - `maxSendsPerRecipient`: 5 per window
+ * - `sendWindow`: 600 seconds (10 minutes)
+ * - `maxSendsPerRecipient`: 10 per window
+ *
+ * The window is short and rolling on purpose: a falsely-throttled recipient
+ * regains capacity within ~10 minutes rather than being unable to receive a
+ * message for up to an hour.
  */
 export const defaultMessageRateLimitPolicy = Object.freeze({
-  sendWindow: 3600,
-  maxSendsPerRecipient: 5,
+  sendWindow: 600,
+  maxSendsPerRecipient: 10,
 } satisfies MessageRateLimitPolicy);


### PR DESCRIPTION
## Summary

Closes [LOG-13685](https://linear.app/silverhand/issue/LOG-13685).

Loosens the system-level per-recipient message send cap in `defaultMessageRateLimitPolicy`:

- `sendWindow`: 3600 → **600** (10 minutes)
- `maxSendsPerRecipient`: 5 → **10**

i.e. **10 sends per recipient per 10 minutes**, counted per `(recipient, action)`.

### Why

The window is **rolling** and the cap is a **hard, non-tenant-configurable** limit, so the previous `5 / hour` meant a falsely-throttled recipient could be unable to receive *any* message for up to ~60 minutes. Shortening the window cuts worst-case recovery to ~10 minutes and gives more burst headroom (10 vs 5), at the cost of a higher sustained ceiling (60/hr per recipient per action).

Benchmarked against peer auth providers — a per-recipient/user windowed cap in the 5–10 range is in-band: AWS Cognito 5/hour per user, Auth0 email-OTP 5 per 5 min (60/hr ceiling), Auth0 SMS 10/hour.

### Scope

- Schemas constant + doc comment only. Still gated behind `isDevFeaturesEnabled`, so no changeset.
- The five integration tests covering the wired send paths derive their loop count from `defaultMessageRateLimitPolicy.maxSendsPerRecipient`, so they pick up the new value automatically — no test changes needed.

### Follow-up (separate, not in this PR)

Peers also ship a short server-side per-recipient resend cooldown (Okta 30 s, Supabase 60 s); Logto currently enforces a resend cooldown only client-side. Worth a separate issue.

## Testing

N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
