### PR TITLE
feat(account,core): add passkey sign-in skip control to account center

### DIFF
--- a/packages/account/src/apis/logto-config.ts
+++ b/packages/account/src/apis/logto-config.ts
@@ -1,0 +1,34 @@
+import { type UserMfaData, type UserPasskeySignInData } from '@logto/schemas';
+
+import { verificationRecordIdHeader } from './account';
+import { createAuthenticatedKy } from './base-ky';
+
+export type UserLogtoConfigResponse = {
+  mfa: {
+    enabled?: boolean;
+    skipped: boolean;
+    skipMfaOnSignIn: boolean;
+  };
+  passkeySignIn: {
+    skipped: boolean;
+  };
+};
+
+export const getLogtoConfig = async (accessToken: string): Promise<UserLogtoConfigResponse> => {
+  return createAuthenticatedKy(accessToken)
+    .get('/api/my-account/logto-configs')
+    .json<UserLogtoConfigResponse>();
+};
+
+export const updateLogtoConfig = async (
+  accessToken: string,
+  verificationRecordId: string,
+  payload: { mfa?: UserMfaData; passkeySignIn?: UserPasskeySignInData }
+): Promise<UserLogtoConfigResponse> => {
+  return createAuthenticatedKy(accessToken)
+    .patch('/api/my-account/logto-configs', {
+      json: payload,
+      headers: { [verificationRecordIdHeader]: verificationRecordId },
+    })
+    .json<UserLogtoConfigResponse>();
+};

--- a/packages/account/src/pages/Security/PasskeySection/index.module.scss
+++ b/packages/account/src/pages/Security/PasskeySection/index.module.scss
@@ -1,0 +1,79 @@
+@use '@experience/shared/scss/underscore' as _;
+@use '../components/skeleton';
+
+.toggleRow {
+  display: flex;
+  align-items: center;
+  gap: _.unit(6);
+  padding: _.unit(5) _.unit(6);
+}
+
+.toggleInfo {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: _.unit(1);
+  min-width: 0;
+}
+
+.toggleTitle {
+  font: var(--font-label-2);
+  color: var(--color-type-primary);
+}
+
+.toggleDescription {
+  font: var(--font-body-2);
+  color: var(--color-type-secondary);
+}
+
+.divider {
+  height: 1px;
+  background: var(--color-line-divider);
+}
+
+.skeletonBlock {
+  @include skeleton.skeleton-block;
+}
+
+.skeletonToggleTitle {
+  width: 200px;
+  max-width: 60%;
+  height: 16px;
+}
+
+.skeletonToggleDescription {
+  width: 360px;
+  max-width: 100%;
+  height: 14px;
+}
+
+.skeletonSwitch {
+  width: 44px;
+  height: 24px;
+  flex-shrink: 0;
+  border-radius: 12px;
+}
+
+@include skeleton.shimmer-keyframes;
+
+:global(body.mobile) {
+  .toggleRow {
+    gap: _.unit(3);
+    padding: _.unit(4);
+  }
+
+  .toggleInfo {
+    gap: _.unit(1.5);
+  }
+
+  .toggleTitle,
+  .toggleDescription {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .skeletonToggleTitle,
+  .skeletonToggleDescription {
+    max-width: 100%;
+  }
+}

--- a/packages/account/src/pages/Security/PasskeySection/index.test.tsx
+++ b/packages/account/src/pages/Security/PasskeySection/index.test.tsx
@@ -11,8 +11,15 @@ import renderWithPageContext, {
   mockAccountCenterSettings,
   mockSignInExperienceSettings,
 } from '@ac/__mocks__/RenderWithPageContext';
-import { passkeyAddRoute, passkeyManageRoute, securityRoute } from '@ac/constants/routes';
+import {
+  passkeyAddRoute,
+  passkeyManageRoute,
+  securityRoute,
+  verifiedActionRoute,
+} from '@ac/constants/routes';
+import { sessionStorage } from '@ac/utils/session-storage';
 
+import { getLogtoConfig, updateLogtoConfig } from '../../../apis/logto-config';
 import { getMfaVerifications } from '../../../apis/mfa';
 import MfaVerificationsProvider from '../MfaVerificationsProvider';
 
@@ -35,22 +42,40 @@ jest.mock('../../../apis/mfa', () => ({
   getMfaVerifications: jest.fn(),
 }));
 
+jest.mock('../../../apis/logto-config', () => ({
+  getLogtoConfig: jest.fn(),
+  updateLogtoConfig: jest.fn(),
+}));
+
 const mockGetMfaVerifications = getMfaVerifications as jest.MockedFunction<
   typeof getMfaVerifications
 >;
+const mockGetLogtoConfig = getLogtoConfig as jest.MockedFunction<typeof getLogtoConfig>;
+const mockUpdateLogtoConfig = updateLogtoConfig as jest.MockedFunction<typeof updateLogtoConfig>;
+
+const buildLogtoConfigResponse = (passkeySignInSkipped: boolean) => ({
+  mfa: { skipped: false, skipMfaOnSignIn: true },
+  passkeySignIn: { skipped: passkeySignInSkipped },
+});
 
 type RenderOptions = {
   mfaVerifications?: UserMfaVerificationResponse;
   passkeyControl?: AccountCenterControlValue;
   passkeySignInEnabled?: boolean;
+  passkeySignInSkipped?: boolean;
+  verificationId?: string;
 };
 
 const renderPasskeySection = ({
   mfaVerifications = [],
   passkeyControl = AccountCenterControlValue.Edit,
   passkeySignInEnabled = true,
+  passkeySignInSkipped = false,
+  verificationId,
 }: RenderOptions = {}) => {
   mockGetMfaVerifications.mockResolvedValue(mfaVerifications);
+  mockGetLogtoConfig.mockResolvedValue(buildLogtoConfigResponse(passkeySignInSkipped));
+  mockUpdateLogtoConfig.mockResolvedValue(buildLogtoConfigResponse(passkeySignInSkipped));
 
   return renderWithPageContext(
     <Routes>
@@ -64,6 +89,7 @@ const renderPasskeySection = ({
       />
       <Route path={passkeyAddRoute} element={<div>passkey add page</div>} />
       <Route path={passkeyManageRoute} element={<div>passkey manage page</div>} />
+      <Route path={verifiedActionRoute} element={<div>verified action page</div>} />
     </Routes>,
     {
       initialEntries: [securityRoute],
@@ -71,6 +97,7 @@ const renderPasskeySection = ({
     },
     {
       pageContext: {
+        verificationId,
         accountCenterSettings: {
           ...mockAccountCenterSettings,
           fields: { ...mockAccountCenterSettings.fields, passkey: passkeyControl },
@@ -138,6 +165,7 @@ describe('<PasskeySection />', () => {
     expect(queryAllByText('account_center.security.passkeys')).toHaveLength(2);
     expect(queryByText('account_center.security.add')).toBeNull();
     expect(queryByText('account_center.security.manage')).toBeNull();
+    expect(queryByText('account_center.security.passkey_sign_in_prompt')).toBeNull();
   });
 
   it('renders nothing when passkey sign-in is disabled', () => {
@@ -154,5 +182,49 @@ describe('<PasskeySection />', () => {
 
     expect(queryByText('account_center.security.passkeys')).toBeNull();
     expect(mockGetMfaVerifications).not.toHaveBeenCalled();
+  });
+
+  it('reflects the current passkey sign-in skip state in the toggle', async () => {
+    const { getByRole } = renderPasskeySection({ passkeySignInSkipped: true });
+
+    await waitFor(() => {
+      expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(false);
+    });
+  });
+
+  it('navigates to identity verification when toggling without a verification record', async () => {
+    const { getByRole, getByText } = renderPasskeySection({ passkeySignInSkipped: false });
+
+    await waitFor(() => {
+      expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
+    });
+
+    fireEvent.click(getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(getByText('verified action page')).not.toBeNull();
+    });
+
+    expect(sessionStorage.getPendingVerifiedAction()).toBe('disable-passkey-prompt');
+    expect(mockUpdateLogtoConfig).not.toHaveBeenCalled();
+  });
+
+  it('updates the passkey sign-in skip state directly when already verified', async () => {
+    const { getByRole } = renderPasskeySection({
+      passkeySignInSkipped: false,
+      verificationId: 'verification-id',
+    });
+
+    await waitFor(() => {
+      expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
+    });
+
+    fireEvent.click(getByRole('checkbox'));
+
+    await waitFor(() => {
+      expect(mockUpdateLogtoConfig).toHaveBeenCalledWith('access-token', 'verification-id', {
+        passkeySignIn: { skipped: true },
+      });
+    });
   });
 });

--- a/packages/account/src/pages/Security/PasskeySection/index.tsx
+++ b/packages/account/src/pages/Security/PasskeySection/index.tsx
@@ -1,28 +1,45 @@
 import { MfaFactor } from '@logto/schemas';
-import { useCallback, useContext } from 'react';
+import classNames from 'classnames';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import WebAuthnIcon from '@ac/assets/icons/factor-webauthn.svg?react';
-import { passkeyAddRoute, passkeyManageRoute } from '@ac/constants/routes';
+import ToggleSwitch from '@ac/components/ToggleSwitch';
+import { passkeyAddRoute, passkeyManageRoute, verifiedActionRoute } from '@ac/constants/routes';
 import { getPendingReturn, setPendingReturn } from '@ac/utils/account-center-route';
 import {
   getPasskeyFieldControl,
   hasVisiblePasskeySection,
   isEditableField,
 } from '@ac/utils/security-page';
+import { sessionStorage } from '@ac/utils/session-storage';
 
+import { getLogtoConfig, updateLogtoConfig } from '../../../apis/logto-config';
+import useApi from '../../../hooks/use-api';
+import useErrorHandler from '../../../hooks/use-error-handler';
 import { useMfaVerifications } from '../MfaVerificationsProvider';
 import SecurityRow, { type SecurityRowData } from '../components/SecurityRow';
 import SecuritySection from '../components/SecuritySection';
 import { SecurityRowSkeleton, SecuritySkeleton } from '../components/SecuritySkeleton';
 
+import styles from './index.module.scss';
+
 const PasskeySection = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { accountCenterSettings, experienceSettings } = useContext(PageContext);
+  const { accountCenterSettings, experienceSettings, verificationId, setVerificationId, setToast } =
+    useContext(PageContext);
   const { mfaVerifications, isLoading, hasLoaded } = useMfaVerifications();
+  const handleError = useErrorHandler();
+
+  const [passkeySignInSkipped, setPasskeySignInSkipped] = useState<boolean>();
+  const [hasLoadedConfig, setHasLoadedConfig] = useState(false);
+  const [isLoadingConfig, setIsLoadingConfig] = useState(false);
+
+  const getLogtoConfigRequest = useApi(getLogtoConfig, { silent: true });
+  const updateLogtoConfigApi = useApi(updateLogtoConfig);
 
   const passkeyControl = getPasskeyFieldControl(
     accountCenterSettings?.fields.passkey,
@@ -30,7 +47,27 @@ const PasskeySection = () => {
   );
   const isEditable = isEditableField(passkeyControl);
   const isSectionVisible = hasVisiblePasskeySection(passkeyControl, experienceSettings);
-  const isSectionLoading = isSectionVisible && (!hasLoaded || isLoading);
+  const showToggle = isSectionVisible && isEditable;
+  const isPromptEnabled = passkeySignInSkipped === false;
+  const isSectionLoading =
+    (isSectionVisible && (!hasLoaded || isLoading)) ||
+    (showToggle && (!hasLoadedConfig || isLoadingConfig));
+
+  const fetchLogtoConfig = useCallback(async () => {
+    setIsLoadingConfig(true);
+    const [error, result] = await getLogtoConfigRequest();
+    if (!error && result) {
+      setPasskeySignInSkipped(result.passkeySignIn.skipped);
+    }
+    setHasLoadedConfig(true);
+    setIsLoadingConfig(false);
+  }, [getLogtoConfigRequest]);
+
+  useEffect(() => {
+    if (showToggle) {
+      void fetchLogtoConfig();
+    }
+  }, [showToggle, fetchLogtoConfig]);
 
   const navigateTo = useCallback(
     (route: string) => {
@@ -39,6 +76,57 @@ const PasskeySection = () => {
     },
     [navigate]
   );
+
+  const updatePasskeySignInSkipped = useCallback(
+    async (verifiedId: string, skipped: boolean) => {
+      const [error] = await updateLogtoConfigApi(verifiedId, { passkeySignIn: { skipped } });
+
+      if (error) {
+        await handleError(error, {
+          'verification_record.permission_denied': async () => {
+            setVerificationId(undefined);
+            setToast(t('account_center.verification.verification_required'));
+          },
+        });
+        return;
+      }
+
+      setPasskeySignInSkipped(skipped);
+    },
+    [handleError, setToast, setVerificationId, t, updateLogtoConfigApi]
+  );
+
+  const handleToggleChange = useCallback(
+    async (checked: boolean) => {
+      const skipped = !checked;
+
+      if (verificationId) {
+        await updatePasskeySignInSkipped(verificationId, skipped);
+        return;
+      }
+
+      sessionStorage.setPendingVerifiedAction(
+        checked ? 'enable-passkey-prompt' : 'disable-passkey-prompt'
+      );
+      navigateTo(verifiedActionRoute);
+    },
+    [navigateTo, updatePasskeySignInSkipped, verificationId]
+  );
+
+  useEffect(() => {
+    if (!verificationId) {
+      return;
+    }
+
+    const pendingAction = sessionStorage.getPendingVerifiedAction();
+
+    if (pendingAction !== 'enable-passkey-prompt' && pendingAction !== 'disable-passkey-prompt') {
+      return;
+    }
+
+    sessionStorage.clearPendingVerifiedAction();
+    void updatePasskeySignInSkipped(verificationId, pendingAction === 'disable-passkey-prompt');
+  }, [updatePasskeySignInSkipped, verificationId]);
 
   if (!isSectionVisible) {
     return null;
@@ -69,15 +157,55 @@ const PasskeySection = () => {
       : undefined,
   };
 
-  return (
-    <SecuritySection title={t('account_center.security.passkeys')}>
-      {isSectionLoading ? (
+  if (isSectionLoading) {
+    return (
+      <SecuritySection title={t('account_center.security.passkeys')}>
         <SecuritySkeleton ariaLabel={t('account_center.security.passkeys')}>
+          {showToggle && (
+            <>
+              <div className={styles.toggleRow}>
+                <div className={styles.toggleInfo}>
+                  <div className={classNames(styles.skeletonBlock, styles.skeletonToggleTitle)} />
+                  <div
+                    className={classNames(styles.skeletonBlock, styles.skeletonToggleDescription)}
+                  />
+                </div>
+                <div className={classNames(styles.skeletonBlock, styles.skeletonSwitch)} />
+              </div>
+              <div className={styles.divider} />
+            </>
+          )}
           <SecurityRowSkeleton hasAction={isEditable} />
         </SecuritySkeleton>
-      ) : (
-        <SecurityRow row={passkeyRow} />
+      </SecuritySection>
+    );
+  }
+
+  return (
+    <SecuritySection title={t('account_center.security.passkeys')}>
+      {showToggle && (
+        <>
+          <div className={styles.toggleRow}>
+            <div className={styles.toggleInfo}>
+              <div className={styles.toggleTitle}>
+                {t('account_center.security.passkey_sign_in_prompt')}
+              </div>
+              <div className={styles.toggleDescription}>
+                {t('account_center.security.passkey_sign_in_prompt_description')}
+              </div>
+            </div>
+            <ToggleSwitch
+              isChecked={isPromptEnabled}
+              ariaLabel={t('account_center.security.passkey_sign_in_prompt')}
+              onChange={(checked) => {
+                void handleToggleChange(checked);
+              }}
+            />
+          </div>
+          <div className={styles.divider} />
+        </>
       )}
+      <SecurityRow row={passkeyRow} />
     </SecuritySection>
   );
 };

--- a/packages/account/src/pages/Security/index.passkey.test.tsx
+++ b/packages/account/src/pages/Security/index.passkey.test.tsx
@@ -13,6 +13,7 @@ import renderWithPageContext, {
 } from '@ac/__mocks__/RenderWithPageContext';
 import { securityRoute, verifiedActionRoute } from '@ac/constants/routes';
 
+import { getLogtoConfig, updateLogtoConfig } from '../../apis/logto-config';
 import { getMfaSettings, getMfaVerifications, updateMfaSettings } from '../../apis/mfa';
 
 import Security from '.';
@@ -36,11 +37,23 @@ jest.mock('../../apis/mfa', () => ({
   updateMfaSettings: jest.fn(),
 }));
 
+jest.mock('../../apis/logto-config', () => ({
+  getLogtoConfig: jest.fn(),
+  updateLogtoConfig: jest.fn(),
+}));
+
 const mockGetMfaSettings = getMfaSettings as jest.MockedFunction<typeof getMfaSettings>;
 const mockGetMfaVerifications = getMfaVerifications as jest.MockedFunction<
   typeof getMfaVerifications
 >;
 const mockUpdateMfaSettings = updateMfaSettings as jest.MockedFunction<typeof updateMfaSettings>;
+const mockGetLogtoConfig = getLogtoConfig as jest.MockedFunction<typeof getLogtoConfig>;
+const mockUpdateLogtoConfig = updateLogtoConfig as jest.MockedFunction<typeof updateLogtoConfig>;
+
+const mockLogtoConfigResponse = {
+  mfa: { skipped: false, skipMfaOnSignIn: true },
+  passkeySignIn: { skipped: false },
+};
 
 const renderSecurity = ({
   factors,
@@ -91,6 +104,8 @@ describe('<Security /> with passkey sign-in enabled', () => {
     mockGetAccessToken.mockResolvedValue('access-token');
     mockGetMfaSettings.mockResolvedValue({ skipMfaOnSignIn: true });
     mockUpdateMfaSettings.mockResolvedValue({ skipMfaOnSignIn: true });
+    mockGetLogtoConfig.mockResolvedValue(mockLogtoConfigResponse);
+    mockUpdateLogtoConfig.mockResolvedValue(mockLogtoConfigResponse);
     window.sessionStorage.clear();
   });
 

--- a/packages/account/src/pages/VerifiedAction/index.tsx
+++ b/packages/account/src/pages/VerifiedAction/index.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import PageContext from '@ac/Providers/PageContextProvider/PageContext';
 import ErrorPage from '@ac/components/ErrorPage';
 import VerificationMethodList from '@ac/components/VerificationMethodList';
+import { getPasskeyFieldControl } from '@ac/utils/security-page';
 import { sessionStorage } from '@ac/utils/session-storage';
 import type { PendingVerifiedAction } from '@ac/utils/session-storage';
 
@@ -40,6 +41,15 @@ const VerifiedAction = () => {
       case 'enable-mfa':
       case 'disable-mfa': {
         return accountCenterSettings.fields.mfa === AccountCenterControlValue.Edit;
+      }
+      case 'enable-passkey-prompt':
+      case 'disable-passkey-prompt': {
+        return (
+          getPasskeyFieldControl(
+            accountCenterSettings.fields.passkey,
+            accountCenterSettings.fields.mfa
+          ) === AccountCenterControlValue.Edit
+        );
       }
       case 'remove-email': {
         return accountCenterSettings.fields.email === AccountCenterControlValue.Edit;

--- a/packages/account/src/utils/session-storage.ts
+++ b/packages/account/src/utils/session-storage.ts
@@ -85,6 +85,8 @@ const storedSocialFlowRecordGuard = s.union([
 const pendingVerifiedActions = Object.freeze([
   'enable-mfa',
   'disable-mfa',
+  'enable-passkey-prompt',
+  'disable-passkey-prompt',
   'remove-username',
   'remove-email',
   'remove-phone',

--- a/packages/core/src/routes/account/logto-config.test.ts
+++ b/packages/core/src/routes/account/logto-config.test.ts
@@ -1,0 +1,124 @@
+import { UserScope } from '@logto/core-kit';
+import { AccountCenterControlValue, userPasskeySignInDataKey, type User } from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockUser } from '#src/__mocks__/index.js';
+import koaErrorHandler from '#src/middleware/koa-error-handler.js';
+import koaI18next from '#src/middleware/koa-i18next.js';
+import type Queries from '#src/tenants/Queries.js';
+import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const mockedQueries = {
+  users: {
+    findUserById: jest.fn(async () => mockUser),
+    updateUserById: jest.fn(async (_userId: string, data: Partial<User>) => ({
+      ...mockUser,
+      ...data,
+    })),
+  },
+} satisfies Partial2<Queries>;
+
+const { findUserById, updateUserById } = mockedQueries.users;
+
+const logtoConfigRoutes = await pickDefault(import('./logto-config.js'));
+
+describe('account logto-config routes', () => {
+  const tenantContext = new MockTenant(undefined, mockedQueries);
+
+  const buildRequester = (
+    options: { identityVerified?: boolean; fields?: Record<string, AccountCenterControlValue> } = {}
+  ) => {
+    const { identityVerified = true, fields = { passkey: AccountCenterControlValue.Edit } } =
+      options;
+
+    return createRequester({
+      middlewares: [koaI18next(), koaErrorHandler()],
+      authedRoutes: [
+        (router) => {
+          router.use(async (ctx, next) => {
+            ctx.auth = {
+              ...ctx.auth,
+              id: mockUser.id,
+              identityVerified,
+              scopes: new Set([UserScope.Identities]),
+            };
+            ctx.accountCenter = {
+              enabled: true,
+              fields,
+            };
+            ctx.appendDataHookContext = jest.fn();
+
+            return next();
+          });
+        },
+        logtoConfigRoutes as never,
+      ],
+      tenantContext,
+    });
+  };
+
+  const accountRequest = buildRequester();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/my-account/logto-configs', () => {
+    it('returns the user logto config with default values', async () => {
+      const response = await accountRequest.get('/my-account/logto-configs');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        mfa: { skipped: false, skipMfaOnSignIn: false },
+        passkeySignIn: { skipped: false },
+      });
+    });
+  });
+
+  describe('PATCH /api/my-account/logto-configs', () => {
+    it('updates the passkey sign-in skip flag when identity is verified', async () => {
+      const response = await accountRequest
+        .patch('/my-account/logto-configs')
+        .send({ passkeySignIn: { skipped: true } });
+
+      expect(response.status).toBe(200);
+      expect(response.body.passkeySignIn).toEqual({ skipped: true });
+
+      const [updatedUserId, updatedData] = updateUserById.mock.calls[0] ?? [];
+      expect(updatedUserId).toBe(mockUser.id);
+      expect(updatedData?.logtoConfig).toMatchObject({
+        [userPasskeySignInDataKey]: { skipped: true },
+      });
+    });
+
+    it('rejects the update when identity is not verified', async () => {
+      const unverifiedRequest = buildRequester({ identityVerified: false });
+
+      const response = await unverifiedRequest
+        .patch('/my-account/logto-configs')
+        .send({ passkeySignIn: { skipped: true } });
+
+      expect(response.status).toBe(401);
+      expect(response.body).toHaveProperty('code', 'verification_record.permission_denied');
+      expect(findUserById).not.toHaveBeenCalled();
+      expect(updateUserById).not.toHaveBeenCalled();
+    });
+
+    it('rejects the update when the passkey field is not editable', async () => {
+      const readOnlyRequest = buildRequester({
+        fields: { passkey: AccountCenterControlValue.ReadOnly },
+      });
+
+      const response = await readOnlyRequest
+        .patch('/my-account/logto-configs')
+        .send({ passkeySignIn: { skipped: true } });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('code', 'account_center.field_not_editable');
+      expect(updateUserById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/routes/account/logto-config.ts
+++ b/packages/core/src/routes/account/logto-config.ts
@@ -65,7 +65,12 @@ export default function logtoConfigRoutes<T extends UserRouter>(...args: RouterI
       status: [200, 400, 401],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes } = ctx.auth;
+      const { id: userId, identityVerified, scopes } = ctx.auth;
+
+      assertThat(
+        identityVerified,
+        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
+      );
       assertThat(
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })

--- a/packages/integration-tests/src/api/my-account.ts
+++ b/packages/integration-tests/src/api/my-account.ts
@@ -177,13 +177,17 @@ export const getMyLogtoConfig = async (api: KyInstance) =>
 
 export const updateMyLogtoConfig = async (
   api: KyInstance,
-  logtoConfig: { mfa: { skipped: boolean } }
+  logtoConfig: { mfa?: { skipped: boolean }; passkeySignIn?: { skipped: boolean } },
+  verificationRecordId?: string
 ) =>
   api
     .patch('api/my-account/logto-configs', {
       json: logtoConfig,
+      ...(verificationRecordId && {
+        headers: { [verificationRecordIdHeader]: verificationRecordId },
+      }),
     })
-    .json<{ mfa: { skipped: boolean } }>();
+    .json<{ mfa: { skipped: boolean }; passkeySignIn: { skipped: boolean } }>();
 
 export const getSocialAccessToken = async (api: KyInstance, target: string) => {
   return api

--- a/packages/integration-tests/src/api/my-account.ts
+++ b/packages/integration-tests/src/api/my-account.ts
@@ -173,7 +173,10 @@ export const updateMfaSettings = async (
     .json<{ skipMfaOnSignIn: boolean }>();
 
 export const getMyLogtoConfig = async (api: KyInstance) =>
-  api.get('api/my-account/logto-configs').json<{ mfa: { skipped: boolean } }>();
+  api.get('api/my-account/logto-configs').json<{
+    mfa: { enabled?: boolean; skipped: boolean; skipMfaOnSignIn: boolean };
+    passkeySignIn: { skipped: boolean };
+  }>();
 
 export const updateMyLogtoConfig = async (
   api: KyInstance,
@@ -187,7 +190,10 @@ export const updateMyLogtoConfig = async (
         headers: { [verificationRecordIdHeader]: verificationRecordId },
       }),
     })
-    .json<{ mfa: { skipped: boolean }; passkeySignIn: { skipped: boolean } }>();
+    .json<{
+      mfa: { enabled?: boolean; skipped: boolean; skipMfaOnSignIn: boolean };
+      passkeySignIn: { skipped: boolean };
+    }>();
 
 export const getSocialAccessToken = async (api: KyInstance, target: string) => {
   return api

--- a/packages/integration-tests/src/tests/api/account/mfa-settings.test.ts
+++ b/packages/integration-tests/src/tests/api/account/mfa-settings.test.ts
@@ -200,7 +200,12 @@ describe('my-account (mfa-settings)', () => {
         scopes: [UserScope.Profile, UserScope.Identities],
       });
 
-      const response = await updateMyLogtoConfig(api, { mfa: { skipped: true } });
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+      const response = await updateMyLogtoConfig(
+        api,
+        { mfa: { skipped: true } },
+        verificationRecordId
+      );
       expect(response).toEqual({
         mfa: { skipped: true, skipMfaOnSignIn: false },
         passkeySignIn: { skipped: false },
@@ -209,7 +214,12 @@ describe('my-account (mfa-settings)', () => {
       const updatedConfig = await getMyLogtoConfig(api);
       expect(updatedConfig.mfa.skipped).toBe(true);
 
-      const response2 = await updateMyLogtoConfig(api, { mfa: { skipped: false } });
+      const verificationRecordId2 = await createVerificationRecordByPassword(api, password);
+      const response2 = await updateMyLogtoConfig(
+        api,
+        { mfa: { skipped: false } },
+        verificationRecordId2
+      );
       expect(response2).toEqual({
         mfa: { skipped: false, skipMfaOnSignIn: false },
         passkeySignIn: { skipped: false },
@@ -221,16 +231,60 @@ describe('my-account (mfa-settings)', () => {
       await deleteDefaultTenantUser(user.id);
     });
 
+    it('should update passkey sign-in skip state successfully', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Identities],
+      });
+
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+      const response = await updateMyLogtoConfig(
+        api,
+        { passkeySignIn: { skipped: true } },
+        verificationRecordId
+      );
+      expect(response.passkeySignIn).toEqual({ skipped: true });
+
+      const verificationRecordId2 = await createVerificationRecordByPassword(api, password);
+      const response2 = await updateMyLogtoConfig(
+        api,
+        { passkeySignIn: { skipped: false } },
+        verificationRecordId2
+      );
+      expect(response2.passkeySignIn).toEqual({ skipped: false });
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should throw error if identity is not verified', async () => {
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Identities],
+      });
+
+      await expectRejects(updateMyLogtoConfig(api, { mfa: { skipped: true } }), {
+        code: 'verification_record.permission_denied',
+        status: 401,
+      });
+
+      await deleteDefaultTenantUser(user.id);
+    });
+
     it('should throw error if user does not have Identities scope', async () => {
       const { user, username, password } = await createDefaultTenantUserWithPassword();
       const api = await signInAndGetUserApi(username, password, {
         scopes: [UserScope.Profile],
       });
 
-      await expectRejects(updateMyLogtoConfig(api, { mfa: { skipped: true } }), {
-        code: 'auth.unauthorized',
-        status: 401,
-      });
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      await expectRejects(
+        updateMyLogtoConfig(api, { mfa: { skipped: true } }, verificationRecordId),
+        {
+          code: 'auth.unauthorized',
+          status: 401,
+        }
+      );
 
       await deleteDefaultTenantUser(user.id);
     });
@@ -246,10 +300,15 @@ describe('my-account (mfa-settings)', () => {
         scopes: [UserScope.Profile, UserScope.Identities],
       });
 
-      await expectRejects(updateMyLogtoConfig(api, { mfa: { skipped: true } }), {
-        code: 'account_center.field_not_editable',
-        status: 400,
-      });
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      await expectRejects(
+        updateMyLogtoConfig(api, { mfa: { skipped: true } }, verificationRecordId),
+        {
+          code: 'account_center.field_not_editable',
+          status: 400,
+        }
+      );
 
       await deleteDefaultTenantUser(user.id);
       await enableAllAccountCenterFields();
@@ -266,10 +325,15 @@ describe('my-account (mfa-settings)', () => {
         scopes: [UserScope.Profile, UserScope.Identities],
       });
 
-      await expectRejects(updateMyLogtoConfig(api, { mfa: { skipped: true } }), {
-        code: 'account_center.field_not_editable',
-        status: 400,
-      });
+      const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+      await expectRejects(
+        updateMyLogtoConfig(api, { mfa: { skipped: true } }, verificationRecordId),
+        {
+          code: 'account_center.field_not_editable',
+          status: 400,
+        }
+      );
 
       await deleteDefaultTenantUser(user.id);
       await enableAllAccountCenterFields();

--- a/packages/phrases-experience/src/locales/ar/account-center.ts
+++ b/packages/phrases-experience/src/locales/ar/account-center.ts
@@ -101,6 +101,9 @@ const account_center = {
     disable_2_step_verification: 'تعطيل',
     no_verification_method_warning:
       'لم تقم بإضافة طريقة تحقق ثانية. أضف طريقة واحدة على الأقل لتفعيل التحقق بخطوتين عند تسجيل الدخول.',
+    passkey_sign_in_prompt: 'مطالبة بإعداد مفتاح مرور',
+    passkey_sign_in_prompt_description:
+      'عند التفعيل، سيُطلب منك إعداد مفتاح مرور لتسجيل دخول أسرع وأكثر أمانًا.',
     account_removal: 'حذف الحساب',
     delete_your_account: 'احذف حسابك',
     delete_account: 'حذف الحساب',

--- a/packages/phrases-experience/src/locales/cs/account-center.ts
+++ b/packages/phrases-experience/src/locales/cs/account-center.ts
@@ -101,6 +101,9 @@ const account_center = {
     disable_2_step_verification: 'Vypnout',
     no_verification_method_warning:
       'Nepřidali jste druhou ověřovací metodu. Přidejte alespoň jednu pro povolení dvoufázového ověření při přihlášení.',
+    passkey_sign_in_prompt: 'Vyzvat k nastavení přístupového klíče',
+    passkey_sign_in_prompt_description:
+      'Když je zapnuto, budete vyzváni k nastavení přístupového klíče pro rychlejší a bezpečnější přihlášení.',
     account_removal: 'Smazání účtu',
     delete_your_account: 'Smazat svůj účet',
     delete_account: 'Smazat účet',

--- a/packages/phrases-experience/src/locales/de/account-center.ts
+++ b/packages/phrases-experience/src/locales/de/account-center.ts
@@ -108,6 +108,9 @@ const account_center = {
     disable_2_step_verification: 'Deaktivieren',
     no_verification_method_warning:
       'Sie haben keine zweite Verifizierungsmethode hinzugefügt. Fügen Sie mindestens eine hinzu, um die 2-Faktor-Verifizierung bei der Anmeldung zu aktivieren.',
+    passkey_sign_in_prompt: 'Zur Einrichtung eines Passkeys auffordern',
+    passkey_sign_in_prompt_description:
+      'Wenn aktiviert, werden Sie aufgefordert, einen Passkey für eine schnellere und sicherere Anmeldung einzurichten.',
     account_removal: 'Kontolöschung',
     delete_your_account: 'Ihr Konto löschen',
     delete_account: 'Konto löschen',

--- a/packages/phrases-experience/src/locales/en/account-center.ts
+++ b/packages/phrases-experience/src/locales/en/account-center.ts
@@ -102,6 +102,9 @@ const account_center = {
     disable_2_step_verification: 'Disable',
     no_verification_method_warning:
       "You haven't added a second verification method. Add at least one to enable 2-step verification at sign-in.",
+    passkey_sign_in_prompt: 'Prompt to set up a passkey',
+    passkey_sign_in_prompt_description:
+      "When on, you'll be asked to set up a passkey for faster, more secure sign-in.",
     account_removal: 'Account removal',
     delete_your_account: 'Delete your account',
     delete_account: 'Delete account',

--- a/packages/phrases-experience/src/locales/es/account-center.ts
+++ b/packages/phrases-experience/src/locales/es/account-center.ts
@@ -105,6 +105,9 @@ const account_center = {
     disable_2_step_verification: 'Desactivar',
     no_verification_method_warning:
       'No has añadido un segundo método de verificación. Añade al menos uno para activar la verificación en dos pasos al iniciar sesión.',
+    passkey_sign_in_prompt: 'Solicitar la configuración de un passkey',
+    passkey_sign_in_prompt_description:
+      'Cuando está activado, se te pedirá que configures un passkey para iniciar sesión de forma más rápida y segura.',
     account_removal: 'Eliminación de la cuenta',
     delete_your_account: 'Elimina tu cuenta',
     delete_account: 'Eliminar cuenta',

--- a/packages/phrases-experience/src/locales/fa-ir/account-center.ts
+++ b/packages/phrases-experience/src/locales/fa-ir/account-center.ts
@@ -101,6 +101,9 @@ const account_center = {
     disable_2_step_verification: 'غیرفعال کردن',
     no_verification_method_warning:
       'شما روش تأیید دومی اضافه نکرده‌اید. برای فعال کردن تأیید دو مرحله‌ای هنگام ورود، حداقل یک روش اضافه کنید.',
+    passkey_sign_in_prompt: 'درخواست تنظیم کلید عبور',
+    passkey_sign_in_prompt_description:
+      'وقتی فعال باشد، از شما خواسته می‌شود برای ورود سریع‌تر و امن‌تر یک کلید عبور تنظیم کنید.',
     account_removal: 'حذف حساب',
     delete_your_account: 'حساب خود را حذف کنید',
     delete_account: 'حذف حساب',

--- a/packages/phrases-experience/src/locales/fr/account-center.ts
+++ b/packages/phrases-experience/src/locales/fr/account-center.ts
@@ -107,6 +107,9 @@ const account_center = {
     disable_2_step_verification: 'Désactiver',
     no_verification_method_warning:
       "Vous n'avez pas ajouté de deuxième méthode de vérification. Ajoutez-en au moins une pour activer la vérification en deux étapes lors de la connexion.",
+    passkey_sign_in_prompt: 'Inviter à configurer un passkey',
+    passkey_sign_in_prompt_description:
+      'Lorsque cette option est activée, il vous sera demandé de configurer un passkey pour une connexion plus rapide et plus sécurisée.',
     account_removal: 'Suppression du compte',
     delete_your_account: 'Supprimez votre compte',
     delete_account: 'Supprimer le compte',

--- a/packages/phrases-experience/src/locales/it/account-center.ts
+++ b/packages/phrases-experience/src/locales/it/account-center.ts
@@ -106,6 +106,9 @@ const account_center = {
     disable_2_step_verification: 'Disattiva',
     no_verification_method_warning:
       "Non hai aggiunto un secondo metodo di verifica. Aggiungine almeno uno per attivare la verifica in due passaggi all'accesso.",
+    passkey_sign_in_prompt: 'Richiedi la configurazione di un passkey',
+    passkey_sign_in_prompt_description:
+      'Quando è attivo, ti verrà chiesto di configurare un passkey per un accesso più rapido e sicuro.',
     account_removal: "Eliminazione dell'account",
     delete_your_account: 'Elimina il tuo account',
     delete_account: "Elimina l'account",

--- a/packages/phrases-experience/src/locales/ja/account-center.ts
+++ b/packages/phrases-experience/src/locales/ja/account-center.ts
@@ -101,6 +101,9 @@ const account_center = {
     disable_2_step_verification: '無効にする',
     no_verification_method_warning:
       '2つ目の認証方法が追加されていません。サインイン時の2段階認証を有効にするには、少なくとも1つ追加してください。',
+    passkey_sign_in_prompt: 'パスキーの設定を促す',
+    passkey_sign_in_prompt_description:
+      'オンにすると、より速く安全なサインインのためにパスキーの設定を求められます。',
     account_removal: 'アカウント削除',
     delete_your_account: 'アカウントを削除',
     delete_account: 'アカウントを削除',

--- a/packages/phrases-experience/src/locales/ko/account-center.ts
+++ b/packages/phrases-experience/src/locales/ko/account-center.ts
@@ -100,6 +100,9 @@ const account_center = {
     disable_2_step_verification: '비활성화',
     no_verification_method_warning:
       '두 번째 인증 방법을 추가하지 않았습니다. 로그인 시 2단계 인증을 활성화하려면 최소 하나를 추가하세요.',
+    passkey_sign_in_prompt: '패스키 설정 안내 표시',
+    passkey_sign_in_prompt_description:
+      '켜면 더 빠르고 안전한 로그인을 위해 패스키를 설정하라는 안내를 받게 됩니다.',
     account_removal: '계정 삭제',
     delete_your_account: '내 계정 삭제',
     delete_account: '계정 삭제',

--- a/packages/phrases-experience/src/locales/pl-pl/account-center.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/account-center.ts
@@ -102,6 +102,9 @@ const account_center = {
     disable_2_step_verification: 'Wyłącz',
     no_verification_method_warning:
       'Nie dodałeś drugiej metody weryfikacji. Dodaj co najmniej jedną, aby włączyć weryfikację dwuetapową podczas logowania.',
+    passkey_sign_in_prompt: 'Monituj o skonfigurowanie passkey',
+    passkey_sign_in_prompt_description:
+      'Gdy włączone, zostaniesz poproszony o skonfigurowanie passkey w celu szybszego i bezpieczniejszego logowania.',
     account_removal: 'Usunięcie konta',
     delete_your_account: 'Usuń swoje konto',
     delete_account: 'Usuń konto',

--- a/packages/phrases-experience/src/locales/pt-br/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-br/account-center.ts
@@ -104,6 +104,9 @@ const account_center = {
     disable_2_step_verification: 'Desativar',
     no_verification_method_warning:
       'Você não adicionou um segundo método de verificação. Adicione pelo menos um para ativar a verificação em duas etapas ao fazer login.',
+    passkey_sign_in_prompt: 'Solicitar a configuração de uma passkey',
+    passkey_sign_in_prompt_description:
+      'Quando ativado, será solicitado que você configure uma passkey para um login mais rápido e seguro.',
     account_removal: 'Exclusão da conta',
     delete_your_account: 'Excluir sua conta',
     delete_account: 'Excluir conta',

--- a/packages/phrases-experience/src/locales/pt-pt/account-center.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/account-center.ts
@@ -105,6 +105,9 @@ const account_center = {
     disable_2_step_verification: 'Desativar',
     no_verification_method_warning:
       'Não adicionou um segundo método de verificação. Adicione pelo menos um para ativar a verificação em duas etapas ao iniciar sessão.',
+    passkey_sign_in_prompt: 'Solicitar a configuração de uma passkey',
+    passkey_sign_in_prompt_description:
+      'Quando ativado, ser-lhe-á pedido para configurar uma passkey para um início de sessão mais rápido e seguro.',
     account_removal: 'Eliminação da conta',
     delete_your_account: 'Elimine a sua conta',
     delete_account: 'Eliminar conta',

--- a/packages/phrases-experience/src/locales/ru/account-center.ts
+++ b/packages/phrases-experience/src/locales/ru/account-center.ts
@@ -101,6 +101,9 @@ const account_center = {
     disable_2_step_verification: 'Отключить',
     no_verification_method_warning:
       'Вы не добавили второй способ верификации. Добавьте хотя бы один, чтобы включить двухэтапную верификацию при входе.',
+    passkey_sign_in_prompt: 'Предлагать настроить passkey',
+    passkey_sign_in_prompt_description:
+      'Когда включено, вам будет предложено настроить passkey для более быстрого и безопасного входа.',
     account_removal: 'Удаление аккаунта',
     delete_your_account: 'Удалите свой аккаунт',
     delete_account: 'Удалить аккаунт',

--- a/packages/phrases-experience/src/locales/th/account-center.ts
+++ b/packages/phrases-experience/src/locales/th/account-center.ts
@@ -101,6 +101,9 @@ const account_center = {
     disable_2_step_verification: 'ปิด',
     no_verification_method_warning:
       'คุณยังไม่ได้เพิ่มวิธีการยืนยันตัวตนที่สอง เพิ่มอย่างน้อยหนึ่งวิธีเพื่อเปิดใช้งานการยืนยันตัวตนสองขั้นตอนเมื่อลงชื่อเข้าใช้',
+    passkey_sign_in_prompt: 'แจ้งให้ตั้งค่า passkey',
+    passkey_sign_in_prompt_description:
+      'เมื่อเปิดใช้งาน คุณจะถูกขอให้ตั้งค่า passkey เพื่อการลงชื่อเข้าใช้ที่รวดเร็วและปลอดภัยยิ่งขึ้น',
     account_removal: 'การลบบัญชี',
     delete_your_account: 'ลบบัญชีของคุณ',
     delete_account: 'ลบบัญชี',

--- a/packages/phrases-experience/src/locales/tr-tr/account-center.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/account-center.ts
@@ -102,6 +102,9 @@ const account_center = {
     disable_2_step_verification: 'Devre dışı bırak',
     no_verification_method_warning:
       'İkinci bir doğrulama yöntemi eklemediniz. Oturum açarken 2 adımlı doğrulamayı etkinleştirmek için en az bir tane ekleyin.',
+    passkey_sign_in_prompt: 'Passkey kurulumu için sor',
+    passkey_sign_in_prompt_description:
+      'Açık olduğunda, daha hızlı ve daha güvenli oturum açma için bir passkey kurmanız istenir.',
     account_removal: 'Hesap silme',
     delete_your_account: 'Hesabını sil',
     delete_account: 'Hesabı sil',

--- a/packages/phrases-experience/src/locales/uk-ua/account-center.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/account-center.ts
@@ -103,6 +103,9 @@ const account_center = {
     disable_2_step_verification: 'Вимкнути',
     no_verification_method_warning:
       'Ви не додали другий метод верифікації. Додайте принаймні один, щоб увімкнути двоетапну верифікацію при вході.',
+    passkey_sign_in_prompt: 'Пропонувати налаштувати passkey',
+    passkey_sign_in_prompt_description:
+      'Коли ввімкнено, вам буде запропоновано налаштувати passkey для швидшого та безпечнішого входу.',
     account_removal: 'Видалення акаунта',
     delete_your_account: 'Видаліть свій акаунт',
     delete_account: 'Видалити акаунт',

--- a/packages/phrases-experience/src/locales/zh-cn/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/account-center.ts
@@ -99,6 +99,9 @@ const account_center = {
     disable_2_step_verification: '关闭',
     no_verification_method_warning:
       '你尚未添加第二种验证方式。请至少添加一种以在登录时启用两步验证。',
+    passkey_sign_in_prompt: '提示设置通行密钥',
+    passkey_sign_in_prompt_description:
+      '开启后，系统会提示你设置通行密钥，以实现更快速、更安全的登录。',
     account_removal: '账号删除',
     delete_your_account: '删除你的账号',
     delete_account: '删除账号',

--- a/packages/phrases-experience/src/locales/zh-hk/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/account-center.ts
@@ -99,6 +99,9 @@ const account_center = {
     disable_2_step_verification: '關閉',
     no_verification_method_warning:
       '你尚未添加第二種驗證方式。請至少添加一種以在登入時啟用兩步驗證。',
+    passkey_sign_in_prompt: '提示設定通行密鑰',
+    passkey_sign_in_prompt_description:
+      '開啟後，系統會提示你設定通行密鑰，以實現更快速、更安全的登入。',
     account_removal: '帳戶刪除',
     delete_your_account: '刪除你的帳戶',
     delete_account: '刪除帳戶',

--- a/packages/phrases-experience/src/locales/zh-tw/account-center.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/account-center.ts
@@ -99,6 +99,9 @@ const account_center = {
     disable_2_step_verification: '關閉',
     no_verification_method_warning:
       '你尚未新增第二種驗證方式。請至少新增一種以在登入時啟用兩步驟驗證。',
+    passkey_sign_in_prompt: '提示設定通行密鑰',
+    passkey_sign_in_prompt_description:
+      '開啟後，系統會提示你設定通行密鑰，以實現更快速、更安全的登入。',
     account_removal: '帳戶刪除',
     delete_your_account: '刪除你的帳戶',
     delete_account: '刪除帳戶',


### PR DESCRIPTION
## Summary

Adds a user-facing control in the Account Center passkey section that lets users opt out of the "set up a passkey" sign-in prompt, mirroring the existing `skipMfaOnSignIn` toggle in the MFA section.

The toggle reads/writes the user-scoped `passkey_sign_in.skipped` flag through the account API:

- `GET /api/my-account/logto-configs` → `{ mfa, passkeySignIn: { skipped } }`
- `PATCH /api/my-account/logto-configs` with `{ passkeySignIn: { skipped } }`

The `PATCH` route now asserts `ctx.auth.identityVerified` before applying any update (`401 verification_record.permission_denied` otherwise), matching the `/mfa-settings` guard so the backend can't be used to bypass the frontend verification flow.

The toggle is presented as "prompt enabled" (`isChecked = !skipped`). Like the MFA toggle, changing it requires identity verification first, so flipping it stores a pending action and routes through the verification flow:

```ts
// PasskeySection
const handleToggleChange = async (checked: boolean) => {
  const skipped = !checked;
  if (verificationId) {
    await updateLogtoConfig(token, verificationId, { passkeySignIn: { skipped } });
    return;
  }
  sessionStorage.setPendingVerifiedAction(checked ? 'enable-passkey-prompt' : 'disable-passkey-prompt');
  navigateTo(verifiedActionRoute);
};

// After returning from verification, the section applies the pending action.
```

Changes:
- `apis/logto-config.ts` (new): `getLogtoConfig` / `updateLogtoConfig` clients.
- `PasskeySection`: toggle UI + loading skeleton, wired to the verification flow.
- `session-storage`: new `enable-passkey-prompt` / `disable-passkey-prompt` pending verified actions.
- `VerifiedAction`: allows the new actions when the passkey field control (falling back to MFA) is editable.
- `core/routes/account/logto-config.ts`: PATCH now requires identity verification.
- `phrases-experience`: `passkey_sign_in_prompt` + `passkey_sign_in_prompt_description` across all locales.

## Testing

Unit tests

Integration tests

Link to Devin session: https://app.devin.ai/sessions/b5747f814c7341f09754b030faba260b
Requested by: @wangsijie