### PR TITLE
feat(core): emit Message.RateLimited hook on send throttle

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,4 +1,9 @@
-import { defaultMessageRateLimitPolicy, InteractionEvent, SignInIdentifier } from '@logto/schemas';
+import {
+  defaultMessageRateLimitPolicy,
+  InteractionEvent,
+  SentinelActivityAction,
+  SignInIdentifier,
+} from '@logto/schemas';
 
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -216,6 +221,7 @@ describe('sendCode parameter passing', () => {
     const ctx = {
       request: { ip: '127.0.0.1' },
       createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+      appendExceptionHookContext: jest.fn(),
       experienceInteraction: mockExperienceInteraction,
       emailI18n: {},
     };
@@ -230,8 +236,13 @@ describe('sendCode parameter passing', () => {
         queries: mockQueries,
         ctx: ctx as unknown as ExperienceInteractionRouterContext,
       })
-    ).rejects.toMatchObject({ code: 'request.rate_limited', status: 429 });
+    ).rejects.toMatchObject({ code: 'request.message_rate_limited', status: 429 });
 
     expect(mockSendVerificationCode).not.toHaveBeenCalled();
+    // The throttle emits the `Message.RateLimited` exception hook for webhook delivery.
+    expect(ctx.appendExceptionHookContext).toHaveBeenCalledWith('Message.RateLimited', {
+      action: SentinelActivityAction.VerificationCodeSend,
+      recipient: 'spammed@example.com',
+    });
   });
 });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -146,11 +146,21 @@ export const sendCode = async ({
   // is sent, so the rate guard is bypassed.
   const send = async () => codeVerification.sendVerificationCode(payload, { skipDelivery });
 
+  const messageRateLimit = {
+    action: SentinelActivityAction.VerificationCodeSend,
+    recipient: identifier.value,
+  };
+
   await (skipDelivery || !EnvSet.values.isDevFeaturesEnabled
     ? send()
     : withMessageRateGuard(
         new MessageRateGuard(queries.sentinelActivities),
-        { action: SentinelActivityAction.VerificationCodeSend, recipient: identifier.value },
+        {
+          ...messageRateLimit,
+          onRateLimited: () => {
+            ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
+          },
+        },
         send
       ));
 

--- a/packages/core/src/routes/interaction/additional.test.ts
+++ b/packages/core/src/routes/interaction/additional.test.ts
@@ -1,5 +1,10 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { demoAppApplicationId, InteractionEvent, MfaFactor } from '@logto/schemas';
+import {
+  defaultMessageRateLimitPolicy,
+  demoAppApplicationId,
+  InteractionEvent,
+  MfaFactor,
+} from '@logto/schemas';
 import { createMockUtils } from '@logto/shared/esm';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
@@ -173,8 +178,8 @@ describe('interaction routes', () => {
     });
 
     it('should reject with 429 and not send when the recipient is over the rate-limit cap', async () => {
-      // Default policy allows 5 sends per recipient per window; simulate the cap being reached.
-      countActivities.mockResolvedValueOnce(5);
+      // Simulate the per-recipient cap being reached for the default policy.
+      countActivities.mockResolvedValueOnce(defaultMessageRateLimitPolicy.maxSendsPerRecipient);
 
       const response = await sessionRequest.post(path).send({ email: 'spammed@logto.io' });
 

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -126,10 +126,20 @@ export default function verificationRoutes<T extends UserRouter>(
           ...emailContextPayload,
         });
 
+      const messageRateLimit = {
+        action: SentinelActivityAction.VerificationCodeSend,
+        recipient: identifier.value,
+      };
+
       await (EnvSet.values.isDevFeaturesEnabled
         ? withMessageRateGuard(
             new MessageRateGuard(queries.sentinelActivities),
-            { action: SentinelActivityAction.VerificationCodeSend, recipient: identifier.value },
+            {
+              ...messageRateLimit,
+              onRateLimited: () => {
+                ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
+              },
+            },
             send
           )
         : send());

--- a/packages/core/src/sentinel/message-rate-guard.test.ts
+++ b/packages/core/src/sentinel/message-rate-guard.test.ts
@@ -42,7 +42,7 @@ describe('MessageRateGuard', () => {
     countActivities.mockResolvedValueOnce(3);
 
     await expect(buildGuard().guard(action, recipient)).rejects.toMatchObject({
-      code: 'request.rate_limited',
+      code: 'request.message_rate_limited',
       status: 429,
     });
   });
@@ -95,6 +95,27 @@ describe('withMessageRateGuard', () => {
     ).rejects.toMatchObject({ status: 429 });
     expect(send).not.toHaveBeenCalled();
     expect(insertActivity).not.toHaveBeenCalled();
+  });
+
+  it('invokes onRateLimited then rethrows when over the cap', async () => {
+    countActivities.mockResolvedValueOnce(3);
+    const send = jest.fn();
+    const onRateLimited = jest.fn();
+
+    await expect(
+      withMessageRateGuard(buildGuard(), { action, recipient, onRateLimited }, send)
+    ).rejects.toMatchObject({ code: 'request.message_rate_limited', status: 429 });
+    expect(onRateLimited).toHaveBeenCalledTimes(1);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke onRateLimited when under the cap', async () => {
+    countActivities.mockResolvedValueOnce(0);
+    const send = jest.fn().mockResolvedValueOnce('sent');
+    const onRateLimited = jest.fn();
+
+    await withMessageRateGuard(buildGuard(), { action, recipient, onRateLimited }, send);
+    expect(onRateLimited).not.toHaveBeenCalled();
   });
 
   it('still sends when the rate-limit query fails (fails open)', async () => {

--- a/packages/core/src/sentinel/message-rate-guard.ts
+++ b/packages/core/src/sentinel/message-rate-guard.ts
@@ -54,7 +54,10 @@ export class MessageRateGuard {
     );
 
     if (count !== undefined && count >= this.policy.maxSendsPerRecipient) {
-      throw new RequestError({ code: 'request.rate_limited', status: 429 });
+      // Dedicated code (not the generic `request.rate_limited`) so a send throttle is distinctly
+      // identifiable in the audit log and to API consumers, mirroring the verify-time lockout's
+      // own `session.verification_blocked_too_many_attempts`.
+      throw new RequestError({ code: 'request.message_rate_limited', status: 429 });
     }
   }
 
@@ -85,10 +88,33 @@ export class MessageRateGuard {
  */
 export const withMessageRateGuard = async <T>(
   guard: MessageRateGuard,
-  { action, recipient }: { action: SentinelActivityAction; recipient: string },
+  {
+    action,
+    recipient,
+    onRateLimited,
+  }: {
+    action: SentinelActivityAction;
+    recipient: string;
+    /**
+     * Invoked when the guard rejects the send as over the per-recipient cap, just before the 429 is
+     * rethrown. End-user-facing routes use it to emit the `Message.RateLimited` exception hook
+     * context; callers without a request context (e.g. library-level senders) omit it.
+     */
+    onRateLimited?: () => void;
+  },
   send: () => Promise<T>
 ): Promise<T> => {
-  await guard.guard(action, recipient);
+  try {
+    await guard.guard(action, recipient);
+  } catch (error) {
+    // Only the per-recipient cap rejection (a 429) is an abuse signal; don't emit the hook for an
+    // unexpected error from the guard, which would be a false `Message.RateLimited` event.
+    if (error instanceof RequestError && error.status === 429) {
+      onRateLimited?.();
+    }
+    throw error;
+  }
+
   const result = await send();
   await guard.record(action, recipient);
 

--- a/packages/integration-tests/src/tests/api/account/verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/account/verification-code-rate-limit.test.ts
@@ -45,7 +45,7 @@ devFeatureTest.describe('Account verification code send rate limit', () => {
       }
 
       await expectRejects(sendAccountVerificationCode(api, email), {
-        code: 'request.rate_limited',
+        code: 'request.message_rate_limited',
         status: 429,
       });
     } finally {

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code-rate-limit.test.ts
@@ -36,7 +36,7 @@ devFeatureTest.describe('Verification code send rate limit', () => {
         interactionEvent: InteractionEvent.SignIn,
         identifier,
       }),
-      { code: 'request.rate_limited', status: 429 }
+      { code: 'request.message_rate_limited', status: 429 }
     );
   });
 
@@ -57,7 +57,7 @@ devFeatureTest.describe('Verification code send rate limit', () => {
         interactionEvent: InteractionEvent.SignIn,
         identifier: cappedIdentifier,
       }),
-      { code: 'request.rate_limited', status: 429 }
+      { code: 'request.message_rate_limited', status: 429 }
     );
 
     // The same session sending to a different recipient still succeeds: the bucket is keyed by

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.message-rate-limited.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.message-rate-limited.test.ts
@@ -1,0 +1,72 @@
+import {
+  defaultMessageRateLimitPolicy,
+  InteractionEvent,
+  SentinelActivityAction,
+  SignInIdentifier,
+} from '@logto/schemas';
+
+import { initExperienceClient } from '#src/helpers/client.js';
+import { resetPasswordlessConnectors } from '#src/helpers/connector.js';
+import { successfullySendVerificationCode } from '#src/helpers/experience/verification-code.js';
+import { WebHookApiTest } from '#src/helpers/hook.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { enableAllVerificationCodeSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+import WebhookMockServer from './WebhookMockServer.js';
+import { assertHookLogResult } from './utils.js';
+
+const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
+
+const webHookMockServer = new WebhookMockServer(9999);
+const webHookApi = new WebHookApiTest();
+const hookName = 'messageRateLimitedHookEventListener';
+
+// The send rate guard (and thus the `Message.RateLimited` exception hook) is gated behind dev
+// features, so only assert it when enabled.
+devFeatureTest.describe('trigger `Message.RateLimited` exception hook', () => {
+  beforeAll(async () => {
+    // Provision the mock email connector (so codes can be sent and read) and allow email
+    // verification-code sign-in, then register a listener for the exception hook event.
+    await webHookMockServer.listen();
+    await resetPasswordlessConnectors();
+    await enableAllVerificationCodeSignInMethods();
+    await webHookApi.create({
+      name: hookName,
+      events: ['Message.RateLimited'],
+      config: { url: webHookMockServer.endpoint },
+    });
+  });
+
+  afterAll(async () => {
+    await Promise.all([webHookApi.cleanUp(), webHookMockServer.close()]);
+  });
+
+  it('logs the `Message.RateLimited` hook once the recipient send cap is exceeded', async () => {
+    const identifier = { type: SignInIdentifier.Email, value: generateEmail() } as const;
+    const client = await initExperienceClient();
+
+    // Sends up to the cap all succeed; the guard counts by recipient.
+    for (const _ of Array.from({ length: maxSendsPerRecipient })) {
+      // eslint-disable-next-line no-await-in-loop -- sequential sends required to reach the cap deterministically
+      await successfullySendVerificationCode(client, {
+        interactionEvent: InteractionEvent.SignIn,
+        identifier,
+      });
+    }
+
+    // The next send exceeds the cap: it is rejected with the dedicated code, which fires the hook.
+    await expectRejects(
+      client.sendVerificationCode({ interactionEvent: InteractionEvent.SignIn, identifier }),
+      { code: 'request.message_rate_limited', status: 429 }
+    );
+
+    await assertHookLogResult(webHookApi.hooks.get(hookName)!, 'Message.RateLimited', {
+      hookPayload: {
+        event: 'Message.RateLimited',
+        action: SentinelActivityAction.VerificationCodeSend,
+        recipient: identifier.value,
+      },
+    });
+  });
+});

--- a/packages/integration-tests/src/tests/api/me-verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/me-verification-code-rate-limit.test.ts
@@ -41,7 +41,7 @@ devFeatureTest.describe('Account center (/me) verification code send rate limit'
         expect(response.status).toBe(204);
       }
 
-      await expectRejects(sendCode(), { code: 'request.rate_limited', status: 429 });
+      await expectRejects(sendCode(), { code: 'request.message_rate_limited', status: 429 });
     } finally {
       await deleteUser(id);
     }

--- a/packages/integration-tests/src/tests/api/organization/organization-invitation.rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-invitation.rate-limit.test.ts
@@ -41,6 +41,6 @@ devFeatureTest.describe('organization invitation send rate limit', () => {
       expect(response.status).toBe(204);
     }
 
-    await expectRejects(resend(), { code: 'request.rate_limited', status: 429 });
+    await expectRejects(resend(), { code: 'request.message_rate_limited', status: 429 });
   });
 });

--- a/packages/integration-tests/src/tests/api/verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/verification-code-rate-limit.test.ts
@@ -31,7 +31,7 @@ devFeatureTest.describe('Management verification code send rate limit', () => {
     }
 
     await expectRejects(requestVerificationCode({ email }), {
-      code: 'request.rate_limited',
+      code: 'request.message_rate_limited',
       status: 429,
     });
   });
@@ -46,7 +46,7 @@ devFeatureTest.describe('Management verification code send rate limit', () => {
     }
 
     await expectRejects(requestVerificationCode({ phone }), {
-      code: 'request.rate_limited',
+      code: 'request.message_rate_limited',
       status: 429,
     });
   });

--- a/packages/phrases/src/locales/en/errors/request.ts
+++ b/packages/phrases/src/locales/en/errors/request.ts
@@ -4,6 +4,7 @@ const request = {
   range_not_satisfiable: 'Range not satisfiable.',
   feature_not_supported: 'This feature is not supported in the current environment.',
   rate_limited: 'Too many requests. Please try again later.',
+  message_rate_limited: 'Too many messages sent to this recipient. Please try again later.',
 };
 
 export default Object.freeze(request);

--- a/packages/schemas/src/foundations/jsonb-types/hooks.ts
+++ b/packages/schemas/src/foundations/jsonb-types/hooks.ts
@@ -48,7 +48,7 @@ type CustomDataHookMutableSchema =
 type DataHookPropertyUpdateEvent =
   `${CustomDataHookMutableSchema}.${DataHookDetailMutationType.Updated}`;
 
-export type ExceptionHookEvent = 'Identifier.Lockout';
+export type ExceptionHookEvent = 'Identifier.Lockout' | 'Message.RateLimited';
 
 export type DataHookEvent = BasicDataHookEvent | DataHookPropertyUpdateEvent;
 
@@ -81,6 +81,7 @@ export const hookEvents = Object.freeze([
   'OrganizationScope.Deleted',
   'OrganizationScope.Data.Updated',
   'Identifier.Lockout',
+  'Message.RateLimited',
 ] as const satisfies Array<InteractionHookEvent | DataHookEvent | ExceptionHookEvent>);
 
 /** The type of hook event values that can be registered. */


### PR DESCRIPTION
## Summary
Refs LOG-13647.

Makes message-send rate-limit ("throttle") rejections observable, mirroring how identifier lockout is surfaced. Behind `isDevFeaturesEnabled`.

### What changed
- New `Message.RateLimited` exception hook event (`packages/schemas/src/foundations/jsonb-types/hooks.ts`), emitted on the two **end-user** verification-code send paths — Experience API (`verification-code-helpers.ts`) and Account API (`routes/verification/index.ts`) — when the per-recipient send cap is hit. This is the exact surface where `Identifier.Lockout` already fires; admin/first-party sends (management verification-code, organization invitation, `/me`) deliberately don't emit it.
- `withMessageRateGuard` gains an optional `onRateLimited` callback so the koa-agnostic guard stays decoupled from the hook context; the two route call sites pass it to emit `appendExceptionHookContext('Message.RateLimited', { action, recipient })`.
- The guard now throws a dedicated `request.message_rate_limited` 429 (was the generic `request.rate_limited`), so the throttle is distinctly identifiable to API consumers and in the existing console audit-log table. No dedicated audit-log key is added: the send-code log entry already records the failing error code/message via the audit middleware, mirroring lockout (which also has no audit-log key).

### Drive-by test fix (second commit)
- `test(core): align legacy interaction rate-limit test with default cap` — `interaction/additional.test.ts` (added by #9043) hardcoded a recipient count of 5 to trip the cap, but #9051 had already loosened `defaultMessageRateLimitPolicy.maxSendsPerRecipient` to 10, so the test broke on `master` (204 instead of 429). It now mocks the count from the policy constant. Folded in here because #9053 is first in the stack to merge, so the fix reaches `master` soonest.

### Reviewer notes
- The new event is subscribable via the Management API but is **not yet listed in the console webhook-event picker** (`BasicWebhookForm`). That UI wiring is intentionally deferred to the flag-removal follow-up to avoid surfacing a non-functional event in production.
- No changeset: the behavior is gated behind `isDevFeaturesEnabled`.

## Testing
Unit tests, integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments

