### PR TITLE
feat(core): support internal per-tenant message rate-limit override

### DIFF
--- a/packages/core/src/caches/well-known.ts
+++ b/packages/core/src/caches/well-known.ts
@@ -11,6 +11,8 @@ import {
   idTokenConfigGuard,
   type SigningKeyRotationState,
   signingKeyRotationStateGuard,
+  type MessageRateLimitOverride,
+  messageRateLimitOverrideGuard,
 } from '@logto/schemas';
 import { type Nullable } from '@silverhand/essentials';
 import { type ZodType, z } from 'zod';
@@ -33,6 +35,7 @@ type WellKnownMap = {
   'is-development-tenant': boolean;
   'account-center': AccountCenter;
   'id-token-config': Nullable<IdTokenConfig>;
+  'message-rate-limit-override': Nullable<MessageRateLimitOverride>;
 };
 
 type WellKnownCacheType = keyof WellKnownMap;
@@ -49,6 +52,7 @@ const valueGuards: { [Key in WellKnownCacheType]: ZodType<WellKnownMap[Key]> } =
   'is-development-tenant': z.boolean(),
   'account-center': AccountCenters.guard,
   'id-token-config': idTokenConfigGuard.nullable(),
+  'message-rate-limit-override': messageRateLimitOverrideGuard.nullable(),
 };
 
 // Cannot use generic type here, but direct type works.

--- a/packages/core/src/libraries/organization-invitation.ts
+++ b/packages/core/src/libraries/organization-invitation.ts
@@ -13,7 +13,7 @@ import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import OrganizationQueries from '#src/queries/organization/index.js';
 import { createUserQueries } from '#src/queries/user.js';
-import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
+import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 import type Queries from '#src/tenants/Queries.js';
 import {
   buildOrganizationContextInfo,
@@ -268,7 +268,7 @@ export class OrganizationInvitationLibrary {
 
     return EnvSet.values.isDevFeaturesEnabled
       ? withMessageRateGuard(
-          new MessageRateGuard(this.queries.sentinelActivities),
+          await buildMessageRateGuard(this.queries),
           { action: SentinelActivityAction.MessageSend, recipient: to },
           send
         )

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -14,6 +14,7 @@ import {
   type LogtoOidcConfigType,
   signingKeyRotationStateGuard,
   type SigningKeyRotationState,
+  messageRateLimitOverrideGuard,
 } from '@logto/schemas';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
@@ -238,6 +239,19 @@ export const createLogtoConfigQueries = (
     ['id-token-config']
   );
 
+  // Internal, ops-only per-tenant override of the system message send-rate-limit policy. There is
+  // intentionally no upsert counterpart: the key is set by direct DB write only (no API), so the
+  // cache picks it up on its next expiry (or tenant restart).
+  const getMessageRateLimitOverride = wellKnownCache.memoize(async () => {
+    const { rows } = await getRowsByKeys([LogtoTenantConfigKey.MessageRateLimitOverride]);
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    return messageRateLimitOverrideGuard.parse(rows[0]?.value);
+  }, ['message-rate-limit-override']);
+
   return {
     getAdminConsoleConfig,
     updateAdminConsoleConfig,
@@ -256,5 +270,6 @@ export const createLogtoConfigQueries = (
     deleteJwtCustomizer,
     getIdTokenConfig,
     upsertIdTokenConfig,
+    getMessageRateLimitOverride,
   };
 };

--- a/packages/core/src/routes-me/verification-code.ts
+++ b/packages/core/src/routes-me/verification-code.ts
@@ -6,7 +6,7 @@ import { object, string } from 'zod';
 import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type { RouterInitArgs } from '#src/routes/types.js';
-import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
+import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
 import RequestError from '../errors/RequestError/index.js';
 import assertThat from '../utils/assert-that.js';
@@ -20,7 +20,6 @@ export default function verificationCodeRoutes<T extends AuthedMeRouter>(
   const codeType = TemplateType.Generic;
   const {
     queries: {
-      sentinelActivities,
       users: { findUserById },
     },
     libraries: {
@@ -49,7 +48,7 @@ export default function verificationCodeRoutes<T extends AuthedMeRouter>(
 
       await (EnvSet.values.isDevFeaturesEnabled
         ? withMessageRateGuard(
-            new MessageRateGuard(sentinelActivities),
+            await buildMessageRateGuard(tenant.queries),
             {
               action: SentinelActivityAction.VerificationCodeSend,
               recipient: ctx.guard.body.email,

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -34,6 +34,11 @@ const mockSentinelActivities = {
   insertActivity: jest.fn().mockImplementation(resolveVoid),
 };
 
+// `buildMessageRateGuard` reads the per-tenant override; default to none so the system policy applies.
+const mockLogtoConfigs = {
+  getMessageRateLimitOverride: jest.fn().mockResolvedValue(null),
+};
+
 describe('sendCode parameter passing', () => {
   // To make a void callable function/method
   const mockSendVerificationCode = jest.fn().mockImplementation(resolveVoid);
@@ -59,6 +64,7 @@ describe('sendCode parameter passing', () => {
 
   const mockQueries = {
     sentinelActivities: mockSentinelActivities,
+    logtoConfigs: mockLogtoConfigs,
     users: {
       hasUserWithEmail: jest.fn().mockResolvedValue(true),
       hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(true),
@@ -105,6 +111,7 @@ describe('sendCode parameter passing', () => {
   it('should skip delivery for forgot-password with non-existing email user', async () => {
     const mockQueriesNoUser = {
       sentinelActivities: mockSentinelActivities,
+      logtoConfigs: mockLogtoConfigs,
       users: {
         hasUserWithEmail: jest.fn().mockResolvedValue(false),
         hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
@@ -144,6 +151,7 @@ describe('sendCode parameter passing', () => {
   it('should not skip delivery for forgot-password with existing user', async () => {
     const mockQueriesWithUser = {
       sentinelActivities: mockSentinelActivities,
+      logtoConfigs: mockLogtoConfigs,
       users: {
         hasUserWithEmail: jest.fn().mockResolvedValue(true),
         hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(true),
@@ -182,6 +190,7 @@ describe('sendCode parameter passing', () => {
   it('should not check user existence for non-ForgotPassword events', async () => {
     const mockQueriesTracking = {
       sentinelActivities: mockSentinelActivities,
+      logtoConfigs: mockLogtoConfigs,
       users: {
         hasUserWithEmail: jest.fn().mockResolvedValue(false),
         hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -12,7 +12,7 @@ import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { type LogContext } from '#src/middleware/koa-audit-log.js';
-import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
+import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import { getLogtoCookie } from '#src/utils/cookie.js';
@@ -154,7 +154,7 @@ export const sendCode = async ({
   await (skipDelivery || !EnvSet.values.isDevFeaturesEnabled
     ? send()
     : withMessageRateGuard(
-        new MessageRateGuard(queries.sentinelActivities),
+        await buildMessageRateGuard(queries),
         {
           ...messageRateLimit,
           onRateLimited: () => {

--- a/packages/core/src/routes/interaction/additional.test.ts
+++ b/packages/core/src/routes/interaction/additional.test.ts
@@ -116,6 +116,10 @@ const tenantContext = new MockTenant(
       countActivities,
       insertActivity,
     },
+    // `buildMessageRateGuard` reads the per-tenant override; default to none so the system policy applies.
+    logtoConfigs: {
+      getMessageRateLimitOverride: jest.fn().mockResolvedValue(null),
+    },
   },
   {
     getLogtoConnectorById: async (connectorId: string) => {

--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -27,7 +27,7 @@ import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { type WithI18nContext } from '#src/middleware/koa-i18next.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
-import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
+import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { getLogtoCookie } from '#src/utils/cookie.js';
@@ -80,6 +80,7 @@ export default function additionalRoutes<T extends IRouterParamContext>(
     queries: {
       users: { findUserById },
       sentinelActivities,
+      logtoConfigs,
     },
   } = tenant;
 
@@ -150,7 +151,7 @@ export default function additionalRoutes<T extends IRouterParamContext>(
 
       await (EnvSet.values.isDevFeaturesEnabled
         ? withMessageRateGuard(
-            new MessageRateGuard(sentinelActivities),
+            await buildMessageRateGuard({ sentinelActivities, logtoConfigs }),
             { action: SentinelActivityAction.VerificationCodeSend, recipient },
             send
           )

--- a/packages/core/src/routes/verification-code.ts
+++ b/packages/core/src/routes/verification-code.ts
@@ -7,7 +7,7 @@ import {
 
 import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
+import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 
@@ -37,7 +37,7 @@ export default function verificationCodeRoutes<T extends ManagementApiRouter>(
 
       await (EnvSet.values.isDevFeaturesEnabled
         ? withMessageRateGuard(
-            new MessageRateGuard(queries.sentinelActivities),
+            await buildMessageRateGuard(queries),
             { action: SentinelActivityAction.VerificationCodeSend, recipient },
             send
           )

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -14,7 +14,7 @@ import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import { MessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
+import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
 import {
   buildVerificationRecordByIdAndType,
@@ -133,7 +133,7 @@ export default function verificationRoutes<T extends UserRouter>(
 
       await (EnvSet.values.isDevFeaturesEnabled
         ? withMessageRateGuard(
-            new MessageRateGuard(queries.sentinelActivities),
+            await buildMessageRateGuard(queries),
             {
               ...messageRateLimit,
               onRateLimited: () => {

--- a/packages/core/src/sentinel/message-rate-guard.test.ts
+++ b/packages/core/src/sentinel/message-rate-guard.test.ts
@@ -3,12 +3,15 @@ import {
   SentinelActivityAction,
   SentinelActivityTargetType,
   SentinelDecision,
+  defaultMessageRateLimitPolicy,
   type MessageRateLimitPolicy,
 } from '@logto/schemas';
 
 const { jest } = import.meta;
 
-const { MessageRateGuard, withMessageRateGuard } = await import('./message-rate-guard.js');
+const { MessageRateGuard, withMessageRateGuard, buildMessageRateGuard } = await import(
+  './message-rate-guard.js'
+);
 
 const policy: MessageRateLimitPolicy = { sendWindow: 60, maxSendsPerRecipient: 3 };
 const action = SentinelActivityAction.VerificationCodeSend;
@@ -16,12 +19,19 @@ const recipient = 'recipient@example.com';
 
 const countActivities = jest.fn();
 const insertActivity = jest.fn();
+const getMessageRateLimitOverride = jest.fn();
 
 const buildGuard = () => new MessageRateGuard({ countActivities, insertActivity }, policy);
+
+const buildFactoryQueries = () => ({
+  sentinelActivities: { countActivities, insertActivity },
+  logtoConfigs: { getMessageRateLimitOverride },
+});
 
 beforeEach(() => {
   countActivities.mockReset();
   insertActivity.mockReset();
+  getMessageRateLimitOverride.mockReset();
 });
 
 describe('MessageRateGuard', () => {
@@ -126,5 +136,55 @@ describe('withMessageRateGuard', () => {
       'sent'
     );
     expect(send).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('buildMessageRateGuard', () => {
+  it('uses the system default policy when no override is set', async () => {
+    getMessageRateLimitOverride.mockResolvedValueOnce(null);
+    countActivities.mockResolvedValueOnce(0);
+
+    const guard = await buildMessageRateGuard(buildFactoryQueries());
+    await guard.guard(action, recipient);
+
+    expect(countActivities).toHaveBeenCalledWith(
+      expect.objectContaining({ windowSeconds: defaultMessageRateLimitPolicy.sendWindow })
+    );
+  });
+
+  it('merges a partial override over the system default per field', async () => {
+    // Override only the cap; the window is left to fall back to the system default.
+    getMessageRateLimitOverride.mockResolvedValueOnce({ maxSendsPerRecipient: 100 });
+    // A count that would block at the default cap (10) but is allowed under the overridden cap (100).
+    countActivities.mockResolvedValueOnce(50);
+
+    const guard = await buildMessageRateGuard(buildFactoryQueries());
+
+    await expect(guard.guard(action, recipient)).resolves.toBeUndefined();
+    expect(countActivities).toHaveBeenCalledWith(
+      expect.objectContaining({ windowSeconds: defaultMessageRateLimitPolicy.sendWindow })
+    );
+  });
+
+  it('applies an overridden window', async () => {
+    getMessageRateLimitOverride.mockResolvedValueOnce({ sendWindow: 60 });
+    countActivities.mockResolvedValueOnce(0);
+
+    const guard = await buildMessageRateGuard(buildFactoryQueries());
+    await guard.guard(action, recipient);
+
+    expect(countActivities).toHaveBeenCalledWith(expect.objectContaining({ windowSeconds: 60 }));
+  });
+
+  it('falls back to the system default when the override read fails (fails open)', async () => {
+    getMessageRateLimitOverride.mockRejectedValueOnce(new Error('cache unavailable'));
+    countActivities.mockResolvedValueOnce(0);
+
+    const guard = await buildMessageRateGuard(buildFactoryQueries());
+
+    await expect(guard.guard(action, recipient)).resolves.toBeUndefined();
+    expect(countActivities).toHaveBeenCalledWith(
+      expect.objectContaining({ windowSeconds: defaultMessageRateLimitPolicy.sendWindow })
+    );
   });
 });

--- a/packages/core/src/sentinel/message-rate-guard.ts
+++ b/packages/core/src/sentinel/message-rate-guard.ts
@@ -11,6 +11,7 @@ import { trySafe } from '@silverhand/essentials';
 import { sha256 } from 'hash-wasm';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import { type createLogtoConfigQueries } from '#src/queries/logto-config.js';
 import { type createSentinelActivitiesQueries } from '#src/queries/sentinel-activities.js';
 
 type SentinelActivitiesQueries = ReturnType<typeof createSentinelActivitiesQueries>;
@@ -19,6 +20,8 @@ type MessageRateGuardQueries = Pick<
   SentinelActivitiesQueries,
   'countActivities' | 'insertActivity'
 >;
+
+type LogtoConfigQueries = ReturnType<typeof createLogtoConfigQueries>;
 
 /**
  * A mandatory, system-level rate limit on outbound messages (verification codes, organization
@@ -78,6 +81,26 @@ export class MessageRateGuard {
     );
   }
 }
+
+/**
+ * Builds a {@link MessageRateGuard} with the effective policy for the current tenant: the
+ * system-wide {@link defaultMessageRateLimitPolicy} with any per-field values from the internal,
+ * ops-only `messageRateLimitOverride` config applied on top. The override is read through the
+ * tenant config cache, so the common (no-override) path adds no per-send database hit.
+ */
+export const buildMessageRateGuard = async (queries: {
+  sentinelActivities: MessageRateGuardQueries;
+  logtoConfigs: Pick<LogtoConfigQueries, 'getMessageRateLimitOverride'>;
+}): Promise<MessageRateGuard> => {
+  // Fail open: a failed override read must not block a legitimate send, mirroring the guard's own
+  // best-effort count query. `trySafe` returns `undefined` on error, so we fall back to the default.
+  const override = await trySafe(queries.logtoConfigs.getMessageRateLimitOverride());
+  const policy: MessageRateLimitPolicy = override
+    ? { ...defaultMessageRateLimitPolicy, ...override }
+    : defaultMessageRateLimitPolicy;
+
+  return new MessageRateGuard(queries.sentinelActivities, policy);
+};
 
 /**
  * Wraps a message send with the {@link MessageRateGuard}: rejects with a 429 before sending if the

--- a/packages/schemas/src/consts/message-rate-limit.ts
+++ b/packages/schemas/src/consts/message-rate-limit.ts
@@ -43,3 +43,15 @@ export const defaultMessageRateLimitPolicy = Object.freeze({
   sendWindow: 600,
   maxSendsPerRecipient: 10,
 } satisfies MessageRateLimitPolicy);
+
+/**
+ * Internal, ops-only per-tenant override of {@link defaultMessageRateLimitPolicy}. Stored under the
+ * `messageRateLimitOverride` key in `logto_configs` and not exposed by any API — it exists solely
+ * as a relief valve for a legitimately high-volume tenant that trips the system cap.
+ *
+ * Every field is optional: the effective policy is resolved per field as `override ?? system
+ * default`, so a partial override only changes the fields it sets.
+ */
+export const messageRateLimitOverrideGuard = messageRateLimitPolicyGuard.partial();
+
+export type MessageRateLimitOverride = z.infer<typeof messageRateLimitOverrideGuard>;

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -4,6 +4,11 @@ import type { ZodType } from 'zod';
 import { z } from 'zod';
 
 import {
+  type MessageRateLimitOverride,
+  messageRateLimitOverrideGuard,
+} from '../../consts/message-rate-limit.js';
+
+import {
   type AccessTokenJwtCustomizer,
   type ClientCredentialsJwtCustomizer,
   accessTokenJwtCustomizerGuard,
@@ -171,6 +176,8 @@ export enum LogtoTenantConfigKey {
   IdToken = 'idToken',
   /** Tenant-scoped rotation state for staged private signing key activation. */
   SigningKeyRotationState = 'signingKeyRotationState',
+  /** Internal, ops-only override of the system message send-rate-limit policy. Not exposed by any API. */
+  MessageRateLimitOverride = 'messageRateLimitOverride',
 }
 export type LogtoTenantConfigType = {
   [LogtoTenantConfigKey.AdminConsole]: AdminConsoleData;
@@ -178,6 +185,7 @@ export type LogtoTenantConfigType = {
   [LogtoTenantConfigKey.SessionNotFoundRedirectUrl]: { url: string };
   [LogtoTenantConfigKey.IdToken]: IdTokenConfig;
   [LogtoTenantConfigKey.SigningKeyRotationState]: SigningKeyRotationState;
+  [LogtoTenantConfigKey.MessageRateLimitOverride]: MessageRateLimitOverride;
 };
 
 export const logtoTenantConfigGuard: Readonly<{
@@ -188,6 +196,7 @@ export const logtoTenantConfigGuard: Readonly<{
   [LogtoTenantConfigKey.SessionNotFoundRedirectUrl]: z.object({ url: z.string() }),
   [LogtoTenantConfigKey.IdToken]: idTokenConfigGuard,
   [LogtoTenantConfigKey.SigningKeyRotationState]: signingKeyRotationStateGuard,
+  [LogtoTenantConfigKey.MessageRateLimitOverride]: messageRateLimitOverrideGuard,
 });
 
 /* --- Summary --- */


### PR DESCRIPTION
## Summary
Refs LOG-13645.

Adds an internal, ops-only per-tenant override of the system message send-rate-limit policy — a relief valve so a legitimately high-volume tenant that trips the system cap can be raised with a single DB write instead of a code change or repeated `sentinel_activities` deletes.

### What changed
- New internal `LogtoTenantConfigKey.MessageRateLimitOverride` (`@logto/schemas`) — a **partial** of `MessageRateLimitPolicy` (`{ sendWindow?, maxSendsPerRecipient? }`).
- `buildMessageRateGuard(queries)` in `message-rate-guard.ts` resolves the effective policy as `{ ...defaultMessageRateLimitPolicy, ...override }` and constructs the guard. It reads the override through the tenant config cache (new cached `getMessageRateLimitOverride` query via `WellKnownCache.memoize`), so the common no-override path adds no per-send DB hit, and it **fails open** to the default if the read errors.
- All 5 guard call sites now build the guard via the factory (experience, account, management, `/me`, organization-invitation).

### Expected result
- No behavior change for tenants without the override key (the common path) — pure system default.
- A tenant with the override gets the merged, per-field limits, taking effect within ≤30 min of the DB write (config-cache TTL) or immediately on tenant restart.
- All gated behind `isDevFeaturesEnabled`.

### Reviewer notes
- **Not tenant-editable, by design.** The key is added to `logtoTenantConfigGuard` for validation only; the `/configs` API is a per-key allow-list and this PR wires **no route and no write method** for it, so it is settable by ops via direct DB write only (like `idToken` / `signingKeyRotationState`).
- No changeset (flag-gated). No console/UI surface; the productized, tenant-facing tunable band is deferred to the Hosted Email Service & Usage project.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
