### PR TITLE
fix(account): hide profile page when no fields are enabled

### DIFF
--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -69,7 +69,11 @@ import Username from './pages/Username';
 import VerifiedAction from './pages/VerifiedAction';
 import { useAuthRedirect } from './use-auth-redirect';
 import { accountCenterBasePath, handleAccountCenterRoute } from './utils/account-center-route';
-import { hasVisibleSecuritySection, hasVisibleSessionsPage } from './utils/security-page';
+import {
+  hasVisibleProfilePage,
+  hasVisibleSecuritySection,
+  hasVisibleSessionsPage,
+} from './utils/security-page';
 import '@experience/shared/scss/normalized.scss';
 import './scss/normalized.scss';
 
@@ -132,6 +136,7 @@ export const Main = () => {
 
   const showsSecurityPage = hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
   const showsSessionsPage = hasVisibleSessionsPage(accountCenterSettings);
+  const showsProfilePage = hasVisibleProfilePage(accountCenterSettings, experienceSettings);
 
   return (
     <Routes>
@@ -185,7 +190,7 @@ export const Main = () => {
       />
       {showsSecurityPage && <Route path={securityRoute} element={<Security />} />}
       {showsSessionsPage && <Route path={sessionsRoute} element={<Sessions />} />}
-      <Route path={profileRoute} element={<Profile />} />
+      {showsProfilePage && <Route path={profileRoute} element={<Profile />} />}
       <Route index element={<Home />} />
       <Route path="*" element={<Home />} />
     </Routes>
@@ -199,19 +204,19 @@ const Layout = () => {
   const { pathname } = useLocation();
   const showsSecurityPage = hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
   const showsSessionsPage = hasVisibleSessionsPage(accountCenterSettings);
-  const hasProfilePage = true;
+  const showsProfilePage = hasVisibleProfilePage(accountCenterSettings, experienceSettings);
   const isFullPage =
     (pathname === securityRoute && showsSecurityPage) ||
     (pathname === sessionsRoute && showsSessionsPage) ||
-    (pathname === profileRoute && hasProfilePage);
+    (pathname === profileRoute && showsProfilePage);
   const accountNavItems = useMemo(
     () =>
       buildAccountNavItems({
-        hasProfile: hasProfilePage,
+        hasProfile: showsProfilePage,
         hasSecurity: showsSecurityPage,
         hasSessions: showsSessionsPage,
       }),
-    [hasProfilePage, showsSecurityPage, showsSessionsPage]
+    [showsProfilePage, showsSecurityPage, showsSessionsPage]
   );
   const showsMultiPageNav = isFullPage && accountNavItems.length > 1;
   const showsMobileTabNav = platform === 'mobile' && showsMultiPageNav;

--- a/packages/account/src/pages/Profile/index.tsx
+++ b/packages/account/src/pages/Profile/index.tsx
@@ -10,16 +10,13 @@ import AvatarUploadField from '@ac/components/AvatarUploadField';
 import PageFooter from '@ac/components/PageFooter';
 import { layoutClassNames } from '@ac/constants/layout';
 import useApi from '@ac/hooks/use-api';
+import { getProfileFieldControlKey } from '@ac/utils/profile-field-control';
 
 import homeStyles from '../Home/index.module.scss';
 
 import EditProfileFieldModal from './EditProfileFieldModal';
 import styles from './index.module.scss';
-import {
-  getAccountCenterProfileFields,
-  getProfileFieldControlKey,
-  getProfileFieldValue,
-} from './profile-field-values';
+import { getAccountCenterProfileFields, getProfileFieldValue } from './profile-field-values';
 import type { ProfileFieldRow } from './types';
 
 const profileLabelKeys: Record<string, string> = {

--- a/packages/account/src/pages/Profile/profile-field-values.tsx
+++ b/packages/account/src/pages/Profile/profile-field-values.tsx
@@ -1,5 +1,4 @@
 import {
-  builtInCustomProfileFieldKeys,
   CustomProfileFieldType,
   fullnameKeys,
   userProfileAddressKeys,
@@ -11,40 +10,16 @@ import {
 } from '@logto/schemas';
 import type { ReactNode } from 'react';
 
-import { getSelectOptionLabel } from './select-options';
-import type { ProfileFieldControlKey } from './types';
+import { isBuiltInProfileField } from '@ac/utils/profile-field-control';
 
-const builtInCustomProfileFieldKeySet = new Set<string>(builtInCustomProfileFieldKeys);
+import { getSelectOptionLabel } from './select-options';
+
 const fullnameKeySet = new Set<string>(fullnameKeys);
 const addressKeySet = new Set<string>(userProfileAddressKeys);
 
 export const getAccountCenterProfileFields = (
   settings?: AccountCenter
 ): AccountCenterProfileFields => settings?.profileFields ?? [];
-
-const isCompositeProfileField = (field?: CustomProfileField): boolean =>
-  field?.type === CustomProfileFieldType.Fullname || field?.type === CustomProfileFieldType.Address;
-
-const isBuiltInProfileField = (fieldName: string, field?: CustomProfileField): boolean =>
-  (builtInCustomProfileFieldKeySet.has(fieldName) &&
-    fieldName !== 'name' &&
-    fieldName !== 'avatar') ||
-  (fieldName === 'fullname' && field === undefined);
-
-export const getProfileFieldControlKey = (
-  fieldName: string,
-  field?: CustomProfileField
-): ProfileFieldControlKey => {
-  if (fieldName === 'name' || fieldName === 'avatar') {
-    return fieldName;
-  }
-
-  if (isBuiltInProfileField(fieldName, field) || isCompositeProfileField(field)) {
-    return 'profile';
-  }
-
-  return 'customData';
-};
 
 const joinValues = (values: Array<string | undefined>, separator = ' '): string | undefined => {
   const value = values.filter(Boolean).join(separator);

--- a/packages/account/src/pages/Profile/types.ts
+++ b/packages/account/src/pages/Profile/types.ts
@@ -1,13 +1,8 @@
-import {
-  type AccountCenterControlValue,
-  type AccountCenterFieldControl,
-  type CustomProfileField,
-} from '@logto/schemas';
+import { type AccountCenterControlValue, type CustomProfileField } from '@logto/schemas';
 
-export type ProfileFieldControlKey = Extract<
-  keyof AccountCenterFieldControl,
-  'name' | 'avatar' | 'profile' | 'customData'
->;
+import type { ProfileFieldControlKey } from '@ac/utils/profile-field-control';
+
+export type { ProfileFieldControlKey } from '@ac/utils/profile-field-control';
 
 export type ProfileFieldRow = {
   name: string;

--- a/packages/account/src/utils/profile-field-control.ts
+++ b/packages/account/src/utils/profile-field-control.ts
@@ -1,0 +1,37 @@
+import {
+  builtInCustomProfileFieldKeys,
+  CustomProfileFieldType,
+  type AccountCenterFieldControl,
+  type CustomProfileField,
+} from '@logto/schemas';
+
+export type ProfileFieldControlKey = Extract<
+  keyof AccountCenterFieldControl,
+  'name' | 'avatar' | 'profile' | 'customData'
+>;
+
+const builtInCustomProfileFieldKeySet = new Set<string>(builtInCustomProfileFieldKeys);
+
+export const isBuiltInProfileField = (fieldName: string, field?: CustomProfileField): boolean =>
+  (builtInCustomProfileFieldKeySet.has(fieldName) &&
+    fieldName !== 'name' &&
+    fieldName !== 'avatar') ||
+  (fieldName === 'fullname' && field === undefined);
+
+export const isCompositeProfileField = (field?: CustomProfileField): boolean =>
+  field?.type === CustomProfileFieldType.Fullname || field?.type === CustomProfileFieldType.Address;
+
+export const getProfileFieldControlKey = (
+  fieldName: string,
+  field?: CustomProfileField
+): ProfileFieldControlKey => {
+  if (fieldName === 'name' || fieldName === 'avatar') {
+    return fieldName;
+  }
+
+  if (isBuiltInProfileField(fieldName, field) || isCompositeProfileField(field)) {
+    return 'profile';
+  }
+
+  return 'customData';
+};

--- a/packages/account/src/utils/security-page.test.ts
+++ b/packages/account/src/utils/security-page.test.ts
@@ -1,4 +1,10 @@
-import { AccountCenterControlValue, ConnectorPlatform, MfaFactor, MfaPolicy } from '@logto/schemas';
+import {
+  AccountCenterControlValue,
+  ConnectorPlatform,
+  CustomProfileFieldType,
+  MfaFactor,
+  MfaPolicy,
+} from '@logto/schemas';
 
 import {
   canManageSocialIdentitiesWithoutVerification,
@@ -8,6 +14,7 @@ import {
   canOpenPasswordEditFlow,
   hasAvailableSecurityVerificationMethod,
   hasVisibleMfaSection,
+  hasVisibleProfilePage,
   hasVisibleSecuritySection,
   hasVisibleSocialSection,
 } from './security-page';
@@ -242,5 +249,151 @@ describe('security-page utils', () => {
       })
     ).toBe(false);
     expect(canOpenPasswordEditFlow(AccountCenterControlValue.Edit)).toBe(false);
+  });
+
+  describe('hasVisibleProfilePage', () => {
+    it('returns false when account center is disabled', () => {
+      expect(
+        hasVisibleProfilePage({
+          enabled: false,
+          fields: { name: AccountCenterControlValue.Edit },
+          profileFields: [{ name: 'name' }],
+        })
+      ).toBe(false);
+    });
+
+    it('returns false when settings are undefined', () => {
+      expect(hasVisibleProfilePage()).toBe(false);
+    });
+
+    it('returns false when profileFields is empty', () => {
+      expect(
+        hasVisibleProfilePage({
+          enabled: true,
+          fields: { name: AccountCenterControlValue.Edit },
+          profileFields: [],
+        })
+      ).toBe(false);
+    });
+
+    it('returns false when all profile fields have their control set to Off', () => {
+      expect(
+        hasVisibleProfilePage({
+          enabled: true,
+          fields: {
+            name: AccountCenterControlValue.Off,
+            avatar: AccountCenterControlValue.Off,
+          },
+          profileFields: [{ name: 'name' }, { name: 'avatar' }],
+        })
+      ).toBe(false);
+    });
+
+    it('returns true when at least one built-in field (name) is visible', () => {
+      expect(
+        hasVisibleProfilePage({
+          enabled: true,
+          fields: {
+            name: AccountCenterControlValue.Edit,
+            avatar: AccountCenterControlValue.Off,
+          },
+          profileFields: [{ name: 'name' }, { name: 'avatar' }],
+        })
+      ).toBe(true);
+    });
+
+    it('returns true when a built-in profile field (nickname) uses the profile control', () => {
+      expect(
+        hasVisibleProfilePage({
+          enabled: true,
+          fields: { profile: AccountCenterControlValue.ReadOnly },
+          profileFields: [{ name: 'nickname' }],
+        })
+      ).toBe(true);
+    });
+
+    it('returns true when a custom field uses the customData control', () => {
+      expect(
+        hasVisibleProfilePage(
+          {
+            enabled: true,
+            fields: { customData: AccountCenterControlValue.Edit },
+            profileFields: [{ name: 'company' }],
+          },
+          {
+            customProfileFields: [
+              {
+                tenantId: 'default',
+                id: 'field-1',
+                name: 'company',
+                type: CustomProfileFieldType.Text,
+                label: 'Company',
+                description: null,
+                required: false,
+                config: {},
+                createdAt: 0,
+                sieOrder: 0,
+              },
+            ],
+          }
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when custom field control (customData) is Off', () => {
+      expect(
+        hasVisibleProfilePage(
+          {
+            enabled: true,
+            fields: { customData: AccountCenterControlValue.Off },
+            profileFields: [{ name: 'company' }],
+          },
+          {
+            customProfileFields: [
+              {
+                tenantId: 'default',
+                id: 'field-1',
+                name: 'company',
+                type: CustomProfileFieldType.Text,
+                label: 'Company',
+                description: null,
+                required: false,
+                config: {},
+                createdAt: 0,
+                sieOrder: 0,
+              },
+            ],
+          }
+        )
+      ).toBe(false);
+    });
+
+    it('returns true for composite field type (Address) using profile control', () => {
+      expect(
+        hasVisibleProfilePage(
+          {
+            enabled: true,
+            fields: { profile: AccountCenterControlValue.Edit },
+            profileFields: [{ name: 'address' }],
+          },
+          {
+            customProfileFields: [
+              {
+                tenantId: 'default',
+                id: 'field-2',
+                name: 'address',
+                type: CustomProfileFieldType.Address,
+                label: 'Address',
+                description: null,
+                required: false,
+                config: {},
+                createdAt: 0,
+                sieOrder: 0,
+              },
+            ],
+          }
+        )
+      ).toBe(true);
+    });
   });
 });

--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -5,15 +5,11 @@ import type {
   UserMfaVerificationResponse,
   UserProfileResponse,
 } from '@logto/schemas';
-import {
-  AccountCenterControlValue,
-  builtInCustomProfileFieldKeys,
-  CustomProfileFieldType,
-  MfaFactor,
-} from '@logto/schemas';
+import { AccountCenterControlValue, MfaFactor } from '@logto/schemas';
 
 import { isDevFeaturesEnabled } from '@ac/constants/env';
 
+import { getProfileFieldControlKey } from './profile-field-control';
 import { getAvailableSocialConnectors } from './social-connector.js';
 
 type SecurityPageSettings = Pick<AccountCenter, 'enabled' | 'fields' | 'deleteAccountUrl'>;
@@ -175,32 +171,6 @@ export const canOpenPasswordEditFlow = (
   (hasAvailableSecurityVerificationMethod(userInfo) ||
     canSetInitialPasswordWithoutVerification(userInfo, accountCenterFields));
 
-const builtInCustomProfileFieldKeySet = new Set<string>(builtInCustomProfileFieldKeys);
-
-const getProfileFieldControlKeyForVisibility = (
-  fieldName: string,
-  field?: CustomProfileField
-): 'name' | 'avatar' | 'profile' | 'customData' => {
-  if (fieldName === 'name' || fieldName === 'avatar') {
-    return fieldName;
-  }
-
-  const isBuiltIn =
-    (builtInCustomProfileFieldKeySet.has(fieldName) &&
-      fieldName !== 'name' &&
-      fieldName !== 'avatar') ||
-    (fieldName === 'fullname' && field === undefined);
-  const isComposite =
-    field?.type === CustomProfileFieldType.Fullname ||
-    field?.type === CustomProfileFieldType.Address;
-
-  if (isBuiltIn || isComposite) {
-    return 'profile';
-  }
-
-  return 'customData';
-};
-
 type ProfilePageSettings = Pick<AccountCenter, 'enabled' | 'fields' | 'profileFields'>;
 type ProfilePageExperienceSettings = Partial<
   Pick<SignInExperienceResponse, 'customProfileFieldCatalog' | 'customProfileFields'>
@@ -228,7 +198,7 @@ export const hasVisibleProfilePage = (
 
   return profileFields.some(({ name }) => {
     const field = catalogMap.get(name);
-    const controlKey = getProfileFieldControlKeyForVisibility(name, field);
+    const controlKey = getProfileFieldControlKey(name, field);
     return isVisibleField(accountCenterSettings.fields[controlKey]);
   });
 };

--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -1,10 +1,16 @@
 import type { SignInExperienceResponse } from '@experience/shared/types';
 import type {
   AccountCenter,
+  CustomProfileField,
   UserMfaVerificationResponse,
   UserProfileResponse,
 } from '@logto/schemas';
-import { AccountCenterControlValue, MfaFactor } from '@logto/schemas';
+import {
+  AccountCenterControlValue,
+  builtInCustomProfileFieldKeys,
+  CustomProfileFieldType,
+  MfaFactor,
+} from '@logto/schemas';
 
 import { isDevFeaturesEnabled } from '@ac/constants/env';
 
@@ -168,3 +174,61 @@ export const canOpenPasswordEditFlow = (
   userInfo !== undefined &&
   (hasAvailableSecurityVerificationMethod(userInfo) ||
     canSetInitialPasswordWithoutVerification(userInfo, accountCenterFields));
+
+const builtInCustomProfileFieldKeySet = new Set<string>(builtInCustomProfileFieldKeys);
+
+const getProfileFieldControlKeyForVisibility = (
+  fieldName: string,
+  field?: CustomProfileField
+): 'name' | 'avatar' | 'profile' | 'customData' => {
+  if (fieldName === 'name' || fieldName === 'avatar') {
+    return fieldName;
+  }
+
+  const isBuiltIn =
+    (builtInCustomProfileFieldKeySet.has(fieldName) &&
+      fieldName !== 'name' &&
+      fieldName !== 'avatar') ||
+    (fieldName === 'fullname' && field === undefined);
+  const isComposite =
+    field?.type === CustomProfileFieldType.Fullname ||
+    field?.type === CustomProfileFieldType.Address;
+
+  if (isBuiltIn || isComposite) {
+    return 'profile';
+  }
+
+  return 'customData';
+};
+
+type ProfilePageSettings = Pick<AccountCenter, 'enabled' | 'fields' | 'profileFields'>;
+type ProfilePageExperienceSettings = Partial<
+  Pick<SignInExperienceResponse, 'customProfileFieldCatalog' | 'customProfileFields'>
+>;
+
+export const hasVisibleProfilePage = (
+  accountCenterSettings?: ProfilePageSettings,
+  experienceSettings?: ProfilePageExperienceSettings
+): boolean => {
+  if (!accountCenterSettings?.enabled) {
+    return false;
+  }
+
+  const profileFields = accountCenterSettings.profileFields ?? [];
+
+  if (profileFields.length === 0) {
+    return false;
+  }
+
+  const catalog =
+    experienceSettings?.customProfileFieldCatalog ?? experienceSettings?.customProfileFields ?? [];
+  const catalogMap = new Map<string, CustomProfileField>(
+    catalog.map((field) => [field.name, field])
+  );
+
+  return profileFields.some(({ name }) => {
+    const field = catalogMap.get(name);
+    const controlKey = getProfileFieldControlKeyForVisibility(name, field);
+    return isVisibleField(accountCenterSettings.fields[controlKey]);
+  });
+};


### PR DESCRIPTION
## Summary

When no profile fields are enabled in the account center (either `profileFields` is empty or all fields have their control set to `Off`), the profile page is now inaccessible and its tab entry is hidden from the sidebar/mobile nav.

Previously `hasProfilePage` was hardcoded to `true`. Now it uses a new `hasVisibleProfilePage(accountCenterSettings, experienceSettings)` utility (mirrors the logic in the Profile component itself) that checks whether at least one entry in `profileFields` has a visible control value. When it returns `false`:

- The profile `<Route>` is not rendered → direct navigation falls through to the `*` catch-all error page (`<Home />`)
- `buildAccountNavItems` receives `hasProfile: false` → the sidebar/mobile tab entry is omitted

### Screenshots

**With fields enabled** — Profile page renders normally with sidebar tab:

![with fields](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctY2ZmZDZiODk0YWZjNDFjM2E4OGRmMjAwMDY1NzRjOGIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctY2ZmZDZiODk0YWZjNDFjM2E4OGRmMjAwMDY1NzRjOGIvYjNkOWQzMWYtZGQyYy00MTM0LTlmZmQtYWYxZWNhM2ZjZjVlIiwiaWF0IjoxNzgxODM0MDEzLCJleHAiOjE3ODI0Mzg4MTMsImZpbGVuYW1lIjoicHJvZmlsZV93aXRoX2ZpZWxkcy5wbmcifQ.Yo-5t4eVLLv-nOcHUi1XWPwPC17EPV1FIDjQ1sS26NA)

**Without fields** — `/account/profile` shows error page, no "Personal info" tab:

![no fields - error page](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctY2ZmZDZiODk0YWZjNDFjM2E4OGRmMjAwMDY1NzRjOGIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctY2ZmZDZiODk0YWZjNDFjM2E4OGRmMjAwMDY1NzRjOGIvZWI4YmQwMjUtZTIyMi00OTY2LWE1OGQtNDhkZmIxN2RmMWFmIiwiaWF0IjoxNzgxODM0MDEzLCJleHAiOjE3ODI0Mzg4MTMsImZpbGVuYW1lIjoicHJvZmlsZV9ub19maWVsZHMucG5nIn0.mSwNEbL_ox5f1i5LeaML5SL-En1_Ky9bFPxsJynjLQI)

![no fields - security page without profile tab](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctY2ZmZDZiODk0YWZjNDFjM2E4OGRmMjAwMDY1NzRjOGIiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctY2ZmZDZiODk0YWZjNDFjM2E4OGRmMjAwMDY1NzRjOGIvMjQxMzQ4YmYtY2VhZC00ODUxLWI4NDQtYzAwOTk2M2Q1MjJkIiwiaWF0IjoxNzgxODM0MDEzLCJleHAiOjE3ODI0Mzg4MTMsImZpbGVuYW1lIjoic2VjdXJpdHlfbm9fcHJvZmlsZV90YWIucG5nIn0.8xyatqLto9d_tpA2KvdcGDWCl_i4WVi8VRQHSGMWBE4)

### Testing

Tested locally
Unit tests

Link to Devin session: https://app.devin.ai/sessions/d7fe3da249784959a0c16d4616908b64
Requested by: @wangsijie