### PR TITLE
fix(account): redirect root to first tab

### DIFF
--- a/packages/account/src/App.test.tsx
+++ b/packages/account/src/App.test.tsx
@@ -1,4 +1,5 @@
 import { Prompt, useLogto } from '@logto/react';
+import { AccountCenterControlValue } from '@logto/schemas';
 import { type ReactNode } from 'react';
 
 import { Main } from './App';
@@ -31,6 +32,20 @@ jest.mock('@logto/react', () => ({
   useLogto: jest.fn(),
   useHandleSignInCallback: jest.fn(() => ({ error: undefined })),
 }));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom') as unknown as Record<string, unknown>;
+  const React = jest.requireActual('react') as unknown as {
+    createElement: (type: string, props: Record<string, string>) => unknown;
+  };
+
+  return {
+    __esModule: true,
+    ...actual,
+    Navigate: ({ to }: { readonly to: string }) =>
+      React.createElement('div', { 'data-testid': 'navigate', 'data-to': to }),
+  };
+});
 
 const setLocation = (pathname: string, search = '') => {
   // eslint-disable-next-line @silverhand/fp/no-mutating-methods
@@ -72,12 +87,12 @@ describe('Account Center <Main /> auth-redirect effects', () => {
 
   describe('userInfoError while authenticated', () => {
     it('attempts silent re-auth via Prompt.None when account center is enabled', () => {
-      setLocation('/account');
+      setLocation('/account/profile');
       const { signIn } = setupUseLogto();
 
       renderWithPageContext(
         <Main />,
-        { initialEntries: ['/account'] },
+        { initialEntries: ['/profile'] },
         { pageContext: { userInfoError: new Error('userinfo failed') } }
       );
 
@@ -105,18 +120,25 @@ describe('Account Center <Main /> auth-redirect effects', () => {
   });
 
   describe('silent re-auth failure fallback', () => {
-    it('falls back to Prompt.Login when redirected back with error=login_required', () => {
+    it('redirects the root account route before falling back to tab-level auth', () => {
       setLocation('/account', '?error=login_required');
       const { signIn } = setupUseLogto({ isAuthenticated: false });
 
-      renderWithPageContext(
+      const { getByTestId } = renderWithPageContext(
         <Main />,
         { initialEntries: ['/account?error=login_required'] },
-        { pageContext: {} }
+        {
+          pageContext: {
+            accountCenterSettings: {
+              ...mockAccountCenterSettings,
+              profileFields: [{ name: 'name' }],
+            },
+          },
+        }
       );
 
-      expect(signIn).toHaveBeenCalledTimes(1);
-      expect(signIn).toHaveBeenCalledWith(expect.objectContaining({ prompt: Prompt.Login }));
+      expect(getByTestId('navigate').dataset.to).toBe('/profile');
+      expect(signIn).not.toHaveBeenCalled();
     });
 
     it('does not trigger any signIn when account center is disabled', () => {
@@ -138,11 +160,11 @@ describe('Account Center <Main /> auth-redirect effects', () => {
   });
 
   describe('unauthenticated landing', () => {
-    it('starts a regular sign-in without a prompt when account center is enabled', () => {
-      setLocation('/account');
+    it('starts a regular sign-in without a prompt when landing on a tab', () => {
+      setLocation('/account/profile');
       const { signIn } = setupUseLogto({ isAuthenticated: false });
 
-      renderWithPageContext(<Main />, { initialEntries: ['/account'] }, { pageContext: {} });
+      renderWithPageContext(<Main />, { initialEntries: ['/profile'] }, { pageContext: {} });
 
       expect(signIn).toHaveBeenCalledTimes(1);
       expect(signIn.mock.calls[0]?.[0]).toEqual(
@@ -150,6 +172,110 @@ describe('Account Center <Main /> auth-redirect effects', () => {
         expect.objectContaining({ redirectUri: expect.any(String) })
       );
       expect(signIn.mock.calls[0]?.[0]?.prompt).toBeUndefined();
+    });
+  });
+
+  describe('root account route redirect', () => {
+    it('redirects to the profile tab when it is available', () => {
+      setLocation('/account');
+      const { signIn } = setupUseLogto({ isAuthenticated: false, isLoading: true });
+
+      const { getByTestId } = renderWithPageContext(
+        <Main />,
+        { initialEntries: ['/account'] },
+        {
+          pageContext: {
+            accountCenterSettings: {
+              ...mockAccountCenterSettings,
+              profileFields: [{ name: 'name' }],
+            },
+            userInfo: undefined,
+            isLoadingUserInfo: true,
+          },
+        }
+      );
+
+      expect(getByTestId('navigate').dataset.to).toBe('/profile');
+      expect(signIn).not.toHaveBeenCalled();
+    });
+
+    it('redirects to the security tab when profile is unavailable', () => {
+      setLocation('/account');
+      setupUseLogto({ isAuthenticated: false });
+
+      const { getByTestId } = renderWithPageContext(
+        <Main />,
+        { initialEntries: ['/account'] },
+        {
+          pageContext: {
+            accountCenterSettings: {
+              ...mockAccountCenterSettings,
+              profileFields: [],
+            },
+          },
+        }
+      );
+
+      expect(getByTestId('navigate').dataset.to).toBe('/security');
+    });
+
+    it('redirects to the sessions tab when profile and security are unavailable', () => {
+      setLocation('/account');
+      setupUseLogto({ isAuthenticated: false });
+
+      const { getByTestId } = renderWithPageContext(
+        <Main />,
+        { initialEntries: ['/account'] },
+        {
+          pageContext: {
+            accountCenterSettings: {
+              ...mockAccountCenterSettings,
+              profileFields: [],
+              fields: {
+                ...mockAccountCenterSettings.fields,
+                email: AccountCenterControlValue.Off,
+                mfa: AccountCenterControlValue.Off,
+                password: AccountCenterControlValue.Off,
+                phone: AccountCenterControlValue.Off,
+                session: AccountCenterControlValue.Edit,
+                username: AccountCenterControlValue.Off,
+              },
+            },
+          },
+        }
+      );
+
+      expect(getByTestId('navigate').dataset.to).toBe('/sessions');
+    });
+
+    it('shows the home error page when no tab is available', () => {
+      setLocation('/account');
+      const { signIn } = setupUseLogto({ isAuthenticated: false });
+
+      const { getByText } = renderWithPageContext(
+        <Main />,
+        { initialEntries: ['/account'] },
+        {
+          pageContext: {
+            accountCenterSettings: {
+              ...mockAccountCenterSettings,
+              profileFields: [],
+              fields: {
+                ...mockAccountCenterSettings.fields,
+                email: AccountCenterControlValue.Off,
+                mfa: AccountCenterControlValue.Off,
+                password: AccountCenterControlValue.Off,
+                phone: AccountCenterControlValue.Off,
+                session: AccountCenterControlValue.Off,
+                username: AccountCenterControlValue.Off,
+              },
+            },
+          },
+        }
+      );
+
+      expect(getByText('account_center.home.title')).toBeTruthy();
+      expect(signIn).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -3,14 +3,13 @@ import { LogtoProvider, ReservedScope, useLogto, UserScope } from '@logto/react'
 import { accountCenterApplicationId, SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
 import { useContext, useMemo } from 'react';
-import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import AppBoundary from '@ac/Providers/AppBoundary';
 import LoadingContextProvider from '@ac/Providers/LoadingContextProvider';
 import MobileTabNav from '@ac/components/MobileTabNav';
 import PageHeader from '@ac/components/PageHeader';
 import Sidebar from '@ac/components/Sidebar';
-import { buildAccountNavItems } from '@ac/components/account-nav-items';
 import { layoutClassNames } from '@ac/constants/layout';
 
 import styles from './App.module.scss';
@@ -69,11 +68,7 @@ import Username from './pages/Username';
 import VerifiedAction from './pages/VerifiedAction';
 import { useAuthRedirect } from './use-auth-redirect';
 import { accountCenterBasePath, handleAccountCenterRoute } from './utils/account-center-route';
-import {
-  hasVisibleProfilePage,
-  hasVisibleSecuritySection,
-  hasVisibleSessionsPage,
-} from './utils/security-page';
+import { getAccountTabSettings } from './utils/account-tabs';
 import '@experience/shared/scss/normalized.scss';
 import './scss/normalized.scss';
 
@@ -83,15 +78,13 @@ void initI18n();
 export const Main = () => {
   const params = new URLSearchParams(window.location.search);
   const { pathname } = window.location;
+  const isAccountRoot =
+    pathname === accountCenterBasePath || pathname === `${accountCenterBasePath}/`;
   const isSocialCallback = pathname.startsWith(
     `${accountCenterBasePath}${socialCallbackRoutePrefix}/`
   );
-  const isAuthCallback =
-    Boolean(params.get('code')) &&
-    (pathname === accountCenterBasePath || pathname === `${accountCenterBasePath}/`);
-  const isSilentAuthFailed =
-    params.get('error') === 'login_required' &&
-    (pathname === accountCenterBasePath || pathname === `${accountCenterBasePath}/`);
+  const isAuthCallback = Boolean(params.get('code')) && isAccountRoot;
+  const isSilentAuthFailed = params.get('error') === 'login_required' && isAccountRoot;
   const isInCallback = isSocialCallback || isAuthCallback;
   const { isAuthenticated, isLoading } = useLogto();
   const {
@@ -103,7 +96,7 @@ export const Main = () => {
   } = useContext(PageContext);
   const isInitialAuthLoading = !isAuthenticated && isLoading;
 
-  useAuthRedirect({ isInCallback, isSilentAuthFailed });
+  useAuthRedirect({ isInCallback: isInCallback || isAccountRoot, isSilentAuthFailed });
 
   if (isSocialCallback) {
     return (
@@ -117,7 +110,7 @@ export const Main = () => {
     return <Callback />;
   }
 
-  if (isInitialAuthLoading || isLoadingExperience || isLoadingUserInfo) {
+  if (isLoadingExperience || (!isAccountRoot && (isInitialAuthLoading || isLoadingUserInfo))) {
     return <GlobalLoading />;
   }
 
@@ -130,13 +123,33 @@ export const Main = () => {
     );
   }
 
+  const {
+    hasProfile,
+    hasSecurity,
+    hasSessions,
+    navItems: accountNavItems,
+  } = getAccountTabSettings({
+    accountCenterSettings,
+    experienceSettings,
+  });
+
+  if (isAccountRoot) {
+    const [firstAvailableNavItem] = accountNavItems;
+
+    if (!firstAvailableNavItem) {
+      return (
+        <Routes>
+          <Route path="*" element={<Home />} />
+        </Routes>
+      );
+    }
+
+    return <Navigate replace to={firstAvailableNavItem.to} />;
+  }
+
   if (!userInfo) {
     return <GlobalLoading />;
   }
-
-  const showsSecurityPage = hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
-  const showsSessionsPage = hasVisibleSessionsPage(accountCenterSettings);
-  const showsProfilePage = hasVisibleProfilePage(accountCenterSettings, experienceSettings);
 
   return (
     <Routes>
@@ -188,36 +201,24 @@ export const Main = () => {
         path={`${socialRoutePrefix}/:connectorId/remove`}
         element={<SocialFlow mode="remove" />}
       />
-      {showsSecurityPage && <Route path={securityRoute} element={<Security />} />}
-      {showsSessionsPage && <Route path={sessionsRoute} element={<Sessions />} />}
-      {showsProfilePage && <Route path={profileRoute} element={<Profile />} />}
+      {hasSecurity && <Route path={securityRoute} element={<Security />} />}
+      {hasSessions && <Route path={sessionsRoute} element={<Sessions />} />}
+      {hasProfile && <Route path={profileRoute} element={<Profile />} />}
       <Route index element={<Home />} />
       <Route path="*" element={<Home />} />
     </Routes>
   );
 };
 
-// eslint-disable-next-line complexity
 const Layout = () => {
   const { accountCenterSettings, experienceSettings, theme, platform } = useContext(PageContext);
   const hideLogtoBranding = experienceSettings?.hideLogtoBranding === true;
   const { pathname } = useLocation();
-  const showsSecurityPage = hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
-  const showsSessionsPage = hasVisibleSessionsPage(accountCenterSettings);
-  const showsProfilePage = hasVisibleProfilePage(accountCenterSettings, experienceSettings);
-  const isFullPage =
-    (pathname === securityRoute && showsSecurityPage) ||
-    (pathname === sessionsRoute && showsSessionsPage) ||
-    (pathname === profileRoute && showsProfilePage);
   const accountNavItems = useMemo(
-    () =>
-      buildAccountNavItems({
-        hasProfile: showsProfilePage,
-        hasSecurity: showsSecurityPage,
-        hasSessions: showsSessionsPage,
-      }),
-    [showsProfilePage, showsSecurityPage, showsSessionsPage]
+    () => getAccountTabSettings({ accountCenterSettings, experienceSettings }).navItems,
+    [accountCenterSettings, experienceSettings]
   );
+  const isFullPage = accountNavItems.some(({ to }) => to === pathname);
   const showsMultiPageNav = isFullPage && accountNavItems.length > 1;
   const showsMobileTabNav = platform === 'mobile' && showsMultiPageNav;
   const showsSidebar = platform !== 'mobile' && showsMultiPageNav;

--- a/packages/account/src/utils/account-tabs.ts
+++ b/packages/account/src/utils/account-tabs.ts
@@ -1,0 +1,29 @@
+import type { PageContextType } from '@ac/Providers/PageContextProvider/PageContext';
+import { buildAccountNavItems } from '@ac/components/account-nav-items';
+
+import {
+  hasVisibleProfilePage,
+  hasVisibleSecuritySection,
+  hasVisibleSessionsPage,
+} from './security-page';
+
+type AccountTabSettings = {
+  readonly accountCenterSettings?: PageContextType['accountCenterSettings'];
+  readonly experienceSettings?: PageContextType['experienceSettings'];
+};
+
+export const getAccountTabSettings = ({
+  accountCenterSettings,
+  experienceSettings,
+}: AccountTabSettings) => {
+  const hasSecurity = hasVisibleSecuritySection(accountCenterSettings, experienceSettings);
+  const hasSessions = hasVisibleSessionsPage(accountCenterSettings);
+  const hasProfile = hasVisibleProfilePage(accountCenterSettings, experienceSettings);
+
+  return {
+    hasProfile,
+    hasSecurity,
+    hasSessions,
+    navItems: buildAccountNavItems({ hasProfile, hasSecurity, hasSessions }),
+  };
+};


### PR DESCRIPTION
## Summary

- Redirect the Account Center root route to the first available tab before triggering tab-level auth handling.
- Share tab visibility resolution between routing and layout navigation.
- Add coverage for profile, security, sessions, and no-tab root route outcomes.

## Root cause

The root `/account` route could run auth redirect handling directly before resolving to a concrete Account Center tab, so OAuth errors returned to the root route could restart sign-in instead of letting a tab own the login flow.

## Testing

Unit tests
Tested locally
