### PR TITLE
fix(core): prevent tenant db pool shutdown race during cache reload

### DIFF
--- a/packages/core/src/app/init.ts
+++ b/packages/core/src/app/init.ts
@@ -75,15 +75,16 @@ export default async function initApp(app: Koa): Promise<void> {
       return next();
     }
 
+    // The request slot is reserved by `tenantPool.get()` so the database pool stays alive until
+    // this request finishes; release it exactly once here.
     try {
-      tenant.requestStart();
       await tenant.run(ctx, next);
-      tenant.requestEnd();
     } catch (error: unknown) {
-      tenant.requestEnd();
       void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));
 
       throw error;
+    } finally {
+      tenant.requestEnd();
     }
   });
 

--- a/packages/core/src/tenants/Tenant.test.ts
+++ b/packages/core/src/tenants/Tenant.test.ts
@@ -89,6 +89,48 @@ describe('Tenant `.run()`', () => {
   });
 });
 
+describe('Tenant request lifecycle and disposal', () => {
+  it('reserves and releases request slots', async () => {
+    const tenant = await Tenant.create({ id: defaultTenantId, redisCache: new RedisCache() });
+
+    expect(tenant.requestStart()).toBe(true);
+    tenant.requestEnd();
+  });
+
+  it('ends the database pool and rejects new requests once disposed', async () => {
+    const tenant = await Tenant.create({ id: defaultTenantId, redisCache: new RedisCache() });
+    const end = Sinon.stub(tenant.envSet, 'end').resolves();
+
+    expect(await tenant.dispose()).toBe(true);
+
+    expect(end.calledOnce).toBe(true);
+    // The instance must not serve new requests after disposal.
+    expect(tenant.requestStart()).toBe(false);
+  });
+
+  it('waits for in-flight requests before ending the database pool', async () => {
+    const tenant = await Tenant.create({ id: defaultTenantId, redisCache: new RedisCache() });
+    const end = Sinon.stub(tenant.envSet, 'end').resolves();
+
+    expect(tenant.requestStart()).toBe(true);
+
+    const disposed = tenant.dispose();
+    await Promise.resolve();
+
+    // The pool must stay alive while a request is still in flight.
+    expect(end.called).toBe(false);
+    // New requests must be rejected while draining.
+    expect(tenant.requestStart()).toBe(false);
+    expect(end.called).toBe(false);
+
+    tenant.requestEnd();
+    expect(await disposed).toBe(true);
+
+    expect(end.calledOnce).toBe(true);
+    expect(tenant.requestStart()).toBe(false);
+  });
+});
+
 describe('Tenant cache health check', () => {
   it('uses the qualified rotation-state update query when invalidating cache', async () => {
     const redisCache = new RedisCache();

--- a/packages/core/src/tenants/Tenant.test.ts
+++ b/packages/core/src/tenants/Tenant.test.ts
@@ -55,6 +55,7 @@ const Tenant = await pickDefault(import('./Tenant.js'));
 describe('Tenant', () => {
   afterEach(() => {
     jest.clearAllMocks();
+    jest.useRealTimers();
   });
 
   it('should call middleware factories for user tenants', async () => {
@@ -128,6 +129,25 @@ describe('Tenant request lifecycle and disposal', () => {
 
     expect(end.calledOnce).toBe(true);
     expect(tenant.requestStart()).toBe(false);
+  });
+
+  it('keeps the database pool open until the disposal drain timeout elapses', async () => {
+    const tenant = await Tenant.create({ id: defaultTenantId, redisCache: new RedisCache() });
+    const end = Sinon.stub(tenant.envSet, 'end').resolves();
+
+    expect(tenant.requestStart()).toBe(true);
+
+    jest.useFakeTimers();
+    const disposed = tenant.dispose();
+    await Promise.resolve();
+
+    jest.advanceTimersByTime(129_999);
+    expect(end.called).toBe(false);
+
+    jest.advanceTimersByTime(1);
+
+    await expect(disposed).resolves.toBe('timeout');
+    expect(end.calledOnce).toBe(true);
   });
 
   it('rejects when ending the database pool fails while draining requests', async () => {
@@ -308,8 +328,12 @@ describe('Tenant cache health check', () => {
 
   it('invalidates tenant instances when staged activation is due', async () => {
     const tenant = await Tenant.create({ id: defaultTenantId, redisCache: new RedisCache() });
+    const signingKeyRotationAt = Date.now() + 1000;
+
+    jest.useFakeTimers().setSystemTime(signingKeyRotationAt);
+
     Sinon.stub(tenant.queries.logtoConfigs, 'getSigningKeyRotationState').value(
-      jest.fn(async () => ({ signingKeyRotationAt: Date.now() - 1 }))
+      jest.fn(async () => ({ signingKeyRotationAt }))
     );
 
     expect(await tenant.checkHealth()).toBe(false);

--- a/packages/core/src/tenants/Tenant.test.ts
+++ b/packages/core/src/tenants/Tenant.test.ts
@@ -129,6 +129,20 @@ describe('Tenant request lifecycle and disposal', () => {
     expect(end.calledOnce).toBe(true);
     expect(tenant.requestStart()).toBe(false);
   });
+
+  it('rejects when ending the database pool fails while draining requests', async () => {
+    const tenant = await Tenant.create({ id: defaultTenantId, redisCache: new RedisCache() });
+    const error = new Error('failed to end database pool');
+    const end = Sinon.stub(tenant.envSet, 'end').rejects(error);
+
+    expect(tenant.requestStart()).toBe(true);
+
+    const disposed = tenant.dispose();
+    tenant.requestEnd();
+
+    await expect(disposed).rejects.toThrow(error);
+    expect(end.calledOnce).toBe(true);
+  });
 });
 
 describe('Tenant cache health check', () => {

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -322,17 +322,24 @@ export default class Tenant implements TenantContext {
       return true;
     }
 
-    return new Promise<true | 'timeout'>((resolve) => {
-      const timeout = setTimeout(async () => {
+    return new Promise<true | 'timeout'>((resolve, reject) => {
+      const endEnvSet = async (result: true | 'timeout') => {
+        try {
+          await this.envSet.end();
+          resolve(result);
+        } catch (error: unknown) {
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      };
+
+      const timeout = setTimeout(() => {
         this.#onRequestEmpty = undefined;
-        await this.envSet.end();
-        resolve('timeout');
+        void endEnvSet('timeout');
       }, 5000);
 
       this.#onRequestEmpty = async () => {
         clearTimeout(timeout);
-        await this.envSet.end();
-        resolve(true);
+        await endEnvSet(true);
       };
     });
   }

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -86,6 +86,11 @@ export default class Tenant implements TenantContext {
   readonly #createdAt = Date.now();
   #requestCount = 0;
   #onRequestEmpty?: () => Promise<void>;
+  /**
+   * Whether the database pool of this instance has been (or is about to be) ended by
+   * {@link dispose}. Once `true`, the instance must not serve new requests.
+   */
+  #disposed = false;
 
   // eslint-disable-next-line max-params
   private constructor(
@@ -269,8 +274,24 @@ export default class Tenant implements TenantContext {
         : mount(this.app);
   }
 
-  public requestStart() {
+  /**
+   * Register the start of a request so that {@link dispose} waits for it to finish before
+   * ending the database pool.
+   *
+   * This is synchronous and must be called right after acquiring the instance (see
+   * {@link TenantPool.get}) to avoid a window where the instance is disposed while a request
+   * is about to use it.
+   *
+   * @returns `true` if the slot was reserved, or `false` if the instance has already been
+   * disposed and must not be used. Callers should acquire another instance when `false`.
+   */
+  public requestStart(): boolean {
+    if (this.#disposed) {
+      return false;
+    }
+
     this.#requestCount += 1;
+    return true;
   }
 
   public requestEnd() {
@@ -291,6 +312,10 @@ export default class Tenant implements TenantContext {
    * @returns Resolves `true` for a normal disposal and `'timeout'` for a timeout.
    */
   public async dispose() {
+    // Mark as disposed *synchronously* (no `await` before this point) so a concurrent
+    // `requestStart()` cannot reserve a slot after we have decided to end the pool.
+    this.#disposed = true;
+
     if (this.#requestCount <= 0) {
       await this.envSet.end();
 

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -1,5 +1,6 @@
 import { adminTenantId, experience } from '@logto/schemas';
 import { ConsoleLog } from '@logto/shared';
+import { once } from '@silverhand/essentials';
 import type { MiddlewareType } from 'koa';
 import Koa from 'koa';
 import compose from 'koa-compose';
@@ -50,6 +51,9 @@ import {
 import { getTenantDatabaseDsn } from './utils.js';
 
 const consoleLog = new ConsoleLog('tenant');
+// Keep tenant disposal draining longer than the HTTP server timeout (120s in app/init.ts) so
+// ordinary in-flight requests can finish before the database pool is closed.
+const tenantDisposeDrainTimeout = 130_000;
 
 /** Data for creating a tenant instance. */
 type CreateTenant = {
@@ -85,7 +89,7 @@ export default class Tenant implements TenantContext {
 
   readonly #createdAt = Date.now();
   #requestCount = 0;
-  #onRequestEmpty?: () => Promise<void>;
+  #onRequestEmpty?: () => void;
   /**
    * Whether the database pool of this instance has been (or is about to be) ended by
    * {@link dispose}. Once `true`, the instance must not serve new requests.
@@ -299,13 +303,14 @@ export default class Tenant implements TenantContext {
       this.#requestCount -= 1;
 
       if (this.#requestCount === 0) {
-        void this.#onRequestEmpty?.();
+        this.#onRequestEmpty?.();
       }
     }
   }
 
   /**
-   * Try to dispose the tenant resources. If there are any pending requests, this function will wait for them to end with 5s timeout.
+   * Try to dispose the tenant resources. If there are any pending requests, this function
+   * waits up to the tenant disposal drain timeout for them to end.
    *
    * Currently this function only ends the database pool.
    *
@@ -323,23 +328,26 @@ export default class Tenant implements TenantContext {
     }
 
     return new Promise<true | 'timeout'>((resolve, reject) => {
-      const endEnvSet = async (result: true | 'timeout') => {
-        try {
-          await this.envSet.end();
-          resolve(result);
-        } catch (error: unknown) {
-          reject(error instanceof Error ? error : new Error(String(error)));
-        }
-      };
+      const endEnvSet = once((result: true | 'timeout', timeout: ReturnType<typeof setTimeout>) => {
+        this.#onRequestEmpty = undefined;
+        clearTimeout(timeout);
+
+        void (async () => {
+          try {
+            await this.envSet.end();
+            resolve(result);
+          } catch (error: unknown) {
+            reject(error instanceof Error ? error : new Error(String(error)));
+          }
+        })();
+      });
 
       const timeout = setTimeout(() => {
-        this.#onRequestEmpty = undefined;
-        void endEnvSet('timeout');
-      }, 5000);
+        endEnvSet('timeout', timeout);
+      }, tenantDisposeDrainTimeout);
 
-      this.#onRequestEmpty = async () => {
-        clearTimeout(timeout);
-        await endEnvSet(true);
+      this.#onRequestEmpty = () => {
+        endEnvSet(true, timeout);
       };
     });
   }

--- a/packages/core/src/tenants/index.ts
+++ b/packages/core/src/tenants/index.ts
@@ -19,9 +19,20 @@ const maxTenantAcquireAttempts = 10;
 class TenantPool {
   protected cache = new LRUCache<string, Promise<Tenant>>({
     max: EnvSet.values.tenantPoolSize,
-    dispose: async (entry) => {
-      const tenant = await entry;
-      void tenant.dispose();
+    dispose: (entry) => {
+      void (async () => {
+        try {
+          const tenant = await entry;
+
+          try {
+            await tenant.dispose();
+          } catch (error: unknown) {
+            consoleLog.warn('Failed to dispose tenant:', error);
+          }
+        } catch {
+          // Rejected tenant creation promises are evicted so future requests can retry.
+        }
+      })();
     },
   });
 
@@ -31,63 +42,10 @@ class TenantPool {
    * {@link Tenant.requestEnd} exactly once when the request finishes. Acquisition retries to
    * converge on a healthy instance, with a capped fallback to avoid looping forever.
    */
-  async get(tenantId: string, customDomain?: string, attempt = 0): Promise<Tenant> {
+  async get(tenantId: string, customDomain?: string): Promise<Tenant> {
     const cacheKey = `${tenantId}-${customDomain ?? 'default'}`;
-    const tenantPromise = this.cache.get(cacheKey);
 
-    if (tenantPromise && attempt < maxTenantAcquireAttempts) {
-      const tenant = await this.resolveCachedTenant(cacheKey, tenantPromise);
-
-      // Reserve a request slot *before* the async health check. If the instance has been
-      // disposed concurrently, `requestStart()` returns `false` and we retry to acquire a
-      // fresh one; otherwise the reserved slot keeps the database pool alive while this
-      // request uses it, closing the dispose-before-request race.
-      if (!tenant.requestStart()) {
-        return this.get(tenantId, customDomain, attempt + 1);
-      }
-
-      // If the current LRU cached tenant instance is still healthy, return it (slot held).
-      // Release the reserved slot if the health check itself fails before the request owns it.
-      try {
-        if (await tenant.checkHealth()) {
-          return tenant;
-        }
-      } catch (error: unknown) {
-        tenant.requestEnd();
-        throw error;
-      }
-
-      // Otherwise the instance is stale: release our slot and recreate it. Deduplicate
-      // concurrent recreations so racing requests don't dispose each other's freshly created
-      // instances — only the caller that still sees this exact stale promise replaces it,
-      // others retry and pick up the new instance.
-      tenant.requestEnd();
-
-      if (this.cache.get(cacheKey) === tenantPromise) {
-        consoleLog.info('Reload tenant:', tenantId, 'Custom domain:', customDomain);
-        this.cache.set(cacheKey, Tenant.create({ id: tenantId, redisCache, customDomain }));
-      }
-
-      return this.get(tenantId, customDomain, attempt + 1);
-    }
-
-    if (!tenantPromise) {
-      consoleLog.info('Init tenant:', tenantId, 'Custom domain:', customDomain);
-      this.cache.set(cacheKey, Tenant.create({ id: tenantId, redisCache, customDomain }));
-
-      return this.get(tenantId, customDomain, attempt + 1);
-    }
-
-    // Attempt limit reached: reserve a slot on whatever is cached, dropping a disposed instance.
-    const tenant = await this.resolveCachedTenant(cacheKey, tenantPromise);
-
-    if (!tenant.requestStart()) {
-      this.cache.delete(cacheKey);
-
-      return this.get(tenantId, customDomain, attempt + 1);
-    }
-
-    return tenant;
+    return this.getWithAttempts(cacheKey, tenantId, customDomain, 0);
   }
 
   async endAll(): Promise<void> {
@@ -95,9 +53,115 @@ class TenantPool {
       this.cache.dump().map(async ([, entry]) => {
         const tenant = await entry.value;
 
-        return tenant.envSet.end();
+        return tenant.dispose();
       })
     );
+  }
+
+  private async getWithAttempts(
+    cacheKey: string,
+    tenantId: string,
+    customDomain: string | undefined,
+    attempt: number
+  ): Promise<Tenant> {
+    if (attempt >= maxTenantAcquireAttempts) {
+      return this.getAfterAttemptLimit(cacheKey, tenantId, customDomain);
+    }
+
+    const { tenantPromise } = this.getOrCreateTenant(cacheKey, tenantId, customDomain);
+    const tenant = await this.resolveCachedTenant(cacheKey, tenantPromise);
+
+    // Reserve a request slot *before* the async health check. If the instance has been
+    // disposed concurrently, `requestStart()` returns `false` and we retry to acquire a
+    // fresh one; otherwise the reserved slot keeps the database pool alive while this
+    // request uses it, closing the dispose-before-request race.
+    if (!tenant.requestStart()) {
+      this.deleteCachedTenant(cacheKey, tenantPromise);
+
+      return this.getWithAttempts(cacheKey, tenantId, customDomain, attempt + 1);
+    }
+
+    // If the current LRU cached tenant instance is still healthy, return it (slot held).
+    // Release the reserved slot if the health check itself fails before the request owns it.
+    try {
+      if (await tenant.checkHealth()) {
+        return tenant;
+      }
+    } catch (error: unknown) {
+      tenant.requestEnd();
+      throw error;
+    }
+
+    // Otherwise the instance is stale: release our slot and recreate it. Deduplicate
+    // concurrent recreations so racing requests don't dispose each other's freshly created
+    // instances — only the caller that still sees this exact stale promise replaces it,
+    // others retry and pick up the new instance.
+    tenant.requestEnd();
+
+    if (this.cache.get(cacheKey) === tenantPromise) {
+      this.createAndCacheTenant(cacheKey, tenantId, customDomain, 'Reload');
+    }
+
+    return this.getWithAttempts(cacheKey, tenantId, customDomain, attempt + 1);
+  }
+
+  private async getAfterAttemptLimit(
+    cacheKey: string,
+    tenantId: string,
+    customDomain: string | undefined
+  ): Promise<Tenant> {
+    // Attempt limit reached: reserve a slot on whatever is cached, dropping a disposed instance
+    // with an identity check so a racing replacement is not removed accidentally.
+    const { tenantPromise } = this.getOrCreateTenant(cacheKey, tenantId, customDomain);
+    const tenant = await this.resolveCachedTenant(cacheKey, tenantPromise);
+
+    if (!tenant.requestStart()) {
+      this.deleteCachedTenant(cacheKey, tenantPromise);
+
+      return this.getAfterAttemptLimit(cacheKey, tenantId, customDomain);
+    }
+
+    consoleLog.warn(
+      'Tenant acquire retry limit reached; serving cached tenant without a health check:',
+      tenantId,
+      'Custom domain:',
+      customDomain
+    );
+
+    return tenant;
+  }
+
+  private getOrCreateTenant(
+    cacheKey: string,
+    tenantId: string,
+    customDomain?: string
+  ): { tenantPromise: Promise<Tenant> } {
+    const tenantPromise = this.cache.get(cacheKey);
+
+    if (tenantPromise) {
+      return { tenantPromise };
+    }
+
+    return this.createAndCacheTenant(cacheKey, tenantId, customDomain, 'Init');
+  }
+
+  private deleteCachedTenant(cacheKey: string, tenantPromise: Promise<Tenant>) {
+    if (this.cache.get(cacheKey) === tenantPromise) {
+      this.cache.delete(cacheKey);
+    }
+  }
+
+  private createAndCacheTenant(
+    cacheKey: string,
+    tenantId: string,
+    customDomain: string | undefined,
+    action: 'Init' | 'Reload'
+  ): { tenantPromise: Promise<Tenant> } {
+    consoleLog.info(`${action} tenant:`, tenantId, 'Custom domain:', customDomain);
+    const newTenantPromise = Tenant.create({ id: tenantId, redisCache, customDomain });
+    this.cache.set(cacheKey, newTenantPromise);
+
+    return { tenantPromise: newTenantPromise };
   }
 
   private async resolveCachedTenant(

--- a/packages/core/src/tenants/index.ts
+++ b/packages/core/src/tenants/index.ts
@@ -26,16 +26,17 @@ class TenantPool {
   });
 
   /**
-   * Resolve a healthy tenant instance and atomically reserve a request slot on it (see
+   * Resolve a tenant instance and atomically reserve a request slot on it (see
    * {@link Tenant.requestStart}). The caller owns the slot and must call
-   * {@link Tenant.requestEnd} exactly once when the request finishes.
+   * {@link Tenant.requestEnd} exactly once when the request finishes. Acquisition retries to
+   * converge on a healthy instance, with a capped fallback to avoid looping forever.
    */
   async get(tenantId: string, customDomain?: string, attempt = 0): Promise<Tenant> {
     const cacheKey = `${tenantId}-${customDomain ?? 'default'}`;
     const tenantPromise = this.cache.get(cacheKey);
 
     if (tenantPromise && attempt < maxTenantAcquireAttempts) {
-      const tenant = await tenantPromise;
+      const tenant = await this.resolveCachedTenant(cacheKey, tenantPromise);
 
       // Reserve a request slot *before* the async health check. If the instance has been
       // disposed concurrently, `requestStart()` returns `false` and we retry to acquire a
@@ -78,7 +79,7 @@ class TenantPool {
     }
 
     // Attempt limit reached: reserve a slot on whatever is cached, dropping a disposed instance.
-    const tenant = await tenantPromise;
+    const tenant = await this.resolveCachedTenant(cacheKey, tenantPromise);
 
     if (!tenant.requestStart()) {
       this.cache.delete(cacheKey);
@@ -97,6 +98,21 @@ class TenantPool {
         return tenant.envSet.end();
       })
     );
+  }
+
+  private async resolveCachedTenant(
+    cacheKey: string,
+    tenantPromise: Promise<Tenant>
+  ): Promise<Tenant> {
+    try {
+      return await tenantPromise;
+    } catch (error: unknown) {
+      if (this.cache.get(cacheKey) === tenantPromise) {
+        this.cache.delete(cacheKey);
+      }
+
+      throw error;
+    }
   }
 }
 

--- a/packages/core/src/tenants/index.ts
+++ b/packages/core/src/tenants/index.ts
@@ -9,6 +9,13 @@ import Tenant from './Tenant.js';
 
 const consoleLog = new ConsoleLog(chalk.magenta('tenant'));
 
+/**
+ * Safety cap on how many times {@link TenantPool.get} retries to converge on a healthy tenant
+ * instance. Acquisition normally settles within one or two attempts; the cap only guards against
+ * an unbounded loop under continuous cache invalidation.
+ */
+const maxTenantAcquireAttempts = 10;
+
 class TenantPool {
   protected cache = new LRUCache<string, Promise<Tenant>>({
     max: EnvSet.values.tenantPoolSize,
@@ -18,24 +25,68 @@ class TenantPool {
     },
   });
 
-  async get(tenantId: string, customDomain?: string): Promise<Tenant> {
+  /**
+   * Resolve a healthy tenant instance and atomically reserve a request slot on it (see
+   * {@link Tenant.requestStart}). The caller owns the slot and must call
+   * {@link Tenant.requestEnd} exactly once when the request finishes.
+   */
+  async get(tenantId: string, customDomain?: string, attempt = 0): Promise<Tenant> {
     const cacheKey = `${tenantId}-${customDomain ?? 'default'}`;
     const tenantPromise = this.cache.get(cacheKey);
 
-    if (tenantPromise) {
+    if (tenantPromise && attempt < maxTenantAcquireAttempts) {
       const tenant = await tenantPromise;
-      // If the current LRU cached tenant instance is still healthy, return it
-      if (await tenant.checkHealth()) {
-        return tenantPromise;
+
+      // Reserve a request slot *before* the async health check. If the instance has been
+      // disposed concurrently, `requestStart()` returns `false` and we retry to acquire a
+      // fresh one; otherwise the reserved slot keeps the database pool alive while this
+      // request uses it, closing the dispose-before-request race.
+      if (!tenant.requestStart()) {
+        return this.get(tenantId, customDomain, attempt + 1);
       }
-      // Otherwise, create a new tenant instance and store in LRU cache, using the code below.
+
+      // If the current LRU cached tenant instance is still healthy, return it (slot held).
+      // Release the reserved slot if the health check itself fails before the request owns it.
+      try {
+        if (await tenant.checkHealth()) {
+          return tenant;
+        }
+      } catch (error: unknown) {
+        tenant.requestEnd();
+        throw error;
+      }
+
+      // Otherwise the instance is stale: release our slot and recreate it. Deduplicate
+      // concurrent recreations so racing requests don't dispose each other's freshly created
+      // instances — only the caller that still sees this exact stale promise replaces it,
+      // others retry and pick up the new instance.
+      tenant.requestEnd();
+
+      if (this.cache.get(cacheKey) === tenantPromise) {
+        consoleLog.info('Reload tenant:', tenantId, 'Custom domain:', customDomain);
+        this.cache.set(cacheKey, Tenant.create({ id: tenantId, redisCache, customDomain }));
+      }
+
+      return this.get(tenantId, customDomain, attempt + 1);
     }
 
-    consoleLog.info('Init tenant:', tenantId, 'Custom domain:', customDomain);
-    const newTenantPromise = Tenant.create({ id: tenantId, redisCache, customDomain });
-    this.cache.set(cacheKey, newTenantPromise);
+    if (!tenantPromise) {
+      consoleLog.info('Init tenant:', tenantId, 'Custom domain:', customDomain);
+      this.cache.set(cacheKey, Tenant.create({ id: tenantId, redisCache, customDomain }));
 
-    return newTenantPromise;
+      return this.get(tenantId, customDomain, attempt + 1);
+    }
+
+    // Attempt limit reached: reserve a slot on whatever is cached, dropping a disposed instance.
+    const tenant = await tenantPromise;
+
+    if (!tenant.requestStart()) {
+      this.cache.delete(cacheKey);
+
+      return this.get(tenantId, customDomain, attempt + 1);
+    }
+
+    return tenant;
   }
 
   async endAll(): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes an intermittent `500 Internal Server Error` caused by a race condition in `TenantPool.get()` / `Tenant.dispose()`. When `tenant.invalidateCache()` marks a tenant as unhealthy (e.g. after OIDC config changes or signing key rotation), concurrent requests that arrive during the reload window each independently recreate the tenant instance, causing LRU `dispose` to end intermediate instances' database pools while in-flight requests still reference them:

```
UnexpectedStateError: Connection pool shutdown has been already initiated.
    at createConnection → hasUser → POST /api/users 500
```

The fix has three parts working together:

1. **Deduplicate concurrent recreations** — after detecting an unhealthy tenant, `get()` only replaces the cache entry if it still points to the same stale promise; concurrent callers retry and pick up the single new instance instead of each creating (and disposing) their own.

2. **Reserve request slot before health check** — `get()` now calls `tenant.requestStart()` before the async `checkHealth()`, so `dispose()`'s graceful drain always accounts for the request. The caller (`app/init.ts`) releases the slot in a `finally` block.

3. **Atomically reject requests on disposed instances** — `Tenant` gains a `#disposed` flag set synchronously before `envSet.end()`. `requestStart()` returns `false` when disposed, causing `get()` to retry with a fresh instance. This closes the TOCTOU gap where a dispose could end the pool between `get()` resolving and the old `requestStart()` call.

### Testing

Integration tests

Link to Devin session: https://app.devin.ai/sessions/fba09b5f4620401a9c66f95d303924c9
Requested by: @wangsijie