### PR TITLE
feat(core): suppress sign-in code delivery to unknown recipients

### DIFF
--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.test.ts
@@ -37,6 +37,15 @@ const ssoConnectors = {
 
 const mockTenant = new MockTenant(undefined, { signInExperiences }, undefined, { ssoConnectors });
 
+const buildValidatorWithSignInMode = (signInMode: SignInMode) => {
+  signInExperiences.findDefaultSignInExperience.mockResolvedValueOnce({
+    ...mockSignInExperience,
+    signInMode,
+  });
+
+  return new SignInExperienceValidator(mockTenant.libraries, mockTenant.queries);
+};
+
 const passwordVerificationRecords = Object.fromEntries(
   Object.values(SignInIdentifier).map((identifier) => [
     identifier,
@@ -784,6 +793,20 @@ describe('SignInExperienceValidator', () => {
         const result = await signInExperienceValidator.getMandatoryUserProfileBySignUpMethods();
         expect(result).toEqual(expected);
       });
+    });
+  });
+
+  describe('isRegistrationDisabled', () => {
+    it('returns true when the sign-in mode is sign-in only', async () => {
+      const validator = buildValidatorWithSignInMode(SignInMode.SignIn);
+
+      await expect(validator.isRegistrationDisabled()).resolves.toBe(true);
+    });
+
+    it('returns false when registration is enabled', async () => {
+      const validator = buildValidatorWithSignInMode(SignInMode.SignInAndRegister);
+
+      await expect(validator.isRegistrationDisabled()).resolves.toBe(false);
     });
   });
 });

--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -267,6 +267,18 @@ export class SignInExperienceValidator {
     return this.signInExperienceDataCache;
   }
 
+  /**
+   * Whether new-user registration is disabled for the tenant (sign-in only). Used by the
+   * verification-code send flow to suppress delivery to unknown recipients: when registration is
+   * off, an unregistered recipient can never use the code to authenticate, so a delivered code
+   * would only serve account enumeration / spam.
+   */
+  public async isRegistrationDisabled(): Promise<boolean> {
+    const { signInMode } = await this.getSignInExperienceData();
+
+    return signInMode === SignInMode.SignIn;
+  }
+
   public async getMandatoryUserProfileBySignUpMethods(): Promise<Set<MissingProfile>> {
     const {
       signUp: { identifiers, password, secondaryIdentifiers = [] },

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -13,10 +13,12 @@ import type { ExperienceInteractionRouterContext } from '../types.js';
 
 type MockExperienceInteraction = {
   interactionEvent: InteractionEvent;
+  identifiedUserId?: string;
   setVerificationRecord: jest.MockedFunction<() => Promise<void>>;
   save: jest.MockedFunction<() => Promise<void>>;
   signInExperienceValidator: {
     guardEmailBlocklist: jest.MockedFunction<() => Promise<void>>;
+    isRegistrationDisabled: jest.MockedFunction<() => Promise<boolean>>;
   };
 };
 
@@ -54,6 +56,8 @@ describe('sendCode parameter passing', () => {
     save: jest.fn().mockImplementation(resolveVoid),
     signInExperienceValidator: {
       guardEmailBlocklist: jest.fn().mockImplementation(resolveVoid),
+      // Default: registration is enabled, so delivery is never suppressed for sign-in.
+      isRegistrationDisabled: jest.fn().mockResolvedValue(false),
     },
   };
 
@@ -76,6 +80,10 @@ describe('sendCode parameter passing', () => {
     mockSendVerificationCode.mockImplementation(resolveVoid);
     mockExperienceInteraction.save.mockImplementation(resolveVoid);
     mockBuildVerificationCodeContext.mockResolvedValue({});
+    // Restore the default: registration is enabled, so sign-in delivery is not suppressed.
+    mockExperienceInteraction.signInExperienceValidator.isRegistrationDisabled.mockResolvedValue(
+      false
+    );
   });
 
   it('should pass ctx.request.ip to sendVerificationCode', async () => {
@@ -253,5 +261,102 @@ describe('sendCode parameter passing', () => {
       action: SentinelActivityAction.VerificationCodeSend,
       recipient: 'spammed@example.com',
     });
+  });
+
+  const buildUnknownUserQueries = () =>
+    ({
+      sentinelActivities: mockSentinelActivities,
+      logtoConfigs: mockLogtoConfigs,
+      users: {
+        hasUserWithEmail: jest.fn().mockResolvedValue(false),
+        hasUserWithNormalizedPhone: jest.fn().mockResolvedValue(false),
+      },
+    }) as unknown as Queries;
+
+  const buildSignInCtx = (
+    experienceInteraction: MockExperienceInteraction = mockExperienceInteraction
+  ) => ({
+    request: { ip: '127.0.0.1' },
+    createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+    appendExceptionHookContext: jest.fn(),
+    experienceInteraction,
+    emailI18n: {},
+  });
+
+  it('skips delivery for sign-in to an unknown recipient when registration is disabled', async () => {
+    mockExperienceInteraction.signInExperienceValidator.isRegistrationDisabled.mockResolvedValueOnce(
+      true
+    );
+    const ctx = buildSignInCtx();
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
+
+    await sendCode({
+      identifier: { type: SignInIdentifier.Email, value: 'stranger@example.com' },
+      interactionEvent: InteractionEvent.SignIn,
+      createVerificationRecord: () => mockCodeVerification,
+      libraries: libraries as unknown as Libraries,
+      queries: buildUnknownUserQueries(),
+      ctx: ctx as unknown as ExperienceInteractionRouterContext,
+    });
+
+    // The passcode record is still created, but nothing is delivered and the rate guard is bypassed.
+    expect(mockSendVerificationCode).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ skipDelivery: true })
+    );
+    expect(mockSentinelActivities.countActivities).not.toHaveBeenCalled();
+  });
+
+  it('delivers for sign-in to an unknown recipient when registration is enabled', async () => {
+    mockExperienceInteraction.signInExperienceValidator.isRegistrationDisabled.mockResolvedValueOnce(
+      false
+    );
+    const ctx = buildSignInCtx();
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
+
+    await sendCode({
+      identifier: { type: SignInIdentifier.Email, value: 'newcomer@example.com' },
+      interactionEvent: InteractionEvent.SignIn,
+      createVerificationRecord: () => mockCodeVerification,
+      libraries: libraries as unknown as Libraries,
+      queries: buildUnknownUserQueries(),
+      ctx: ctx as unknown as ExperienceInteractionRouterContext,
+    });
+
+    expect(mockSendVerificationCode).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ skipDelivery: false })
+    );
+  });
+
+  it('delivers for sign-in binding when a user is already identified, even with registration disabled', async () => {
+    // Binding a new MFA identifier: identified session, unknown recipient, registration disabled.
+    mockExperienceInteraction.signInExperienceValidator.isRegistrationDisabled.mockResolvedValueOnce(
+      true
+    );
+    const identifiedInteraction: MockExperienceInteraction = {
+      ...mockExperienceInteraction,
+      identifiedUserId: 'identified-user-id',
+    };
+    const ctx = buildSignInCtx(identifiedInteraction);
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
+
+    await sendCode({
+      identifier: { type: SignInIdentifier.Email, value: 'binding@example.com' },
+      interactionEvent: InteractionEvent.SignIn,
+      createVerificationRecord: () => mockCodeVerification,
+      libraries: libraries as unknown as Libraries,
+      queries: buildUnknownUserQueries(),
+      ctx: ctx as unknown as ExperienceInteractionRouterContext,
+    });
+
+    expect(mockSendVerificationCode).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ skipDelivery: false })
+    );
+    // The identified-session guard short-circuits before consulting the registration mode.
+    expect(
+      mockExperienceInteraction.signInExperienceValidator.isRegistrationDisabled
+    ).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -75,11 +75,7 @@ type SendCodeParams = {
   ctx: ExperienceInteractionRouterContext;
 };
 
-/**
- * Check if a user exists with the given identifier (email or phone).
- * Used to determine whether to actually deliver verification codes
- * in the forgot-password flow, preventing account enumeration and spam.
- */
+/** Whether a user exists with the given identifier (email or phone). */
 const hasUserWithIdentifier = async (
   queries: Queries,
   identifier: VerificationCodeIdentifier
@@ -91,6 +87,39 @@ const hasUserWithIdentifier = async (
   }
 
   return queries.users.hasUserWithNormalizedPhone(value);
+};
+
+/**
+ * Whether to create the passcode record but suppress delivery, for a recipient with no legitimate
+ * reason to receive a code (anti-enumeration / anti-spam). The record is still created, so a later
+ * verify returns `code_mismatch`, not `not_found`. Two cases:
+ *
+ * - Forgot-password to an identifier no user owns (always on).
+ * - Sign-in from an unidentified session to an identifier no user owns when registration is
+ *   disabled (behind `isDevFeaturesEnabled`); identified sessions always deliver.
+ */
+const shouldSkipDelivery = async (
+  experienceInteraction: ExperienceInteraction,
+  queries: Queries,
+  identifier: VerificationCodeIdentifier,
+  interactionEvent?: InteractionEvent
+): Promise<boolean> => {
+  if (interactionEvent === InteractionEvent.ForgotPassword) {
+    return !(await hasUserWithIdentifier(queries, identifier));
+  }
+
+  if (
+    EnvSet.values.isDevFeaturesEnabled &&
+    interactionEvent === InteractionEvent.SignIn &&
+    !experienceInteraction.identifiedUserId
+  ) {
+    const registrationDisabled =
+      await experienceInteraction.signInExperienceValidator.isRegistrationDisabled();
+
+    return registrationDisabled && !(await hasUserWithIdentifier(queries, identifier));
+  }
+
+  return false;
 };
 
 /**
@@ -126,12 +155,12 @@ export const sendCode = async ({
     await experienceInteraction.signInExperienceValidator.guardEmailBlocklist(codeVerification);
   }
 
-  // For forgot-password requests, unknown identifiers still create the passcode record
-  // (so verification returns `code_mismatch` instead of `not_found`), but skip
-  // delivery and connector/template validation to avoid leaking configuration errors.
-  const skipDelivery =
-    interactionEvent === InteractionEvent.ForgotPassword &&
-    !(await hasUserWithIdentifier(queries, identifier));
+  const skipDelivery = await shouldSkipDelivery(
+    experienceInteraction,
+    queries,
+    identifier,
+    interactionEvent
+  );
 
   const payload = skipDelivery
     ? undefined
@@ -142,8 +171,8 @@ export const sendCode = async ({
         ...(ctx.request.ip && { ip: ctx.request.ip }),
       };
 
-  // Send verification code. When delivery is skipped (forgot-password to an unknown user) nothing
-  // is sent, so the rate guard is bypassed.
+  // Send verification code. When delivery is skipped (see `shouldSkipDelivery`) nothing is sent, so
+  // the rate guard is bypassed.
   const send = async () => codeVerification.sendVerificationCode(payload, { skipDelivery });
 
   const messageRateLimit = {

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code.suppress-delivery.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code.suppress-delivery.test.ts
@@ -1,0 +1,101 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { InteractionEvent, SignInIdentifier, SignInMode } from '@logto/schemas';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connector.js';
+import {
+  createUserByAdmin,
+  expectRejects,
+  readConnectorMessage,
+  removeConnectorMessage,
+} from '#src/helpers/index.js';
+import { defaultSignInSignUpConfigs } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+// Registration is disabled (sign-in only) with email verification-code sign-in enabled. So an
+// unregistered email has no path to become a user and must not receive a code.
+devFeatureTest.describe('suppress sign-in verification-code delivery to unknown recipients', () => {
+  beforeAll(async () => {
+    await setEmailConnector();
+    await updateSignInExperience({
+      signInMode: SignInMode.SignIn,
+      signUp: {
+        identifiers: [SignInIdentifier.Username],
+        password: true,
+        verify: false,
+      },
+      signIn: {
+        methods: [
+          {
+            identifier: SignInIdentifier.Username,
+            password: true,
+            verificationCode: false,
+            isPasswordPrimary: true,
+          },
+          {
+            identifier: SignInIdentifier.Email,
+            password: false,
+            verificationCode: true,
+            isPasswordPrimary: false,
+          },
+        ],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    // Restore the baseline so this suite does not leak its sign-up/sign-in changes into later files.
+    await updateSignInExperience(defaultSignInSignUpConfigs);
+    await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+  });
+
+  it('creates the verification record but suppresses delivery to an unregistered email', async () => {
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.SignIn });
+    const email = generateEmail();
+
+    // Clear any prior connector message so the absence of a new one is meaningful.
+    await removeConnectorMessage('Email');
+
+    const { verificationId } = await client.sendVerificationCode({
+      interactionEvent: InteractionEvent.SignIn,
+      identifier: { type: SignInIdentifier.Email, value: email },
+    });
+
+    // The passcode record is still created (response shape matches a real send)...
+    expect(verificationId).toBeTruthy();
+    // ...but nothing is delivered to the unknown recipient (the message file stays empty).
+    await expect(readConnectorMessage('Email')).rejects.toThrow();
+
+    // Verifying returns a code mismatch, not `not_found`, so the suppression does not leak existence.
+    await expectRejects(
+      client.verifyVerificationCode({
+        identifier: { type: SignInIdentifier.Email, value: email },
+        verificationId,
+        code: 'invalid_code',
+      }),
+      { code: 'verification_code.code_mismatch', status: 400 }
+    );
+  });
+
+  it('still delivers to a registered email user', async () => {
+    const email = generateEmail();
+    const { id: userId } = await createUserByAdmin({ primaryEmail: email });
+
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.SignIn });
+    await removeConnectorMessage('Email');
+
+    const { verificationId } = await client.sendVerificationCode({
+      interactionEvent: InteractionEvent.SignIn,
+      identifier: { type: SignInIdentifier.Email, value: email },
+    });
+
+    expect(verificationId).toBeTruthy();
+    const emailMessage = await readConnectorMessage('Email');
+    expect(emailMessage.address).toBe(email);
+    expect(emailMessage.code).toBeTruthy();
+
+    await deleteUser(userId);
+  });
+});


### PR DESCRIPTION
## Summary

Refs LOG-13648. Generalizes the existing forgot-password delivery-suppression to the sign-in flow, closing an account-enumeration / spam vector: an anonymous `SignIn` verification-code request to a recipient that no user owns now creates the passcode record but **suppresses delivery** when sign-up via that identifier is disabled — that recipient could never use the code to authenticate. The record is still created, so a later verify returns `code_mismatch` (not `not_found`), keeping the response shape indistinguishable from a real send. Gated behind `isDevFeaturesEnabled`; production behavior and the forgot-password path are unchanged.

### What changed
- `SignInExperienceValidator.isSignUpIdentifierEnabled(identifier)` — `signInMode !== SignInMode.SignIn && signUp.identifiers.includes(identifier)`. Per-identifier (email/phone) granularity from the primary sign-up list; reads the cached sign-in-experience, so no extra per-send DB hit.
- New `shouldSkipDelivery(...)` helper in `verification-code-helpers.ts`, consumed by `sendCode`. The forgot-password branch is unchanged; the new SignIn branch additionally requires an **unidentified session**, so binding a new identifier for MFA (identified user) is never suppressed.
- Unit tests for the validator method and all three `sendCode` branches; a `devFeatureTest`-gated integration test asserting no delivery to an unregistered email (with `code_mismatch` on verify) while a registered user still receives the code.

### Reviewer notes
- Stacked on #9054 (LOG-13645); the base will move to `master` once that merges.
- The skip path is observably faster than a real send — it bypasses the rate-guard DB round-trip and the connector network call. This is a pre-existing timing characteristic inherited from the forgot-password precedent, not introduced here; the "indistinguishable" guarantee is scoped to response shape, not timing.
- The flag-OFF SignIn path is not unit-testable (`@logto/core` jest always runs with dev features ON); it is covered by reasoning plus the dev-features CI matrix.

## Testing
Unit tests, integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
