### PR TITLE
feat(console): redirect console profile entry and legacy profile URLs to account center

### DIFF
--- a/packages/console/src/cloud/AppRoutes.tsx
+++ b/packages/console/src/cloud/AppRoutes.tsx
@@ -2,7 +2,9 @@ import { Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import DelayedSuspenseFallback from '@/components/DelayedSuspenseFallback';
+import RedirectToAccountCenter from '@/components/RedirectToAccountCenter';
 import { EnterpriseSubscriptionTabs } from '@/consts';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import ProtectedRoutes from '@/containers/ProtectedRoutes';
 import { GlobalAnonymousRoute, GlobalRoute } from '@/contexts/TenantsProvider';
 import { OnboardingApp } from '@/onboarding';
@@ -42,7 +44,10 @@ function AppRoutes() {
             element={<AcceptInvitation />}
           />
           <Route element={<ProtectedRoutes />}>
-            <Route path={GlobalRoute.Profile + '/*'} element={<Profile />} />
+            <Route
+              path={GlobalRoute.Profile + '/*'}
+              element={isDevFeaturesEnabled ? <RedirectToAccountCenter /> : <Profile />}
+            />
             <Route path={GlobalRoute.HandleSocial} element={<HandleSocialCallback />} />
             <Route
               path={GlobalRoute.CheckoutSuccessCallback}

--- a/packages/console/src/components/RedirectToAccountCenter/index.tsx
+++ b/packages/console/src/components/RedirectToAccountCenter/index.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+import { adminTenantEndpoint } from '@/consts';
+import { isCloud } from '@/consts/env';
+import useTenantPathname from '@/hooks/use-tenant-pathname';
+
+/**
+ * Redirects the current window to the Account Center security page with a `redirect` query
+ * parameter pointing back to the Console origin (or the tenant-scoped Console path for OSS).
+ */
+function RedirectToAccountCenter() {
+  const { getUrl } = useTenantPathname();
+
+  useEffect(() => {
+    const redirectUrl = isCloud ? window.location.origin : getUrl('/').href;
+    const accountUrl = new URL('/account/security', adminTenantEndpoint.href);
+    accountUrl.searchParams.set('redirect', redirectUrl);
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    window.location.href = accountUrl.toString();
+  }, [getUrl]);
+
+  return null;
+}
+
+export default RedirectToAccountCenter;

--- a/packages/console/src/components/Topbar/UserInfo/index.tsx
+++ b/packages/console/src/components/Topbar/UserInfo/index.tsx
@@ -11,7 +11,8 @@ import Profile from '@/assets/icons/profile.svg?react';
 import SignOut from '@/assets/icons/sign-out.svg?react';
 import UserAvatar from '@/components/UserAvatar';
 import UserInfoCard from '@/components/UserInfoCard';
-import { isCloud } from '@/consts/env';
+import { adminTenantEndpoint } from '@/consts';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import Divider from '@/ds-components/Divider';
 import Dropdown, { DropdownItem } from '@/ds-components/Dropdown';
 import FlipOnRtl from '@/ds-components/FlipOnRtl';
@@ -80,6 +81,14 @@ function UserInfo() {
           className={classNames(styles.dropdownItem, isLoading && styles.loading)}
           icon={<Profile className={styles.icon} />}
           onClick={() => {
+            if (isDevFeaturesEnabled) {
+              const redirectUrl = isCloud ? window.location.origin : getUrl('/').href;
+              const accountUrl = new URL('/account/security', adminTenantEndpoint.href);
+              accountUrl.searchParams.set('redirect', redirectUrl);
+              window.open(accountUrl.toString(), '_blank');
+              return;
+            }
+
             // In OSS version, there will be a `/console` context path in the URL.
             const profileRouteWithConsoleContext = getUrl('/profile');
 

--- a/packages/console/src/containers/ConsoleRoutes/index.tsx
+++ b/packages/console/src/containers/ConsoleRoutes/index.tsx
@@ -5,6 +5,7 @@ import { safeLazy } from 'react-safe-lazy';
 import { SWRConfig } from 'swr';
 
 import AppLoading from '@/components/AppLoading';
+import RedirectToAccountCenter from '@/components/RedirectToAccountCenter';
 import { isCloud, isDevFeaturesEnabled, isProduction } from '@/consts/env';
 import AppBoundary from '@/containers/AppBoundary';
 import AppContent, { RedirectToFirstItem } from '@/containers/AppContent';
@@ -53,7 +54,10 @@ export function ConsoleRoutes() {
             <Route path="__internal__/import-error" element={<__Internal__ImportError />} />
           )}
           <Route element={<ProtectedRoutes />}>
-            <Route path={dropLeadingSlash(GlobalRoute.Profile) + '/*'} element={<Profile />} />
+            <Route
+              path={dropLeadingSlash(GlobalRoute.Profile) + '/*'}
+              element={isDevFeaturesEnabled ? <RedirectToAccountCenter /> : <Profile />}
+            />
             <Route element={<TenantAccess />}>
               {!isCloud && isProduction && isDevFeaturesEnabled && (
                 <Route path="onboarding" element={<OssOnboarding />} />


### PR DESCRIPTION
## Summary

Redirect Console Profile entry and legacy `/profile` URLs to the Account Center security page.

- **Topbar "Profile" menu item** (`UserInfo`): opens `{adminTenantEndpoint}/account/security?redirect={consoleOrigin}` in a new tab instead of `/profile`.
- **Legacy URL redirects**: both Cloud (`/profile/*` in `AppRoutes`) and OSS (`/:tenantId/profile/*` in `ConsoleRoutes`) now render a `RedirectToAccountCenter` component that sets `window.location.href` to the Account Center with a `redirect` param back to the Console origin.
- OSS preserves the `/console` tenant path context via `getUrl('/').href`.

### Testing

Tested locally

Link to Devin session: https://app.devin.ai/sessions/b364af1b012e455196d56c7451a45eef
Requested by: @wangsijie