### PR TITLE
fix(core): handle custom UI asset upload timeout

### DIFF
--- a/.changeset/moody-wasps-shout.md
+++ b/.changeset/moody-wasps-shout.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+fix custom UI asset upload timeout caused by Azure blob existence checks

--- a/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.test.ts
@@ -128,6 +128,23 @@ describe('POST /sign-in-exp/default/custom-ui-assets', () => {
     const response = await uploadCustomUiAssets(pathToZip);
     expect(response.status).toBe(500);
     expect(response.text).toBe('Failed to upload file to the storage provider.');
-    expect(mockedIsFileExisted).toHaveBeenCalledTimes(10);
+    expect(mockedIsFileExisted).toHaveBeenCalledTimes(12);
+  });
+
+  it('should succeed if the upload zip is removed on the final retry', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let assetsZipChecks = 0;
+    mockedIsFileExisted.mockImplementation(async (filename) => {
+      if (filename.endsWith('assets.zip')) {
+        // eslint-disable-next-line @silverhand/fp/no-mutation
+        assetsZipChecks += 1;
+        return assetsZipChecks < 6;
+      }
+
+      return false;
+    });
+    const response = await uploadCustomUiAssets(pathToZip);
+    expect(response.status).toBe(200);
+    expect(mockedIsFileExisted).toHaveBeenCalledTimes(12);
   });
 });

--- a/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.ts
+++ b/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.ts
@@ -19,38 +19,6 @@ import { type ManagementApiRouter, type RouterInitArgs } from '../../types.js';
 
 const maxRetryCount = 5;
 
-const getBlobEndpointHost = (connectionString: string) => {
-  const blobEndpoint = /(?:^|;)BlobEndpoint=([^;]+)/u.exec(connectionString)?.[1];
-
-  if (blobEndpoint) {
-    try {
-      return new URL(blobEndpoint).host;
-    } catch {
-      return 'invalid-blob-endpoint';
-    }
-  }
-
-  return /(?:^|;)AccountName=([^;]+)/u.exec(connectionString)?.[1];
-};
-
-const getErrorProperty = (error: unknown, property: string) => {
-  if (typeof error !== 'object' || error === null || !(property in error)) {
-    return;
-  }
-
-  const value: unknown = Reflect.get(error, property);
-
-  return typeof value === 'string' || typeof value === 'number' ? String(value) : undefined;
-};
-
-const getStorageErrorDiagnostics = (error: unknown) => ({
-  name: error instanceof Error ? error.name : undefined,
-  message: error instanceof Error ? error.message : String(error),
-  code: getErrorProperty(error, 'code'),
-  errno: getErrorProperty(error, 'errno'),
-  type: getErrorProperty(error, 'type'),
-});
-
 export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
   ...[
     router,
@@ -89,7 +57,6 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
         'storage.not_configured'
       );
       const { connectionString, container } = experienceZipsProviderConfig;
-      const blobEndpointHost = getBlobEndpointHost(connectionString);
 
       const { uploadFile, downloadFile, isFileExisted } = buildAzureStorage(
         connectionString,
@@ -99,7 +66,6 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
       const customUiAssetId = generateStandardId(8);
       const objectKey = `${tenantId}/${customUiAssetId}/assets.zip`;
       const errorLogObjectKey = `${tenantId}/${customUiAssetId}/error.log`;
-      const consoleLog = getConsoleLogFromContext(ctx);
 
       try {
         // Upload the zip file to `experience-zips` container, in which a blob trigger is configured,
@@ -109,94 +75,21 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
         await uploadFile(await readFile(file.filepath), objectKey, {
           contentType: file.mimetype,
         });
-        consoleLog.info('[custom-ui-assets] uploaded zip for unzip polling', {
-          tenantId,
-          customUiAssetId,
-          container,
-          blobEndpointHost,
-          objectKey,
-          errorLogObjectKey,
-        });
 
         const hasUnzipCompleted = async (retryTimes: number) => {
-          const startedAt = Date.now();
-          const logContext = {
-            retryTimes,
-            maxRetryCount,
-            tenantId,
-            customUiAssetId,
-            container,
-            blobEndpointHost,
-          };
-          const checkFileExisted = async (objectKeyToCheck: string, target: 'zip' | 'errorLog') => {
-            const checkStartedAt = Date.now();
-            consoleLog.info('[custom-ui-assets] unzip polling exists check started', {
-              ...logContext,
-              target,
-              objectKey: objectKeyToCheck,
-            });
-
-            try {
-              const exists = await isFileExisted(objectKeyToCheck);
-              consoleLog.info('[custom-ui-assets] unzip polling exists check succeeded', {
-                ...logContext,
-                target,
-                objectKey: objectKeyToCheck,
-                exists,
-                durationMs: Date.now() - checkStartedAt,
-              });
-              return exists;
-            } catch (error: unknown) {
-              consoleLog.error('[custom-ui-assets] unzip polling exists check failed', {
-                ...logContext,
-                target,
-                objectKey: objectKeyToCheck,
-                durationMs: Date.now() - checkStartedAt,
-                error: getStorageErrorDiagnostics(error),
-              });
-              throw error;
-            }
-          };
           const [hasZip, hasError] = await Promise.all([
-            checkFileExisted(objectKey, 'zip'),
-            checkFileExisted(errorLogObjectKey, 'errorLog'),
+            isFileExisted(objectKey),
+            isFileExisted(errorLogObjectKey),
           ]);
-          consoleLog.info('[custom-ui-assets] unzip polling status', {
-            ...logContext,
-            objectKey,
-            errorLogObjectKey,
-            hasZip,
-            hasError,
-            durationMs: Date.now() - startedAt,
-          });
           if (hasError) {
             const errorLogBlob = await downloadFile(errorLogObjectKey);
             const errorLog = await streamToString(errorLogBlob.readableStreamBody);
             throw new AbortError(errorLog || 'Unzipping failed.');
           }
           if (!hasZip) {
-            consoleLog.info('[custom-ui-assets] unzip polling completed', {
-              retryTimes,
-              maxRetryCount,
-              tenantId,
-              customUiAssetId,
-              container,
-              blobEndpointHost,
-              objectKey,
-            });
             return;
           }
           if (retryTimes > maxRetryCount) {
-            consoleLog.warn('[custom-ui-assets] unzip polling timeout', {
-              retryTimes,
-              maxRetryCount,
-              tenantId,
-              customUiAssetId,
-              container,
-              blobEndpointHost,
-              objectKey,
-              errorLogObjectKey,
-            });
             throw new AbortError('Unzip timeout. Max retry count reached.');
           }
           throw new Error('Unzip in progress...');
@@ -206,7 +99,7 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
           retries: maxRetryCount,
         });
       } catch (error: unknown) {
-        consoleLog.error(error);
+        getConsoleLogFromContext(ctx).error(error);
         throw new RequestError(
           {
             code: 'storage.upload_error',

--- a/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.ts
+++ b/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.ts
@@ -19,6 +19,20 @@ import { type ManagementApiRouter, type RouterInitArgs } from '../../types.js';
 
 const maxRetryCount = 5;
 
+const getBlobEndpointHost = (connectionString: string) => {
+  const blobEndpoint = /(?:^|;)BlobEndpoint=([^;]+)/u.exec(connectionString)?.[1];
+
+  if (blobEndpoint) {
+    try {
+      return new URL(blobEndpoint).host;
+    } catch {
+      return 'invalid-blob-endpoint';
+    }
+  }
+
+  return /(?:^|;)AccountName=([^;]+)/u.exec(connectionString)?.[1];
+};
+
 export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
   ...[
     router,
@@ -57,6 +71,7 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
         'storage.not_configured'
       );
       const { connectionString, container } = experienceZipsProviderConfig;
+      const blobEndpointHost = getBlobEndpointHost(connectionString);
 
       const { uploadFile, downloadFile, isFileExisted } = buildAzureStorage(
         connectionString,
@@ -66,6 +81,7 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
       const customUiAssetId = generateStandardId(8);
       const objectKey = `${tenantId}/${customUiAssetId}/assets.zip`;
       const errorLogObjectKey = `${tenantId}/${customUiAssetId}/error.log`;
+      const consoleLog = getConsoleLogFromContext(ctx);
 
       try {
         // Upload the zip file to `experience-zips` container, in which a blob trigger is configured,
@@ -75,21 +91,62 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
         await uploadFile(await readFile(file.filepath), objectKey, {
           contentType: file.mimetype,
         });
+        consoleLog.info('[custom-ui-assets] uploaded zip for unzip polling', {
+          tenantId,
+          customUiAssetId,
+          container,
+          blobEndpointHost,
+          objectKey,
+          errorLogObjectKey,
+        });
 
         const hasUnzipCompleted = async (retryTimes: number) => {
+          const startedAt = Date.now();
           const [hasZip, hasError] = await Promise.all([
             isFileExisted(objectKey),
             isFileExisted(errorLogObjectKey),
           ]);
+          consoleLog.info('[custom-ui-assets] unzip polling status', {
+            retryTimes,
+            maxRetryCount,
+            tenantId,
+            customUiAssetId,
+            container,
+            blobEndpointHost,
+            objectKey,
+            errorLogObjectKey,
+            hasZip,
+            hasError,
+            durationMs: Date.now() - startedAt,
+          });
           if (hasError) {
             const errorLogBlob = await downloadFile(errorLogObjectKey);
             const errorLog = await streamToString(errorLogBlob.readableStreamBody);
             throw new AbortError(errorLog || 'Unzipping failed.');
           }
           if (!hasZip) {
+            consoleLog.info('[custom-ui-assets] unzip polling completed', {
+              retryTimes,
+              maxRetryCount,
+              tenantId,
+              customUiAssetId,
+              container,
+              blobEndpointHost,
+              objectKey,
+            });
             return;
           }
           if (retryTimes > maxRetryCount) {
+            consoleLog.warn('[custom-ui-assets] unzip polling timeout', {
+              retryTimes,
+              maxRetryCount,
+              tenantId,
+              customUiAssetId,
+              container,
+              blobEndpointHost,
+              objectKey,
+              errorLogObjectKey,
+            });
             throw new AbortError('Unzip timeout. Max retry count reached.');
           }
           throw new Error('Unzip in progress...');
@@ -99,7 +156,7 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
           retries: maxRetryCount,
         });
       } catch (error: unknown) {
-        getConsoleLogFromContext(ctx).error(error);
+        consoleLog.error(error);
         throw new RequestError(
           {
             code: 'storage.upload_error',

--- a/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.ts
+++ b/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.ts
@@ -77,21 +77,22 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
         });
 
         const hasUnzipCompleted = async (retryTimes: number) => {
-          if (retryTimes > maxRetryCount) {
-            throw new AbortError('Unzip timeout. Max retry count reached.');
-          }
           const [hasZip, hasError] = await Promise.all([
             isFileExisted(objectKey),
             isFileExisted(errorLogObjectKey),
           ]);
-          if (hasZip) {
-            throw new Error('Unzip in progress...');
-          }
           if (hasError) {
             const errorLogBlob = await downloadFile(errorLogObjectKey);
             const errorLog = await streamToString(errorLogBlob.readableStreamBody);
             throw new AbortError(errorLog || 'Unzipping failed.');
           }
+          if (!hasZip) {
+            return;
+          }
+          if (retryTimes > maxRetryCount) {
+            throw new AbortError('Unzip timeout. Max retry count reached.');
+          }
+          throw new Error('Unzip in progress...');
         };
 
         await pRetry(hasUnzipCompleted, {

--- a/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.ts
+++ b/packages/core/src/routes/sign-in-experience/custom-ui-assets/index.ts
@@ -33,6 +33,24 @@ const getBlobEndpointHost = (connectionString: string) => {
   return /(?:^|;)AccountName=([^;]+)/u.exec(connectionString)?.[1];
 };
 
+const getErrorProperty = (error: unknown, property: string) => {
+  if (typeof error !== 'object' || error === null || !(property in error)) {
+    return;
+  }
+
+  const value: unknown = Reflect.get(error, property);
+
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : undefined;
+};
+
+const getStorageErrorDiagnostics = (error: unknown) => ({
+  name: error instanceof Error ? error.name : undefined,
+  message: error instanceof Error ? error.message : String(error),
+  code: getErrorProperty(error, 'code'),
+  errno: getErrorProperty(error, 'errno'),
+  type: getErrorProperty(error, 'type'),
+});
+
 export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
   ...[
     router,
@@ -102,17 +120,49 @@ export default function customUiAssetsRoutes<T extends ManagementApiRouter>(
 
         const hasUnzipCompleted = async (retryTimes: number) => {
           const startedAt = Date.now();
-          const [hasZip, hasError] = await Promise.all([
-            isFileExisted(objectKey),
-            isFileExisted(errorLogObjectKey),
-          ]);
-          consoleLog.info('[custom-ui-assets] unzip polling status', {
+          const logContext = {
             retryTimes,
             maxRetryCount,
             tenantId,
             customUiAssetId,
             container,
             blobEndpointHost,
+          };
+          const checkFileExisted = async (objectKeyToCheck: string, target: 'zip' | 'errorLog') => {
+            const checkStartedAt = Date.now();
+            consoleLog.info('[custom-ui-assets] unzip polling exists check started', {
+              ...logContext,
+              target,
+              objectKey: objectKeyToCheck,
+            });
+
+            try {
+              const exists = await isFileExisted(objectKeyToCheck);
+              consoleLog.info('[custom-ui-assets] unzip polling exists check succeeded', {
+                ...logContext,
+                target,
+                objectKey: objectKeyToCheck,
+                exists,
+                durationMs: Date.now() - checkStartedAt,
+              });
+              return exists;
+            } catch (error: unknown) {
+              consoleLog.error('[custom-ui-assets] unzip polling exists check failed', {
+                ...logContext,
+                target,
+                objectKey: objectKeyToCheck,
+                durationMs: Date.now() - checkStartedAt,
+                error: getStorageErrorDiagnostics(error),
+              });
+              throw error;
+            }
+          };
+          const [hasZip, hasError] = await Promise.all([
+            checkFileExisted(objectKey, 'zip'),
+            checkFileExisted(errorLogObjectKey, 'errorLog'),
+          ]);
+          consoleLog.info('[custom-ui-assets] unzip polling status', {
+            ...logContext,
             objectKey,
             errorLogObjectKey,
             hasZip,

--- a/packages/core/src/utils/storage/azure-storage.test.ts
+++ b/packages/core/src/utils/storage/azure-storage.test.ts
@@ -1,0 +1,71 @@
+import { createMockUtils } from '@logto/shared/esm';
+
+const { jest } = import.meta;
+const { mockEsm } = createMockUtils(jest);
+
+const mockedUploadData = jest.fn();
+const mockedDownload = jest.fn();
+const mockedExists = jest.fn();
+const mockedGetProperties = jest.fn();
+const mockedGetBlockBlobClient = jest.fn(() => ({
+  uploadData: mockedUploadData,
+  download: mockedDownload,
+  exists: mockedExists,
+  getProperties: mockedGetProperties,
+}));
+const mockedGetContainerClient = jest.fn(() => ({
+  getBlockBlobClient: mockedGetBlockBlobClient,
+}));
+
+mockEsm('@azure/storage-blob', () => ({
+  BlobServiceClient: {
+    fromConnectionString: jest.fn(() => ({
+      accountName: 'mock-account',
+      getContainerClient: mockedGetContainerClient,
+    })),
+  },
+}));
+
+const { buildAzureStorage } = await import('./azure-storage.js');
+
+class PrematureCloseError extends Error {
+  code = 'ERR_STREAM_PREMATURE_CLOSE';
+  errno = 'ERR_STREAM_PREMATURE_CLOSE';
+  type = 'system';
+}
+
+describe('buildAzureStorage()', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isFileExisted()', () => {
+    it('should return the blob exists result', async () => {
+      mockedExists.mockResolvedValueOnce(true);
+      const { isFileExisted } = buildAzureStorage('connectionString', 'container');
+
+      await expect(isFileExisted('foo.txt')).resolves.toBe(true);
+      expect(mockedGetContainerClient).toHaveBeenCalledWith('container');
+      expect(mockedGetBlockBlobClient).toHaveBeenCalledWith('foo.txt');
+    });
+
+    it('should treat Azure premature close errors as missing blobs', async () => {
+      mockedExists.mockRejectedValueOnce(
+        new PrematureCloseError(
+          'Invalid response body while trying to fetch https://example.com/foo.txt: Premature close'
+        )
+      );
+      const { isFileExisted } = buildAzureStorage('connectionString', 'container');
+
+      await expect(isFileExisted('foo.txt')).resolves.toBe(false);
+    });
+
+    it('should rethrow other blob exists errors', async () => {
+      const error = new Error('Storage service unavailable');
+      mockedExists.mockRejectedValueOnce(error);
+      const { isFileExisted } = buildAzureStorage('connectionString', 'container');
+
+      await expect(isFileExisted('foo.txt')).rejects.toBe(error);
+    });
+  });
+});

--- a/packages/core/src/utils/storage/azure-storage.ts
+++ b/packages/core/src/utils/storage/azure-storage.ts
@@ -19,10 +19,9 @@ const getErrorProperty = (error: unknown, property: string) => {
   return typeof value === 'string' || typeof value === 'number' ? String(value) : undefined;
 };
 
-const isPrematureCloseStorageFetchError = (error: unknown) =>
-  error instanceof Error &&
-  error.message.includes('Invalid response body while trying to fetch') &&
-  getErrorProperty(error, 'code') === 'ERR_STREAM_PREMATURE_CLOSE';
+const isPrematureCloseStorageError = (error: unknown) =>
+  getErrorProperty(error, 'code') === 'ERR_STREAM_PREMATURE_CLOSE' ||
+  getErrorProperty(error, 'errno') === 'ERR_STREAM_PREMATURE_CLOSE';
 
 export const buildAzureStorage = (
   connectionString: string,
@@ -73,7 +72,7 @@ export const buildAzureStorage = (
       return await blockBlobClient.exists();
     } catch (error: unknown) {
       // Azure Blob `exists()` may throw this when the blob is missing in some runtime/proxy paths.
-      if (isPrematureCloseStorageFetchError(error)) {
+      if (isPrematureCloseStorageError(error)) {
         return false;
       }
 

--- a/packages/core/src/utils/storage/azure-storage.ts
+++ b/packages/core/src/utils/storage/azure-storage.ts
@@ -9,6 +9,21 @@ import type { UploadFile } from './types.js';
 
 const defaultPublicDomain = 'blob.core.windows.net';
 
+const getErrorProperty = (error: unknown, property: string) => {
+  if (typeof error !== 'object' || error === null || !(property in error)) {
+    return;
+  }
+
+  const value: unknown = Reflect.get(error, property);
+
+  return typeof value === 'string' || typeof value === 'number' ? String(value) : undefined;
+};
+
+const isPrematureCloseStorageFetchError = (error: unknown) =>
+  error instanceof Error &&
+  error.message.includes('Invalid response body while trying to fetch') &&
+  getErrorProperty(error, 'code') === 'ERR_STREAM_PREMATURE_CLOSE';
+
 export const buildAzureStorage = (
   connectionString: string,
   container: string
@@ -54,7 +69,16 @@ export const buildAzureStorage = (
 
   const isFileExisted = async (objectKey: string) => {
     const blockBlobClient = containerClient.getBlockBlobClient(objectKey);
-    return blockBlobClient.exists();
+    try {
+      return await blockBlobClient.exists();
+    } catch (error: unknown) {
+      // Azure Blob `exists()` may throw this when the blob is missing in some runtime/proxy paths.
+      if (isPrematureCloseStorageFetchError(error)) {
+        return false;
+      }
+
+      throw error;
+    }
   };
 
   const getFileProperties = async (objectKey: string) => {


### PR DESCRIPTION
## Summary
Fix custom UI asset upload polling so it no longer reports a false unzip timeout when Azure finishes between the last scheduled check and the final `p-retry` attempt.

Handle Azure Blob `exists()` `ERR_STREAM_PREMATURE_CLOSE` errors as missing blobs, since Azure can throw this when checking a blob that no longer exists.

The upload now succeeds once `assets.zip` is gone and no `error.log` exists, including on the final retry attempt.

## Testing
- `pnpm --dir /Users/charleszhao/Workspace/logto/packages/core build:test`
- `pnpm --dir /Users/charleszhao/Workspace/logto/packages/core test:only build/routes/sign-in-experience/custom-ui-assets/index.test.js build/utils/storage/azure-storage.test.js --runInBand`

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
