### PR TITLE
feat(console): expose Message.RateLimited webhook event

### DIFF
--- a/packages/console/src/components/BasicWebhookForm/index.tsx
+++ b/packages/console/src/components/BasicWebhookForm/index.tsx
@@ -2,6 +2,7 @@ import { type Hook, type HookConfig, type HookEvent } from '@logto/schemas';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import {
   dataHookEventsLabel,
   interactionHookEvents,
@@ -31,7 +32,11 @@ const hookEventGroups: Array<CheckboxOptionGroup<HookEvent>> = [
   },
   {
     title: 'webhooks.schemas.security',
-    options: [{ value: 'Identifier.Lockout' }],
+    options: [
+      { value: 'Identifier.Lockout' },
+      // `Message.RateLimited` stays behind the dev-features flag until the email-security feature ships.
+      ...(isDevFeaturesEnabled ? [{ value: 'Message.RateLimited' as const }] : []),
+    ],
   },
 ];
 


### PR DESCRIPTION
## Summary

Refs LOG-13724. The `Message.RateLimited` exception hook event (added in #9053) is registered in `@logto/schemas` `hookEvents`, so the Management API already accepts a webhook subscribing to it — but the Console event picker was never updated, so it couldn't be selected from the UI. This adds it to the picker's "Security" group, alongside `Identifier.Lockout`.

- The option is gated behind `isDevFeaturesEnabled`, so it stays hidden in production until the email-security feature ships — consistent with the backend, which only emits the event when dev features are on. The gate should be removed at release (LOG-13649).
- The "Security" group is a hardcoded list (unlike the interaction/data groups, which derive from enums), so adding the event to schemas did not automatically surface it here; `ExceptionHookEvent` is a type union, not an enum.
- The checkbox renders the raw event value when no label is set — same as `Identifier.Lockout` — so no new phrase is required.
- `BasicWebhookForm` backs both the create modal and the webhook detail/edit page, so both surfaces get the option.

## Testing

N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
