### PR TITLE
feat: release passkey Account Center controls

### DIFF
--- a/.changeset/release-passkey-account-center-access-control.md
+++ b/.changeset/release-passkey-account-center-access-control.md
@@ -2,7 +2,6 @@
 "@logto/core": minor
 "@logto/console": minor
 "@logto/account": minor
-"@logto/schemas": minor
 ---
 
 add independent Account Center passkey controls for passkey sign-in

--- a/.changeset/release-passkey-account-center-access-control.md
+++ b/.changeset/release-passkey-account-center-access-control.md
@@ -1,0 +1,10 @@
+---
+"@logto/core": minor
+"@logto/console": minor
+"@logto/account": minor
+"@logto/schemas": minor
+---
+
+add independent Account Center passkey controls for passkey sign-in
+
+Admins can now configure passkey visibility separately from MFA in Account Center, and users can manage passkeys plus their passkey sign-in prompt preference when passkey sign-in is enabled.

--- a/packages/account/src/pages/Security/PasskeySection/index.test.tsx
+++ b/packages/account/src/pages/Security/PasskeySection/index.test.tsx
@@ -25,11 +25,6 @@ import MfaVerificationsProvider from '../MfaVerificationsProvider';
 
 import PasskeySection from '.';
 
-jest.mock('@ac/constants/env', () => ({
-  __esModule: true,
-  isDevFeaturesEnabled: true,
-}));
-
 const mockGetAccessToken = jest.fn().mockResolvedValue('access-token');
 
 jest.mock('@logto/react', () => ({

--- a/packages/account/src/pages/Security/index.passkey.test.tsx
+++ b/packages/account/src/pages/Security/index.passkey.test.tsx
@@ -18,11 +18,6 @@ import { getMfaSettings, getMfaVerifications, updateMfaSettings } from '../../ap
 
 import Security from '.';
 
-jest.mock('@ac/constants/env', () => ({
-  __esModule: true,
-  isDevFeaturesEnabled: true,
-}));
-
 const mockGetAccessToken = jest.fn().mockResolvedValue('access-token');
 
 jest.mock('@logto/react', () => ({

--- a/packages/account/src/utils/security-page.passkey.test.ts
+++ b/packages/account/src/utils/security-page.passkey.test.ts
@@ -15,11 +15,6 @@ import {
   isWebAuthnConfigurable,
 } from './security-page';
 
-jest.mock('@ac/constants/env', () => ({
-  __esModule: true,
-  isDevFeaturesEnabled: true,
-}));
-
 describe('security-page utils with passkey sign-in enabled', () => {
   const experienceSettings = {
     socialConnectors: [],

--- a/packages/account/src/utils/security-page.test.ts
+++ b/packages/account/src/utils/security-page.test.ts
@@ -128,7 +128,7 @@ describe('security-page utils', () => {
     ).toBe(true);
   });
 
-  it('hasVisibleMfaSection ignores passkey sign-in when dev features are disabled', () => {
+  it('hasVisibleMfaSection ignores passkey sign-in when no second factor is enabled', () => {
     expect(
       hasVisibleMfaSection(AccountCenterControlValue.Edit, {
         socialConnectors: [],
@@ -138,14 +138,14 @@ describe('security-page utils', () => {
     ).toBe(false);
   });
 
-  it('isPasskeySignInEnabled returns false when dev features are disabled', () => {
+  it('isPasskeySignInEnabled returns true when passkey sign-in is enabled', () => {
     expect(
       isPasskeySignInEnabled({
         socialConnectors: [],
         mfa: { factors: [], policy: MfaPolicy.UserControlled },
         passkeySignIn: { enabled: true },
       })
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('isEditableField returns true only for edit control', () => {

--- a/packages/account/src/utils/security-page.ts
+++ b/packages/account/src/utils/security-page.ts
@@ -7,8 +7,6 @@ import type {
 } from '@logto/schemas';
 import { AccountCenterControlValue, MfaFactor } from '@logto/schemas';
 
-import { isDevFeaturesEnabled } from '@ac/constants/env';
-
 import { getProfileFieldControlKey } from './profile-field-control';
 import { getAvailableSocialConnectors } from './social-connector.js';
 
@@ -34,7 +32,7 @@ export const hasVisibleSocialSection = (
 
 export const isPasskeySignInEnabled = (
   experienceSettings?: SecurityPageExperienceSettings
-): boolean => isDevFeaturesEnabled && Boolean(experienceSettings?.passkeySignIn?.enabled);
+): boolean => Boolean(experienceSettings?.passkeySignIn?.enabled);
 
 /**
  * Whether a WebAuthn passkey credential can be registered or managed. Mirrors the backend binding

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.ts
@@ -1,7 +1,5 @@
 import type { AdminConsoleKey } from '@logto/phrases';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
-
 import type { AccountCenterFieldKey } from '../../types';
 
 export type AccountCenterFieldItem = {
@@ -49,9 +47,7 @@ export const accountCenterSections: AccountCenterFieldSection[] = [
             key: 'mfa',
             title: 'sign_in_exp.account_center.fields.mfa',
           },
-          ...(isDevFeaturesEnabled
-            ? ([{ key: 'passkey', title: 'sign_in_exp.account_center.fields.passkey' }] as const)
-            : []),
+          { key: 'passkey', title: 'sign_in_exp.account_center.fields.passkey' },
         ],
       },
       {

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/index.tsx
@@ -5,7 +5,6 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import FormCard from '@/components/FormCard';
 import PageMeta from '@/components/PageMeta';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import CodeEditor from '@/ds-components/CodeEditor';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
@@ -69,7 +68,7 @@ function AccountCenter({ isActive, data }: Props) {
 
   // When passkey sign-in is enabled, passkey can serve as a verification method, so the
   // "no MFA factor configured" warning on the MFA field is no longer relevant.
-  const isPasskeySignInEnabled = isDevFeaturesEnabled && Boolean(data.passkeySignIn.enabled);
+  const isPasskeySignInEnabled = Boolean(data.passkeySignIn.enabled);
 
   const handleToggle = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/console/src/pages/SignInExperience/PageContent/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/index.tsx
@@ -29,6 +29,7 @@ import usePreviewConfigs from '../hooks/use-preview-configs';
 import {
   SignInExperienceTab,
   convertAccountCenterToForm,
+  normalizeAccountCenterFieldsForSubmit,
   type SignInExperiencePageManagedData,
   type SignInExperienceForm,
   type AccountCenterFormValues,
@@ -107,6 +108,9 @@ function PageContent({ data, onSignInExperienceUpdated, onAccountCenterUpdated }
         accountCenter.webauthnRelatedOrigins
       );
       const deleteAccountUrl = normalizeDeleteAccountUrl(accountCenter.deleteAccountUrl);
+      const fields = accountCenter.enabled
+        ? normalizeAccountCenterFieldsForSubmit(accountCenter.fields, data.accountCenter.fields)
+        : {};
 
       const updatedData = await api
         .patch('api/sign-in-exp', {
@@ -122,7 +126,7 @@ function PageContent({ data, onSignInExperienceUpdated, onAccountCenterUpdated }
           json: {
             enabled: accountCenter.enabled,
             // Disable all fields when account center is disabled
-            fields: accountCenter.enabled ? accountCenter.fields : {},
+            fields,
             webauthnRelatedOrigins,
             deleteAccountUrl,
             customCss: accountCenter.customCss?.length ? accountCenter.customCss : null,
@@ -146,6 +150,7 @@ function PageContent({ data, onSignInExperienceUpdated, onAccountCenterUpdated }
     }
   }, [
     api,
+    data.accountCenter.fields,
     getValues,
     isCustomUiCspEnabled,
     onAccountCenterUpdated,

--- a/packages/console/src/pages/SignInExperience/types.test.ts
+++ b/packages/console/src/pages/SignInExperience/types.test.ts
@@ -1,0 +1,52 @@
+import { AccountCenterControlValue, type AccountCenterFieldControl } from '@logto/schemas';
+
+import { normalizeAccountCenterFieldsForSubmit, type AccountCenterFormValues } from './types';
+
+const createAccountCenterFields = (
+  overrides: Partial<AccountCenterFormValues['fields']> = {}
+): AccountCenterFormValues['fields'] => ({
+  email: AccountCenterControlValue.Off,
+  phone: AccountCenterControlValue.Off,
+  social: AccountCenterControlValue.Off,
+  password: AccountCenterControlValue.Off,
+  mfa: AccountCenterControlValue.Off,
+  passkey: AccountCenterControlValue.Off,
+  username: AccountCenterControlValue.Off,
+  name: AccountCenterControlValue.Off,
+  avatar: AccountCenterControlValue.Off,
+  profile: AccountCenterControlValue.Off,
+  customData: AccountCenterControlValue.Off,
+  session: AccountCenterControlValue.Off,
+  ...overrides,
+});
+
+describe('SignInExperience types utils', () => {
+  it('omits default passkey field when the original account center config did not set it', () => {
+    const normalizedFields = normalizeAccountCenterFieldsForSubmit(createAccountCenterFields(), {
+      mfa: AccountCenterControlValue.Edit,
+    });
+
+    expect(normalizedFields).not.toHaveProperty('passkey');
+  });
+
+  it('keeps explicit passkey field from existing account center config', () => {
+    const originalFields: AccountCenterFieldControl = {
+      passkey: AccountCenterControlValue.Off,
+    };
+
+    expect(
+      normalizeAccountCenterFieldsForSubmit(createAccountCenterFields(), originalFields)
+    ).toHaveProperty('passkey', AccountCenterControlValue.Off);
+  });
+
+  it('keeps passkey field when the form enables it for the first time', () => {
+    const normalizedFields = normalizeAccountCenterFieldsForSubmit(
+      createAccountCenterFields({ passkey: AccountCenterControlValue.Edit }),
+      {
+        mfa: AccountCenterControlValue.Edit,
+      }
+    );
+
+    expect(normalizedFields).toHaveProperty('passkey', AccountCenterControlValue.Edit);
+  });
+});

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -10,9 +10,7 @@ import {
   type SignUpProfileFields,
   type AccountCenterFieldControl,
 } from '@logto/schemas';
-import { conditionalArray } from '@silverhand/essentials';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 /**
  * Fields not managed by the sign-in experience page form. `usernamePolicy` is owned by its own
  * modal (see `SignUpAndSignIn/UsernamePolicy`), mirroring how `passwordPolicy` lives on its own page.
@@ -43,7 +41,7 @@ const accountCenterFieldKeys: Array<keyof AccountCenterFieldControl> = [
   'social',
   'password',
   'mfa',
-  ...conditionalArray(isDevFeaturesEnabled && ('passkey' as const)),
+  'passkey',
   'username',
   'name',
   'avatar',

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -95,6 +95,19 @@ export const convertAccountCenterToForm = (
   profileFields: accountCenter?.profileFields ?? [],
 });
 
+export const normalizeAccountCenterFieldsForSubmit = (
+  fields: AccountCenterFormValues['fields'],
+  originalFields?: AccountCenterConfig['fields']
+): AccountCenterFieldControl => {
+  const { passkey, ...fieldsWithoutPasskey } = fields;
+
+  if (originalFields?.passkey === undefined && passkey === AccountCenterControlValue.Off) {
+    return fieldsWithoutPasskey;
+  }
+
+  return fields;
+};
+
 /**
  * @deprecated
  */

--- a/packages/core/src/routes/account/mfa-verifications.test.ts
+++ b/packages/core/src/routes/account/mfa-verifications.test.ts
@@ -8,7 +8,6 @@ import {
   mockUserTotpMfaVerification,
   mockUserWebAuthnMfaVerification,
 } from '#src/__mocks__/index.js';
-import { EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
@@ -48,8 +47,6 @@ const { findDefaultSignInExperience } = mockedQueries.signInExperiences;
 
 const accountMfaRoutes = await pickDefault(import('./mfa-verifications.js'));
 
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-
 describe('account mfa verification routes', () => {
   const tenantContext = new MockTenant(undefined, mockedQueries);
   const accountRequest = createRequester({
@@ -85,9 +82,6 @@ describe('account mfa verification routes', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
-    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
-      originalIsDevFeaturesEnabled;
   });
 
   describe('PUT /api/my-account/mfa-verifications/totp', () => {
@@ -185,9 +179,6 @@ describe('account mfa verification routes', () => {
 
   describe('POST /api/my-account/mfa-verifications passkey permission and binding', () => {
     it('should allow WebAuthn binding when passkeySignIn.enabled is true (without MFA factor)', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
-      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-
       findDefaultSignInExperience.mockResolvedValueOnce({
         ...mockSignInExperience,
         mfa: { ...mockSignInExperience.mfa, factors: [] },
@@ -206,9 +197,6 @@ describe('account mfa verification routes', () => {
     });
 
     it('should reject WebAuthn binding when both mfa.factors and passkeySignIn.enabled are off', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
-      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-
       findDefaultSignInExperience.mockResolvedValueOnce({
         ...mockSignInExperience,
         mfa: { ...mockSignInExperience.mfa, factors: [] },
@@ -224,10 +212,7 @@ describe('account mfa verification routes', () => {
       expect(findDefaultSignInExperience).toHaveBeenCalled();
     });
 
-    it('should use fields.passkey for WebAuthn permission when isDevFeaturesEnabled', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
-      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-
+    it('should use fields.passkey for WebAuthn permission', async () => {
       const passkeyRequest = createRequester({
         authedRoutes: [
           (router) => {
@@ -270,10 +255,7 @@ describe('account mfa verification routes', () => {
       expect(response.body).not.toHaveProperty('code', 'account_center.field_not_editable');
     });
 
-    it('should fall back to fields.mfa for non-WebAuthn types even when isDevFeaturesEnabled', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
-      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-
+    it('should fall back to fields.mfa for non-WebAuthn types', async () => {
       const response = await accountRequest.post('/my-account/mfa-verifications').send({
         type: MfaFactor.TOTP,
         secret: 'totp_secret',
@@ -285,10 +267,7 @@ describe('account mfa verification routes', () => {
   });
 
   describe('PATCH /api/my-account/mfa-verifications/:id/name passkey permission', () => {
-    it('should use fields.passkey for permission when isDevFeaturesEnabled', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
-      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-
+    it('should use fields.passkey for permission', async () => {
       const passkeyRequest = createRequester({
         authedRoutes: [
           (router) => {
@@ -327,10 +306,7 @@ describe('account mfa verification routes', () => {
       expect(response.status).toBe(200);
     });
 
-    it('should reject when passkey field is not editable with isDevFeaturesEnabled', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
-      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-
+    it('should reject when passkey field is not editable', async () => {
       const passkeyRequest = createRequester({
         authedRoutes: [
           (router) => {
@@ -366,10 +342,7 @@ describe('account mfa verification routes', () => {
   });
 
   describe('DELETE /api/my-account/mfa-verifications/:id passkey permission', () => {
-    it('should use fields.passkey for WebAuthn verification deletion when isDevFeaturesEnabled', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
-      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-
+    it('should use fields.passkey for WebAuthn verification deletion', async () => {
       const passkeyRequest = createRequester({
         authedRoutes: [
           (router) => {
@@ -408,10 +381,7 @@ describe('account mfa verification routes', () => {
       expect(response.status).toBe(204);
     });
 
-    it('should use fields.mfa for non-WebAuthn verification deletion when isDevFeaturesEnabled', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
-      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-
+    it('should use fields.mfa for non-WebAuthn verification deletion', async () => {
       findUserById.mockResolvedValueOnce({
         ...mockUser,
         mfaVerifications: [mockUserTotpMfaVerification],
@@ -426,9 +396,6 @@ describe('account mfa verification routes', () => {
     });
 
     it('should reject WebAuthn deletion when passkey field is not editable', async () => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for this feature-gate test.
-      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
-
       const passkeyRequest = createRequester({
         authedRoutes: [
           (router) => {

--- a/packages/core/src/routes/account/mfa-verifications.ts
+++ b/packages/core/src/routes/account/mfa-verifications.ts
@@ -9,7 +9,6 @@ import {
 import { generateStandardId } from '@logto/shared';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import {
   generateBackupCodes,
@@ -94,10 +93,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
       );
       const { fields } = ctx.accountCenter;
       const isWebAuthn = ctx.guard.body.type === MfaFactor.WebAuthn;
-      const passkeyControl =
-        EnvSet.values.isDevFeaturesEnabled && isWebAuthn
-          ? (fields.passkey ?? fields.mfa)
-          : fields.mfa;
+      const passkeyControl = isWebAuthn ? (fields.passkey ?? fields.mfa) : fields.mfa;
       assertThat(
         passkeyControl === AccountCenterControlValue.Edit,
         'account_center.field_not_editable'
@@ -112,10 +108,9 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
 
       // Check sign in experience, if mfa factor is enabled
       const { mfa, passkeySignIn } = await findDefaultSignInExperience();
-      const isFactorEnabled =
-        EnvSet.values.isDevFeaturesEnabled && isWebAuthn
-          ? mfa.factors.includes(MfaFactor.WebAuthn) || passkeySignIn.enabled
-          : mfa.factors.includes(ctx.guard.body.type);
+      const isFactorEnabled = isWebAuthn
+        ? mfa.factors.includes(MfaFactor.WebAuthn) || passkeySignIn.enabled
+        : mfa.factors.includes(ctx.guard.body.type);
       assertThat(isFactorEnabled, 'session.mfa.mfa_factor_not_enabled');
 
       switch (ctx.guard.body.type) {
@@ -400,9 +395,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
       );
       const { name } = ctx.guard.body;
       const { fields } = ctx.accountCenter;
-      const passkeyControl = EnvSet.values.isDevFeaturesEnabled
-        ? (fields.passkey ?? fields.mfa)
-        : fields.mfa;
+      const passkeyControl = fields.passkey ?? fields.mfa;
       assertThat(
         passkeyControl === AccountCenterControlValue.Edit,
         'account_center.field_not_editable'
@@ -464,10 +457,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
 
       const { fields } = ctx.accountCenter;
       const isWebAuthnVerification = mfaVerification.type === MfaFactor.WebAuthn;
-      const deleteControl =
-        EnvSet.values.isDevFeaturesEnabled && isWebAuthnVerification
-          ? (fields.passkey ?? fields.mfa)
-          : fields.mfa;
+      const deleteControl = isWebAuthnVerification ? (fields.passkey ?? fields.mfa) : fields.mfa;
       assertThat(
         deleteControl === AccountCenterControlValue.Edit,
         'account_center.field_not_editable'


### PR DESCRIPTION
## Summary

- Enables independent Account Center passkey controls in Console and Account Center.
- Uses the passkey field for WebAuthn Account API permission checks while preserving MFA behavior for non-WebAuthn factors.
- Adds a changeset for the Account Center passkey release.

## Testing

Tested locally
Unit tests