### PR TITLE
fix(core): map Azure Blob transport failures to 502

### DIFF
--- a/.changeset/curly-bikes-travel.md
+++ b/.changeset/curly-bikes-travel.md
@@ -1,0 +1,6 @@
+---
+"@logto/core": patch
+"@logto/phrases": patch
+---
+
+map custom UI asset Azure Blob transport failures to retryable storage download errors

--- a/packages/core/src/middleware/koa-serve-custom-ui-assets.test.ts
+++ b/packages/core/src/middleware/koa-serve-custom-ui-assets.test.ts
@@ -42,8 +42,22 @@ await mockEsmWithActual('#src/utils/tenant.js', () => ({
 
 const koaServeCustomUiAssets = await pickDefault(import('./koa-serve-custom-ui-assets.js'));
 
+class TransientStorageError extends Error {
+  code = 'ERR_STREAM_PREMATURE_CLOSE';
+  errno = 'ERR_STREAM_PREMATURE_CLOSE';
+}
+
 describe('koaServeCustomUiAssets middleware', () => {
   const next = jest.fn();
+
+  beforeEach(() => {
+    mockedIsFileExisted.mockReset();
+    mockedIsFileExisted.mockResolvedValue(true);
+    mockedDownloadFile.mockReset();
+    mockedGetFileProperties.mockReset();
+    mockedGetFileProperties.mockResolvedValue({ contentLength: 100 });
+    next.mockClear();
+  });
 
   it('should serve the file directly if the request path contains a dot', async () => {
     const mockBodyStream = Readable.from('javascript content');
@@ -88,6 +102,43 @@ describe('koaServeCustomUiAssets middleware', () => {
 
     await expect(koaServeCustomUiAssets('custom-ui-asset-id')(ctx, next)).rejects.toMatchError(
       new RequestError({ code: 'entity.not_found', status: 404 })
+    );
+  });
+
+  it('should return 502 if the blob existence check hits a transient storage error', async () => {
+    mockedIsFileExisted.mockRejectedValueOnce(new TransientStorageError('Premature close'));
+    const ctx = createMockContext({ url: '/fake.txt' });
+
+    await expect(koaServeCustomUiAssets('custom-ui-asset-id')(ctx, next)).rejects.toMatchError(
+      new RequestError(
+        { code: 'storage.download_error', status: 502 },
+        { details: 'Premature close' }
+      )
+    );
+  });
+
+  it('should return 502 if downloading the blob hits a transient storage error', async () => {
+    mockedDownloadFile.mockRejectedValueOnce(new TransientStorageError('Premature close'));
+    const ctx = createMockContext({ url: '/fake.txt' });
+
+    await expect(koaServeCustomUiAssets('custom-ui-asset-id')(ctx, next)).rejects.toMatchError(
+      new RequestError(
+        { code: 'storage.download_error', status: 502 },
+        { details: 'Premature close' }
+      )
+    );
+  });
+
+  it('should return 502 if reading blob properties hits a transient storage error', async () => {
+    mockedDownloadFile.mockResolvedValueOnce({ readableStreamBody: Readable.from('content') });
+    mockedGetFileProperties.mockRejectedValueOnce(new TransientStorageError('Premature close'));
+    const ctx = createMockContext({ url: '/fake.txt' });
+
+    await expect(koaServeCustomUiAssets('custom-ui-asset-id')(ctx, next)).rejects.toMatchError(
+      new RequestError(
+        { code: 'storage.download_error', status: 502 },
+        { details: 'Premature close' }
+      )
     );
   });
 

--- a/packages/core/src/middleware/koa-serve-custom-ui-assets.ts
+++ b/packages/core/src/middleware/koa-serve-custom-ui-assets.ts
@@ -4,13 +4,22 @@ import type { MiddlewareType } from 'koa';
 
 import SystemContext from '#src/tenants/SystemContext.js';
 import assertThat from '#src/utils/assert-that.js';
-import { buildAzureStorage } from '#src/utils/storage/azure-storage.js';
+import {
+  buildAzureStorage,
+  isTransientAzureStorageError,
+} from '#src/utils/storage/azure-storage.js';
 import { getTenantId } from '#src/utils/tenant.js';
 
 import RequestError from '../errors/RequestError/index.js';
 
 const noCache = 'no-cache, no-store, must-revalidate';
 const maxAgeSevenDays = 'max-age=604_800_000';
+
+const buildStorageDownloadError = (error: unknown) =>
+  new RequestError(
+    { code: 'storage.download_error', status: 502 },
+    { details: error instanceof Error ? error.message : String(error) }
+  );
 
 /**
  * Middleware that serves custom UI assets user uploaded previously through sign-in experience settings.
@@ -36,35 +45,43 @@ export default function koaServeCustomUiAssets(customUiAssetId: string) {
     const isFileAssetRequest = isFileAssetPath(requestPath);
 
     const fileObjectKey = `${contextPath}${isFileAssetRequest ? requestPath : '/index.html'}`;
-    const isExisted = await isFileExisted(fileObjectKey);
-    assertThat(isExisted, 'entity.not_found', 404);
+    try {
+      const isExisted = await isFileExisted(fileObjectKey, { throwOnTransientError: true });
+      assertThat(isExisted, 'entity.not_found', 404);
 
-    const range = ctx.get('range');
-    const { start, end, count } = tryThat(
-      () => parseRange(range),
-      new RequestError({ code: 'request.range_not_satisfiable', status: 416 })
-    );
-
-    const [
-      { contentLength = 0, readableStreamBody, contentType },
-      { contentLength: totalFileSize = 0 },
-    ] = await Promise.all([
-      downloadFile(fileObjectKey, start, count),
-      getFileProperties(fileObjectKey),
-    ]);
-
-    ctx.body = readableStreamBody;
-    ctx.type = contentType ?? 'application/octet-stream';
-    ctx.status = range ? 206 : 200;
-
-    ctx.set('Cache-Control', isFileAssetRequest ? maxAgeSevenDays : noCache);
-    ctx.set('Content-Length', contentLength.toString());
-    if (range) {
-      ctx.set('Accept-Ranges', 'bytes');
-      ctx.set(
-        'Content-Range',
-        `bytes ${start ?? 0}-${end ?? Math.max(totalFileSize - 1, 0)}/${totalFileSize}`
+      const range = ctx.get('range');
+      const { start, end, count } = tryThat(
+        () => parseRange(range),
+        new RequestError({ code: 'request.range_not_satisfiable', status: 416 })
       );
+
+      const [
+        { contentLength = 0, readableStreamBody, contentType },
+        { contentLength: totalFileSize = 0 },
+      ] = await Promise.all([
+        downloadFile(fileObjectKey, start, count),
+        getFileProperties(fileObjectKey),
+      ]);
+
+      ctx.body = readableStreamBody;
+      ctx.type = contentType ?? 'application/octet-stream';
+      ctx.status = range ? 206 : 200;
+
+      ctx.set('Cache-Control', isFileAssetRequest ? maxAgeSevenDays : noCache);
+      ctx.set('Content-Length', contentLength.toString());
+      if (range) {
+        ctx.set('Accept-Ranges', 'bytes');
+        ctx.set(
+          'Content-Range',
+          `bytes ${start ?? 0}-${end ?? Math.max(totalFileSize - 1, 0)}/${totalFileSize}`
+        );
+      }
+    } catch (error: unknown) {
+      if (isTransientAzureStorageError(error)) {
+        throw buildStorageDownloadError(error);
+      }
+
+      throw error;
     }
 
     return next();

--- a/packages/core/src/utils/storage/azure-storage.test.ts
+++ b/packages/core/src/utils/storage/azure-storage.test.ts
@@ -34,6 +34,16 @@ class PrematureCloseError extends Error {
   type = 'system';
 }
 
+class TransientStorageError extends Error {
+  constructor(
+    message: string,
+    readonly code: string,
+    readonly errno = code
+  ) {
+    super(message);
+  }
+}
+
 describe('buildAzureStorage()', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -50,14 +60,30 @@ describe('buildAzureStorage()', () => {
     });
 
     it('should treat Azure premature close errors as missing blobs', async () => {
-      mockedExists.mockRejectedValueOnce(
-        new PrematureCloseError(
-          'Invalid response body while trying to fetch https://example.com/foo.txt: Premature close'
-        )
-      );
+      mockedExists.mockRejectedValue(new PrematureCloseError('Premature close'));
       const { isFileExisted } = buildAzureStorage('connectionString', 'container');
 
       await expect(isFileExisted('foo.txt')).resolves.toBe(false);
+      expect(mockedExists).toHaveBeenCalledTimes(3);
+    });
+
+    it('should retry Azure premature close errors before returning the blob exists result', async () => {
+      mockedExists
+        .mockRejectedValueOnce(new PrematureCloseError('Premature close'))
+        .mockResolvedValueOnce(true);
+      const { isFileExisted } = buildAzureStorage('connectionString', 'container');
+
+      await expect(isFileExisted('foo.txt')).resolves.toBe(true);
+      expect(mockedExists).toHaveBeenCalledTimes(2);
+    });
+
+    it('should rethrow Azure premature close errors when requested', async () => {
+      const error = new PrematureCloseError('Premature close');
+      mockedExists.mockRejectedValue(error);
+      const { isFileExisted } = buildAzureStorage('connectionString', 'container');
+
+      await expect(isFileExisted('foo.txt', { throwOnTransientError: true })).rejects.toBe(error);
+      expect(mockedExists).toHaveBeenCalledTimes(3);
     });
 
     it('should rethrow other blob exists errors', async () => {
@@ -66,6 +92,32 @@ describe('buildAzureStorage()', () => {
       const { isFileExisted } = buildAzureStorage('connectionString', 'container');
 
       await expect(isFileExisted('foo.txt')).rejects.toBe(error);
+    });
+  });
+
+  describe('downloadFile()', () => {
+    it('should retry transient Azure storage download errors', async () => {
+      const downloadResponse = { contentLength: 42 };
+      mockedDownload
+        .mockRejectedValueOnce(new TransientStorageError('Socket reset', 'ECONNRESET'))
+        .mockResolvedValueOnce(downloadResponse);
+      const { downloadFile } = buildAzureStorage('connectionString', 'container');
+
+      await expect(downloadFile('foo.txt')).resolves.toBe(downloadResponse);
+      expect(mockedDownload).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getFileProperties()', () => {
+    it('should retry transient Azure storage get properties errors', async () => {
+      const propertiesResponse = { contentLength: 42 };
+      mockedGetProperties
+        .mockRejectedValueOnce(new TransientStorageError('Timed out', 'ETIMEDOUT'))
+        .mockResolvedValueOnce(propertiesResponse);
+      const { getFileProperties } = buildAzureStorage('connectionString', 'container');
+
+      await expect(getFileProperties('foo.txt')).resolves.toBe(propertiesResponse);
+      expect(mockedGetProperties).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/core/src/utils/storage/azure-storage.ts
+++ b/packages/core/src/utils/storage/azure-storage.ts
@@ -23,6 +23,40 @@ const isPrematureCloseStorageError = (error: unknown) =>
   getErrorProperty(error, 'code') === 'ERR_STREAM_PREMATURE_CLOSE' ||
   getErrorProperty(error, 'errno') === 'ERR_STREAM_PREMATURE_CLOSE';
 
+const transientAzureStorageErrorCodes = new Set([
+  'ERR_STREAM_PREMATURE_CLOSE',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'EPIPE',
+]);
+
+const maxTransientAzureStorageRetries = 2;
+
+export const isTransientAzureStorageError = (error: unknown) => {
+  const code = getErrorProperty(error, 'code');
+  const errno = getErrorProperty(error, 'errno');
+
+  return (
+    (code !== undefined && transientAzureStorageErrorCodes.has(code)) ||
+    (errno !== undefined && transientAzureStorageErrorCodes.has(errno))
+  );
+};
+
+const retryOnTransientAzureStorageError = async <T>(
+  operation: () => Promise<T>,
+  retriesLeft = maxTransientAzureStorageRetries
+): Promise<T> => {
+  try {
+    return await operation();
+  } catch (error: unknown) {
+    if (!isTransientAzureStorageError(error) || retriesLeft === 0) {
+      throw error;
+    }
+
+    return retryOnTransientAzureStorageError(operation, retriesLeft - 1);
+  }
+};
+
 export const buildAzureStorage = (
   connectionString: string,
   container: string
@@ -34,7 +68,10 @@ export const buildAzureStorage = (
     count?: number,
     options?: BlobDownloadOptions
   ) => Promise<BlobDownloadResponseParsed>;
-  isFileExisted: (objectKey: string) => Promise<boolean>;
+  isFileExisted: (
+    objectKey: string,
+    options?: { throwOnTransientError?: boolean }
+  ) => Promise<boolean>;
   getFileProperties: (objectKey: string) => Promise<BlobGetPropertiesResponse>;
 } => {
   const blobServiceClient = BlobServiceClient.fromConnectionString(connectionString);
@@ -63,16 +100,21 @@ export const buildAzureStorage = (
     options?: BlobDownloadOptions
   ) => {
     const blockBlobClient = containerClient.getBlockBlobClient(objectKey);
-    return blockBlobClient.download(offset, count, options);
+    return retryOnTransientAzureStorageError(async () =>
+      blockBlobClient.download(offset, count, options)
+    );
   };
 
-  const isFileExisted = async (objectKey: string) => {
+  const isFileExisted = async (
+    objectKey: string,
+    { throwOnTransientError = false }: { throwOnTransientError?: boolean } = {}
+  ) => {
     const blockBlobClient = containerClient.getBlockBlobClient(objectKey);
     try {
-      return await blockBlobClient.exists();
+      return await retryOnTransientAzureStorageError(async () => blockBlobClient.exists());
     } catch (error: unknown) {
       // Azure Blob `exists()` may throw this when the blob is missing in some runtime/proxy paths.
-      if (isPrematureCloseStorageError(error)) {
+      if (!throwOnTransientError && isPrematureCloseStorageError(error)) {
         return false;
       }
 
@@ -82,7 +124,7 @@ export const buildAzureStorage = (
 
   const getFileProperties = async (objectKey: string) => {
     const blockBlobClient = containerClient.getBlockBlobClient(objectKey);
-    return blockBlobClient.getProperties();
+    return retryOnTransientAzureStorageError(async () => blockBlobClient.getProperties());
   };
 
   return { uploadFile, downloadFile, isFileExisted, getFileProperties };

--- a/packages/phrases/src/locales/ar/errors/storage.ts
+++ b/packages/phrases/src/locales/ar/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'مزود التخزين غير مكون.',
   missing_parameter: 'معلمة مفقودة {{parameter}} لمزود التخزين.',
   upload_error: 'فشل في تحميل الملف إلى مزود التخزين.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/de/errors/storage.ts
+++ b/packages/phrases/src/locales/de/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'Der Storage-Anbieter ist nicht konfiguriert.',
   missing_parameter: 'Fehlender Parameter {{parameter}} für den Storage-Anbieter.',
   upload_error: 'Das Hochladen der Datei zum Storage-Anbieter ist fehlgeschlagen.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/en/errors/storage.ts
+++ b/packages/phrases/src/locales/en/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'Storage provider is not configured.',
   missing_parameter: 'Missing parameter {{parameter}} for storage provider.',
   upload_error: 'Failed to upload file to the storage provider.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/es/errors/storage.ts
+++ b/packages/phrases/src/locales/es/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'Proveedor de almacenamiento no está configurado.',
   missing_parameter: 'Falta el parámetro {{parameter}} para el proveedor de almacenamiento.',
   upload_error: 'Error al cargar el archivo al proveedor de almacenamiento.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/fa-ir/errors/storage.ts
+++ b/packages/phrases/src/locales/fa-ir/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'ارائه‌دهنده ذخیره‌سازی پیکربندی نشده است.',
   missing_parameter: 'پارامتر {{parameter}} برای ارائه‌دهنده ذخیره‌سازی وجود ندارد.',
   upload_error: 'آپلود فایل به ارائه‌دهنده ذخیره‌سازی ناموفق بود.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/fr/errors/storage.ts
+++ b/packages/phrases/src/locales/fr/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: "Le fournisseur de stockage n'est pas configuré.",
   missing_parameter: 'Paramètre manquant {{parameter}} pour le fournisseur de stockage.',
   upload_error: "Échec de l'envoi du fichier au fournisseur de stockage.",
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/it/errors/storage.ts
+++ b/packages/phrases/src/locales/it/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'Provider di archiviazione non configurato.',
   missing_parameter: 'Parametro mancante {{parameter}} per il provider di archiviazione.',
   upload_error: 'Impossibile caricare il file sul provider di archiviazione.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/ja/errors/storage.ts
+++ b/packages/phrases/src/locales/ja/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'ストレージプロバイダが設定されていません。',
   missing_parameter: 'ストレージプロバイダの{{parameter}}が欠落しています。',
   upload_error: 'ファイルのアップロードに失敗しました。',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/ko/errors/storage.ts
+++ b/packages/phrases/src/locales/ko/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: '저장소 공급자가 구성되지 않았습니다.',
   missing_parameter: '저장소 공급자에 대한 누락된 매개변수 {{parameter}}.',
   upload_error: '파일을 저장소 공급자에 업로드하지 못했습니다.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/pl-pl/errors/storage.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'Nie skonfigurowano dostawcy magazynu.',
   missing_parameter: 'Brak parametru {{parameter}} dla dostawcy magazynu.',
   upload_error: 'Nie udało się przesłać pliku do dostawcy magazynu.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/pt-br/errors/storage.ts
+++ b/packages/phrases/src/locales/pt-br/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'O provedor de armazenamento não está configurado.',
   missing_parameter: 'Parâmetro {{parameter}} ausente para o provedor de armazenamento.',
   upload_error: 'Falha ao fazer upload do arquivo para o provedor de armazenamento.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/pt-pt/errors/storage.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'O provedor de armazenamento não está configurado.',
   missing_parameter: 'Faltando o parâmetro {{parameter}} para o provedor de armazenamento.',
   upload_error: 'Falha ao enviar o arquivo para o provedor de armazenamento.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/ru/errors/storage.ts
+++ b/packages/phrases/src/locales/ru/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'Провайдер хранилища не настроен.',
   missing_parameter: 'Отсутствует параметр {{parameter}} для провайдера хранилища.',
   upload_error: 'Не удалось загрузить файл в провайдер хранилища.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/th/errors/storage.ts
+++ b/packages/phrases/src/locales/th/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'ยังไม่ได้กำหนดผู้ให้บริการจัดเก็บข้อมูล',
   missing_parameter: 'ขาดพารามิเตอร์ {{parameter}} สำหรับผู้ให้บริการจัดเก็บข้อมูล',
   upload_error: 'อัปโหลดไฟล์ไปยังผู้ให้บริการจัดเก็บข้อมูลไม่สำเร็จ',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/tr-tr/errors/storage.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: 'Depolama sağlayıcısı yapılandırılmamış.',
   missing_parameter: 'Depolama sağlayıcısı için eksik parametre {{parameter}}.',
   upload_error: 'Dosya yüklenemedi.',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/zh-cn/errors/storage.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: '未配置存储提供程序。',
   missing_parameter: '存储提供程序缺少参数 {{parameter}}。',
   upload_error: '无法将文件上传到存储提供程序。',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/zh-hk/errors/storage.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: '未配置存儲提供程序。',
   missing_parameter: '存儲提供程序缺少參數 {{parameter}}。',
   upload_error: '無法將文件上載到存儲提供程序。',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);

--- a/packages/phrases/src/locales/zh-tw/errors/storage.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/storage.ts
@@ -2,6 +2,7 @@ const storage = {
   not_configured: '未配置存儲提供程序。',
   missing_parameter: '存儲提供程序缺少參數 {{parameter}}。',
   upload_error: '無法將檔案上傳到存儲提供程序。',
+  download_error: 'Failed to download file from the storage provider.',
 };
 
 export default Object.freeze(storage);


### PR DESCRIPTION
## Summary
Map transient Azure Blob transport failures from storage-backed file serving to a storage download error with a 502 status instead of letting them surface as generic 500s.

Retry transient Azure Blob errors such as `ERR_STREAM_PREMATURE_CLOSE`, `ECONNRESET`, `ETIMEDOUT`, and `EPIPE` for blob existence, download, and properties calls. Strict existence checks now let exhausted transient failures surface as upstream storage dependency failures instead of misleading missing-file responses.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments