### PR TITLE
perf(core): reduce Azure Blob property requests

### DIFF
--- a/packages/core/src/middleware/koa-serve-custom-ui-assets.test.ts
+++ b/packages/core/src/middleware/koa-serve-custom-ui-assets.test.ts
@@ -76,6 +76,7 @@ describe('koaServeCustomUiAssets middleware', () => {
 
     expect(ctx.type).toEqual('text/javascript');
     expect(ctx.body).toEqual(mockBodyStream);
+    expect(mockedGetFileProperties).not.toHaveBeenCalled();
   });
 
   it('should serve the index.html', async () => {
@@ -94,6 +95,7 @@ describe('koaServeCustomUiAssets middleware', () => {
 
     expect(ctx.type).toEqual('text/html');
     expect(ctx.body).toEqual(mockBodyStream);
+    expect(mockedGetFileProperties).not.toHaveBeenCalled();
   });
 
   it('should return 404 if the file does not exist', async () => {
@@ -132,7 +134,7 @@ describe('koaServeCustomUiAssets middleware', () => {
   it('should return 502 if reading blob properties hits a transient storage error', async () => {
     mockedDownloadFile.mockResolvedValueOnce({ readableStreamBody: Readable.from('content') });
     mockedGetFileProperties.mockRejectedValueOnce(new TransientStorageError('Premature close'));
-    const ctx = createMockContext({ url: '/fake.txt' });
+    const ctx = createMockContext({ url: '/fake.txt', headers: { range: 'bytes=0-10' } });
 
     await expect(koaServeCustomUiAssets('custom-ui-asset-id')(ctx, next)).rejects.toMatchError(
       new RequestError(
@@ -162,6 +164,7 @@ describe('koaServeCustomUiAssets middleware', () => {
     await koaServeCustomUiAssets('custom-ui-asset-id')(ctx, next);
 
     expect(mockedDownloadFile).toHaveBeenCalledWith('default/custom-ui-asset-id/video.mp4', 0, 11);
+    expect(mockedGetFileProperties).toHaveBeenCalledWith('default/custom-ui-asset-id/video.mp4');
     expect(ctx.type).toEqual('video/mp4');
     expect(ctx.body).toEqual(mockBodyStream);
     expect(ctx.status).toEqual(206);

--- a/packages/core/src/middleware/koa-serve-custom-ui-assets.ts
+++ b/packages/core/src/middleware/koa-serve-custom-ui-assets.ts
@@ -55,13 +55,9 @@ export default function koaServeCustomUiAssets(customUiAssetId: string) {
         new RequestError({ code: 'request.range_not_satisfiable', status: 416 })
       );
 
-      const [
-        { contentLength = 0, readableStreamBody, contentType },
-        { contentLength: totalFileSize = 0 },
-      ] = await Promise.all([
-        downloadFile(fileObjectKey, start, count),
-        getFileProperties(fileObjectKey),
-      ]);
+      const downloadFilePromise = downloadFile(fileObjectKey, start, count);
+      const filePropertiesPromise = range ? getFileProperties(fileObjectKey) : undefined;
+      const { contentLength = 0, readableStreamBody, contentType } = await downloadFilePromise;
 
       ctx.body = readableStreamBody;
       ctx.type = contentType ?? 'application/octet-stream';
@@ -69,7 +65,9 @@ export default function koaServeCustomUiAssets(customUiAssetId: string) {
 
       ctx.set('Cache-Control', isFileAssetRequest ? maxAgeSevenDays : noCache);
       ctx.set('Content-Length', contentLength.toString());
-      if (range) {
+      if (filePropertiesPromise) {
+        const { contentLength: totalFileSize = 0 } = await filePropertiesPromise;
+
         ctx.set('Accept-Ranges', 'bytes');
         ctx.set(
           'Content-Range',


### PR DESCRIPTION
## Summary
Reduce redundant Azure Blob Storage property requests in storage-backed file serving. Non-range file requests now use metadata returned by the download response directly, while range requests still fetch blob properties to build the Content-Range header.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments