### PR TITLE
feat(schemas): add inline hook config guards

### DIFF
--- a/packages/schemas/src/types/logto-config/index.test.ts
+++ b/packages/schemas/src/types/logto-config/index.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  LogtoInlineHookKey,
   type LogtoOidcConfigType,
   LogtoOidcConfigKey,
   LogtoTenantConfigKey,
   OidcSigningKeyStatus,
+  inlineHookConfigGuard,
   logtoOidcConfigGuard,
+  logtoConfigGuards,
+  logtoConfigKeys,
   logtoTenantConfigGuard,
   oidcConfigKeysResponseGuard,
 } from './index.js';
@@ -41,5 +45,36 @@ describe('logto config guards', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('accepts inline hook configs', () => {
+    const result = inlineHookConfigGuard[LogtoInlineHookKey.PostFirstFactorVerification].safeParse({
+      script: 'export default async () => ({ action: "createUser" });',
+      environmentVariables: {
+        endpoint: 'https://example.com',
+      },
+      contextSample: ['json', { value: true }],
+      enabled: true,
+      onExecutionError: 'block',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid inline hook execution error policy', () => {
+    const result = inlineHookConfigGuard[LogtoInlineHookKey.PostSignIn].safeParse({
+      script: 'export default async () => ({ action: "updateUser" });',
+      onExecutionError: 'ignore',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('includes inline hook keys in the logto config summary guards', () => {
+    expect(logtoConfigKeys).toContain(LogtoInlineHookKey.PostFirstFactorVerification);
+    expect(logtoConfigKeys).toContain(LogtoInlineHookKey.PostSignIn);
+    expect(logtoConfigGuards[LogtoInlineHookKey.PostSignIn]).toBe(
+      inlineHookConfigGuard[LogtoInlineHookKey.PostSignIn]
+    );
   });
 });

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -8,6 +8,7 @@ import {
   messageRateLimitOverrideGuard,
 } from '../../consts/message-rate-limit.js';
 
+import { type InlineHook, LogtoInlineHookKey, inlineHookGuard } from './inline-hook.js';
 import {
   type AccessTokenJwtCustomizer,
   type ClientCredentialsJwtCustomizer,
@@ -17,6 +18,7 @@ import {
 
 export * from './oidc-provider.js';
 export * from './jwt-customizer.js';
+export * from './inline-hook.js';
 
 /**
  * Logto OIDC signing key types, used mainly in REST API routes.
@@ -101,6 +103,18 @@ export const jwtCustomizerConfigGuard: Readonly<{
 }> = Object.freeze({
   [LogtoJwtTokenKey.AccessToken]: accessTokenJwtCustomizerGuard,
   [LogtoJwtTokenKey.ClientCredentials]: clientCredentialsJwtCustomizerGuard,
+});
+
+export type InlineHookType = {
+  [LogtoInlineHookKey.PostFirstFactorVerification]: InlineHook;
+  [LogtoInlineHookKey.PostSignIn]: InlineHook;
+};
+
+export const inlineHookConfigGuard: Readonly<{
+  [key in LogtoInlineHookKey]: ZodType<InlineHookType[key]>;
+}> = Object.freeze({
+  [LogtoInlineHookKey.PostFirstFactorVerification]: inlineHookGuard,
+  [LogtoInlineHookKey.PostSignIn]: inlineHookGuard,
 });
 
 export const jwtCustomizerConfigsGuard = z.discriminatedUnion('key', [
@@ -200,21 +214,32 @@ export const logtoTenantConfigGuard: Readonly<{
 });
 
 /* --- Summary --- */
-export type LogtoConfigKey = LogtoOidcConfigKey | LogtoJwtTokenKey | LogtoTenantConfigKey;
-export type LogtoConfigType = LogtoOidcConfigType | JwtCustomizerType | LogtoTenantConfigType;
+export type LogtoConfigKey =
+  | LogtoOidcConfigKey
+  | LogtoJwtTokenKey
+  | LogtoInlineHookKey
+  | LogtoTenantConfigKey;
+export type LogtoConfigType =
+  | LogtoOidcConfigType
+  | JwtCustomizerType
+  | InlineHookType
+  | LogtoTenantConfigType;
 export type LogtoConfigGuard = typeof logtoOidcConfigGuard &
   typeof jwtCustomizerConfigGuard &
+  typeof inlineHookConfigGuard &
   typeof logtoTenantConfigGuard;
 
 export const logtoConfigKeys: readonly LogtoConfigKey[] = Object.freeze([
   ...Object.values(LogtoOidcConfigKey),
   ...Object.values(LogtoJwtTokenKey),
+  ...Object.values(LogtoInlineHookKey),
   ...Object.values(LogtoTenantConfigKey),
 ]);
 
 export const logtoConfigGuards: LogtoConfigGuard = Object.freeze({
   ...logtoOidcConfigGuard,
   ...jwtCustomizerConfigGuard,
+  ...inlineHookConfigGuard,
   ...logtoTenantConfigGuard,
 });
 

--- a/packages/schemas/src/types/logto-config/inline-hook.ts
+++ b/packages/schemas/src/types/logto-config/inline-hook.ts
@@ -1,0 +1,73 @@
+import { jsonGuard } from '@logto/connector-kit';
+import { z } from 'zod';
+
+import type { Json } from '../../foundations/index.js';
+import type { InteractionEvent, InteractionIdentifier } from '../interactions.js';
+import type { UserInfo } from '../user.js';
+
+export enum LogtoInlineHookKey {
+  PostFirstFactorVerification = 'inlineHook.postFirstFactorVerification',
+  PostSignIn = 'inlineHook.postSignIn',
+}
+
+export const inlineHookExecutionErrorPolicies = Object.freeze(['block', 'allow'] as const);
+
+export type InlineHookExecutionErrorPolicy = (typeof inlineHookExecutionErrorPolicies)[number];
+
+export type InlineHook = {
+  script: string;
+  environmentVariables?: Record<string, string>;
+  contextSample?: Json;
+  enabled?: boolean;
+  onExecutionError?: InlineHookExecutionErrorPolicy;
+};
+
+export const inlineHookGuard = z
+  .object({
+    script: z.string(),
+    environmentVariables: z.record(z.string()).optional(),
+    contextSample: jsonGuard.optional(),
+    enabled: z.boolean().optional(),
+    onExecutionError: z.enum(inlineHookExecutionErrorPolicies).optional(),
+  })
+  .strict() satisfies z.ZodType<InlineHook>;
+
+export type HookUser = Pick<
+  UserInfo,
+  | 'id'
+  | 'username'
+  | 'primaryEmail'
+  | 'primaryPhone'
+  | 'name'
+  | 'avatar'
+  | 'customData'
+  | 'profile'
+  | 'applicationId'
+  | 'isSuspended'
+>;
+
+export type HookUserPatch = Partial<HookUser>;
+
+export type PostFirstFactorVerificationEvent = {
+  key: LogtoInlineHookKey.PostFirstFactorVerification;
+  interactionEvent: InteractionEvent.SignIn;
+  identifier: InteractionIdentifier;
+  password: string;
+};
+
+export type PostSignInEvent = {
+  key: LogtoInlineHookKey.PostSignIn;
+  interactionEvent: InteractionEvent.SignIn;
+  user: HookUser;
+};
+
+export type PostFirstFactorVerificationResult = {
+  action: 'createUser' | 'updateUser';
+  user: HookUserPatch;
+  passwordVerified: true;
+};
+
+export type PostSignInResult = {
+  action: 'updateUser';
+  user?: HookUserPatch;
+};

--- a/packages/schemas/src/types/logto-config/inline-hook.ts
+++ b/packages/schemas/src/types/logto-config/inline-hook.ts
@@ -46,12 +46,13 @@ export type HookUser = Pick<
   | 'isSuspended'
 >;
 
-export type HookUserPatch = Partial<HookUser>;
+export type HookUserPatch = Partial<Omit<HookUser, 'id'>>;
 
 export type PostFirstFactorVerificationEvent = {
   key: LogtoInlineHookKey.PostFirstFactorVerification;
   interactionEvent: InteractionEvent.SignIn;
   identifier: InteractionIdentifier;
+  /** Sensitive credential provided for inline hook controlled password verification. */
   password: string;
 };
 


### PR DESCRIPTION
## Summary

- Add inline hook config keys and strict Zod guards for the two initial inline hook slots.
- Add typed inline hook event, user patch, and result contracts for the stacked runtime work.
- Include inline hook guards in the shared Logto config key and guard summaries.

## Testing

Unit tests
