### PR TITLE
feat(core): add local VM timeout enforcement

### DIFF
--- a/packages/console/src/cloud/types/router.ts
+++ b/packages/console/src/cloud/types/router.ts
@@ -17,24 +17,34 @@ export type TenantUsageAddOnSkus = GuardedResponse<
 
 export type SystemLimit = GuardedResponse<GetRoutes['/api/tenants/my/subscription']>['systemLimit'];
 
-export type SubscriptionUsageResponse = GuardedResponse<
+type CompleteSubscriptionUsageResponse = GuardedResponse<
   GetRoutes['/api/tenants/:tenantId/subscription-usage']
 >;
 
 export type SubscriptionQuota = Omit<
-  SubscriptionUsageResponse['quota'],
+  CompleteSubscriptionUsageResponse['quota'],
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the quota keys for now to avoid confusion.
   'organizationsEnabled'
->;
+> & {
+  inlineHooksEnabled: boolean;
+};
+
+export type SubscriptionUsageResponse = Omit<
+  CompleteSubscriptionUsageResponse,
+  'basicQuota' | 'quota'
+> & {
+  basicQuota: SubscriptionQuota;
+  quota: SubscriptionQuota;
+};
 
 export type SubscriptionCountBasedUsage = Omit<
-  SubscriptionUsageResponse['usage'],
+  CompleteSubscriptionUsageResponse['usage'],
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
   'organizationsEnabled'
 >;
-export type SubscriptionResourceScopeUsage = SubscriptionUsageResponse['resources'];
+export type SubscriptionResourceScopeUsage = CompleteSubscriptionUsageResponse['resources'];
 export type SubscriptionRoleScopeUsage = Omit<
-  SubscriptionUsageResponse['roles'],
+  CompleteSubscriptionUsageResponse['roles'],
   // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the quota keys for now to avoid confusion.
   'organizationsEnabled'
 >;

--- a/packages/console/src/consts/tenants.ts
+++ b/packages/console/src/consts/tenants.ts
@@ -114,6 +114,7 @@ export const defaultSubscriptionQuota: SubscriptionQuota = {
   thirdPartyApplicationsLimit: 0,
   tenantMembersLimit: 1,
   customJwtEnabled: false,
+  inlineHooksEnabled: false,
   subjectTokenEnabled: false,
   bringYourUiEnabled: false,
   collectUserProfileEnabled: false,

--- a/packages/console/src/contexts/SubscriptionDataProvider/use-subscription-data.ts
+++ b/packages/console/src/contexts/SubscriptionDataProvider/use-subscription-data.ts
@@ -3,7 +3,11 @@ import { useContext, useEffect, useMemo } from 'react';
 import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
-import { type LogtoSkuResponse, type SubscriptionUsageResponse } from '@/cloud/types/router';
+import {
+  type LogtoSkuResponse,
+  type SubscriptionQuota,
+  type SubscriptionUsageResponse,
+} from '@/cloud/types/router';
 import {
   defaultLogtoSku,
   defaultTenantResponse,
@@ -18,6 +22,14 @@ import { formatLogtoSkusResponses } from '@/utils/subscription';
 import useSubscription from '../../hooks/use-subscription';
 
 import { type SubscriptionContext } from './types';
+
+type CloudSubscriptionQuota = Omit<SubscriptionQuota, 'inlineHooksEnabled'> &
+  Partial<Pick<SubscriptionQuota, 'inlineHooksEnabled'>>;
+
+const withInlineHooksQuota = (quota: CloudSubscriptionQuota): SubscriptionQuota => ({
+  ...quota,
+  inlineHooksEnabled: quota.inlineHooksEnabled ?? false,
+});
 
 const useSubscriptionData: () => SubscriptionContext & { isLoading: boolean } = () => {
   const cloudApi = useCloudApi();
@@ -36,10 +48,17 @@ const useSubscriptionData: () => SubscriptionContext & { isLoading: boolean } = 
     mutate: mutateSubscriptionQuotaAndUsages,
   } = useSWR<SubscriptionUsageResponse, Error>(
     isCloud && currentTenantId && `/api/tenants/${currentTenantId}/subscription-usage`,
-    async () =>
-      cloudApi.get('/api/tenants/:tenantId/subscription-usage', {
+    async () => {
+      const data = await cloudApi.get('/api/tenants/:tenantId/subscription-usage', {
         params: { tenantId: currentTenantId },
-      })
+      });
+
+      return {
+        ...data,
+        basicQuota: withInlineHooksQuota(data.basicQuota),
+        quota: withInlineHooksQuota(data.quota),
+      };
+    }
   );
 
   // Fetch tenant specific available SKUs

--- a/packages/console/src/types/skus.ts
+++ b/packages/console/src/types/skus.ts
@@ -6,7 +6,7 @@ export enum LogtoSkuType {
   AddOn = 'AddOn',
 }
 
-export type LogtoSkuQuota = SubscriptionQuota & {
+export type LogtoSkuQuota = Omit<SubscriptionQuota, 'inlineHooksEnabled'> & {
   // Add ticket support quota item to the plan since it will be compared in the downgrade plan notification modal.
   ticketSupportResponseTime: number;
 };

--- a/packages/core/src/__mocks__/cloud-connection.ts
+++ b/packages/core/src/__mocks__/cloud-connection.ts
@@ -53,6 +53,7 @@ export const mockQuota = {
   thirdPartyApplicationsLimit: 0,
   tenantMembersLimit: 1,
   customJwtEnabled: false,
+  inlineHooksEnabled: false,
   subjectTokenEnabled: false,
   bringYourUiEnabled: false,
   collectUserProfileEnabled: false,

--- a/packages/core/src/libraries/inline-hook.test.ts
+++ b/packages/core/src/libraries/inline-hook.test.ts
@@ -1,0 +1,128 @@
+import { LogtoInlineHookKey } from '@logto/schemas';
+
+import { EnvSet } from '#src/env-set/index.js';
+import { LocalVmError } from '#src/utils/custom-jwt/index.js';
+
+import { InlineHookLibrary } from './inline-hook.js';
+import type { LogtoConfigLibrary } from './logto-config.js';
+
+const { jest } = import.meta;
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+const getInlineHook = jest.fn() as jest.MockedFunction<LogtoConfigLibrary['getInlineHook']>;
+const library = new InlineHookLibrary({ getInlineHook } as unknown as LogtoConfigLibrary);
+
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', isDevFeaturesEnabled);
+};
+
+describe('InlineHookLibrary', () => {
+  beforeEach(() => {
+    setDevFeaturesEnabled(true);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
+  it('loads hook config and runs enabled inline hook script in local VM', async () => {
+    getInlineHook.mockResolvedValueOnce({
+      enabled: true,
+      environmentVariables: {
+        NAME_SUFFIX: ' updated',
+      },
+      script: `
+        const runInlineHook = ({ event, environmentVariables, api }) => ({
+          action: 'updateUser',
+          user: {
+            name: event.user.name + environmentVariables.NAME_SUFFIX,
+          },
+          apiFrozen: Object.isFrozen(api),
+        });
+      `,
+    });
+
+    await expect(
+      library.runHook({
+        key: LogtoInlineHookKey.PostSignIn,
+        event: {
+          key: LogtoInlineHookKey.PostSignIn,
+          interactionEvent: 'SignIn',
+          user: {
+            id: 'foo',
+            name: 'Foo',
+          },
+        },
+      })
+    ).resolves.toEqual({
+      action: 'updateUser',
+      user: {
+        name: 'Foo updated',
+      },
+      apiFrozen: true,
+    });
+
+    expect(getInlineHook).toHaveBeenCalledWith(LogtoInlineHookKey.PostSignIn);
+  });
+
+  it('does not load or run hooks when dev features are disabled', async () => {
+    setDevFeaturesEnabled(false);
+
+    await expect(
+      library.runHook({
+        key: LogtoInlineHookKey.PostSignIn,
+        event: {},
+      })
+    ).resolves.toBeUndefined();
+
+    expect(getInlineHook).not.toHaveBeenCalled();
+  });
+
+  it('does not run disabled hooks', async () => {
+    getInlineHook.mockResolvedValueOnce({
+      enabled: false,
+      script: `
+        const runInlineHook = () => {
+          throw new Error('should not run');
+        };
+      `,
+    });
+
+    await expect(
+      library.runHook({
+        key: LogtoInlineHookKey.PostSignIn,
+        event: {},
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws LocalVmError when inline hook denies access', async () => {
+    const script = `
+      const runInlineHook = ({ api }) => api.denyAccess('Nope');
+    `;
+
+    await expect(
+      InlineHookLibrary.runScriptInLocalVm({
+        script,
+        event: {},
+      })
+    ).rejects.toBeInstanceOf(LocalVmError);
+
+    try {
+      await InlineHookLibrary.runScriptInLocalVm({
+        script,
+        event: {},
+      });
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(LocalVmError);
+      await expect((error as LocalVmError).response.json()).resolves.toEqual({
+        message: 'Nope',
+        error: {
+          code: 'AccessDenied',
+          message: 'Nope',
+        },
+      });
+    }
+  });
+});

--- a/packages/core/src/libraries/inline-hook.ts
+++ b/packages/core/src/libraries/inline-hook.ts
@@ -6,6 +6,7 @@ import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import {
   buildLocalVmErrorBody,
   LocalVmError,
+  LocalVmTimeoutError,
   runScriptFunctionInLocalVm,
 } from '#src/utils/custom-jwt/index.js';
 
@@ -59,6 +60,10 @@ export class InlineHookLibrary {
     } catch (error: unknown) {
       if (error instanceof LocalVmError) {
         throw error;
+      }
+
+      if (error instanceof LocalVmTimeoutError) {
+        throw new LocalVmError(buildLocalVmErrorBody(error), 504);
       }
 
       if (error instanceof ZodError) {

--- a/packages/core/src/libraries/inline-hook.ts
+++ b/packages/core/src/libraries/inline-hook.ts
@@ -1,0 +1,106 @@
+import { type LogtoInlineHookKey } from '@logto/schemas';
+import { ZodError } from 'zod';
+
+import { EnvSet } from '#src/env-set/index.js';
+import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
+import {
+  buildLocalVmErrorBody,
+  LocalVmError,
+  runScriptFunctionInLocalVm,
+} from '#src/utils/custom-jwt/index.js';
+
+const inlineHookFunctionName = 'runInlineHook';
+
+type InlineHookApiContext = {
+  denyAccess: (message?: string) => never;
+};
+
+type InlineHookScriptPayload<Event> = {
+  event: Event;
+  environmentVariables?: Record<string, string>;
+  api: InlineHookApiContext;
+};
+
+type InlineHookRunnerData<Event> = {
+  script: string;
+  event: Event;
+  environmentVariables?: Record<string, string>;
+};
+
+const apiContext: InlineHookApiContext = Object.freeze({
+  denyAccess: (message = 'Access denied') => {
+    throw new LocalVmError(
+      {
+        message,
+        error: {
+          code: 'AccessDenied',
+          message,
+        },
+      },
+      403
+    );
+  },
+});
+
+export class InlineHookLibrary {
+  static async runScriptInLocalVm<Event>({
+    script,
+    event,
+    environmentVariables,
+  }: InlineHookRunnerData<Event>): Promise<unknown> {
+    try {
+      const payload: InlineHookScriptPayload<Event> = {
+        event,
+        environmentVariables,
+        api: apiContext,
+      };
+
+      return await runScriptFunctionInLocalVm(script, inlineHookFunctionName, payload);
+    } catch (error: unknown) {
+      if (error instanceof LocalVmError) {
+        throw error;
+      }
+
+      if (error instanceof ZodError) {
+        throw new LocalVmError(
+          {
+            message: 'Invalid input',
+            errors: error.errors,
+          },
+          400
+        );
+      }
+
+      throw new LocalVmError(
+        buildLocalVmErrorBody(error),
+        error instanceof SyntaxError || error instanceof TypeError ? 422 : 500
+      );
+    }
+  }
+
+  constructor(private readonly logtoConfigs: LogtoConfigLibrary) {}
+
+  async runHook<Event>({
+    key,
+    event,
+  }: {
+    key: LogtoInlineHookKey;
+    event: Event;
+  }): Promise<unknown> {
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    const inlineHook = await this.logtoConfigs.getInlineHook(key);
+
+    if (!inlineHook?.enabled) {
+      return;
+    }
+
+    return InlineHookLibrary.runScriptInLocalVm({
+      script: inlineHook.script,
+      event,
+      environmentVariables: inlineHook.environmentVariables,
+    });
+  }
+}

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -36,6 +36,7 @@ import { type UserLibrary } from '#src/libraries/user.js';
 import type Queries from '#src/tenants/Queries.js';
 import {
   LocalVmError,
+  LocalVmTimeoutError,
   getJwtCustomizerScripts,
   runScriptFunctionInLocalVm,
   buildLocalVmErrorBody,
@@ -78,6 +79,10 @@ export class JwtCustomizerLibrary {
     } catch (error: unknown) {
       if (error instanceof LocalVmError) {
         throw error;
+      }
+
+      if (error instanceof LocalVmTimeoutError) {
+        throw new LocalVmError(buildLocalVmErrorBody(error), 504);
       }
 
       // Assuming we only use zod for request body validation

--- a/packages/core/src/libraries/logto-config.ts
+++ b/packages/core/src/libraries/logto-config.ts
@@ -3,6 +3,7 @@ import crypto from 'node:crypto';
 import type {
   CloudConnectionData,
   IdTokenConfig,
+  InlineHookType,
   JwtCustomizerType,
   LogtoOidcConfigType,
   OidcConfigKey,
@@ -11,6 +12,7 @@ import type {
 } from '@logto/schemas';
 import {
   LogtoConfigs,
+  LogtoInlineHookKey,
   LogtoJwtTokenKey,
   LogtoOidcConfigKey,
   OidcSigningKeyStatus,
@@ -20,6 +22,7 @@ import {
   oidcConfigKeysResponseGuard,
   rotateOidcPrivateKeyStatuses,
   idTokenConfigGuard,
+  inlineHookConfigGuard,
   jwtCustomizerConfigGuard,
   logtoOidcConfigGuard,
 } from '@logto/schemas';
@@ -39,6 +42,7 @@ export const createLogtoConfigLibrary = ({
     getRowsByKeys,
     getCloudConnectionData: queryCloudConnectionData,
     upsertJwtCustomizer: queryUpsertJwtCustomizer,
+    upsertInlineHook: queryUpsertInlineHook,
     upsertIdTokenConfig: queryUpsertIdTokenConfig,
     getSigningKeyRotationState,
   },
@@ -156,6 +160,66 @@ export const createLogtoConfigLibrary = ({
     return updatedRow.value;
   };
 
+  const upsertInlineHook = async <T extends LogtoInlineHookKey>(
+    key: T,
+    value: InlineHookType[T]
+  ) => {
+    const { value: rawValue } = await queryUpsertInlineHook(key, value);
+
+    return {
+      key,
+      value: inlineHookConfigGuard[key].parse(rawValue),
+    };
+  };
+
+  const getInlineHook = async <T extends LogtoInlineHookKey>(key: T) => {
+    const { rows } = await getRowsByKeys([key]);
+
+    if (rows.length === 0) {
+      throw new RequestError({
+        code: 'entity.not_exists_with_id',
+        name: LogtoConfigs.tableSingular,
+        id: key,
+        status: 404,
+      });
+    }
+
+    return z.object({ value: inlineHookConfigGuard[key] }).parse(rows[0]).value;
+  };
+
+  const getInlineHooks = async (consoleLog: ConsoleLog): Promise<Partial<InlineHookType>> => {
+    try {
+      const { rows } = await getRowsByKeys(Object.values(LogtoInlineHookKey));
+
+      return z
+        .object(inlineHookConfigGuard)
+        .partial()
+        .parse(Object.fromEntries(rows.map(({ key, value }) => [key, value])));
+    } catch (error: unknown) {
+      if (error instanceof ZodError) {
+        consoleLog.error(
+          error.issues
+            .map(({ message, path }) => `${message} at ${chalk.green(path.join('.'))}`)
+            .join('\n')
+        );
+      } else {
+        consoleLog.error(error);
+      }
+
+      throw new Error('Failed to get inline hooks');
+    }
+  };
+
+  const updateInlineHook = async <T extends LogtoInlineHookKey>(
+    key: T,
+    value: InlineHookType[T]
+  ): Promise<InlineHookType[T]> => {
+    const originValue = await getInlineHook(key);
+    const result = inlineHookConfigGuard[key].parse({ ...originValue, ...value });
+    const updatedRow = await upsertInlineHook(key, result);
+    return updatedRow.value;
+  };
+
   const upsertIdTokenConfig = async (idTokenConfig: IdTokenConfig) => {
     const { value } = await queryUpsertIdTokenConfig(idTokenConfig);
     return idTokenConfigGuard.parse(value);
@@ -235,6 +299,10 @@ export const createLogtoConfigLibrary = ({
     getJwtCustomizer,
     getJwtCustomizers,
     updateJwtCustomizer,
+    upsertInlineHook,
+    getInlineHook,
+    getInlineHooks,
+    updateInlineHook,
     upsertIdTokenConfig,
     getRedactedOidcKeyResponse,
     promoteScheduledSigningKeyRotation,

--- a/packages/core/src/queries/logto-config.test.ts
+++ b/packages/core/src/queries/logto-config.test.ts
@@ -1,6 +1,7 @@
 import {
   type LogtoConfigKey,
   LogtoConfigs,
+  LogtoInlineHookKey,
   LogtoOidcConfigKey,
   LogtoTenantConfigKey,
   OidcSigningKeyStatus,
@@ -31,9 +32,11 @@ const {
   getSigningKeyRotationState,
   setSigningKeyRotationAt,
   setTenantCacheExpiresAt,
+  upsertInlineHook,
   upsertSigningKeyRotationState,
   updateAdminConsoleConfig,
   updateOidcConfigsByKey,
+  deleteInlineHook,
 } = createLogtoConfigQueries(pool, new MockWellKnownCache());
 
 describe('connector queries', () => {
@@ -150,6 +153,59 @@ describe('connector queries', () => {
     });
 
     void updateOidcConfigsByKey(LogtoOidcConfigKey.Session, targetValue);
+  });
+
+  test('upsertInlineHook', async () => {
+    const targetValue = {
+      script: 'export default async () => ({ action: "updateUser" });',
+      environmentVariables: {
+        API_KEY: '<api-key>',
+      },
+      enabled: true,
+      onExecutionError: 'allow' as const,
+    };
+    const targetRowData = [{ key: LogtoInlineHookKey.PostSignIn, value: targetValue }];
+    const expectSql = sql`
+      insert into ${table} (${fields.key}, ${fields.value})
+        values (${LogtoInlineHookKey.PostSignIn}, ${sql.jsonb(targetValue)})
+        on conflict (${fields.tenantId}, ${fields.key}) do update set ${fields.value} = ${sql.jsonb(
+          targetValue
+        )}
+        returning *
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toMatchObject([
+        LogtoInlineHookKey.PostSignIn,
+        JSON.stringify(targetValue),
+        JSON.stringify(targetValue),
+      ]);
+
+      return createMockQueryResult(targetRowData as never);
+    });
+
+    await expect(upsertInlineHook(LogtoInlineHookKey.PostSignIn, targetValue)).resolves.toEqual(
+      targetRowData[0]
+    );
+  });
+
+  test('deleteInlineHook', async () => {
+    const expectSql = sql`
+      delete from ${table}
+      where ${fields.key}=${LogtoInlineHookKey.PostFirstFactorVerification}
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toEqual([LogtoInlineHookKey.PostFirstFactorVerification]);
+
+      return { ...createMockQueryResult([]), rowCount: 1 };
+    });
+
+    await expect(
+      deleteInlineHook(LogtoInlineHookKey.PostFirstFactorVerification)
+    ).resolves.toBeUndefined();
   });
 
   test('getSigningKeyRotationState', async () => {

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -1,4 +1,5 @@
 import {
+  type inlineHookConfigGuard,
   type jwtCustomizerConfigGuard,
   LogtoConfigs,
   LogtoTenantConfigKey,
@@ -6,6 +7,7 @@ import {
   type IdTokenConfig,
   type LogtoConfig,
   type LogtoConfigKey,
+  type LogtoInlineHookKey,
   LogtoOidcConfigKey,
   type LogtoJwtTokenKey,
   type OidcPrivateKey,
@@ -218,6 +220,23 @@ export const createLogtoConfigQueries = (
 
   const deleteJwtCustomizer = async <T extends LogtoJwtTokenKey>(key: T) => deleteRowByKey(key);
 
+  const upsertInlineHook = async <T extends LogtoInlineHookKey>(
+    key: T,
+    value: z.infer<(typeof inlineHookConfigGuard)[T]>
+  ) =>
+    pool.one<{ key: T; value: z.infer<(typeof inlineHookConfigGuard)[T]> }>(
+      sql`
+        insert into ${table} (${fields.key}, ${fields.value})
+          values (${key}, ${sql.jsonb(value)})
+          on conflict (${fields.tenantId}, ${fields.key}) do update set ${
+            fields.value
+          } = ${sql.jsonb(value)}
+          returning *
+      `
+    );
+
+  const deleteInlineHook = async <T extends LogtoInlineHookKey>(key: T) => deleteRowByKey(key);
+
   const getIdTokenConfig = wellKnownCache.memoize(async () => {
     const { rows } = await getRowsByKeys([LogtoTenantConfigKey.IdToken]);
 
@@ -268,6 +287,8 @@ export const createLogtoConfigQueries = (
     setSigningKeyRotationAt,
     upsertJwtCustomizer,
     deleteJwtCustomizer,
+    upsertInlineHook,
+    deleteInlineHook,
     getIdTokenConfig,
     upsertIdTokenConfig,
     getMessageRateLimitOverride,

--- a/packages/core/src/queries/tenant-usage/types.ts
+++ b/packages/core/src/queries/tenant-usage/types.ts
@@ -86,6 +86,7 @@ export const isSystemUsageKey = (key: UsageKey): key is SystemUsageKey =>
 const quotaUsageKeyGuard = z.enum([
   ...sharedUsageKeyGuard.options,
   'customJwtEnabled',
+  'inlineHooksEnabled',
   'subjectTokenEnabled',
   'bringYourUiEnabled',
   'collectUserProfileEnabled',
@@ -132,6 +133,7 @@ type BooleanQuotaUsageKey = {
 
 const booleanQuotaUsageKeyGuard = z.enum([
   'customJwtEnabled',
+  'inlineHooksEnabled',
   'subjectTokenEnabled',
   'bringYourUiEnabled',
   'collectUserProfileEnabled',

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -5,6 +5,7 @@ import type { ConnectorLibrary } from '#src/libraries/connector.js';
 import { createCustomProfileFieldsLibrary } from '#src/libraries/custom-profile-fields/index.js';
 import { createDomainLibrary } from '#src/libraries/domain.js';
 import { createHookLibrary } from '#src/libraries/hook/index.js';
+import { InlineHookLibrary } from '#src/libraries/inline-hook.js';
 import { JwtCustomizerLibrary } from '#src/libraries/jwt-customizer.js';
 import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import { OidcPrivateKeyLibrary } from '#src/libraries/oidc-private-key.js';
@@ -31,6 +32,7 @@ export default class Libraries {
   users = createUserLibrary(this.tenantId, this.queries);
   phrases = createPhraseLibrary(this.queries);
   hooks = createHookLibrary(this.queries);
+  inlineHooks = new InlineHookLibrary(this.logtoConfigs);
   scopes = createScopeLibrary(this.queries);
   socials = createSocialLibrary(this.queries, this.connectors);
   jwtCustomizers = new JwtCustomizerLibrary(

--- a/packages/core/src/test-utils/mock-libraries.ts
+++ b/packages/core/src/test-utils/mock-libraries.ts
@@ -16,6 +16,10 @@ export const mockLogtoConfigsLibrary: jest.Mocked<LogtoConfigLibrary> = {
   getJwtCustomizer: jest.fn(),
   getJwtCustomizers: jest.fn(),
   updateJwtCustomizer: jest.fn(),
+  upsertInlineHook: jest.fn(),
+  getInlineHook: jest.fn(),
+  getInlineHooks: jest.fn(),
+  updateInlineHook: jest.fn(),
   upsertIdTokenConfig: jest.fn(),
 };
 

--- a/packages/core/src/utils/custom-jwt/local-vm.test.ts
+++ b/packages/core/src/utils/custom-jwt/local-vm.test.ts
@@ -1,0 +1,132 @@
+import {
+  buildLocalVmErrorBody,
+  localVmTimeoutErrorCode,
+  LocalVmTimeoutError,
+  runScriptFunctionInLocalVm,
+} from './local-vm.js';
+
+const { jest } = import.meta;
+
+describe('runScriptFunctionInLocalVm', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('throws timeout error when script evaluation exceeds the deadline', async () => {
+    await expect(
+      runScriptFunctionInLocalVm(
+        `
+          while (true) {}
+          const getCustomJwtClaims = () => ({});
+        `,
+        'getCustomJwtClaims',
+        {},
+        { timeout: 30 }
+      )
+    ).rejects.toMatchObject({
+      code: localVmTimeoutErrorCode,
+      timeout: 30,
+    });
+  });
+
+  it('throws timeout error when synchronous function execution exceeds the deadline', async () => {
+    await expect(
+      runScriptFunctionInLocalVm(
+        `
+          const getCustomJwtClaims = () => {
+            while (true) {}
+          };
+        `,
+        'getCustomJwtClaims',
+        {},
+        { timeout: 30 }
+      )
+    ).rejects.toMatchObject({
+      code: localVmTimeoutErrorCode,
+      timeout: 30,
+    });
+  });
+
+  it('aborts fetch and throws timeout error when async execution exceeds the deadline', async () => {
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+      const { signal } = init ?? {};
+
+      if (!signal) {
+        throw new Error('Expected abort signal');
+      }
+
+      return new Promise<Response>((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          reject(signal.reason instanceof Error ? signal.reason : new Error('Aborted'));
+        });
+      });
+    });
+
+    await expect(
+      runScriptFunctionInLocalVm(
+        `
+          const getCustomJwtClaims = async () => {
+            await fetch('https://example.com/slow');
+            return {};
+          };
+        `,
+        'getCustomJwtClaims',
+        {},
+        { timeout: 30 }
+      )
+    ).rejects.toMatchObject({
+      code: localVmTimeoutErrorCode,
+      timeout: 30,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const signal = init?.signal;
+
+    expect(signal?.aborted).toBe(true);
+    expect(signal?.reason).toBeInstanceOf(LocalVmTimeoutError);
+  });
+
+  it('aborts pending fetches after function execution is complete', async () => {
+    const fetchMock = jest.spyOn(globalThis, 'fetch').mockImplementation(async (_input, init) => {
+      return new Promise<Response>(() => {
+        // Keep the request pending until the runner cleanup aborts it.
+      });
+    });
+
+    await expect(
+      runScriptFunctionInLocalVm(
+        `
+          const getCustomJwtClaims = () => {
+            fetch('https://example.com/fire-and-forget');
+            return { ok: true };
+          };
+        `,
+        'getCustomJwtClaims',
+        {},
+        { timeout: 300 }
+      )
+    ).resolves.toEqual({ ok: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    const signal = init?.signal;
+
+    expect(signal?.aborted).toBe(true);
+  });
+});
+
+describe('buildLocalVmErrorBody', () => {
+  it('returns structured timeout error body', () => {
+    const error = new LocalVmTimeoutError(3000);
+
+    expect(buildLocalVmErrorBody(error)).toEqual({
+      message: 'Script execution timed out after 3000ms',
+      error: {
+        code: localVmTimeoutErrorCode,
+        message: 'Script execution timed out after 3000ms',
+        timeout: 3000,
+      },
+    });
+  });
+});

--- a/packages/core/src/utils/custom-jwt/local-vm.ts
+++ b/packages/core/src/utils/custom-jwt/local-vm.ts
@@ -1,3 +1,4 @@
+import { setTimeout as sleep } from 'node:timers/promises';
 import { types } from 'node:util';
 import { runInNewContext } from 'node:vm';
 
@@ -23,6 +24,111 @@ export class LocalVmError extends ResponseError {
   }
 }
 
+export const localVmTimeoutErrorCode = 'LocalVmTimeout';
+const defaultLocalVmTimeout = 3000;
+
+type LocalVmRunnerOptions = {
+  timeout?: number;
+};
+
+export class LocalVmTimeoutError extends Error {
+  readonly code = localVmTimeoutErrorCode;
+
+  constructor(readonly timeout: number) {
+    super(`Script execution timed out after ${timeout}ms`);
+    this.name = 'LocalVmTimeoutError';
+  }
+}
+
+const isNodeVmTimeoutError = (error: unknown) =>
+  types.isNativeError(error) && error.message.startsWith('Script execution timed out after ');
+
+const getRemainingTimeout = (deadline: number, timeoutError: LocalVmTimeoutError) => {
+  const remainingTimeout = deadline - Date.now();
+
+  if (remainingTimeout <= 0) {
+    throw timeoutError;
+  }
+
+  return remainingTimeout;
+};
+
+const createAbortableFetch = (abortController: AbortController) => {
+  const pendingFetches = new Set<Promise<Response>>();
+
+  const abortableFetch: typeof fetch = async (...args) => {
+    const [input, init] = args;
+    const signal = init?.signal
+      ? AbortSignal.any([abortController.signal, init.signal])
+      : abortController.signal;
+    const fetchPromise = fetch(input, { ...init, signal });
+
+    pendingFetches.add(fetchPromise);
+    void (async () => {
+      try {
+        await fetchPromise;
+      } catch {
+        // Fetch errors are surfaced to awaited script calls; this avoids unhandled rejections
+        // when cleanup aborts fire-and-forget fetches.
+      } finally {
+        pendingFetches.delete(fetchPromise);
+      }
+    })();
+
+    return fetchPromise;
+  };
+
+  return {
+    fetch: abortableFetch,
+    abortPendingFetches: (reason?: unknown) => {
+      if (!abortController.signal.aborted) {
+        abortController.abort(reason);
+      }
+
+      pendingFetches.clear();
+    },
+  };
+};
+
+const runWithDeadline = async <Result>(
+  promise: Promise<Result>,
+  timeout: number,
+  remainingTimeout: number,
+  abortController: AbortController
+) => {
+  const timeoutError = new LocalVmTimeoutError(timeout);
+  const timeoutAbortController = new AbortController();
+
+  const timeoutPromise = (async () => {
+    try {
+      await sleep(remainingTimeout, undefined, { signal: timeoutAbortController.signal });
+      abortController.abort(timeoutError);
+      throw timeoutError;
+    } catch (error: unknown) {
+      if (timeoutAbortController.signal.aborted) {
+        return new Promise<never>(() => {
+          // Keep the canceled timeout out of the race after execution completes.
+        });
+      }
+
+      throw error;
+    }
+  })();
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } catch (error: unknown) {
+    if (abortController.signal.reason === timeoutError) {
+      throw timeoutError;
+    }
+
+    throw error;
+  } finally {
+    timeoutAbortController.abort();
+    abortController.abort();
+  }
+};
+
 /**
  * This function is used to execute a named function in a customized code script in a local
  * virtual machine with the given payload as input.
@@ -35,32 +141,54 @@ export class LocalVmError extends ResponseError {
 export const runScriptFunctionInLocalVm = async (
   script: string,
   functionName: string,
-  payload: unknown
+  payload: unknown,
+  { timeout = defaultLocalVmTimeout }: LocalVmRunnerOptions = {}
 ) => {
+  const deadline = Date.now() + timeout;
+  const timeoutError = new LocalVmTimeoutError(timeout);
+  const abortController = new AbortController();
+  const { fetch: abortableFetch, abortPendingFetches } = createAbortableFetch(abortController);
   const globalContext = Object.freeze({
-    fetch: async (...args: Parameters<typeof fetch>) => fetch(...args),
+    fetch: abortableFetch,
   });
-  const customFunction: unknown = runInNewContext(script + `;${functionName};`, globalContext);
 
-  if (typeof customFunction !== 'function') {
-    throw new TypeError(`The script does not have a function named \`${functionName}\``);
+  try {
+    const customFunction: unknown = runInNewContext(script + `;${functionName};`, globalContext, {
+      timeout: getRemainingTimeout(deadline, timeoutError),
+    });
+
+    if (typeof customFunction !== 'function') {
+      throw new TypeError(`The script does not have a function named \`${functionName}\``);
+    }
+
+    /**
+     * We can not use top-level await in `vm`, use the following implementation instead.
+     *
+     * Ref:
+     * 1. https://github.com/nodejs/node/issues/40898
+     * 2. https://github.com/n-riesco/ijavascript/issues/173#issuecomment-693924098
+     */
+    const result: unknown = runInNewContext(
+      '(async () => customFunction(payload))();',
+      Object.freeze({ customFunction, payload }),
+      { timeout: getRemainingTimeout(deadline, timeoutError) }
+    );
+
+    return await runWithDeadline(
+      Promise.resolve(result),
+      timeout,
+      getRemainingTimeout(deadline, timeoutError),
+      abortController
+    );
+  } catch (error: unknown) {
+    if (isNodeVmTimeoutError(error)) {
+      throw timeoutError;
+    }
+
+    throw error;
+  } finally {
+    abortPendingFetches();
   }
-
-  /**
-   * We can not use top-level await in `vm`, use the following implementation instead.
-   *
-   * Ref:
-   * 1. https://github.com/nodejs/node/issues/40898
-   * 2. https://github.com/n-riesco/ijavascript/issues/173#issuecomment-693924098
-   */
-  const result: unknown = await runInNewContext(
-    '(async () => customFunction(payload))();',
-    Object.freeze({ customFunction, payload }),
-    // Limit the execution time to 3 seconds, throws error if the script takes too long to execute.
-    { timeout: 3000 }
-  );
-
-  return result;
 };
 
 /**
@@ -74,6 +202,15 @@ export const runScriptFunctionInLocalVm = async (
  *
  */
 export const buildLocalVmErrorBody = (error: unknown) =>
-  types.isNativeError(error)
-    ? { message: error.message, stack: error.stack }
-    : { message: String(error) };
+  error instanceof LocalVmTimeoutError
+    ? {
+        message: error.message,
+        error: {
+          code: error.code,
+          message: error.message,
+          timeout: error.timeout,
+        },
+      }
+    : types.isNativeError(error)
+      ? { message: error.message, stack: error.stack }
+      : { message: String(error) };

--- a/packages/core/src/utils/subscription/index.ts
+++ b/packages/core/src/utils/subscription/index.ts
@@ -10,6 +10,14 @@ import {
   allReportSubscriptionUpdatesUsageKeys,
 } from './types.js';
 
+type CloudSubscriptionQuota = Omit<SubscriptionQuota, 'inlineHooksEnabled'> &
+  Partial<Pick<SubscriptionQuota, 'inlineHooksEnabled'>>;
+
+const withInlineHooksQuota = (quota: CloudSubscriptionQuota): SubscriptionQuota => ({
+  ...quota,
+  inlineHooksEnabled: quota.inlineHooksEnabled ?? false,
+});
+
 export const getTenantSubscription = async (
   cloudConnection: CloudConnectionLibrary
 ): Promise<Subscription> => {
@@ -24,6 +32,7 @@ export const getTenantSubscription = async (
     ...rest,
     currentPeriodStart: new Date(currentPeriodStart).toISOString(),
     currentPeriodEnd: new Date(currentPeriodEnd).toISOString(),
+    quota: withInlineHooksQuota(subscription.quota),
   };
 };
 

--- a/packages/core/src/utils/subscription/types.ts
+++ b/packages/core/src/utils/subscription/types.ts
@@ -11,14 +11,27 @@ type RouteResponseType<T extends { search?: unknown; body?: unknown; response?: 
 type RouteRequestBodyType<T extends { search?: unknown; body?: ZodType; response?: unknown }> =
   z.infer<NonNullable<T['body']>>;
 
+type CompleteSubscription = RouteResponseType<GetRoutes['/api/tenants/my/subscription']>;
+type CompleteSubscriptionUsage = RouteResponseType<GetRoutes['/api/tenants/my/subscription-usage']>;
+
+export type SubscriptionQuota = Omit<
+  CompleteSubscriptionUsage['quota'],
+  | 'auditLogsRetentionDays'
+  // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
+  | 'organizationsEnabled'
+> & {
+  inlineHooksEnabled: boolean;
+};
+
 /**
  * The subscription data is fetched from the Cloud API.
  * All the dates are in ISO 8601 format, we need to manually fix the type to string here.
  */
 export type Subscription = Omit<
-  RouteResponseType<GetRoutes['/api/tenants/my/subscription']>,
+  CompleteSubscription,
   | 'currentPeriodStart'
   | 'currentPeriodEnd'
+  | 'quota'
   /**
    * Temporarily omit `quotaScope` for backward compatibility.
    * When we require this field, implement the related logic here.
@@ -28,20 +41,8 @@ export type Subscription = Omit<
 > & {
   currentPeriodStart: string;
   currentPeriodEnd: string;
+  quota: SubscriptionQuota;
 };
-
-type CompleteSubscriptionUsage = RouteResponseType<GetRoutes['/api/tenants/my/subscription-usage']>;
-
-/**
- * @remarks
- * The `auditLogsRetentionDays` will be handled by cron job in Azure Functions, outdated audit logs will be removed automatically.
- */
-export type SubscriptionQuota = Omit<
-  CompleteSubscriptionUsage['quota'],
-  | 'auditLogsRetentionDays'
-  // Since we are deprecation the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
-  | 'organizationsEnabled'
->;
 
 export type SubscriptionUsage = Omit<
   CompleteSubscriptionUsage['usage'],
@@ -102,6 +103,7 @@ const logtoSkuQuotaGuard = z.object({
   hooksLimit: z.number().nullable(),
   auditLogsRetentionDays: z.number().nullable(),
   customJwtEnabled: z.boolean(),
+  inlineHooksEnabled: z.boolean(),
   subjectTokenEnabled: z.boolean(),
   bringYourUiEnabled: z.boolean(),
   collectUserProfileEnabled: z.boolean(),

--- a/packages/schemas/src/types/logto-config/index.test.ts
+++ b/packages/schemas/src/types/logto-config/index.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  LogtoInlineHookKey,
   type LogtoOidcConfigType,
   LogtoOidcConfigKey,
   LogtoTenantConfigKey,
   OidcSigningKeyStatus,
+  inlineHookConfigGuard,
   logtoOidcConfigGuard,
+  logtoConfigGuards,
+  logtoConfigKeys,
   logtoTenantConfigGuard,
   oidcConfigKeysResponseGuard,
 } from './index.js';
@@ -41,5 +45,36 @@ describe('logto config guards', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('accepts inline hook configs', () => {
+    const result = inlineHookConfigGuard[LogtoInlineHookKey.PostFirstFactorVerification].safeParse({
+      script: 'export default async () => ({ action: "createUser" });',
+      environmentVariables: {
+        endpoint: 'https://example.com',
+      },
+      contextSample: ['json', { value: true }],
+      enabled: true,
+      onExecutionError: 'block',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid inline hook execution error policy', () => {
+    const result = inlineHookConfigGuard[LogtoInlineHookKey.PostSignIn].safeParse({
+      script: 'export default async () => ({ action: "updateUser" });',
+      onExecutionError: 'ignore',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('includes inline hook keys in the logto config summary guards', () => {
+    expect(logtoConfigKeys).toContain(LogtoInlineHookKey.PostFirstFactorVerification);
+    expect(logtoConfigKeys).toContain(LogtoInlineHookKey.PostSignIn);
+    expect(logtoConfigGuards[LogtoInlineHookKey.PostSignIn]).toBe(
+      inlineHookConfigGuard[LogtoInlineHookKey.PostSignIn]
+    );
   });
 });

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -8,6 +8,7 @@ import {
   messageRateLimitOverrideGuard,
 } from '../../consts/message-rate-limit.js';
 
+import { type InlineHook, LogtoInlineHookKey, inlineHookGuard } from './inline-hook.js';
 import {
   type AccessTokenJwtCustomizer,
   type ClientCredentialsJwtCustomizer,
@@ -17,6 +18,7 @@ import {
 
 export * from './oidc-provider.js';
 export * from './jwt-customizer.js';
+export * from './inline-hook.js';
 
 /**
  * Logto OIDC signing key types, used mainly in REST API routes.
@@ -101,6 +103,18 @@ export const jwtCustomizerConfigGuard: Readonly<{
 }> = Object.freeze({
   [LogtoJwtTokenKey.AccessToken]: accessTokenJwtCustomizerGuard,
   [LogtoJwtTokenKey.ClientCredentials]: clientCredentialsJwtCustomizerGuard,
+});
+
+export type InlineHookType = {
+  [LogtoInlineHookKey.PostFirstFactorVerification]: InlineHook;
+  [LogtoInlineHookKey.PostSignIn]: InlineHook;
+};
+
+export const inlineHookConfigGuard: Readonly<{
+  [key in LogtoInlineHookKey]: ZodType<InlineHookType[key]>;
+}> = Object.freeze({
+  [LogtoInlineHookKey.PostFirstFactorVerification]: inlineHookGuard,
+  [LogtoInlineHookKey.PostSignIn]: inlineHookGuard,
 });
 
 export const jwtCustomizerConfigsGuard = z.discriminatedUnion('key', [
@@ -200,21 +214,32 @@ export const logtoTenantConfigGuard: Readonly<{
 });
 
 /* --- Summary --- */
-export type LogtoConfigKey = LogtoOidcConfigKey | LogtoJwtTokenKey | LogtoTenantConfigKey;
-export type LogtoConfigType = LogtoOidcConfigType | JwtCustomizerType | LogtoTenantConfigType;
+export type LogtoConfigKey =
+  | LogtoOidcConfigKey
+  | LogtoJwtTokenKey
+  | LogtoInlineHookKey
+  | LogtoTenantConfigKey;
+export type LogtoConfigType =
+  | LogtoOidcConfigType
+  | JwtCustomizerType
+  | InlineHookType
+  | LogtoTenantConfigType;
 export type LogtoConfigGuard = typeof logtoOidcConfigGuard &
   typeof jwtCustomizerConfigGuard &
+  typeof inlineHookConfigGuard &
   typeof logtoTenantConfigGuard;
 
 export const logtoConfigKeys: readonly LogtoConfigKey[] = Object.freeze([
   ...Object.values(LogtoOidcConfigKey),
   ...Object.values(LogtoJwtTokenKey),
+  ...Object.values(LogtoInlineHookKey),
   ...Object.values(LogtoTenantConfigKey),
 ]);
 
 export const logtoConfigGuards: LogtoConfigGuard = Object.freeze({
   ...logtoOidcConfigGuard,
   ...jwtCustomizerConfigGuard,
+  ...inlineHookConfigGuard,
   ...logtoTenantConfigGuard,
 });
 

--- a/packages/schemas/src/types/logto-config/inline-hook.ts
+++ b/packages/schemas/src/types/logto-config/inline-hook.ts
@@ -1,0 +1,73 @@
+import { jsonGuard } from '@logto/connector-kit';
+import { z } from 'zod';
+
+import type { Json } from '../../foundations/index.js';
+import type { InteractionEvent, InteractionIdentifier } from '../interactions.js';
+import type { UserInfo } from '../user.js';
+
+export enum LogtoInlineHookKey {
+  PostFirstFactorVerification = 'inlineHook.postFirstFactorVerification',
+  PostSignIn = 'inlineHook.postSignIn',
+}
+
+export const inlineHookExecutionErrorPolicies = Object.freeze(['block', 'allow'] as const);
+
+export type InlineHookExecutionErrorPolicy = (typeof inlineHookExecutionErrorPolicies)[number];
+
+export type InlineHook = {
+  script: string;
+  environmentVariables?: Record<string, string>;
+  contextSample?: Json;
+  enabled?: boolean;
+  onExecutionError?: InlineHookExecutionErrorPolicy;
+};
+
+export const inlineHookGuard = z
+  .object({
+    script: z.string(),
+    environmentVariables: z.record(z.string()).optional(),
+    contextSample: jsonGuard.optional(),
+    enabled: z.boolean().optional(),
+    onExecutionError: z.enum(inlineHookExecutionErrorPolicies).optional(),
+  })
+  .strict() satisfies z.ZodType<InlineHook>;
+
+export type HookUser = Pick<
+  UserInfo,
+  | 'id'
+  | 'username'
+  | 'primaryEmail'
+  | 'primaryPhone'
+  | 'name'
+  | 'avatar'
+  | 'customData'
+  | 'profile'
+  | 'applicationId'
+  | 'isSuspended'
+>;
+
+export type HookUserPatch = Partial<HookUser>;
+
+export type PostFirstFactorVerificationEvent = {
+  key: LogtoInlineHookKey.PostFirstFactorVerification;
+  interactionEvent: InteractionEvent.SignIn;
+  identifier: InteractionIdentifier;
+  password: string;
+};
+
+export type PostSignInEvent = {
+  key: LogtoInlineHookKey.PostSignIn;
+  interactionEvent: InteractionEvent.SignIn;
+  user: HookUser;
+};
+
+export type PostFirstFactorVerificationResult = {
+  action: 'createUser' | 'updateUser';
+  user: HookUserPatch;
+  passwordVerified: true;
+};
+
+export type PostSignInResult = {
+  action: 'updateUser';
+  user?: HookUserPatch;
+};


### PR DESCRIPTION
## Summary

- Enforce a wall-clock deadline across local VM script evaluation and function execution.
- Inject an abortable `fetch` and clean up pending fetches when execution completes or times out.
- Expose a structured local VM timeout error body for the inline hook fail-mode handling to consume next.

## Testing

Unit tests