### PR TITLE
fix(core): rate-limit suppressed verification-code sends

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -154,6 +154,8 @@ describe('sendCode parameter passing', () => {
       undefined,
       expect.objectContaining({ skipDelivery: true })
     );
+    // The suppressed send still passes through the rate guard so it counts toward the cap.
+    expect(mockSentinelActivities.countActivities).toHaveBeenCalled();
   });
 
   it('should not skip delivery for forgot-password with existing user', async () => {
@@ -273,6 +275,44 @@ describe('sendCode parameter passing', () => {
       },
     }) as unknown as Queries;
 
+  it('rejects with 429 for a suppressed send over the cap, so suppression cannot be enumerated', async () => {
+    // Forgot-password to an unknown user suppresses delivery, but the send must still be rate-limited:
+    // hitting the cap here proves an unregistered recipient is throttled exactly like a registered one.
+    mockSentinelActivities.countActivities.mockResolvedValueOnce(
+      defaultMessageRateLimitPolicy.maxSendsPerRecipient
+    );
+
+    const ctx = {
+      request: { ip: '127.0.0.1' },
+      createLog: jest.fn(() => ({ append: jest.fn().mockImplementation(resolveVoid) })),
+      appendExceptionHookContext: jest.fn(),
+      experienceInteraction: {
+        ...mockExperienceInteraction,
+        interactionEvent: InteractionEvent.ForgotPassword,
+      },
+      emailI18n: {},
+    };
+    const libraries = { passcodes: mockPasscodeLibrary } as unknown as Partial<Libraries>;
+
+    await expect(
+      sendCode({
+        identifier: { type: SignInIdentifier.Email, value: 'unknown@example.com' },
+        interactionEvent: InteractionEvent.ForgotPassword,
+        createVerificationRecord: () => mockCodeVerification,
+        libraries: libraries as unknown as Libraries,
+        queries: buildUnknownUserQueries(),
+        ctx: ctx as unknown as ExperienceInteractionRouterContext,
+      })
+    ).rejects.toMatchObject({ code: 'request.message_rate_limited', status: 429 });
+
+    // The guard rejects before the (suppressed) send runs, and the throttle still emits the hook.
+    expect(mockSendVerificationCode).not.toHaveBeenCalled();
+    expect(ctx.appendExceptionHookContext).toHaveBeenCalledWith('Message.RateLimited', {
+      action: SentinelActivityAction.VerificationCodeSend,
+      recipient: 'unknown@example.com',
+    });
+  });
+
   const buildSignInCtx = (
     experienceInteraction: MockExperienceInteraction = mockExperienceInteraction
   ) => ({
@@ -299,12 +339,13 @@ describe('sendCode parameter passing', () => {
       ctx: ctx as unknown as ExperienceInteractionRouterContext,
     });
 
-    // The passcode record is still created, but nothing is delivered and the rate guard is bypassed.
+    // The passcode record is still created and nothing is delivered, but the rate guard still runs:
+    // a suppressed send must consume the recipient's quota so registration status cannot be probed.
     expect(mockSendVerificationCode).toHaveBeenCalledWith(
       undefined,
       expect.objectContaining({ skipDelivery: true })
     );
-    expect(mockSentinelActivities.countActivities).not.toHaveBeenCalled();
+    expect(mockSentinelActivities.countActivities).toHaveBeenCalled();
   });
 
   it('delivers for sign-in to an unknown recipient when registration is enabled', async () => {

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -171,8 +171,8 @@ export const sendCode = async ({
         ...(ctx.request.ip && { ip: ctx.request.ip }),
       };
 
-  // Send verification code. When delivery is skipped (see `shouldSkipDelivery`) nothing is sent, so
-  // the rate guard is bypassed.
+  // Send verification code. When delivery is skipped (see `shouldSkipDelivery`) the passcode record is
+  // still created but nothing is sent.
   const send = async () => codeVerification.sendVerificationCode(payload, { skipDelivery });
 
   const messageRateLimit = {
@@ -180,9 +180,11 @@ export const sendCode = async ({
     recipient: identifier.value,
   };
 
-  await (skipDelivery || !EnvSet.values.isDevFeaturesEnabled
-    ? send()
-    : withMessageRateGuard(
+  // The rate guard runs even for suppressed sends: a suppressed send must still count toward the
+  // per-recipient cap, otherwise an unknown recipient never hits 429 while a registered one does —
+  // leaking registration status (account enumeration) and defeating the point of suppression.
+  await (EnvSet.values.isDevFeaturesEnabled
+    ? withMessageRateGuard(
         await buildMessageRateGuard(queries),
         {
           ...messageRateLimit,
@@ -191,7 +193,8 @@ export const sendCode = async ({
           },
         },
         send
-      ));
+      )
+    : send());
 
   // Save state
   experienceInteraction.setVerificationRecord(codeVerification);

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code.suppress-delivery.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code.suppress-delivery.test.ts
@@ -1,5 +1,10 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { InteractionEvent, SignInIdentifier, SignInMode } from '@logto/schemas';
+import {
+  defaultMessageRateLimitPolicy,
+  InteractionEvent,
+  SignInIdentifier,
+  SignInMode,
+} from '@logto/schemas';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -97,5 +102,32 @@ devFeatureTest.describe('suppress sign-in verification-code delivery to unknown 
     expect(emailMessage.code).toBeTruthy();
 
     await deleteUser(userId);
+  });
+
+  it('still counts suppressed sends toward the per-recipient rate-limit cap', async () => {
+    // A suppressed send must consume the recipient's quota; otherwise an unregistered recipient never
+    // hits 429 while a registered one does, leaking registration status. Use a fresh recipient so the
+    // count is isolated from other tests sharing the activity store.
+    const email = generateEmail();
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.SignIn });
+
+    // Sends up to the cap all return 200 even though delivery is suppressed (no message is sent).
+    for (const _ of Array.from({ length: defaultMessageRateLimitPolicy.maxSendsPerRecipient })) {
+      // eslint-disable-next-line no-await-in-loop -- sequential sends to accumulate the per-recipient count
+      await client.sendVerificationCode({
+        interactionEvent: InteractionEvent.SignIn,
+        identifier: { type: SignInIdentifier.Email, value: email },
+      });
+    }
+
+    // The next suppressed send to the same recipient exceeds the cap and is rejected, exactly as it
+    // would be for a registered recipient — so the rate-limit response cannot be used to enumerate.
+    await expectRejects(
+      client.sendVerificationCode({
+        interactionEvent: InteractionEvent.SignIn,
+        identifier: { type: SignInIdentifier.Email, value: email },
+      }),
+      { code: 'request.message_rate_limited', status: 429 }
+    );
   });
 });


### PR DESCRIPTION
## Summary

Refs LOG-13726. When delivery is suppressed (`skipDelivery` — forgot-password to an unregistered identifier, or sign-in to an unregistered identifier while registration is disabled), `sendCode` bypassed the message rate guard entirely. Because suppression is meant to make unknown recipients indistinguishable from real ones, this reintroduced a **user-enumeration oracle**: past the per-recipient cap a registered recipient returns `429`, while a suppressed (unregistered) recipient keeps returning `200` — so an attacker can probe registration status by sending 11+ requests and watching for the throttle.

The whole rate guard is behind `isDevFeaturesEnabled`, so this is not exposed in production yet — it's a pre-release bug that should be fixed before the feature ships (LOG-13649).

### What changed
- `verification-code-helpers.ts`: dropped `skipDelivery` from the rate-guard bypass condition. Now every send runs through `withMessageRateGuard` when dev features are enabled, so suppressed sends count toward the per-recipient cap and a suppressed recipient hits `429` exactly like a real one. The passcode record is still created and nothing is delivered — only the rate accounting changes. (Ternary flipped to positive-first to satisfy `no-negated-condition`.)
- Unit tests: the sign-in suppression case now asserts the guard **runs** (was asserting it was bypassed); the forgot-password suppression case asserts the same; added a case proving a suppressed forgot-password send over the cap rejects with `429` and emits the `Message.RateLimited` hook.
- Integration test: added a case to the suppress-delivery suite asserting that suppressed sign-in sends to an unregistered email still hit `429` at the cap.

### Note
This closes the status-code oracle. A residual timing side-channel remains (a real send does a connector round-trip; a suppressed send doesn't) — pre-existing and acknowledged in #9063, out of scope here.

## Testing

Unit tests, integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
