### PR TITLE
feat(core, console): ship message send rate limiting and delivery suppression

### DIFF
--- a/.changeset/message-send-rate-limit.md
+++ b/.changeset/message-send-rate-limit.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": minor
+"@logto/schemas": minor
+"@logto/console": minor
+---
+
+rate-limit outbound verification-code and message sends per recipient and suppress delivery to unknown recipients
+
+Adds a mandatory, system-level per-recipient send rate limit across all email/SMS send paths (experience verification codes including MFA, the account and management verification-code APIs, `/me`, organization invitations, and the legacy interaction API), emits a `Message.RateLimited` webhook when a send is throttled, and suppresses verification-code delivery to unregistered recipients when registration is disabled to prevent account enumeration. The `Message.RateLimited` event is now selectable in the Console webhook settings.

--- a/packages/console/src/components/BasicWebhookForm/index.tsx
+++ b/packages/console/src/components/BasicWebhookForm/index.tsx
@@ -2,7 +2,6 @@ import { type Hook, type HookConfig, type HookEvent } from '@logto/schemas';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 import {
   dataHookEventsLabel,
   interactionHookEvents,
@@ -32,11 +31,7 @@ const hookEventGroups: Array<CheckboxOptionGroup<HookEvent>> = [
   },
   {
     title: 'webhooks.schemas.security',
-    options: [
-      { value: 'Identifier.Lockout' },
-      // `Message.RateLimited` stays behind the dev-features flag until the email-security feature ships.
-      ...(isDevFeaturesEnabled ? [{ value: 'Message.RateLimited' as const }] : []),
-    ],
+    options: [{ value: 'Identifier.Lockout' }, { value: 'Message.RateLimited' }],
   },
 ];
 

--- a/packages/core/src/libraries/organization-invitation.ts
+++ b/packages/core/src/libraries/organization-invitation.ts
@@ -9,7 +9,6 @@ import {
 import { generateStandardId } from '@logto/shared';
 import { conditional, type Nullable, removeUndefinedKeys } from '@silverhand/essentials';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import OrganizationQueries from '#src/queries/organization/index.js';
 import { createUserQueries } from '#src/queries/user.js';
@@ -266,12 +265,10 @@ export class OrganizationInvitationLibrary {
         ...(ip && { ip }),
       });
 
-    return EnvSet.values.isDevFeaturesEnabled
-      ? withMessageRateGuard(
-          await buildMessageRateGuard(this.queries),
-          { action: SentinelActivityAction.MessageSend, recipient: to },
-          send
-        )
-      : send();
+    return withMessageRateGuard(
+      await buildMessageRateGuard(this.queries),
+      { action: SentinelActivityAction.MessageSend, recipient: to },
+      send
+    );
   }
 }

--- a/packages/core/src/routes-me/verification-code.ts
+++ b/packages/core/src/routes-me/verification-code.ts
@@ -3,7 +3,6 @@ import { emailRegEx } from '@logto/core-kit';
 import { SentinelActivityAction } from '@logto/schemas';
 import { object, string } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type { RouterInitArgs } from '#src/routes/types.js';
 import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
@@ -46,16 +45,14 @@ export default function verificationCodeRoutes<T extends AuthedMeRouter>(
         });
       };
 
-      await (EnvSet.values.isDevFeaturesEnabled
-        ? withMessageRateGuard(
-            await buildMessageRateGuard(tenant.queries),
-            {
-              action: SentinelActivityAction.VerificationCodeSend,
-              recipient: ctx.guard.body.email,
-            },
-            send
-          )
-        : send());
+      await withMessageRateGuard(
+        await buildMessageRateGuard(tenant.queries),
+        {
+          action: SentinelActivityAction.VerificationCodeSend,
+          recipient: ctx.guard.body.email,
+        },
+        send
+      );
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -30,7 +30,7 @@ async function resolveVoid(): Promise<void> {
 
 const { sendCode } = await import('./verification-code-helpers.js');
 
-// The message rate guard runs when dev features are enabled; provide a permissive activity store.
+// Provide a permissive activity store so the message rate guard allows sends by default.
 const mockSentinelActivities = {
   countActivities: jest.fn().mockResolvedValue(0),
   insertActivity: jest.fn().mockImplementation(resolveVoid),

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -8,7 +8,6 @@ import {
 } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { type LogContext } from '#src/middleware/koa-audit-log.js';
@@ -96,7 +95,7 @@ const hasUserWithIdentifier = async (
  *
  * - Forgot-password to an identifier no user owns (always on).
  * - Sign-in from an unidentified session to an identifier no user owns when registration is
- *   disabled (behind `isDevFeaturesEnabled`); identified sessions always deliver.
+ *   disabled; identified sessions always deliver.
  */
 const shouldSkipDelivery = async (
   experienceInteraction: ExperienceInteraction,
@@ -108,11 +107,7 @@ const shouldSkipDelivery = async (
     return !(await hasUserWithIdentifier(queries, identifier));
   }
 
-  if (
-    EnvSet.values.isDevFeaturesEnabled &&
-    interactionEvent === InteractionEvent.SignIn &&
-    !experienceInteraction.identifiedUserId
-  ) {
+  if (interactionEvent === InteractionEvent.SignIn && !experienceInteraction.identifiedUserId) {
     const registrationDisabled =
       await experienceInteraction.signInExperienceValidator.isRegistrationDisabled();
 
@@ -183,18 +178,16 @@ export const sendCode = async ({
   // The rate guard runs even for suppressed sends: a suppressed send must still count toward the
   // per-recipient cap, otherwise an unknown recipient never hits 429 while a registered one does —
   // leaking registration status (account enumeration) and defeating the point of suppression.
-  await (EnvSet.values.isDevFeaturesEnabled
-    ? withMessageRateGuard(
-        await buildMessageRateGuard(queries),
-        {
-          ...messageRateLimit,
-          onRateLimited: () => {
-            ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
-          },
-        },
-        send
-      )
-    : send());
+  await withMessageRateGuard(
+    await buildMessageRateGuard(queries),
+    {
+      ...messageRateLimit,
+      onRateLimited: () => {
+        ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
+      },
+    },
+    send
+  );
 
   // Save state
   experienceInteraction.setVerificationRecord(codeVerification);

--- a/packages/core/src/routes/interaction/additional.test.ts
+++ b/packages/core/src/routes/interaction/additional.test.ts
@@ -100,7 +100,7 @@ const baseProviderMock = {
 };
 
 const findUserById = jest.fn().mockResolvedValue(mockUser);
-// The message rate guard runs when dev features are enabled; provide a permissive activity store.
+// Provide a permissive activity store so the message rate guard allows sends by default.
 const countActivities = jest.fn().mockResolvedValue(0);
 const insertActivity = jest.fn();
 const tenantContext = new MockTenant(

--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -14,7 +14,6 @@ import { authenticator } from 'otplib';
 import qrcode from 'qrcode';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { createSocialAuthorizationUrl } from '#src/libraries/verification-helpers/social-verification.js';
@@ -149,13 +148,11 @@ export default function additionalRoutes<T extends IRouterParamContext>(
           passcodes
         );
 
-      await (EnvSet.values.isDevFeaturesEnabled
-        ? withMessageRateGuard(
-            await buildMessageRateGuard({ sentinelActivities, logtoConfigs }),
-            { action: SentinelActivityAction.VerificationCodeSend, recipient },
-            send
-          )
-        : send());
+      await withMessageRateGuard(
+        await buildMessageRateGuard({ sentinelActivities, logtoConfigs }),
+        { action: SentinelActivityAction.VerificationCodeSend, recipient },
+        send
+      );
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/verification-code.ts
+++ b/packages/core/src/routes/verification-code.ts
@@ -5,7 +5,6 @@ import {
   verifyVerificationCodePayloadGuard,
 } from '@logto/schemas';
 
-import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
@@ -35,13 +34,11 @@ export default function verificationCodeRoutes<T extends ManagementApiRouter>(
         return sendPasscode(code, { ip: ctx.request.ip });
       };
 
-      await (EnvSet.values.isDevFeaturesEnabled
-        ? withMessageRateGuard(
-            await buildMessageRateGuard(queries),
-            { action: SentinelActivityAction.VerificationCodeSend, recipient },
-            send
-          )
-        : send());
+      await withMessageRateGuard(
+        await buildMessageRateGuard(queries),
+        { action: SentinelActivityAction.VerificationCodeSend, recipient },
+        send
+      );
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -12,7 +12,6 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
@@ -131,18 +130,16 @@ export default function verificationRoutes<T extends UserRouter>(
         recipient: identifier.value,
       };
 
-      await (EnvSet.values.isDevFeaturesEnabled
-        ? withMessageRateGuard(
-            await buildMessageRateGuard(queries),
-            {
-              ...messageRateLimit,
-              onRateLimited: () => {
-                ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
-              },
-            },
-            send
-          )
-        : send());
+      await withMessageRateGuard(
+        await buildMessageRateGuard(queries),
+        {
+          ...messageRateLimit,
+          onRateLimited: () => {
+            ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
+          },
+        },
+        send
+      );
 
       const { expiresAt } = await insertVerificationRecord(
         codeVerification,

--- a/packages/integration-tests/src/tests/api/account/verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/account/verification-code-rate-limit.test.ts
@@ -12,7 +12,7 @@ import {
   signInAndGetUserApi,
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateEmail } from '#src/utils.js';
 
 const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
 
@@ -21,8 +21,7 @@ const sendAccountVerificationCode = async (api: KyInstance, email: string) =>
     json: { identifier: { type: SignInIdentifier.Email, value: email } },
   });
 
-// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
-devFeatureTest.describe('Account verification code send rate limit', () => {
+describe('Account verification code send rate limit', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
     await setEmailConnector(authedAdminApi);

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code-rate-limit.test.ts
@@ -5,12 +5,11 @@ import { initExperienceClient } from '#src/helpers/client.js';
 import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connector.js';
 import { successfullySendVerificationCode } from '#src/helpers/experience/verification-code.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateEmail } from '#src/utils.js';
 
 const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
 
-// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
-devFeatureTest.describe('Verification code send rate limit', () => {
+describe('Verification code send rate limit', () => {
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email]);
     await setEmailConnector();

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code.suppress-delivery.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/verification-code.suppress-delivery.test.ts
@@ -17,11 +17,11 @@ import {
   removeConnectorMessage,
 } from '#src/helpers/index.js';
 import { defaultSignInSignUpConfigs } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateEmail } from '#src/utils.js';
 
 // Registration is disabled (sign-in only) with email verification-code sign-in enabled. So an
 // unregistered email has no path to become a user and must not receive a code.
-devFeatureTest.describe('suppress sign-in verification-code delivery to unknown recipients', () => {
+describe('suppress sign-in verification-code delivery to unknown recipients', () => {
   beforeAll(async () => {
     await setEmailConnector();
     await updateSignInExperience({

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.message-rate-limited.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.message-rate-limited.test.ts
@@ -11,7 +11,7 @@ import { successfullySendVerificationCode } from '#src/helpers/experience/verifi
 import { WebHookApiTest } from '#src/helpers/hook.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { enableAllVerificationCodeSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateEmail } from '#src/utils.js';
 
 import WebhookMockServer from './WebhookMockServer.js';
 import { assertHookLogResult } from './utils.js';
@@ -22,9 +22,7 @@ const webHookMockServer = new WebhookMockServer(9999);
 const webHookApi = new WebHookApiTest();
 const hookName = 'messageRateLimitedHookEventListener';
 
-// The send rate guard (and thus the `Message.RateLimited` exception hook) is gated behind dev
-// features, so only assert it when enabled.
-devFeatureTest.describe('trigger `Message.RateLimited` exception hook', () => {
+describe('trigger `Message.RateLimited` exception hook', () => {
   beforeAll(async () => {
     // Provision the mock email connector (so codes can be sent and read) and allow email
     // verification-code sign-in, then register a listener for the exception hook event.

--- a/packages/integration-tests/src/tests/api/me-verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/me-verification-code-rate-limit.test.ts
@@ -11,12 +11,11 @@ import {
 } from '#src/helpers/admin-tenant.js';
 import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateEmail } from '#src/utils.js';
 
 const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
 
-// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
-devFeatureTest.describe('Account center (/me) verification code send rate limit', () => {
+describe('Account center (/me) verification code send rate limit', () => {
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email], api);
     await setEmailConnector(api);

--- a/packages/integration-tests/src/tests/api/organization/organization-invitation.rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-invitation.rate-limit.test.ts
@@ -4,14 +4,13 @@ import { authedAdminApi } from '#src/api/api.js';
 import { setEmailConnector } from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { OrganizationApiTest, OrganizationInvitationApiTest } from '#src/helpers/organization.js';
-import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateEmail } from '#src/utils.js';
 
 const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
 
 const resendPayload = { link: 'https://example.com' };
 
-// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
-devFeatureTest.describe('organization invitation send rate limit', () => {
+describe('organization invitation send rate limit', () => {
   const invitationApi = new OrganizationInvitationApiTest();
   const organizationApi = new OrganizationApiTest();
 

--- a/packages/integration-tests/src/tests/api/verification-code-rate-limit.test.ts
+++ b/packages/integration-tests/src/tests/api/verification-code-rate-limit.test.ts
@@ -8,12 +8,11 @@ import {
   setSmsConnector,
 } from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { devFeatureTest, generateEmail, generatePhone } from '#src/utils.js';
+import { generateEmail, generatePhone } from '#src/utils.js';
 
 const { maxSendsPerRecipient } = defaultMessageRateLimitPolicy;
 
-// The message rate guard is gated behind dev features, so only assert its behavior when enabled.
-devFeatureTest.describe('Management verification code send rate limit', () => {
+describe('Management verification code send rate limit', () => {
   beforeAll(async () => {
     await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
     await setEmailConnector();


### PR DESCRIPTION
## Summary

Closes LOG-13649 — the release gate for **Email Security Enhancements**.

The production `isDevFeaturesEnabled` gate removals (core send paths, the 1B sign-in suppression branch, and the Console `Message.RateLimited` webhook option) already landed on `master` via #9086. This PR finishes the ship:

- **Un-gates the 7 integration suites** (`devFeatureTest.describe` → `describe`) so they run in both CI dev-feature lanes now that the feature is always-on: experience / account / management / `me` / organization-invitation rate limits, the registration-disabled suppression suite, and the `Message.RateLimited` hook.
- **Refreshes 2 stale unit-test comments** that still referenced the removed dev gate.
- **Adds the release changeset** — `@logto/core`, `@logto/schemas`, `@logto/console` (all minor). The behavior shipped on master without a changeset (it was dev-gated); this declares the version bump + changelog.

A full dev-feature-guard scan confirms no email-security gate remains in core, console, or the test suites. Unrelated `isDevFeaturesEnabled` usages (passkey/WebAuthn MFA, SSO, adaptive MFA, swagger, header-mapping, authn, jwt-customizer) are untouched.

## Testing

Tested locally

## Checklist
- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
