### PR TITLE
fix(console): handle mismatched invitation token links

### DIFF
--- a/packages/console/src/pages/AcceptInvitation/index.test.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.test.tsx
@@ -1,0 +1,127 @@
+import { useLogto } from '@logto/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import useSWR from 'swr';
+
+import AcceptInvitation from '.';
+
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@logto/react', () => ({
+  useLogto: jest.fn(),
+}));
+
+jest.mock('@/consts/env', () => ({
+  isDevFeaturesEnabled: true,
+}));
+
+jest.mock('@/cloud/hooks/use-cloud-api', () => ({
+  useCloudApi: jest.fn(() => ({
+    get: jest.fn(),
+    patch: jest.fn(),
+  })),
+}));
+
+jest.mock('@/hooks/use-redirect-uri', () => ({
+  __esModule: true,
+  default: jest.fn(() => new URL('/callback', window.location.origin)),
+}));
+
+jest.mock('@/contexts/TenantsProvider', () => {
+  const { createContext } = jest.requireActual<typeof React>('react');
+
+  return {
+    TenantsContext: createContext({
+      navigateTenant: jest.fn(),
+      resetTenants: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('@/utils/storage', () => ({
+  saveRedirect: jest.fn(),
+}));
+
+jest.mock('@/components/AppLoading', () => ({
+  __esModule: true,
+  default: () => <div>loading</div>,
+}));
+
+jest.mock('@/components/AppError', () => ({
+  __esModule: true,
+  default: ({ errorMessage }: { readonly errorMessage: string }) => <div>{errorMessage}</div>,
+}));
+
+jest.mock('./SwitchAccount', () => ({
+  __esModule: true,
+  default: () => <button type="button">switch account</button>,
+}));
+
+const mockedUseLogto = jest.mocked(useLogto);
+const mockedUseSWR = jest.mocked(useSWR);
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ invitationId: 'invitation-id' }),
+}));
+
+const renderAcceptInvitation = (entry: string) =>
+  render(
+    <MemoryRouter
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+      initialEntries={[entry]}
+    >
+      <AcceptInvitation />
+    </MemoryRouter>
+  );
+
+describe('AcceptInvitation', () => {
+  const requestSubmit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(HTMLFormElement.prototype, 'requestSubmit').mockImplementation(requestSubmit);
+    mockedUseLogto.mockReturnValue({
+      isLoading: false,
+      isAuthenticated: true,
+      signIn: jest.fn(),
+    } as unknown as ReturnType<typeof useLogto>);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('starts invitation one-time-token auth for a signed-in mismatched user', async () => {
+    mockedUseSWR.mockReturnValue({
+      error: { status: 403 },
+    } as unknown as ReturnType<typeof useSWR>);
+
+    renderAcceptInvitation('/accept/invitation-id?one_time_token=one-time-token');
+
+    await waitFor(() => {
+      expect(requestSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByRole('button', { name: 'switch account' })).toBeNull();
+    expect(document.querySelector('form')?.getAttribute('method')).toBe('post');
+    expect(document.querySelector('form')?.getAttribute('action')).toBe(
+      '/api/invitations/invitation-id/auth?one_time_token=one-time-token'
+    );
+  });
+
+  it('shows the manual switch-account page for a signed-in mismatched user without one-time token', () => {
+    mockedUseSWR.mockReturnValue({
+      error: { status: 403 },
+    } as unknown as ReturnType<typeof useSWR>);
+
+    renderAcceptInvitation('/accept/invitation-id');
+
+    expect(requestSubmit).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'switch account' })).toBeTruthy();
+  });
+});

--- a/packages/console/src/pages/AcceptInvitation/index.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.tsx
@@ -38,21 +38,32 @@ function AcceptInvitation() {
   );
 
   useEffect(() => {
-    if (isLoading || isAuthenticated || !invitationId || hasStartedSignIn.current) {
+    if (isLoading || !invitationId || hasStartedSignIn.current) {
+      return;
+    }
+
+    if (!isAuthenticated) {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- React ref guards against duplicate sign-in redirects
+      hasStartedSignIn.current = true;
+
+      if (!isDevFeaturesEnabled || !oneTimeToken) {
+        saveRedirect(buildInvitationAcceptUrl(invitationId));
+        void signIn(redirectUri.href, 'signUp');
+        return;
+      }
+
+      authFormRef.current?.requestSubmit();
+      return;
+    }
+
+    if (!isDevFeaturesEnabled || !oneTimeToken || error?.status !== 403) {
       return;
     }
 
     // eslint-disable-next-line @silverhand/fp/no-mutation -- React ref guards against duplicate sign-in redirects
     hasStartedSignIn.current = true;
-
-    if (!isDevFeaturesEnabled || !oneTimeToken) {
-      saveRedirect(buildInvitationAcceptUrl(invitationId));
-      void signIn(redirectUri.href, 'signUp');
-      return;
-    }
-
     authFormRef.current?.requestSubmit();
-  }, [invitationId, isAuthenticated, isLoading, oneTimeToken, redirectUri, signIn]);
+  }, [error?.status, invitationId, isAuthenticated, isLoading, oneTimeToken, redirectUri, signIn]);
 
   useEffect(() => {
     if (!invitation || invitation.status !== OrganizationInvitationStatus.Pending) {
@@ -98,6 +109,15 @@ function AcceptInvitation() {
 
   // No invitation returned, indicating the current signed-in user is not the invitee.
   if (error?.status === 403) {
+    if (isDevFeaturesEnabled && oneTimeToken) {
+      return (
+        <>
+          {invitationAuthForm}
+          <AppLoading />
+        </>
+      );
+    }
+
     return (
       <SwitchAccount
         onClickSwitch={() => {


### PR DESCRIPTION
## Summary
Route signed-in mismatched users into the invitation one-time-token auth flow when the accept link includes `one_time_token`.

This keeps the fix behind the existing dev feature guard, so legacy accept links without `one_time_token` continue to use the existing manual switch-account page until the rollout PR removes the guard.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments