### PR TITLE
fix(console): show invoice amount due in billing history

### DIFF
--- a/packages/console/src/cloud/pages/EnterpriseSubscription/BillingHistory/index.tsx
+++ b/packages/console/src/cloud/pages/EnterpriseSubscription/BillingHistory/index.tsx
@@ -72,9 +72,9 @@ function BillingHistory() {
           },
           {
             title: <DynamicT forKey="subscription.billing_history.amount_column" />,
-            dataIndex: 'amountPaid',
-            render: ({ amountPaid }) => {
-              return `$${(amountPaid / 100).toFixed(2)}`;
+            dataIndex: 'amountDue',
+            render: ({ amountDue }) => {
+              return `$${(amountDue / 100).toFixed(2)}`;
             },
           },
           {

--- a/packages/console/src/pages/TenantSettings/BillingHistory/index.tsx
+++ b/packages/console/src/pages/TenantSettings/BillingHistory/index.tsx
@@ -82,9 +82,9 @@ function BillingHistory() {
           },
           {
             title: <DynamicT forKey="subscription.billing_history.amount_column" />,
-            dataIndex: 'amountPaid',
-            render: ({ amountPaid }) => {
-              return `$${(amountPaid / 100).toFixed(2)}`;
+            dataIndex: 'amountDue',
+            render: ({ amountDue }) => {
+              return `$${(amountDue / 100).toFixed(2)}`;
             },
           },
           {


### PR DESCRIPTION
## Summary
The billing history tables display the invoice amount column using `amountPaid`, which reads `$0.00` for invoices that haven't been paid (e.g. open or overdue invoices). Switch the column to `amountDue` so it reflects the amount owed for each invoice.

This applies to both billing history tables:
- `packages/console/src/pages/TenantSettings/BillingHistory/index.tsx` (tenant settings)
- `packages/console/src/cloud/pages/EnterpriseSubscription/BillingHistory/index.tsx` (enterprise subscription)

Cloud-only console feature, so no changeset is needed.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments