### PR TITLE
fix(experience): prevent switch account back loop

### DIFF
--- a/packages/console/src/pages/AcceptInvitation/index.test.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.test.tsx
@@ -4,6 +4,8 @@ import type * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import useSWR from 'swr';
 
+import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
+
 import AcceptInvitation from '.';
 
 jest.mock('swr', () => ({
@@ -15,11 +17,19 @@ jest.mock('@logto/react', () => ({
   useLogto: jest.fn(),
 }));
 
+const mockCloudApi = {
+  get: jest.fn(),
+  patch: jest.fn(),
+};
+const mockSilentCloudApi = {
+  get: jest.fn(),
+  patch: jest.fn(),
+};
+
 jest.mock('@/cloud/hooks/use-cloud-api', () => ({
-  useCloudApi: jest.fn(() => ({
-    get: jest.fn(),
-    patch: jest.fn(),
-  })),
+  useCloudApi: jest.fn((options?: { readonly hideErrorToast?: boolean }) =>
+    options?.hideErrorToast ? mockSilentCloudApi : mockCloudApi
+  ),
 }));
 
 jest.mock('@/hooks/use-redirect-uri', () => ({
@@ -58,6 +68,7 @@ jest.mock('./SwitchAccount', () => ({
 }));
 
 const mockedUseLogto = jest.mocked(useLogto);
+const mockedUseCloudApi = jest.mocked(useCloudApi);
 const mockedUseSWR = jest.mocked(useSWR);
 
 jest.mock('react-router-dom', () => ({
@@ -90,6 +101,22 @@ describe('AcceptInvitation', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it('loads the invitation details with error toast suppressed', async () => {
+    mockedUseSWR.mockReturnValue({} as unknown as ReturnType<typeof useSWR>);
+    mockSilentCloudApi.get.mockResolvedValue({});
+
+    renderAcceptInvitation('/accept/invitation-id?one_time_token=one-time-token');
+
+    const fetchInvitation = mockedUseSWR.mock.calls[0]?.[1] as () => Promise<unknown>;
+    await fetchInvitation();
+
+    expect(mockedUseCloudApi).toHaveBeenCalledWith({ hideErrorToast: true });
+    expect(mockSilentCloudApi.get).toHaveBeenCalledWith('/api/invitations/:invitationId', {
+      params: { invitationId: 'invitation-id' },
+    });
+    expect(mockCloudApi.get).not.toHaveBeenCalled();
   });
 
   it('starts invitation one-time-token auth for a signed-in mismatched user', async () => {

--- a/packages/console/src/pages/AcceptInvitation/index.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.tsx
@@ -25,15 +25,16 @@ function AcceptInvitation() {
   const [searchParameters] = useSearchParams();
   const oneTimeToken = searchParameters.get('one_time_token');
   const cloudApi = useCloudApi();
+  const silentCloudApi = useCloudApi({ hideErrorToast: true });
   const { navigateTenant, resetTenants } = useContext(TenantsContext);
   const hasStartedSignIn = useRef(false);
   const authFormRef = useRef<HTMLFormElement>(null);
 
   // The request is only made when the user has signed-in and the invitation ID is available.
-  // The response data is returned only when the current user matches the invitee email. Otherwise, it returns 404.
+  // The response data is returned only when the current user matches the invitee email. Otherwise, it returns 403.
   const { data: invitation, error } = useSWR<InvitationResponse, RequestError>(
     isAuthenticated && invitationId && `/api/invitations/${invitationId}`,
-    async () => cloudApi.get('/api/invitations/:invitationId', { params: { invitationId } })
+    async () => silentCloudApi.get('/api/invitations/:invitationId', { params: { invitationId } })
   );
 
   useEffect(() => {

--- a/packages/experience/src/pages/SwitchAccount/index.test.tsx
+++ b/packages/experience/src/pages/SwitchAccount/index.test.tsx
@@ -1,0 +1,118 @@
+import { experience, type ConsentInfoResponse } from '@logto/schemas';
+import { fireEvent, waitFor } from '@testing-library/react';
+
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { getConsentInfo } from '@/apis/consent';
+
+import SwitchAccount from '.';
+
+const navigate = jest.fn();
+
+jest.mock('@/apis/consent', () => ({
+  getConsentInfo: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-navigate-with-preserved-search-params', () => ({
+  __esModule: true,
+  default: () => navigate,
+  usePreserveSearchParams: () => ({ getTo: (to: unknown) => to }),
+}));
+
+const mockedGetConsentInfo = getConsentInfo as jest.MockedFunction<typeof getConsentInfo>;
+
+const consentInfo: ConsentInfoResponse = {
+  application: {
+    id: 'application_id',
+    name: 'Application',
+    displayName: null,
+    privacyPolicyUrl: null,
+    termsOfUseUrl: null,
+  },
+  user: {
+    id: 'user_id',
+    name: null,
+    avatar: null,
+    username: 'user',
+    primaryEmail: 'current@example.com',
+    primaryPhone: null,
+  },
+  missingOIDCScope: [],
+  missingResourceScopes: [],
+  redirectUri: 'https://example.com/callback',
+};
+
+const renderSwitchAccount = () =>
+  renderWithPageContext(
+    <SettingsProvider>
+      <SwitchAccount />
+    </SettingsProvider>,
+    {
+      future: { v7_relativeSplatPath: true, v7_startTransition: true },
+      initialEntries: [
+        `/${experience.routes.switchAccount}?login_hint=invitee%40example.com&one_time_token=token`,
+      ],
+    }
+  );
+
+describe('SwitchAccount', () => {
+  const originalLocation = window.location;
+  const assign = jest.fn();
+
+  beforeAll(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        assign,
+      },
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetConsentInfo.mockResolvedValue(consentInfo);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('continues the one-time-token flow only when the user confirms switching account', async () => {
+    const { getByText, queryByText } = renderSwitchAccount();
+
+    await waitFor(() => {
+      expect(queryByText('action.continue_as')).not.toBeNull();
+    });
+
+    fireEvent.click(getByText('action.continue_as'));
+
+    expect(navigate).toHaveBeenCalledWith(
+      {
+        pathname: `/${experience.routes.oneTimeToken}`,
+        search: '?login_hint=invitee%40example.com&one_time_token=token',
+      },
+      { replace: true }
+    );
+  });
+
+  it('returns to the client origin without navigating back to token-bearing history entries', async () => {
+    const { getByText, queryByText } = renderSwitchAccount();
+
+    await waitFor(() => {
+      expect(queryByText('action.back_to_current_account')).not.toBeNull();
+    });
+
+    fireEvent.click(getByText('action.back_to_current_account'));
+    expect(assign).toHaveBeenCalledWith('https://example.com');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/experience/src/pages/SwitchAccount/index.tsx
+++ b/packages/experience/src/pages/SwitchAccount/index.tsx
@@ -10,6 +10,7 @@ import useApi from '@/hooks/use-api';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import UserProfile from '@/pages/Consent/UserProfile';
+import { getRedirectUriOrigin } from '@/pages/Consent/util';
 import ErrorPage from '@/pages/ErrorPage';
 import Button from '@/shared/components/Button';
 import DynamicT from '@/shared/components/DynamicT';
@@ -59,6 +60,9 @@ const SwitchAccount = () => {
     branding,
   } = experienceSettings;
   const logoUrl = getBrandingLogoUrl({ theme, branding, isDarkModeEnabled });
+  const redirectUriOrigin = consentData.redirectUri
+    ? getRedirectUriOrigin(consentData.redirectUri)
+    : undefined;
 
   return (
     <StaticPageLayout>
@@ -91,8 +95,10 @@ const SwitchAccount = () => {
         <div className={styles.linkButton}>
           <TextLink
             text="action.back_to_current_account"
-            onClick={async () => {
-              history.back();
+            onClick={() => {
+              if (redirectUriOrigin) {
+                window.location.assign(redirectUriOrigin);
+              }
             }}
           />
         </div>


### PR DESCRIPTION
## Summary
- route the switch-account **Back to current account** action to the OIDC client origin instead of the experience app root, browser history, or consent
- suppress the invitation lookup error toast on the accept-invitation entry so the expected account-mismatch branch can continue cleanly
- keep one-time-token verification behind the explicit **Continue as** action
- add coverage for AcceptInvitation and SwitchAccount continue/back paths

## Testing
- `pnpm --filter @logto/console exec jest src/pages/AcceptInvitation/index.test.tsx --runInBand`
- `pnpm --filter @logto/console exec eslint --ext .tsx,.ts src/pages/AcceptInvitation/index.tsx src/pages/AcceptInvitation/index.test.tsx src/cloud/hooks/use-cloud-api.ts`
- `pnpm --filter @logto/experience exec jest src/pages/SwitchAccount/index.test.tsx --runInBand`
- `pnpm --filter @logto/experience exec eslint --ext .tsx,.ts src/pages/SwitchAccount/index.tsx src/pages/SwitchAccount/index.test.tsx`
- `pnpm --filter @logto/experience check`

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments