### PR TITLE
chore(console): document swift sdk v2 beta alongside v1 in the guide

### DIFF
--- a/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
@@ -23,13 +23,45 @@ https://github.com/logto-io/swift.git
 
 Since Xcode 11, you can [directly import a swift package](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app) w/o any additional tool.
 
+Logto Swift SDK comes in two major versions:
+
+- **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social connectors, but does not support [passkey sign-in](https://docs.logto.io/end-user-flows/sign-up-and-sign-in/passkey-sign-in) (WebView does not support WebAuthn, the underlying standard of passkeys).
+- **v2 (beta)**: Opens the sign-in experience in [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes support for the [WeChat (Native)](https://docs.logto.io/integrations/wechat-native) and [Alipay (Native)](https://docs.logto.io/integrations/alipay-native) connectors; you can use [WeChat (Web)](https://docs.logto.io/integrations/wechat-web) and [Alipay (Web)](https://docs.logto.io/integrations/alipay-web) instead, which work through the browser. If you depend on the native connectors, stay on v1.
+
+This guide covers both versions. Pick the same version in the tabs throughout this guide.
+
+When Xcode asks for the package version, select the version according to the SDK line:
+
+<Tabs>
+
+<TabItem value="v1" label="v1">
+
+Use the latest stable v1 release:
+
+```text
+v1.2.0
+```
+
+</TabItem>
+
+<TabItem value="v2" label="v2 (beta)">
+
+v2 is released as `v2.0.0-beta.x` prerelease tags until GA. Use the latest prerelease tag:
+
+```text
+v2.0.0-beta.1
+```
+
+</TabItem>
+
+</Tabs>
+
 We do not support **Carthage** and **CocoaPods** at the time due to some technical issues.
 
 <Details>
   <summary>Carthage</summary>
 
-Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385), but `swift package generate-xcodeproj` will report a failure since we are using binary targets
-for native social plugins. We will try to find a workaround later.
+Carthage [needs a `xcodeproj` file to build](https://github.com/Carthage/Carthage/issues/1226#issuecomment-290931385). We will try to find a workaround later.
 
 </Details>
 
@@ -75,23 +107,89 @@ let config = try? LogtoConfig(
 )
 ```
 
+In v2, the system browser session is shared by default. To request an isolated browser session, set `prefersEphemeralWebBrowserSession` to `true`:
+
+```swift
+let config = try? LogtoConfig(
+  // ...
+  prefersEphemeralWebBrowserSession: true
+)
+```
+
 </Step>
 
 <Step title="Configure redirect URI">
 
 <RedirectUrisNative />
 
+<Tabs>
+
+<TabItem value="v1" label="v1">
+
 <InlineNotification>
   The Redirect URI in iOS SDK is only for internal use. There's <em>NO NEED</em> to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
 </InlineNotification>
+
+</TabItem>
+
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, the sign-in experience opens in `ASWebAuthenticationSession` (the system browser), and the redirect is routed back to your app through the redirect URI. For a custom scheme redirect URI, register only the scheme part in your app's `Info.plist`, not the full redirect URI.
+
+For example, if the redirect URI is `io.logto://callback`, register `io.logto` as a URL scheme:
+
+```xml title="Info.plist"
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleTypeRole</key>
+    <string>Editor</string>
+    <key>CFBundleURLName</key>
+    <string>io.logto</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>io.logto</string>
+    </array>
+  </dict>
+</array>
+```
+
+Replace `io.logto` with your redirect URI's scheme. In Xcode, you can also open your app target, select **Info**, expand **URL Types**, and add the scheme to **URL Schemes**.
+
+<details>
+
+<summary>Use Universal Links instead of a custom scheme?</summary>
+
+<div>
+
+To use an HTTPS redirect URI such as `https://example.com/callback`:
+
+1. Add the Associated Domains capability to your app.
+2. Configure `webcredentials:example.com` so `ASWebAuthenticationSession` can match HTTPS callbacks on iOS 17.4 and newer.
+3. If the same URL should also open your app as a Universal Link outside the authentication session, configure `applinks:example.com` and host a valid `apple-app-site-association` file for the domain and path.
+4. Add the HTTPS URI to the "Redirect URIs" field above and pass it to `signInWithBrowser`.
+
+On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callback API so HTTPS redirects can automatically complete and dismiss the session. On older iOS versions, the authorization request can still use the HTTPS redirect URI, but the session may not close automatically unless your app handles the Universal Link callback itself. Keep a custom scheme redirect as a compatibility option if you need automatic completion on older iOS versions.
+
+</div>
+
+</details>
+
+</TabItem>
+
+</Tabs>
 
 </Step>
 
 <Step title="Implement sign-in and sign-out">
 
-You can use `client.signInWithBrowser(redirectUri:)` to sign in the user and `client.signOut()` to sign out the user.
+After the redirect URI is configured, use `client.signInWithBrowser(redirectUri:)` to sign in the user. Sign-out differs by SDK version.
 
 For example, in a SwiftUI app:
+
+<Tabs>
+
+<TabItem value="v1" label="v1">
 
 <Code title="ContentView.swift" className="language-swift">
     {`struct ContentView: View {
@@ -107,7 +205,7 @@ For example, in a SwiftUI app:
         Button("Sign Out") {
           Task { [self] in
             await client.signOut()
-            isAuthenticated = false
+            isAuthenticated = client.isAuthenticated
           }
         }
       } else {
@@ -119,7 +217,7 @@ For example, in a SwiftUI app:
               }")
               isAuthenticated = true
             } catch let error as LogtoClientErrors.SignIn {
-              // error occured during sign in
+              // error occurred during sign in
             } catch {
               // other errors
             }
@@ -130,6 +228,70 @@ For example, in a SwiftUI app:
   }
 }`}
 </Code>
+
+</TabItem>
+
+<TabItem value="v2" label="v2 (beta)">
+
+In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it clears the local credentials, revokes the refresh token, and ends the Logto session by opening the end session endpoint in the browser. The browser then navigates back to your app through the post sign-out redirect URI. If the post sign-out redirect URI uses a custom scheme, register that scheme in `Info.plist` as well. Let's configure it first:
+
+<UriInputField name="postLogoutRedirectUris" />
+
+<Code title="ContentView.swift" className="language-swift">
+    {`struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            let error = await client.signOut(
+              postLogoutRedirectUri: "${props.postLogoutRedirectUris[0] ?? '<your-post-sign-out-redirect-uri>'}"
+            )
+
+            if let error {
+              // error occurred during sign out
+              print(error)
+            }
+
+            isAuthenticated = client.isAuthenticated
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: "${
+                props.redirectUris[0] ?? defaultRedirectUri
+              }")
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}`}
+</Code>
+
+<InlineNotification>
+
+You can also call `client.signOut()` without a post sign-out redirect URI. No configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually. If no UI context is available, call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
+
+</InlineNotification>
+
+</TabItem>
+
+</Tabs>
 
 </Step>
 

--- a/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
@@ -28,21 +28,11 @@ Logto Swift SDK comes in two major versions:
 - **v1**: Opens the sign-in experience in an embedded WebView, which is required by the native social connectors, but does not support [passkey sign-in](https://docs.logto.io/end-user-flows/sign-up-and-sign-in/passkey-sign-in) (WebView does not support WebAuthn, the underlying standard of passkeys).
 - **v2 (beta)**: Opens the sign-in experience in [ASWebAuthenticationSession](https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v2 removes support for the [WeChat (Native)](https://docs.logto.io/integrations/wechat-native) and [Alipay (Native)](https://docs.logto.io/integrations/alipay-native) connectors; you can use [WeChat (Web)](https://docs.logto.io/integrations/wechat-web) and [Alipay (Web)](https://docs.logto.io/integrations/alipay-web) instead, which work through the browser. If you depend on the native connectors, stay on v1.
 
-This guide covers both versions. Pick the same version in the tabs throughout this guide.
+This guide covers both versions.
 
 When Xcode asks for the package version, select the version according to the SDK line:
 
 <Tabs>
-
-<TabItem value="v1" label="v1">
-
-Use the latest stable v1 release:
-
-```text
-v1.2.0
-```
-
-</TabItem>
 
 <TabItem value="v2" label="v2 (beta)">
 
@@ -50,6 +40,16 @@ v2 is released as `v2.0.0-beta.x` prerelease tags until GA. Use the latest prere
 
 ```text
 v2.0.0-beta.1
+```
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+Use the latest stable v1 release:
+
+```text
+v1.2.0
 ```
 
 </TabItem>
@@ -124,14 +124,6 @@ let config = try? LogtoConfig(
 
 <Tabs>
 
-<TabItem value="v1" label="v1">
-
-<InlineNotification>
-  The Redirect URI in iOS SDK is only for internal use. There's <em>NO NEED</em> to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
-</InlineNotification>
-
-</TabItem>
-
 <TabItem value="v2" label="v2 (beta)">
 
 In v2, the sign-in experience opens in `ASWebAuthenticationSession` (the system browser), and the redirect is routed back to your app through the redirect URI. For a custom scheme redirect URI, register only the scheme part in your app's `Info.plist`, not the full redirect URI.
@@ -177,6 +169,14 @@ On iOS 17.4 and newer, the SDK uses `ASWebAuthenticationSession`'s HTTPS callbac
 
 </TabItem>
 
+<TabItem value="v1" label="v1">
+
+<InlineNotification>
+  The Redirect URI in iOS SDK is only for internal use. There's <em>NO NEED</em> to add a [Custom URL Scheme](https://developer.apple.com/documentation/xcode/defining-a-custom-url-scheme-for-your-app) until a connector asks.
+</InlineNotification>
+
+</TabItem>
+
 </Tabs>
 
 </Step>
@@ -188,48 +188,6 @@ After the redirect URI is configured, use `client.signInWithBrowser(redirectUri:
 For example, in a SwiftUI app:
 
 <Tabs>
-
-<TabItem value="v1" label="v1">
-
-<Code title="ContentView.swift" className="language-swift">
-    {`struct ContentView: View {
-  @State var isAuthenticated: Bool
-
-  init() {
-    isAuthenticated = client.isAuthenticated
-  }
-
-  var body: some View {
-    VStack {
-      if isAuthenticated {
-        Button("Sign Out") {
-          Task { [self] in
-            await client.signOut()
-            isAuthenticated = client.isAuthenticated
-          }
-        }
-      } else {
-        Button("Sign In") {
-          Task { [self] in
-            do {
-              try await client.signInWithBrowser(redirectUri: "${
-                props.redirectUris[0] ?? defaultRedirectUri
-              }")
-              isAuthenticated = true
-            } catch let error as LogtoClientErrors.SignIn {
-              // error occurred during sign in
-            } catch {
-              // other errors
-            }
-          }
-        }
-      }
-    }
-  }
-}`}
-</Code>
-
-</TabItem>
 
 <TabItem value="v2" label="v2 (beta)">
 
@@ -288,6 +246,48 @@ In v2, `client.signOut(postLogoutRedirectUri:)` performs a complete sign-out: it
 You can also call `client.signOut()` without a post sign-out redirect URI. No configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually. If no UI context is available, call `client.clearCredentials()` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signInWithBrowser` may silently sign the user back in through that session.
 
 </InlineNotification>
+
+</TabItem>
+
+<TabItem value="v1" label="v1">
+
+<Code title="ContentView.swift" className="language-swift">
+    {`struct ContentView: View {
+  @State var isAuthenticated: Bool
+
+  init() {
+    isAuthenticated = client.isAuthenticated
+  }
+
+  var body: some View {
+    VStack {
+      if isAuthenticated {
+        Button("Sign Out") {
+          Task { [self] in
+            await client.signOut()
+            isAuthenticated = client.isAuthenticated
+          }
+        }
+      } else {
+        Button("Sign In") {
+          Task { [self] in
+            do {
+              try await client.signInWithBrowser(redirectUri: "${
+                props.redirectUris[0] ?? defaultRedirectUri
+              }")
+              isAuthenticated = true
+            } catch let error as LogtoClientErrors.SignIn {
+              // error occurred during sign in
+            } catch {
+              // other errors
+            }
+          }
+        }
+      }
+    }
+  }
+}`}
+</Code>
 
 </TabItem>
 


### PR DESCRIPTION
## Summary

Updates the Console iOS Swift integration guide after the Swift SDK v2.0.0-beta.1 release, following the same structure as the Android SDK guide update in #9016.

The guide now covers both SDK major versions with v1 / v2 (beta) tabs in each version-specific step:

- Installation: adds a short intro of the two versions and shows the stable v1 tag (`v1.2.0`) and the v2 beta tag (`v2.0.0-beta.1`).
- Init: documents `prefersEphemeralWebBrowserSession` for the v2 system browser flow.
- Configure redirect URI: keeps the v1 embedded WebView note, and adds v2 custom scheme `Info.plist` setup plus a Universal Links section.
- Implement sign-in and sign-out: keeps the v1 sample and adds the v2 browser sign-out flow with post sign-out redirect URI configuration, plus the no-redirect `signOut()` and local-only `clearCredentials()` alternatives.

Also removes the outdated Carthage note that referenced native social plugin binary targets.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset` (N/A - guide content only)
- [ ] unit tests (N/A)
- [ ] integration tests (N/A)
- [ ] necessary TSDoc comments (N/A)