### PR TITLE
fix(account): correct apple icon theme in account center

### DIFF
--- a/packages/account/src/pages/Security/SocialSection/index.tsx
+++ b/packages/account/src/pages/Security/SocialSection/index.tsx
@@ -205,7 +205,6 @@ const SocialSection = () => {
                       theme,
                       logoUrl: connector.logo,
                       darkLogoUrl: connector.logoDark,
-                      isApple: connector.target === 'apple',
                     })}
                     alt={connectorName}
                   />

--- a/packages/experience/src/shared/utils/logo.ts
+++ b/packages/experience/src/shared/utils/logo.ts
@@ -6,11 +6,10 @@ export type GetLogoUrl = {
   theme: Theme;
   logoUrl: string;
   darkLogoUrl?: Nullable<string>;
-  isApple?: boolean;
 };
 
-export const getLogoUrl = ({ theme, logoUrl, darkLogoUrl, isApple }: GetLogoUrl) => {
-  if (theme === (isApple ? Theme.Light : Theme.Dark)) {
+export const getLogoUrl = ({ theme, logoUrl, darkLogoUrl }: GetLogoUrl) => {
+  if (theme === Theme.Dark) {
     return darkLogoUrl ?? logoUrl;
   }
 


### PR DESCRIPTION
## Summary

Fixes #9093.

On the account center security page (`/account/security`), the Apple social sign-in icon was effectively invisible: it used a white icon on the white (light mode) background, and a black icon on the dark (dark mode) background.

### Root cause

`getLogoUrl` (in `packages/experience/src/shared/utils/logo.ts`) had an `isApple` special case that **inverted** the logo selection for Apple:

```ts
if (theme === (isApple ? Theme.Light : Theme.Dark)) {
  return darkLogoUrl ?? logoUrl;
}
return logoUrl;
```

So for Apple it returned `logoDark` (white) in light mode and `logo` (black) in dark mode.

However, the Apple connector already follows the same convention as every other connector — `logo` is the black icon (for light backgrounds) and `logoDark` is the white icon (for dark backgrounds). The inversion was therefore wrong for the account center, which renders the icon on the plain page background.

This special case is a leftover from the old sign-in experience, where the Apple social button had an inverted (`.inverse`) background and so needed an inverted icon. The current account center has no such inverted background, and the sign-in experience (`SocialSignInList`, `SingleSignOnConnectors`) already calls `getLogoUrl` **without** `isApple`. The account center was the only remaining caller passing it.

### Fix

Remove the now-unused `isApple` option from `getLogoUrl` and its only caller (`SocialSection`). The account center now uses the standard theme logic, consistent with the sign-in experience:

- **Light mode** → black icon (`logo`)
- **Dark mode** → white icon (`logoDark`)

### Changes

- `packages/experience/src/shared/utils/logo.ts` — drop the `isApple` option and its inverted branch.
- `packages/account/src/pages/Security/SocialSection/index.tsx` — stop passing `isApple` to `getLogoUrl`.

### Testing

- [ ] Configure Sign in with Apple and open `/account/security`; confirm the Apple icon is a black icon in light mode and a white icon in dark mode, and that other connectors are unaffected.