### PR TITLE
fix(core): fetch OIDC discovery config as text

### DIFF
--- a/.changeset/oidc-discovery-text-response.md
+++ b/.changeset/oidc-discovery-text-response.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+fix OIDC enterprise connector discovery config fetching for providers with strict response negotiation
+
+OIDC enterprise connectors can now fetch discovery configuration from providers that reject JSON-only response negotiation with `406 Not Acceptable`.

--- a/.changeset/oidc-discovery-text-response.md
+++ b/.changeset/oidc-discovery-text-response.md
@@ -2,6 +2,6 @@
 "@logto/core": patch
 ---
 
-fix OIDC enterprise connector discovery config fetching for providers with strict response negotiation
+support OIDC enterprise connector discovery endpoints that reject JSON-only response negotiation
 
 OIDC enterprise connectors can now fetch discovery configuration from providers that reject JSON-only response negotiation with `406 Not Acceptable`.

--- a/packages/core/src/sso/OidcConnector/utils.test.ts
+++ b/packages/core/src/sso/OidcConnector/utils.test.ts
@@ -69,9 +69,7 @@ describe('fetchOidcConfig', () => {
         error: 'invalid endpoint',
       })
     );
-    expect(getMock).toBeCalledWith(`${issuer}/.well-known/openid-configuration`, {
-      responseType: 'json',
-    });
+    expect(getMock).toBeCalledWith(`${issuer}/.well-known/openid-configuration`);
   });
 
   it('should throw connector error if the discovery endpoint returns invalid config', async () => {
@@ -80,7 +78,7 @@ describe('fetchOidcConfig', () => {
     };
 
     getMock.mockResolvedValueOnce({
-      body,
+      body: JSON.stringify(body),
     });
 
     const result = oidcConfigResponseGuard.safeParse(body);
@@ -100,7 +98,7 @@ describe('fetchOidcConfig', () => {
 
   it('should return the config if the discovery endpoint returns valid config', async () => {
     getMock.mockResolvedValueOnce({
-      body: oidcConfigResponse,
+      body: JSON.stringify(oidcConfigResponse),
     });
 
     await expect(fetchOidcConfig(issuer)).resolves.toEqual(oidcConfigResponseCamelCase);

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -27,11 +27,9 @@ import {
  * @returns The full-list of OIDC config
  */
 export const fetchOidcConfigRaw = async (issuer: string) => {
-  const { body } = await got.get(`${issuer}/.well-known/openid-configuration`, {
-    responseType: 'json',
-  });
+  const { body } = await got.get(`${issuer}/.well-known/openid-configuration`);
 
-  return camelcaseKeys(oidcConfigResponseGuard.parse(body));
+  return camelcaseKeys(oidcConfigResponseGuard.parse(parseJson(body)));
 };
 
 export const fetchOidcConfig = async (


### PR DESCRIPTION
## Summary

Fixes OIDC enterprise connector discovery config fetching for providers that reject Logto's previous JSON response negotiation with `406 Not Acceptable`.

The discovery request now reads the response body as text and parses it with the existing connector `parseJson()` helper before validating the OIDC configuration shape. This keeps the same config validation while avoiding got's automatic `Accept: application/json` header from `responseType: 'json'`.

Closes #5485

## Testing

Unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to how the discovery HTTP response is read; validation and error mapping stay the same, with limited blast radius beyond OIDC enterprise connector setup.
> 
> **Overview**
> Fixes enterprise OIDC SSO discovery when an IdP rejects requests that negotiate JSON only and respond with **406 Not Acceptable**.
> 
> `fetchOidcConfigRaw` no longer uses got’s `responseType: 'json'` (which sends `Accept: application/json`). It fetches the discovery document as a text body and parses it with the existing connector **`parseJson()`** before the same **`oidcConfigResponseGuard`** validation and camel-casing. Unit tests now mock stringified discovery responses and assert the GET call without `responseType`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af1f474b467185034103bf6dfd14365419d55c23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->