### PR TITLE
fix(core): make organization role creation atomic

### DIFF
--- a/.changeset/clean-org-role-transactions.md
+++ b/.changeset/clean-org-role-transactions.md
@@ -2,6 +2,6 @@
 "@logto/core": patch
 ---
 
-fix organization role creation rollback when scope assignment fails
+make organization role creation transactional when assigning initial scopes
 
-When creating an organization role with initial organization scopes or resource scopes, invalid scope IDs no longer leave a partially created role.
+When creating an organization role with initial organization scopes or resource scopes, Logto now saves the role and its scope assignments in a single transaction. If any provided scope ID is invalid, the whole request fails without leaving a partially created role.

--- a/.changeset/clean-org-role-transactions.md
+++ b/.changeset/clean-org-role-transactions.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+fix organization role creation rollback when scope assignment fails
+
+When creating an organization role with initial organization scopes or resource scopes, invalid scope IDs no longer leave a partially created role.

--- a/packages/core/src/queries/organization/index.ts
+++ b/packages/core/src/queries/organization/index.ts
@@ -326,6 +326,52 @@ export default class OrganizationQueries extends SchemaQueries<
     super(pool, Organizations);
   }
 
+  async createRoleWithScopes(
+    data: CreateOrganizationRole,
+    organizationScopeIds: readonly string[],
+    resourceScopeIds: readonly string[]
+  ): Promise<Readonly<OrganizationRole>> {
+    return this.pool.transaction(async (transaction) => {
+      const roles = new OrganizationRolesQueries(transaction, OrganizationRoles, {
+        field: 'name',
+        order: 'asc',
+      });
+      const rolesScopes = new TwoRelationsQueries(
+        transaction,
+        OrganizationRoleScopeRelations.table,
+        OrganizationRoles,
+        OrganizationScopes
+      );
+      const rolesResourceScopes = new TwoRelationsQueries(
+        transaction,
+        OrganizationRoleResourceScopeRelations.table,
+        OrganizationRoles,
+        Scopes
+      );
+      const role = await roles.insert(data);
+
+      if (organizationScopeIds.length > 0) {
+        await rolesScopes.insert(
+          ...organizationScopeIds.map((id) => ({
+            organizationRoleId: role.id,
+            organizationScopeId: id,
+          }))
+        );
+      }
+
+      if (resourceScopeIds.length > 0) {
+        await rolesResourceScopes.insert(
+          ...resourceScopeIds.map((id) => ({
+            organizationRoleId: role.id,
+            scopeId: id,
+          }))
+        );
+      }
+
+      return role;
+    });
+  }
+
   /**
    * Get the multi-factor authentication (MFA) status for the given organization and user.
    *

--- a/packages/core/src/routes/organization-role/index.ts
+++ b/packages/core/src/routes/organization-role/index.ts
@@ -30,16 +30,16 @@ export default function organizationRoleRoutes<T extends ManagementApiRouter>(
     originalRouter,
     {
       id: tenantId,
-      queries: {
-        organizations: {
-          roles,
-          relations: { rolesScopes, rolesResourceScopes },
-        },
-      },
+      queries: { organizations },
       libraries: { quota },
     },
   ]: RouterInitArgs<T>
 ) {
+  const {
+    roles,
+    relations: { rolesScopes, rolesResourceScopes },
+  } = organizations;
+
   const router = new SchemaRouter<
     OrganizationRoleKeys,
     CreateOrganizationRole,
@@ -108,25 +108,11 @@ export default function organizationRoleRoutes<T extends ManagementApiRouter>(
           : 'organizationUserRolesLimit'
       );
 
-      const role = await roles.insert({ id: generateStandardId(), ...data });
-
-      if (organizationScopeIds.length > 0) {
-        await rolesScopes.insert(
-          ...organizationScopeIds.map((id) => ({
-            organizationRoleId: role.id,
-            organizationScopeId: id,
-          }))
-        );
-      }
-
-      if (resourceScopeIds.length > 0) {
-        await rolesResourceScopes.insert(
-          ...resourceScopeIds.map((id) => ({
-            organizationRoleId: role.id,
-            scopeId: id,
-          }))
-        );
-      }
+      const role = await organizations.createRoleWithScopes(
+        { id: generateStandardId(), ...data },
+        organizationScopeIds,
+        resourceScopeIds
+      );
 
       ctx.body = role;
       ctx.status = 201;

--- a/packages/integration-tests/src/tests/api/organization/organization-role.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-role.test.ts
@@ -128,6 +128,50 @@ describe('organization role APIs', () => {
       }
     });
 
+    it('should not create the organization role when an initial organization scope does not exist', async () => {
+      const name = 'test' + randomId();
+      const response = await roleApi
+        .create({
+          name,
+          organizationScopeIds: [generateStandardId()],
+        })
+        .catch((error: unknown) => error);
+
+      assert(response instanceof HTTPError);
+      expect(response.response.status).toBe(422);
+      expect(await response.response.json()).toMatchObject(
+        expect.objectContaining({
+          code: 'entity.relation_foreign_key_not_found',
+        })
+      );
+
+      const roles = await roleApi.getList(new URLSearchParams({ q: name }));
+      expect(roles).toHaveLength(0);
+    });
+
+    it('should roll back the organization role when an initial resource scope does not exist', async () => {
+      const name = 'test' + randomId();
+      const scope = await scopeApi.create({ name: 'test' + randomId() });
+      const response = await roleApi
+        .create({
+          name,
+          organizationScopeIds: [scope.id],
+          resourceScopeIds: [generateStandardId()],
+        })
+        .catch((error: unknown) => error);
+
+      assert(response instanceof HTTPError);
+      expect(response.response.status).toBe(422);
+      expect(await response.response.json()).toMatchObject(
+        expect.objectContaining({
+          code: 'entity.relation_foreign_key_not_found',
+        })
+      );
+
+      const roles = await roleApi.getList(new URLSearchParams({ q: name }));
+      expect(roles).toHaveLength(0);
+    });
+
     it('should fail when try to get an organization role that does not exist', async () => {
       const response = await roleApi.get('0').catch((error: unknown) => error);
 


### PR DESCRIPTION
## Summary

- Create organization roles and their initial organization/resource scope relations in one database transaction.
- Prevent invalid initial scope IDs from leaving a partially created organization role.
- Add regression coverage for invalid initial organization scope and resource scope IDs.

Fixes #6891.

## Testing

Tested locally
