### PR TITLE
fix(console): sync guide tabs across a page and fix note spacing

### DIFF
--- a/packages/console/src/assets/docs/guides/m2m-general/README.mdx
+++ b/packages/console/src/assets/docs/guides/m2m-general/README.mdx
@@ -69,7 +69,7 @@ scope=all`}
 </Step>
 <Step title="Request an access token">
 
-<Tabs>
+<Tabs groupId="m2m-api-target">
 
 <TabItem value="Logto Management API" label="For Logto Management API">
 
@@ -86,7 +86,7 @@ Logto also provides a pre-configured "Logto Management API access" M2M role for 
 
 Now, compose all we have and send the request:
 
-<Tabs>
+<Tabs groupId="m2m-client">
 <TabItem value="Node.js" label="Node.js">
 
 <Code className="language-js">
@@ -161,7 +161,7 @@ Before accessing your API resource, make sure your M2M app has been assigned wit
 
 Now, compose all we have and send the request:
 
-<Tabs>
+<Tabs groupId="m2m-client">
 
 <TabItem value="Node.js" label="Node.js">
 
@@ -227,12 +227,12 @@ A successful access token response body would be like:
 
 You may notice the token response has a `token_type` field, which it's fixed to `Bearer`. Thus you should put the access token in the `Authorization` field of HTTP headers with the Bearer format (`Bearer <your-access-token>`).
 
-<Tabs>
+<Tabs groupId="m2m-api-target">
 <TabItem value="Logto Management API" label="Interact with Logto Management API">
 
 Using the requested access token with the built-in Logto Management API resource `https://[your-tenant-id].logto.app/api` to get all applications in your Logto tenant:
 
-<Tabs>
+<Tabs groupId="m2m-client">
 <TabItem value="Node.js" label="Node.js">
 
 <Code className="language-js">
@@ -269,7 +269,7 @@ const fetchLogtoApplications = async () => {
 
 Using the requested access token with the API resource `https://shopping.api` to get all products in the shopping API:
 
-<Tabs>
+<Tabs groupId="m2m-client">
 <TabItem value="Node.js" label="Node.js">
 
 ```js

--- a/packages/console/src/assets/docs/guides/native-android/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-android/README.mdx
@@ -19,10 +19,10 @@ import Checkpoint from '../../fragments/_checkpoint.md';
 
 Logto Android SDK comes in two major versions:
 
-- **v2**: Opens the sign-in experience in an embedded WebView, which is required by the native social connectors, but does not support [passkey sign-in](https://docs.logto.io/end-user-flows/sign-up-and-sign-in/passkey-sign-in) (WebView does not support WebAuthn, the underlying standard of passkeys).
 - **v3 (beta)**: Opens the sign-in experience in [Chrome Custom Tabs](https://developer.android.com/develop/ui/views/layout/webapps/overview-of-android-custom-tabs) (the system browser), which unlocks passkey sign-in and shares the browser session. Note that v3 removes support for the [WeChat (Native)](https://docs.logto.io/integrations/wechat-native) and [Alipay (Native)](https://docs.logto.io/integrations/alipay-native) connectors; you can use [WeChat (Web)](https://docs.logto.io/integrations/wechat-web) and [Alipay (Web)](https://docs.logto.io/integrations/alipay-web) instead, which work through the browser. If you depend on the native connectors, stay on v2.
+- **v2**: Opens the sign-in experience in an embedded WebView, which is required by the native social connectors, but does not support [passkey sign-in](https://docs.logto.io/end-user-flows/sign-up-and-sign-in/passkey-sign-in) (WebView does not support WebAuthn, the underlying standard of passkeys).
 
-This guide covers both versions. Pick the same version in the tabs throughout this guide.
+This guide covers both versions.
 
 Before you install Logto Android SDK, ensure `mavenCentral()` is added to your repository configuration in the Gradle project build file:
 
@@ -36,17 +36,7 @@ Before you install Logto Android SDK, ensure `mavenCentral()` is added to your r
 
 Add Logto Android SDK to your dependencies:
 
-<Tabs>
-
-<TabItem value="v2" label="v2">
-
-```kotlin title="build.gradle.kts"
-dependencies {
-    implementation("io.logto.sdk:android:2.0.3")
-}
-```
-
-</TabItem>
+<Tabs groupId="android-sdk-version">
 
 <TabItem value="v3" label="v3 (beta)">
 
@@ -55,6 +45,16 @@ v3 is released as `3.0.0-beta` prereleases until GA. Use the latest prerelease a
 ```kotlin title="build.gradle.kts"
 dependencies {
     implementation("io.logto.sdk:android:3.0.0-beta")
+}
+```
+
+</TabItem>
+
+<TabItem value="v2" label="v2">
+
+```kotlin title="build.gradle.kts"
+dependencies {
+    implementation("io.logto.sdk:android:2.0.3")
 }
 ```
 
@@ -143,13 +143,7 @@ In Android, the redirect URI follows the pattern: `$(LOGTO_REDIRECT_SCHEME)://$(
 
 Assuming you treat `io.logto.android` as the custom `LOGTO_REDIRECT_SCHEME`, and `io.logto.sample` is your app package name, the Redirect URI should be `io.logto.android://io.logto.sample/callback`.
 
-<Tabs>
-
-<TabItem value="v2" label="v2">
-
-No additional setup is required. The sign-in experience opens in an embedded WebView, and the SDK intercepts the redirect inside the WebView.
-
-</TabItem>
+<Tabs groupId="android-sdk-version">
 
 <TabItem value="v3" label="v3 (beta)">
 
@@ -211,6 +205,12 @@ Keep in mind that the callback is now a real URL on your domain, so serve a fall
 
 </TabItem>
 
+<TabItem value="v2" label="v2">
+
+No additional setup is required. The sign-in experience opens in an embedded WebView, and the SDK intercepts the redirect inside the WebView.
+
+</TabItem>
+
 </Tabs>
 
 </Step>
@@ -219,80 +219,7 @@ Keep in mind that the callback is now a real URL on your domain, so serve a fall
 
 After the redirect URI is configured, we can use `logtoClient.signIn` to sign in the user and `logtoClient.signOut` to sign out the user.
 
-<Tabs>
-
-<TabItem value="v2" label="v2">
-
-Now let's use them in your `LogtoViewModel.kt`:
-
-<Code title="LogtoViewModel.kt" className="language-kotlin">
-    {`//...with other imports
-class LogtoViewModel(application: Application) : AndroidViewModel(application) {
-    // ...other codes
-
-    // Add a live data to observe the authentication status
-    private val _authenticated = MutableLiveData(logtoClient.isAuthenticated)
-    val authenticated: LiveData<Boolean>
-        get() = _authenticated
-
-    fun signIn(context: Activity) {
-        logtoClient.signIn(context, "${props.redirectUris[0] ?? '<your-redirect-uri>'}") { logtoException ->
-            logtoException?.let { println(it) }
-            // Update the live data
-            _authenticated.postValue(logtoClient.isAuthenticated)
-        }
-    }
-
-    fun signOut() {
-        logtoClient.signOut { logtoException ->
-            logtoException?.let { println(it) }
-            // Update the live data
-            _authenticated.postValue(logtoClient.isAuthenticated)
-        }
-    }
-}`}
-</Code>
-
-Now setup on-click listener for the sign-in button and sign-out button in your `MainActivity.kt`:
-
-```kotlin title="MainActivity.kt"
-//...with other imports
-class MainActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        //...other codes
-
-        // Assume you have a button with id "sign_in_button" in your layout
-        val signInButton = findViewById<Button>(R.id.sign_in_button)
-        signInButton.setOnClickListener {
-            logtoViewModel.signIn(this)
-        }
-
-        // Assume you have a button with id "sign_out_button" in your layout
-        val signOutButton = findViewById<Button>(R.id.sign_out_button)
-        signOutButton.setOnClickListener {
-            if (logtoViewModel.authenticated) { // Check if the user is authenticated
-                logtoViewModel.signOut()
-            }
-        }
-
-        // Observe the authentication status to update the UI
-        logtoViewModel.authenticated.observe(this) { authenticated ->
-            if (authenticated) {
-                // The user is authenticated
-                signInButton.visibility = View.GONE
-                signOutButton.visibility = View.VISIBLE
-            } else {
-                // The user is not authenticated
-                signInButton.visibility = View.VISIBLE
-                signOutButton.visibility = View.GONE
-            }
-        }
-
-    }
-}
-```
-
-</TabItem>
+<Tabs groupId="android-sdk-version">
 
 <TabItem value="v3" label="v3 (beta)">
 
@@ -374,6 +301,79 @@ class MainActivity : AppCompatActivity() {
 You can also call `logtoClient.signOut(context)` without a post sign-out redirect URI. No configuration is needed in this case: the browser shows the Logto sign-out page, and the user returns to the app by dismissing it manually. If no UI context is available, you can call `logtoClient.clearCredentials` to clear the local credentials and revoke the refresh token. Note that this keeps the Logto session in the browser, so the next `signIn` may silently sign the user back in through that session.
 
 </InlineNotification>
+
+</TabItem>
+
+<TabItem value="v2" label="v2">
+
+Now let's use them in your `LogtoViewModel.kt`:
+
+<Code title="LogtoViewModel.kt" className="language-kotlin">
+    {`//...with other imports
+class LogtoViewModel(application: Application) : AndroidViewModel(application) {
+    // ...other codes
+
+    // Add a live data to observe the authentication status
+    private val _authenticated = MutableLiveData(logtoClient.isAuthenticated)
+    val authenticated: LiveData<Boolean>
+        get() = _authenticated
+
+    fun signIn(context: Activity) {
+        logtoClient.signIn(context, "${props.redirectUris[0] ?? '<your-redirect-uri>'}") { logtoException ->
+            logtoException?.let { println(it) }
+            // Update the live data
+            _authenticated.postValue(logtoClient.isAuthenticated)
+        }
+    }
+
+    fun signOut() {
+        logtoClient.signOut { logtoException ->
+            logtoException?.let { println(it) }
+            // Update the live data
+            _authenticated.postValue(logtoClient.isAuthenticated)
+        }
+    }
+}`}
+</Code>
+
+Now setup on-click listener for the sign-in button and sign-out button in your `MainActivity.kt`:
+
+```kotlin title="MainActivity.kt"
+//...with other imports
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        //...other codes
+
+        // Assume you have a button with id "sign_in_button" in your layout
+        val signInButton = findViewById<Button>(R.id.sign_in_button)
+        signInButton.setOnClickListener {
+            logtoViewModel.signIn(this)
+        }
+
+        // Assume you have a button with id "sign_out_button" in your layout
+        val signOutButton = findViewById<Button>(R.id.sign_out_button)
+        signOutButton.setOnClickListener {
+            if (logtoViewModel.authenticated) { // Check if the user is authenticated
+                logtoViewModel.signOut()
+            }
+        }
+
+        // Observe the authentication status to update the UI
+        logtoViewModel.authenticated.observe(this) { authenticated ->
+            if (authenticated) {
+                // The user is authenticated
+                signInButton.visibility = View.GONE
+                signOutButton.visibility = View.VISIBLE
+            } else {
+                // The user is not authenticated
+                signInButton.visibility = View.VISIBLE
+                signOutButton.visibility = View.GONE
+            }
+        }
+
+    }
+}
+```
 
 </TabItem>
 

--- a/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
+++ b/packages/console/src/assets/docs/guides/native-ios-swift/README.mdx
@@ -32,7 +32,7 @@ This guide covers both versions.
 
 When Xcode asks for the package version, select the version according to the SDK line:
 
-<Tabs>
+<Tabs groupId="swift-sdk-version">
 
 <TabItem value="v2" label="v2 (beta)">
 
@@ -122,7 +122,7 @@ let config = try? LogtoConfig(
 
 <RedirectUrisNative />
 
-<Tabs>
+<Tabs groupId="swift-sdk-version">
 
 <TabItem value="v2" label="v2 (beta)">
 
@@ -187,7 +187,7 @@ After the redirect URI is configured, use `client.signInWithBrowser(redirectUri:
 
 For example, in a SwiftUI app:
 
-<Tabs>
+<Tabs groupId="swift-sdk-version">
 
 <TabItem value="v2" label="v2 (beta)">
 

--- a/packages/console/src/components/Guide/index.module.scss
+++ b/packages/console/src/components/Guide/index.module.scss
@@ -58,6 +58,13 @@
       }
     }
 
+    // Notes (`InlineNotification`) are custom block components without the
+    // vertical rhythm that markdown paragraphs get, so they can hug an adjacent
+    // code block or tab bar. Give them the same spacing as paragraphs.
+    [class*='inlineNotification'] {
+      margin-block: _.unit(4);
+    }
+
     hr {
       border-color: var(--color-border);
 

--- a/packages/console/src/mdx-components/Tabs/index.test.tsx
+++ b/packages/console/src/mdx-components/Tabs/index.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import TabItem from '../TabItem';
+
+import Tabs from '.';
+
+const renderVersionTabs = (groupId?: string, testId = 'tabs') => (
+  <Tabs groupId={groupId}>
+    <TabItem value="v2" label="v2">
+      <span data-testid={`${testId}-content`}>v2 content</span>
+    </TabItem>
+    <TabItem value="v1" label="v1">
+      <span data-testid={`${testId}-content`}>v1 content</span>
+    </TabItem>
+  </Tabs>
+);
+
+describe('<Tabs />', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('selects the first tab by default and switches on click', async () => {
+    render(renderVersionTabs());
+
+    expect(screen.getByRole('tab', { name: 'v2' }).getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'v1' }));
+
+    expect(screen.getByRole('tab', { name: 'v1' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByRole('tab', { name: 'v2' }).getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('keeps tab groups sharing the same `groupId` in sync', async () => {
+    render(
+      <>
+        {renderVersionTabs('sync-test', 'first')}
+        {renderVersionTabs('sync-test', 'second')}
+      </>
+    );
+
+    const [firstV1, secondV1] = screen.getAllByRole('tab', { name: 'v1' });
+    const [firstV2, secondV2] = screen.getAllByRole('tab', { name: 'v2' });
+
+    // Both groups start on the default first tab.
+    expect(firstV2?.getAttribute('aria-selected')).toBe('true');
+    expect(secondV2?.getAttribute('aria-selected')).toBe('true');
+
+    // Switching one group switches the other.
+    fireEvent.click(firstV1!);
+
+    expect(firstV1?.getAttribute('aria-selected')).toBe('true');
+    expect(secondV1?.getAttribute('aria-selected')).toBe('true');
+
+    // And it is persisted for future visits.
+    expect(localStorage.getItem('logto:admin_console:guide_tab_group:sync-test')).toBe('v1');
+  });
+
+  it('does not sync tab groups without a `groupId`', async () => {
+    render(
+      <>
+        {renderVersionTabs(undefined, 'first')}
+        {renderVersionTabs(undefined, 'second')}
+      </>
+    );
+
+    const [firstV1] = screen.getAllByRole('tab', { name: 'v1' });
+    const [, secondV2] = screen.getAllByRole('tab', { name: 'v2' });
+
+    fireEvent.click(firstV1!);
+
+    expect(firstV1?.getAttribute('aria-selected')).toBe('true');
+    // The second group stays on its own default selection.
+    expect(secondV2?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('restores the persisted choice on mount', () => {
+    localStorage.setItem('logto:admin_console:guide_tab_group:restore-test', 'v1');
+
+    render(renderVersionTabs('restore-test'));
+
+    expect(screen.getByRole('tab', { name: 'v1' }).getAttribute('aria-selected')).toBe('true');
+  });
+});

--- a/packages/console/src/mdx-components/Tabs/index.tsx
+++ b/packages/console/src/mdx-components/Tabs/index.tsx
@@ -7,16 +7,31 @@
 
 import type { Nullable } from '@silverhand/essentials';
 import classNames from 'classnames';
-import { useState, isValidElement, type ReactElement, cloneElement, useRef, Children } from 'react';
+import {
+  useState,
+  isValidElement,
+  type ReactElement,
+  cloneElement,
+  useRef,
+  useEffect,
+  Children,
+} from 'react';
 
 import type { Props as TabItemProps } from '../TabItem';
 
 import styles from './index.module.scss';
+import useTabGroupChoice from './use-tab-group-choice';
 
 type MaybeArray<T> = T | T[];
 
 type Props = {
   readonly className?: string;
+  /**
+   * Tab groups sharing the same `groupId` stay in sync and remember the selected
+   * value across visits. Useful when the same choice (e.g. an SDK version) is
+   * repeated across a guide.
+   */
+  readonly groupId?: string;
   readonly children: MaybeArray<ReactElement<TabItemProps>>;
 };
 
@@ -26,7 +41,7 @@ function isTabItem(comp: ReactElement): comp is ReactElement<TabItemProps> {
   return comp.props.value !== undefined;
 }
 
-function Tabs({ className, children }: Props): JSX.Element {
+function Tabs({ className, groupId, children }: Props): JSX.Element {
   const verifiedChildren = Children.map(children, (child) => {
     if (isValidElement(child) && isTabItem(child)) {
       return child;
@@ -40,10 +55,32 @@ function Tabs({ className, children }: Props): JSX.Element {
       label,
     }));
 
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [groupChoice, setGroupChoice] = useTabGroupChoice(groupId);
+  const isValidValue = (value: Nullable<string>) =>
+    values.some((tabValue) => tabValue.value === value);
+
+  // Selection is tracked by value (instead of index) so synced groups can share
+  // the same choice even when their tabs are declared in a different order.
+  const [selectedValue, setSelectedValue] = useState(() =>
+    isValidValue(groupChoice) ? groupChoice : values[0]?.value
+  );
+
+  // Sync the persisted choice (changed by another tab group) into local state.
+  useEffect(() => {
+    if (isValidValue(groupChoice) && groupChoice !== selectedValue) {
+      setSelectedValue(groupChoice);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only react to external choice changes
+  }, [groupChoice]);
+
+  const selectValue = (value: string) => {
+    setSelectedValue(value);
+    setGroupChoice(value);
+  };
+
   const tabReferences = useRef<Array<Nullable<HTMLLIElement>>>(
     // eslint-disable-next-line @typescript-eslint/ban-types
-    Array.from<null>({ length }).fill(null)
+    Array.from<null>({ length: values.length }).fill(null)
   );
 
   const handleKeydown = (event: React.KeyboardEvent<HTMLLIElement>) => {
@@ -88,14 +125,14 @@ function Tabs({ className, children }: Props): JSX.Element {
               tabReferences.current[index] = element;
             }}
             role="tab"
-            tabIndex={selectedIndex === index ? 0 : -1}
-            aria-selected={selectedIndex === index}
+            tabIndex={selectedValue === value ? 0 : -1}
+            aria-selected={selectedValue === value}
             onKeyDown={handleKeydown}
             onFocus={() => {
-              setSelectedIndex(index);
+              selectValue(value);
             }}
             onClick={() => {
-              setSelectedIndex(index);
+              selectValue(value);
             }}
           >
             {label ?? value}
@@ -103,10 +140,10 @@ function Tabs({ className, children }: Props): JSX.Element {
         ))}
       </ul>
       <div>
-        {verifiedChildren.map((tabItem, index) =>
+        {verifiedChildren.map((tabItem) =>
           cloneElement(tabItem, {
             key: tabItem.props.value,
-            className: index === selectedIndex ? undefined : styles.hidden,
+            className: tabItem.props.value === selectedValue ? undefined : styles.hidden,
           })
         )}
       </div>

--- a/packages/console/src/mdx-components/Tabs/use-tab-group-choice.ts
+++ b/packages/console/src/mdx-components/Tabs/use-tab-group-choice.ts
@@ -1,0 +1,97 @@
+import type { Nullable } from '@silverhand/essentials';
+import { noop, trySafe } from '@silverhand/essentials';
+import { useCallback, useSyncExternalStore } from 'react';
+
+/**
+ * Keep guide tab groups in sync: persist the selected tab value per `groupId` in
+ * `localStorage`, so every `<Tabs>` sharing the same `groupId` (e.g. the SDK
+ * version selector repeated across a guide) reflects the same choice and
+ * remembers it across visits.
+ */
+const getStorageKey = (groupId: string) => `logto:admin_console:guide_tab_group:${groupId}`;
+
+/**
+ * The native `storage` event only fires in *other* windows, so we keep our own
+ * registry of subscribers per storage key to notify the tab groups living in the
+ * current window when the choice changes here.
+ */
+const currentWindowListeners = new Map<string, Set<() => void>>();
+
+const subscribeCurrentWindow = (key: string, onChange: () => void) => {
+  const listeners = currentWindowListeners.get(key) ?? new Set();
+  listeners.add(onChange);
+  currentWindowListeners.set(key, listeners);
+
+  return () => {
+    listeners.delete(onChange);
+    if (listeners.size === 0) {
+      currentWindowListeners.delete(key);
+    }
+  };
+};
+
+const notifyCurrentWindow = (key: string) => {
+  for (const listener of currentWindowListeners.get(key) ?? []) {
+    listener();
+  }
+};
+
+/**
+ * Returns the persisted choice for the given `groupId` and a setter that updates
+ * every tab group sharing it. When no `groupId` is provided the hook is a no-op
+ * (the tab group keeps its own local selection).
+ */
+const useTabGroupChoice = (
+  groupId?: string
+): [choice: Nullable<string>, setChoice: (value: string) => void] => {
+  const key = groupId === undefined ? undefined : getStorageKey(groupId);
+
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (key === undefined) {
+        return noop;
+      }
+
+      // Cross-window updates arrive through the native `storage` event...
+      const onStorage = (event: StorageEvent) => {
+        if (event.key === key) {
+          onChange();
+        }
+      };
+      window.addEventListener('storage', onStorage);
+      // ...while same-window updates come from our own registry.
+      const unsubscribeCurrentWindow = subscribeCurrentWindow(key, onChange);
+
+      return () => {
+        window.removeEventListener('storage', onStorage);
+        unsubscribeCurrentWindow();
+      };
+    },
+    [key]
+  );
+
+  const getSnapshot = useCallback(
+    () => (key === undefined ? null : (trySafe(() => localStorage.getItem(key)) ?? null)),
+    [key]
+  );
+
+  const choice = useSyncExternalStore(subscribe, getSnapshot, () => null);
+
+  const setChoice = useCallback(
+    (value: string) => {
+      if (key === undefined) {
+        return;
+      }
+
+      trySafe(() => {
+        localStorage.setItem(key, value);
+      });
+      notifyCurrentWindow(key);
+    },
+    [key]
+  );
+
+  return [choice, setChoice];
+};
+
+export default useTabGroupChoice;


### PR DESCRIPTION
## Summary

Guide tab groups now stay in sync across a page.

- **`<Tabs>` gains an optional `groupId`.** Tab groups sharing the same id stay in sync and remember the choice across visits via `localStorage`. It uses a `useSyncExternalStore` subscription over `localStorage`, plus a synthetic `storage` event so same-page groups react immediately (native `storage` events only fire in other windows). Selection is tracked by tab *value* instead of index, so synced groups stay aligned even when their tabs are declared in a different order. Without a `groupId`, a tab group keeps its own local selection.
- **Only the guides that actually repeat a choice opt in:** the Android and Swift SDK-version tabs, and the Machine-to-Machine guide (both the "which API" and the request-client tabs, which are nested). Single-tab guides are untouched, since there is nothing to sync.
- **Android guide leads with and defaults to v3.** The v3 tab is listed first in each group and the version intro lists v3 first, so v3 is the default selection for new visitors.
- **Note spacing fix.** Notes (`InlineNotification`) in guide content had no vertical margin, so they could render flush against an adjacent code block or tab bar. They now get the same vertical spacing as paragraphs.

## Testing

Added unit tests for `<Tabs>` (default selection, click switching, cross-group sync + persistence, no-sync without `groupId`, restore from storage). Also tested locally.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
