### PR TITLE
fix(account): correct account center profile redirect

### DIFF
--- a/packages/account/src/utils/account-center-route.test.ts
+++ b/packages/account/src/utils/account-center-route.test.ts
@@ -90,6 +90,18 @@ describe('account-center-route', () => {
       expect(getPendingReturn()).toBe('https://example.com/dashboard');
     });
 
+    it('does not store redirect query parameter on account center tab routes', () => {
+      setLocation(
+        '/account/security',
+        '?redirect=https%3A%2F%2Fexample.com%2Fdashboard&show_success=1'
+      );
+
+      handleAccountCenterRoute();
+
+      expect(getPendingReturn()).toBeUndefined();
+      expect(accountStorage.showSuccess.get()).toBe(false);
+    });
+
     it('stores show_success flag from query parameters', () => {
       setLocation('/account/email', '?redirect=https%3A%2F%2Fexample.com&show_success=1');
 

--- a/packages/account/src/utils/account-center-route.ts
+++ b/packages/account/src/utils/account-center-route.ts
@@ -10,6 +10,7 @@ import {
   usernameRoute,
   usernameSuccessRoute,
   authenticatorAppRoute,
+  authenticatorAppReplaceRoute,
   authenticatorAppSuccessRoute,
   backupCodesGenerateRoute,
   backupCodesRegenerateRoute,
@@ -63,11 +64,36 @@ const knownRoutePrefixes: readonly string[] = [
   socialRoutePrefix,
 ];
 
+const taskFlowRoutes = new Set([
+  emailRoute,
+  phoneRoute,
+  passwordRoute,
+  usernameRoute,
+  authenticatorAppRoute,
+  authenticatorAppReplaceRoute,
+  backupCodesGenerateRoute,
+  backupCodesRegenerateRoute,
+  backupCodesManageRoute,
+  passkeyAddRoute,
+  passkeyManageRoute,
+]);
+
 const isKnownRoute = (pathname?: string): pathname is string =>
   pathname !== undefined &&
   knownRoutePrefixes.some((prefix) =>
     pathname.replace(accountCenterBasePath, '').startsWith(prefix)
   );
+
+const getInternalPathname = (pathname: string) =>
+  pathname.replace(accountCenterBasePath, '') || '/';
+
+const isTaskFlowRoute = (pathname: string): boolean => {
+  const internalPathname = getInternalPathname(pathname);
+
+  return (
+    taskFlowRoutes.has(internalPathname) || internalPathname.startsWith(`${socialRoutePrefix}/`)
+  );
+};
 
 const parseStoredRoute = (storedRoute: string | undefined): string | undefined => {
   if (storedRoute && isKnownRoute(storedRoute)) {
@@ -94,10 +120,14 @@ export const {
 } = sessionStorage;
 
 /**
- * Parse and store the redirect URL and show success flag from query parameters.
+ * Parse and store the redirect URL and show success flag from single-task flow query parameters.
  * This needs to be done before OAuth flow starts so it persists through the sign-in.
  */
 const handleRedirectParameter = () => {
+  if (!isTaskFlowRoute(window.location.pathname)) {
+    return;
+  }
+
   const parameters = new URLSearchParams(window.location.search);
   const redirectUrl = parameters.get(redirectUrlParameter);
   const showSuccess = parameters.get(showSuccessParameter);

--- a/packages/console/src/components/RedirectToAccountCenter/index.tsx
+++ b/packages/console/src/components/RedirectToAccountCenter/index.tsx
@@ -1,23 +1,16 @@
 import { useEffect } from 'react';
 
 import { adminTenantEndpoint } from '@/consts';
-import { isCloud } from '@/consts/env';
-import useTenantPathname from '@/hooks/use-tenant-pathname';
 
 /**
- * Redirects the current window to the Account Center security page with a `redirect` query
- * parameter pointing back to the Console origin (or the tenant-scoped Console path for OSS).
+ * Redirects the current window to the Account Center profile page.
  */
 function RedirectToAccountCenter() {
-  const { getUrl } = useTenantPathname();
-
   useEffect(() => {
-    const redirectUrl = isCloud ? window.location.origin : getUrl('/').href;
-    const accountUrl = new URL('/account/security', adminTenantEndpoint.href);
-    accountUrl.searchParams.set('redirect', redirectUrl);
+    const accountUrl = new URL('/account/profile', adminTenantEndpoint.href);
     // eslint-disable-next-line @silverhand/fp/no-mutation
     window.location.href = accountUrl.toString();
-  }, [getUrl]);
+  }, []);
 
   return null;
 }

--- a/packages/console/src/components/Topbar/UserInfo/index.tsx
+++ b/packages/console/src/components/Topbar/UserInfo/index.tsx
@@ -12,7 +12,6 @@ import SignOut from '@/assets/icons/sign-out.svg?react';
 import UserAvatar from '@/components/UserAvatar';
 import UserInfoCard from '@/components/UserInfoCard';
 import { adminTenantEndpoint } from '@/consts';
-import { isCloud } from '@/consts/env';
 import Divider from '@/ds-components/Divider';
 import Dropdown, { DropdownItem } from '@/ds-components/Dropdown';
 import FlipOnRtl from '@/ds-components/FlipOnRtl';
@@ -21,7 +20,6 @@ import { Ring as Spinner } from '@/ds-components/Spinner';
 import useCurrentUser from '@/hooks/use-current-user';
 import useRedirectUri from '@/hooks/use-redirect-uri';
 import useSignOut from '@/hooks/use-sign-out';
-import useTenantPathname from '@/hooks/use-tenant-pathname';
 import useUserPreferences from '@/hooks/use-user-preferences';
 import { DynamicAppearanceMode } from '@/types/appearance-mode';
 import { onKeyDownHandler } from '@/utils/a11y';
@@ -32,7 +30,6 @@ import styles from './index.module.scss';
 
 function UserInfo() {
   const { signOut } = useSignOut();
-  const { getUrl } = useTenantPathname();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { user, isLoading: isLoadingUser } = useCurrentUser();
   const anchorRef = useRef<HTMLDivElement>(null);
@@ -81,10 +78,8 @@ function UserInfo() {
           className={classNames(styles.dropdownItem, isLoading && styles.loading)}
           icon={<Profile className={styles.icon} />}
           onClick={() => {
-            const redirectUrl = isCloud ? window.location.origin : getUrl('/').href;
-            const accountUrl = new URL('/account/security', adminTenantEndpoint.href);
-            accountUrl.searchParams.set('redirect', redirectUrl);
-            window.open(accountUrl.toString(), '_blank');
+            const accountUrl = new URL('/account/profile', adminTenantEndpoint.href);
+            window.open(accountUrl.toString(), '_blank', 'noopener,noreferrer');
           }}
         >
           {t('menu.profile')}

--- a/packages/schemas/alterations/next-1782354362-set-admin-account-center-profile-fields.ts
+++ b/packages/schemas/alterations/next-1782354362-set-admin-account-center-profile-fields.ts
@@ -1,0 +1,28 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const adminTenantId = 'admin';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      update account_centers
+      set profile_fields = '[{"name": "name"}, {"name": "avatar"}]'::jsonb
+      where tenant_id = ${adminTenantId}
+        and id = 'default'
+        and profile_fields is null
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      update account_centers
+      set profile_fields = null
+      where tenant_id = ${adminTenantId}
+        and id = 'default'
+        and profile_fields = '[{"name": "name"}, {"name": "avatar"}]'::jsonb
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/seeds/account-center.ts
+++ b/packages/schemas/src/seeds/account-center.ts
@@ -33,4 +33,5 @@ export const createAdminTenantAccountCenter = (): Readonly<CreateAccountCenter> 
       customData: AccountCenterControlValue.Edit,
       mfa: AccountCenterControlValue.Edit,
     },
+    profileFields: [{ name: 'name' }, { name: 'avatar' }],
   });


### PR DESCRIPTION
## Summary
- Open the Console profile entry directly on the Account Center profile tab without passing a `redirect` query parameter.
- Limit Account Center `redirect` / `show_success` parsing to single-task flow routes so full tabs ignore flow-only parameters.
- Seed and migrate admin Account Center profile fields with `name` and `avatar` so the profile tab is visible by default.

## Root Cause
The Console profile entry was opening a full Account Center tab with a task-flow `redirect` parameter. That made later task completions reuse the Console return target even though the full Account Center page itself has no completion/return semantics.

## Testing
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted routing and Console link changes plus a conservative DB update for admin `profile_fields` only when null; no auth or broad data-path changes.
> 
> **Overview**
> Fixes Console profile navigation so it opens **Account Center `/account/profile`** directly, without a `redirect` back to Console. That stops full-tab visits from persisting a task-flow return URL that later single-task completions would incorrectly reuse.
> 
> **Account Center routing** now parses and stores `redirect`, `show_success`, and related query params only on **single-task flow routes** (email, password, MFA flows, social sub-routes, etc.), not on tab routes like `/account/security` or `/account/profile`.
> 
> **Admin tenant Account Center** is seeded and migrated so `profile_fields` includes `name` and `avatar` when previously null, making the profile tab visible by default for the admin console experience.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe1b4308bc58d0d0503266e3d7437dd5df8946f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->