### PR TITLE
perf(schemas): cover service_logs tenant/type index with created_at

### DIFF
--- a/packages/schemas/alterations/next-1782375106-cover-service-logs-tenant-type-index-with-created-at.ts
+++ b/packages/schemas/alterations/next-1782375106-cover-service-logs-tenant-type-index-with-created-at.ts
@@ -1,0 +1,36 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    // Cover the windowed hosted-email usage count (`where tenant_id=? and type=? and created_at>=?`) by
+    // adding `created_at` to the existing `(tenant_id, type)` index, then drop the now-redundant
+    // 2-column index (a left-prefix subset of the new one). `concurrently` keeps the write path
+    // unlocked — this unbounded table is written on every send.
+    await pool.query(sql`
+      create index concurrently if not exists service_logs__tenant_id__type__created_at
+        on service_logs (tenant_id, type, created_at);
+    `);
+    await pool.query(sql`
+      drop index concurrently if exists service_logs__tenant_id__type;
+    `);
+  },
+  up: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      create index concurrently if not exists service_logs__tenant_id__type
+        on service_logs (tenant_id, type);
+    `);
+    await pool.query(sql`
+      drop index concurrently if exists service_logs__tenant_id__type__created_at;
+    `);
+  },
+  down: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/service_logs.sql
+++ b/packages/schemas/tables/service_logs.sql
@@ -10,7 +10,7 @@ create table service_logs (
 create index service_logs__id
   on service_logs (id);
 
-create index service_logs__tenant_id__type
-  on service_logs (tenant_id, type);
+create index service_logs__tenant_id__type__created_at
+  on service_logs (tenant_id, type, created_at);
 
 /* no_after_each */


### PR DESCRIPTION
## Summary
Refs LOG-13651.

Replaces the `service_logs (tenant_id, type)` index with a covering `service_logs (tenant_id, type, created_at)` index, so the windowed hosted-email usage count (`where tenant_id = ? and type = ? and created_at >= ?`) stays index-served as `service_logs` grows unbounded (the table has no prune/TTL). The old 2-column index is a left-prefix subset of the new one, so it becomes redundant and is dropped.

Uses the `create index concurrently` / `drop index concurrently` pattern (in `beforeUp` / `beforeDown`, empty `up` / `down`) to avoid locking the write path on this written-on-every-send table — matching the precedent in `next-1781689400-add-sentinel-activities-created-at-index.ts`.

Inert in this PR: the windowed count this index backs lands with the upcoming cloud `/mails` usage guard. No changeset — the index ships unconditionally as infrastructure for the (still flag-gated) hosted-email usage feature.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
