### PR TITLE
fix: restore isDevFeaturesEnabled guards removed by #9072

### DIFF
--- a/packages/account/src/App.test.tsx
+++ b/packages/account/src/App.test.tsx
@@ -7,6 +7,11 @@ import renderWithPageContext, {
   mockAccountCenterSettings,
 } from './__mocks__/RenderWithPageContext';
 
+jest.mock('@ac/constants/env', () => ({
+  __esModule: true,
+  isDevFeaturesEnabled: false,
+}));
+
 // Note: jest.requireActual('@logto/react') can't be used here, as it pulls in
 // @logto/client → @logto/js, which fails to resolve under the monorepo's
 // pnpm/jest module layout. Prompt/ReservedScope/UserScope are OIDC/OAuth

--- a/packages/account/src/jest.setup.ts
+++ b/packages/account/src/jest.setup.ts
@@ -11,6 +11,11 @@ if (typeof document !== 'undefined') {
   ReactModal.setAppElement(document.body);
 }
 
+jest.mock('@ac/constants/env', () => ({
+  __esModule: true,
+  isDevFeaturesEnabled: false,
+}));
+
 jest.mock('overlayscrollbars-react', () => {
   const OverlayScrollbarsComponent = forwardRef<HTMLDivElement, Readonly<{ children?: ReactNode }>>(
     ({ children }, ref) => createElement('div', { ref }, children)

--- a/packages/console/src/cloud/AppRoutes.tsx
+++ b/packages/console/src/cloud/AppRoutes.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import DelayedSuspenseFallback from '@/components/DelayedSuspenseFallback';
 import RedirectToAccountCenter from '@/components/RedirectToAccountCenter';
 import { EnterpriseSubscriptionTabs } from '@/consts';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import ProtectedRoutes from '@/containers/ProtectedRoutes';
 import { GlobalAnonymousRoute, GlobalRoute } from '@/contexts/TenantsProvider';
 import { OnboardingApp } from '@/onboarding';
@@ -48,7 +49,9 @@ function AppRoutes() {
               element={<CheckoutSuccessCallback />}
             />
             <Route path={GlobalRoute.Onboarding + '/*'} element={<OnboardingApp />} />
-            <Route path={GlobalRoute.DeleteAccount} element={<DeleteAccount />} />
+            {isDevFeaturesEnabled && (
+              <Route path={GlobalRoute.DeleteAccount} element={<DeleteAccount />} />
+            )}
             <Route index element={<Main />} />
             <Route
               path={`${GlobalRoute.EnterpriseSubscription}/:logtoEnterpriseId`}

--- a/packages/console/src/components/BasicWebhookForm/index.tsx
+++ b/packages/console/src/components/BasicWebhookForm/index.tsx
@@ -2,6 +2,7 @@ import { type Hook, type HookConfig, type HookEvent } from '@logto/schemas';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import {
   dataHookEventsLabel,
   interactionHookEvents,
@@ -31,7 +32,11 @@ const hookEventGroups: Array<CheckboxOptionGroup<HookEvent>> = [
   },
   {
     title: 'webhooks.schemas.security',
-    options: [{ value: 'Identifier.Lockout' }, { value: 'Message.RateLimited' }],
+    options: [
+      { value: 'Identifier.Lockout' },
+      // `Message.RateLimited` stays behind the dev-features flag until the email-security feature ships.
+      ...(isDevFeaturesEnabled ? [{ value: 'Message.RateLimited' as const }] : []),
+    ],
   },
 ];
 

--- a/packages/console/src/components/ConnectorForm/ConfigForm/ConfigFormFields/index.tsx
+++ b/packages/console/src/components/ConnectorForm/ConfigForm/ConfigFormFields/index.tsx
@@ -5,6 +5,7 @@ import { useCallback } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { CheckboxGroup } from '@/ds-components/Checkbox';
 import CodeEditor from '@/ds-components/CodeEditor';
 import DangerousRaw from '@/ds-components/DangerousRaw';
@@ -38,6 +39,10 @@ function ConfigFormFields({ formItems }: Props) {
 
   const showFormItems = useCallback(
     (formItem: ConnectorConfigFormItem) => {
+      if (formItem.isDevFeature && !isDevFeaturesEnabled) {
+        return false;
+      }
+
       if (!formItem.showConditions) {
         return true;
       }

--- a/packages/console/src/components/Guide/hooks.tsx
+++ b/packages/console/src/components/Guide/hooks.tsx
@@ -4,7 +4,7 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { guides } from '@/assets/docs/guides';
 import { type Guide } from '@/assets/docs/guides/types';
-import { isCloud as isCloudEnv, isProtectedAppEnabled } from '@/consts/env';
+import { isCloud as isCloudEnv, isDevFeaturesEnabled, isProtectedAppEnabled } from '@/consts/env';
 import { thirdPartyApp } from '@/consts/external-links';
 import TextLink from '@/ds-components/TextLink';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
@@ -46,11 +46,12 @@ export const useAppGuideMetadata = (): {
   const appGuides = useMemo(
     () =>
       guides.filter(
-        ({ metadata: { target, isCloud } }) =>
+        ({ metadata: { target, isCloud, isDevFeature } }) =>
           target !== 'API' &&
           (isCloudEnv ||
             !isCloud ||
-            (isProtectedAppEnabled && target === ApplicationType.Protected))
+            (isProtectedAppEnabled && target === ApplicationType.Protected)) &&
+          (isDevFeaturesEnabled || !isDevFeature)
       ),
     []
   );

--- a/packages/console/src/consts/env.ts
+++ b/packages/console/src/consts/env.ts
@@ -12,7 +12,6 @@ export const isProtectedAppLocalDevEnabled =
 export const isProtectedAppEnabled = isCloud || isProtectedAppLocalDevEnabled;
 export const adminEndpoint = normalizeEnv(import.meta.env.ADMIN_ENDPOINT);
 
-// eslint-disable-next-line import/no-unused-modules
 export const isDevFeaturesEnabled =
   !isProduction ||
   yes(normalizeEnv(import.meta.env.DEV_FEATURES_ENABLED)) ||

--- a/packages/console/src/consts/storage.ts
+++ b/packages/console/src/consts/storage.ts
@@ -21,6 +21,7 @@ export const storageKeys = Object.freeze({
   /** The react-router redirect location after sign in. The value should be a stringified Location object. */
   redirectAfterSignIn: getStorageKey('redirect_after_sign_in'),
   webhookTestResult: getStorageKey('webhook_test_result'),
+  /** Whether the under-development features are enabled. */
   isDevFeaturesEnabled: getStorageKey('is_dev_features_enabled'),
   /** The local expiry timestamp for dismissing the OSS sidebar cloud upsell card. */
   ossSidebarCloudUpsellDismissedUntil: getStorageKey('oss_sidebar_cloud_upsell_dismissed_until'),

--- a/packages/console/src/containers/ConsoleContent/Sidebar/OssCloudCard.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/OssCloudCard.tsx
@@ -1,4 +1,5 @@
 import { Theme } from '@logto/schemas';
+import classNames from 'classnames';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -7,7 +8,7 @@ import CloudIconDark from '@/assets/icons/cloud-icon-dark.svg?react';
 import CloudIcon from '@/assets/icons/cloud-icon.svg?react';
 import ExternalLinkIcon from '@/assets/icons/external-link.svg?react';
 import { storageKeys } from '@/consts';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import IconButton from '@/ds-components/IconButton';
 import TextLink from '@/ds-components/TextLink';
 import useTheme from '@/hooks/use-theme';
@@ -61,7 +62,7 @@ function OssCloudCard() {
   };
 
   return (
-    <div className={styles.wrapper}>
+    <div className={classNames(styles.wrapper, isDevFeaturesEnabled && styles.withDevStatusOffset)}>
       <div className={styles.card}>
         <div className={styles.header}>
           <div className={styles.icon}>

--- a/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/index.module.scss
@@ -1,4 +1,5 @@
 @use '@/scss/underscore' as _;
+@use '../dev-status-spacing' as devStatusSpacing;
 
 .sidebar {
   width: 248px;
@@ -17,6 +18,12 @@
   min-height: 100%;
   display: flex;
   flex-direction: column;
+}
+
+.devStatusSpacer {
+  // Keep the last sidebar item clear of the floating "Dev features enabled" status badge.
+  height: devStatusSpacing.$dev-status-reserved-space;
+  pointer-events: none;
 }
 
 .skeleton {

--- a/packages/console/src/containers/ConsoleContent/Sidebar/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
 import useMatchTenantPath from '@/hooks/use-tenant-pathname';
 
@@ -43,6 +44,7 @@ function Sidebar() {
               )}
             </Section>
           ))}
+          {isDevFeaturesEnabled && <div aria-hidden className={styles.devStatusSpacer} />}
           <OssCloudCard />
         </div>
       </OverlayScrollbar>

--- a/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
@@ -1,4 +1,5 @@
 @use '@/scss/underscore' as _;
+@use '../dev-status-spacing' as devStatusSpacing;
 
 .wrapper {
   padding: _.unit(4) _.unit(4) 0;
@@ -8,6 +9,10 @@
   z-index: 1;
   // Keep the fade aligned with the sidebar background instead of forcing card-like layer color.
   background: linear-gradient(180deg, transparent 0, var(--color-base) _.unit(4));
+}
+
+.withDevStatusOffset {
+  padding-bottom: devStatusSpacing.$dev-status-reserved-space;
 }
 
 .card {

--- a/packages/console/src/containers/ConsoleContent/_dev-status-spacing.scss
+++ b/packages/console/src/containers/ConsoleContent/_dev-status-spacing.scss
@@ -1,0 +1,10 @@
+@use '@/scss/underscore' as _;
+
+$dev-status-bottom-offset-factor: 3;
+$dev-status-gap-factor: 3;
+$dev-status-height-factor: 5;
+
+$dev-status-bottom-offset: _.unit($dev-status-bottom-offset-factor);
+$dev-status-reserved-space: _.unit(
+  $dev-status-bottom-offset-factor + $dev-status-gap-factor + $dev-status-height-factor
+);

--- a/packages/console/src/containers/ConsoleContent/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/index.module.scss
@@ -1,4 +1,5 @@
 @use '@/scss/underscore' as _;
+@use './dev-status-spacing' as devStatusSpacing;
 
 .content {
   flex-grow: 1;
@@ -24,6 +25,13 @@
   [class='appInsightsWrapper'] > :not(svg) {
     @include _.main-content-width;
   }
+}
+
+.devStatus {
+  color: var(--color-text-secondary);
+  position: absolute;
+  bottom: devStatusSpacing.$dev-status-bottom-offset;
+  inset-inline-start: _.unit(4);
 }
 
 .daisy {

--- a/packages/console/src/containers/ConsoleContent/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/index.tsx
@@ -3,7 +3,9 @@ import { useOutletContext, useRoutes } from 'react-router-dom';
 import { safeLazy } from 'react-safe-lazy';
 
 import DelayedSuspenseFallback from '@/components/DelayedSuspenseFallback';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
+import Tag from '@/ds-components/Tag';
 import { useConsoleRoutes } from '@/hooks/use-console-routes';
 import { usePlausiblePageview } from '@/hooks/use-plausible-pageview';
 
@@ -34,6 +36,11 @@ function ConsoleContent() {
           <Suspense fallback={<DelayedSuspenseFallback />}>{routes}</Suspense>
         </div>
       </OverlayScrollbar>
+      {isDevFeaturesEnabled && (
+        <Tag type="state" status="success" variant="plain" className={styles.devStatus}>
+          Dev features enabled
+        </Tag>
+      )}
     </div>
   );
 }

--- a/packages/console/src/containers/ConsoleRoutes/index.tsx
+++ b/packages/console/src/containers/ConsoleRoutes/index.tsx
@@ -6,7 +6,7 @@ import { SWRConfig } from 'swr';
 
 import AppLoading from '@/components/AppLoading';
 import RedirectToAccountCenter from '@/components/RedirectToAccountCenter';
-import { isCloud, isProduction } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled, isProduction } from '@/consts/env';
 import AppBoundary from '@/containers/AppBoundary';
 import AppContent, { RedirectToFirstItem } from '@/containers/AppContent';
 import ConsoleContent from '@/containers/ConsoleContent';
@@ -49,14 +49,18 @@ export function ConsoleRoutes() {
         <Route path="/:tenantId" element={<Layout />}>
           <Route path="callback" element={<Callback />} />
           <Route path="welcome" element={<Welcome />} />
-          <Route path="__internal__/import-error" element={<__Internal__ImportError />} />
+          {isDevFeaturesEnabled && (
+            <Route path="__internal__/import-error" element={<__Internal__ImportError />} />
+          )}
           <Route element={<ProtectedRoutes />}>
             <Route
               path={dropLeadingSlash(GlobalRoute.Profile) + '/*'}
               element={<RedirectToAccountCenter />}
             />
             <Route element={<TenantAccess />}>
-              {!isCloud && isProduction && <Route path="onboarding" element={<OssOnboarding />} />}
+              {!isCloud && isProduction && isDevFeaturesEnabled && (
+                <Route path="onboarding" element={<OssOnboarding />} />
+              )}
               {isCloud && (
                 <Route
                   path={dropLeadingSlash(GlobalRoute.CheckoutSuccessCallback)}

--- a/packages/console/src/containers/OssOnboardingGuard/index.tsx
+++ b/packages/console/src/containers/OssOnboardingGuard/index.tsx
@@ -1,7 +1,7 @@
 import { useParams, Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import AppLoading from '@/components/AppLoading';
-import { isCloud, isProduction } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled, isProduction } from '@/consts/env';
 import useOssOnboardingData from '@/hooks/use-oss-onboarding-data';
 
 import { getOssOnboardingRedirectPath } from './utils';
@@ -18,6 +18,7 @@ function OssOnboardingGuard() {
   const redirectPath = tenantId
     ? getOssOnboardingRedirectPath({
         isCloud,
+        isDevFeaturesEnabled,
         isProduction,
         hasError: Boolean(error),
         isLoading,

--- a/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.test.ts
@@ -5,6 +5,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: false,
         isLoading: false,
@@ -19,6 +20,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: false,
         isLoading: false,
@@ -31,6 +33,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: false,
         isLoading: false,
@@ -45,6 +48,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: true,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: false,
         isLoading: false,
@@ -59,7 +63,23 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: false,
+        hasError: false,
+        isLoading: false,
+        isOnboardingDone: false,
+        tenantId: 'console',
+        pathname: '/console/get-started',
+      })
+    ).toBeUndefined();
+  });
+
+  test('does not redirect when dev features are disabled', () => {
+    expect(
+      getOssOnboardingRedirectPath({
+        isCloud: false,
+        isDevFeaturesEnabled: false,
+        isProduction: true,
         hasError: false,
         isLoading: false,
         isOnboardingDone: false,
@@ -73,6 +93,7 @@ describe('OSS onboarding guard utils', () => {
     expect(
       getOssOnboardingRedirectPath({
         isCloud: false,
+        isDevFeaturesEnabled: true,
         isProduction: true,
         hasError: true,
         isLoading: false,

--- a/packages/console/src/containers/OssOnboardingGuard/utils.ts
+++ b/packages/console/src/containers/OssOnboardingGuard/utils.ts
@@ -1,5 +1,6 @@
 type GetOssOnboardingRedirectPathOptions = {
   isCloud: boolean;
+  isDevFeaturesEnabled: boolean;
   isProduction: boolean;
   hasError: boolean;
   isLoading: boolean;
@@ -12,6 +13,7 @@ const onboardingPath = 'onboarding';
 
 export const getOssOnboardingRedirectPath = ({
   isCloud,
+  isDevFeaturesEnabled,
   isProduction,
   hasError,
   isLoading,
@@ -21,6 +23,7 @@ export const getOssOnboardingRedirectPath = ({
 }: GetOssOnboardingRedirectPathOptions): string | undefined => {
   if (
     isCloud ||
+    !isDevFeaturesEnabled ||
     !isProduction ||
     hasError ||
     isLoading ||

--- a/packages/console/src/pages/AcceptInvitation/index.test.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.test.tsx
@@ -4,8 +4,6 @@ import type * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import useSWR from 'swr';
 
-import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
-
 import AcceptInvitation from '.';
 
 jest.mock('swr', () => ({
@@ -17,19 +15,15 @@ jest.mock('@logto/react', () => ({
   useLogto: jest.fn(),
 }));
 
-const mockCloudApi = {
-  get: jest.fn(),
-  patch: jest.fn(),
-};
-const mockSilentCloudApi = {
-  get: jest.fn(),
-  patch: jest.fn(),
-};
+jest.mock('@/consts/env', () => ({
+  isDevFeaturesEnabled: true,
+}));
 
 jest.mock('@/cloud/hooks/use-cloud-api', () => ({
-  useCloudApi: jest.fn((options?: { readonly hideErrorToast?: boolean }) =>
-    options?.hideErrorToast ? mockSilentCloudApi : mockCloudApi
-  ),
+  useCloudApi: jest.fn(() => ({
+    get: jest.fn(),
+    patch: jest.fn(),
+  })),
 }));
 
 jest.mock('@/hooks/use-redirect-uri', () => ({
@@ -68,7 +62,6 @@ jest.mock('./SwitchAccount', () => ({
 }));
 
 const mockedUseLogto = jest.mocked(useLogto);
-const mockedUseCloudApi = jest.mocked(useCloudApi);
 const mockedUseSWR = jest.mocked(useSWR);
 
 jest.mock('react-router-dom', () => ({
@@ -101,22 +94,6 @@ describe('AcceptInvitation', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-  });
-
-  it('loads the invitation details with error toast suppressed', async () => {
-    mockedUseSWR.mockReturnValue({} as unknown as ReturnType<typeof useSWR>);
-    mockSilentCloudApi.get.mockResolvedValue({});
-
-    renderAcceptInvitation('/accept/invitation-id?one_time_token=one-time-token');
-
-    const fetchInvitation = mockedUseSWR.mock.calls[0]?.[1] as () => Promise<unknown>;
-    await fetchInvitation();
-
-    expect(mockedUseCloudApi).toHaveBeenCalledWith({ hideErrorToast: true });
-    expect(mockSilentCloudApi.get).toHaveBeenCalledWith('/api/invitations/:invitationId', {
-      params: { invitationId: 'invitation-id' },
-    });
-    expect(mockCloudApi.get).not.toHaveBeenCalled();
   });
 
   it('starts invitation one-time-token auth for a signed-in mismatched user', async () => {

--- a/packages/console/src/pages/AcceptInvitation/index.test.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.test.tsx
@@ -4,6 +4,8 @@ import type * as React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import useSWR from 'swr';
 
+import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
+
 import AcceptInvitation from '.';
 
 jest.mock('swr', () => ({
@@ -15,15 +17,19 @@ jest.mock('@logto/react', () => ({
   useLogto: jest.fn(),
 }));
 
-jest.mock('@/consts/env', () => ({
-  isDevFeaturesEnabled: true,
-}));
+const mockCloudApi = {
+  get: jest.fn(),
+  patch: jest.fn(),
+};
+const mockSilentCloudApi = {
+  get: jest.fn(),
+  patch: jest.fn(),
+};
 
 jest.mock('@/cloud/hooks/use-cloud-api', () => ({
-  useCloudApi: jest.fn(() => ({
-    get: jest.fn(),
-    patch: jest.fn(),
-  })),
+  useCloudApi: jest.fn((options?: { readonly hideErrorToast?: boolean }) =>
+    options?.hideErrorToast ? mockSilentCloudApi : mockCloudApi
+  ),
 }));
 
 jest.mock('@/hooks/use-redirect-uri', () => ({
@@ -62,6 +68,7 @@ jest.mock('./SwitchAccount', () => ({
 }));
 
 const mockedUseLogto = jest.mocked(useLogto);
+const mockedUseCloudApi = jest.mocked(useCloudApi);
 const mockedUseSWR = jest.mocked(useSWR);
 
 jest.mock('react-router-dom', () => ({
@@ -94,6 +101,22 @@ describe('AcceptInvitation', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it('loads the invitation details with error toast suppressed', async () => {
+    mockedUseSWR.mockReturnValue({} as unknown as ReturnType<typeof useSWR>);
+    mockSilentCloudApi.get.mockResolvedValue({});
+
+    renderAcceptInvitation('/accept/invitation-id?one_time_token=one-time-token');
+
+    const fetchInvitation = mockedUseSWR.mock.calls[0]?.[1] as () => Promise<unknown>;
+    await fetchInvitation();
+
+    expect(mockedUseCloudApi).toHaveBeenCalledWith({ hideErrorToast: true });
+    expect(mockSilentCloudApi.get).toHaveBeenCalledWith('/api/invitations/:invitationId', {
+      params: { invitationId: 'invitation-id' },
+    });
+    expect(mockCloudApi.get).not.toHaveBeenCalled();
   });
 
   it('starts invitation one-time-token auth for a signed-in mismatched user', async () => {

--- a/packages/console/src/pages/AcceptInvitation/index.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.tsx
@@ -9,6 +9,7 @@ import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type InvitationResponse } from '@/cloud/types/router';
 import AppError from '@/components/AppError';
 import AppLoading from '@/components/AppLoading';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import { type RequestError } from '@/hooks/use-api';
 import useRedirectUri from '@/hooks/use-redirect-uri';
@@ -25,16 +26,15 @@ function AcceptInvitation() {
   const [searchParameters] = useSearchParams();
   const oneTimeToken = searchParameters.get('one_time_token');
   const cloudApi = useCloudApi();
-  const silentCloudApi = useCloudApi({ hideErrorToast: true });
   const { navigateTenant, resetTenants } = useContext(TenantsContext);
   const hasStartedSignIn = useRef(false);
   const authFormRef = useRef<HTMLFormElement>(null);
 
   // The request is only made when the user has signed-in and the invitation ID is available.
-  // The response data is returned only when the current user matches the invitee email. Otherwise, it returns 403.
+  // The response data is returned only when the current user matches the invitee email. Otherwise, it returns 404.
   const { data: invitation, error } = useSWR<InvitationResponse, RequestError>(
     isAuthenticated && invitationId && `/api/invitations/${invitationId}`,
-    async () => silentCloudApi.get('/api/invitations/:invitationId', { params: { invitationId } })
+    async () => cloudApi.get('/api/invitations/:invitationId', { params: { invitationId } })
   );
 
   useEffect(() => {
@@ -46,7 +46,7 @@ function AcceptInvitation() {
       // eslint-disable-next-line @silverhand/fp/no-mutation -- React ref guards against duplicate sign-in redirects
       hasStartedSignIn.current = true;
 
-      if (!oneTimeToken) {
+      if (!isDevFeaturesEnabled || !oneTimeToken) {
         saveRedirect(buildInvitationAcceptUrl(invitationId));
         void signIn(redirectUri.href, 'signUp');
         return;
@@ -56,7 +56,7 @@ function AcceptInvitation() {
       return;
     }
 
-    if (!oneTimeToken || error?.status !== 403) {
+    if (!isDevFeaturesEnabled || !oneTimeToken || error?.status !== 403) {
       return;
     }
 
@@ -89,7 +89,7 @@ function AcceptInvitation() {
     return <AppError errorMessage={t('invitation.invitation_not_found')} />;
   }
 
-  const invitationAuthForm = oneTimeToken && (
+  const invitationAuthForm = isDevFeaturesEnabled && oneTimeToken && (
     <form
       ref={authFormRef}
       hidden
@@ -109,7 +109,7 @@ function AcceptInvitation() {
 
   // No invitation returned, indicating the current signed-in user is not the invitee.
   if (error?.status === 403) {
-    if (oneTimeToken) {
+    if (isDevFeaturesEnabled && oneTimeToken) {
       return (
         <>
           {invitationAuthForm}

--- a/packages/console/src/pages/AcceptInvitation/index.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.tsx
@@ -25,15 +25,16 @@ function AcceptInvitation() {
   const [searchParameters] = useSearchParams();
   const oneTimeToken = searchParameters.get('one_time_token');
   const cloudApi = useCloudApi();
+  const silentCloudApi = useCloudApi({ hideErrorToast: true });
   const { navigateTenant, resetTenants } = useContext(TenantsContext);
   const hasStartedSignIn = useRef(false);
   const authFormRef = useRef<HTMLFormElement>(null);
 
   // The request is only made when the user has signed-in and the invitation ID is available.
-  // The response data is returned only when the current user matches the invitee email. Otherwise, it returns 404.
+  // The response data is returned only when the current user matches the invitee email. Otherwise, it returns 403.
   const { data: invitation, error } = useSWR<InvitationResponse, RequestError>(
     isAuthenticated && invitationId && `/api/invitations/${invitationId}`,
-    async () => cloudApi.get('/api/invitations/:invitationId', { params: { invitationId } })
+    async () => silentCloudApi.get('/api/invitations/:invitationId', { params: { invitationId } })
   );
 
   useEffect(() => {

--- a/packages/console/src/pages/AcceptInvitation/index.tsx
+++ b/packages/console/src/pages/AcceptInvitation/index.tsx
@@ -9,7 +9,6 @@ import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
 import { type InvitationResponse } from '@/cloud/types/router';
 import AppError from '@/components/AppError';
 import AppLoading from '@/components/AppLoading';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import { type RequestError } from '@/hooks/use-api';
 import useRedirectUri from '@/hooks/use-redirect-uri';
@@ -46,7 +45,7 @@ function AcceptInvitation() {
       // eslint-disable-next-line @silverhand/fp/no-mutation -- React ref guards against duplicate sign-in redirects
       hasStartedSignIn.current = true;
 
-      if (!isDevFeaturesEnabled || !oneTimeToken) {
+      if (!oneTimeToken) {
         saveRedirect(buildInvitationAcceptUrl(invitationId));
         void signIn(redirectUri.href, 'signUp');
         return;
@@ -56,7 +55,7 @@ function AcceptInvitation() {
       return;
     }
 
-    if (!isDevFeaturesEnabled || !oneTimeToken || error?.status !== 403) {
+    if (!oneTimeToken || error?.status !== 403) {
       return;
     }
 
@@ -89,7 +88,7 @@ function AcceptInvitation() {
     return <AppError errorMessage={t('invitation.invitation_not_found')} />;
   }
 
-  const invitationAuthForm = isDevFeaturesEnabled && oneTimeToken && (
+  const invitationAuthForm = oneTimeToken && (
     <form
       ref={authFormRef}
       hidden
@@ -109,7 +108,7 @@ function AcceptInvitation() {
 
   // No invitation returned, indicating the current signed-in user is not the invitee.
   if (error?.status === 403) {
-    if (isDevFeaturesEnabled && oneTimeToken) {
+    if (oneTimeToken) {
       return (
         <>
           {invitationAuthForm}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
@@ -154,7 +154,7 @@ function InstructionTab({ isActive, section, action }: Props) {
               options={typeDefinitionCodeEditorOptions}
             />
           </GuideCard>
-          {tokenType === LogtoJwtTokenKeyType.AccessToken && isDevFeaturesEnabled && (
+          {tokenType === LogtoJwtTokenKeyType.AccessToken && (
             <GuideCard
               name={CardType.OrganizationData}
               isExpanded={expendCard === CardType.OrganizationData}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/index.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import FormField from '@/ds-components/FormField';
 import InlineNotification from '@/ds-components/InlineNotification';
 import Switch from '@/ds-components/Switch';
@@ -53,6 +54,10 @@ function InstructionTab({ isActive, section, action }: Props) {
   const tokenType = watch('tokenType');
   const isDataSourceSection = section === InstructionTabSection.DataSource;
   const isErrorHandlingSection = section === InstructionTabSection.ErrorHandling;
+
+  if (isErrorHandlingSection && !isDevFeaturesEnabled) {
+    return null;
+  }
 
   return (
     <div className={classNames(tabContentStyles.tabContent, isActive && tabContentStyles.active)}>
@@ -149,7 +154,7 @@ function InstructionTab({ isActive, section, action }: Props) {
               options={typeDefinitionCodeEditorOptions}
             />
           </GuideCard>
-          {tokenType === LogtoJwtTokenKeyType.AccessToken && (
+          {tokenType === LogtoJwtTokenKeyType.AccessToken && isDevFeaturesEnabled && (
             <GuideCard
               name={CardType.OrganizationData}
               isExpanded={expendCard === CardType.OrganizationData}
@@ -225,7 +230,7 @@ function InstructionTab({ isActive, section, action }: Props) {
           </GuideCard>
         </>
       )}
-      {isErrorHandlingSection && (
+      {isErrorHandlingSection && isDevFeaturesEnabled && (
         <GuideCard
           name={CardType.ErrorHandling}
           isExpanded={expendCard === CardType.ErrorHandling}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/index.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import BookIcon from '@/assets/icons/book.svg?react';
 import FlaskIcon from '@/assets/icons/conical-flask.svg?react';
 import ErrorHandlingIcon from '@/assets/icons/error-handling.svg?react';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import Button from '@/ds-components/Button';
 import { type Action } from '@/pages/CustomizeJwt/utils/type';
 
@@ -23,7 +24,11 @@ type Props = {
 
 function SettingsSection({ action }: Props) {
   const [activeTab, setActiveTab] = useState<Tab>(Tab.DataSource);
-  const tabs = [Tab.DataSource, Tab.Test, Tab.ErrorHandling] as const;
+  const tabs = [
+    Tab.DataSource,
+    Tab.Test,
+    ...(isDevFeaturesEnabled ? [Tab.ErrorHandling] : []),
+  ] as const;
 
   const tabIcons = {
     [Tab.DataSource]: <BookIcon />,
@@ -52,11 +57,13 @@ function SettingsSection({ action }: Props) {
         section={InstructionTabSection.DataSource}
       />
       <TestTab isActive={activeTab === Tab.Test} />
-      <InstructionTab
-        isActive={activeTab === Tab.ErrorHandling}
-        section={InstructionTabSection.ErrorHandling}
-        action={action}
-      />
+      {isDevFeaturesEnabled && (
+        <InstructionTab
+          isActive={activeTab === Tab.ErrorHandling}
+          section={InstructionTabSection.ErrorHandling}
+          action={action}
+        />
+      )}
     </div>
   );
 }

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
@@ -15,7 +15,6 @@ import { type EditorProps } from '@monaco-editor/react';
 
 import TokenFileIcon from '@/assets/icons/token-file-icon.svg?react';
 import UserFileIcon from '@/assets/icons/user-file-icon.svg?react';
-import { isDevFeaturesEnabled } from '@/consts/env';
 
 import type { ModelSettings } from '../MainContent/MonacoCodeEditor/type.js';
 
@@ -25,18 +24,13 @@ import {
   buildClientCredentialsJwtCustomizerContextTsDefinition,
 } from './type-definitions.js';
 
-// TODO: remove dev-features gating once the organization context is launched
-const accessTokenOrganizationContextParamDefinition = isDevFeaturesEnabled
-  ? `\n * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerOrganizationContext}} [organization] - The target organization, present only for organization (API resource) tokens.`
-  : '';
+const accessTokenOrganizationContextParamDefinition = `\n * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerOrganizationContext}} [organization] - The target organization, present only for organization (API resource) tokens.`;
 
-const accessTokenOrganizationContextFieldDefinition = isDevFeaturesEnabled
-  ? `
+const accessTokenOrganizationContextFieldDefinition = `
   /**
    * The target organization, present only for organization (API resource) tokens.
    */
-  organization?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerOrganizationContext};`
-  : '';
+  organization?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerOrganizationContext};`;
 
 /**
  * Define the user access token JwtCustomizer payload type definitions
@@ -352,8 +346,7 @@ export const defaultUserTokenContextData = {
   grant: defaultGrantContext,
   interaction: defaultUserInteractionContext,
   application: defaultApplicationContext,
-  // TODO: remove dev-features gating once the organization context is launched
-  ...(isDevFeaturesEnabled && { organization: defaultOrganizationContext }),
+  organization: defaultOrganizationContext,
 };
 
 export const defaultM2mTokenContextData = {

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/config.tsx
@@ -15,6 +15,7 @@ import { type EditorProps } from '@monaco-editor/react';
 
 import TokenFileIcon from '@/assets/icons/token-file-icon.svg?react';
 import UserFileIcon from '@/assets/icons/user-file-icon.svg?react';
+import { isDevFeaturesEnabled } from '@/consts/env';
 
 import type { ModelSettings } from '../MainContent/MonacoCodeEditor/type.js';
 
@@ -24,13 +25,18 @@ import {
   buildClientCredentialsJwtCustomizerContextTsDefinition,
 } from './type-definitions.js';
 
-const accessTokenOrganizationContextParamDefinition = `\n * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerOrganizationContext}} [organization] - The target organization, present only for organization (API resource) tokens.`;
+// TODO: remove dev-features gating once the organization context is launched
+const accessTokenOrganizationContextParamDefinition = isDevFeaturesEnabled
+  ? `\n * @param {${JwtCustomizerTypeDefinitionKey.JwtCustomizerOrganizationContext}} [organization] - The target organization, present only for organization (API resource) tokens.`
+  : '';
 
-const accessTokenOrganizationContextFieldDefinition = `
+const accessTokenOrganizationContextFieldDefinition = isDevFeaturesEnabled
+  ? `
   /**
    * The target organization, present only for organization (API resource) tokens.
    */
-  organization?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerOrganizationContext};`;
+  organization?: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerOrganizationContext};`
+  : '';
 
 /**
  * Define the user access token JwtCustomizer payload type definitions
@@ -346,8 +352,8 @@ export const defaultUserTokenContextData = {
   grant: defaultGrantContext,
   interaction: defaultUserInteractionContext,
   application: defaultApplicationContext,
-
-  organization: defaultOrganizationContext,
+  // TODO: remove dev-features gating once the organization context is launched
+  ...(isDevFeaturesEnabled && { organization: defaultOrganizationContext }),
 };
 
 export const defaultM2mTokenContextData = {

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
@@ -1,4 +1,3 @@
-import { isDevFeaturesEnabled } from '@/consts/env';
 import {
   JwtCustomizerTypeDefinitionKey,
   accessTokenPayloadTypeDefinition,
@@ -35,10 +34,9 @@ export const buildAccessTokenJwtCustomizerContextTsDefinition = () => {
 
   declare ${jwtCustomizerUserInteractionContextTypeDefinition}
 
-  declare ${jwtCustomizerApplicationContextTypeDefinition}${
-    // TODO: remove dev-features gating once the organization context is launched
-    isDevFeaturesEnabled ? `\n\n  declare ${jwtCustomizerOrganizationContextTypeDefinition}` : ''
-  }`;
+  declare ${jwtCustomizerApplicationContextTypeDefinition}
+
+  declare ${jwtCustomizerOrganizationContextTypeDefinition}`;
 };
 
 export const buildClientCredentialsJwtCustomizerContextTsDefinition = () =>

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
@@ -1,3 +1,4 @@
+import { isDevFeaturesEnabled } from '@/consts/env';
 import {
   JwtCustomizerTypeDefinitionKey,
   accessTokenPayloadTypeDefinition,
@@ -34,9 +35,10 @@ export const buildAccessTokenJwtCustomizerContextTsDefinition = () => {
 
   declare ${jwtCustomizerUserInteractionContextTypeDefinition}
 
-  declare ${jwtCustomizerApplicationContextTypeDefinition}
-
-  declare ${jwtCustomizerOrganizationContextTypeDefinition}`;
+  declare ${jwtCustomizerApplicationContextTypeDefinition}${
+    // TODO: remove dev-features gating once the organization context is launched
+    isDevFeaturesEnabled ? `\n\n  declare ${jwtCustomizerOrganizationContextTypeDefinition}` : ''
+  }`;
 };
 
 export const buildClientCredentialsJwtCustomizerContextTsDefinition = () =>

--- a/packages/console/src/pages/EnterpriseSsoDetails/index.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/index.tsx
@@ -16,7 +16,7 @@ import Skeleton from '@/components/DetailsPage/Skeleton';
 import Drawer from '@/components/Drawer';
 import PageMeta from '@/components/PageMeta';
 import { EnterpriseSsoDetailsTabs } from '@/consts';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import ConfirmModal from '@/ds-components/ConfirmModal';
 import DynamicT from '@/ds-components/DynamicT';
@@ -69,6 +69,7 @@ function EnterpriseSsoDetails() {
 
   const isIdpInitiatedAuthConfigEnabled = useMemo(
     () =>
+      isDevFeaturesEnabled &&
       isCloud &&
       ssoConnector?.providerType === SsoProviderType.SAML &&
       currentSubscriptionQuota.idpInitiatedSsoEnabled,

--- a/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
+++ b/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.test.ts
@@ -5,6 +5,8 @@ import type { OssOnboardingFormData } from './utils';
 
 // Module-level mocks for env constants. Must be declared before importing the module under test.
 // eslint-disable-next-line @silverhand/fp/no-let
+let mockIsDevFeaturesEnabled = true;
+// eslint-disable-next-line @silverhand/fp/no-let
 let mockOssSurveyEndpoint: string | undefined = 'https://survey.example.com';
 
 const mockKyPost = jest.fn<Promise<{ ok: boolean }>, [URL, Options?]>();
@@ -43,6 +45,9 @@ jest.mock('ky', () => ({
 }));
 
 jest.mock('@/consts/env', () => ({
+  get isDevFeaturesEnabled() {
+    return mockIsDevFeaturesEnabled;
+  },
   get ossSurveyEndpoint() {
     return mockOssSurveyEndpoint;
   },
@@ -88,6 +93,8 @@ describe('submitOssOnboarding', () => {
     mockKyPost.mockResolvedValue({ ok: true });
     // eslint-disable-next-line @silverhand/fp/no-mutation
     mockKyOptions.current = undefined;
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    mockIsDevFeaturesEnabled = true;
     // eslint-disable-next-line @silverhand/fp/no-mutation
     mockOssSurveyEndpoint = 'https://survey.example.com';
   });
@@ -302,6 +309,25 @@ describe('submitOssOnboarding', () => {
     });
 
     expect(mockKyPost).toHaveBeenCalledTimes(2);
+    expect(navigate).toHaveBeenCalledWith('/get-started', { replace: true });
+  });
+
+  it('does not report when isDevFeaturesEnabled is false', async () => {
+    const submitOssOnboarding = await getSubmitOssOnboarding();
+    const update = jest.fn<Promise<void>, [Partial<OssUserOnboardingData>]>();
+    const navigate = jest.fn<void, [string, { replace: boolean }]>();
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    mockIsDevFeaturesEnabled = false;
+    update.mockResolvedValue();
+
+    await submitOssOnboarding({
+      formData: mockFormData,
+      navigate,
+      update,
+    });
+
+    expect(mockKyPost).not.toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith('/get-started', { replace: true });
   });
 

--- a/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.ts
+++ b/packages/console/src/pages/OssOnboarding/submit-oss-onboarding.ts
@@ -2,7 +2,7 @@ import type { OssSurveyReportPayload, OssUserOnboardingData } from '@logto/schem
 import { type Optional, trySafe } from '@silverhand/essentials';
 import ky from 'ky';
 
-import { ossSurveyEndpoint } from '@/consts/env';
+import { isDevFeaturesEnabled, ossSurveyEndpoint } from '@/consts/env';
 
 import {
   getBaseOssOnboardingPayload,
@@ -32,6 +32,10 @@ const postOssSurvey = async (url: URL, payload: OssSurveyReportPayload) =>
   });
 
 const getOssSurveyUrl = (): Optional<URL> => {
+  if (!isDevFeaturesEnabled) {
+    return;
+  }
+
   const endpointUrl = trySafe(() => (ossSurveyEndpoint ? new URL(ossSurveyEndpoint) : undefined));
 
   if (!endpointUrl) {

--- a/packages/console/src/pages/SignInExperience/PageContent/Content/LanguagesForm/ManageLanguage/LanguageEditor/constants.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/Content/LanguagesForm/ManageLanguage/LanguageEditor/constants.ts
@@ -8,10 +8,36 @@ import {
  *
  * Note:
  * - Not allowed customized phrases groups should be added here. Currently only the `development_tenant` group is not allowed.
+ *
+ * - Unreleased feature phrase group keys should be added here and controlled by the `isDevFeaturesEnabled` flag.
+ * @example
+ * ```ts
+ * export const hiddenLocalePhraseGroups: readonly LocalePhraseGroupKey[] = [
+ *  'development_tenant',
+ *  ...conditionalArray(!isDevFeaturesEnabled && 'mfa'),
+ * ];
+ * ```
  */
 export const hiddenLocalePhraseGroups: readonly LocalePhraseGroupKey[] = ['development_tenant'];
 
 /**
  * List of locale phrase key that should be hidden from the experience UI language editor.
+ *
+ * Note:
+ * Unreleased feature phrase keys should be added here and controlled by the `isDevFeaturesEnabled` flag.
+ * @example
+ * ```ts
+ * export const hiddenLocalePhrases: readonly LocalePhraseKey[] = [
+ * ...conditionalArray(
+ *    !isDevFeaturesEnabled &&
+ *      ([
+ *        'action.copy',
+ *        'action.verify_via_passkey',
+ *        'action.download',
+ *        'input.backup_code',
+ *      ] satisfies LocalePhraseKey[])
+ *  ),
+ * ];
+ * ```
  */
 export const hiddenLocalePhrases: readonly LocalePhraseKey[] = [];

--- a/packages/core/src/libraries/organization-invitation.ts
+++ b/packages/core/src/libraries/organization-invitation.ts
@@ -9,6 +9,7 @@ import {
 import { generateStandardId } from '@logto/shared';
 import { conditional, type Nullable, removeUndefinedKeys } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import OrganizationQueries from '#src/queries/organization/index.js';
 import { createUserQueries } from '#src/queries/user.js';
@@ -265,10 +266,12 @@ export class OrganizationInvitationLibrary {
         ...(ip && { ip }),
       });
 
-    return withMessageRateGuard(
-      await buildMessageRateGuard(this.queries),
-      { action: SentinelActivityAction.MessageSend, recipient: to },
-      send
-    );
+    return EnvSet.values.isDevFeaturesEnabled
+      ? withMessageRateGuard(
+          await buildMessageRateGuard(this.queries),
+          { action: SentinelActivityAction.MessageSend, recipient: to },
+          send
+        )
+      : send();
   }
 }

--- a/packages/core/src/libraries/verification-helpers/single-sign-on.test.ts
+++ b/packages/core/src/libraries/verification-helpers/single-sign-on.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import { createMockUtils } from '@logto/shared/esm';
 import type { Provider } from 'oidc-provider';
+import Sinon from 'sinon';
 
 import {
   mockSsoConnector,
@@ -356,6 +357,11 @@ describe('Single sign on util methods tests', () => {
   });
 
   describe('getSsoAuthorizationUrl tests with idp initiated sso session', () => {
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      isDevFeaturesEnabled: true,
+    });
+
     const payload = {
       state: 'state',
       redirectUri: 'https://example.com',
@@ -372,6 +378,10 @@ describe('Single sign on util methods tests', () => {
         },
       }),
     };
+
+    afterAll(() => {
+      stub.restore();
+    });
 
     beforeEach(() => {
       getAuthorizationUrlMock.mockResolvedValueOnce(samlAuthorizationUrl);

--- a/packages/core/src/libraries/verification-helpers/single-sign-on.ts
+++ b/packages/core/src/libraries/verification-helpers/single-sign-on.ts
@@ -14,6 +14,7 @@ import { conditional, trySafe } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import { idpInitiatedSamlSsoSessionCookieName } from '#src/constants/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type HookContextManager } from '#src/libraries/hook/context-manager.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
@@ -71,7 +72,11 @@ export const getSsoAuthorizationUrl = async (
 
     const { jti } = await provider.interactionDetails(ctx.req, ctx.res);
 
-    if (connectorInstance instanceof SamlConnector) {
+    if (
+      // TODO: Remove this check when IdP-initiated SSO is fully supported
+      EnvSet.values.isDevFeaturesEnabled &&
+      connectorInstance instanceof SamlConnector
+    ) {
       // Check if a IdP-initiated SSO session exists
       const sessionId = ctx.cookies.get(idpInitiatedSamlSsoSessionCookieName);
 

--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -24,6 +24,7 @@ jest.unstable_mockModule('#src/libraries/jwt-customizer.js', () => ({
   },
 }));
 
+const { EnvSet } = await import('#src/env-set/index.js');
 const { getExtraTokenClaimsForJwtCustomization } = await import('./extra-token-claims.js');
 
 const buildContextAndToken = ({ organizationId }: { organizationId?: string } = {}) => {
@@ -132,8 +133,15 @@ const createResponseError = (status: number, body: Record<string, unknown>) =>
   );
 
 describe('getExtraTokenClaimsForJwtCustomization', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
   beforeEach(() => {
     runScriptInLocalVm.mockReset().mockResolvedValue({});
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+  });
+
+  afterAll(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('includes sign-in context in interaction context when lastSubmission has it', async () => {
@@ -148,8 +156,9 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
     });
   });
 
-  it('includes adaptive MFA sign-in context in custom claims payload', async () => {
+  it('includes adaptive MFA sign-in context in custom claims payload when dev features are disabled', async () => {
     const signInContext = { country: 'US', botScore: '10' };
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
 
     await callGetExtraTokenClaimsForJwtCustomization({ signInContext });
 
@@ -183,6 +192,14 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
     expect(runScriptInLocalVm.mock.calls[0]?.[0]?.context).not.toHaveProperty('organization');
   });
 
+  it('omits organization context when dev features are disabled', async () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+
+    await callGetExtraTokenClaimsForJwtCustomization({ organizationId: 'org-1' });
+
+    expect(runScriptInLocalVm.mock.calls[0]?.[0]?.context).not.toHaveProperty('organization');
+  });
+
   it('throws invalid request with original error message on script failure when blocking is enabled', async () => {
     runScriptInLocalVm.mockRejectedValue(new Error('boom'));
 
@@ -209,6 +226,15 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
       error_description: "Custom claims script error: 'abc' not exists in 'context'.",
       statusCode: 400,
     });
+  });
+
+  it('keeps fail-open on script failure when dev features are disabled', async () => {
+    runScriptInLocalVm.mockRejectedValue(new Error('boom'));
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+
+    await expect(
+      callGetExtraTokenClaimsForJwtCustomization({ blockIssuanceOnError: true })
+    ).resolves.toBeUndefined();
   });
 
   it('throws access denied when denyAccess is called in custom script', async () => {

--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -192,14 +192,6 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
     expect(runScriptInLocalVm.mock.calls[0]?.[0]?.context).not.toHaveProperty('organization');
   });
 
-  it('omits organization context when dev features are disabled', async () => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
-
-    await callGetExtraTokenClaimsForJwtCustomization({ organizationId: 'org-1' });
-
-    expect(runScriptInLocalVm.mock.calls[0]?.[0]?.context).not.toHaveProperty('organization');
-  });
-
   it('throws invalid request with original error message on script failure when blocking is enabled', async () => {
     runScriptInLocalVm.mockRejectedValue(new Error('boom'));
 

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -210,7 +210,8 @@ export const getExtraTokenClaimsForJwtCustomization = async (
     return;
   }
 
-  const shouldBlockIssuanceOnError = Boolean(blockIssuanceOnError);
+  const shouldBlockIssuanceOnError =
+    EnvSet.values.isDevFeaturesEnabled && Boolean(blockIssuanceOnError);
   const defaultJwtCustomizerErrorMessage = 'Failed to customize token claims';
 
   try {
@@ -251,7 +252,7 @@ export const getExtraTokenClaimsForJwtCustomization = async (
     // can attach per-org claims. The `organization_id` claim itself is added afterwards in
     // `getExtraTokenClaimsForOrganizationApiResource`, so it is not visible on `token` here.
     const organizationId =
-      typeof ctx.oidc.params?.organization_id === 'string'
+      EnvSet.values.isDevFeaturesEnabled && typeof ctx.oidc.params?.organization_id === 'string'
         ? ctx.oidc.params.organization_id
         : undefined;
     const organizationContext = conditional(

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -252,7 +252,7 @@ export const getExtraTokenClaimsForJwtCustomization = async (
     // can attach per-org claims. The `organization_id` claim itself is added afterwards in
     // `getExtraTokenClaimsForOrganizationApiResource`, so it is not visible on `token` here.
     const organizationId =
-      EnvSet.values.isDevFeaturesEnabled && typeof ctx.oidc.params?.organization_id === 'string'
+      typeof ctx.oidc.params?.organization_id === 'string'
         ? ctx.oidc.params.organization_id
         : undefined;
     const organizationContext = conditional(

--- a/packages/core/src/routes-me/verification-code.ts
+++ b/packages/core/src/routes-me/verification-code.ts
@@ -3,6 +3,7 @@ import { emailRegEx } from '@logto/core-kit';
 import { SentinelActivityAction } from '@logto/schemas';
 import { object, string } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type { RouterInitArgs } from '#src/routes/types.js';
 import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
@@ -45,14 +46,16 @@ export default function verificationCodeRoutes<T extends AuthedMeRouter>(
         });
       };
 
-      await withMessageRateGuard(
-        await buildMessageRateGuard(tenant.queries),
-        {
-          action: SentinelActivityAction.VerificationCodeSend,
-          recipient: ctx.guard.body.email,
-        },
-        send
-      );
+      await (EnvSet.values.isDevFeaturesEnabled
+        ? withMessageRateGuard(
+            await buildMessageRateGuard(tenant.queries),
+            {
+              action: SentinelActivityAction.VerificationCodeSend,
+              recipient: ctx.guard.body.email,
+            },
+            send
+          )
+        : send());
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/authn.ts
+++ b/packages/core/src/routes/authn.ts
@@ -4,6 +4,7 @@ import { jsonObjectGuard, SsoAuthenticationQueryKey } from '@logto/schemas';
 import { z } from 'zod';
 
 import { idpInitiatedSamlSsoSessionCookieName, ssoPath } from '#src/constants/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaAuditLog from '#src/middleware/koa-audit-log.js';
 import { verifyBearerTokenFromRequest } from '#src/middleware/koa-auth/index.js';
@@ -205,7 +206,7 @@ export default function authnRoutes<T extends AnonymousRouter>(
       const { RelayState: jti } = body;
 
       // IdP initiated SSO does not provide the RelayState, we need to check if the IdP initiated SSO flow is enabled.
-      if (!jti) {
+      if (!jti && EnvSet.values.isDevFeaturesEnabled) {
         const idpInitiatedAuthConfig =
           await queries.ssoConnectors.getIdpInitiatedAuthConfigByConnectorId(connectorId);
 

--- a/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
@@ -27,9 +27,13 @@ import { MfaValidator } from './libraries/mfa-validator.js';
 const { jest } = import.meta;
 const { mockEsmWithActual } = createMockUtils(jest);
 
+const mockEnvSetValues = {
+  isDevFeaturesEnabled: true,
+};
+
 await mockEsmWithActual('#src/env-set/index.js', () => ({
   EnvSet: {
-    values: {},
+    values: mockEnvSetValues,
   },
 }));
 
@@ -68,6 +72,8 @@ describe('ExperienceInteraction adaptive MFA', () => {
         factors: [MfaFactor.TOTP],
       },
     });
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    mockEnvSetValues.isDevFeaturesEnabled = true;
   });
 
   // Truth table for MfaValidator.isMfaRequired
@@ -806,6 +812,8 @@ describe('ExperienceInteraction adaptive MFA', () => {
   });
 
   it('does not force adaptive MFA binding on submit when dev features are disabled', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    mockEnvSetValues.isDevFeaturesEnabled = false;
     signInExperiences.findDefaultSignInExperience.mockResolvedValue({
       ...mockSignInExperience,
       adaptiveMfa: { enabled: true },
@@ -949,6 +957,8 @@ describe('ExperienceInteraction adaptive MFA', () => {
   });
 
   it('still triggers adaptive MFA hook result when dev features are disabled', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    mockEnvSetValues.isDevFeaturesEnabled = false;
     signInExperiences.findDefaultSignInExperience.mockResolvedValueOnce({
       ...mockSignInExperience,
       adaptiveMfa: { enabled: true },
@@ -1016,6 +1026,8 @@ describe('ExperienceInteraction adaptive MFA', () => {
   });
 
   it('does not allow skipMfaOnSignIn when adaptive MFA triggers and dev features are disabled', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    mockEnvSetValues.isDevFeaturesEnabled = false;
     signInExperiences.findDefaultSignInExperience.mockResolvedValueOnce({
       ...mockSignInExperience,
       adaptiveMfa: { enabled: true },

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -14,6 +14,7 @@ import { createMockUtils, pickDefault } from '@logto/shared/esm';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import { mockUser, mockUserWithMfaVerifications } from '#src/__mocks__/user.js';
+import { EnvSet } from '#src/env-set/index.js';
 import { type InsertUserResult } from '#src/libraries/user.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
@@ -160,6 +161,12 @@ const createSignInInteraction = ({
 };
 
 describe('ExperienceInteraction class', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+  const setDevFeaturesEnabled = (enabled: boolean) => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = enabled;
+  };
+
   const tenant = new MockTenant(
     createMockProvider(mockProviderInteractionDetails),
     {
@@ -193,6 +200,10 @@ describe('ExperienceInteraction class', () => {
 
   beforeAll(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
   });
 
   describe('new user registration', () => {
@@ -230,6 +241,7 @@ describe('ExperienceInteraction class', () => {
 
   describe('sign-in submission', () => {
     it('should record geo context when dev features are disabled', async () => {
+      setDevFeaturesEnabled(false);
       const { experienceInteraction, userGeoLocations, userSignInCountries } =
         createSignInInteraction();
 
@@ -244,6 +256,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should record geo location and sign-in country when dev features are enabled', async () => {
+      setDevFeaturesEnabled(true);
       const { experienceInteraction, userGeoLocations, userSignInCountries } =
         createSignInInteraction();
 
@@ -258,6 +271,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should allow zero coordinates and record them', async () => {
+      setDevFeaturesEnabled(true);
       const { experienceInteraction, userGeoLocations } = createSignInInteraction({
         headers: {
           'x-logto-cf-country': 'US',
@@ -272,6 +286,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should skip invalid coordinates but still record valid country', async () => {
+      setDevFeaturesEnabled(true);
       const { experienceInteraction, userGeoLocations, userSignInCountries } =
         createSignInInteraction({
           headers: {
@@ -288,6 +303,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should skip out-of-range latitude but still record valid country', async () => {
+      setDevFeaturesEnabled(true);
       const { experienceInteraction, userGeoLocations, userSignInCountries } =
         createSignInInteraction({
           headers: {
@@ -304,6 +320,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should skip invalid country codes but record coordinates', async () => {
+      setDevFeaturesEnabled(true);
       const invalidCountries = ['USA', 'jpn'];
 
       for (const country of invalidCountries) {
@@ -332,6 +349,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should normalize lowercase country codes', async () => {
+      setDevFeaturesEnabled(true);
       const { experienceInteraction, userSignInCountries } = createSignInInteraction({
         headers: {
           'x-logto-cf-country': 'jp',
@@ -346,6 +364,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should record country when coordinates are missing', async () => {
+      setDevFeaturesEnabled(true);
       const { experienceInteraction, userGeoLocations, userSignInCountries } =
         createSignInInteraction({
           headers: {
@@ -360,6 +379,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should skip recording coordinates when only latitude is provided', async () => {
+      setDevFeaturesEnabled(true);
       const { experienceInteraction, userGeoLocations, userSignInCountries } =
         createSignInInteraction({
           headers: {
@@ -377,6 +397,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should record geo context when adaptive MFA is disabled', async () => {
+      setDevFeaturesEnabled(true);
       const { experienceInteraction, userGeoLocations, userSignInCountries } =
         createSignInInteraction({ adaptiveMfaEnabled: false });
 
@@ -391,6 +412,7 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('should record geo context for register interactions', async () => {
+      setDevFeaturesEnabled(true);
       const { experienceInteraction, userGeoLocations, userSignInCountries } =
         createSignInInteraction({ interactionEvent: InteractionEvent.Register });
 

--- a/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/index.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/adaptive-mfa-validator/index.test.ts
@@ -4,6 +4,7 @@ import { type IncomingHttpHeaders } from 'node:http';
 import { InteractionEvent, type User } from '@logto/schemas';
 
 import { mockUser } from '#src/__mocks__/user.js';
+import { EnvSet } from '#src/env-set/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import { defaultInjectedHeaderMapping } from '#src/utils/injected-header-mapping.js';
 
@@ -13,6 +14,12 @@ import { AdaptiveMfaValidator, adaptiveMfaNewCountryWindowDays } from './index.j
 import { type AdaptiveMfaContext } from './types.js';
 
 const { jest } = import.meta;
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+const setDevFeaturesEnabled = (value: boolean) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = value;
+};
+
 const createQueries = (overrides?: {
   recentCountries?: Array<{ country: string; lastSignInAt: number }>;
   geoLocation?: { latitude: number; longitude: number } | undefined;
@@ -91,6 +98,14 @@ const buildMockContext = (context: AdaptiveMfaContext) =>
   }) as WithLogContext;
 
 describe('AdaptiveMfaValidator', () => {
+  beforeEach(() => {
+    setDevFeaturesEnabled(true);
+  });
+
+  afterAll(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
   it('triggers new country rule when current country is not in recent list', async () => {
     const now = new Date('2024-01-02T00:00:00Z');
 
@@ -385,6 +400,8 @@ describe('AdaptiveMfaValidator', () => {
   });
 
   it('records sign-in geo context when dev features are disabled', async () => {
+    setDevFeaturesEnabled(false);
+
     const user: User = {
       ...mockUser,
       lastSignInAt: Date.now(),
@@ -420,6 +437,8 @@ describe('AdaptiveMfaValidator', () => {
   });
 
   it('evaluates adaptive MFA rules when dev features are disabled', async () => {
+    setDevFeaturesEnabled(false);
+
     const now = new Date('2024-01-02T00:00:00Z');
 
     jest.useFakeTimers().setSystemTime(now);

--- a/packages/core/src/routes/experience/classes/verifications/social-verification.test.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.test.ts
@@ -19,9 +19,14 @@ await mockEsmWithActual('@logto/connector-kit', () => ({
   isExternalGoogleOneTap: isExternalGoogleOneTapChecker,
 }));
 
+// Mock EnvSet
+const mockEnvSetValues = {
+  isDevFeaturesEnabled: false,
+};
+
 jest.mock('#src/env-set/index.js', () => ({
   EnvSet: {
-    values: {},
+    values: mockEnvSetValues,
   },
 }));
 
@@ -90,6 +95,12 @@ describe('SocialVerification', () => {
   });
 
   describe('verify method with legacy implementation', () => {
+    beforeEach(() => {
+      // Set mock to false to use legacy implementation
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      mockEnvSetValues.isDevFeaturesEnabled = false;
+    });
+
     it('should skip CSRF token validation for external website Google One Tap via legacy verify', async () => {
       const verification = new SocialVerification(tenant.libraries, tenant.queries, {
         id: 'test-id',
@@ -177,6 +188,12 @@ describe('SocialVerification', () => {
   });
 
   describe('verifySocialIdentity (dev features enabled)', () => {
+    beforeEach(() => {
+      // Set mock to true to enable dev features
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      mockEnvSetValues.isDevFeaturesEnabled = true;
+    });
+
     it('should skip CSRF token validation for external website Google One Tap with interactionSession', async () => {
       const verification = new SocialVerification(tenant.libraries, tenant.queries, {
         id: 'test-id',

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -14,6 +14,7 @@ import type { IRouterParamContext } from 'koa-router';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import { mockUser, mockUserTotpMfaVerification } from '#src/__mocks__/user.js';
+import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -181,11 +182,19 @@ describe('POST /experience/profile', () => {
 });
 
 describe('POST /experience/submit', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+  const setDevFeaturesEnabled = (enabled: boolean) => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = enabled;
+  };
+
   afterEach(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
     jest.useRealTimers();
   });
 
   it('should record geo context when dev features are disabled', async () => {
+    setDevFeaturesEnabled(false);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks();
 
     const response = await requester
@@ -204,6 +213,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should record geo location and sign-in country after successful sign-in', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks();
 
     const response = await requester
@@ -222,6 +232,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should append adaptive MFA context to submit audit log', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, mockAppend } = createRequesterWithMocks({ adaptiveMfaEnabled: true });
 
     const response = await requester
@@ -251,6 +262,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should append adaptive MFA result to submit audit log', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, mockAppend } = createRequesterWithMocks({ adaptiveMfaEnabled: true });
 
     const response = await requester.post('/experience/submit').set('x-logto-cf-bot-score', '10');
@@ -271,6 +283,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should allow zero coordinates and record them', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations } = createRequesterWithMocks();
 
     const response = await requester
@@ -284,6 +297,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should skip invalid coordinates but still record valid country', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks();
 
     const response = await requester
@@ -298,6 +312,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should skip out-of-range latitude but still record valid country', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks();
 
     const response = await requester
@@ -312,6 +327,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should skip invalid country codes but record coordinates', async () => {
+    setDevFeaturesEnabled(true);
     const invalidCountries = ['JPN', 'jpn'];
 
     for (const country of invalidCountries) {
@@ -338,6 +354,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should normalize lowercase country codes', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userSignInCountries } = createRequesterWithMocks();
 
     const response = await requester
@@ -351,6 +368,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should record country when coordinates are missing', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks();
 
     const response = await requester.post('/experience/submit').set('x-logto-cf-country', 'JP');
@@ -361,6 +379,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should skip recording coordinates when only latitude is provided', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks();
 
     const response = await requester
@@ -376,6 +395,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should record coordinates when country is missing', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks();
 
     const response = await requester
@@ -396,6 +416,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should skip recording when no geo headers are provided', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks();
 
     const response = await requester.post('/experience/submit');
@@ -406,6 +427,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should record geo context when adaptive MFA is disabled', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks({
       adaptiveMfaEnabled: false,
     });
@@ -426,6 +448,7 @@ describe('POST /experience/submit', () => {
   });
 
   it('should record geo context for register interactions', async () => {
+    setDevFeaturesEnabled(true);
     const { requester, userGeoLocations, userSignInCountries } = createRequesterWithMocks({
       interactionEvent: InteractionEvent.Register,
     });
@@ -465,6 +488,7 @@ describe('POST /experience/submit', () => {
   ])(
     'should allow adaptive MFA submit after binding $name via /experience/profile/mfa',
     async ({ factor, verificationType, identifierType, identifierValue, updatePatch }) => {
+      setDevFeaturesEnabled(true);
       const verificationId = `mock-${identifierType}-verification-id`;
       const user = {
         ...mockUser,

--- a/packages/core/src/routes/experience/verification-routes/mfa-sentinel-guard.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/mfa-sentinel-guard.test.ts
@@ -3,6 +3,7 @@ import { createMockUtils } from '@logto/shared/esm';
 import { z } from 'zod';
 
 import { mockUser } from '#src/__mocks__/user.js';
+import { EnvSet } from '#src/env-set/index.js';
 
 const { jest } = import.meta;
 const { mockEsm } = createMockUtils(jest);
@@ -92,6 +93,8 @@ const { default: totpVerificationRoutes } = await import('./totp-verification.js
 const { default: backupCodeVerificationRoutes } = await import('./backup-code-verification.js');
 const { default: webAuthnVerificationRoute } = await import('./web-authn-verification.js');
 
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
 const createRouter = (): RouterLike => ({
   post: jest.fn<void, [string, ...unknown[]]>(),
 });
@@ -118,6 +121,14 @@ describe('MFA verification routes sentinel guard', () => {
     totpVerificationRecord.verifyUserExistingTotp.mockImplementation(resolveVoid);
     backupCodeVerificationRecord.verify.mockImplementation(resolveVoid);
     webAuthnVerificationRecord.verifyWebAuthnAuthentication.mockImplementation(resolveVoid);
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = false;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+      originalIsDevFeaturesEnabled;
   });
 
   it('applies sentinel to TOTP MFA verification even when dev features are disabled', async () => {

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -8,6 +8,7 @@ import {
 } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { type LogContext } from '#src/middleware/koa-audit-log.js';
@@ -93,9 +94,9 @@ const hasUserWithIdentifier = async (
  * reason to receive a code (anti-enumeration / anti-spam). The record is still created, so a later
  * verify returns `code_mismatch`, not `not_found`. Two cases:
  *
- * - Forgot-password to an identifier no user owns.
+ * - Forgot-password to an identifier no user owns (always on).
  * - Sign-in from an unidentified session to an identifier no user owns when registration is
- *   disabled; identified sessions always deliver.
+ *   disabled (behind `isDevFeaturesEnabled`); identified sessions always deliver.
  */
 const shouldSkipDelivery = async (
   experienceInteraction: ExperienceInteraction,
@@ -107,7 +108,11 @@ const shouldSkipDelivery = async (
     return !(await hasUserWithIdentifier(queries, identifier));
   }
 
-  if (interactionEvent === InteractionEvent.SignIn && !experienceInteraction.identifiedUserId) {
+  if (
+    EnvSet.values.isDevFeaturesEnabled &&
+    interactionEvent === InteractionEvent.SignIn &&
+    !experienceInteraction.identifiedUserId
+  ) {
     const registrationDisabled =
       await experienceInteraction.signInExperienceValidator.isRegistrationDisabled();
 
@@ -175,16 +180,21 @@ export const sendCode = async ({
     recipient: identifier.value,
   };
 
-  await withMessageRateGuard(
-    await buildMessageRateGuard(queries),
-    {
-      ...messageRateLimit,
-      onRateLimited: () => {
-        ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
-      },
-    },
-    send
-  );
+  // The rate guard runs even for suppressed sends: a suppressed send must still count toward the
+  // per-recipient cap, otherwise an unknown recipient never hits 429 while a registered one does —
+  // leaking registration status (account enumeration) and defeating the point of suppression.
+  await (EnvSet.values.isDevFeaturesEnabled
+    ? withMessageRateGuard(
+        await buildMessageRateGuard(queries),
+        {
+          ...messageRateLimit,
+          onRateLimited: () => {
+            ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
+          },
+        },
+        send
+      )
+    : send());
 
   // Save state
   experienceInteraction.setVerificationRecord(codeVerification);

--- a/packages/core/src/routes/interaction/additional.ts
+++ b/packages/core/src/routes/interaction/additional.ts
@@ -14,6 +14,7 @@ import { authenticator } from 'otplib';
 import qrcode from 'qrcode';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type PasscodeLibrary } from '#src/libraries/passcode.js';
 import { createSocialAuthorizationUrl } from '#src/libraries/verification-helpers/social-verification.js';
@@ -148,11 +149,13 @@ export default function additionalRoutes<T extends IRouterParamContext>(
           passcodes
         );
 
-      await withMessageRateGuard(
-        await buildMessageRateGuard({ sentinelActivities, logtoConfigs }),
-        { action: SentinelActivityAction.VerificationCodeSend, recipient },
-        send
-      );
+      await (EnvSet.values.isDevFeaturesEnabled
+        ? withMessageRateGuard(
+            await buildMessageRateGuard({ sentinelActivities, logtoConfigs }),
+            { action: SentinelActivityAction.VerificationCodeSend, recipient },
+            send
+          )
+        : send());
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -90,6 +90,7 @@ const signInExperienceRequester = createRequester({
   authedRoutes: signInExperiencesRoutes,
   tenantContext,
 });
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 const originalIsCloud = EnvSet.values.isCloud;
 const originalIsProduction = EnvSet.values.isProduction;
 
@@ -99,6 +100,7 @@ const createDevFeaturesDisabledRequester = async () => {
   await mockEsmWithActual('#src/env-set/index.js', () => ({
     EnvSet: {
       values: {
+        isDevFeaturesEnabled: false,
         isCloud: false,
         isProduction: false,
         isUnitTest: true,
@@ -172,7 +174,13 @@ const createSignUpProfileFieldsRequester = (
   return { requester, updateDefaultSignInExperience, normalizeProfileFields };
 };
 
-const createCustomUiCspRequester = async ({ isCloud = true, isProduction = false } = {}) => {
+const createCustomUiCspRequester = async ({
+  isDevFeaturesEnabled = true,
+  isCloud = true,
+  isProduction = false,
+} = {}) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet in this route test without reloading mocked modules.
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
   // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet in this route test without reloading mocked modules.
   (EnvSet.values as { isCloud: boolean }).isCloud = isCloud;
   // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet in this route test without reloading mocked modules.
@@ -868,6 +876,9 @@ describe('PATCH /sign-in-exp signUpProfileFields', () => {
 describe('PATCH /sign-in-exp customUiCsp', () => {
   afterEach(() => {
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+      originalIsDevFeaturesEnabled;
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
     (EnvSet.values as { isCloud: boolean }).isCloud = originalIsCloud;
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after each feature-gate test.
     (EnvSet.values as { isProduction: boolean }).isProduction = originalIsProduction;
@@ -944,7 +955,7 @@ describe('PATCH /sign-in-exp customUiCsp', () => {
 
   it('should allow non-empty Custom UI CSP updates when dev features are disabled', async () => {
     const { requester, updateDefaultSignInExperience, guardTenantUsageByKey } =
-      await createCustomUiCspRequester();
+      await createCustomUiCspRequester({ isDevFeaturesEnabled: false });
 
     const response = await requester.patch('/sign-in-exp').send({
       customUiCsp: {
@@ -978,7 +989,7 @@ describe('PATCH /sign-in-exp customUiCsp', () => {
 
   it('should allow clearing Custom UI CSP config without checking quota', async () => {
     const { requester, updateDefaultSignInExperience, guardTenantUsageByKey } =
-      await createCustomUiCspRequester();
+      await createCustomUiCspRequester({ isDevFeaturesEnabled: false });
 
     const response = await requester.patch('/sign-in-exp').send({
       customUiCsp: {

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -359,5 +359,8 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
     }
   );
 
-  ssoConnectorIdpInitiatedAuthConfigRoutes(...args);
+  // TODO: @simeng Remove this when IdP initiated SAML SSO is ready for production
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    ssoConnectorIdpInitiatedAuthConfigRoutes(...args);
+  }
 }

--- a/packages/core/src/routes/swagger/utils/documents.ts
+++ b/packages/core/src/routes/swagger/utils/documents.ts
@@ -17,6 +17,7 @@ import { managementApiAuthDescription, userApiAuthDescription } from '../consts.
 
 import {
   type FindSupplementFilesOptions,
+  devFeatureTag,
   findSupplementFiles,
   pruneSwaggerDocument,
   removeUnnecessaryOperations,
@@ -252,7 +253,12 @@ export const getSupplementDocuments = async (
     )
   );
 
-  const supplementDocuments = allSupplementDocuments;
+  // Filter out supplement documents that are for dev features when dev features are disabled.
+  const supplementDocuments = allSupplementDocuments.filter(
+    (supplement) =>
+      EnvSet.values.isDevFeaturesEnabled ||
+      !supplement.tags?.find((tag) => tag?.name === devFeatureTag)
+  );
 
   return supplementDocuments;
 };

--- a/packages/core/src/routes/swagger/utils/general.test.ts
+++ b/packages/core/src/routes/swagger/utils/general.test.ts
@@ -1,8 +1,16 @@
 import { type OpenAPIV3 } from 'openapi-types';
 
+import { EnvSet } from '#src/env-set/index.js';
 import { type DeepPartial } from '#src/test-utils/tenant.js';
 
 import { devFeatureSchemaExtension, removeUnnecessaryOperations } from './general.js';
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Tests need to cover both dev-feature states.
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
+};
 
 const createDevFeatureBooleanSchema = () =>
   ({
@@ -41,7 +49,44 @@ const createDocument = (): DeepPartial<OpenAPIV3.Document> => ({
 });
 
 describe('swagger general utils', () => {
-  it('should keep dev feature schema properties without exposing the internal marker', () => {
+  afterEach(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
+  it('should remove dev feature schema properties when dev features are disabled', () => {
+    setDevFeaturesEnabled(false);
+
+    const document = removeUnnecessaryOperations(createDocument());
+
+    expect(document).toMatchObject({
+      paths: {
+        '/api/mock': {
+          patch: {
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    required: ['name'],
+                    properties: {
+                      name: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(document)).not.toContain('beta');
+    expect(JSON.stringify(document)).not.toContain(devFeatureSchemaExtension);
+  });
+
+  it('should keep dev feature schema properties without exposing the internal marker when dev features are enabled', () => {
+    setDevFeaturesEnabled(true);
+
     const document = removeUnnecessaryOperations(createDocument());
 
     expect(document).toMatchObject({

--- a/packages/core/src/routes/swagger/utils/general.ts
+++ b/packages/core/src/routes/swagger/utils/general.ts
@@ -17,8 +17,8 @@ const capitalize = (value: string) => value.charAt(0).toUpperCase() + value.slic
 /** The tag name used in the supplement document to indicate that the operation is cloud only. */
 const cloudOnlyTag = 'Cloud only';
 /** The tag name is used in the supplement document to indicate that the corresponding API operation is a dev feature. */
-const devFeatureTag = 'Dev feature';
-/** The OpenAPI schema extension used as an internal marker on dev-feature schema properties. */
+export const devFeatureTag = 'Dev feature';
+/** The OpenAPI schema extension that hides a schema property when dev features are disabled. */
 export const devFeatureSchemaExtension = 'x-logto-dev-feature';
 
 const reservedTags = new Set([cloudOnlyTag, devFeatureTag]);
@@ -41,6 +41,10 @@ const tagMap = new Map([
   ['one-time-tokens', 'One-time tokens'],
   ['custom-profile-fields', 'Custom profile fields'],
 ]);
+
+if (EnvSet.values.isDevFeaturesEnabled) {
+  // TagMap.set('foo-bar', 'Foo bar');
+}
 
 /**
  * Build a tag name from the given absolute path. The function will get the root component name
@@ -256,26 +260,33 @@ export const validateSwaggerDocument = (document: OpenAPIV3.Document) => {
  * **CAUTION**: This function mutates the input document.
  *
  * Remove operations (path + method) that are tagged with `Cloud only` if the application is not
- * running in the cloud. It also strips the `x-logto-dev-feature` internal marker from schema
- * properties (the properties themselves are kept).
+ * running in the cloud and remove operations with `Dev feature` tag if Logto's
+ * `isDevFeaturesEnabled` flag is set to be false. It also prunes schema properties marked with
+ * `x-logto-dev-feature` when dev features are disabled, and removes the internal marker when they
+ * are enabled.
  *
  * This will prevent the swagger validation from failing in the OSS environment.
  *
  */
+// eslint-disable-next-line complexity
 export const removeUnnecessaryOperations = (
   document: DeepPartial<OpenAPIV3.Document>
 ): DeepPartial<OpenAPIV3.Document> => {
-  const { isCloud } = EnvSet.values;
+  const { isCloud, isDevFeaturesEnabled } = EnvSet.values;
 
   removeDevFeatureSchemaProperties(document);
 
-  if (isCloud || !document.paths) {
+  if ((isCloud && isDevFeaturesEnabled) || !document.paths) {
     return document;
   }
 
   for (const [path, pathItem] of Object.entries(document.paths)) {
     for (const method of Object.values(OpenAPIV3.HttpMethods)) {
-      if (pathItem?.[method]?.tags?.includes(cloudOnlyTag)) {
+      if (
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        (!isCloud && pathItem?.[method]?.tags?.includes(cloudOnlyTag)) ||
+        (!isDevFeaturesEnabled && pathItem?.[method]?.tags?.includes(devFeatureTag))
+      ) {
         // eslint-disable-next-line @silverhand/fp/no-delete, @typescript-eslint/no-dynamic-delete -- intended
         delete pathItem[method];
       }
@@ -292,10 +303,47 @@ export const removeUnnecessaryOperations = (
 
 const isRecord = (value: unknown): value is Record<string, unknown> => isObject(value);
 
-const removeDevFeatureExtensionMarker = (propertySchema: unknown) => {
-  if (isRecord(propertySchema) && propertySchema[devFeatureSchemaExtension] === true) {
-    Reflect.deleteProperty(propertySchema, devFeatureSchemaExtension);
+const removeRequiredProperty = (
+  schema: Record<string, unknown>,
+  required: unknown,
+  propertyName: string
+) => {
+  if (!Array.isArray(required)) {
+    return;
   }
+
+  const nextRequired = required.filter((item) => item !== propertyName);
+
+  if (nextRequired.length === 0) {
+    Reflect.deleteProperty(schema, 'required');
+
+    return;
+  }
+
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Pruning the supplement document is intentionally in-place.
+  schema.required = nextRequired;
+};
+
+const removeDevFeatureSchemaProperty = (
+  schema: Record<string, unknown>,
+  properties: Record<string, unknown>,
+  propertyName: string,
+  propertySchema: unknown
+) => {
+  if (!isRecord(propertySchema) || propertySchema[devFeatureSchemaExtension] !== true) {
+    return false;
+  }
+
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    Reflect.deleteProperty(properties, propertyName);
+    removeRequiredProperty(schema, schema.required, propertyName);
+
+    return true;
+  }
+
+  Reflect.deleteProperty(propertySchema, devFeatureSchemaExtension);
+
+  return false;
 };
 
 const removeDevFeatureSchemaProperties = (value: unknown) => {
@@ -315,8 +363,10 @@ const removeDevFeatureSchemaProperties = (value: unknown) => {
   const { properties } = schema;
 
   if (isRecord(properties)) {
-    for (const propertySchema of Object.values(properties)) {
-      removeDevFeatureExtensionMarker(propertySchema);
+    for (const [propertyName, propertySchema] of Object.entries(properties)) {
+      if (removeDevFeatureSchemaProperty(schema, properties, propertyName, propertySchema)) {
+        continue;
+      }
     }
   }
 

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -27,6 +27,11 @@ const methodToVerb = Object.freeze({
 
 type RouteDictionary = Record<`${OpenAPIV3.HttpMethods} ${string}`, string>;
 
+const devFeatureCustomRoutes: Readonly<RouteDictionary> = Object.freeze({
+  'get /configs/oidc/session': 'GetOidcSessionConfig',
+  'patch /configs/oidc/session': 'UpdateOidcSessionConfig',
+});
+
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   // Authn
   'get /authn/hasura': 'GetHasuraAuth',
@@ -106,6 +111,7 @@ export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   // Session config
   'get /configs/oidc/session': 'GetOidcSessionConfig',
   'patch /configs/oidc/session': 'UpdateOidcSessionConfig',
+  ...(EnvSet.values.isDevFeaturesEnabled ? devFeatureCustomRoutes : {}),
 } satisfies RouteDictionary); // Key assertion doesn't work without `satisfies`
 
 /**

--- a/packages/core/src/routes/verification-code.ts
+++ b/packages/core/src/routes/verification-code.ts
@@ -5,6 +5,7 @@ import {
   verifyVerificationCodePayloadGuard,
 } from '@logto/schemas';
 
+import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
@@ -34,11 +35,13 @@ export default function verificationCodeRoutes<T extends ManagementApiRouter>(
         return sendPasscode(code, { ip: ctx.request.ip });
       };
 
-      await withMessageRateGuard(
-        await buildMessageRateGuard(queries),
-        { action: SentinelActivityAction.VerificationCodeSend, recipient },
-        send
-      );
+      await (EnvSet.values.isDevFeaturesEnabled
+        ? withMessageRateGuard(
+            await buildMessageRateGuard(queries),
+            { action: SentinelActivityAction.VerificationCodeSend, recipient },
+            send
+          )
+        : send());
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -12,6 +12,7 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
 
@@ -130,16 +131,18 @@ export default function verificationRoutes<T extends UserRouter>(
         recipient: identifier.value,
       };
 
-      await withMessageRateGuard(
-        await buildMessageRateGuard(queries),
-        {
-          ...messageRateLimit,
-          onRateLimited: () => {
-            ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
-          },
-        },
-        send
-      );
+      await (EnvSet.values.isDevFeaturesEnabled
+        ? withMessageRateGuard(
+            await buildMessageRateGuard(queries),
+            {
+              ...messageRateLimit,
+              onRateLimited: () => {
+                ctx.appendExceptionHookContext('Message.RateLimited', messageRateLimit);
+              },
+            },
+            send
+          )
+        : send());
 
       const { expiresAt } = await insertVerificationRecord(
         codeVerification,

--- a/packages/core/src/utils/injected-header-mapping.test.ts
+++ b/packages/core/src/utils/injected-header-mapping.test.ts
@@ -9,7 +9,7 @@ const { mockEsm } = createMockUtils(jest);
 const loadGetInjectedHeaderValues = async (
   injectedHeaderMappingJson?: string,
   debugInjectedHeadersJson?: string,
-  isProduction = false
+  isDevFeaturesEnabled = true
 ) => {
   jest.resetModules();
   mockEsm('#src/env-set/index.js', () => ({
@@ -17,7 +17,7 @@ const loadGetInjectedHeaderValues = async (
       values: {
         injectedHeaderMappingJson,
         debugInjectedHeadersJson,
-        isProduction,
+        isDevFeaturesEnabled,
       },
     },
   }));
@@ -68,7 +68,7 @@ describe('getInjectedHeaderValues', () => {
     expect(getInjectedHeaderValues(headers)).toEqual({ country: 'US' });
   });
 
-  it('should use debug injected headers when not in production', async () => {
+  it('should use debug injected headers when enabled', async () => {
     const getInjectedHeaderValues = await loadGetInjectedHeaderValues(
       undefined,
       JSON.stringify({ country: 'FR', botScore: 10 })
@@ -80,11 +80,11 @@ describe('getInjectedHeaderValues', () => {
     expect(getInjectedHeaderValues(headers)).toEqual({ country: 'FR', botScore: '10' });
   });
 
-  it('should ignore debug injected headers in production', async () => {
+  it('should ignore debug injected headers when dev features disabled', async () => {
     const getInjectedHeaderValues = await loadGetInjectedHeaderValues(
       undefined,
-      JSON.stringify({ country: 'FR', botScore: 10 }),
-      true
+      JSON.stringify({ country: 'FR' }),
+      false
     );
     const headers: IncomingHttpHeaders = {
       'x-logto-cf-country': 'US',

--- a/packages/core/src/utils/injected-header-mapping.ts
+++ b/packages/core/src/utils/injected-header-mapping.ts
@@ -101,7 +101,7 @@ export const getInjectedHeaderValues = (
   headers: IncomingHttpHeaders
 ): Optional<InjectedHeaderValues> => {
   const debugInjectedHeaderValues = conditional(
-    !EnvSet.values.isProduction &&
+    EnvSet.values.isDevFeaturesEnabled &&
       parseDebugInjectedHeaderValues(EnvSet.values.debugInjectedHeadersJson)
   );
 

--- a/packages/experience/src/constants/env.ts
+++ b/packages/experience/src/constants/env.ts
@@ -1,1 +1,4 @@
-export {}; // Keep module declaration
+import { yes } from '@silverhand/essentials';
+
+export const isDevFeaturesEnabled =
+  process.env.NODE_ENV !== 'production' || yes(process.env.DEV_FEATURES_ENABLED);

--- a/packages/integration-tests/src/constants.ts
+++ b/packages/integration-tests/src/constants.ts
@@ -4,7 +4,7 @@ import {
   demoAppApplicationId,
   type CreateSsoConnector,
 } from '@logto/schemas';
-import { appendPath, getEnv } from '@silverhand/essentials';
+import { appendPath, getEnv, yes } from '@silverhand/essentials';
 
 export const logtoUrl = getEnv('INTEGRATION_TESTS_LOGTO_URL', 'http://localhost:3001');
 export const logtoOidcUrl = appendPath(new URL(logtoUrl), 'oidc').toString();
@@ -47,3 +47,5 @@ export const newOidcSsoConnectorPayload = {
     issuer: `${logtoUrl}/oidc`,
   },
 } satisfies Partial<CreateSsoConnector>;
+
+export const isDevFeaturesEnabled = yes(getEnv('DEV_FEATURES_ENABLED'));

--- a/packages/integration-tests/src/tests/api/oidc/client-credentials-grant.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/client-credentials-grant.test.ts
@@ -29,7 +29,7 @@ import { assignScopesToRole, createRole as createRoleApi, deleteRole } from '#sr
 import { createScope as createScopeApi } from '#src/api/scope.js';
 import { logtoUrl } from '#src/constants.js';
 import { OrganizationApiTest } from '#src/helpers/organization.js';
-import { devFeatureTest, randomString } from '#src/utils.js';
+import { devFeatureDisabledTest, devFeatureTest, randomString } from '#src/utils.js';
 
 type TokenResponse = {
   access_token: string;
@@ -321,6 +321,23 @@ describe('client credentials grant', () => {
       await expectError({ resource: resource.indicator }, 400, {
         error: 'access_denied',
       });
+    });
+  });
+
+  devFeatureDisabledTest.describe('custom jwt error handling (dev features disabled)', () => {
+    it('should keep fail-open when script throws and blocking is enabled', async () => {
+      const resource = await createResource();
+
+      await upsertJwtCustomizer('client-credentials', {
+        script: `const getCustomJwtClaims = async () => {
+  throw new Error('boom');
+};`,
+        blockIssuanceOnError: true,
+      });
+
+      const { access_token: accessToken } = await post({ resource: resource.indicator });
+      const verified = await jwtVerify(accessToken, jwkSet, { audience: resource.indicator });
+      expect(verified.payload.client_id).toBe(client.id);
     });
   });
 });

--- a/packages/integration-tests/src/tests/api/oidc/token-exchange/index.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/token-exchange/index.test.ts
@@ -29,6 +29,7 @@ import { createUserByAdmin } from '#src/helpers/index.js';
 import { OrganizationApiTest } from '#src/helpers/organization.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import {
+  devFeatureDisabledTest,
   devFeatureTest,
   getAccessTokenPayload,
   randomString,
@@ -531,6 +532,40 @@ describe('Token Exchange', () => {
         expect(
           oidcInvalidRequestErrorGuard.safeParse(await (error as HTTPError).response.json()).success
         ).toBe(true);
+
+        await deleteJwtCustomizer('access-token');
+      }
+    );
+
+    devFeatureDisabledTest.it(
+      'should keep fail-open when access-token script throws and blocking is enabled',
+      async () => {
+        const { subjectToken } = await createSubjectToken(testUserId, { foo: 'bar' });
+
+        await upsertJwtCustomizer('access-token', {
+          script: `const getCustomJwtClaims = async () => {
+  throw new Error('boom');
+};`,
+          blockIssuanceOnError: true,
+        });
+
+        const { access_token } = await oidcApi
+          .post('token', {
+            headers: {
+              ...formUrlEncodedHeaders,
+              Authorization: authorizationHeader,
+            },
+            body: new URLSearchParams({
+              grant_type: GrantType.TokenExchange,
+              subject_token: subjectToken,
+              subject_token_type: impersonationTokenType,
+              resource: testApiResourceInfo.indicator,
+            }),
+          })
+          .json<{
+            access_token: string;
+          }>();
+        expect(getAccessTokenPayload(access_token).sub).toBe(testUserId);
 
         await deleteJwtCustomizer('access-token');
       }

--- a/packages/integration-tests/src/tests/console/bootstrap.test.ts
+++ b/packages/integration-tests/src/tests/console/bootstrap.test.ts
@@ -5,6 +5,7 @@ import { authedAdminTenantApi } from '#src/api/api.js';
 import {
   consolePassword,
   consoleUsername,
+  isDevFeaturesEnabled,
   logtoConsoleUrl as logtoConsoleUrlString,
 } from '#src/constants.js';
 import { switchToLanguage } from '#src/ui-helpers/switch-language.js';
@@ -83,7 +84,7 @@ describe('smoke testing for console admin account creation and sign-in', () => {
 
     const getStartedUrl = new URL('console/get-started', logtoConsoleUrl).href;
     const onboardingUrl = new URL('console/onboarding', logtoConsoleUrl).href;
-    const expectedUrls = [onboardingUrl, getStartedUrl];
+    const expectedUrls = isDevFeaturesEnabled ? [onboardingUrl, getStartedUrl] : [getStartedUrl];
     await page.waitForFunction(
       (expectedUrls) => expectedUrls.includes(window.location.href),
       {},
@@ -173,5 +174,11 @@ describe('smoke testing for console admin account creation and sign-in', () => {
       })
     );
     await expect(page).toMatchElement(activeSelector, { text: 'Dashboard', visible: true });
+  });
+
+  it(`should ${isDevFeaturesEnabled ? '' : 'not '}show the dev features label`, async () => {
+    await (isDevFeaturesEnabled
+      ? expect(page).toMatchElement('div', { text: 'Dev features enabled' })
+      : expect(page).not.toMatchElement('div', { text: 'Dev features enabled' }));
   });
 });

--- a/packages/integration-tests/src/utils.ts
+++ b/packages/integration-tests/src/utils.ts
@@ -5,6 +5,8 @@ import { generateStandardId } from '@logto/shared';
 import { assert } from '@silverhand/essentials';
 import { type Page } from 'puppeteer';
 
+import { isDevFeaturesEnabled } from './constants.js';
+
 export const generateName = () => crypto.randomUUID();
 export const generateUserId = () => crypto.randomUUID();
 export const generateUsername = () => `usr_${crypto.randomUUID().replaceAll('-', '_')}`;
@@ -157,8 +159,13 @@ export const generateTestName = () => `test_${generateStandardId(4)}`;
 export const randomString = () => crypto.randomBytes(8).toString('hex');
 
 export const devFeatureTest = Object.freeze({
-  it,
-  describe,
+  it: isDevFeaturesEnabled ? it : it.skip,
+  describe: isDevFeaturesEnabled ? describe : describe.skip,
+});
+
+export const devFeatureDisabledTest = Object.freeze({
+  it: isDevFeaturesEnabled ? it.skip : it,
+  describe: isDevFeaturesEnabled ? describe.skip : describe,
 });
 
 export const parseInteractionCookie = (cookie: string): Record<string, string> => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR #9072 intended to remove the Console Profile page and redirect profile entry points to Account Center, but it also removed `isDevFeaturesEnabled` guards across ~60 files in console, core, experience, account, and integration-tests. This prematurely exposed many unreleased features.

This PR restores all `isDevFeaturesEnabled` guards from before #9072, while keeping only the console profile page changes:

- `/profile` routes always redirect to Account Center (no guard)
- Topbar profile menu always opens Account Center (no guard)
- Console Profile page and related components remain deleted

Restored guards include (non-exhaustive):

- Delete Account route
- OSS onboarding route and guard
- Dev status UI badge and spacing
- Webhook `Message.RateLimited` event
- Connector dev-feature form fields
- JWT customizer error handling and organization context
- Organization invitation one-time token auth
- Core API dev-feature routes and OpenAPI filtering
- Integration test `devFeatureTest` / `devFeatureDisabledTest` helpers

## Testing

Unit tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be077593-0096-42f4-8bd8-676bd197e8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be077593-0096-42f4-8bd8-676bd197e8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

