### PR TITLE
fix(core): add wall-clock timeout for local VM async execution

### DIFF
--- a/packages/core/src/utils/local-vm/index.test.ts
+++ b/packages/core/src/utils/local-vm/index.test.ts
@@ -1,0 +1,76 @@
+import { runScriptFunctionInLocalVm } from './index.js';
+
+const { jest } = import.meta;
+
+describe('runScriptFunctionInLocalVm', () => {
+  it('executes async scripts and returns the result', async () => {
+    await expect(
+      runScriptFunctionInLocalVm(
+        `
+          const testFn = async ({ value }) => ({
+            doubled: value * 2,
+          });
+        `,
+        'testFn',
+        { value: 21 }
+      )
+    ).resolves.toEqual({ doubled: 42 });
+  });
+
+  it('rejects when async script execution exceeds the wall-clock timeout', async () => {
+    jest.useFakeTimers();
+
+    try {
+      const promise = runScriptFunctionInLocalVm(
+        `
+          const testFn = async () => new Promise(() => {});
+        `,
+        'testFn',
+        {}
+      );
+
+      jest.advanceTimersByTime(3000);
+
+      await expect(promise).rejects.toThrow('Script execution timed out after 3000ms');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('aborts in-flight fetch when the wall-clock timeout is reached', async () => {
+    jest.useFakeTimers();
+
+    const fetchMock = jest.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        })
+    );
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    try {
+      const promise = runScriptFunctionInLocalVm(
+        `
+          const testFn = async () => fetch('https://example.com');
+        `,
+        'testFn',
+        {}
+      );
+
+      jest.advanceTimersByTime(3000);
+
+      await expect(promise).rejects.toThrow('Script execution timed out after 3000ms');
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://example.com',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+      expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      jest.useRealTimers();
+    }
+  });
+});

--- a/packages/core/src/utils/local-vm/index.ts
+++ b/packages/core/src/utils/local-vm/index.ts
@@ -34,37 +34,59 @@ export class LocalVmError extends ResponseError {
  */
 const localVmTimeout = 3000;
 
+const localVmTimeoutErrorMessage = `Script execution timed out after ${localVmTimeout}ms`;
+
 export const runScriptFunctionInLocalVm = async (
   script: string,
   functionName: string,
   payload: unknown
 ) => {
-  const globalContext = Object.freeze({
-    fetch: async (...args: Parameters<typeof fetch>) => fetch(...args),
-  });
-  const customFunction: unknown = runInNewContext(script + `;${functionName};`, globalContext, {
-    timeout: localVmTimeout,
+  const abortController = new AbortController();
+
+  const execute = async () => {
+    const globalContext = Object.freeze({
+      fetch: async (input: RequestInfo | URL, init?: RequestInit) =>
+        fetch(input, { ...init, signal: abortController.signal }),
+    });
+    const customFunction: unknown = runInNewContext(script + `;${functionName};`, globalContext, {
+      timeout: localVmTimeout,
+    });
+
+    if (typeof customFunction !== 'function') {
+      throw new TypeError(`The script does not have a function named \`${functionName}\``);
+    }
+
+    /**
+     * We can not use top-level await in `vm`, use the following implementation instead.
+     *
+     * Ref:
+     * 1. https://github.com/nodejs/node/issues/40898
+     * 2. https://github.com/n-riesco/ijavascript/issues/173#issuecomment-693924098
+     */
+    return runInNewContext(
+      '(async () => customFunction(payload))();',
+      Object.freeze({ customFunction, payload }),
+      // Limit the execution time to 3 seconds, throws error if the script takes too long to execute.
+      { timeout: localVmTimeout }
+    );
+  };
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      abortController.abort();
+      reject(new Error(localVmTimeoutErrorMessage));
+    }, localVmTimeout);
   });
 
-  if (typeof customFunction !== 'function') {
-    throw new TypeError(`The script does not have a function named \`${functionName}\``);
+  try {
+    return await Promise.race([execute(), timeoutPromise]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   }
-
-  /**
-   * We can not use top-level await in `vm`, use the following implementation instead.
-   *
-   * Ref:
-   * 1. https://github.com/nodejs/node/issues/40898
-   * 2. https://github.com/n-riesco/ijavascript/issues/173#issuecomment-693924098
-   */
-  const result: unknown = await runInNewContext(
-    '(async () => customFunction(payload))();',
-    Object.freeze({ customFunction, payload }),
-    // Limit the execution time to 3 seconds, throws error if the script takes too long to execute.
-    { timeout: localVmTimeout }
-  );
-
-  return result;
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Superseded — changes were pushed directly to #9080's branch per author request.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99d606d1-3a61-456e-9ef4-83f6357a47d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99d606d1-3a61-456e-9ef4-83f6357a47d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

