### PR TITLE
fix(console): open delete account route

### DIFF
--- a/packages/console/src/cloud/AppRoutes.tsx
+++ b/packages/console/src/cloud/AppRoutes.tsx
@@ -4,7 +4,6 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import DelayedSuspenseFallback from '@/components/DelayedSuspenseFallback';
 import RedirectToAccountCenter from '@/components/RedirectToAccountCenter';
 import { EnterpriseSubscriptionTabs } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import ProtectedRoutes from '@/containers/ProtectedRoutes';
 import { GlobalAnonymousRoute, GlobalRoute } from '@/contexts/TenantsProvider';
 import { OnboardingApp } from '@/onboarding';
@@ -49,9 +48,7 @@ function AppRoutes() {
               element={<CheckoutSuccessCallback />}
             />
             <Route path={GlobalRoute.Onboarding + '/*'} element={<OnboardingApp />} />
-            {isDevFeaturesEnabled && (
-              <Route path={GlobalRoute.DeleteAccount} element={<DeleteAccount />} />
-            )}
+            <Route path={GlobalRoute.DeleteAccount} element={<DeleteAccount />} />
             <Route index element={<Main />} />
             <Route
               path={`${GlobalRoute.EnterpriseSubscription}/:logtoEnterpriseId`}


### PR DESCRIPTION
## Summary

- Make the Console `/delete-account` route available to authenticated users.

## Testing

Tested locally