### PR TITLE
fix(core): avoid regex in email subaddressing blocklist check

### DIFF
--- a/.changeset/email-subaddressing-check.md
+++ b/.changeset/email-subaddressing-check.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+avoid constructing a regular expression from user-controlled input in the email subaddressing blocklist check

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -53,6 +53,23 @@ describe('validateEmailAgainstBlocklistPolicy', () => {
     );
   });
 
+  it('blocks subaddressing regardless of regex metacharacters in the address', async () => {
+    // The local part contains `+`, so it is blocked as subaddressing no matter what other
+    // characters appear in the address; the check treats the address as plain text, not a pattern,
+    // so it stays linear-time.
+    const complexEmail = 'x+y@(a+)+$@' + 'a'.repeat(40) + '.com';
+    const start = Date.now();
+    await expect(
+      validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, complexEmail)
+    ).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_subaddressing_not_allowed',
+        status: 422,
+      })
+    );
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
   it('should throw if the email domain is in the custom blocklist', async () => {
     const emails = ['test@foo.com', 'bar@foo.com'];
 

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -138,9 +138,12 @@ export const validateEmailAgainstBlocklistPolicy = async (
 
   // Guard email subaddressing if enabled
   if (blockSubaddressing) {
-    const subaddressingRegex = new RegExp(`^.*\\+.*@${domain}$`);
+    // Subaddressing puts a `+` in the local part (e.g. `user+tag@example.com`). Check the local
+    // part directly instead of building a `RegExp` from the user-controlled domain — a plain
+    // string check is simpler and avoids interpreting user input as a pattern.
+    const localPart = email.split('@')[0] ?? '';
     assertThat(
-      !subaddressingRegex.test(email),
+      !localPart.includes('+'),
       new RequestError({
         code: 'session.email_blocklist.email_subaddressing_not_allowed',
         status: 422,

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -65,7 +65,9 @@ export type VerificationCodeIdentifier<
 export const verificationCodeIdentifierGuard = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(SignInIdentifier.Email),
-    value: z.string().regex(emailRegEx),
+    // `.max(256)` caps the input length as defense-in-depth for downstream email processing
+    // (a valid address is at most 254 chars per RFC 5321).
+    value: z.string().max(256).regex(emailRegEx),
   }),
   z.object({
     type: z.literal(SignInIdentifier.Phone),


### PR DESCRIPTION
## Summary

The email subaddressing blocklist check built a `RegExp` from the user-controlled email domain (`new RegExp('^.*\\+.*@' + domain + '$')`) and tested the full address against it. Building a pattern out of user input is fragile and unnecessary — subaddressing only depends on whether the local part contains a `+`.

This replaces the regex with a direct local-part check (`localPart.includes('+')`): simpler, identical behavior for normal addresses, and linear-time. It also adds a `.max(256)` length guard on the email identifier in the verification-code payload as small input hardening.

## Testing

Unit tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
