### PR TITLE
fix(core): upgrade samlify to ^2.13.0

### DIFF
--- a/.changeset/samlify-2-13-0.md
+++ b/.changeset/samlify-2-13-0.md
@@ -1,0 +1,6 @@
+---
+"@logto/core": patch
+"@logto/connector-saml": patch
+---
+
+upgrade `samlify` to `^2.13.0`, which consistently XML-escapes attribute values in generated SAML assertions, and adapt the SAML application and SSO connector call sites to its stricter return types (`getAssertionConsumerService`, `getX509Certificate`, and the `createLoginResponse` binding-context union)

--- a/packages/connectors/connector-saml/package.json
+++ b/packages/connectors/connector-saml/package.json
@@ -8,7 +8,7 @@
     "@silverhand/essentials": "^2.9.1",
     "fast-xml-parser": "^5.3.4",
     "got": "^14.0.0",
-    "samlify": "2.10.0",
+    "samlify": "^2.13.0",
     "snakecase-keys": "^8.0.1",
     "zod": "3.24.3"
   },

--- a/packages/connectors/connector-saml/src/utils.ts
+++ b/packages/connectors/connector-saml/src/utils.ts
@@ -99,7 +99,6 @@ export const samlAssertionHandler = async (
     await setSession({
       extractedRawProfile: {
         ...(Boolean(assertionResult.extract.nameID) && {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           id: assertionResult.extract.nameID,
         }),
         ...assertionResult.extract.attributes,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -96,7 +96,7 @@
     "raw-body": "^3.0.0",
     "redis": "^4.6.14",
     "roarr": "^7.11.0",
-    "samlify": "2.10.0",
+    "samlify": "^2.13.0",
     "semver": "^7.3.8",
     "snake-case": "^4.0.0",
     "snakecase-keys": "^8.0.1",

--- a/packages/core/src/saml-application/SamlApplication/index.test.ts
+++ b/packages/core/src/saml-application/SamlApplication/index.test.ts
@@ -87,6 +87,45 @@ describe('SamlApplication', () => {
       expect(result.id).toBe('ID_' + generatedId);
       expect(typeof result.context).toBe('string');
     });
+
+    it('XML-escapes markup in attribute values', () => {
+      // A value containing XML markup must be emitted as escaped text in the generated assertion,
+      // not as raw markup that adds elements or changes the structure.
+      const valueWithMarkup =
+        'x</saml:AttributeValue></saml:Attribute>' +
+        '<saml:Attribute Name="role"><saml:AttributeValue>admin';
+      const template =
+        '<saml:Attribute Name="name"><saml:AttributeValue>{attrName}</saml:AttributeValue></saml:Attribute>';
+
+      const { context } = samlApp.exposedCreateSamlTemplateCallback({
+        userInfo: { ...mockUser, name: valueWithMarkup },
+        samlRequestId: null,
+        sessionId: undefined,
+        sessionExpiresAt: undefined,
+      })(template);
+
+      // The markup must not create a new element, and its angle brackets must be escaped.
+      expect(context).not.toMatch(/<saml:Attribute\s+Name="role"/);
+      expect(context).toContain('&lt;/saml:AttributeValue&gt;');
+    });
+
+    it('should leave a legitimate attribute value intact (backward compatibility)', () => {
+      // A normal value containing XML metacharacters must round-trip as a single escaped value,
+      // not be mangled or double-escaped.
+      const template =
+        '<saml:Attribute Name="name"><saml:AttributeValue>{attrName}</saml:AttributeValue></saml:Attribute>';
+
+      const { context } = samlApp.exposedCreateSamlTemplateCallback({
+        userInfo: { ...mockUser, name: 'Tom & Jerry <co>' },
+        samlRequestId: null,
+        sessionId: undefined,
+        sessionExpiresAt: undefined,
+      })(template);
+
+      expect(context).toContain(
+        '<saml:AttributeValue>Tom &amp; Jerry &lt;co&gt;</saml:AttributeValue>'
+      );
+    });
   });
 
   describe('exchangeAuthorizationCode', () => {

--- a/packages/core/src/saml-application/SamlApplication/index.ts
+++ b/packages/core/src/saml-application/SamlApplication/index.ts
@@ -200,8 +200,7 @@ export class SamlApplication {
   }> => {
     const optionalRelayState = conditional(relayState);
     // TODO: fix binding method
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const { context, entityEndpoint } = await this.idp.createLoginResponse(
+    const loginResponse = await this.idp.createLoginResponse(
       this.sp,
       // @ts-expect-error --fix request object later
       null,
@@ -212,8 +211,19 @@ export class SamlApplication {
       optionalRelayState
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    return { context, entityEndpoint, relayState: optionalRelayState };
+    // The `post` binding yields a `PostBindingContext`, which carries `entityEndpoint`; samlify
+    // only types the union of binding contexts. Assert it rather than silently defaulting, so a
+    // samlify contract change surfaces instead of producing an empty ACS endpoint.
+    assertThat(
+      'entityEndpoint' in loginResponse,
+      new Error('Expected a POST binding context from `createLoginResponse`.')
+    );
+
+    return {
+      context: loginResponse.context,
+      entityEndpoint: loginResponse.entityEndpoint,
+      relayState: optionalRelayState,
+    };
   };
 
   // Helper functions for SAML callback
@@ -425,9 +435,13 @@ export class SamlApplication {
       sessionExpiresAt: Optional<string>;
     }) =>
     (template: string) => {
-      const assertionConsumerServiceUrl = this.sp.entityMeta.getAssertionConsumerService(
+      const rawAssertionConsumerServiceUrl = this.sp.entityMeta.getAssertionConsumerService(
         saml.Constants.wording.binding.post
       );
+      // The `samlify` type models this as `string | string[]`; a SP has a single POST ACS URL.
+      const assertionConsumerServiceUrl = Array.isArray(rawAssertionConsumerServiceUrl)
+        ? (rawAssertionConsumerServiceUrl[0] ?? '')
+        : rawAssertionConsumerServiceUrl;
 
       const { nameIDFormat } = this.idp.entitySetting;
       assertThat(nameIDFormat, 'application.saml.name_id_format_required');

--- a/packages/core/src/sso/SamlConnector/utils.ts
+++ b/packages/core/src/sso/SamlConnector/utils.ts
@@ -57,11 +57,14 @@ export const parseXmlMetadata = (
     signInEndpoint: singleSignOnService,
   };
 
-  // The type inference of the return type of `getX509Certificate` is any, will be guarded by later zod parser if it is not string-typed.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const rawX509Certificate: string = idP.entityMeta.getX509Certificate(
+  // The `samlify` type models `getX509Certificate` as `string | string[]`; the signing use has a
+  // single cert. A missing value falls through to `getPemCertificate`, which rejects it below.
+  const rawX509CertificateValue = idP.entityMeta.getX509Certificate(
     saml.Constants.wording.certUse.signing
   );
+  const rawX509Certificate = Array.isArray(rawX509CertificateValue)
+    ? (rawX509CertificateValue[0] ?? '')
+    : rawX509CertificateValue;
 
   const certificate = tryThat(
     () => getPemCertificate(rawX509Certificate),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,7 +147,7 @@ importers:
         version: 6.0.1(eslint@8.57.0)(prettier@3.5.3)(typescript@5.5.3)
       '@silverhand/eslint-config-react':
         specifier: 6.0.2
-        version: 6.0.2(eslint@8.57.0)(postcss@8.5.14)(prettier@3.5.3)(stylelint@15.11.0(typescript@5.5.3))(typescript@5.5.3)
+        version: 6.0.2(eslint@8.57.0)(postcss@8.5.15)(prettier@3.5.3)(stylelint@15.11.0(typescript@5.5.3))(typescript@5.5.3)
       '@silverhand/essentials':
         specifier: ^2.9.1
         version: 2.9.2
@@ -2785,8 +2785,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       samlify:
-        specifier: 2.10.0
-        version: 2.10.0
+        specifier: ^2.13.0
+        version: 2.13.1
       snakecase-keys:
         specifier: ^8.0.1
         version: 8.0.1
@@ -4075,7 +4075,7 @@ importers:
     dependencies:
       '@authenio/samlify-node-xmllint':
         specifier: ^2.0.0
-        version: 2.0.0(samlify@2.10.0)
+        version: 2.0.0(samlify@2.13.1)
       '@aws-sdk/client-s3':
         specifier: ^3.556.0
         version: 3.556.0
@@ -4281,8 +4281,8 @@ importers:
         specifier: ^7.11.0
         version: 7.21.1
       samlify:
-        specifier: 2.10.0
-        version: 2.10.0
+        specifier: ^2.13.0
+        version: 2.13.1
       semver:
         specifier: ^7.3.8
         version: 7.7.1
@@ -13549,9 +13549,6 @@ packages:
   packet-reader@1.0.0:
     resolution: {integrity: sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==}
 
-  pako@1.0.11:
-    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -14618,8 +14615,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  samlify@2.10.0:
-    resolution: {integrity: sha512-IIFg193YPn9IpTd2jCWVvLLC9xdWz/eLn1rtF9YMSwK/B1rt2OM2zAuP99cw3MPYyYsm+I9rlvYgq9FuJ9JqSA==}
+  samlify@2.13.1:
+    resolution: {integrity: sha512-vdYr/zohDGBbfWNU4miEzc1jmWOtkLySPViapC6nfGkv9KxzLq4UlGkKyryzwLw4jVlZk88Rw93HaCRVpe+t+g==}
 
   sass@1.77.8:
     resolution: {integrity: sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==}
@@ -15924,6 +15921,10 @@ packages:
     resolution: {integrity: sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==}
     engines: {node: '>=0.6.0'}
 
+  xpath@0.0.34:
+    resolution: {integrity: sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==}
+    engines: {node: '>=0.6.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -16046,10 +16047,10 @@ snapshots:
       lru-cache: 10.4.3
     optional: true
 
-  '@authenio/samlify-node-xmllint@2.0.0(samlify@2.10.0)':
+  '@authenio/samlify-node-xmllint@2.0.0(samlify@2.13.1)':
     dependencies:
       node-xmllint: 1.0.0
-      samlify: 2.10.0
+      samlify: 2.13.1
 
   '@authenio/xml-encryption@2.0.2':
     dependencies:
@@ -19141,10 +19142,10 @@ snapshots:
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
       eslint-config-xo: 0.44.0(eslint@8.57.0)
       eslint-config-xo-typescript: 4.0.0(@typescript-eslint/eslint-plugin@7.7.0(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3))(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0)(typescript@5.5.3)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.5.3)
@@ -22667,13 +22668,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
       debug: 4.4.1(supports-color@5.5.0)
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -22701,14 +22702,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.7.0(eslint@8.57.0)(typescript@5.5.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22741,7 +22742,7 @@ snapshots:
       eslint: 8.57.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -22751,7 +22752,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -26637,8 +26638,6 @@ snapshots:
 
   packet-reader@1.0.0: {}
 
-  pako@1.0.11: {}
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -27833,19 +27832,15 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  samlify@2.10.0:
+  samlify@2.13.1:
     dependencies:
       '@authenio/xml-encryption': 2.0.2
       '@xmldom/xmldom': 0.8.13
-      camelcase: 6.3.0
-      node-forge: 1.4.0
       node-rsa: 1.1.1
-      pako: 1.0.11
-      uuid: 11.1.1
       xml: 1.0.1
       xml-crypto: 6.1.2
       xml-escape: 1.1.0
-      xpath: 0.0.32
+      xpath: 0.0.34
 
   sass@1.77.8:
     dependencies:
@@ -29316,6 +29311,8 @@ snapshots:
   xpath@0.0.32: {}
 
   xpath@0.0.33: {}
+
+  xpath@0.0.34: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary

Upgrades `samlify` from `2.10.0` to `^2.13.0` in `@logto/core` and `@logto/connector-saml`.

The newer version tightens several return types, so this adapts the SAML application and SSO connector call sites:

- `createLoginResponse` now returns a binding-context union — narrow it to read `entityEndpoint`, asserting the expected POST binding context instead of silently defaulting.
- `getAssertionConsumerService` and `getX509Certificate` now return `string | string[]` — normalize each to the single value the call site expects.

Also adds unit tests covering XML escaping of attribute values in the generated assertion.

## Testing

Unit tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
