### PR TITLE
fix(core): block unsafe webhook endpoints

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -73,6 +73,8 @@ jobs:
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres
+      # Integration tests use local mock webhook endpoints.
+      ALLOW_PRIVATE_OUTBOUND_REQUESTS: true
       # Mock key for authorized status API access during integration tests
       STATUS_API_KEY: test-status-api-key
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -44,6 +44,8 @@ jobs:
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres
+      # Integration tests use local mock webhook endpoints.
+      ALLOW_PRIVATE_OUTBOUND_REQUESTS: true
       # Mock key for authorized status API access during integration tests
       STATUS_API_KEY: test-status-api-key
 

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -71,7 +71,7 @@ export const createHookLibrary = (queries: Queries) => {
       logEntry.append({
         result: LogResult.Error,
         response: conditional(error instanceof HTTPError && (await parseResponse(error.response))),
-        error: String(normalizeError(error)),
+        error: error instanceof RequestError ? error.code : String(normalizeError(error)),
       });
     }
 
@@ -229,6 +229,10 @@ export const createHookLibrary = (queries: Queries) => {
         })
       );
     } catch (error: unknown) {
+      if (error instanceof RequestError && error.code === 'hook.endpoint_not_allowed') {
+        throw error;
+      }
+
       if (error instanceof HTTPError) {
         throw new RequestError(
           {

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -16,6 +16,10 @@ mockEsm('#src/utils/sign.js', () => ({
   sign: () => mockSignature,
 }));
 
+mockEsm('#src/utils/outbound-request.js', () => ({
+  safeKyPost: async (url: string, options: Parameters<typeof ky.post>[1]) => ky.post(url, options),
+}));
+
 const {
   generateHookTestPayload,
   sendWebhookRequest,

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -10,8 +10,9 @@ import {
 import { conditional, trySafe } from '@silverhand/essentials';
 import { type Context } from 'koa';
 import { type IRouterParamContext } from 'koa-router';
-import ky, { type KyResponse } from 'ky';
+import { type KyResponse } from 'ky';
 
+import { safeKyPost } from '#src/utils/outbound-request.js';
 import { sign } from '#src/utils/sign.js';
 
 export const parseResponse = async (response: KyResponse) => {
@@ -36,7 +37,7 @@ export const sendWebhookRequest = async ({
 }: SendWebhookRequest) => {
   const { url, headers, retries } = hookConfig;
 
-  return ky.post(url, {
+  return safeKyPost(url, {
     headers: {
       'user-agent': 'Logto (https://logto.io/)',
       ...headers,

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -9,7 +9,7 @@ import {
   type HookEvents,
   type Log,
 } from '@logto/schemas';
-import { pickDefault } from '@logto/shared/esm';
+import { createMockUtils, pickDefault } from '@logto/shared/esm';
 import { subDays } from 'date-fns';
 
 import {
@@ -19,11 +19,21 @@ import {
   mockNanoIdForHook,
   mockTenantIdForHook,
 } from '#src/__mocks__/hook.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import { createMockQuotaLibrary } from '#src/test-utils/quota.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
 const { jest } = import.meta;
+const { mockEsm } = createMockUtils(jest);
+
+const assertSafeWebhookEndpointUrl = jest.fn(async () => {
+  await Promise.resolve();
+});
+
+mockEsm('#src/utils/outbound-request.js', () => ({
+  assertSafeWebhookEndpointUrl,
+}));
 
 const hooks = {
   getTotalNumberOfHooks: async (): Promise<{ count: number }> => ({ count: mockHookList.length }),
@@ -287,6 +297,21 @@ describe('hook routes', () => {
       enabled: true,
       createdAt: mockCreatedAtForHook,
     });
+    expect(assertSafeWebhookEndpointUrl).toHaveBeenCalledWith(config.url);
+  });
+
+  it('POST /hooks rejects disallowed endpoints', async () => {
+    assertSafeWebhookEndpointUrl.mockRejectedValueOnce(
+      new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 })
+    );
+
+    const response = await hookRequest.post('/hooks').send({
+      name: 'fooName',
+      events: [InteractionHookEvent.PostRegister],
+      config: { url: 'http://127.0.0.1:3000' },
+    });
+
+    expect(response.status).toEqual(422);
   });
 
   it('POST /hooks should be able to create a hook with multi events', async () => {
@@ -365,11 +390,28 @@ describe('hook routes', () => {
 
   it('POST /hooks/:id/test should return 204 if test is successful', async () => {
     const targetMockHook = mockHookList[0] ?? mockHook;
+    const config = { url: 'https://example.com' };
     const response = await hookRequest.post(`/hooks/${targetMockHook.id}/test`).send({
       events: [InteractionHookEvent.PostRegister],
-      config: { url: 'https://example.com' },
+      config,
     });
     expect(response.status).toEqual(204);
+    expect(assertSafeWebhookEndpointUrl).toHaveBeenCalledWith(config.url);
+  });
+
+  it('POST /hooks/:id/test rejects disallowed endpoints', async () => {
+    assertSafeWebhookEndpointUrl.mockRejectedValueOnce(
+      new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 })
+    );
+
+    const targetMockHook = mockHookList[0] ?? mockHook;
+    const response = await hookRequest.post(`/hooks/${targetMockHook.id}/test`).send({
+      events: [InteractionHookEvent.PostRegister],
+      config: { url: 'http://127.0.0.1:3000' },
+    });
+
+    expect(response.status).toEqual(422);
+    expect(triggerTestHook).not.toHaveBeenCalled();
   });
 
   it('POST /hooks/:id/test should support adaptive MFA event', async () => {
@@ -401,6 +443,20 @@ describe('hook routes', () => {
       config,
       enabled: false,
     });
+    expect(assertSafeWebhookEndpointUrl).toHaveBeenCalledWith(config.url);
+  });
+
+  it('PATCH /hooks/:id rejects disallowed endpoints', async () => {
+    assertSafeWebhookEndpointUrl.mockRejectedValueOnce(
+      new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 })
+    );
+
+    const targetMockHook = mockHookList[0] ?? mockHook;
+    const response = await hookRequest.patch(`/hooks/${targetMockHook.id}`).send({
+      config: { url: 'http://127.0.0.1:3000' },
+    });
+
+    expect(response.status).toEqual(422);
   });
 
   it('PATCH /hooks/:id should success when update a hook with multi events', async () => {

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -21,6 +21,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { koaReportSubscriptionUpdates, koaQuotaGuard } from '#src/middleware/koa-quota-guard.js';
 import assertThat from '#src/utils/assert-that.js';
+import { assertSafeWebhookEndpointUrl } from '#src/utils/outbound-request.js';
 import { parseTimestampParam, validateTimeWindow } from '#src/utils/time-window.js';
 
 import { captureEvent } from '../utils/posthog.js';
@@ -188,7 +189,7 @@ export default function hookRoutes<T extends ManagementApiRouter>(
         events: nonemptyUniqueHookEventsGuard.optional(),
       }),
       response: Hooks.guard,
-      status: [201, 400],
+      status: [201, 400, 422],
     }),
     koaReportSubscriptionUpdates({
       key: 'hooksLimit',
@@ -198,6 +199,7 @@ export default function hookRoutes<T extends ManagementApiRouter>(
       const { event, events, enabled, ...rest } = ctx.guard.body;
 
       assertThat(events ?? event, new RequestError({ code: 'hook.missing_events', status: 400 }));
+      await assertSafeWebhookEndpointUrl(rest.config.url);
 
       ctx.body = await insertHook({
         ...rest,
@@ -228,6 +230,7 @@ export default function hookRoutes<T extends ManagementApiRouter>(
         body: { events, config },
       } = ctx.guard;
 
+      await assertSafeWebhookEndpointUrl(config.url);
       await triggerTestHook(id, events, config);
 
       ctx.status = 204;
@@ -247,13 +250,17 @@ export default function hookRoutes<T extends ManagementApiRouter>(
         })
         .partial(),
       response: Hooks.guard,
-      status: [200, 404],
+      status: [200, 404, 422],
     }),
     async (ctx, next) => {
       const {
         params: { id },
         body,
       } = ctx.guard;
+
+      if (body.config) {
+        await assertSafeWebhookEndpointUrl(body.config.url);
+      }
 
       ctx.body = await updateHookById(id, body, 'replace');
 

--- a/packages/core/src/utils/outbound-request.test.ts
+++ b/packages/core/src/utils/outbound-request.test.ts
@@ -75,6 +75,20 @@ describe('assertSafeOutboundRequestUrl', () => {
     );
   });
 
+  it('rejects invalid endpoint URLs', async () => {
+    await expect(assertSafeOutboundRequestUrl('not_work_url')).rejects.toMatchError(
+      new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 })
+    );
+  });
+
+  it('rejects endpoints that can not be resolved', async () => {
+    lookup.mockRejectedValueOnce(new Error('getaddrinfo ENOTFOUND missing.example.com'));
+
+    await expect(
+      assertSafeOutboundRequestUrl('https://missing.example.com/webhook')
+    ).rejects.toMatchError(new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 }));
+  });
+
   it.each([
     'http://localhost:3000',
     'http://127.0.0.1:3000',

--- a/packages/core/src/utils/outbound-request.test.ts
+++ b/packages/core/src/utils/outbound-request.test.ts
@@ -1,0 +1,173 @@
+import { isIP } from 'node:net';
+
+import { createMockUtils } from '@logto/shared/esm';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+
+const { jest } = import.meta;
+const { mockEsm } = createMockUtils(jest);
+
+const lookup = jest.fn();
+const post = jest.fn();
+
+class MockHTTPError extends Error {
+  constructor(
+    public readonly response: Response,
+    public readonly request: Request,
+    public readonly options: unknown
+  ) {
+    super('HTTPError');
+  }
+}
+
+mockEsm('node:dns/promises', () => ({ lookup }));
+mockEsm('ky', () => ({
+  default: { post },
+  HTTPError: MockHTTPError,
+}));
+
+const { assertSafeOutboundRequestUrl, safeKyPost } = await import('./outbound-request.js');
+
+const setAllowPrivateOutboundRequests = (value: boolean) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for outbound request tests.
+  (EnvSet.values as { allowPrivateOutboundRequests: boolean }).allowPrivateOutboundRequests = value;
+};
+
+const setResolvedAddresses = (addressesByHost: Record<string, string[]>) => {
+  lookup.mockImplementation(async (hostname: string) =>
+    (addressesByHost[hostname] ?? []).map((address) => ({
+      address,
+      family: isIP(address),
+    }))
+  );
+};
+
+describe('assertSafeOutboundRequestUrl', () => {
+  const originalAllowPrivateOutboundRequests = EnvSet.values.allowPrivateOutboundRequests;
+
+  beforeEach(() => {
+    setAllowPrivateOutboundRequests(false);
+    setResolvedAddresses({
+      'example.com': ['93.184.216.34'],
+      'internal.example.com': ['10.0.0.1'],
+      'redirect.example.com': ['93.184.216.34'],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    setAllowPrivateOutboundRequests(originalAllowPrivateOutboundRequests);
+  });
+
+  it('allows public HTTP and HTTPS endpoints', async () => {
+    await expect(
+      assertSafeOutboundRequestUrl('https://example.com/webhook')
+    ).resolves.toBeUndefined();
+    await expect(
+      assertSafeOutboundRequestUrl('http://example.com/webhook')
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects non-HTTP(S) endpoints', async () => {
+    await expect(assertSafeOutboundRequestUrl('file:///tmp/payload')).rejects.toMatchError(
+      new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 })
+    );
+  });
+
+  it.each([
+    'http://localhost:3000',
+    'http://127.0.0.1:3000',
+    'http://10.0.0.1',
+    'http://172.16.0.1',
+    'http://192.168.1.1',
+    'http://[::1]',
+    'http://[fe80::1]',
+  ])('rejects private endpoint %s by default', async (url) => {
+    await expect(assertSafeOutboundRequestUrl(url)).rejects.toMatchError(
+      new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 })
+    );
+  });
+
+  it('rejects hosts that resolve to private addresses by default', async () => {
+    await expect(
+      assertSafeOutboundRequestUrl('https://internal.example.com/webhook')
+    ).rejects.toMatchError(new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 }));
+  });
+
+  it('allows private addresses when ALLOW_PRIVATE_OUTBOUND_REQUESTS is enabled', async () => {
+    setAllowPrivateOutboundRequests(true);
+
+    await expect(
+      assertSafeOutboundRequestUrl('https://internal.example.com/webhook')
+    ).resolves.toBeUndefined();
+    await expect(assertSafeOutboundRequestUrl('http://10.0.0.1')).resolves.toBeUndefined();
+  });
+
+  it('always rejects metadata endpoints', async () => {
+    setAllowPrivateOutboundRequests(true);
+
+    await expect(
+      assertSafeOutboundRequestUrl('http://169.254.169.254/latest/meta-data')
+    ).rejects.toMatchError(new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 }));
+    await expect(
+      assertSafeOutboundRequestUrl('http://[fd00:ec2::254]/latest/meta-data')
+    ).rejects.toMatchError(new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 }));
+  });
+});
+
+describe('safeKyPost', () => {
+  beforeEach(() => {
+    setAllowPrivateOutboundRequests(false);
+    setResolvedAddresses({
+      'example.com': ['93.184.216.34'],
+      'redirect.example.com': ['93.184.216.34'],
+      'internal.example.com': ['10.0.0.1'],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('follows redirects to public endpoints', async () => {
+    post
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'https://redirect.example.com/webhook' },
+        })
+      )
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await expect(safeKyPost('https://example.com/webhook')).resolves.toHaveProperty('status', 200);
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects redirects to private endpoints', async () => {
+    post.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://internal.example.com/webhook' },
+      })
+    );
+
+    await expect(safeKyPost('https://example.com/webhook')).rejects.toMatchError(
+      new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 })
+    );
+  });
+
+  it('rejects redirects to metadata endpoints even when private outbound requests are allowed', async () => {
+    setAllowPrivateOutboundRequests(true);
+    post.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'http://169.254.169.254/latest/meta-data' },
+      })
+    );
+
+    await expect(safeKyPost('https://example.com/webhook')).rejects.toMatchError(
+      new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 })
+    );
+  });
+});

--- a/packages/core/src/utils/outbound-request.ts
+++ b/packages/core/src/utils/outbound-request.ts
@@ -26,8 +26,24 @@ type IpBlock = {
   readonly type: IpVersion;
 };
 
-const throwEndpointNotAllowed = () => {
+const throwEndpointNotAllowed = (): never => {
   throw new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 });
+};
+
+const parseUrl = (url: string): URL => {
+  try {
+    return new URL(url);
+  } catch {
+    return throwEndpointNotAllowed();
+  }
+};
+
+const resolveSafeUrlAddresses = async (url: URL): Promise<string[]> => {
+  try {
+    return await resolveUrlAddresses(url);
+  } catch {
+    return throwEndpointNotAllowed();
+  }
 };
 
 const metadataIpBlocks: readonly IpBlock[] = [
@@ -141,13 +157,13 @@ export const assertSafeOutboundRequestUrl = async (
     allowPrivateIp = EnvSet.values.allowPrivateOutboundRequests,
   }: AssertSafeOutboundRequestUrlOptions = {}
 ) => {
-  const parsedUrl = new URL(url);
+  const parsedUrl = parseUrl(url);
 
   if (!allowedProtocols.has(parsedUrl.protocol)) {
     throwEndpointNotAllowed();
   }
 
-  const addresses = await resolveUrlAddresses(parsedUrl);
+  const addresses = await resolveSafeUrlAddresses(parsedUrl);
 
   if (addresses.some((address) => isMetadataIpAddress(address))) {
     throwEndpointNotAllowed();

--- a/packages/core/src/utils/outbound-request.ts
+++ b/packages/core/src/utils/outbound-request.ts
@@ -1,0 +1,211 @@
+import { lookup } from 'node:dns/promises';
+import { BlockList, isIP } from 'node:net';
+
+import ky, { HTTPError, type Options } from 'ky';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+
+const allowedProtocols = new Set(['http:', 'https:']);
+const redirectStatuses = new Set([301, 302, 303, 307, 308]);
+const defaultMaxRedirects = 5;
+
+type AssertSafeOutboundRequestUrlOptions = {
+  readonly allowPrivateIp?: boolean;
+};
+
+type SafeKyPostOptions = Options & {
+  readonly maxRedirects?: number;
+};
+
+type IpVersion = 'ipv4' | 'ipv6';
+
+type IpBlock = {
+  readonly address: string;
+  readonly prefix?: number;
+  readonly type: IpVersion;
+};
+
+const throwEndpointNotAllowed = () => {
+  throw new RequestError({ code: 'hook.endpoint_not_allowed', status: 422 });
+};
+
+const metadataIpBlocks: readonly IpBlock[] = [
+  { address: '169.254.169.254', type: 'ipv4' },
+  { address: 'fd00:ec2::254', type: 'ipv6' },
+  { address: '::ffff:169.254.169.254', type: 'ipv6' },
+];
+
+const blockedIpBlocks: readonly IpBlock[] = [
+  { address: '0.0.0.0', prefix: 8, type: 'ipv4' },
+  { address: '10.0.0.0', prefix: 8, type: 'ipv4' },
+  { address: '127.0.0.0', prefix: 8, type: 'ipv4' },
+  { address: '100.64.0.0', prefix: 10, type: 'ipv4' },
+  { address: '169.254.0.0', prefix: 16, type: 'ipv4' },
+  { address: '172.16.0.0', prefix: 12, type: 'ipv4' },
+  { address: '192.168.0.0', prefix: 16, type: 'ipv4' },
+  { address: '192.0.0.0', prefix: 24, type: 'ipv4' },
+  { address: '192.0.2.0', prefix: 24, type: 'ipv4' },
+  { address: '198.18.0.0', prefix: 15, type: 'ipv4' },
+  { address: '198.51.100.0', prefix: 24, type: 'ipv4' },
+  { address: '203.0.113.0', prefix: 24, type: 'ipv4' },
+  { address: '224.0.0.0', prefix: 3, type: 'ipv4' },
+  { address: '::', type: 'ipv6' },
+  { address: '::1', type: 'ipv6' },
+  { address: 'fc00::', prefix: 7, type: 'ipv6' },
+  { address: 'fe80::', prefix: 10, type: 'ipv6' },
+  { address: 'ff00::', prefix: 8, type: 'ipv6' },
+  { address: '2001:db8::', prefix: 32, type: 'ipv6' },
+  { address: '::ffff:0.0.0.0', prefix: 104, type: 'ipv6' },
+  { address: '::ffff:10.0.0.0', prefix: 104, type: 'ipv6' },
+  { address: '::ffff:127.0.0.0', prefix: 104, type: 'ipv6' },
+  { address: '::ffff:100.64.0.0', prefix: 106, type: 'ipv6' },
+  { address: '::ffff:169.254.0.0', prefix: 112, type: 'ipv6' },
+  { address: '::ffff:172.16.0.0', prefix: 108, type: 'ipv6' },
+  { address: '::ffff:192.168.0.0', prefix: 112, type: 'ipv6' },
+  { address: '::ffff:192.0.0.0', prefix: 120, type: 'ipv6' },
+  { address: '::ffff:192.0.2.0', prefix: 120, type: 'ipv6' },
+  { address: '::ffff:198.18.0.0', prefix: 111, type: 'ipv6' },
+  { address: '::ffff:198.51.100.0', prefix: 120, type: 'ipv6' },
+  { address: '::ffff:203.0.113.0', prefix: 120, type: 'ipv6' },
+  { address: '::ffff:224.0.0.0', prefix: 99, type: 'ipv6' },
+];
+
+const createBlockList = (blocks: readonly IpBlock[]) => {
+  const blockList = new BlockList();
+
+  for (const { address, prefix, type } of blocks) {
+    if (prefix === undefined) {
+      blockList.addAddress(address, type);
+      continue;
+    }
+
+    blockList.addSubnet(address, prefix, type);
+  }
+
+  return blockList;
+};
+
+const metadataBlockList = createBlockList(metadataIpBlocks);
+const blockedIpBlockList = createBlockList(blockedIpBlocks);
+
+const normalizeIpAddress = (address: string) => {
+  const withoutOpeningBracket = address.startsWith('[') ? address.slice(1) : address;
+
+  return (
+    withoutOpeningBracket.endsWith(']') ? withoutOpeningBracket.slice(0, -1) : withoutOpeningBracket
+  ).toLowerCase();
+};
+
+const getIpVersion = (address: string): IpVersion | undefined => {
+  const version = isIP(address);
+
+  if (version === 4) {
+    return 'ipv4';
+  }
+
+  if (version === 6) {
+    return 'ipv6';
+  }
+};
+
+const isBlockedBy = (blockList: BlockList, address: string) => {
+  const ipVersion = getIpVersion(address);
+
+  return ipVersion === undefined ? false : blockList.check(address, ipVersion);
+};
+
+const isMetadataIpAddress = (address: string) => isBlockedBy(metadataBlockList, address);
+
+const isBlockedIpAddress = (address: string) => isBlockedBy(blockedIpBlockList, address);
+
+const resolveUrlAddresses = async ({ hostname }: URL) => {
+  const normalizedHostname = normalizeIpAddress(hostname);
+
+  if (normalizedHostname === 'localhost') {
+    return ['127.0.0.1'];
+  }
+
+  if (isIP(normalizedHostname)) {
+    return [normalizedHostname];
+  }
+
+  const addresses = await lookup(normalizedHostname, { all: true, verbatim: true });
+
+  return addresses.map(({ address }) => address);
+};
+
+export const assertSafeOutboundRequestUrl = async (
+  url: string,
+  {
+    allowPrivateIp = EnvSet.values.allowPrivateOutboundRequests,
+  }: AssertSafeOutboundRequestUrlOptions = {}
+) => {
+  const parsedUrl = new URL(url);
+
+  if (!allowedProtocols.has(parsedUrl.protocol)) {
+    throwEndpointNotAllowed();
+  }
+
+  const addresses = await resolveUrlAddresses(parsedUrl);
+
+  if (addresses.some((address) => isMetadataIpAddress(address))) {
+    throwEndpointNotAllowed();
+  }
+
+  if (!allowPrivateIp && addresses.some((address) => isBlockedIpAddress(address))) {
+    throwEndpointNotAllowed();
+  }
+};
+
+export const assertSafeWebhookEndpointUrl = async (url: string) =>
+  assertSafeOutboundRequestUrl(url);
+
+export const safeKyPost = async (url: string, options: SafeKyPostOptions = {}) => {
+  const { maxRedirects = defaultMaxRedirects, ...kyOptions } = options;
+
+  const postWithRedirectValidation = async (
+    requestUrl: string,
+    redirectCount = 0
+  ): Promise<Response> => {
+    if (redirectCount > maxRedirects) {
+      throw new TypeError('Webhook endpoint redirected too many times.');
+    }
+
+    await assertSafeWebhookEndpointUrl(requestUrl);
+
+    const response = await ky.post(requestUrl, {
+      ...kyOptions,
+      redirect: 'manual',
+      throwHttpErrors: false,
+    });
+
+    if (!redirectStatuses.has(response.status)) {
+      if (!response.ok && kyOptions.throwHttpErrors !== false) {
+        throw new HTTPError(
+          response,
+          new Request(requestUrl, { method: 'POST' }),
+          // eslint-disable-next-line no-restricted-syntax -- HTTPError requires ky's internal normalized options.
+          kyOptions as never
+        );
+      }
+
+      return response;
+    }
+
+    const location = response.headers.get('location');
+
+    if (!location) {
+      throw new HTTPError(
+        response,
+        new Request(requestUrl, { method: 'POST' }),
+        // eslint-disable-next-line no-restricted-syntax -- HTTPError requires ky's internal normalized options.
+        kyOptions as never
+      );
+    }
+
+    return postWithRedirectValidation(new URL(location, requestUrl).href, redirectCount + 1);
+  };
+
+  return postWithRedirectValidation(url);
+};

--- a/packages/integration-tests/src/helpers/hook.ts
+++ b/packages/integration-tests/src/helpers/hook.ts
@@ -8,7 +8,7 @@ type HookCreationPayload = Pick<Hook, 'name' | 'events'> & {
 
 export const getHookCreationPayload = (
   event: HookEvent,
-  url = 'not_work_url'
+  url = 'https://example.com/webhook'
 ): HookCreationPayload => ({
   name: 'hook_name',
   events: [event],

--- a/packages/integration-tests/src/tests/api/hook/hook.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.test.ts
@@ -30,7 +30,7 @@ describe('hooks', () => {
     const payload = {
       event: InteractionHookEvent.PostRegister,
       config: {
-        url: 'not_work_url',
+        url: 'https://example.com/webhook',
         retries: 2,
       },
     };

--- a/packages/integration-tests/src/tests/api/hook/hook.testing.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.testing.test.ts
@@ -58,7 +58,7 @@ describe('hook testing', () => {
     );
   });
 
-  it('should return 422 if the hook endpoint is not working', async () => {
+  it('should return 422 if the hook endpoint is not allowed', async () => {
     const payload = getHookCreationPayload(InteractionHookEvent.PostRegister);
     const created = await authedAdminApi.post('hooks', { json: payload }).json<Hook>();
     await expectRejects(
@@ -66,7 +66,7 @@ describe('hook testing', () => {
         json: { events: [InteractionHookEvent.PostSignIn], config: { url: 'not_work_url' } },
       }),
       {
-        code: 'hook.send_test_payload_failed',
+        code: 'hook.endpoint_not_allowed',
         status: 422,
       }
     );

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.experience.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.experience.test.ts
@@ -10,6 +10,7 @@ import {
 import { authenticator } from 'otplib';
 
 import { createUserMfaVerification, deleteUser } from '#src/api/admin-user.js';
+import { authedAdminApi } from '#src/api/index.js';
 import { getWebhookRecentLogs } from '#src/api/logs.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { SsoConnectorApi } from '#src/api/sso-connector.js';
@@ -83,31 +84,21 @@ afterAll(async () => {
 afterEach(async () => {
   await Promise.all([organizationApi.cleanUp(), ssoConnectorApi.cleanUp()]);
 });
-describe('trigger invalid hook', () => {
-  beforeAll(async () => {
-    await webHookApi.create({
-      name: 'invalidHookEventListener',
-      events: [InteractionHookEvent.PostSignIn],
-      config: { url: 'not_work_url' },
-    });
-  });
-
-  it('should log invalid hook url error', async () => {
-    await signInWithPassword({
-      identifier: {
-        type: SignInIdentifier.Username,
-        value: username,
-      },
-      password,
-    });
-
-    const hook = webHookApi.hooks.get('invalidHookEventListener')!;
-    await assertHookLogResult(hook, InteractionHookEvent.PostSignIn, {
-      errorMessage: 'Failed to parse URL from not_work_url',
-    });
-  });
-  afterAll(async () => {
-    await webHookApi.cleanUp();
+describe('invalid hook endpoint', () => {
+  it('should reject invalid hook url', async () => {
+    await expectRejects(
+      authedAdminApi.post('hooks', {
+        json: {
+          name: 'invalidHookEventListener',
+          events: [InteractionHookEvent.PostSignIn],
+          config: { url: 'not_work_url' },
+        },
+      }),
+      {
+        code: 'hook.endpoint_not_allowed',
+        status: 422,
+      }
+    );
   });
 });
 

--- a/packages/integration-tests/src/tests/console/webhooks/helpers.ts
+++ b/packages/integration-tests/src/tests/console/webhooks/helpers.ts
@@ -5,7 +5,7 @@ export const expectToCreateWebhook = async (page: Page) => {
   await expect(page).toClick('span[class$=label]', { text: 'PostRegister' });
   await expect(page).toClick('span[class$=label]', { text: 'User.Data.Updated' });
   await expect(page).toFill('input[name=name]', 'hook_name');
-  await expect(page).toFill('input[name=url]', 'https://localhost/webhook');
+  await expect(page).toFill('input[name=url]', 'https://example.com/webhook');
   await expect(page).toClick('button[type=submit]');
   await page.waitForSelector('div[class$=header] div[class$=metadata] div[class$=name]');
 };

--- a/packages/integration-tests/src/tests/console/webhooks/index.test.ts
+++ b/packages/integration-tests/src/tests/console/webhooks/index.test.ts
@@ -52,7 +52,7 @@ describe('webhooks', () => {
 
     await expect(page).toClick('div[class$=main] div[class$=headline] > button');
     await expect(page).toFill('input[name=name]', 'hook_name');
-    await expect(page).toFill('input[name=url]', 'https://localhost/webhook');
+    await expect(page).toFill('input[name=url]', 'https://example.com/webhook');
     await expect(page).toClick('button[type=submit]');
     await expect(page).toMatchElement('.ReactModalPortal div[class$=errorMessage]', {
       text: 'You have to select at least one event.',
@@ -66,7 +66,7 @@ describe('webhooks', () => {
     await expect(page).toClick('span[class$=label]', { text: 'PostRegister' });
     await expect(page).toClick('span[class$=label]', { text: 'User.Create' });
     await expect(page).toFill('input[name=name]', 'hook_name');
-    await expect(page).toFill('input[name=url]', 'http://localhost/webhook');
+    await expect(page).toFill('input[name=url]', 'http://example.com/webhook');
     await expect(page).toClick('button[type=submit]');
     await expect(page).toMatchElement('div[class$=main] div[class$=metadata] div[class$=name]', {
       text: 'hook_name',
@@ -79,7 +79,7 @@ describe('webhooks', () => {
     await expectToCreateWebhook(page);
 
     await expect(page).toFill('input[name=name]', 'hook_name_updated');
-    await expect(page).toFill('input[name=url]', 'https://localhost/new-webhook');
+    await expect(page).toFill('input[name=url]', 'https://example.com/new-webhook');
 
     await expectToSaveChanges(page);
     await waitForToast(page, { text: 'Saved' });

--- a/packages/phrases/src/locales/ar/errors/hook.ts
+++ b/packages/phrases/src/locales/ar/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'يجب أن تقدم على الأقل حدث واحد.',
   send_test_payload_failed: 'فشل في إرسال حمولة الاختبار: {{message}}',
   endpoint_responded_with_error: 'ردت النقطة النهائية بخطأ.',
+  endpoint_not_allowed: 'عنوان URL للنقطة النهائية غير مسموح به.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/de/errors/hook.ts
+++ b/packages/phrases/src/locales/de/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'Sie müssen mindestens ein Ereignis angeben.',
   send_test_payload_failed: 'Fehler beim Senden des Testpayloads: {{message}}',
   endpoint_responded_with_error: 'Endpunkt antwortete mit Fehler.',
+  endpoint_not_allowed: 'Endpunkt-URL ist nicht erlaubt.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/en/errors/hook.ts
+++ b/packages/phrases/src/locales/en/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'You need to provide at least one event.',
   send_test_payload_failed: 'Failed to send test payload: {{message}}',
   endpoint_responded_with_error: 'Endpoint responded with error.',
+  endpoint_not_allowed: 'Endpoint URL is not allowed.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/es/errors/hook.ts
+++ b/packages/phrases/src/locales/es/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'Necesita proporcionar al menos un evento.',
   send_test_payload_failed: 'Error al enviar carga útil de prueba: {{message}}',
   endpoint_responded_with_error: 'El punto de enlace respondió con un error.',
+  endpoint_not_allowed: 'La URL del punto de enlace no está permitida.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/fa-ir/errors/hook.ts
+++ b/packages/phrases/src/locales/fa-ir/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'باید حداقل یک رویداد ارائه دهید.',
   send_test_payload_failed: 'ارسال بار آزمایشی ناموفق بود: {{message}}',
   endpoint_responded_with_error: 'مقصد با خطا پاسخ داد.',
+  endpoint_not_allowed: 'نشانی URL مقصد مجاز نیست.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/fr/errors/hook.ts
+++ b/packages/phrases/src/locales/fr/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'Vous devez fournir au moins un événement.',
   send_test_payload_failed: "Échec de l'envoi de la charge utile de test : {{message}}",
   endpoint_responded_with_error: 'Le point de terminaison a répondu avec une erreur.',
+  endpoint_not_allowed: "L'URL du point de terminaison n'est pas autorisée.",
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/it/errors/hook.ts
+++ b/packages/phrases/src/locales/it/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'È necessario fornire almeno un evento.',
   send_test_payload_failed: 'Impossibile inviare il payload di prova: {{message}}',
   endpoint_responded_with_error: 'Il punto di accesso ha risposto con un errore.',
+  endpoint_not_allowed: "L'URL del punto di accesso non è consentito.",
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/ja/errors/hook.ts
+++ b/packages/phrases/src/locales/ja/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: '少なくとも1つのイベントを提供する必要があります。',
   send_test_payload_failed: 'テストペイロードの送信に失敗しました：{{message}}',
   endpoint_responded_with_error: 'エンドポイントがエラーで応答しました：{{message}}。',
+  endpoint_not_allowed: 'エンドポイント URL は許可されていません。',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/ko/errors/hook.ts
+++ b/packages/phrases/src/locales/ko/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: '최소한 하나의 이벤트를 제공해야 합니다.',
   send_test_payload_failed: '테스트 페이로드 보내기 실패: {{message}}',
   endpoint_responded_with_error: '엔드포인트가 오류로 응답했습니다.',
+  endpoint_not_allowed: '엔드포인트 URL은 허용되지 않습니다.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/pl-pl/errors/hook.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'Musisz podać przynajmniej jedno zdarzenie.',
   send_test_payload_failed: 'Błąd podczas wysyłania testowego ładunku: {{message}}',
   endpoint_responded_with_error: 'Punkt końcowy odpowiedział błędem.',
+  endpoint_not_allowed: 'Adres URL punktu końcowego jest niedozwolony.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/pt-br/errors/hook.ts
+++ b/packages/phrases/src/locales/pt-br/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'Você precisa fornecer pelo menos um evento.',
   send_test_payload_failed: 'Falha ao enviar uma carga de teste: {{message}}',
   endpoint_responded_with_error: 'O ponto de extremidade respondeu com erro.',
+  endpoint_not_allowed: 'A URL do ponto de extremidade não é permitida.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/pt-pt/errors/hook.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'Você precisa fornecer pelo menos um evento.',
   send_test_payload_failed: 'Falha ao enviar carga de teste: {{message}}',
   endpoint_responded_with_error: 'O ponto de extremidade respondeu com erro.',
+  endpoint_not_allowed: 'O URL do ponto de extremidade não é permitido.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/ru/errors/hook.ts
+++ b/packages/phrases/src/locales/ru/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'Вы должны предоставить как минимум одно событие.',
   send_test_payload_failed: 'Не удалось отправить тестовую нагрузку: {{message}}',
   endpoint_responded_with_error: 'Конечная точка ответила ошибкой.',
+  endpoint_not_allowed: 'URL конечной точки не разрешен.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/th/errors/hook.ts
+++ b/packages/phrases/src/locales/th/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'คุณต้องระบุเหตุการณ์อย่างน้อยหนึ่งรายการ',
   send_test_payload_failed: 'ส่งข้อมูลทดสอบไม่สำเร็จ: {{message}}',
   endpoint_responded_with_error: 'ปลายทางตอบกลับด้วยข้อผิดพลาด',
+  endpoint_not_allowed: 'ไม่อนุญาต URL ของปลายทางนี้',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/tr-tr/errors/hook.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: 'En az bir etkinlik sağlamanız gerekiyor.',
   send_test_payload_failed: 'Test yükü gönderilemedi: {{message}}',
   endpoint_responded_with_error: 'Nokta yanıt verdi hatayla.',
+  endpoint_not_allowed: 'Uç nokta URL’sine izin verilmiyor.',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/zh-cn/errors/hook.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: '你需要提供至少一个事件。',
   send_test_payload_failed: '无法发送测试内容：{{message}}',
   endpoint_responded_with_error: '端点返回了错误。',
+  endpoint_not_allowed: '端点 URL 不被允许。',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/zh-hk/errors/hook.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: '你需要至少提供一個事件。',
   send_test_payload_failed: '無法發送測試内容：{{message}}',
   endpoint_responded_with_error: '端點返回了錯誤。',
+  endpoint_not_allowed: '端點 URL 不被允許。',
 };
 
 export default Object.freeze(hook);

--- a/packages/phrases/src/locales/zh-tw/errors/hook.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/hook.ts
@@ -2,6 +2,7 @@ const hook = {
   missing_events: '你需要至少提供一個事件。',
   send_test_payload_failed: '無法发送測試内容：{{message}}',
   endpoint_responded_with_error: '端點返回了錯誤。',
+  endpoint_not_allowed: '端點 URL 不被允許。',
 };
 
 export default Object.freeze(hook);

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -171,6 +171,7 @@ export default class GlobalValues {
   public readonly developmentUserId = getEnv('DEVELOPMENT_USER_ID');
   public readonly trustProxyHeader = yes(getEnv('TRUST_PROXY_HEADER'));
   public readonly ignoreConnectorVersionCheck = yes(getEnv('IGNORE_CONNECTOR_VERSION_CHECK'));
+  public readonly allowPrivateOutboundRequests = yes(getEnv('ALLOW_PRIVATE_OUTBOUND_REQUESTS'));
   public readonly injectedHeaderMappingJson = getEnv('INJECTED_HEADER_MAPPING_JSON');
   public readonly debugInjectedHeadersJson = getEnv('DEBUG_INJECTED_HEADERS_JSON');
 


### PR DESCRIPTION
## Summary
- validate webhook endpoint URLs before create, update, test, and delivery
- reject non-HTTP(S), metadata, and private/reserved resolved addresses by default
- allow private/reserved endpoints only when ALLOW_PRIVATE_OUTBOUND_REQUESTS is true, while metadata endpoints remain blocked

## Testing
Unit tests