### PR TITLE
fix: prevent TOTP replay

### DIFF
--- a/.changeset/prevent-totp-replay.md
+++ b/.changeset/prevent-totp-replay.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+prevent replaying an already accepted TOTP code during MFA verification
+
+Existing TOTP verification now records the accepted TOTP time-step counter and rejects any later verification that matches the same or an older counter. This enforces one-time use for TOTP codes across the RFC 6238 acceptance window.

--- a/packages/core/src/libraries/verification-helpers/totp-validation.test.ts
+++ b/packages/core/src/libraries/verification-helpers/totp-validation.test.ts
@@ -1,8 +1,7 @@
 const { jest } = import.meta;
 
-const { generateTotpSecret, validateTotpToken, validateTotpSecret } = await import(
-  './totp-validation.js'
-);
+const { generateTotpSecret, getTotpTokenTimeStep, validateTotpToken, validateTotpSecret } =
+  await import('./totp-validation.js');
 
 describe('generateTotpSecret', () => {
   it('should generate a secret', () => {
@@ -42,5 +41,30 @@ describe('validateTotpToken', () => {
     const token = '123456';
 
     expect(validateTotpToken(secret, token)).toBe(false);
+  });
+});
+
+describe('getTotpTokenTimeStep', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(1_695_010_563_617));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  it('should return the matched TOTP time step', () => {
+    const secret = 'JBSWY3DPEHPK3PXP';
+    const token = '971144';
+
+    expect(getTotpTokenTimeStep(secret, token)).toBe(56_500_352);
+  });
+
+  it('should return undefined on invalid token', () => {
+    const secret = 'JBSWY3DPEHPK3PXP';
+    const token = '123456';
+
+    expect(getTotpTokenTimeStep(secret, token)).toBeUndefined();
   });
 });

--- a/packages/core/src/libraries/verification-helpers/totp-validation.ts
+++ b/packages/core/src/libraries/verification-helpers/totp-validation.ts
@@ -26,3 +26,17 @@ export const validateTotpSecret = (secret: string) => {
 export const validateTotpToken = (secret: string, token: string) => {
   return authenticator.check(token, secret);
 };
+
+export const getTotpTokenTimeStep = (secret: string, token: string) => {
+  const epoch = Date.now();
+  const authenticatorAtEpoch = authenticator.clone({ epoch });
+  const delta = authenticatorAtEpoch.checkDelta(token, secret);
+
+  if (delta === null) {
+    return;
+  }
+
+  const { step } = authenticatorAtEpoch.allOptions();
+
+  return Math.floor(epoch / step / 1000) + delta;
+};

--- a/packages/core/src/queries/user.test.ts
+++ b/packages/core/src/queries/user.test.ts
@@ -354,8 +354,8 @@ describe('user query', () => {
           case
             when item->>'id' = $1 and item->>'type' = $2
               then item || jsonb_build_object(
-                'lastUsedAt', $3,
-                'lastUsedTimeStep', $4
+                'lastUsedAt', $3::text,
+                'lastUsedTimeStep', $4::integer
               )
             else item
           end
@@ -373,7 +373,7 @@ describe('user query', () => {
               not (item ? 'lastUsedTimeStep')
               or case
                 when jsonb_typeof(item->'lastUsedTimeStep') = 'number'
-                  then (item->>'lastUsedTimeStep')::numeric < $8
+                  then (item->>'lastUsedTimeStep')::integer < $8::integer
                 else false
               end
             )

--- a/packages/core/src/queries/user.test.ts
+++ b/packages/core/src/queries/user.test.ts
@@ -30,6 +30,7 @@ const {
   hasUserWithIdentity,
   hasUserWithPhone,
   updateUserById,
+  updateUserTotpMfaVerificationLastUsed,
   deleteUserById,
   deleteUserIdentity,
 } = createUserQueries(pool);
@@ -339,6 +340,66 @@ describe('user query', () => {
     });
 
     await expect(updateUserById(id, { username })).resolves.toEqual(databaseValue);
+  });
+
+  it('updateUserTotpMfaVerificationLastUsed', async () => {
+    const id = 'foo';
+    const mfaVerificationId = 'totp-id';
+    const usedTimeStep = 100;
+    const lastUsedAt = '2024-01-01T00:00:00.000Z';
+    const expectSql = sql`
+      update ${table}
+      set ${fields.mfaVerifications} = (
+        select jsonb_agg(
+          case
+            when item->>'id' = $1 and item->>'type' = $2
+              then item || jsonb_build_object(
+                'lastUsedAt', $3,
+                'lastUsedTimeStep', $4
+              )
+            else item
+          end
+          order by ordinal
+        )
+        from jsonb_array_elements(${fields.mfaVerifications}::jsonb) with ordinality as mfa(item, ordinal)
+      )
+      where ${fields.id} = $5
+        and exists (
+          select 1
+          from jsonb_array_elements(${fields.mfaVerifications}::jsonb) as mfa(item)
+          where item->>'id' = $6
+            and item->>'type' = $7
+            and (
+              not (item ? 'lastUsedTimeStep')
+              or case
+                when jsonb_typeof(item->'lastUsedTimeStep') = 'number'
+                  then (item->>'lastUsedTimeStep')::numeric < $8
+                else false
+              end
+            )
+        )
+      returning *
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toEqual([
+        mfaVerificationId,
+        MfaFactor.TOTP,
+        lastUsedAt,
+        usedTimeStep,
+        id,
+        mfaVerificationId,
+        MfaFactor.TOTP,
+        usedTimeStep,
+      ]);
+
+      return createMockQueryResult([databaseValue]);
+    });
+
+    await expect(
+      updateUserTotpMfaVerificationLastUsed(id, mfaVerificationId, usedTimeStep, lastUsedAt)
+    ).resolves.toEqual(databaseValue);
   });
 
   it('deleteUserById', async () => {

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -405,6 +405,46 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
     });
   };
 
+  const updateUserTotpMfaVerificationLastUsed = async (
+    id: string,
+    mfaVerificationId: string,
+    usedTimeStep: number,
+    lastUsedAt = new Date().toISOString()
+  ) =>
+    pool.maybeOne<User>(sql`
+      update ${table}
+      set ${fields.mfaVerifications} = (
+        select jsonb_agg(
+          case
+            when item->>'id' = ${mfaVerificationId} and item->>'type' = ${MfaFactor.TOTP}
+              then item || jsonb_build_object(
+                'lastUsedAt', ${lastUsedAt},
+                'lastUsedTimeStep', ${usedTimeStep}
+              )
+            else item
+          end
+          order by ordinal
+        )
+        from jsonb_array_elements(${fields.mfaVerifications}::jsonb) with ordinality as mfa(item, ordinal)
+      )
+      where ${fields.id} = ${id}
+        and exists (
+          select 1
+          from jsonb_array_elements(${fields.mfaVerifications}::jsonb) as mfa(item)
+          where item->>'id' = ${mfaVerificationId}
+            and item->>'type' = ${MfaFactor.TOTP}
+            and (
+              not (item ? 'lastUsedTimeStep')
+              or case
+                when jsonb_typeof(item->'lastUsedTimeStep') = 'number'
+                  then (item->>'lastUsedTimeStep')::numeric < ${usedTimeStep}
+                else false
+              end
+            )
+        )
+      returning *
+    `);
+
   const insertUserQuery = buildInsertIntoWithPool(pool)(Users, {
     returning: true,
   });
@@ -483,6 +523,7 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
     findUsers,
     findUsersByIds,
     updateUserById,
+    updateUserTotpMfaVerificationLastUsed,
     insertUser,
     deleteUserById,
     deleteUserIdentity,

--- a/packages/core/src/queries/user.ts
+++ b/packages/core/src/queries/user.ts
@@ -418,8 +418,8 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
           case
             when item->>'id' = ${mfaVerificationId} and item->>'type' = ${MfaFactor.TOTP}
               then item || jsonb_build_object(
-                'lastUsedAt', ${lastUsedAt},
-                'lastUsedTimeStep', ${usedTimeStep}
+                'lastUsedAt', ${lastUsedAt}::text,
+                'lastUsedTimeStep', ${usedTimeStep}::integer
               )
             else item
           end
@@ -437,7 +437,7 @@ export const createUserQueries = (pool: CommonQueryMethods) => {
               not (item ? 'lastUsedTimeStep')
               or case
                 when jsonb_typeof(item->'lastUsedTimeStep') = 'number'
-                  then (item->>'lastUsedTimeStep')::numeric < ${usedTimeStep}
+                  then (item->>'lastUsedTimeStep')::integer < ${usedTimeStep}::integer
                 else false
               end
             )

--- a/packages/core/src/routes/experience/classes/verifications/totp-verification.test.ts
+++ b/packages/core/src/routes/experience/classes/verifications/totp-verification.test.ts
@@ -19,14 +19,15 @@ const { TotpVerification } = await import('./totp-verification.js');
 describe('TotpVerification', () => {
   const userId = 'userId';
   const findUserById = jest.fn();
-  const updateUserById = jest.fn();
+  const updateUserTotpMfaVerificationLastUsed = jest.fn();
   const tenant = new MockTenant(undefined, {
-    users: { findUserById, updateUserById },
+    users: { findUserById, updateUserTotpMfaVerificationLastUsed },
   });
 
   beforeEach(() => {
     jest.clearAllMocks();
     getTotpTokenTimeStep.mockReturnValue(100);
+    updateUserTotpMfaVerificationLastUsed.mockResolvedValue({});
   });
 
   const createVerification = () =>
@@ -54,14 +55,7 @@ describe('TotpVerification', () => {
     await verification.verifyUserExistingTotp('123456');
 
     expect(verification.isVerified).toBe(true);
-    expect(updateUserById).toHaveBeenCalledWith(userId, {
-      mfaVerifications: [
-        expect.objectContaining({
-          id: 'totpId',
-          lastUsedTimeStep: 100,
-        }),
-      ],
-    });
+    expect(updateUserTotpMfaVerificationLastUsed).toHaveBeenCalledWith(userId, 'totpId', 100);
   });
 
   it('should reject a TOTP code whose time step was already used', async () => {
@@ -82,6 +76,27 @@ describe('TotpVerification', () => {
     await expect(verification.verifyUserExistingTotp('123456')).rejects.toEqual(
       new RequestError('session.mfa.invalid_totp_code')
     );
-    expect(updateUserById).not.toHaveBeenCalled();
+    expect(updateUserTotpMfaVerificationLastUsed).not.toHaveBeenCalled();
+  });
+
+  it('should reject when the used time step fails to persist atomically', async () => {
+    findUserById.mockResolvedValueOnce({
+      mfaVerifications: [
+        {
+          id: 'totpId',
+          type: MfaFactor.TOTP,
+          key: 'key',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    updateUserTotpMfaVerificationLastUsed.mockResolvedValueOnce(null);
+
+    const verification = createVerification();
+
+    await expect(verification.verifyUserExistingTotp('123456')).rejects.toEqual(
+      new RequestError('session.mfa.invalid_totp_code')
+    );
+    expect(verification.isVerified).toBe(false);
   });
 });

--- a/packages/core/src/routes/experience/classes/verifications/totp-verification.test.ts
+++ b/packages/core/src/routes/experience/classes/verifications/totp-verification.test.ts
@@ -1,0 +1,87 @@
+import { MfaFactor, VerificationType } from '@logto/schemas';
+import { createMockUtils } from '@logto/shared/esm';
+
+import RequestError from '#src/errors/RequestError/index.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+const { jest } = import.meta;
+const { mockEsmWithActual } = createMockUtils(jest);
+
+const { getTotpTokenTimeStep } = await mockEsmWithActual(
+  '#src/libraries/verification-helpers/totp-validation.js',
+  () => ({
+    getTotpTokenTimeStep: jest.fn().mockReturnValue(100),
+  })
+);
+
+const { TotpVerification } = await import('./totp-verification.js');
+
+describe('TotpVerification', () => {
+  const userId = 'userId';
+  const findUserById = jest.fn();
+  const updateUserById = jest.fn();
+  const tenant = new MockTenant(undefined, {
+    users: { findUserById, updateUserById },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getTotpTokenTimeStep.mockReturnValue(100);
+  });
+
+  const createVerification = () =>
+    new TotpVerification(tenant.libraries, tenant.queries, {
+      id: 'verificationId',
+      type: VerificationType.TOTP,
+      verified: false,
+      userId,
+    });
+
+  it('should verify existing TOTP and persist the used time step', async () => {
+    findUserById.mockResolvedValueOnce({
+      mfaVerifications: [
+        {
+          id: 'totpId',
+          type: MfaFactor.TOTP,
+          key: 'key',
+          createdAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const verification = createVerification();
+
+    await verification.verifyUserExistingTotp('123456');
+
+    expect(verification.isVerified).toBe(true);
+    expect(updateUserById).toHaveBeenCalledWith(userId, {
+      mfaVerifications: [
+        expect.objectContaining({
+          id: 'totpId',
+          lastUsedTimeStep: 100,
+        }),
+      ],
+    });
+  });
+
+  it('should reject a TOTP code whose time step was already used', async () => {
+    findUserById.mockResolvedValueOnce({
+      mfaVerifications: [
+        {
+          id: 'totpId',
+          type: MfaFactor.TOTP,
+          key: 'key',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          lastUsedTimeStep: 100,
+        },
+      ],
+    });
+
+    const verification = createVerification();
+
+    await expect(verification.verifyUserExistingTotp('123456')).rejects.toEqual(
+      new RequestError('session.mfa.invalid_totp_code')
+    );
+    expect(updateUserById).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
@@ -125,7 +125,7 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
    */
   async verifyUserExistingTotp(code: string) {
     const {
-      users: { findUserById, updateUserById },
+      users: { findUserById, updateUserTotpMfaVerificationLastUsed },
     } = this.queries;
 
     const { mfaVerifications } = await findUserById(this.userId);
@@ -145,22 +145,14 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
       'session.mfa.invalid_totp_code'
     );
 
+    const updatedUser = await updateUserTotpMfaVerificationLastUsed(
+      this.userId,
+      totpVerification.id,
+      usedTimeStep
+    );
+    assertThat(updatedUser, 'session.mfa.invalid_totp_code');
+
     this.verified = true;
-
-    // Update last used time
-    await updateUserById(this.userId, {
-      mfaVerifications: mfaVerifications.map((mfa) => {
-        if (mfa.id !== totpVerification.id) {
-          return mfa;
-        }
-
-        return {
-          ...mfa,
-          lastUsedAt: new Date().toISOString(),
-          lastUsedTimeStep: usedTimeStep,
-        };
-      }),
-    });
   }
 
   toBindMfa(): BindTotp {

--- a/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
@@ -14,6 +14,7 @@ import qrcode from 'qrcode';
 
 import {
   generateTotpSecret,
+  getTotpTokenTimeStep,
   validateTotpToken,
 } from '#src/libraries/verification-helpers/totp-validation.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
@@ -135,7 +136,14 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
     // Can not found totp verification, this is an invalid request, throw invalid code error anyway for security reason
     assertThat(totpVerification, 'session.mfa.invalid_totp_code');
 
-    assertThat(validateTotpToken(totpVerification.key, code), 'session.mfa.invalid_totp_code');
+    const usedTimeStep = getTotpTokenTimeStep(totpVerification.key, code);
+
+    assertThat(usedTimeStep !== undefined, 'session.mfa.invalid_totp_code');
+    assertThat(
+      totpVerification.lastUsedTimeStep === undefined ||
+        usedTimeStep > totpVerification.lastUsedTimeStep,
+      'session.mfa.invalid_totp_code'
+    );
 
     this.verified = true;
 
@@ -149,6 +157,7 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
         return {
           ...mfa,
           lastUsedAt: new Date().toISOString(),
+          lastUsedTimeStep: usedTimeStep,
         };
       }),
     });

--- a/packages/core/src/routes/experience/verification-routes/totp-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/totp-verification.ts
@@ -92,7 +92,6 @@ export default function totpVerificationRoutes<T extends ExperienceInteractionRo
       verificationAuditLog.append({
         payload: {
           verificationId,
-          code,
         },
       });
 

--- a/packages/core/src/routes/interaction/mfa.test.ts
+++ b/packages/core/src/routes/interaction/mfa.test.ts
@@ -66,6 +66,7 @@ const baseProviderMock = {
 };
 
 const updateUserById = jest.fn();
+const updateUserTotpMfaVerificationLastUsed = jest.fn().mockResolvedValue({});
 const findDefaultSignInExperience = jest.fn().mockResolvedValue(mockSignInExperience);
 
 const tenantContext = new MockTenant(
@@ -77,6 +78,7 @@ const tenantContext = new MockTenant(
     users: {
       findUserById: jest.fn().mockResolvedValue(mockUserWithMfaVerifications),
       updateUserById,
+      updateUserTotpMfaVerificationLastUsed,
     },
   }
 );
@@ -224,6 +226,7 @@ describe('interaction routes (MFA verification)', () => {
       verifyMfaPayloadVerification.mockResolvedValue({
         type: MfaFactor.TOTP,
         id: 'id',
+        usedTimeStep: 100,
       });
 
       const body = {
@@ -235,7 +238,8 @@ describe('interaction routes (MFA verification)', () => {
       expect(response.status).toEqual(204);
       expect(getInteractionStorage).toBeCalled();
       expect(verifyMfaPayloadVerification).toBeCalled();
-      expect(updateUserById).toBeCalled();
+      expect(updateUserTotpMfaVerificationLastUsed).toBeCalledWith('accountId', 'id', 100);
+      expect(updateUserById).not.toBeCalled();
       expect(storeInteractionResult).toBeCalledWith(
         {
           verifiedMfa: {
@@ -247,6 +251,30 @@ describe('interaction routes (MFA verification)', () => {
         expect.anything(),
         expect.anything()
       );
+    });
+
+    it('should reject when the used TOTP time step fails to persist atomically', async () => {
+      getInteractionStorage.mockReturnValue({
+        event: InteractionEvent.SignIn,
+      });
+      verifyIdentifier.mockResolvedValue({
+        event: InteractionEvent.SignIn,
+        accountId: 'accountId',
+      });
+      verifyMfaPayloadVerification.mockResolvedValue({
+        type: MfaFactor.TOTP,
+        id: 'id',
+        usedTimeStep: 100,
+      });
+      updateUserTotpMfaVerificationLastUsed.mockResolvedValueOnce(null);
+
+      const response = await sessionRequest.put(path).send({
+        type: MfaFactor.TOTP,
+        code: '123456',
+      });
+
+      expect(response.status).toEqual(400);
+      expect(storeInteractionResult).not.toBeCalled();
     });
   });
 

--- a/packages/core/src/routes/interaction/mfa.ts
+++ b/packages/core/src/routes/interaction/mfa.ts
@@ -128,6 +128,7 @@ export default function mfaRoutes<T extends IRouterParamContext>(
         interactionStorage,
         { accountId, rpId: hostname, origin }
       );
+      const { usedTimeStep, ...verifiedMfaResult } = verifiedMfa;
 
       // Update last used time
       const user = await queries.users.findUserById(accountId);
@@ -140,11 +141,12 @@ export default function mfaRoutes<T extends IRouterParamContext>(
           return {
             ...mfa,
             lastUsedAt: new Date().toISOString(),
+            ...(usedTimeStep !== undefined && { lastUsedTimeStep: usedTimeStep }),
           };
         }),
       });
 
-      await storeInteractionResult({ verifiedMfa }, ctx, provider, true);
+      await storeInteractionResult({ verifiedMfa: verifiedMfaResult }, ctx, provider, true);
 
       ctx.status = 204;
 

--- a/packages/core/src/routes/interaction/mfa.ts
+++ b/packages/core/src/routes/interaction/mfa.ts
@@ -131,20 +131,28 @@ export default function mfaRoutes<T extends IRouterParamContext>(
       const { usedTimeStep, ...verifiedMfaResult } = verifiedMfa;
 
       // Update last used time
-      const user = await queries.users.findUserById(accountId);
-      await queries.users.updateUserById(accountId, {
-        mfaVerifications: user.mfaVerifications.map((mfa) => {
-          if (mfa.id !== verifiedMfa.id) {
-            return mfa;
-          }
+      if (usedTimeStep === undefined) {
+        const user = await queries.users.findUserById(accountId);
+        await queries.users.updateUserById(accountId, {
+          mfaVerifications: user.mfaVerifications.map((mfa) => {
+            if (mfa.id !== verifiedMfa.id) {
+              return mfa;
+            }
 
-          return {
-            ...mfa,
-            lastUsedAt: new Date().toISOString(),
-            ...(usedTimeStep !== undefined && { lastUsedTimeStep: usedTimeStep }),
-          };
-        }),
-      });
+            return {
+              ...mfa,
+              lastUsedAt: new Date().toISOString(),
+            };
+          }),
+        });
+      } else {
+        const updatedUser = await queries.users.updateUserTotpMfaVerificationLastUsed(
+          accountId,
+          verifiedMfa.id,
+          usedTimeStep
+        );
+        assertThat(updatedUser, 'session.mfa.invalid_totp_code');
+      }
 
       await storeInteractionResult({ verifiedMfa: verifiedMfaResult }, ctx, provider, true);
 

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.test.ts
@@ -31,9 +31,10 @@ const tenantContext = new MockTenant(undefined, {
   },
 });
 
-const { validateTotpToken } = mockEsm(
+const { getTotpTokenTimeStep, validateTotpToken } = mockEsm(
   '#src/libraries/verification-helpers/totp-validation.js',
   () => ({
+    getTotpTokenTimeStep: jest.fn().mockReturnValue(100),
     validateTotpToken: jest.fn().mockReturnValue(true),
   })
 );
@@ -60,6 +61,14 @@ mockEsm('@simplewebauthn/server/helpers', () => ({
 const { bindMfaPayloadVerification, verifyMfaPayloadVerification } = await import(
   './mfa-payload-verification.js'
 );
+
+const verifyTotpPayload = async () =>
+  verifyMfaPayloadVerification(
+    tenantContext,
+    { type: MfaFactor.TOTP, code: '123456' },
+    { event: InteractionEvent.SignIn },
+    { rpId: 'rpId', origin: 'origin', accountId: 'accountId' }
+  );
 
 const additionalParameters = {
   rpId: 'logto.io',
@@ -227,64 +236,53 @@ describe('bindMfaPayloadVerification', () => {
 
 describe('verifyMfaPayloadVerification', () => {
   describe('totp', () => {
+    beforeEach(() => {
+      getTotpTokenTimeStep.mockReturnValue(100);
+    });
+
     it('should return result of VerifyMfaResult', async () => {
       findUserById.mockResolvedValueOnce({
         mfaVerifications: [{ type: MfaFactor.TOTP, key: 'key', id: 'id' }],
       });
 
-      await expect(
-        verifyMfaPayloadVerification(
-          tenantContext,
-          {
-            type: MfaFactor.TOTP,
-            code: '123456',
-          },
-          { event: InteractionEvent.SignIn },
-          { rpId: 'rpId', origin: 'origin', accountId: 'accountId' }
-        )
-      ).resolves.toMatchObject({
+      await expect(verifyTotpPayload()).resolves.toMatchObject({
         type: MfaFactor.TOTP,
         id: 'id',
       });
 
       expect(findUserById).toHaveBeenCalled();
-      expect(validateTotpToken).toHaveBeenCalled();
+      expect(getTotpTokenTimeStep).toHaveBeenCalled();
     });
 
     it('should reject when totp can not be found in user mfaVerifications', async () => {
       findUserById.mockResolvedValueOnce({
         mfaVerifications: [],
       });
-      await expect(
-        verifyMfaPayloadVerification(
-          tenantContext,
-          {
-            type: MfaFactor.TOTP,
-            code: '123456',
-          },
-          { event: InteractionEvent.SignIn },
-          { rpId: 'rpId', origin: 'origin', accountId: 'accountId' }
-        )
-      ).rejects.toEqual(new RequestError('session.mfa.invalid_totp_code'));
+
+      await expect(verifyTotpPayload()).rejects.toEqual(
+        new RequestError('session.mfa.invalid_totp_code')
+      );
     });
 
     it('should reject when code is invalid', async () => {
       findUserById.mockResolvedValueOnce({
         mfaVerifications: [{ type: MfaFactor.TOTP, key: 'key', id: 'id' }],
       });
-      validateTotpToken.mockReturnValueOnce(false);
+      getTotpTokenTimeStep.mockReset();
 
-      await expect(
-        verifyMfaPayloadVerification(
-          tenantContext,
-          {
-            type: MfaFactor.TOTP,
-            code: '123456',
-          },
-          { event: InteractionEvent.SignIn },
-          { rpId: 'rpId', origin: 'origin', accountId: 'accountId' }
-        )
-      ).rejects.toEqual(new RequestError('session.mfa.invalid_totp_code'));
+      await expect(verifyTotpPayload()).rejects.toEqual(
+        new RequestError('session.mfa.invalid_totp_code')
+      );
+    });
+
+    it('should reject when TOTP code time step is already used', async () => {
+      findUserById.mockResolvedValueOnce({
+        mfaVerifications: [{ type: MfaFactor.TOTP, key: 'key', id: 'id', lastUsedTimeStep: 100 }],
+      });
+
+      await expect(verifyTotpPayload()).rejects.toEqual(
+        new RequestError('session.mfa.invalid_totp_code')
+      );
     });
   });
 

--- a/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
+++ b/packages/core/src/routes/interaction/verifications/mfa-payload-verification.ts
@@ -21,7 +21,10 @@ import {
 import { pick } from '@silverhand/essentials';
 import { isoBase64URL } from '@simplewebauthn/server/helpers';
 
-import { validateTotpToken } from '#src/libraries/verification-helpers/totp-validation.js';
+import {
+  getTotpTokenTimeStep,
+  validateTotpToken,
+} from '#src/libraries/verification-helpers/totp-validation.js';
 import {
   verifyWebAuthnAuthentication,
   verifyWebAuthnRegistration,
@@ -31,6 +34,10 @@ import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import type { AnonymousInteractionResult } from '../types/index.js';
+
+export type VerifyMfaPayloadVerificationResult = VerifyMfaResult & {
+  usedTimeStep?: number;
+};
 
 const verifyBindTotp = async (
   interactionStorage: AnonymousInteractionResult,
@@ -59,18 +66,23 @@ const findUserTotp = (
 const verifyTotp = async (
   mfaVerifications: User['mfaVerifications'],
   payload: TotpVerificationPayload
-): Promise<VerifyMfaResult> => {
+): Promise<VerifyMfaPayloadVerificationResult> => {
   const totp = findUserTotp(mfaVerifications);
 
   // Can not found totp verification, this is an invalid request, throw invalid code error anyway for security reason
   assertThat(totp, 'session.mfa.invalid_totp_code');
 
   const { code } = payload;
-  const { key, id, type } = totp;
+  const { key, id, type, lastUsedTimeStep } = totp;
+  const usedTimeStep = getTotpTokenTimeStep(key, code);
 
-  assertThat(validateTotpToken(key, code), 'session.mfa.invalid_totp_code');
+  assertThat(usedTimeStep !== undefined, 'session.mfa.invalid_totp_code');
+  assertThat(
+    lastUsedTimeStep === undefined || usedTimeStep > lastUsedTimeStep,
+    'session.mfa.invalid_totp_code'
+  );
 
-  return { type, id };
+  return { type, id, usedTimeStep };
 };
 
 const verifyBindWebAuthn = async (
@@ -215,7 +227,7 @@ export async function verifyMfaPayloadVerification(
     origin: string;
     accountId: string;
   }
-): Promise<VerifyMfaResult> {
+): Promise<VerifyMfaPayloadVerificationResult> {
   const user = await tenant.queries.users.findUserById(accountId);
 
   if (verifyMfaPayload.type === MfaFactor.TOTP) {

--- a/packages/schemas/src/foundations/jsonb-types/users.ts
+++ b/packages/schemas/src/foundations/jsonb-types/users.ts
@@ -76,7 +76,7 @@ export const mfaVerificationTotp = z.object({
   type: z.literal(MfaFactor.TOTP),
   ...baseMfaVerification,
   key: z.string(),
-  lastUsedTimeStep: z.number().optional(),
+  lastUsedTimeStep: z.number().int().nonnegative().optional(),
 });
 
 export type MfaVerificationTotp = z.infer<typeof mfaVerificationTotp>;

--- a/packages/schemas/src/foundations/jsonb-types/users.ts
+++ b/packages/schemas/src/foundations/jsonb-types/users.ts
@@ -76,6 +76,7 @@ export const mfaVerificationTotp = z.object({
   type: z.literal(MfaFactor.TOTP),
   ...baseMfaVerification,
   key: z.string(),
+  lastUsedTimeStep: z.number().optional(),
 });
 
 export type MfaVerificationTotp = z.infer<typeof mfaVerificationTotp>;


### PR DESCRIPTION
## Summary

- Prevent replay of already accepted TOTP codes by recording the matched TOTP time-step counter.
- Apply the replay check to both the Experience API existing-TOTP verifier and the legacy interaction MFA verifier.
- Stop including the raw submitted TOTP code in the Experience TOTP verification audit payload.

## Root cause

Existing TOTP verification only used the stateless RFC 6238 window check, so a code that had already succeeded could still be accepted again while it remained inside the configured acceptance window.

## Testing

Unit tests