### PR TITLE
fix(core): restrict account center step-up verification

### DIFF
--- a/.changeset/pink-windows-glow.md
+++ b/.changeset/pink-windows-glow.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+restrict account center step-up verification to user permission verification records

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
@@ -151,30 +151,47 @@ describe('koaOidcAuth middleware', () => {
     expect(ctx.auth.identityVerified).toBe(true);
   });
 
-  it('should set identityVerified with a verified user permission code verification record', async () => {
-    ctx.request = {
-      ...ctx.request,
-      headers: {
-        authorization: 'Bearer access_token',
-        [verificationRecordIdHeader]: 'verification-record-id',
+  it.each([
+    {
+      name: 'email',
+      type: VerificationType.EmailVerificationCode,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: 'foo@example.com',
       },
-    };
-    Sinon.stub(provider.AccessToken, 'find').resolves(mockAccessToken);
-
-    await koaOidcAuth(
-      createTenantWithVerificationRecord({
-        type: VerificationType.EmailVerificationCode,
-        identifier: {
-          type: SignInIdentifier.Email,
-          value: 'foo@example.com',
+    },
+    {
+      name: 'phone',
+      type: VerificationType.PhoneVerificationCode,
+      identifier: {
+        type: SignInIdentifier.Phone,
+        value: '+1234567890',
+      },
+    },
+  ])(
+    'should set identityVerified with a verified user permission $name code verification record',
+    async ({ type, identifier }) => {
+      ctx.request = {
+        ...ctx.request,
+        headers: {
+          authorization: 'Bearer access_token',
+          [verificationRecordIdHeader]: 'verification-record-id',
         },
-        templateType: TemplateType.UserPermissionValidation,
-        verified: true,
-      })
-    )(ctx, next);
+      };
+      Sinon.stub(provider.AccessToken, 'find').resolves(mockAccessToken);
 
-    expect(ctx.auth.identityVerified).toBe(true);
-  });
+      await koaOidcAuth(
+        createTenantWithVerificationRecord({
+          type,
+          identifier,
+          templateType: TemplateType.UserPermissionValidation,
+          verified: true,
+        })
+      )(ctx, next);
+
+      expect(ctx.auth.identityVerified).toBe(true);
+    }
+  );
 
   it('should not set identityVerified with a verified MFA binding code verification record', async () => {
     ctx.request = {

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.test.ts
@@ -1,3 +1,5 @@
+import { TemplateType } from '@logto/connector-kit';
+import { AdditionalIdentifier, SignInIdentifier, VerificationType } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 import type { Context } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
@@ -5,10 +7,13 @@ import { Provider } from 'oidc-provider';
 import Sinon from 'sinon';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import type Queries from '#src/tenants/Queries.js';
+import { type Partial2 } from '#src/test-utils/tenant.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
 import { MockTenant } from '../../test-utils/tenant.js';
 
+import { verificationRecordIdHeader } from './constants.js';
 import type { WithAuthContext } from './index.js';
 
 const { jest } = import.meta;
@@ -23,6 +28,21 @@ const mockAccessToken = {
 };
 
 const koaOidcAuth = await pickDefault(import('./koa-oidc-auth.js'));
+
+const createTenantWithVerificationRecord = (
+  data: Record<string, unknown>,
+  userId: string | undefined = mockAccessToken.accountId
+) =>
+  new MockTenant(provider, {
+    verificationRecords: {
+      findActiveVerificationRecordById: jest.fn(async (id: string) => ({
+        id,
+        userId,
+        data,
+        expiresAt: Date.now() + 60_000,
+      })),
+    },
+  } as unknown as Partial2<Queries>);
 
 afterEach(() => {
   Sinon.restore();
@@ -105,6 +125,103 @@ describe('koaOidcAuth middleware', () => {
       clientId: mockAccessToken.clientId,
       sessionUid: 'fooSessionUid',
     });
+  });
+
+  it('should set identityVerified with a verified password verification record', async () => {
+    ctx.request = {
+      ...ctx.request,
+      headers: {
+        authorization: 'Bearer access_token',
+        [verificationRecordIdHeader]: 'verification-record-id',
+      },
+    };
+    Sinon.stub(provider.AccessToken, 'find').resolves(mockAccessToken);
+
+    await koaOidcAuth(
+      createTenantWithVerificationRecord({
+        type: VerificationType.Password,
+        identifier: {
+          type: AdditionalIdentifier.UserId,
+          value: mockAccessToken.accountId,
+        },
+        verified: true,
+      })
+    )(ctx, next);
+
+    expect(ctx.auth.identityVerified).toBe(true);
+  });
+
+  it('should set identityVerified with a verified user permission code verification record', async () => {
+    ctx.request = {
+      ...ctx.request,
+      headers: {
+        authorization: 'Bearer access_token',
+        [verificationRecordIdHeader]: 'verification-record-id',
+      },
+    };
+    Sinon.stub(provider.AccessToken, 'find').resolves(mockAccessToken);
+
+    await koaOidcAuth(
+      createTenantWithVerificationRecord({
+        type: VerificationType.EmailVerificationCode,
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: 'foo@example.com',
+        },
+        templateType: TemplateType.UserPermissionValidation,
+        verified: true,
+      })
+    )(ctx, next);
+
+    expect(ctx.auth.identityVerified).toBe(true);
+  });
+
+  it('should not set identityVerified with a verified MFA binding code verification record', async () => {
+    ctx.request = {
+      ...ctx.request,
+      headers: {
+        authorization: 'Bearer access_token',
+        [verificationRecordIdHeader]: 'verification-record-id',
+      },
+    };
+    Sinon.stub(provider.AccessToken, 'find').resolves(mockAccessToken);
+
+    await koaOidcAuth(
+      createTenantWithVerificationRecord({
+        type: VerificationType.EmailVerificationCode,
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: 'foo@example.com',
+        },
+        templateType: TemplateType.BindMfa,
+        verified: true,
+      })
+    )(ctx, next);
+
+    expect(ctx.auth.identityVerified).toBe(false);
+  });
+
+  it('should not set identityVerified with a verified WebAuthn registration record', async () => {
+    ctx.request = {
+      ...ctx.request,
+      headers: {
+        authorization: 'Bearer access_token',
+        [verificationRecordIdHeader]: 'verification-record-id',
+      },
+    };
+    Sinon.stub(provider.AccessToken, 'find').resolves(mockAccessToken);
+
+    await koaOidcAuth(
+      createTenantWithVerificationRecord({
+        type: VerificationType.WebAuthn,
+        userId: mockAccessToken.accountId,
+        verified: true,
+        registrationChallenge: 'challenge',
+        registrationRpId: 'logto.test',
+      })
+    )(ctx, next);
+
+    expect(ctx.auth.identityVerified).toBe(false);
   });
 
   it('expect to throw if authorization header is missing', async () => {

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
@@ -1,3 +1,5 @@
+import { TemplateType } from '@logto/connector-kit';
+import { VerificationType } from '@logto/schemas';
 import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
@@ -5,6 +7,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import {
   verificationRecordDataGuard,
   buildVerificationRecord,
+  type VerificationRecord,
 } from '#src/routes/experience/classes/verifications/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -14,6 +17,25 @@ import assertThat from '#src/utils/assert-that.js';
 import { verificationRecordIdHeader } from './constants.js';
 import { type WithAuthContext } from './types.js';
 import { extractBearerTokenFromHeaders } from './utils.js';
+
+const isUserPermissionVerificationRecord = (record: VerificationRecord) => {
+  if (!record.isVerified) {
+    return false;
+  }
+
+  switch (record.type) {
+    case VerificationType.Password: {
+      return true;
+    }
+    case VerificationType.EmailVerificationCode:
+    case VerificationType.PhoneVerificationCode: {
+      return record.templateType === TemplateType.UserPermissionValidation;
+    }
+    default: {
+      return false;
+    }
+  }
+};
 
 /**
  * Builds a verification record by its id.
@@ -45,7 +67,7 @@ const getVerificationRecordResultById = async ({
   }
 
   const instance = buildVerificationRecord(libraries, queries, result.data);
-  return instance.isVerified;
+  return isUserPermissionVerificationRecord(instance);
 };
 
 /**

--- a/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
+++ b/packages/core/src/middleware/koa-auth/koa-oidc-auth.ts
@@ -38,8 +38,8 @@ const isUserPermissionVerificationRecord = (record: VerificationRecord) => {
 };
 
 /**
- * Builds a verification record by its id.
- * The `userId` is optional and is only used for user sensitive permission verifications.
+ * Checks whether the verification record exists, belongs to the given user, and can be used for
+ * user permission verification.
  */
 const getVerificationRecordResultById = async ({
   id,


### PR DESCRIPTION
## Summary

- restrict Account Center step-up derivation to user permission verification records
- keep password and UserPermissionValidation email/phone code records valid for identityVerified
- add regression coverage so WebAuthn registration and BindMfa records do not satisfy step-up

## Testing

Unit tests