### PR TITLE
fix(connector): treat aliyun hk sms numbers as overseas

### DIFF
--- a/.changeset/fix-aliyun-hk-phone.md
+++ b/.changeset/fix-aliyun-hk-phone.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-aliyun-sms": patch
+---
+
+treat Hong Kong phone numbers as overseas in the Aliyun SMS connector

--- a/packages/connectors/connector-aliyun-sms/src/index.test.ts
+++ b/packages/connectors/connector-aliyun-sms/src/index.test.ts
@@ -70,5 +70,19 @@ describe('sendMessage()', () => {
       }),
       mockedConnectorConfig.accessKeySecret
     );
+
+    sendSms.mockClear();
+
+    await connector.sendMessage({
+      to: '85268326366',
+      type: TemplateType.Register,
+      payload: { code: codeTest },
+    });
+    expect(sendSms).toHaveBeenCalledWith(
+      expect.objectContaining({
+        TemplateCode: 'TemplateCode2',
+      }),
+      mockedConnectorConfig.accessKeySecret
+    );
   });
 });

--- a/packages/connectors/connector-aliyun-sms/src/utils.test.ts
+++ b/packages/connectors/connector-aliyun-sms/src/utils.test.ts
@@ -42,6 +42,7 @@ describe('isChinaNumber()', () => {
     expect(isChinaNumber('+8613812345678')).toBe(true);
 
     // Invalid cases
+    expect(isChinaNumber('85268326366')).toBe(false); // Hong Kong number
     expect(isChinaNumber('1381234567')).toBe(false); // Too short
     expect(isChinaNumber('138123456789')).toBe(false); // Too long
     expect(isChinaNumber('abcdefghijk')).toBe(false); // Non-numeric
@@ -56,6 +57,7 @@ describe('isChinaNumber()', () => {
 
     // Invalid cases
     expect(isChinaNumber('13812345678', true)).toBe(false); // Missing region code
+    expect(isChinaNumber('85268326366', true)).toBe(false); // Hong Kong number
     expect(isChinaNumber('1381234567', true)).toBe(false); // Too short
     expect(isChinaNumber('138123456789', true)).toBe(false); // Too long
     expect(isChinaNumber('abcdefghijk', true)).toBe(false); // Non-numeric

--- a/packages/connectors/connector-aliyun-sms/src/utils.ts
+++ b/packages/connectors/connector-aliyun-sms/src/utils.ts
@@ -63,11 +63,15 @@ export const request = async (
   });
 };
 
+const chinaMobileNumber = '1\\d{10}';
+const chinaNumberRegExp = new RegExp(`^(?:\\+86|0086|86)?${chinaMobileNumber}$`);
+const strictChinaNumberRegExp = new RegExp(`^(?:\\+86|0086|86)${chinaMobileNumber}$`);
+
 // When `isStrictOnRegionNumber` is true, it means the mobile phone number area code needs to be strictly matched; the default is false, for backward compatibility, as some old phone numbers do not have region codes, which would cause the method to make mistakes on validation.
 export const isChinaNumber = (to: string, isStrictOnRegionNumber?: boolean) => {
   if (isStrictOnRegionNumber) {
-    return /^(\+86|0086|86)\d{11}$/.test(to);
+    return strictChinaNumberRegExp.test(to);
   }
 
-  return /^(\+86|0086|86)?\d{11}$/.test(to);
+  return chinaNumberRegExp.test(to);
 };


### PR DESCRIPTION
## Summary

Fixes #5889.

The Aliyun SMS connector treated any bare 11-digit phone number as a mainland China number in non-strict mode. This keeps backward-compatible bare mainland mobile numbers (`1` + 10 digits), while routing Hong Kong numbers such as `85268326366` to the overseas template.

## Changes

- Narrowed Aliyun China-number detection to mainland mobile number shape with optional China region code.
- Added helper and connector-level coverage for the reported Hong Kong number.
- Added a connector patch changeset.

## Testing

Unit tests

- `corepack pnpm@10.33.4 --dir packages/connectors/connector-aliyun-sms test`

## Verification

- `corepack pnpm@10.33.4 install --frozen-lockfile`
- `pnpm prepack`
- `corepack pnpm@10.33.4 --dir packages/connectors/connector-aliyun-sms lint`
- `corepack pnpm@10.33.4 --dir packages/connectors/connector-aliyun-sms check`