### PR TITLE
fix: prevent commitlint PR title injection

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -31,4 +31,6 @@ jobs:
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
       - name: Commitlint on PR title
-        run: echo '${{ github.event.pull_request.title }}' | npx commitlint
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | npx commitlint


### PR DESCRIPTION
## Summary
Pass the pull request title to the commitlint workflow through an environment variable before piping it to commitlint. This prevents pull request titles from being interpreted as shell syntax.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments