### PR TITLE
fix(tunnel): prevent static path traversal

### DIFF
--- a/.changeset/fix-tunnel-path-traversal.md
+++ b/.changeset/fix-tunnel-path-traversal.md
@@ -1,0 +1,5 @@
+---
+"@logto/tunnel": patch
+---
+
+prevent static file requests from reading files outside the configured experience path

--- a/packages/tunnel/src/commands/tunnel/utils.test.ts
+++ b/packages/tunnel/src/commands/tunnel/utils.test.ts
@@ -1,6 +1,8 @@
+import path from 'node:path';
+
 import { expect, describe, it } from 'vitest';
 
-import { getMimeType } from './utils.js';
+import { getMimeType, getSafeStaticFilePath } from './utils.js';
 
 describe('Tunnel utils', () => {
   it('should be able to get mime type according to request path', () => {
@@ -9,5 +11,26 @@ describe('Tunnel utils', () => {
     expect(getMimeType('/style.css')).toEqual('text/css');
     expect(getMimeType('/index.html')).toEqual('text/html');
     expect(getMimeType('/')).toEqual('text/html; charset=utf-8');
+  });
+
+  it('should resolve static file paths within the static root', () => {
+    const staticPath = '/tmp/logto-ui/static';
+
+    expect(getSafeStaticFilePath(staticPath, '/scripts.js')).toEqual(
+      path.resolve(staticPath, 'scripts.js')
+    );
+    expect(getSafeStaticFilePath(staticPath, '/assets/app.js?v=1')).toEqual(
+      path.resolve(staticPath, 'assets/app.js')
+    );
+  });
+
+  it('should reject static file paths outside the static root', () => {
+    const staticPath = '/tmp/logto-ui/static';
+
+    expect(getSafeStaticFilePath(staticPath, '/../secret.txt')).toBeUndefined();
+    expect(getSafeStaticFilePath(staticPath, '/..%2fsecret.txt')).toBeUndefined();
+    expect(getSafeStaticFilePath(staticPath, '/..%5csecret.txt')).toBeUndefined();
+    expect(getSafeStaticFilePath(staticPath, '/%2e%2e%2f.env')).toBeUndefined();
+    expect(getSafeStaticFilePath(staticPath, '/../.ssh/id_rsa/.')).toBeUndefined();
   });
 });

--- a/packages/tunnel/src/commands/tunnel/utils.ts
+++ b/packages/tunnel/src/commands/tunnel/utils.ts
@@ -43,6 +43,59 @@ const indexContentType = 'text/html; charset=utf-8';
 const noCache = 'no-cache, no-store, must-revalidate';
 const maxAgeSevenDays = 'max-age=604_800_000';
 
+export const getSafeStaticFilePath = (staticPath: string, requestUrl: string) => {
+  const [pathname = ''] = requestUrl.split(/[#?]/);
+  const decodedPathname = trySafe(() => decodeURIComponent(pathname));
+
+  if (!decodedPathname || decodedPathname.includes('\\')) {
+    return;
+  }
+
+  const staticRoot = path.resolve(staticPath);
+  const requestPath = decodedPathname.replace(/^\/+/, '');
+  const resolvedPath = path.resolve(staticRoot, requestPath);
+  const relativePath = path.relative(staticRoot, resolvedPath);
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return;
+  }
+
+  return resolvedPath;
+};
+
+const readFile = async (requestPath: string, start?: number, end?: number) => {
+  const fileHandle = await fs.open(requestPath, 'r');
+  const { size } = await fileHandle.stat();
+  const readStart = start ?? 0;
+  const readEnd = end ?? Math.max(size - 1, 0);
+  const buffer = Buffer.alloc(readEnd - readStart + 1);
+  await fileHandle.read(buffer, 0, buffer.length, readStart);
+  await fileHandle.close();
+  return { buffer, totalFileSize: size };
+};
+
+const setRangeHeaders = (response: http.ServerResponse, range: string, totalFileSize: number) => {
+  if (range) {
+    const { start, end } = parseRange(range);
+    const readStart = start ?? 0;
+    const readEnd = end ?? totalFileSize - 1;
+    response.setHeader('Accept-Ranges', 'bytes');
+    response.setHeader('Content-Range', `bytes ${readStart}-${readEnd}/${totalFileSize}`);
+  }
+};
+
+const isStaticFileProxyMethod = (method?: string) => method === 'HEAD' || method === 'GET';
+
+const getStaticFileRequestPath = (
+  staticPath: string,
+  requestUrl: string,
+  fallBackToIndex: boolean
+) =>
+  fallBackToIndex ? path.resolve(staticPath, index) : getSafeStaticFilePath(staticPath, requestUrl);
+
+const getStaticFileErrorStatusCode = (errorMessage: string, requestPath: string) =>
+  errorMessage === 'Range not satisfiable.' ? 416 : existsSync(requestPath) ? 500 : 404;
+
 export const createStaticFileProxy =
   (staticPath: string) => async (request: http.IncomingMessage, response: http.ServerResponse) => {
     if (!request.url) {
@@ -50,56 +103,36 @@ export const createStaticFileProxy =
       return;
     }
 
-    if (request.method === 'HEAD' || request.method === 'GET') {
-      const fallBackToIndex = !isFileAssetPath(request.url);
-      const requestPath = path.join(staticPath, fallBackToIndex ? index : request.url);
-      const { range = '' } = request.headers;
+    if (!isStaticFileProxyMethod(request.method)) {
+      return;
+    }
 
-      const readFile = async (requestPath: string, start?: number, end?: number) => {
-        const fileHandle = await fs.open(requestPath, 'r');
-        const { size } = await fileHandle.stat();
-        const readStart = start ?? 0;
-        const readEnd = end ?? Math.max(size - 1, 0);
-        const buffer = Buffer.alloc(readEnd - readStart + 1);
-        await fileHandle.read(buffer, 0, buffer.length, readStart);
-        await fileHandle.close();
-        return { buffer, totalFileSize: size };
-      };
+    const fallBackToIndex = !isFileAssetPath(request.url);
+    const requestPath = getStaticFileRequestPath(staticPath, request.url, fallBackToIndex);
+    const { range = '' } = request.headers;
 
-      const setRangeHeaders = (
-        response: http.ServerResponse,
-        range: string,
-        totalFileSize: number
-      ) => {
-        if (range) {
-          const { start, end } = parseRange(range);
-          const readStart = start ?? 0;
-          const readEnd = end ?? totalFileSize - 1;
-          response.setHeader('Accept-Ranges', 'bytes');
-          response.setHeader('Content-Range', `bytes ${readStart}-${readEnd}/${totalFileSize}`);
-        }
-      };
+    if (!requestPath) {
+      response.writeHead(404).end();
+      return;
+    }
 
-      try {
-        const { start, end } = parseRange(range);
-        const { buffer, totalFileSize } = await readFile(requestPath, start, end);
-        response.setHeader('cache-control', fallBackToIndex ? noCache : maxAgeSevenDays);
-        response.setHeader('content-type', getMimeType(request.url));
-        setRangeHeaders(response, range, totalFileSize);
+    try {
+      const { start, end } = parseRange(range);
+      const { buffer, totalFileSize } = await readFile(requestPath, start, end);
+      response.setHeader('cache-control', fallBackToIndex ? noCache : maxAgeSevenDays);
+      response.setHeader('content-type', getMimeType(request.url));
+      setRangeHeaders(response, range, totalFileSize);
 
-        response.setHeader('content-length', String(buffer.length));
-        response.writeHead(range ? 206 : 200);
-        response.end(buffer);
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        consoleLog.error(chalk.red(errorMessage));
+      response.setHeader('content-length', String(buffer.length));
+      response.writeHead(range ? 206 : 200);
+      response.end(buffer);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      consoleLog.error(chalk.red(errorMessage));
 
-        response.setHeader('content-type', getMimeType(request.url));
-        const statusCode =
-          errorMessage === 'Range not satisfiable.' ? 416 : existsSync(request.url) ? 500 : 404;
-        response.writeHead(statusCode);
-        response.end();
-      }
+      response.setHeader('content-type', getMimeType(request.url));
+      response.writeHead(getStaticFileErrorStatusCode(errorMessage, requestPath));
+      response.end();
     }
   };
 


### PR DESCRIPTION
## Summary
Prevent `@logto/tunnel` static file requests from resolving outside the configured custom UI experience path.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
