### PR TITLE
fix(connector): support QQ redirect URI session

### DIFF
--- a/.changeset/quiet-queens-join.md
+++ b/.changeset/quiet-queens-join.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-qq": patch
+---
+
+support QQ social identity verification with stored redirect URI

--- a/packages/connectors/connector-qq/src/index.test.ts
+++ b/packages/connectors/connector-qq/src/index.test.ts
@@ -25,6 +25,7 @@ describe('getAuthorizationUri', () => {
 
   it('should get a valid uri by redirectUri and state', async () => {
     const connector = await createConnector({ getConfig });
+    const setSession = vi.fn();
     const authorizationUri = await connector.getAuthorizationUri(
       {
         state: 'some_state',
@@ -34,15 +35,17 @@ describe('getAuthorizationUri', () => {
         jti: 'some_jti',
         headers: {},
       },
-      vi.fn()
+      setSession
     );
     expect(authorizationUri).toEqual(
       `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&state=some_state&scope=get_user_info`
     );
+    expect(setSession).toHaveBeenCalledWith({ redirectUri: 'http://localhost:3000/callback' });
   });
 
   it('should get a valid uri with custom scope', async () => {
     const connector = await createConnector({ getConfig });
+    const setSession = vi.fn();
     const authorizationUri = await connector.getAuthorizationUri(
       {
         state: 'some_state',
@@ -53,11 +56,12 @@ describe('getAuthorizationUri', () => {
         jti: 'some_jti',
         headers: {},
       },
-      vi.fn()
+      setSession
     );
     expect(authorizationUri).toEqual(
       `${authorizationEndpoint}?response_type=code&client_id=%3Cclient-id%3E&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&state=some_state&scope=custom_scope`
     );
+    expect(setSession).toHaveBeenCalledWith({ redirectUri: 'http://localhost:3000/callback' });
   });
 });
 
@@ -117,6 +121,28 @@ describe('getUserInfo', () => {
       vi.fn()
     );
 
+    expect(socialUserInfo).toStrictEqual({
+      id: 'unionid',
+      avatar: 'https://example.com/example.jpg',
+      name: 'nickname',
+      rawData: mockedUserInfoResponse,
+    });
+  });
+
+  it('should get valid SocialUserInfo with redirectUri from connector session', async () => {
+    nock(userInfoEndpoint).get('').query(true).reply(200, mockedUserInfoResponse);
+
+    const getSession = vi.fn().mockResolvedValue({ redirectUri: 'http://localhost:3000/callback' });
+    const connector = await createConnector({ getConfig });
+    const socialUserInfo = await connector.getUserInfo(
+      {
+        code: 'valid_code',
+        state: 'some_state',
+      },
+      getSession
+    );
+
+    expect(getSession).toHaveBeenCalledTimes(1);
     expect(socialUserInfo).toStrictEqual({
       id: 'unionid',
       avatar: 'https://example.com/example.jpg',

--- a/packages/connectors/connector-qq/src/index.ts
+++ b/packages/connectors/connector-qq/src/index.ts
@@ -5,6 +5,7 @@ import {
   ConnectorError,
   ConnectorErrorCodes,
   type GetAuthorizationUri,
+  type GetSession,
   type GetUserInfo,
   type SocialConnector,
   type CreateConnector,
@@ -70,9 +71,11 @@ const authorizationCallbackHandler = async (parameterObject: unknown) => {
  */
 const getAuthorizationUri =
   (getConfig: GetConnectorConfig): GetAuthorizationUri =>
-  async ({ state, redirectUri, scope: customScope }) => {
+  async ({ state, redirectUri, scope: customScope }, setSession) => {
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, qqConfigGuard);
+
+    await setSession({ redirectUri });
 
     const { clientId, scope } = config;
     const queryParameters = new URLSearchParams({
@@ -85,6 +88,22 @@ const getAuthorizationUri =
 
     return `${authorizationEndpoint}?${queryParameters.toString()}`;
   };
+
+const getRedirectUri = async (redirectUri: string | undefined, getSession: GetSession) => {
+  if (redirectUri) {
+    return redirectUri;
+  }
+
+  const { redirectUri: redirectUriFromSession } = await getSession();
+
+  if (!redirectUriFromSession) {
+    throw new ConnectorError(ConnectorErrorCodes.General, {
+      message: 'Cannot find `redirectUri` from connector session.',
+    });
+  }
+
+  return redirectUriFromSession;
+};
 
 /**
  * Obtains the QQ access token using the authorization code.
@@ -201,14 +220,18 @@ const getOpenIdAndUnionId = async (accessToken: string) => {
  */
 const getUserInfo =
   (getConfig: GetConnectorConfig): GetUserInfo =>
-  async (data) => {
+  async (data, getSession) => {
     const { code, redirectUri } = await authorizationCallbackHandler(data);
 
     const config = await getConfig(defaultMetadata.id);
     validateConfig(config, qqConfigGuard);
 
     const { clientId } = config;
-    const { accessToken } = await getAccessToken(config, code, redirectUri);
+    const { accessToken } = await getAccessToken(
+      config,
+      code,
+      await getRedirectUri(redirectUri, getSession)
+    );
     const { unionid, openid } = await getOpenIdAndUnionId(accessToken);
 
     try {

--- a/packages/connectors/connector-qq/src/types.ts
+++ b/packages/connectors/connector-qq/src/types.ts
@@ -55,7 +55,7 @@ export const authorizationCallbackErrorGuard = z.object({
   error_description: z.string(),
 });
 
-export const authResponseGuard = z.object({ code: z.string(), redirectUri: z.string() });
+export const authResponseGuard = z.object({ code: z.string(), redirectUri: z.string().optional() });
 
 export const getUserInfoErrorGuard = z.object({
   ret: z.number(),


### PR DESCRIPTION
## Summary
Store the QQ connector redirect URI in connector session when creating the authorization URL.

Allow QQ callback verification to read the redirect URI from connector session so social identity verification can complete when the provider callback only contains `code` and `state`.

Fixes #8208

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments