### PR TITLE
fix(core): require the identities scope for Account API third-party token endpoints

### DIFF
--- a/.changeset/account-third-party-token-scope.md
+++ b/.changeset/account-third-party-token-scope.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+require the `identities` user scope to retrieve stored third-party provider access tokens through the Account API, matching the other social and enterprise SSO identity endpoints

--- a/packages/core/src/routes/account/third-party-tokens.test.ts
+++ b/packages/core/src/routes/account/third-party-tokens.test.ts
@@ -1,0 +1,107 @@
+import { UserScope } from '@logto/core-kit';
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockUser } from '#src/__mocks__/index.js';
+import koaErrorHandler from '#src/middleware/koa-error-handler.js';
+import koaI18next from '#src/middleware/koa-i18next.js';
+import type Libraries from '#src/tenants/Libraries.js';
+import type Queries from '#src/tenants/Queries.js';
+import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const findSocialTokenSetSecretByUserIdAndTarget = jest.fn(async () => null);
+const findEnterpriseSsoTokenSetSecretByUserIdAndConnectorId = jest.fn(async () => null);
+
+const mockedQueries = {
+  secrets: {
+    findSocialTokenSetSecretByUserIdAndTarget,
+    findEnterpriseSsoTokenSetSecretByUserIdAndConnectorId,
+  },
+  users: {
+    findUserByIdentity: jest.fn(),
+  },
+} satisfies Partial2<Queries>;
+
+const mockedLibraries = {
+  socials: {
+    upsertSocialTokenSetSecret: jest.fn(),
+  },
+} satisfies Partial2<Libraries>;
+
+const thirdPartyTokensRoutes = await pickDefault(import('./third-party-tokens.js'));
+
+describe('account third-party token route authorization', () => {
+  const tenantContext = new MockTenant(undefined, mockedQueries, undefined, mockedLibraries);
+
+  const buildRequester = (scopes: Set<string>) =>
+    createRequester({
+      middlewares: [koaI18next(), koaErrorHandler()],
+      authedRoutes: [
+        (router) => {
+          router.use(async (ctx, next) => {
+            ctx.auth = { ...ctx.auth, id: mockUser.id, identityVerified: true, scopes };
+            return next();
+          });
+        },
+        thirdPartyTokensRoutes as never,
+      ],
+      tenantContext,
+    });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('without the identities scope (openid only)', () => {
+    const request = buildRequester(new Set(['openid']));
+
+    it('rejects GET social access-token and does not read the stored secret', async () => {
+      const response = await request.get('/my-account/identities/google/access-token');
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty('code', 'auth.forbidden');
+      expect(findSocialTokenSetSecretByUserIdAndTarget).not.toHaveBeenCalled();
+    });
+
+    it('rejects GET enterprise SSO access-token and does not read the stored secret', async () => {
+      const response = await request.get('/my-account/sso-identities/sso-conn/access-token');
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty('code', 'auth.forbidden');
+      expect(findEnterpriseSsoTokenSetSecretByUserIdAndConnectorId).not.toHaveBeenCalled();
+    });
+
+    it('rejects PUT social access-token before any verification work', async () => {
+      const response = await request
+        .put('/my-account/identities/google/access-token')
+        .send({ verificationRecordId: 'mock-verification-record-id' });
+
+      expect(response.status).toBe(403);
+      expect(response.body).toHaveProperty('code', 'auth.forbidden');
+    });
+  });
+
+  describe('with the identities scope', () => {
+    const request = buildRequester(new Set(['openid', UserScope.Identities]));
+
+    it('passes the scope gate for GET social access-token', async () => {
+      const response = await request.get('/my-account/identities/google/access-token');
+
+      // No stored secret in this test, so the handler proceeds past the scope gate to a 404.
+      expect(response.status).toBe(404);
+      expect(findSocialTokenSetSecretByUserIdAndTarget).toHaveBeenCalledWith(mockUser.id, 'google');
+    });
+
+    it('passes the scope gate for GET enterprise SSO access-token', async () => {
+      const response = await request.get('/my-account/sso-identities/sso-conn/access-token');
+
+      expect(response.status).toBe(404);
+      expect(findEnterpriseSsoTokenSetSecretByUserIdAndConnectorId).toHaveBeenCalledWith(
+        mockUser.id,
+        'sso-conn'
+      );
+    });
+  });
+});

--- a/packages/core/src/routes/account/third-party-tokens.ts
+++ b/packages/core/src/routes/account/third-party-tokens.ts
@@ -1,3 +1,4 @@
+import { UserScope } from '@logto/core-kit';
 import {
   type EnterpriseSsoTokenSetSecret,
   getThirdPartyAccessTokenResponseGuard,
@@ -105,12 +106,16 @@ export default function thirdPartyTokensRoutes<T extends UserRouter>(
       params: z.object({
         target: z.string().min(1),
       }),
-      status: [200, 404, 401, 422],
+      status: [200, 404, 403, 401, 422],
       response: getThirdPartyAccessTokenResponseGuard,
     }),
     async (ctx, next) => {
-      const { id: userId } = ctx.auth;
+      const { id: userId, scopes } = ctx.auth;
       const { target } = ctx.guard.params;
+
+      // Stored provider tokens are identity data; require the same `identities` scope as the
+      // other social/SSO identity endpoints.
+      assertThat(scopes.has(UserScope.Identities), 'auth.forbidden', 403);
 
       const tokenSetSecret = await secretsQueries.findSocialTokenSetSecretByUserIdAndTarget(
         userId,
@@ -136,12 +141,16 @@ export default function thirdPartyTokensRoutes<T extends UserRouter>(
       params: z.object({
         connectorId: z.string().min(1),
       }),
-      status: [200, 404, 401],
+      status: [200, 404, 403, 401],
       response: getThirdPartyAccessTokenResponseGuard,
     }),
     async (ctx, next) => {
-      const { id: userId } = ctx.auth;
+      const { id: userId, scopes } = ctx.auth;
       const { connectorId } = ctx.guard.params;
+
+      // Stored provider tokens are identity data; require the same `identities` scope as the
+      // other social/SSO identity endpoints.
+      assertThat(scopes.has(UserScope.Identities), 'auth.forbidden', 403);
 
       const tokenSetSecret =
         await secretsQueries.findEnterpriseSsoTokenSetSecretByUserIdAndConnectorId(
@@ -171,13 +180,17 @@ export default function thirdPartyTokensRoutes<T extends UserRouter>(
       body: z.object({
         verificationRecordId: z.string().min(1),
       }),
-      status: [200, 401, 422],
+      status: [200, 403, 401, 422],
       response: getThirdPartyAccessTokenResponseGuard,
     }),
     async (ctx, next) => {
-      const { id: userId } = ctx.auth;
+      const { id: userId, scopes } = ctx.auth;
       const { target } = ctx.guard.params;
       const { verificationRecordId } = ctx.guard.body;
+
+      // Stored provider tokens are identity data; require the same `identities` scope as the
+      // other social/SSO identity endpoints.
+      assertThat(scopes.has(UserScope.Identities), 'auth.forbidden', 403);
 
       const socialVerificationRecord = await buildVerificationRecordByIdAndType({
         type: VerificationType.Social,


### PR DESCRIPTION
## Summary

The Account API third-party token endpoints (which return social and enterprise SSO provider access tokens) did not enforce the `identities` user scope, unlike the rest of the identity surface — `/identities`, `/sso-identities`, the identity fields in `GET /my-account` (`getScopedProfile`), and MFA verifications all require `UserScope.Identities`.

This adds the same `identities` scope check to all three third-party token endpoints so they're consistent with the other social/SSO identity endpoints:

- `GET /api/my-account/identities/:target/access-token`
- `GET /api/my-account/sso-identities/:connectorId/access-token`
- `PUT /api/my-account/identities/:target/access-token`

A caller without the scope now gets `403`. The `PUT` keeps its existing social-verification-record requirement; the scope check runs first.

## Testing

Unit tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
