### PR TITLE
feat(toolkit): add email blocklist helpers

### DIFF
--- a/.changeset/email-blocklist-helpers.md
+++ b/.changeset/email-blocklist-helpers.md
@@ -1,0 +1,5 @@
+---
+"@logto/core-kit": minor
+---
+
+add reusable email blocklist validation and matching helpers

--- a/packages/toolkit/core-kit/src/email-blocklist.test.ts
+++ b/packages/toolkit/core-kit/src/email-blocklist.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { isEmailBlocklistItem, matchesEmailBlocklistItem } from './email-blocklist.js';
+
+describe('email blocklist helpers', () => {
+  describe('isEmailBlocklistItem', () => {
+    it('validates exact email and domain items without wildcard support', () => {
+      expect(isEmailBlocklistItem('foo@example.com')).toBe(true);
+      expect(isEmailBlocklistItem('@example.com')).toBe(true);
+      expect(isEmailBlocklistItem('foo*@example.com')).toBe(false);
+    });
+
+    it('validates wildcard email and domain items when wildcard support is enabled', () => {
+      expect(isEmailBlocklistItem('foo*@example.com', { allowWildcard: true })).toBe(true);
+      expect(isEmailBlocklistItem('*@example.com', { allowWildcard: true })).toBe(true);
+      expect(isEmailBlocklistItem('foo@*.example.com', { allowWildcard: true })).toBe(true);
+      expect(isEmailBlocklistItem('@foo.*', { allowWildcard: true })).toBe(true);
+      expect(isEmailBlocklistItem('@*.example.com', { allowWildcard: true })).toBe(true);
+    });
+
+    it.each(['foo*', '@*', 'foo@*', 'foo@example', '@example', '*@*.*'])(
+      'rejects malformed wildcard item: %s',
+      (item) => {
+        expect(isEmailBlocklistItem(item, { allowWildcard: true })).toBe(false);
+      }
+    );
+  });
+
+  describe('matchesEmailBlocklistItem', () => {
+    it('matches exact email and domain items case-insensitively', () => {
+      expect(matchesEmailBlocklistItem('foo@example.com', 'Foo@Example.com')).toBe(true);
+      expect(matchesEmailBlocklistItem('@example.com', 'foo@Example.com')).toBe(true);
+      expect(matchesEmailBlocklistItem('foo@example.com', 'bar@example.com')).toBe(false);
+      expect(matchesEmailBlocklistItem('@example.com', 'foo@example.org')).toBe(false);
+    });
+
+    it('matches wildcard email and domain items case-insensitively', () => {
+      expect(matchesEmailBlocklistItem('foo*@example.com', 'FooBar@Example.com')).toBe(true);
+      expect(matchesEmailBlocklistItem('*@example.com', 'anything@Example.com')).toBe(true);
+      expect(matchesEmailBlocklistItem('foo@*.example.com', 'Foo@bar.Example.com')).toBe(true);
+      expect(matchesEmailBlocklistItem('@foo.*', 'bar@Foo.com')).toBe(true);
+      expect(matchesEmailBlocklistItem('@*.example.com', 'bar@Foo.Example.com')).toBe(true);
+    });
+
+    it('treats regex metacharacters as literal characters in wildcard items', () => {
+      expect(matchesEmailBlocklistItem('foo.+*@example.com', 'foo.+bar@example.com')).toBe(true);
+      expect(matchesEmailBlocklistItem('foo.+*@example.com', 'fooxbar@example.com')).toBe(false);
+    });
+  });
+});

--- a/packages/toolkit/core-kit/src/email-blocklist.ts
+++ b/packages/toolkit/core-kit/src/email-blocklist.ts
@@ -1,0 +1,113 @@
+import { emailOrEmailDomainRegEx } from './regex.js';
+
+type EmailBlocklistItemOptions = Readonly<{
+  allowWildcard?: boolean;
+}>;
+
+const wildcard = '*';
+const emailSeparator = '@';
+const domainSeparator = '.';
+const whitespaceRegEx = /\s/u;
+const wildcardOnlyDomainRegEx = /^[*.]+$/u;
+const regexMetaCharacters = new Set([
+  '\\',
+  '^',
+  '$',
+  '+',
+  '?',
+  '.',
+  '(',
+  ')',
+  '|',
+  '[',
+  ']',
+  '{',
+  '}',
+]);
+
+const hasWildcard = (value: string) => value.includes(wildcard);
+
+const escapeRegExp = (value: string) =>
+  [...value]
+    .map((character) => (regexMetaCharacters.has(character) ? `\\${character}` : character))
+    .join('');
+
+const buildWildcardRegExp = (pattern: string) =>
+  new RegExp(`^${escapeRegExp(pattern).replaceAll(wildcard, '.*')}$`, 'u');
+
+const isValidWildcardLocalPart = (localPart: string) =>
+  localPart.length > 0 && !localPart.includes(emailSeparator) && !whitespaceRegEx.test(localPart);
+
+const isValidWildcardDomain = (domain: string) =>
+  domain.length > 0 &&
+  domain.includes(domainSeparator) &&
+  !domain.includes(emailSeparator) &&
+  !domain.includes(`${domainSeparator}${domainSeparator}`) &&
+  !domain.startsWith(domainSeparator) &&
+  !domain.endsWith(domainSeparator) &&
+  !whitespaceRegEx.test(domain) &&
+  !wildcardOnlyDomainRegEx.test(domain);
+
+/**
+ * Validates an email blocklist item.
+ *
+ * An item can be either a full email address (`foo@example.com`) or a domain entry
+ * prefixed with `@` (`@example.com`). When `allowWildcard` is enabled, `*` can be
+ * used inside the local part or domain while keeping the same email/domain shapes.
+ */
+export const isEmailBlocklistItem = (
+  value: string,
+  { allowWildcard = false }: EmailBlocklistItemOptions = {}
+) => {
+  if (!hasWildcard(value)) {
+    return emailOrEmailDomainRegEx.test(value);
+  }
+
+  if (!allowWildcard || whitespaceRegEx.test(value)) {
+    return false;
+  }
+
+  if (value.startsWith(emailSeparator)) {
+    return isValidWildcardDomain(value.slice(1));
+  }
+
+  const emailParts = value.split(emailSeparator);
+
+  if (emailParts.length !== 2) {
+    return false;
+  }
+
+  const [localPart, domain] = emailParts;
+
+  return (
+    localPart !== undefined &&
+    domain !== undefined &&
+    isValidWildcardLocalPart(localPart) &&
+    isValidWildcardDomain(domain)
+  );
+};
+
+/**
+ * Checks whether an email address matches an email blocklist item.
+ *
+ * Matching is case-insensitive. Domain items (`@example.com`) match only the email
+ * domain, while full email items match the complete email address.
+ */
+export const matchesEmailBlocklistItem = (item: string, email: string) => {
+  const normalizedItem = item.toLowerCase();
+  const normalizedEmail = email.toLowerCase();
+  const domain = normalizedEmail.split(emailSeparator)[1];
+
+  if (normalizedItem.startsWith(emailSeparator)) {
+    return Boolean(
+      domain &&
+        (hasWildcard(normalizedItem.slice(1))
+          ? buildWildcardRegExp(normalizedItem.slice(1)).test(domain)
+          : domain === normalizedItem.slice(1))
+    );
+  }
+
+  return hasWildcard(normalizedItem)
+    ? buildWildcardRegExp(normalizedItem).test(normalizedEmail)
+    : normalizedEmail === normalizedItem;
+};

--- a/packages/toolkit/core-kit/src/email-blocklist.ts
+++ b/packages/toolkit/core-kit/src/email-blocklist.ts
@@ -9,28 +9,10 @@ const emailSeparator = '@';
 const domainSeparator = '.';
 const whitespaceRegEx = /\s/u;
 const wildcardOnlyDomainRegEx = /^[*.]+$/u;
-const regexMetaCharacters = new Set([
-  '\\',
-  '^',
-  '$',
-  '+',
-  '?',
-  '.',
-  '(',
-  ')',
-  '|',
-  '[',
-  ']',
-  '{',
-  '}',
-]);
 
 const hasWildcard = (value: string) => value.includes(wildcard);
 
-const escapeRegExp = (value: string) =>
-  [...value]
-    .map((character) => (regexMetaCharacters.has(character) ? `\\${character}` : character))
-    .join('');
+const escapeRegExp = (value: string) => value.replaceAll(/[.+?^${}()|[\]\\]/gu, '\\$&');
 
 const buildWildcardRegExp = (pattern: string) =>
   new RegExp(`^${escapeRegExp(pattern).replaceAll(wildcard, '.*')}$`, 'u');

--- a/packages/toolkit/core-kit/src/index.ts
+++ b/packages/toolkit/core-kit/src/index.ts
@@ -1,5 +1,6 @@
 export * from './utils/index.js';
 export * from './custom-ui-csp.js';
+export * from './email-blocklist.js';
 export * from './regex.js';
 export * from './openid.js';
 export * from './models/index.js';


### PR DESCRIPTION
## Summary
Add reusable core-kit helpers for validating and matching email blocklist items. The helpers support exact address/domain entries and optional wildcard patterns with case-insensitive matching.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments