### PR TITLE
fix(core): match email blocklist case-insensitively

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -71,10 +71,10 @@ describe('validateEmailAgainstBlocklistPolicy', () => {
   });
 
   it('should throw if the email domain is in the custom blocklist', async () => {
-    const emails = ['test@foo.com', 'bar@foo.com'];
+    const emails = ['test@foo.com', 'bar@Foo.com'];
 
     for (const email of emails) {
-      // eslint-disable-next-line no-await-in-loop
+      // eslint-disable-next-line no-await-in-loop -- each assertion needs the current email in the expected error
       await expect(
         validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, email)
       ).rejects.toMatchError(
@@ -88,7 +88,7 @@ describe('validateEmailAgainstBlocklistPolicy', () => {
   });
 
   it('should throw if the email address is in the custom blocklist', async () => {
-    const email = 'foo@bar.com';
+    const email = 'Foo@Bar.com';
     await expect(
       validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, email)
     ).rejects.toMatchError(

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -153,13 +153,17 @@ export const validateEmailAgainstBlocklistPolicy = async (
 
   // Guard custom email address/domain if provided
   if (customBlocklist) {
+    const normalizedEmail = email.toLowerCase();
+    const normalizedDomain = domain.toLowerCase();
     const isCustomBlocklisted = customBlocklist.some((item) => {
+      const normalizedItem = item.toLowerCase();
+
       // Guard email domain
-      if (item.startsWith('@')) {
-        return domain === item.slice(1);
+      if (normalizedItem.startsWith('@')) {
+        return normalizedDomain === normalizedItem.slice(1);
       }
 
-      return email === item;
+      return normalizedEmail === normalizedItem;
     });
 
     assertThat(


### PR DESCRIPTION
## Summary
Fix custom email blocklist matching so exact email and domain entries are compared case-insensitively. The existing validation and stored custom blocklist values are preserved.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments