### PR TITLE
feat(core): support wildcard email blocklist entries

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -1,6 +1,7 @@
 import { type EmailBlocklistPolicy } from '@logto/schemas';
 import { deduplicate } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 
 import {
@@ -11,8 +12,17 @@ import {
 
 const invalidCustomBlockList = ['bar', 'bar@foo', '@foo', '@foo.', 'bar@foo.'];
 const validCustomBlockList = ['bar@foo.com', '@foo.com', 'abc.bar@foo.xyz', 'bar@foo.com'];
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', isDevFeaturesEnabled);
+};
 
 describe('parseEmailBlocklistPolicy', () => {
+  afterEach(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
   it.each(invalidCustomBlockList)(
     'should throw error for invalid custom block list item: %s',
     (item) => {
@@ -32,6 +42,29 @@ describe('parseEmailBlocklistPolicy', () => {
   it('should pass the validation with valid format and deduplicate items', () => {
     const parsed = parseEmailBlocklistPolicy({ customBlocklist: validCustomBlockList });
     expect(parsed).toEqual({ customBlocklist: deduplicate(validCustomBlockList) });
+  });
+
+  it('should reject wildcard items when dev features are disabled', () => {
+    setDevFeaturesEnabled(false);
+
+    expect(() => {
+      parseEmailBlocklistPolicy({ customBlocklist: ['foo*@bar.com'] });
+    }).toMatchError(
+      new RequestError({
+        code: 'sign_in_experiences.invalid_custom_email_blocklist_format',
+        items: ['foo*@bar.com'],
+        status: 400,
+      })
+    );
+  });
+
+  it('should allow wildcard items when dev features are enabled', () => {
+    setDevFeaturesEnabled(true);
+
+    const customBlocklist = ['foo*@bar.com', '*@example.com', '@foo.*', '@*.example.com'];
+    const parsed = parseEmailBlocklistPolicy({ customBlocklist });
+
+    expect(parsed).toEqual({ customBlocklist });
   });
 });
 
@@ -98,6 +131,24 @@ describe('validateEmailAgainstBlocklistPolicy', () => {
         email,
       })
     );
+  });
+
+  it('should throw if the email address matches a wildcard custom blocklist item', async () => {
+    const policy: EmailBlocklistPolicy = {
+      customBlocklist: ['foo*@bar.com', '@*.example.com'],
+    };
+    const emails = ['FooBar@bar.com', 'test@Foo.example.com'];
+
+    for (const email of emails) {
+      // eslint-disable-next-line no-await-in-loop -- each assertion needs the current email in the expected error
+      await expect(validateEmailAgainstBlocklistPolicy(policy, email)).rejects.toMatchError(
+        new RequestError({
+          code: 'session.email_blocklist.email_not_allowed',
+          status: 422,
+          email,
+        })
+      );
+    }
   });
 
   it('should pass the blocklist policy validation', async () => {

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -1,4 +1,4 @@
-import { emailOrEmailDomainRegEx } from '@logto/core-kit';
+import { isEmailBlocklistItem, matchesEmailBlocklistItem } from '@logto/core-kit';
 import { type EmailBlocklistPolicy } from '@logto/schemas';
 import { conditional, deduplicate } from '@silverhand/essentials';
 import { got } from 'got';
@@ -8,11 +8,11 @@ import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
-const validateCustomBlockListFormat = (list: string[]) => {
-  const invalidItems = new Set();
+const validateCustomBlockListFormat = (list: string[], allowWildcard: boolean) => {
+  const invalidItems = new Set<string>();
 
   for (const item of list) {
-    if (!emailOrEmailDomainRegEx.test(item)) {
+    if (!isEmailBlocklistItem(item, { allowWildcard })) {
       invalidItems.add(item);
     }
   }
@@ -22,7 +22,10 @@ const validateCustomBlockListFormat = (list: string[]) => {
 
 const parseCustomBlocklist = (customBlocklist: string[]) => {
   const deduplicated = deduplicate(customBlocklist);
-  const invalidItems = validateCustomBlockListFormat(deduplicated);
+  const invalidItems = validateCustomBlockListFormat(
+    deduplicated,
+    EnvSet.values.isDevFeaturesEnabled
+  );
 
   if (invalidItems.size > 0) {
     throw new RequestError({
@@ -153,18 +156,9 @@ export const validateEmailAgainstBlocklistPolicy = async (
 
   // Guard custom email address/domain if provided
   if (customBlocklist) {
-    const normalizedEmail = email.toLowerCase();
-    const normalizedDomain = domain.toLowerCase();
-    const isCustomBlocklisted = customBlocklist.some((item) => {
-      const normalizedItem = item.toLowerCase();
-
-      // Guard email domain
-      if (normalizedItem.startsWith('@')) {
-        return normalizedDomain === normalizedItem.slice(1);
-      }
-
-      return normalizedEmail === normalizedItem;
-    });
+    const isCustomBlocklisted = customBlocklist.some((item) =>
+      matchesEmailBlocklistItem(item, email)
+    );
 
     assertThat(
       !isCustomBlocklisted,


### PR DESCRIPTION
## Summary
Wire Core custom email blocklist validation and matching through the shared core-kit helpers. This adds support for wildcard custom blocklist entries while preserving existing exact email and domain entry behavior.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments