### PR TITLE
fix(toolkit): tighten email domain regex

### DIFF
--- a/.changeset/email-domain-regex.md
+++ b/.changeset/email-domain-regex.md
@@ -1,0 +1,5 @@
+---
+"@logto/core-kit": patch
+---
+
+fix email or email domain validation to match complete values and stricter domain labels

--- a/packages/toolkit/core-kit/src/regex.test.ts
+++ b/packages/toolkit/core-kit/src/regex.test.ts
@@ -31,22 +31,46 @@ describe('Regular expressions should work as expected', () => {
       expect(domainRegEx.test('foo.bar@')).toBe(false);
       expect(domainRegEx.test('foo.bar@com')).toBe(false);
       expect(emailOrEmailDomainRegEx.test('foo.bar@.com')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('foo@example')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('foo@-example.com')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('foo@example-.com')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('foo@example..com')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('foo@example_.com')).toBe(false);
     });
 
     it('should allow full email address', () => {
       expect(emailOrEmailDomainRegEx.test('bar@example.com')).toBe(true);
       expect(emailOrEmailDomainRegEx.test('foo.bar@example.com')).toBe(true);
       expect(emailOrEmailDomainRegEx.test('foo.bar@example-bar.com')).toBe(true);
+      expect(emailOrEmailDomainRegEx.test('foo+bar@example.com')).toBe(true);
+      expect(emailOrEmailDomainRegEx.test('foo@example.c')).toBe(true);
+    });
+
+    it('should not allow partial full email address matches', () => {
+      expect(emailOrEmailDomainRegEx.test('foo@example.com extra')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('foo@example.com,extra')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('foo@example.com\n')).toBe(false);
     });
 
     it('should not allow partial email domain without @ mark', () => {
       expect(emailOrEmailDomainRegEx.test('foo.com')).toBe(false);
       expect(emailOrEmailDomainRegEx.test('foo.bar.com')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('example')).toBe(false);
     });
 
     it('should allow email domain with @ mark', () => {
       expect(emailOrEmailDomainRegEx.test('@example.com')).toBe(true);
       expect(emailOrEmailDomainRegEx.test('@foo.bar.com')).toBe(true);
+      expect(emailOrEmailDomainRegEx.test('@example-bar.com')).toBe(true);
+    });
+
+    it('should not allow invalid email domain with @ mark', () => {
+      expect(emailOrEmailDomainRegEx.test('@example')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('@-example.com')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('@example-.com')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('@example..com')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('@example_.com')).toBe(false);
+      expect(emailOrEmailDomainRegEx.test('@example.com extra')).toBe(false);
     });
   });
 });

--- a/packages/toolkit/core-kit/src/regex.ts
+++ b/packages/toolkit/core-kit/src/regex.ts
@@ -1,6 +1,7 @@
 export const emailRegEx = /^\S+@\S+\.\S+$/;
 /** Validates full email address or email domain. */
-export const emailOrEmailDomainRegEx = /^\S+@\S+\.\S+|^@\S+\.\S+$/;
+export const emailOrEmailDomainRegEx =
+  /^(?:[^\s@]+@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+|@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)$(?![\s\S])/u;
 export const phoneRegEx = /^\d+$/;
 export const phoneInputRegEx = /^\+?[\d-( )]+$/;
 export const usernameRegEx = /^[A-Z_a-z]\w*$/;


### PR DESCRIPTION
## Summary
Fix the shared email-or-domain validation regex to match complete values and require stricter domain labels. This prevents partial email matches and rejects malformed domain labels such as leading or trailing hyphens, double dots, and unsupported domain characters.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments