### PR TITLE
fix(core): don't offer a profile-linked verification-code factor as MFA

### DIFF
--- a/.changeset/mfa-profile-linked-factor-loop.md
+++ b/.changeset/mfa-profile-linked-factor-loop.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": patch
+---
+
+fix mandatory-MFA enrollment loop when a verification-code factor is also a sign-up identifier
+
+When `PhoneVerificationCode` (or `EmailVerificationCode`) is enabled as an MFA factor and the same identifier is also required at sign-up, a new user gets stuck in an unrecoverable mandatory-MFA loop: the factor is offered in `availableFactors`, but binding it fails with `{phone,email}_exists_in_profile` because the identifier is already on the profile, so the mandatory-MFA gate is never satisfied.
+
+The offer layer now filters out any verification-code factor whose identifier is already on the user's profile, keeping the offered set consistent with what can actually be bound. Both `user.missing_mfa` and `session.mfa.suggest_additional_mfa` derive their `availableFactors` from this filtered set.

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -117,6 +117,29 @@ const isPasskeySkipped = (logtoConfig: JsonObject): boolean => {
   return parsed.success ? parsed.data[userPasskeySignInDataKey].skipped === true : false;
 };
 
+/**
+ * Remove verification-code factors whose identifier is already on the user's profile.
+ *
+ * A `PhoneVerificationCode` / `EmailVerificationCode` factor can only be bound if the user
+ * does NOT already have that identifier on their profile — `profile-validator` rejects an
+ * already-present identifier with `{phone,email}_exists_in_profile`. So when the user already
+ * has a `primaryPhone`/`primaryEmail` (e.g. because it is a sign-up identifier), offering that
+ * factor as an `availableFactors` option is a dead end: the user picks it, verifies the OTP,
+ * and the bind fails — leaving a mandatory-MFA gate permanently unsatisfiable (an unrecoverable
+ * enrollment loop). Filtering it out at the offer layer keeps the offered set consistent with
+ * what can actually be bound.
+ */
+const filterOutProfileLinkedFactors = (factors: MfaFactor[], user: User): MfaFactor[] =>
+  factors.filter((factor) => {
+    if (factor === MfaFactor.PhoneVerificationCode && user.primaryPhone) {
+      return false;
+    }
+    if (factor === MfaFactor.EmailVerificationCode && user.primaryEmail) {
+      return false;
+    }
+    return true;
+  });
+
 type SubmitMfaValidationContext = {
   mfaSettings: MfaSettings;
   user: User;
@@ -511,7 +534,14 @@ export class Mfa {
     }
 
     // Use configured factors for policy fulfillment; backup code is asserted separately below.
-    const configuredFactors = await this.signInExperienceValidator.getConfiguredMfaFactors();
+    // Drop any verification-code factor whose identifier is already on the user's profile:
+    // such a factor can never be bound (`profile-validator` rejects it with
+    // `{email,phone}_exists_in_profile`), so offering it in `availableFactors` dead-locks
+    // a mandatory-MFA gate in an unrecoverable loop.
+    const configuredFactors = filterOutProfileLinkedFactors(
+      await this.signInExperienceValidator.getConfiguredMfaFactors(),
+      identifiedUser
+    );
 
     const { userFactors: factorsInUser } = submitMfaValidationContext;
     const factorsInBind = this.bindMfaFactorsArray.map(({ type }) => type);


### PR DESCRIPTION
## Summary

Fixes an unrecoverable mandatory-MFA enrollment loop that occurs when a verification-code factor (`PhoneVerificationCode` / `EmailVerificationCode`) is enabled as an MFA factor **and** the same identifier is also required at sign-up.

Closes #9123.

## The bug

With a Sign-in Experience where:
- **Sign-up identifiers:** `email` + `phone`, `verify: true`
- **MFA:** policy `Mandatory`, factors include `PhoneVerificationCode`

a new user is offered `PhoneVerificationCode` in `availableFactors`, but binding it fails with `user.phone_exists_in_profile` — the phone is already on the profile because it's a sign-up identifier. The mandatory-MFA gate is therefore never satisfiable: the user picks the factor, verifies the OTP, the bind fails, `submit` returns `user.missing_mfa` again — an infinite loop. The same applies to email.

The offered factor set (`getConfiguredMfaFactors`) and the bind guard (`profile-validator`, `{phone,email}_exists_in_profile`) are inconsistent: the offer layer proposes a factor the bind layer will always reject.

## The fix

Filter out any verification-code factor whose identifier is already on the user's profile, at the offer layer (the `getConfiguredMfaFactors` consumer in `assertUserMandatoryMfaFulfilled`). This keeps the offered set consistent with what can actually be bound.

Because both `user.missing_mfa` and `session.mfa.suggest_additional_mfa` derive their `availableFactors` from this same filtered set (and the suggestion guard receives the filtered list), the single filter fixes every offer path — no other layer needs changing. `Totp` / `BackupCode` remain unaffected, so a user still has a bindable factor under a mandatory policy.

## Reproduction

Reproduced on a clean `ghcr.io/logto-io/logto:latest` (v1.41.0) with the config above; full step-by-step (with exact 422 responses) is in #9123.

## Notes

- No behavior change for configurations where the identifier is not a sign-up identifier (the filtered factor is only dropped when the user actually already has that `primaryPhone` / `primaryEmail`).
- A changeset is included (`@logto/core` patch).
