### PR TITLE
feat(console): add hosted email cap banner

### DIFF
--- a/packages/console/src/components/HostedEmailCapBanner/index.module.scss
+++ b/packages/console/src/components/HostedEmailCapBanner/index.module.scss
@@ -1,0 +1,5 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  padding: _.unit(4) _.unit(6) 0;
+}

--- a/packages/console/src/components/HostedEmailCapBanner/index.tsx
+++ b/packages/console/src/components/HostedEmailCapBanner/index.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+
+import { ConnectorsTabs } from '@/consts/page-tabs';
+import { tenantSettingsPage } from '@/consts/pages';
+import InlineNotification from '@/ds-components/InlineNotification';
+import TextLink from '@/ds-components/TextLink';
+import useHostedEmailUsage from '@/pages/ConnectorDetails/EmailUsage/use-hosted-email-usage';
+
+import styles from './index.module.scss';
+
+/** Surface the banner once either window reaches this fraction of its cap. */
+const bannerThreshold = 0.8;
+
+const connectorsPasswordlessPage = `/connectors/${ConnectorsTabs.Passwordless}`;
+
+/**
+ * Global banner for the hosted email service cap, shown app-wide (below the topbar) once daily or
+ * monthly usage crosses {@link bannerThreshold}. Two states — approaching (>=80%) and reached (at
+ * the cap, a hard block that can interrupt sign-in emails) — each offering to connect an own email
+ * provider or upgrade.
+ *
+ * Gated behind `isDevFeaturesEnabled` and to capped free/dev tenants (paid tenants report `null`
+ * limits, so nothing renders). Dismissible per session; re-shown if the state escalates from
+ * approaching to reached.
+ */
+function HostedEmailCapBanner() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const { isEnabled, data } = useHostedEmailUsage();
+  const [dismissedSituation, setDismissedSituation] = useState<'approaching' | 'reached'>();
+
+  if (!isEnabled || !data) {
+    return null;
+  }
+
+  const { dailyUsage, dailyLimit, periodUsage, periodLimit } = data;
+  // Guard against non-positive limits so a `0` cap can't yield NaN/Infinity ratios.
+  const dailyRatio = dailyLimit !== null && dailyLimit > 0 ? dailyUsage / dailyLimit : 0;
+  const monthlyRatio = periodLimit !== null && periodLimit > 0 ? periodUsage / periodLimit : 0;
+  const ratio = Math.max(dailyRatio, monthlyRatio);
+
+  if (ratio < bannerThreshold) {
+    return null;
+  }
+
+  const situation = ratio >= 1 ? 'reached' : 'approaching';
+
+  if (situation === dismissedSituation) {
+    return null;
+  }
+
+  return (
+    <div className={styles.container}>
+      <InlineNotification
+        severity={situation === 'reached' ? 'error' : 'alert'}
+        action="general.got_it"
+        onClick={() => {
+          setDismissedSituation(situation);
+        }}
+      >
+        <Trans
+          components={{
+            provider: <TextLink to={connectorsPasswordlessPage} />,
+            upgrade: <TextLink to={tenantSettingsPage} />,
+          }}
+        >
+          {t(`connector_details.logto_email.hosted_email_usage.banner.${situation}`)}
+        </Trans>
+      </InlineNotification>
+    </div>
+  );
+}
+
+export default HostedEmailCapBanner;

--- a/packages/console/src/consts/pages.ts
+++ b/packages/console/src/consts/pages.ts
@@ -1,3 +1,6 @@
 import { TenantSettingsTabs } from '.';
 
 export const subscriptionPage = `/tenant-settings/${TenantSettingsTabs.Subscription}`;
+
+/** The tenant settings landing route; redirects to the first available tab. Safe for all tenants (unlike {@link subscriptionPage}, which is not registered for dev tenants). */
+export const tenantSettingsPage = '/tenant-settings';

--- a/packages/console/src/containers/AppContent/index.tsx
+++ b/packages/console/src/containers/AppContent/index.tsx
@@ -4,6 +4,7 @@ import { Navigate, Outlet, useParams } from 'react-router-dom';
 
 import { type SubscriptionCountBasedUsage } from '@/cloud/types/router';
 import AppLoading from '@/components/AppLoading';
+import HostedEmailCapBanner from '@/components/HostedEmailCapBanner';
 import Topbar from '@/components/Topbar';
 import { isCloud } from '@/consts/env';
 import SubscriptionDataProvider from '@/contexts/SubscriptionDataProvider';
@@ -81,7 +82,11 @@ export default function AppContent() {
         <Topbar className={conditional(scrollTop && styles.topbarShadow)} />
         {isTenantSuspended && <TenantSuspendedPage />}
         {!isTenantSuspended && (
-          <Outlet context={{ scrollableContent } satisfies AppContentOutletContext} />
+          <>
+            {/* Key by tenant so the banner's per-session dismissal state resets on tenant switch. */}
+            <HostedEmailCapBanner key={currentTenant.id} />
+            <Outlet context={{ scrollableContent } satisfies AppContentOutletContext} />
+          </>
         )}
       </div>
       <TenantNotificationContainer />

--- a/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
@@ -26,7 +26,7 @@ import { convertResponseToForm } from '@/utils/connector-form';
 import { trySubmitSafe } from '@/utils/form';
 import { removeFalsyValues } from '@/utils/object';
 
-import { getHostedEmailUsageKey } from '../EmailUsage';
+import { getHostedEmailUsageKey } from '../EmailUsage/use-hosted-email-usage';
 
 import EmailServiceConnectorForm from './EmailServiceConnectorForm';
 

--- a/packages/console/src/pages/ConnectorDetails/EmailUsage/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/EmailUsage/index.tsx
@@ -1,16 +1,11 @@
 import { Theme } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
-import { useContext } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
-import useSWR from 'swr';
 
 import EmailSentIconDark from '@/assets/icons/email-sent-dark.svg?react';
 import EmailSentIconLight from '@/assets/icons/email-sent.svg?react';
 import Tip from '@/assets/icons/tip.svg?react';
-import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { builtInEmailService } from '@/consts/external-links';
-import { TenantsContext } from '@/contexts/TenantsProvider';
 import DynamicT from '@/ds-components/DynamicT';
 import IconButton from '@/ds-components/IconButton';
 import TextLink from '@/ds-components/TextLink';
@@ -19,13 +14,7 @@ import useDocumentationUrl from '@/hooks/use-documentation-url';
 import useTheme from '@/hooks/use-theme';
 
 import styles from './index.module.scss';
-
-/**
- * SWR cache key for the per-tenant hosted-email usage endpoint. Exported so the connector test
- * can revalidate it after a send consumes quota.
- */
-export const getHostedEmailUsageKey = (tenantId: string) =>
-  `/api/tenants/${tenantId}/subscription/hosted-email-usage`;
+import useHostedEmailUsage from './use-hosted-email-usage';
 
 type UsageWindowProps = {
   readonly windowKey: 'daily' | 'monthly';
@@ -60,17 +49,7 @@ function EmailUsage({ usage, isCompact }: Props) {
   const theme = useTheme();
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { getDocumentationUrl } = useDocumentationUrl();
-  const { currentTenantId } = useContext(TenantsContext);
-  const cloudApi = useCloudApi({ hideErrorToast: true });
-
-  const isHostedEmailUsageEnabled = isCloud && isDevFeaturesEnabled;
-  const { data: windowedUsage } = useSWR(
-    isHostedEmailUsageEnabled && currentTenantId && getHostedEmailUsageKey(currentTenantId),
-    async () =>
-      cloudApi.get('/api/tenants/:tenantId/subscription/hosted-email-usage', {
-        params: { tenantId: currentTenantId },
-      })
-  );
+  const { isEnabled: isHostedEmailUsageEnabled, data: windowedUsage } = useHostedEmailUsage();
 
   const icon = theme === Theme.Light ? <EmailSentIconLight /> : <EmailSentIconDark />;
   const tipPhraseKey = isHostedEmailUsageEnabled

--- a/packages/console/src/pages/ConnectorDetails/EmailUsage/use-hosted-email-usage.ts
+++ b/packages/console/src/pages/ConnectorDetails/EmailUsage/use-hosted-email-usage.ts
@@ -1,0 +1,36 @@
+import { useContext } from 'react';
+import useSWR from 'swr';
+
+import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { TenantsContext } from '@/contexts/TenantsProvider';
+
+/**
+ * SWR cache key for the per-tenant hosted-email usage endpoint. Exported so the connector test
+ * can revalidate it after a send consumes quota.
+ */
+export const getHostedEmailUsageKey = (tenantId: string) =>
+  `/api/tenants/${tenantId}/subscription/hosted-email-usage`;
+
+/**
+ * Fetches the per-tenant daily and monthly hosted-email usage and limits (Cloud + dev-features
+ * only). Shared by the Connector Details usage card and the cap notices — SWR dedupes the request
+ * so both consumers hit the endpoint once.
+ */
+const useHostedEmailUsage = () => {
+  const { currentTenantId } = useContext(TenantsContext);
+  const cloudApi = useCloudApi({ hideErrorToast: true });
+
+  const isEnabled = isCloud && isDevFeaturesEnabled;
+  const { data } = useSWR(
+    isEnabled && currentTenantId && getHostedEmailUsageKey(currentTenantId),
+    async () =>
+      cloudApi.get('/api/tenants/:tenantId/subscription/hosted-email-usage', {
+        params: { tenantId: currentTenantId },
+      })
+  );
+
+  return { isEnabled, data };
+};
+
+export default useHostedEmailUsage;

--- a/packages/phrases/src/locales/ar/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'شهري <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'شهري <value>{{usage, number}}</value>',
       tip: 'تتضمن خطتا Free و Development حدودًا يومية وشهرية للبريد الإلكتروني المدمج.',
+      banner: {
+        approaching:
+          'أنت تقترب من حد إرسال البريد الإلكتروني المدمج من Logto. <provider>قم بتوصيل مزود البريد الإلكتروني الخاص بك</provider> أو <upgrade>قم بترقية خطتك</upgrade> لمواصلة استخدام البريد الإلكتروني المدمج من Logto.',
+        reached:
+          'لقد وصلت إلى حد إرسال البريد الإلكتروني المدمج من Logto، مما قد يعطل رسائل تسجيل الدخول. <provider>قم بتوصيل مزود البريد الإلكتروني الخاص بك</provider> أو <upgrade>قم بترقية خطتك</upgrade> لمواصلة استخدام البريد الإلكتروني المدمج من Logto.',
+      },
     },
     email_template_title: 'قالب البريد الإلكتروني',
     template_description:

--- a/packages/phrases/src/locales/de/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Monatlich <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Monatlich <value>{{usage, number}}</value>',
       tip: 'Die Tarife Free und Development enthalten tägliche und monatliche Limits für den integrierten E-Mail-Versand.',
+      banner: {
+        approaching:
+          'Sie nähern sich dem Sendelimit Ihres integrierten Logto-E-Mail-Versands. <provider>Verbinden Sie Ihren eigenen E-Mail-Anbieter</provider> oder <upgrade>aktualisieren Sie Ihren Tarif</upgrade>, um den integrierten Logto-E-Mail-Versand weiter zu nutzen.',
+        reached:
+          'Sie haben das Sendelimit Ihres integrierten Logto-E-Mail-Versands erreicht, was Anmelde-E-Mails unterbrechen kann. <provider>Verbinden Sie Ihren eigenen E-Mail-Anbieter</provider> oder <upgrade>aktualisieren Sie Ihren Tarif</upgrade>, um den integrierten Logto-E-Mail-Versand weiter zu nutzen.',
+      },
     },
     email_template_title: 'E-Mail-Vorlage',
     template_description:

--- a/packages/phrases/src/locales/en/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Monthly <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Monthly <value>{{usage, number}}</value>',
       tip: 'Free and Development plans include daily and monthly hosted email limits.',
+      banner: {
+        approaching:
+          "You're approaching your Logto hosted email sending limit. <provider>Connect your own email provider</provider>, or <upgrade>upgrade your plan</upgrade> to keep using Logto hosted email.",
+        reached:
+          "You've reached your Logto hosted email sending limit, which may interrupt sign-in emails. <provider>Connect your own email provider</provider>, or <upgrade>upgrade your plan</upgrade> to keep using Logto hosted email.",
+      },
     },
     email_template_title: 'Email Template',
     template_description:

--- a/packages/phrases/src/locales/es/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Mensual <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Mensual <value>{{usage, number}}</value>',
       tip: 'Los planes Free y Development incluyen límites diarios y mensuales de correo electrónico integrado.',
+      banner: {
+        approaching:
+          'Estás alcanzando el límite de envío de tu correo electrónico integrado de Logto. <provider>Conecta tu propio proveedor de correo</provider> o <upgrade>mejora tu plan</upgrade> para seguir usando el correo integrado de Logto.',
+        reached:
+          'Has alcanzado el límite de envío de tu correo electrónico integrado de Logto, lo que puede interrumpir los correos de inicio de sesión. <provider>Conecta tu propio proveedor de correo</provider> o <upgrade>mejora tu plan</upgrade> para seguir usando el correo integrado de Logto.',
+      },
     },
     email_template_title: 'Plantilla de correo electrónico',
     template_description:

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'ماهانه <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'ماهانه <value>{{usage, number}}</value>',
       tip: 'طرح‌های Free و Development شامل محدودیت‌های روزانه و ماهانه ایمیل داخلی هستند.',
+      banner: {
+        approaching:
+          'شما به حد ارسال ایمیل داخلی Logto نزدیک می‌شوید. برای ادامه استفاده از ایمیل داخلی Logto، <provider>ارائه‌دهنده ایمیل خود را متصل کنید</provider> یا <upgrade>طرح خود را ارتقا دهید</upgrade>.',
+        reached:
+          'به حد ارسال ایمیل داخلی Logto رسیده‌اید که ممکن است ایمیل‌های ورود را مختل کند. برای ادامه استفاده از ایمیل داخلی Logto، <provider>ارائه‌دهنده ایمیل خود را متصل کنید</provider> یا <upgrade>طرح خود را ارتقا دهید</upgrade>.',
+      },
     },
     email_template_title: 'قالب ایمیل',
     template_description:

--- a/packages/phrases/src/locales/fr/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Mensuel <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Mensuel <value>{{usage, number}}</value>',
       tip: 'Les forfaits Free et Development incluent des limites quotidiennes et mensuelles pour les emails intégrés.',
+      banner: {
+        approaching:
+          "Vous approchez de la limite d'envoi de vos emails intégrés Logto. <provider>Connectez votre propre fournisseur d'email</provider> ou <upgrade>mettez à niveau votre forfait</upgrade> pour continuer à utiliser les emails intégrés Logto.",
+        reached:
+          "Vous avez atteint la limite d'envoi de vos emails intégrés Logto, ce qui peut interrompre les emails de connexion. <provider>Connectez votre propre fournisseur d'email</provider> ou <upgrade>mettez à niveau votre forfait</upgrade> pour continuer à utiliser les emails intégrés Logto.",
+      },
     },
     email_template_title: 'Modèle d’email',
     template_description:

--- a/packages/phrases/src/locales/it/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Mensile <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Mensile <value>{{usage, number}}</value>',
       tip: 'I piani Free e Development includono limiti giornalieri e mensili per le email integrate.',
+      banner: {
+        approaching:
+          'Stai per raggiungere il limite di invio delle email integrate di Logto. <provider>Collega il tuo provider email</provider> o <upgrade>aggiorna il tuo piano</upgrade> per continuare a usare le email integrate di Logto.',
+        reached:
+          'Hai raggiunto il limite di invio delle email integrate di Logto, il che può interrompere le email di accesso. <provider>Collega il tuo provider email</provider> o <upgrade>aggiorna il tuo piano</upgrade> per continuare a usare le email integrate di Logto.',
+      },
     },
     email_template_title: 'Modello email',
     template_description:

--- a/packages/phrases/src/locales/ja/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: '月次 <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: '月次 <value>{{usage, number}}</value>',
       tip: 'Free および Development プランには、組み込みメールの日次および月次の上限が含まれます。',
+      banner: {
+        approaching:
+          'Logto の組み込みメールの送信上限に近づいています。Logto の組み込みメールを引き続き使用するには、<provider>独自のメールプロバイダーを接続</provider>するか、<upgrade>プランをアップグレード</upgrade>してください。',
+        reached:
+          'Logto の組み込みメールの送信上限に達しました。サインインメールが中断される可能性があります。Logto の組み込みメールを引き続き使用するには、<provider>独自のメールプロバイダーを接続</provider>するか、<upgrade>プランをアップグレード</upgrade>してください。',
+      },
     },
     email_template_title: 'メールテンプレート',
     template_description:

--- a/packages/phrases/src/locales/ko/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/connector-details.ts
@@ -43,6 +43,12 @@ const connector_details = {
       monthly: '월간 <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: '월간 <value>{{usage, number}}</value>',
       tip: 'Free 및 Development 요금제에는 일일 및 월간 내장형 이메일 한도가 포함됩니다.',
+      banner: {
+        approaching:
+          'Logto 내장형 이메일 발송 한도에 근접하고 있습니다. Logto 내장형 이메일을 계속 사용하려면 <provider>자체 이메일 공급자를 연결</provider>하거나 <upgrade>요금제를 업그레이드</upgrade>하세요.',
+        reached:
+          'Logto 내장형 이메일 발송 한도에 도달하여 로그인 이메일이 중단될 수 있습니다. Logto 내장형 이메일을 계속 사용하려면 <provider>자체 이메일 공급자를 연결</provider>하거나 <upgrade>요금제를 업그레이드</upgrade>하세요.',
+      },
     },
     email_template_title: '이메일 템플릿',
     template_description:

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Miesięcznie <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Miesięcznie <value>{{usage, number}}</value>',
       tip: 'Plany Free i Development obejmują dzienne i miesięczne limity wbudowanej poczty e-mail.',
+      banner: {
+        approaching:
+          'Zbliżasz się do limitu wysyłki wbudowanej poczty e-mail Logto. <provider>Podłącz własnego dostawcę poczty e-mail</provider> lub <upgrade>ulepsz swój plan</upgrade>, aby nadal korzystać z wbudowanej poczty e-mail Logto.',
+        reached:
+          'Osiągnięto limit wysyłki wbudowanej poczty e-mail Logto, co może przerwać e-maile logowania. <provider>Podłącz własnego dostawcę poczty e-mail</provider> lub <upgrade>ulepsz swój plan</upgrade>, aby nadal korzystać z wbudowanej poczty e-mail Logto.',
+      },
     },
     email_template_title: 'Szablon e-maila',
     template_description:

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Mensal <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Mensal <value>{{usage, number}}</value>',
       tip: 'Os planos Free e Development incluem limites diários e mensais de e-mail integrado.',
+      banner: {
+        approaching:
+          'Você está se aproximando do limite de envio do seu e-mail integrado da Logto. <provider>Conecte seu próprio provedor de e-mail</provider> ou <upgrade>atualize seu plano</upgrade> para continuar usando o e-mail integrado da Logto.',
+        reached:
+          'Você atingiu o limite de envio do seu e-mail integrado da Logto, o que pode interromper os e-mails de login. <provider>Conecte seu próprio provedor de e-mail</provider> ou <upgrade>atualize seu plano</upgrade> para continuar usando o e-mail integrado da Logto.',
+      },
     },
     email_template_title: 'Modelo de e-mail',
     template_description:

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Mensal <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Mensal <value>{{usage, number}}</value>',
       tip: 'Os planos Free e Development incluem limites diários e mensais de e-mail interno.',
+      banner: {
+        approaching:
+          'Está a aproximar-se do limite de envio do seu e-mail interno da Logto. <provider>Ligue o seu próprio fornecedor de e-mail</provider> ou <upgrade>atualize o seu plano</upgrade> para continuar a usar o e-mail interno da Logto.',
+        reached:
+          'Atingiu o limite de envio do seu e-mail interno da Logto, o que pode interromper os e-mails de início de sessão. <provider>Ligue o seu próprio fornecedor de e-mail</provider> ou <upgrade>atualize o seu plano</upgrade> para continuar a usar o e-mail interno da Logto.',
+      },
     },
     email_template_title: 'Modelo de e-mail',
     template_description:

--- a/packages/phrases/src/locales/ru/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Ежемесячно <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Ежемесячно <value>{{usage, number}}</value>',
       tip: 'Планы Free и Development включают ежедневные и ежемесячные лимиты встроенной электронной почты.',
+      banner: {
+        approaching:
+          'Вы приближаетесь к лимиту отправки встроенной почты Logto. <provider>Подключите собственного почтового провайдера</provider> или <upgrade>обновите тариф</upgrade>, чтобы продолжить использовать встроенную почту Logto.',
+        reached:
+          'Вы достигли лимита отправки встроенной почты Logto, что может прервать письма для входа. <provider>Подключите собственного почтового провайдера</provider> или <upgrade>обновите тариф</upgrade>, чтобы продолжить использовать встроенную почту Logto.',
+      },
     },
     email_template_title: 'Шаблон электронной почты',
     template_description:

--- a/packages/phrases/src/locales/th/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'รายเดือน <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'รายเดือน <value>{{usage, number}}</value>',
       tip: 'แผน Free และ Development มีขีดจำกัดอีเมลในตัวรายวันและรายเดือน',
+      banner: {
+        approaching:
+          'คุณกำลังใกล้ถึงขีดจำกัดการส่งอีเมลในตัวของ Logto <provider>เชื่อมต่อผู้ให้บริการอีเมลของคุณเอง</provider> หรือ <upgrade>อัปเกรดแผนของคุณ</upgrade> เพื่อใช้อีเมลในตัวของ Logto ต่อไป',
+        reached:
+          'คุณถึงขีดจำกัดการส่งอีเมลในตัวของ Logto แล้ว ซึ่งอาจขัดจังหวะอีเมลการเข้าสู่ระบบ <provider>เชื่อมต่อผู้ให้บริการอีเมลของคุณเอง</provider> หรือ <upgrade>อัปเกรดแผนของคุณ</upgrade> เพื่อใช้อีเมลในตัวของ Logto ต่อไป',
+      },
     },
     email_template_title: 'แม่แบบอีเมล',
     template_description:

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/connector-details.ts
@@ -44,6 +44,12 @@ const connector_details = {
       monthly: 'Aylık <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: 'Aylık <value>{{usage, number}}</value>',
       tip: 'Free ve Development planları, günlük ve aylık dahili e-posta limitleri içerir.',
+      banner: {
+        approaching:
+          'Logto dahili e-posta gönderim sınırınıza yaklaşıyorsunuz. Logto dahili e-postayı kullanmaya devam etmek için <provider>kendi e-posta sağlayıcınızı bağlayın</provider> veya <upgrade>planınızı yükseltin</upgrade>.',
+        reached:
+          'Logto dahili e-posta gönderim sınırınıza ulaştınız, bu da oturum açma e-postalarını kesintiye uğratabilir. Logto dahili e-postayı kullanmaya devam etmek için <provider>kendi e-posta sağlayıcınızı bağlayın</provider> veya <upgrade>planınızı yükseltin</upgrade>.',
+      },
     },
     email_template_title: 'E-posta Şablonu',
     template_description:

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/connector-details.ts
@@ -42,6 +42,12 @@ const connector_details = {
       monthly: '每月 <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: '每月 <value>{{usage, number}}</value>',
       tip: 'Free 和 Development 方案包含每日和每月的内置电子邮件限额。',
+      banner: {
+        approaching:
+          '您即将达到 Logto 内置电子邮件的发送上限。<provider>连接您自己的电子邮件服务商</provider>，或<upgrade>升级您的方案</upgrade>以继续使用 Logto 内置电子邮件。',
+        reached:
+          '您已达到 Logto 内置电子邮件的发送上限，这可能会中断登录邮件。<provider>连接您自己的电子邮件服务商</provider>，或<upgrade>升级您的方案</upgrade>以继续使用 Logto 内置电子邮件。',
+      },
     },
     email_template_title: '电子邮件模板',
     template_description:

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/connector-details.ts
@@ -42,6 +42,12 @@ const connector_details = {
       monthly: '每月 <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: '每月 <value>{{usage, number}}</value>',
       tip: 'Free 和 Development 方案包含每日和每月的內建電子郵件限額。',
+      banner: {
+        approaching:
+          '您即將達到 Logto 內建電子郵件的發送上限。<provider>連接您自己的電子郵件服務商</provider>，或<upgrade>升級您的方案</upgrade>以繼續使用 Logto 內建電子郵件。',
+        reached:
+          '您已達到 Logto 內建電子郵件的發送上限，這可能會中斷登入郵件。<provider>連接您自己的電子郵件服務商</provider>，或<upgrade>升級您的方案</upgrade>以繼續使用 Logto 內建電子郵件。',
+      },
     },
     email_template_title: '郵件模板',
     template_description:

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/connector-details.ts
@@ -42,6 +42,12 @@ const connector_details = {
       monthly: '每月 <value>{{usage, number}}</value> / {{limit, number}}',
       monthly_unlimited: '每月 <value>{{usage, number}}</value>',
       tip: 'Free 和 Development 方案包含每日和每月的內建郵件限額。',
+      banner: {
+        approaching:
+          '您即將達到 Logto 內建郵件的發送上限。<provider>連接您自己的電子郵件服務商</provider>，或<upgrade>升級您的方案</upgrade>以繼續使用 Logto 內建郵件。',
+        reached:
+          '您已達到 Logto 內建郵件的發送上限，這可能會中斷登入郵件。<provider>連接您自己的電子郵件服務商</provider>，或<upgrade>升級您的方案</upgrade>以繼續使用 Logto 內建郵件。',
+      },
     },
     email_template_title: '郵件模板',
     template_description:


### PR DESCRIPTION
## Summary

Part of the Hosted Email Service & Usage work (Refs LOG-13654). Surfaces the hosted email service
cap as a **global banner** (shown app-wide, below the topbar) so tenants can't miss it when sending
is about to be — or already is — blocked.

**Stacked on #9117 (LOG-13655)** — base is that branch until it merges; the diff here is only the
banner work.

### What changed
- **`HostedEmailCapBanner`** (new, rendered in `AppContent` on every page): warns when daily **or**
  monthly hosted-email usage crosses **80%** (approaching) or **hits the cap** (reached — a hard
  block that can interrupt sign-in emails). Each state offers to **connect your own email provider**
  or **upgrade**. Dismissible per session; re-shown if it escalates from approaching to reached.
- **`useHostedEmailUsage`** (new hook): extracts the usage fetch + gating from `EmailUsage` so the
  connector usage card and the banner share one deduped SWR request.
- **i18n**: `banner.approaching` / `banner.reached` phrases (en) + translations for all 17 locales.

### Design note
Mirrors the console's own two-tier limit UX (MAU/token has an inline notice on the Subscription page
plus a global `MauTokenExceededModal`). Here the global surface is a **banner** rather than a modal
(less interrupting), and — since it's global — the connector-page notice was dropped.

### Behavior
- Gated behind `isDevFeaturesEnabled`; applies only to capped (free/dev) tenants — paid tenants
  report `null` limits, so nothing renders.

### Reviewer notes
- No automated tests: the console has no harness for these app-shell / connector components; the
  logic is threshold comparisons covered by typecheck.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
