### PR TITLE
fix(experience): preserve MFA suggestion state

### DIFF
--- a/packages/experience/src/pages/MfaBinding/TotpBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/TotpBinding/index.tsx
@@ -12,7 +12,7 @@ import useSkipMfa from '@/hooks/use-skip-mfa';
 import useSkipOptionalMfa from '@/hooks/use-skip-optional-mfa';
 import ErrorPage from '@/pages/ErrorPage';
 import { UserMfaFlow } from '@/types';
-import { totpBindingStateGuard } from '@/types/guard';
+import { type MfaFlowState, totpBindingStateGuard } from '@/types/guard';
 
 import SecretSection from './SecretSection';
 import VerificationSection from './VerificationSection';
@@ -31,7 +31,20 @@ const TotpBinding = () => {
     return <ErrorPage title="error.invalid_session" />;
   }
 
-  const { availableFactors, skippable, suggestion } = totpBindingState;
+  const {
+    availableFactors,
+    skippable,
+    suggestion,
+    maskedIdentifiers,
+    isWebAuthnUsedAsSignInPasskey,
+  } = totpBindingState;
+  const mfaFlowState: MfaFlowState = {
+    availableFactors,
+    skippable,
+    suggestion,
+    maskedIdentifiers,
+    isWebAuthnUsedAsSignInPasskey,
+  };
 
   return (
     <SecondaryPageLayout
@@ -47,7 +60,7 @@ const TotpBinding = () => {
             <Divider />
             <SwitchMfaFactorsLink
               flow={UserMfaFlow.MfaBinding}
-              flowState={{ availableFactors, skippable }}
+              flowState={mfaFlowState}
               className={styles.switchLink}
             />
           </>

--- a/packages/experience/src/pages/MfaBinding/VerificationCodeMfaBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/VerificationCodeMfaBinding/index.tsx
@@ -106,7 +106,7 @@ const VerificationCodeMfaBinding = ({
       {availableFactors.length > 1 && (
         <SwitchMfaFactorsLink
           flow={UserMfaFlow.MfaBinding}
-          flowState={{ availableFactors, skippable }}
+          flowState={mfaFlowState}
           className={styles.switchLink}
         />
       )}

--- a/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
@@ -8,11 +8,12 @@ import SecondaryPageLayout from '@/Layout/SecondaryPageLayout';
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import SwitchMfaFactorsLink from '@/components/SwitchMfaFactorsLink';
 import useSkipMfa from '@/hooks/use-skip-mfa';
+import useSkipOptionalMfa from '@/hooks/use-skip-optional-mfa';
 import useWebAuthnOperation from '@/hooks/use-webauthn-operation';
 import ErrorPage from '@/pages/ErrorPage';
 import Button from '@/shared/components/Button';
 import { UserMfaFlow } from '@/types';
-import { webAuthnStateGuard } from '@/types/guard';
+import { type MfaFlowState, webAuthnStateGuard } from '@/types/guard';
 import { isWebAuthnOptions } from '@/utils/webauthn';
 
 import styles from './index.module.scss';
@@ -25,13 +26,28 @@ const WebAuthnBinding = () => {
 
   const handleWebAuthn = useWebAuthnOperation();
   const skipMfa = useSkipMfa();
+  const skipOptionalMfa = useSkipOptionalMfa();
   const [isCreatingPasskey, setIsCreatingPasskey] = useState(false);
 
   if (!webAuthnState || !verificationId) {
     return <ErrorPage title="error.invalid_session" />;
   }
 
-  const { options, availableFactors, skippable } = webAuthnState;
+  const {
+    options,
+    availableFactors,
+    skippable,
+    suggestion,
+    maskedIdentifiers,
+    isWebAuthnUsedAsSignInPasskey,
+  } = webAuthnState;
+  const mfaFlowState: MfaFlowState = {
+    availableFactors,
+    skippable,
+    suggestion,
+    maskedIdentifiers,
+    isWebAuthnUsedAsSignInPasskey,
+  };
 
   if (!isWebAuthnOptions(options)) {
     return <ErrorPage title="error.invalid_session" />;
@@ -41,7 +57,7 @@ const WebAuthnBinding = () => {
     <SecondaryPageLayout
       title="mfa.create_a_passkey"
       description="mfa.create_passkey_description"
-      onSkip={conditional(skippable && skipMfa)}
+      onSkip={conditional(skippable && (suggestion ? skipOptionalMfa : skipMfa))}
     >
       <Button
         title="mfa.create_a_passkey"
@@ -54,7 +70,7 @@ const WebAuthnBinding = () => {
       />
       <SwitchMfaFactorsLink
         flow={UserMfaFlow.MfaBinding}
-        flowState={{ availableFactors, skippable }}
+        flowState={mfaFlowState}
         className={styles.switchLink}
       />
     </SecondaryPageLayout>

--- a/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
@@ -104,6 +104,19 @@ describe('Experience - suggest additional MFA after email registration', () => {
     // Click on TOTP factor button to proceed with binding
     await experience.toClick('button', 'Authenticator app OTP');
     await experience.waitForPathname('mfa-binding/Totp');
+
+    await experience.toClickSwitchFactorsLink({ isBinding: true });
+    await experience.waitForPathname('mfa-binding');
+
+    const emailFactorButton = await expect(experience.page).toMatchElement('button', {
+      text: 'Email verification code',
+    });
+    expect(
+      await emailFactorButton.evaluate((element) => (element as HTMLButtonElement).disabled)
+    ).toBe(true);
+
+    await experience.toClick('button', 'Authenticator app OTP');
+    await experience.waitForPathname('mfa-binding/Totp');
     await experience.toBindTotp();
     const userId = await experience.getUserIdFromDemoAppPage();
     await experience.verifyThenEnd();


### PR DESCRIPTION
## Summary

- Preserve MFA suggestion metadata when switching from MFA binding detail pages back to the factor list.
- Keep already-bound email/phone/passkey suggestion factors disabled after users navigate away and back.
- Add regression coverage for switching from the suggested MFA list into TOTP and back.

Fixes #9123

## Root cause

The suggested MFA factor list relies on `suggestion`, `maskedIdentifiers`, and passkey metadata to render already-bound factors as disabled. The binding detail pages were rebuilding `flowState` with only `availableFactors` and `skippable`, so returning to the factor list lost that metadata and made the masked email/phone factor appear selectable. Backend validation still blocked rebinding, which produced the user-facing loop.

## Validation

- `pnpm --filter @logto/experience check`
- `pnpm --filter @logto/integration-tests check`
- targeted ESLint for changed Experience and integration test files
- local Playwright repro with mock email connector confirms `initialEmailDisabled: true` and `afterSwitchEmailDisabled: true`

## Testing

Tested locally