### PR TITLE
feat(core): wire post sign-in inline hook

### DIFF
--- a/packages/core/jest.setup.js
+++ b/packages/core/jest.setup.js
@@ -17,6 +17,7 @@ process.env.NODE_ENV = 'test';
 mockEsm('#src/libraries/logto-config.js', () => ({
   createLogtoConfigLibrary: () => ({
     getOidcConfigs: () => ({}),
+    getInlineHook: async () => undefined,
     promoteScheduledSigningKeyRotation: async () => Promise.resolve(),
   }),
 }));

--- a/packages/core/src/libraries/inline-hook.test.ts
+++ b/packages/core/src/libraries/inline-hook.test.ts
@@ -27,11 +27,14 @@ const createLibrary = (tenantId = 'tenant_id') =>
   );
 
 const originalIsCloud = EnvSet.values.isCloud;
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 
 describe('InlineHookLibrary', () => {
   const library = createLibrary();
 
   beforeEach(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for inline hook runtime tests.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
     getSubscriptionData.mockResolvedValue({
       quota: {
         inlineHooksEnabled: true,
@@ -44,6 +47,9 @@ describe('InlineHookLibrary', () => {
     jest.clearAllMocks();
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after quota tests.
     (EnvSet.values as { isCloud: boolean }).isCloud = originalIsCloud;
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after dev feature tests.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+      originalIsDevFeaturesEnabled;
   });
 
   it('loads hook config and runs enabled inline hook script in local VM', async () => {
@@ -84,6 +90,21 @@ describe('InlineHookLibrary', () => {
     });
 
     expect(getInlineHook).toHaveBeenCalledWith(LogtoInlineHookKey.PostSignIn);
+  });
+
+  it('does not load or run hooks when dev features are disabled', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for dev feature gate test.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = false;
+
+    await expect(
+      library.runHook({
+        key: LogtoInlineHookKey.PostSignIn,
+        event: {},
+      })
+    ).resolves.toBeUndefined();
+
+    expect(getInlineHook).not.toHaveBeenCalled();
+    expect(getSubscriptionData).not.toHaveBeenCalled();
   });
 
   it('does not run disabled hooks', async () => {

--- a/packages/core/src/libraries/inline-hook.test.ts
+++ b/packages/core/src/libraries/inline-hook.test.ts
@@ -53,6 +53,14 @@ describe('InlineHookLibrary', () => {
   });
 
   it('loads hook config and runs enabled inline hook script in local VM', async () => {
+    const getEvent = jest.fn().mockResolvedValue({
+      key: LogtoInlineHookKey.PostSignIn,
+      interactionEvent: 'SignIn',
+      user: {
+        id: 'foo',
+        name: 'Foo',
+      },
+    });
     getInlineHook.mockResolvedValueOnce({
       enabled: true,
       environmentVariables: {
@@ -72,14 +80,7 @@ describe('InlineHookLibrary', () => {
     await expect(
       library.runHook({
         key: LogtoInlineHookKey.PostSignIn,
-        event: {
-          key: LogtoInlineHookKey.PostSignIn,
-          interactionEvent: 'SignIn',
-          user: {
-            id: 'foo',
-            name: 'Foo',
-          },
-        },
+        getEvent,
       })
     ).resolves.toEqual({
       action: 'updateUser',
@@ -90,6 +91,7 @@ describe('InlineHookLibrary', () => {
     });
 
     expect(getInlineHook).toHaveBeenCalledWith(LogtoInlineHookKey.PostSignIn);
+    expect(getEvent).toHaveBeenCalledTimes(1);
   });
 
   it('does not load or run hooks when dev features are disabled', async () => {
@@ -126,6 +128,7 @@ describe('InlineHookLibrary', () => {
   });
 
   it('does not run when inline hook config is missing', async () => {
+    const getEvent = jest.fn().mockResolvedValue({});
     getInlineHook.mockRejectedValueOnce(
       new RequestError({
         code: 'entity.not_exists_with_id',
@@ -136,9 +139,11 @@ describe('InlineHookLibrary', () => {
     await expect(
       library.runHook({
         key: LogtoInlineHookKey.PostSignIn,
-        event: {},
+        getEvent,
       })
     ).resolves.toBeUndefined();
+
+    expect(getEvent).not.toHaveBeenCalled();
   });
 
   it('rethrows non-404 errors when loading inline hook config', async () => {
@@ -157,6 +162,7 @@ describe('InlineHookLibrary', () => {
   });
 
   it('does not run when inline hooks quota is disabled', async () => {
+    const getEvent = jest.fn().mockResolvedValue({});
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for cloud quota test.
     (EnvSet.values as { isCloud: boolean }).isCloud = true;
     getSubscriptionData.mockResolvedValueOnce({
@@ -176,9 +182,11 @@ describe('InlineHookLibrary', () => {
     await expect(
       library.runHook({
         key: LogtoInlineHookKey.PostSignIn,
-        event: {},
+        getEvent,
       })
     ).resolves.toBeUndefined();
+
+    expect(getEvent).not.toHaveBeenCalled();
   });
 
   it('allows PostSignIn execution errors to continue without hook enrichment', async () => {

--- a/packages/core/src/libraries/inline-hook.ts
+++ b/packages/core/src/libraries/inline-hook.ts
@@ -227,6 +227,10 @@ export class InlineHookLibrary {
     key: LogtoInlineHookKey;
     event: Event;
   }): Promise<unknown> {
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
     const inlineHook = await this.findEnabledInlineHook(key);
 
     if (!inlineHook) {

--- a/packages/core/src/libraries/inline-hook.ts
+++ b/packages/core/src/libraries/inline-hook.ts
@@ -47,6 +47,18 @@ type InlineHookRunnerData<Event> = {
   environmentVariables?: Record<string, string>;
 };
 
+type InlineHookEventSource<Event> =
+  | {
+      event: Event;
+    }
+  | {
+      getEvent: () => Promise<Event>;
+    };
+
+type RunInlineHookData<Event> = InlineHookEventSource<Event> & {
+  key: LogtoInlineHookKey;
+};
+
 type InlineHookExecutionErrorHandlingData = {
   key: LogtoInlineHookKey;
   onExecutionError?: InlineHookExecutionErrorPolicy;
@@ -220,13 +232,7 @@ export class InlineHookLibrary {
     }
   }
 
-  async runHook<Event>({
-    key,
-    event,
-  }: {
-    key: LogtoInlineHookKey;
-    event: Event;
-  }): Promise<unknown> {
+  async runHook<Event>({ key, ...eventSource }: RunInlineHookData<Event>): Promise<unknown> {
     if (!EnvSet.values.isDevFeaturesEnabled) {
       return;
     }
@@ -240,6 +246,8 @@ export class InlineHookLibrary {
     if (!(await this.isInlineHooksEnabledByQuota())) {
       return;
     }
+
+    const event = 'getEvent' in eventSource ? await eventSource.getEvent() : eventSource.event;
 
     try {
       return await InlineHookLibrary.runScriptInLocalVm({

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -18,6 +18,7 @@ import { createMockUtils, pickDefault } from '@logto/shared/esm';
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import { mockUser, mockUserWithMfaVerifications } from '#src/__mocks__/user.js';
 import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import { type InsertUserResult } from '#src/libraries/user.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
@@ -349,15 +350,57 @@ describe('ExperienceInteraction class', () => {
       expect(updateUser).toHaveBeenCalledWith(mockUser.id, { name: 'Jane Doe' });
     });
 
-    it('does not update user when PostSignIn inline hook returns no-op', async () => {
-      const { experienceInteraction, runHook } = createSignInInteraction();
-      const updateUser = jest.spyOn(experienceInteraction.provisionLibrary, 'updateUser');
+    it.each([undefined, null, {}, { action: 'updateUser' }])(
+      'does not update user and proceeds when PostSignIn inline hook returns no-op result %#',
+      async (result) => {
+        const { experienceInteraction, provider, runHook } = createSignInInteraction();
+        const updateUser = jest.spyOn(experienceInteraction.provisionLibrary, 'updateUser');
 
-      runHook.mockResolvedValueOnce(null);
+        runHook.mockResolvedValueOnce(result);
 
-      await experienceInteraction.submit();
+        await experienceInteraction.submit();
 
-      expect(updateUser).not.toHaveBeenCalled();
+        expect(updateUser).not.toHaveBeenCalled();
+        expect(provider.interactionResult).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({
+            login: { accountId: mockUser.id },
+          })
+        );
+      }
+    );
+
+    it.each([
+      { action: 'createUser', user: { name: 'Jane Doe' } },
+      { action: 'rejectInvalidCredentials' },
+      { action: 'denyAccess', user: { name: 'Jane Doe' } },
+      { action: 'continue' },
+      { user: { name: 'Jane Doe' } },
+    ])('blocks sign-in when PostSignIn inline hook returns invalid result %#', async (result) => {
+      const { experienceInteraction, provider, runHook } = createSignInInteraction();
+
+      runHook.mockResolvedValueOnce(result);
+
+      await expect(experienceInteraction.submit()).rejects.toMatchError(
+        new RequestError({ code: 'session.verification_failed', status: 400 })
+      );
+
+      expect(provider.interactionResult).not.toHaveBeenCalled();
+    });
+
+    it('blocks sign-in when PostSignIn inline hook execution fails in block mode', async () => {
+      const { experienceInteraction, provider, runHook } = createSignInInteraction();
+
+      runHook.mockRejectedValueOnce(
+        new RequestError({ code: 'session.verification_failed', status: 400 })
+      );
+
+      await expect(experienceInteraction.submit()).rejects.toMatchError(
+        new RequestError({ code: 'session.verification_failed', status: 400 })
+      );
+
+      expect(provider.interactionResult).not.toHaveBeenCalled();
     });
 
     it('should record geo context when dev features are disabled', async () => {

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -1,9 +1,12 @@
+/* eslint-disable max-lines */
 import { TemplateType } from '@logto/connector-kit';
 import {
   adminConsoleApplicationId,
   adminTenantId,
   type CreateUser,
   InteractionEvent,
+  LogtoInlineHookKey,
+  type JwtCustomizerUserContext,
   type SignInExperience,
   SignInIdentifier,
   SignInMode,
@@ -43,6 +46,7 @@ const userQueries = {
   updateUserById: jest.fn().mockResolvedValue(mockUser),
 };
 const userLibraries = {
+  checkIdentifierCollision: jest.fn().mockResolvedValue(null),
   generateUserId: jest.fn().mockResolvedValue('uid'),
   insertUser: jest.fn(async (user: CreateUser): Promise<InsertUserResult> => [user as User]),
   provisionOrganizations: jest.fn().mockResolvedValue([]),
@@ -65,6 +69,28 @@ const signInExperiences = {
 const mockProviderInteractionDetails = jest
   .fn()
   .mockResolvedValue({ params: { client_id: adminConsoleApplicationId } });
+const mockJwtCustomizerUserContext: JwtCustomizerUserContext = {
+  id: mockUser.id,
+  username: mockUser.username,
+  primaryEmail: mockUser.primaryEmail,
+  primaryPhone: mockUser.primaryPhone,
+  name: mockUser.name,
+  avatar: mockUser.avatar,
+  customData: mockUser.customData,
+  identities: mockUser.identities,
+  lastSignInAt: mockUser.lastSignInAt,
+  createdAt: mockUser.createdAt,
+  updatedAt: mockUser.updatedAt,
+  profile: mockUser.profile,
+  applicationId: mockUser.applicationId,
+  isSuspended: mockUser.isSuspended,
+  hasPassword: true,
+  ssoIdentities: [],
+  mfaVerificationFactors: [],
+  roles: [],
+  organizations: [],
+  organizationRoles: [],
+};
 
 const ExperienceInteraction = await pickDefault(import('./experience-interaction.js'));
 
@@ -105,8 +131,14 @@ const createSignInInteraction = ({
     findUserById: jest.fn().mockResolvedValue(user),
     updateUserById: jest.fn().mockResolvedValue(user),
   };
+  const runHook = jest.fn(
+    async <Event>({ event, key }: { event: Event; key: LogtoInlineHookKey }): Promise<unknown> =>
+      undefined
+  );
+  const getUserContext = jest.fn().mockResolvedValue(mockJwtCustomizerUserContext);
+  const provider = createMockProvider();
   const signInTenant = new MockTenant(
-    createMockProvider(),
+    provider,
     {
       users: signInUserQueries,
       signInExperiences: signInExperiencesWithAdaptiveMfa,
@@ -114,7 +146,12 @@ const createSignInInteraction = ({
       userSignInCountries,
     },
     undefined,
-    { users: userLibraries, ssoConnectors }
+    {
+      users: userLibraries,
+      ssoConnectors,
+      inlineHooks: { runHook },
+      jwtCustomizers: { getUserContext },
+    }
   );
   const logContext = createMockLogContext();
   const baseContext = createContextWithRouteParameters(
@@ -153,6 +190,10 @@ const createSignInInteraction = ({
 
   return {
     experienceInteraction,
+    provider,
+    runHook,
+    getUserContext,
+    signInUserQueries,
     userGeoLocations,
     userSignInCountries,
     createLog: logContext.createLog,
@@ -240,6 +281,85 @@ describe('ExperienceInteraction class', () => {
   });
 
   describe('sign-in submission', () => {
+    it('runs PostSignIn inline hook before provider interaction result', async () => {
+      const { experienceInteraction, provider, runHook, getUserContext } =
+        createSignInInteraction();
+
+      await experienceInteraction.submit();
+
+      expect(getUserContext).toHaveBeenCalledWith(mockUser.id);
+      expect(runHook).toHaveBeenCalledWith({
+        key: LogtoInlineHookKey.PostSignIn,
+        event: {
+          key: LogtoInlineHookKey.PostSignIn,
+          interactionEvent: InteractionEvent.SignIn,
+          user: mockJwtCustomizerUserContext,
+        },
+      });
+      expect(runHook.mock.invocationCallOrder[0]).toBeLessThan(
+        (provider.interactionResult as jest.Mock).mock.invocationCallOrder[0]!
+      );
+    });
+
+    it('does not include password in the PostSignIn inline hook event', async () => {
+      const { experienceInteraction, runHook } = createSignInInteraction();
+
+      await experienceInteraction.submit();
+
+      const [{ event }] = runHook.mock.calls[0]!;
+
+      expect(event).not.toHaveProperty('password');
+      expect(JSON.stringify(event)).not.toContain(mockUser.passwordEncrypted);
+    });
+
+    it('does not run PostSignIn inline hook for register interactions', async () => {
+      const { experienceInteraction, runHook, getUserContext } = createSignInInteraction({
+        interactionEvent: InteractionEvent.Register,
+      });
+
+      await experienceInteraction.submit();
+
+      expect(getUserContext).not.toHaveBeenCalled();
+      expect(runHook).not.toHaveBeenCalled();
+    });
+
+    it('does not run PostSignIn inline hook when dev features are disabled', async () => {
+      setDevFeaturesEnabled(false);
+      const { experienceInteraction, runHook, getUserContext } = createSignInInteraction();
+
+      await experienceInteraction.submit();
+
+      expect(getUserContext).not.toHaveBeenCalled();
+      expect(runHook).not.toHaveBeenCalled();
+    });
+
+    it('updates user when PostSignIn inline hook returns updateUser', async () => {
+      const { experienceInteraction, runHook } = createSignInInteraction();
+      const updateUser = jest.spyOn(experienceInteraction.provisionLibrary, 'updateUser');
+
+      runHook.mockResolvedValueOnce({
+        action: 'updateUser',
+        user: {
+          name: 'Jane Doe',
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(updateUser).toHaveBeenCalledWith(mockUser.id, { name: 'Jane Doe' });
+    });
+
+    it('does not update user when PostSignIn inline hook returns no-op', async () => {
+      const { experienceInteraction, runHook } = createSignInInteraction();
+      const updateUser = jest.spyOn(experienceInteraction.provisionLibrary, 'updateUser');
+
+      runHook.mockResolvedValueOnce(null);
+
+      await experienceInteraction.submit();
+
+      expect(updateUser).not.toHaveBeenCalled();
+    });
+
     it('should record geo context when dev features are disabled', async () => {
       setDevFeaturesEnabled(false);
       const { experienceInteraction, userGeoLocations, userSignInCountries } =
@@ -451,3 +571,5 @@ describe('ExperienceInteraction class', () => {
     });
   });
 });
+
+/* eslint-enable max-lines */

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -347,7 +347,47 @@ describe('ExperienceInteraction class', () => {
 
       await experienceInteraction.submit();
 
-      expect(updateUser).toHaveBeenCalledWith(mockUser.id, { name: 'Jane Doe' });
+      expect(updateUser).toHaveBeenCalledWith(
+        mockUser.id,
+        { name: 'Jane Doe' },
+        { mergeCustomData: true }
+      );
+    });
+
+    it('preserves existing customData when PostSignIn inline hook writes customData', async () => {
+      const user = {
+        ...mockUser,
+        customData: {
+          p1Synced: true,
+          source: 'p1',
+        },
+      };
+      const { experienceInteraction, runHook, signInUserQueries } = createSignInInteraction({
+        user,
+      });
+
+      runHook.mockResolvedValueOnce({
+        action: 'updateUser',
+        user: {
+          customData: {
+            p2Synced: true,
+          },
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(signInUserQueries.updateUserById).toHaveBeenCalledWith(
+        mockUser.id,
+        expect.objectContaining({
+          customData: {
+            p1Synced: true,
+            p2Synced: true,
+            source: 'p1',
+          },
+        }),
+        'replace'
+      );
     });
 
     it.each([undefined, null, {}, { action: 'updateUser' }])(

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -132,9 +132,16 @@ const createSignInInteraction = ({
     findUserById: jest.fn().mockResolvedValue(user),
     updateUserById: jest.fn().mockResolvedValue(user),
   };
+  const runHookHandler = jest.fn(
+    async (_input: { event: unknown; key: LogtoInlineHookKey }): Promise<unknown> => undefined
+  );
   const runHook = jest.fn(
-    async <Event>({ event, key }: { event: Event; key: LogtoInlineHookKey }): Promise<unknown> =>
-      undefined
+    async <Event>(
+      input: { key: LogtoInlineHookKey } & ({ event: Event } | { getEvent: () => Promise<Event> })
+    ): Promise<unknown> => {
+      const event = 'getEvent' in input ? await input.getEvent() : input.event;
+      return runHookHandler({ key: input.key, event });
+    }
   );
   const getUserContext = jest.fn().mockResolvedValue(mockJwtCustomizerUserContext);
   const provider = createMockProvider();
@@ -193,6 +200,7 @@ const createSignInInteraction = ({
     experienceInteraction,
     provider,
     runHook,
+    runHookHandler,
     getUserContext,
     signInUserQueries,
     userGeoLocations,
@@ -283,13 +291,16 @@ describe('ExperienceInteraction class', () => {
 
   describe('sign-in submission', () => {
     it('runs PostSignIn inline hook before provider interaction result', async () => {
-      const { experienceInteraction, provider, runHook, getUserContext } =
+      const { experienceInteraction, provider, runHook, runHookHandler, getUserContext } =
         createSignInInteraction();
 
       await experienceInteraction.submit();
 
       expect(getUserContext).toHaveBeenCalledWith(mockUser.id);
-      expect(runHook).toHaveBeenCalledWith({
+      const [runHookInput] = runHook.mock.calls[0]!;
+      expect(runHookInput).toMatchObject({ key: LogtoInlineHookKey.PostSignIn });
+      expect('getEvent' in runHookInput && typeof runHookInput.getEvent).toBe('function');
+      expect(runHookHandler).toHaveBeenCalledWith({
         key: LogtoInlineHookKey.PostSignIn,
         event: {
           key: LogtoInlineHookKey.PostSignIn,
@@ -297,17 +308,17 @@ describe('ExperienceInteraction class', () => {
           user: mockJwtCustomizerUserContext,
         },
       });
-      expect(runHook.mock.invocationCallOrder[0]).toBeLessThan(
+      expect(runHookHandler.mock.invocationCallOrder[0]).toBeLessThan(
         (provider.interactionResult as jest.Mock).mock.invocationCallOrder[0]!
       );
     });
 
     it('does not include password in the PostSignIn inline hook event', async () => {
-      const { experienceInteraction, runHook } = createSignInInteraction();
+      const { experienceInteraction, runHookHandler } = createSignInInteraction();
 
       await experienceInteraction.submit();
 
-      const [{ event }] = runHook.mock.calls[0]!;
+      const [{ event }] = runHookHandler.mock.calls[0]!;
 
       expect(event).not.toHaveProperty('password');
       expect(JSON.stringify(event)).not.toContain(mockUser.passwordEncrypted);
@@ -335,10 +346,10 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('updates user when PostSignIn inline hook returns updateUser', async () => {
-      const { experienceInteraction, runHook } = createSignInInteraction();
+      const { experienceInteraction, runHookHandler } = createSignInInteraction();
       const updateUser = jest.spyOn(experienceInteraction.provisionLibrary, 'updateUser');
 
-      runHook.mockResolvedValueOnce({
+      runHookHandler.mockResolvedValueOnce({
         action: 'updateUser',
         user: {
           name: 'Jane Doe',
@@ -362,11 +373,11 @@ describe('ExperienceInteraction class', () => {
           source: 'p1',
         },
       };
-      const { experienceInteraction, runHook, signInUserQueries } = createSignInInteraction({
+      const { experienceInteraction, runHookHandler, signInUserQueries } = createSignInInteraction({
         user,
       });
 
-      runHook.mockResolvedValueOnce({
+      runHookHandler.mockResolvedValueOnce({
         action: 'updateUser',
         user: {
           customData: {
@@ -393,10 +404,10 @@ describe('ExperienceInteraction class', () => {
     it.each([undefined, null, {}, { action: 'updateUser' }])(
       'does not update user and proceeds when PostSignIn inline hook returns no-op result %#',
       async (result) => {
-        const { experienceInteraction, provider, runHook } = createSignInInteraction();
+        const { experienceInteraction, provider, runHookHandler } = createSignInInteraction();
         const updateUser = jest.spyOn(experienceInteraction.provisionLibrary, 'updateUser');
 
-        runHook.mockResolvedValueOnce(result);
+        runHookHandler.mockResolvedValueOnce(result);
 
         await experienceInteraction.submit();
 
@@ -416,11 +427,12 @@ describe('ExperienceInteraction class', () => {
       { action: 'rejectInvalidCredentials' },
       { action: 'denyAccess', user: { name: 'Jane Doe' } },
       { action: 'continue' },
+      { ignored: true },
       { user: { name: 'Jane Doe' } },
     ])('blocks sign-in when PostSignIn inline hook returns invalid result %#', async (result) => {
-      const { experienceInteraction, provider, runHook } = createSignInInteraction();
+      const { experienceInteraction, provider, runHookHandler } = createSignInInteraction();
 
-      runHook.mockResolvedValueOnce(result);
+      runHookHandler.mockResolvedValueOnce(result);
 
       await expect(experienceInteraction.submit()).rejects.toMatchError(
         new RequestError({ code: 'session.verification_failed', status: 400 })
@@ -430,9 +442,9 @@ describe('ExperienceInteraction class', () => {
     });
 
     it('blocks sign-in when PostSignIn inline hook execution fails in block mode', async () => {
-      const { experienceInteraction, provider, runHook } = createSignInInteraction();
+      const { experienceInteraction, provider, runHookHandler } = createSignInInteraction();
 
-      runHook.mockRejectedValueOnce(
+      runHookHandler.mockRejectedValueOnce(
         new RequestError({ code: 'session.verification_failed', status: 400 })
       );
 

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -728,7 +728,9 @@ export default class ExperienceInteraction {
     });
 
     if (hookResult.action === 'updateUser') {
-      await this.provisionLibrary.updateUser(hookResult.userId, hookResult.user);
+      await this.provisionLibrary.updateUser(hookResult.userId, hookResult.user, {
+        mergeCustomData: true,
+      });
     }
   }
 

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -4,13 +4,16 @@ import { appInsights } from '@logto/app-insights/node';
 import {
   InteractionEvent,
   InteractionHookEvent,
+  LogtoInlineHookKey,
   MfaFactor,
+  type PostSignInEvent,
   VerificationType,
   type User,
 } from '@logto/schemas';
 import { maskEmail, maskPhone } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayload } from '#src/libraries/user.utils.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
@@ -36,6 +39,7 @@ import {
 import { AdaptiveMfaValidator } from './libraries/adaptive-mfa-validator/index.js';
 import { type AdaptiveMfaResult } from './libraries/adaptive-mfa-validator/types.js';
 import { CaptchaValidator } from './libraries/captcha-validator.js';
+import { validatePostSignInHookResult } from './libraries/inline-hook-result-validation.js';
 import { MfaValidator } from './libraries/mfa-validator.js';
 import { ProvisionLibrary } from './libraries/provision-library.js';
 import { SignInExperienceValidator } from './libraries/sign-in-experience-validator.js';
@@ -629,6 +633,8 @@ export default class ExperienceInteraction {
       });
     }
 
+    await this.triggerPostSignInInlineHook(user.id);
+
     const { provider } = this.tenant;
 
     const redirectTo = await provider.interactionResult(this.ctx.req, this.ctx.res, {
@@ -698,6 +704,32 @@ export default class ExperienceInteraction {
       payload: { adaptiveMfaResult },
       userId,
     });
+  }
+
+  private async triggerPostSignInInlineHook(userId: string) {
+    if (this.#interactionEvent !== InteractionEvent.SignIn || !EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    const {
+      libraries: { inlineHooks, jwtCustomizers },
+    } = this.tenant;
+    const event: PostSignInEvent = {
+      key: LogtoInlineHookKey.PostSignIn,
+      interactionEvent: InteractionEvent.SignIn,
+      user: await jwtCustomizers.getUserContext(userId),
+    };
+    const hookResult = validatePostSignInHookResult({
+      event,
+      result: await inlineHooks.runHook({
+        key: LogtoInlineHookKey.PostSignIn,
+        event,
+      }),
+    });
+
+    if (hookResult.action === 'updateUser') {
+      await this.provisionLibrary.updateUser(hookResult.userId, hookResult.user);
+    }
   }
 
   private get verificationRecordsArray() {

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -714,16 +714,15 @@ export default class ExperienceInteraction {
     const {
       libraries: { inlineHooks, jwtCustomizers },
     } = this.tenant;
-    const event: PostSignInEvent = {
-      key: LogtoInlineHookKey.PostSignIn,
-      interactionEvent: InteractionEvent.SignIn,
-      user: await jwtCustomizers.getUserContext(userId),
-    };
     const hookResult = validatePostSignInHookResult({
-      event,
+      userId,
       result: await inlineHooks.runHook({
         key: LogtoInlineHookKey.PostSignIn,
-        event,
+        getEvent: async (): Promise<PostSignInEvent> => ({
+          key: LogtoInlineHookKey.PostSignIn,
+          interactionEvent: InteractionEvent.SignIn,
+          user: await jwtCustomizers.getUserContext(userId),
+        }),
       }),
     });
 

--- a/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
@@ -1,4 +1,9 @@
-import { SignInIdentifier, type HookUser } from '@logto/schemas';
+import {
+  SignInIdentifier,
+  type HookUser,
+  type JwtCustomizerUserContext,
+  UsersPasswordEncryptionMethod,
+} from '@logto/schemas';
 
 import { mockUser } from '#src/__mocks__/user.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -10,7 +15,6 @@ import {
   validatePostSignInHookResult,
 } from './inline-hook-result-validation.js';
 
-const hookUser: HookUser = mockUser;
 const signInIdentifier = {
   type: SignInIdentifier.Email,
   value: 'jane@example.com',
@@ -22,6 +26,28 @@ const p1Event = (
   user,
   identifier: signInIdentifier,
 });
+const hookUser: JwtCustomizerUserContext = {
+  id: mockUser.id,
+  username: mockUser.username,
+  primaryEmail: mockUser.primaryEmail,
+  primaryPhone: mockUser.primaryPhone,
+  name: mockUser.name,
+  avatar: mockUser.avatar,
+  customData: mockUser.customData,
+  identities: mockUser.identities,
+  lastSignInAt: mockUser.lastSignInAt,
+  createdAt: mockUser.createdAt,
+  updatedAt: mockUser.updatedAt,
+  profile: mockUser.profile,
+  applicationId: mockUser.applicationId,
+  isSuspended: mockUser.isSuspended,
+  hasPassword: true,
+  ssoIdentities: [],
+  mfaVerificationFactors: [],
+  roles: [],
+  organizations: [],
+  organizationRoles: [],
+};
 const invalidCredentialsResult: ValidatedPostFirstFactorVerificationHookResult = {
   action: 'rejectInvalidCredentials',
 };

--- a/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
@@ -2,6 +2,7 @@ import { SignInIdentifier, type HookUser, type JwtCustomizerUserContext } from '
 
 import { mockUser } from '#src/__mocks__/user.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import {
   type ValidatedPostFirstFactorVerificationHookResult,
@@ -247,6 +248,17 @@ describe('validatePostSignInHookResult', () => {
     }
   );
 
+  it('accepts an empty plain object returned from a separate VM realm as a no-op', async () => {
+    const result = await runScriptFunctionInLocalVm(
+      'const runInlineHook = () => ({})',
+      'runInlineHook',
+      {}
+    );
+
+    expect(result).toEqual({});
+    expect(validatePostSignInHookResult({ userId: hookUser.id, result })).toEqual(continueResult);
+  });
+
   it('accepts updateUser with a sanitized provisioning profile', () => {
     expect(
       validatePostSignInHookResult({
@@ -292,6 +304,13 @@ describe('validatePostSignInHookResult', () => {
     { action: 'denyAccess', user: { name: 'Jane Doe' } },
     { action: 'continue' },
     { action: 'continue', user: { name: 'Jane Doe' } },
+    new Date(),
+    new Map(),
+    new (class {
+      isInvalidResult() {
+        return true;
+      }
+    })(),
     { ignored: true },
     { user: { name: 'Jane Doe' } },
     { action: 'updateUser', user: null },

--- a/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
@@ -240,7 +240,7 @@ describe('validatePostFirstFactorVerificationHookResult', () => {
 });
 
 describe('validatePostSignInHookResult', () => {
-  it.each([undefined, null, {}, { action: 'updateUser' }, { ignored: true }])(
+  it.each([undefined, null, {}, { action: 'updateUser' }])(
     'returns continue for no-op result %#',
     (result) => {
       expect(
@@ -254,7 +254,7 @@ describe('validatePostSignInHookResult', () => {
     }
   );
 
-  it('accepts updateUser with a provisioning profile', () => {
+  it('accepts updateUser with a sanitized provisioning profile', () => {
     expect(
       validatePostSignInHookResult({
         event: {
@@ -264,6 +264,14 @@ describe('validatePostSignInHookResult', () => {
           action: 'updateUser',
           user: {
             name: 'Jane Doe',
+            profile: {
+              givenName: 'Jane',
+              familyName: 'Doe',
+              ignored: 'not persisted',
+            },
+            customData: {
+              plan: 'pro',
+            },
           },
         },
       })
@@ -272,6 +280,13 @@ describe('validatePostSignInHookResult', () => {
       userId: hookUser.id,
       user: {
         name: 'Jane Doe',
+        profile: {
+          givenName: 'Jane',
+          familyName: 'Doe',
+        },
+        customData: {
+          plan: 'pro',
+        },
       },
     });
   });
@@ -280,6 +295,12 @@ describe('validatePostSignInHookResult', () => {
     [],
     { action: 'createUser' },
     { action: 'createUser', user: { name: 'Jane Doe' } },
+    { action: 'rejectInvalidCredentials' },
+    { action: 'rejectInvalidCredentials', user: { name: 'Jane Doe' } },
+    { action: 'denyAccess' },
+    { action: 'denyAccess', user: { name: 'Jane Doe' } },
+    { action: 'continue' },
+    { action: 'continue', user: { name: 'Jane Doe' } },
     { user: { name: 'Jane Doe' } },
     { action: 'updateUser', user: null },
     { action: 'updateUser', user: { id: 'not-allowed' } },

--- a/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
@@ -240,9 +240,7 @@ describe('validatePostSignInHookResult', () => {
     (result) => {
       expect(
         validatePostSignInHookResult({
-          event: {
-            user: hookUser,
-          },
+          userId: hookUser.id,
           result,
         })
       ).toEqual(continueResult);
@@ -252,9 +250,7 @@ describe('validatePostSignInHookResult', () => {
   it('accepts updateUser with a sanitized provisioning profile', () => {
     expect(
       validatePostSignInHookResult({
-        event: {
-          user: hookUser,
-        },
+        userId: hookUser.id,
         result: {
           action: 'updateUser',
           user: {
@@ -296,15 +292,14 @@ describe('validatePostSignInHookResult', () => {
     { action: 'denyAccess', user: { name: 'Jane Doe' } },
     { action: 'continue' },
     { action: 'continue', user: { name: 'Jane Doe' } },
+    { ignored: true },
     { user: { name: 'Jane Doe' } },
     { action: 'updateUser', user: null },
     { action: 'updateUser', user: { id: 'not-allowed' } },
   ])('throws verification failure for invalid result %#', (result) => {
     expect(() =>
       validatePostSignInHookResult({
-        event: {
-          user: hookUser,
-        },
+        userId: hookUser.id,
         result,
       })
     ).toMatchError(new RequestError({ code: 'session.verification_failed', status: 400 }));

--- a/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.test.ts
@@ -1,9 +1,4 @@
-import {
-  SignInIdentifier,
-  type HookUser,
-  type JwtCustomizerUserContext,
-  UsersPasswordEncryptionMethod,
-} from '@logto/schemas';
+import { SignInIdentifier, type HookUser, type JwtCustomizerUserContext } from '@logto/schemas';
 
 import { mockUser } from '#src/__mocks__/user.js';
 import RequestError from '#src/errors/RequestError/index.js';

--- a/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.ts
+++ b/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.ts
@@ -1,6 +1,5 @@
 import {
   type PostFirstFactorVerificationEvent,
-  type PostSignInEvent,
   SignInIdentifier,
   type HookUserPatch,
   type InteractionIdentifier,
@@ -165,10 +164,10 @@ export const validatePostFirstFactorVerificationHookResult = ({
 };
 
 export const validatePostSignInHookResult = ({
-  event,
+  userId,
   result,
 }: {
-  event: Pick<PostSignInEvent, 'user'>;
+  userId: string;
   result: unknown;
 }): ValidatedPostSignInHookResult => {
   if (result === null || result === undefined) {
@@ -179,9 +178,7 @@ export const validatePostSignInHookResult = ({
     throw verificationFailedError();
   }
 
-  const { action, user } = result;
-
-  if (action === undefined && user === undefined) {
+  if (Object.keys(result).length === 0) {
     return continueResult();
   }
 
@@ -201,7 +198,7 @@ export const validatePostSignInHookResult = ({
 
       return {
         action: 'updateUser',
-        userId: event.user.id,
+        userId,
         user: profile,
       };
     }

--- a/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.ts
+++ b/packages/core/src/routes/experience/classes/libraries/inline-hook-result-validation.ts
@@ -7,6 +7,7 @@ import {
   postSignInResultGuard,
 } from '@logto/schemas';
 import { PhoneNumberParser } from '@logto/shared/universal';
+import { isPlainObject } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -42,7 +43,7 @@ export type ValidatedPostSignInHookResult =
     };
 
 const isInlineHookResultObject = (result: unknown): result is Record<string, unknown> =>
-  typeof result === 'object' && result !== null && !Array.isArray(result);
+  isPlainObject(result);
 
 const invalidCredentialsResult = (): InlineHookRejectInvalidCredentialsResult => ({
   action: 'rejectInvalidCredentials',

--- a/packages/core/src/routes/experience/verification-routes/password-verification.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/password-verification.test.ts
@@ -111,6 +111,16 @@ const getRouteHandler = (router: RouterLike): RouteHandler => {
   return handler as RouteHandler;
 };
 
+const getSentinelPromise = async () => {
+  const sentinelPromise = withSentinel.mock.calls[0]?.[1];
+
+  if (!sentinelPromise) {
+    throw new TypeError('Sentinel promise was not captured');
+  }
+
+  return sentinelPromise;
+};
+
 const runHook = jest.fn();
 const findUserByEmail = jest.fn();
 const createUser = jest.fn();
@@ -228,7 +238,7 @@ describe('password verification route PostFirstFactorVerification fallback', () 
     expect(ctx.status).toBe(200);
   });
 
-  it('preserves invalid credentials when the hook runtime returns no result', async () => {
+  it('wraps local failure and hook-declined invalid credentials in one Sentinel promise', async () => {
     const handler = registerRoute();
     const ctx = createContext();
 
@@ -238,6 +248,8 @@ describe('password verification route PostFirstFactorVerification fallback', () 
       invalidCredentialsError
     );
 
+    expect(withSentinel).toHaveBeenCalledTimes(1);
+    await expect(getSentinelPromise()).rejects.toBe(invalidCredentialsError);
     expect(runHook).toHaveBeenCalledWith({
       key: LogtoInlineHookKey.PostFirstFactorVerification,
       event: {
@@ -270,7 +282,7 @@ describe('password verification route PostFirstFactorVerification fallback', () 
     expect(updateUser).not.toHaveBeenCalled();
   });
 
-  it('creates a user from a validated hook result when the local user is missing', async () => {
+  it('wraps local failure and hook-created user success in one Sentinel promise', async () => {
     const handler = registerRoute();
     const ctx = createContext();
 
@@ -283,6 +295,10 @@ describe('password verification route PostFirstFactorVerification fallback', () 
 
     await handler(ctx, jest.fn().mockImplementation(resolveVoid));
 
+    expect(withSentinel).toHaveBeenCalledTimes(1);
+    await expect(getSentinelPromise()).resolves.toEqual(
+      expect.objectContaining({ hookResult: { action: 'createUser', user: {} } })
+    );
     expect(appendPasswordPayloadToInlineHookProvisioningProfile).toHaveBeenCalledWith(
       {
         primaryEmail: identifier.value,

--- a/packages/core/src/test-utils/tenant.ts
+++ b/packages/core/src/test-utils/tenant.ts
@@ -3,7 +3,6 @@ import { TtlCache } from '@logto/shared';
 import { createMockPool, createMockQueryResult } from '@silverhand/slonik';
 
 import { WellKnownCache } from '#src/caches/well-known.js';
-import RequestError from '#src/errors/RequestError/index.js';
 import type { CloudConnectionLibrary } from '#src/libraries/cloud-connection.js';
 import { createCloudConnectionLibrary } from '#src/libraries/cloud-connection.js';
 import type { ConnectorLibrary } from '#src/libraries/connector.js';
@@ -92,20 +91,8 @@ export class MockTenant implements TenantContext {
     this.wellKnownCache = new MockWellKnownCache();
     this.queries = new MockQueries(queriesOverride, this.wellKnownCache);
 
-    const baseLogtoConfigs = createLogtoConfigLibrary(this.queries);
-    const maybeBaseLogtoConfigs: Partial<LogtoConfigLibrary> = baseLogtoConfigs;
     this.logtoConfigs = {
-      ...baseLogtoConfigs,
-      ...(typeof maybeBaseLogtoConfigs.getInlineHook === 'function'
-        ? {}
-        : {
-            getInlineHook: async () => {
-              throw new RequestError({
-                code: 'entity.not_exists_with_id',
-                status: 404,
-              });
-            },
-          }),
+      ...createLogtoConfigLibrary(this.queries),
       ...logtoConfigsOverride,
     };
     this.cloudConnection = createCloudConnectionLibrary(this.logtoConfigs);

--- a/packages/core/src/test-utils/tenant.ts
+++ b/packages/core/src/test-utils/tenant.ts
@@ -3,6 +3,7 @@ import { TtlCache } from '@logto/shared';
 import { createMockPool, createMockQueryResult } from '@silverhand/slonik';
 
 import { WellKnownCache } from '#src/caches/well-known.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import type { CloudConnectionLibrary } from '#src/libraries/cloud-connection.js';
 import { createCloudConnectionLibrary } from '#src/libraries/cloud-connection.js';
 import type { ConnectorLibrary } from '#src/libraries/connector.js';
@@ -91,7 +92,22 @@ export class MockTenant implements TenantContext {
     this.wellKnownCache = new MockWellKnownCache();
     this.queries = new MockQueries(queriesOverride, this.wellKnownCache);
 
-    this.logtoConfigs = { ...createLogtoConfigLibrary(this.queries), ...logtoConfigsOverride };
+    const baseLogtoConfigs = createLogtoConfigLibrary(this.queries);
+    const maybeBaseLogtoConfigs: Partial<LogtoConfigLibrary> = baseLogtoConfigs;
+    this.logtoConfigs = {
+      ...baseLogtoConfigs,
+      ...(typeof maybeBaseLogtoConfigs.getInlineHook === 'function'
+        ? {}
+        : {
+            getInlineHook: async () => {
+              throw new RequestError({
+                code: 'entity.not_exists_with_id',
+                status: 404,
+              });
+            },
+          }),
+      ...logtoConfigsOverride,
+    };
     this.cloudConnection = createCloudConnectionLibrary(this.logtoConfigs);
     this.connectors = {
       ...createConnectorLibrary(this.queries, this.cloudConnection),

--- a/packages/schemas/src/types/logto-config/inline-hook.ts
+++ b/packages/schemas/src/types/logto-config/inline-hook.ts
@@ -6,6 +6,8 @@ import type { InteractionEvent, InteractionIdentifier } from '../interactions.js
 import { userInfoGuard, type UserInfo } from '../user.js';
 import type { VerificationType } from '../verification-records/index.js';
 
+import type { JwtCustomizerUserContext } from './jwt-customizer.js';
+
 export enum LogtoInlineHookKey {
   PostFirstFactorVerification = 'inlineHook.postFirstFactorVerification',
   PostSignIn = 'inlineHook.postSignIn',
@@ -76,7 +78,7 @@ export type PostFirstFactorVerificationEvent = {
 export type PostSignInEvent = {
   key: LogtoInlineHookKey.PostSignIn;
   interactionEvent: InteractionEvent.SignIn;
-  user: HookUser;
+  user: JwtCustomizerUserContext;
 };
 
 // Nested `user` uses passthrough so password fields survive structural parsing.


### PR DESCRIPTION
## Summary

- Wire the PostSignIn inline hook into ExperienceInteraction.submit after sign-in side effects and before the provider interaction result, using the finalized user context.
- Enforce updateUser-only results, no-op continuation, and blocking behavior for invalid results or block-mode execution failures.
- Preserve existing user customData through shallow-merged PostSignIn updates.

## Testing

Unit tests
