### PR TITLE
fix: parse pasted country code in phone smart input field

### DIFF
--- a/packages/experience/src/shared/components/InputFields/SmartInputField/index.test.tsx
+++ b/packages/experience/src/shared/components/InputFields/SmartInputField/index.test.tsx
@@ -104,6 +104,57 @@ describe('SmartInputField Component', () => {
         value: `${newCountryCode}12315`,
       });
     });
+
+    test('should parse pasted full international phone number', () => {
+      const { container, getByText } = renderInputField({
+        enabledTypes: [SignInIdentifier.Phone],
+      });
+      const input = container.querySelector('input');
+      assert(input, new Error('input should not be null'));
+
+      fireEvent.change(input, { target: { value: '+79370000000' } });
+
+      expect(getByText('+7')).not.toBeNull();
+      expect(input.value).toBe('9370000000');
+      expect(onChange).toHaveBeenLastCalledWith({
+        type: SignInIdentifier.Phone,
+        value: '79370000000',
+      });
+    });
+
+    test('should update country code when pasting an international phone number', () => {
+      const { container, getByText } = renderInputField({
+        defaultValue: '+79370000000',
+        enabledTypes: [SignInIdentifier.Phone],
+      });
+      const input = container.querySelector('input');
+      assert(input, new Error('input should not be null'));
+
+      expect(getByText('+7')).not.toBeNull();
+      expect(input.value).toBe('9370000000');
+
+      fireEvent.change(input, { target: { value: '+16502530000' } });
+
+      expect(getByText('+1')).not.toBeNull();
+      expect(input.value).toBe('6502530000');
+      expect(onChange).toHaveBeenLastCalledWith({
+        type: SignInIdentifier.Phone,
+        value: '16502530000',
+      });
+    });
+
+    test('should keep partial international phone input as raw value', () => {
+      const { container, getByText } = renderInputField({
+        enabledTypes: [SignInIdentifier.Phone],
+      });
+      const input = container.querySelector('input');
+      assert(input, new Error('input should not be null'));
+
+      fireEvent.change(input, { target: { value: '+7' } });
+
+      expect(getByText(`+${defaultCountryCallingCode}`)).not.toBeNull();
+      expect(input.value).toBe('+7');
+    });
   });
 
   describe('username with email', () => {
@@ -279,6 +330,27 @@ describe('SmartInputField Component', () => {
       expect(onChange).toBeCalledWith({
         type: SignInIdentifier.Email,
         value: `11@`,
+      });
+    });
+
+    test('should parse pasted phone number and keep email detection working', () => {
+      const { container, getByText } = renderInputField(config);
+      const input = container.querySelector('input');
+
+      assert(input, new Error('Input field not found'));
+
+      fireEvent.change(input, { target: { value: '+79370000000' } });
+      expect(getByText('+7')).not.toBeNull();
+      expect(input.value).toBe('9370000000');
+      expect(onChange).toHaveBeenLastCalledWith({
+        type: SignInIdentifier.Phone,
+        value: '79370000000',
+      });
+
+      fireEvent.change(input, { target: { value: 'foo@' } });
+      expect(onChange).toHaveBeenLastCalledWith({
+        type: SignInIdentifier.Email,
+        value: 'foo@',
       });
     });
   });

--- a/packages/experience/src/shared/components/InputFields/SmartInputField/index.test.tsx
+++ b/packages/experience/src/shared/components/InputFields/SmartInputField/index.test.tsx
@@ -143,7 +143,7 @@ describe('SmartInputField Component', () => {
       });
     });
 
-    test('should keep partial international phone input as raw value', () => {
+    test('should strip the leading "+" from partial international phone input', () => {
       const { container, getByText } = renderInputField({
         enabledTypes: [SignInIdentifier.Phone],
       });
@@ -152,8 +152,14 @@ describe('SmartInputField Component', () => {
 
       fireEvent.change(input, { target: { value: '+7' } });
 
+      // The `+` is represented by the country code selector, so it should not be kept in the input
+      // value, otherwise `SmartInputField` would emit a malformed value like `${countryCode}+7`.
       expect(getByText(`+${defaultCountryCallingCode}`)).not.toBeNull();
-      expect(input.value).toBe('+7');
+      expect(input.value).toBe('7');
+      expect(onChange).toHaveBeenLastCalledWith({
+        type: SignInIdentifier.Phone,
+        value: `${defaultCountryCallingCode}7`,
+      });
     });
   });
 

--- a/packages/experience/src/shared/components/InputFields/SmartInputField/use-smart-input-field.ts
+++ b/packages/experience/src/shared/components/InputFields/SmartInputField/use-smart-input-field.ts
@@ -2,7 +2,7 @@ import { SignInIdentifier } from '@logto/schemas';
 import { useState, useCallback, useMemo } from 'react';
 import type { ChangeEventHandler } from 'react';
 
-import { getDefaultCountryCallingCode } from '@/utils/country-code';
+import { getDefaultCountryCallingCode, parsePhoneNumber } from '@/utils/country-code';
 import { parseIdentifierValue } from '@/utils/form';
 
 import { detectIdentifierType } from './utils';
@@ -70,12 +70,24 @@ const useSmartInputField = ({ defaultValue, enabledTypes }: Props) => {
   const onInputValueChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
     ({ target: { value } }) => {
       const trimValue = value.trim();
+
+      if (enabledTypeSet.has(SignInIdentifier.Phone) && trimValue.startsWith('+')) {
+        const phoneNumber = parsePhoneNumber(trimValue);
+
+        if (phoneNumber?.nationalNumber) {
+          setCountryCode(phoneNumber.countryCallingCode);
+          setInputValue(phoneNumber.nationalNumber);
+          setCurrentType(SignInIdentifier.Phone);
+          return;
+        }
+      }
+
       setInputValue(trimValue);
 
       const type = detectInputType(trimValue);
       setCurrentType(type);
     },
-    [detectInputType]
+    [detectInputType, enabledTypeSet]
   );
 
   const onInputValueClear = useCallback(() => {

--- a/packages/experience/src/shared/components/InputFields/SmartInputField/use-smart-input-field.ts
+++ b/packages/experience/src/shared/components/InputFields/SmartInputField/use-smart-input-field.ts
@@ -2,8 +2,8 @@ import { SignInIdentifier } from '@logto/schemas';
 import { useState, useCallback, useMemo } from 'react';
 import type { ChangeEventHandler } from 'react';
 
-import { getDefaultCountryCallingCode, parsePhoneNumber } from '@/utils/country-code';
-import { parseIdentifierValue } from '@/utils/form';
+import { getDefaultCountryCallingCode } from '@/utils/country-code';
+import { parseIdentifierValue, parsePhoneIdentifier } from '@/utils/form';
 
 import { detectIdentifierType } from './utils';
 
@@ -72,11 +72,11 @@ const useSmartInputField = ({ defaultValue, enabledTypes }: Props) => {
       const trimValue = value.trim();
 
       if (enabledTypeSet.has(SignInIdentifier.Phone) && trimValue.startsWith('+')) {
-        const phoneNumber = parsePhoneNumber(trimValue);
+        const phoneIdentifier = parsePhoneIdentifier(trimValue);
 
-        if (phoneNumber?.nationalNumber) {
-          setCountryCode(phoneNumber.countryCallingCode);
-          setInputValue(phoneNumber.nationalNumber);
+        if (phoneIdentifier) {
+          setCountryCode(phoneIdentifier.countryCode);
+          setInputValue(phoneIdentifier.inputValue);
           setCurrentType(SignInIdentifier.Phone);
           return;
         }

--- a/packages/experience/src/shared/components/InputFields/SmartInputField/use-smart-input-field.ts
+++ b/packages/experience/src/shared/components/InputFields/SmartInputField/use-smart-input-field.ts
@@ -80,6 +80,18 @@ const useSmartInputField = ({ defaultValue, enabledTypes }: Props) => {
           setCurrentType(SignInIdentifier.Phone);
           return;
         }
+
+        /**
+         * When phone is the only enabled type, the value is always treated as a phone number and
+         * the country calling code is prepended to it. A leading `+` that does not yet parse into a
+         * full number (e.g. `+7`) would otherwise produce a malformed value like `86+7`, so strip
+         * it here since the `+` is already represented by the country code selector.
+         */
+        if (enabledTypeSet.size === 1) {
+          setInputValue(trimValue.slice(1));
+          setCurrentType(SignInIdentifier.Phone);
+          return;
+        }
       }
 
       setInputValue(trimValue);

--- a/packages/experience/src/utils/form.ts
+++ b/packages/experience/src/utils/form.ts
@@ -79,14 +79,31 @@ export const getGeneralIdentifierErrorMessage = (
   return t(code, data);
 };
 
+/**
+ * Try to interpret a value as a full international phone number (e.g. a pasted or stored
+ * E.164 number like `+8613800138000`), splitting it into the country calling code and the
+ * national number. Returns `undefined` when the value does not parse into a national number,
+ * so callers can fall back to treating it as a plain input value.
+ */
+export const parsePhoneIdentifier = (value: string) => {
+  const phoneNumber = parsePhoneNumber(value);
+
+  if (phoneNumber?.nationalNumber) {
+    return {
+      countryCode: phoneNumber.countryCallingCode,
+      inputValue: phoneNumber.nationalNumber,
+    };
+  }
+};
+
 export const parseIdentifierValue = (type?: IdentifierInputType, value?: string) => {
   if (type === SignInIdentifier.Phone && value) {
-    const validPhoneNumber = parsePhoneNumber(value);
+    const phoneIdentifier = parsePhoneIdentifier(value);
 
-    if (validPhoneNumber) {
+    if (phoneIdentifier) {
       return {
-        countryCode: validPhoneNumber.countryCallingCode,
-        inputValue: validPhoneNumber.nationalNumber,
+        countryCode: phoneIdentifier.countryCode,
+        inputValue: phoneIdentifier.inputValue,
       };
     }
   }


### PR DESCRIPTION
## Summary
Pasting a full international phone number (e.g. `+8613800138000`) into the smart input field left the whole string, including the country calling code, in the national-number box and did not switch the country selector. Users then had to manually delete the country code.

## Changes
When the phone identifier is enabled and the pasted/typed value starts with `+`, parse it with the existing `parsePhoneNumber` util and, if it yields a national number, set the country selector to the detected calling code and put just the national number in the field.

## Testing
Added cases to `SmartInputField/index.test.tsx` for a pasted `+<cc><number>` value and for values that should not be reinterpreted.

Fixes #9118
