### PR TITLE
fix(core): log tenant initialization errors

### DIFF
--- a/packages/core/src/app/init.test.ts
+++ b/packages/core/src/app/init.test.ts
@@ -2,8 +2,32 @@ import { createServer } from 'node:http';
 
 import { pickDefault } from '@logto/shared/esm';
 import Koa from 'koa';
+import request from 'supertest';
 
 const { jest } = import.meta;
+
+const getTenantId = jest.fn();
+const tenantPoolGet = jest.fn();
+const trackException = jest.fn();
+
+class TenantNotFoundError extends Error {}
+
+jest.unstable_mockModule('@logto/app-insights/node', () => ({
+  appInsights: {
+    trackException,
+  },
+}));
+
+jest.unstable_mockModule('#src/tenants/index.js', () => ({
+  TenantNotFoundError,
+  tenantPool: {
+    get: tenantPoolGet,
+  },
+}));
+
+jest.unstable_mockModule('#src/utils/tenant.js', () => ({
+  getTenantId,
+}));
 
 const initI18n = await pickDefault(import('../i18n/init.js'));
 const initApp = await pickDefault(import('./init.js'));
@@ -19,5 +43,26 @@ describe('App Init', () => {
     await initApp(app);
 
     expect(listenMock).toBeCalled();
+  });
+
+  it('logs tenant initialization errors to the request console', async () => {
+    const tenantError = new Error('tenant init failed');
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    getTenantId.mockResolvedValueOnce(['default', false]);
+    tenantPoolGet.mockRejectedValueOnce(tenantError);
+
+    try {
+      const app = new Koa();
+      await initApp(app);
+
+      const response = await request(app.callback()).get('/');
+
+      expect(response.status).toBe(500);
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(consoleError.mock.calls[0]).toContain(tenantError);
+      expect(trackException).toHaveBeenCalledWith(tenantError, expect.any(Object));
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/packages/core/src/app/init.ts
+++ b/packages/core/src/app/init.ts
@@ -12,6 +12,7 @@ import { nanoid } from 'nanoid';
 
 import { EnvSet } from '#src/env-set/index.js';
 import { TenantNotFoundError, tenantPool } from '#src/tenants/index.js';
+import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 import { getTenantId } from '#src/utils/tenant.js';
 
@@ -68,6 +69,7 @@ export default async function initApp(app: Koa): Promise<void> {
 
     const tenant = await trySafe(tenantPool.get(tenantId, customEndpoint), (error) => {
       ctx.status = error instanceof TenantNotFoundError ? 404 : 500;
+      getConsoleLogFromContext(ctx).error(error);
       void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));
     });
 


### PR DESCRIPTION
## Summary

- Log tenant initialization failures to the request console before returning the error response.
- Add a regression test for the `tenantPool.get()` rejection path.

Closes #5807

## Testing

Unit tests