### PR TITLE
fix(core): correct TLS protocol check for 'rediss:'

### DIFF
--- a/.changeset/flat-rockets-laugh.md
+++ b/.changeset/flat-rockets-laugh.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+fix TLS not being enabled for Redis cluster connections using the rediss protocol

--- a/packages/core/src/caches/index.test.ts
+++ b/packages/core/src/caches/index.test.ts
@@ -8,29 +8,33 @@ const { mockEsm } = createMockUtils(jest);
 
 const mockFunction = jest.fn();
 
+const createClient = jest.fn((_config?: { socket?: { tls?: boolean } }) => ({
+  // Standalone clients report readiness via `isReady`; default to ready so commands run.
+  isReady: true,
+  set: mockFunction,
+  get: mockFunction,
+  del: mockFunction,
+  ping: async () => 'PONG',
+  connect: mockFunction,
+  disconnect: mockFunction,
+  on: mockFunction,
+}));
+
+const createCluster = jest.fn((_config?: { defaults?: { socket?: { tls?: boolean } } }) => ({
+  // The cluster client only exposes `isOpen`; default to open so commands run.
+  isOpen: true,
+  set: mockFunction,
+  get: mockFunction,
+  del: mockFunction,
+  sendCommand: async () => 'PONG',
+  connect: mockFunction,
+  disconnect: mockFunction,
+  on: mockFunction,
+}));
+
 mockEsm('redis', () => ({
-  createClient: () => ({
-    // Standalone clients report readiness via `isReady`; default to ready so commands run.
-    isReady: true,
-    set: mockFunction,
-    get: mockFunction,
-    del: mockFunction,
-    ping: async () => 'PONG',
-    connect: mockFunction,
-    disconnect: mockFunction,
-    on: mockFunction,
-  }),
-  createCluster: () => ({
-    // The cluster client only exposes `isOpen`; default to open so commands run.
-    isOpen: true,
-    set: mockFunction,
-    get: mockFunction,
-    del: mockFunction,
-    sendCommand: async () => 'PONG',
-    connect: mockFunction,
-    disconnect: mockFunction,
-    on: mockFunction,
-  }),
+  createClient,
+  createCluster,
 }));
 
 const { RedisCache, RedisClusterCache, redisCacheFactory } = await import('./index.js');
@@ -176,4 +180,38 @@ describe('RedisCache', () => {
       warnSpy.mockRestore();
     }
   }, 8000);
+});
+
+describe('TLS socket options derived from the URL protocol', () => {
+  it('enables TLS for a standalone client when the protocol is rediss', () => {
+    jest.clearAllMocks();
+    const cache = new RedisCache('rediss://url');
+
+    expect(cache.client).toBeTruthy();
+    expect(createClient.mock.calls[0]?.[0]?.socket?.tls).toBe(true);
+  });
+
+  it('does not enable TLS for a standalone client when the protocol is redis', () => {
+    jest.clearAllMocks();
+    const cache = new RedisCache('redis://url');
+
+    expect(cache.client).toBeTruthy();
+    expect(createClient.mock.calls[0]?.[0]?.socket?.tls).toBe(false);
+  });
+
+  it('enables TLS on the cluster node defaults when the protocol is rediss', () => {
+    jest.clearAllMocks();
+    const cache = new RedisClusterCache(new URL('rediss://url?cluster=1'));
+
+    expect(cache.client).toBeTruthy();
+    expect(createCluster.mock.calls[0]?.[0]?.defaults?.socket?.tls).toBe(true);
+  });
+
+  it('does not enable TLS on the cluster node defaults when the protocol is redis', () => {
+    jest.clearAllMocks();
+    const cache = new RedisClusterCache(new URL('redis://url?cluster=1'));
+
+    expect(cache.client).toBeTruthy();
+    expect(createCluster.mock.calls[0]?.[0]?.defaults?.socket?.tls).toBe(false);
+  });
 });

--- a/packages/core/src/caches/index.ts
+++ b/packages/core/src/caches/index.ts
@@ -137,7 +137,7 @@ abstract class RedisCacheBase implements CacheStore {
 
     return {
       rejectUnauthorized: yes(url?.searchParams.get('reject_unauthorized')),
-      tls: url?.protocol === 'rediss',
+      tls: url?.protocol === 'rediss:',
       cert: certFile ? fs.readFileSync(certFile).toString() : undefined,
       key: keyFile ? fs.readFileSync(keyFile).toString() : undefined,
       ca: caFile ? fs.readFileSync(caFile).toString() : undefined,


### PR DESCRIPTION
## Summary

`RedisCacheBase.getSocketOptions()` decides whether to enable TLS by comparing the URL protocol against the string `rediss`

```
tls: url?.protocol === 'rediss'
```

However, `URL.prototype.protocol` always includes a trailing colon

```
> new URL('rediss://username:password@abcdefg.serverless.euw1.cache.amazonaws.com:6379?cluster=1')
{
  "href": "rediss://username:password@abcdefg.serverless.euw1.cache.amazonaws.com:6379?cluster=1",
  "protocol": "rediss:",
  "username": "username",
  "password": "password",
  "host": "abcdefg.serverless.euw1.cache.amazonaws.com:6379",
  "hostname": "abcdefg.serverless.euw1.cache.amazonaws.com",
  "port": "6379",
  "pathname": "",
  "search": "?cluster=1",
  "hash": "",
  "origin": "null",
  "searchParams": {
    "cluster": "1"
  }
}
```
Note that the `protocol` property is `"rediss:" (with a trailing colon) and not "rediss". The comparison is therefore always `false`, and TLS is never enabled from the connection URL. Thus, a `rediss://…?cluster=1` connection string opens a plaintext socket to a TLS-only cluster. The client can't complete the handshake or run `CLUSTER SLOTS`, so it hangs on connect and the cache never becomes ready.

## Testing
- Connected a cluster cache (`?cluster=1` with a `rediss://` URL) to a TLS-required Redis running in cluster mode (AWS ElastiCache Serverless). Before the fix, startup hangs on `cluster.connect();` after the fix, the client connects and read/write commands succeed.
- Standalone `rediss://` and plaintext `redis://` connections are unaffected.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
