### PR TITLE
fix(core): decode credentials from connectionUrl

### DIFF
--- a/.changeset/chatty-moons-boil.md
+++ b/.changeset/chatty-moons-boil.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+decode percent-encoded Redis cluster credentials so connections succeed when usernames or passwords include URL-reserved characters

--- a/packages/core/src/caches/index.test.ts
+++ b/packages/core/src/caches/index.test.ts
@@ -137,6 +137,43 @@ describe('RedisCache', () => {
     }
   });
 
+  it('should not throw and decode selectively when credentials mix literal `%` with encoded chars', () => {
+    jest.clearAllMocks();
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      redisUrl: 'rediss://user:pa%s^s@redis.example:6379?cluster=1', // `pa%s^s` parses to `pa%s%5Es`
+    });
+
+    try {
+      redisCacheFactory();
+
+      const options = createCluster.mock.calls[0]?.[0];
+      expect(options?.defaults?.username).toBe('user');
+      expect(options?.defaults?.password).toBe('pa%s^s'); // `%s` kept literal, `%5E`->`^`
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it('should decode multi-byte UTF-8 sequences in credentials', () => {
+    jest.clearAllMocks();
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      // `café`/`你好` -> `caf%C3%A9`/`%E4%BD%A0%E5%A5%BD`
+      redisUrl: 'rediss://caf%C3%A9:%E4%BD%A0%E5%A5%BD@redis.example:6379?cluster=1',
+    });
+
+    try {
+      redisCacheFactory();
+
+      const options = createCluster.mock.calls[0]?.[0];
+      expect(options?.defaults?.username).toBe('café');
+      expect(options?.defaults?.password).toBe('你好');
+    } finally {
+      stub.restore();
+    }
+  });
+
   it('should pass undefined cluster credentials when the URL has none', () => {
     jest.clearAllMocks();
     const stub = Sinon.stub(EnvSet, 'values').value({

--- a/packages/core/src/caches/index.test.ts
+++ b/packages/core/src/caches/index.test.ts
@@ -8,19 +8,22 @@ const { mockEsm } = createMockUtils(jest);
 
 const mockFunction = jest.fn();
 
-mockEsm('redis', () => ({
-  createClient: () => ({
-    // Standalone clients report readiness via `isReady`; default to ready so commands run.
-    isReady: true,
-    set: mockFunction,
-    get: mockFunction,
-    del: mockFunction,
-    ping: async () => 'PONG',
-    connect: mockFunction,
-    disconnect: mockFunction,
-    on: mockFunction,
-  }),
-  createCluster: () => ({
+const createClient = jest.fn((_config?: { socket?: { tls?: boolean } }) => ({
+  // Standalone clients report readiness via `isReady`; default to ready so commands run.
+  isReady: true,
+  set: mockFunction,
+  get: mockFunction,
+  del: mockFunction,
+  ping: async () => 'PONG',
+  connect: mockFunction,
+  disconnect: mockFunction,
+  on: mockFunction,
+}));
+
+const createCluster = jest.fn(
+  (_config?: {
+    defaults?: { username?: string; password?: string; socket?: { tls?: boolean } };
+  }) => ({
     // The cluster client only exposes `isOpen`; default to open so commands run.
     isOpen: true,
     set: mockFunction,
@@ -30,7 +33,12 @@ mockEsm('redis', () => ({
     connect: mockFunction,
     disconnect: mockFunction,
     on: mockFunction,
-  }),
+  })
+);
+
+mockEsm('redis', () => ({
+  createClient,
+  createCluster,
 }));
 
 const { RedisCache, RedisClusterCache, redisCacheFactory } = await import('./index.js');
@@ -107,6 +115,41 @@ describe('RedisCache', () => {
 
       // Do sanity check only
       expect(mockFunction).toBeCalledTimes(6);
+      stub.restore();
+    }
+  });
+
+  it('should decode percent-encoded credentials for the cluster client', () => {
+    jest.clearAllMocks();
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      redisUrl: 'rediss://user:p%40ss%2Fword@redis.example:6379?cluster=1',
+    });
+
+    try {
+      redisCacheFactory();
+
+      const options = createCluster.mock.calls[0]?.[0];
+      expect(options?.defaults?.username).toBe('user');
+      expect(options?.defaults?.password).toBe('p@ss/word'); // `%40`->`@`, `%2F`->`/`
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it('should pass undefined cluster credentials when the URL has none', () => {
+    jest.clearAllMocks();
+    const stub = Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      redisUrl: 'rediss://redis.example:6379?cluster=1',
+    });
+
+    try {
+      redisCacheFactory();
+      const options = createCluster.mock.calls[0]?.[0];
+      expect(options?.defaults?.username).toBeUndefined();
+      expect(options?.defaults?.password).toBeUndefined();
+    } finally {
       stub.restore();
     }
   });

--- a/packages/core/src/caches/index.ts
+++ b/packages/core/src/caches/index.ts
@@ -18,6 +18,21 @@ const redisCacheWriteTimeout = 5000;
 const timeoutSentinel = Symbol('redis-cache-timeout');
 
 /**
+ * Safely decode URL-encoded strings from new URL()
+ *
+ * `new URL()` percent-encodes reserved characters (e.g. `^` becomes `%5E`)
+ * so the raw values must be decoded before being passed to Redis `AUTH`.
+ * However, `decodeURIComponent` throw `URIError` if the string contains a literal `%`
+ * `safeDecode` decode only maximal runs of valid `%XX` sequences and leave any stray `%` untouched.
+ * Takes into account multi-byte UTF-8 sequences like `%C3%A9`
+ */
+const safeDecode = (value: string): string =>
+  value.replaceAll(
+    /(?:%[\dA-Fa-f]{2})+/g,
+    (sequence) => trySafe(() => decodeURIComponent(sequence)) ?? sequence
+  );
+
+/**
  * Race a Redis command against a deadline so cache I/O can never block a request indefinitely.
  * On timeout, logs a warning and resolves to `undefined` so callers degrade to a cache miss.
  * Errors from the underlying Redis command are not caught here — they still reject as usual,
@@ -215,8 +230,8 @@ export class RedisClusterCache extends RedisCacheBase {
       useReplicas: true,
       defaults: {
         socket: this.getSocketOptions(connectionUrl),
-        username: connectionUrl.username ? decodeURIComponent(connectionUrl.username) : undefined,
-        password: connectionUrl.password ? decodeURIComponent(connectionUrl.password) : undefined,
+        username: connectionUrl.username ? safeDecode(connectionUrl.username) : undefined,
+        password: connectionUrl.password ? safeDecode(connectionUrl.password) : undefined,
       },
     });
 

--- a/packages/core/src/caches/index.ts
+++ b/packages/core/src/caches/index.ts
@@ -215,8 +215,8 @@ export class RedisClusterCache extends RedisCacheBase {
       useReplicas: true,
       defaults: {
         socket: this.getSocketOptions(connectionUrl),
-        username: connectionUrl.username,
-        password: connectionUrl.password,
+        username: connectionUrl.username ? decodeURIComponent(connectionUrl.username) : undefined,
+        password: connectionUrl.password ? decodeURIComponent(connectionUrl.password) : undefined,
       },
     });
 

--- a/packages/core/src/caches/index.ts
+++ b/packages/core/src/caches/index.ts
@@ -22,9 +22,9 @@ const timeoutSentinel = Symbol('redis-cache-timeout');
  *
  * `new URL()` percent-encodes reserved characters (e.g. `^` becomes `%5E`)
  * so the raw values must be decoded before being passed to Redis `AUTH`.
- * However, `decodeURIComponent` throw `URIError` if the string contains a literal `%`
- * `safeDecode` decode only maximal runs of valid `%XX` sequences and leave any stray `%` untouched.
- * Takes into account multi-byte UTF-8 sequences like `%C3%A9`
+ * However, `decodeURIComponent` throws a `URIError` if the string contains a literal `%`
+ * `safeDecode` decodes only maximal runs of valid `%XX` sequences and leaves any stray `%` untouched.
+ * It also takes into account multi-byte UTF-8 sequences like `%C3%A9`
  */
 const safeDecode = (value: string): string =>
   value.replaceAll(


### PR DESCRIPTION
## Summary

```
> new URL('rediss://username:pass^word@abcdefg.serverless.euw1.cache.amazonaws.com:6379?cluster=1')
{
  "href": "rediss://username:pass%5Eword@abcdefg.serverless.euw1.cache.amazonaws.com:6379?cluster=1",
  "protocol": "rediss:",
  "username": "username",
  "password": "pass%5Eword",
  "host": "abcdefg.serverless.euw1.cache.amazonaws.com:6379",
  "hostname": "abcdefg.serverless.euw1.cache.amazonaws.com",
  "port": "6379",
  "pathname": "",
  "search": "?cluster=1",
  "hash": "",
  "origin": "null",
  "searchParams": {
    "cluster": "1"
  }
}
```

Note that the `password` is percent-encoded - `pass%5Eword`. Thus, passing it straight into `defaults.username` and `defaults.password` is going to cause the wrong credentials to be passed if those credentials contain characters that are percent-encoded, and `AUTH` fails with `WRONGPASS`.

This PR ensure `connectionUrl.{username|password}` is always decoded.

## Testing
- Without the fix it logged `WRONGPASS`
- Patched the fix and deployed and logs shows Redis was connected successfully

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
