### PR TITLE
test(test): cover email blocklist wildcard matching

### DIFF
--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -26,7 +26,51 @@ import {
   signInAndGetUserApi,
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { generateEmail, generatePhone, generateNationalPhoneNumber } from '#src/utils.js';
+import {
+  devFeatureTest,
+  generateEmail,
+  generatePhone,
+  generateNationalPhoneNumber,
+} from '#src/utils.js';
+
+const expectPrimaryEmailUpdateRejectedByBlocklist = async (
+  email: string,
+  customBlocklist: string[]
+) => {
+  await updateSignInExperience({
+    emailBlocklistPolicy: {
+      customBlocklist,
+    },
+  });
+
+  const { user, username, password } = await createDefaultTenantUserWithPassword();
+  const api = await signInAndGetUserApi(username, password, {
+    scopes: [UserScope.Profile, UserScope.Email],
+  });
+
+  try {
+    const verificationRecordId = await createVerificationRecordByPassword(api, password);
+    const newVerificationRecordId = await createAndVerifyVerificationCode(api, {
+      type: SignInIdentifier.Email,
+      value: email,
+    });
+
+    await expectRejects(
+      updatePrimaryEmail(api, email, verificationRecordId, newVerificationRecordId),
+      {
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+      }
+    );
+  } finally {
+    await updateSignInExperience({
+      emailBlocklistPolicy: {
+        customBlocklist: [],
+      },
+    });
+    await deleteDefaultTenantUser(user.id);
+  }
+};
 
 describe('account (email and phone)', () => {
   beforeAll(async () => {
@@ -144,33 +188,24 @@ describe('account (email and phone)', () => {
 
     it('should reject the email if the email is in the blocklist', async () => {
       const email = generateEmail();
-      await updateSignInExperience({
-        emailBlocklistPolicy: {
-          customBlocklist: [email],
-        },
-      });
 
-      const { user, username, password } = await createDefaultTenantUserWithPassword();
-      const api = await signInAndGetUserApi(username, password, {
-        scopes: [UserScope.Profile, UserScope.Email],
-      });
-
-      const verificationRecordId = await createVerificationRecordByPassword(api, password);
-      const newVerificationRecordId = await createAndVerifyVerificationCode(api, {
-        type: SignInIdentifier.Email,
-        value: email,
-      });
-
-      await expectRejects(
-        updatePrimaryEmail(api, email, verificationRecordId, newVerificationRecordId),
-        {
-          code: 'session.email_blocklist.email_not_allowed',
-          status: 422,
-        }
-      );
-
-      await deleteDefaultTenantUser(user.id);
+      await expectPrimaryEmailUpdateRejectedByBlocklist(email, [email]);
     });
+
+    it('should reject the email if the exact blocklist entry uses different casing', async () => {
+      const email = generateEmail('account-blocklist.com');
+
+      await expectPrimaryEmailUpdateRejectedByBlocklist(email, [email.toUpperCase()]);
+    });
+
+    devFeatureTest.it(
+      'should reject the email if the wildcard blocklist entry uses different casing',
+      async () => {
+        const email = `foo-${generateEmail('account-wildcard.com')}`;
+
+        await expectPrimaryEmailUpdateRejectedByBlocklist(email, ['FOO*@ACCOUNT-WILDCARD.COM']);
+      }
+    );
   });
 
   describe('DELETE /my-account/primary-email', () => {

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
@@ -31,7 +31,15 @@ describe('should reject the email registration if the email is in the blocklist'
   const blockEmail = generateEmail(blockDomain);
 
   afterAll(async () => {
-    await ssoConnectorApi.cleanUp();
+    await Promise.all([
+      ssoConnectorApi.cleanUp(),
+      updateSignInExperience({
+        emailBlocklistPolicy: {
+          blockSubaddressing: false,
+          customBlocklist: [],
+        },
+      }),
+    ]);
   });
 
   beforeAll(async () => {

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
@@ -15,13 +15,19 @@ import {
   successfullyVerifySocialAuthorization,
 } from '#src/helpers/experience/social-verification.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { generateEmail } from '#src/utils.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
+
+const emailNotAllowedError = {
+  code: 'session.email_blocklist.email_not_allowed',
+  status: 422,
+} as const;
 
 describe('should reject the email registration if the email is in the blocklist', () => {
   const ssoConnectorApi = new SsoConnectorApi();
   const ssoDomain = 'sso.com';
   const blockDomain = 'block.com';
-  const ssoEmail = generateEmail(ssoDomain);
+  const exactBlocklistEmail = `ExactBlocked@${ssoDomain}`;
+  const exactBlockedEmail = exactBlocklistEmail.toLowerCase();
   const blockEmail = generateEmail(blockDomain);
 
   afterAll(async () => {
@@ -36,7 +42,7 @@ describe('should reject the email registration if the email is in the blocklist'
       signUp: { identifiers: [SignInIdentifier.Email], password: false, verify: true },
       emailBlocklistPolicy: {
         blockSubaddressing: true,
-        customBlocklist: [`@${blockDomain}`, ssoEmail],
+        customBlocklist: [`@${blockDomain.toUpperCase()}`, exactBlocklistEmail],
       },
     });
   });
@@ -69,7 +75,24 @@ describe('should reject the email registration if the email is in the blocklist'
       value: blockEmail,
     });
 
-    const errorCode = 'session.email_blocklist.email_not_allowed';
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.Register,
+    });
+
+    await expectRejects(
+      client.sendVerificationCode({
+        identifier,
+        interactionEvent: InteractionEvent.Register,
+      }),
+      emailNotAllowedError
+    );
+  });
+
+  it('should reject email with exact address in the custom blocklist case-insensitively', async () => {
+    const identifier = Object.freeze({
+      type: SignInIdentifier.Email,
+      value: exactBlockedEmail,
+    });
 
     const client = await initExperienceClient({
       interactionEvent: InteractionEvent.Register,
@@ -80,10 +103,7 @@ describe('should reject the email registration if the email is in the blocklist'
         identifier,
         interactionEvent: InteractionEvent.Register,
       }),
-      {
-        code: errorCode,
-        status: 422,
-      }
+      emailNotAllowedError
     );
   });
 
@@ -124,11 +144,74 @@ describe('should reject the email registration if the email is in the blocklist'
         client.identifyUser({
           verificationId,
         }),
-        {
-          code: 'session.email_blocklist.email_not_allowed',
-          status: 422,
-        }
+        emailNotAllowedError
       );
+    });
+  });
+
+  devFeatureTest.describe('wildcard email blocklist entries', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({
+        emailBlocklistPolicy: {
+          blockSubaddressing: true,
+          customBlocklist: [
+            `@${blockDomain.toUpperCase()}`,
+            exactBlocklistEmail,
+            'foo*@example.com',
+            '@foo.*',
+          ],
+        },
+      });
+    });
+
+    it('should reject email matched by a wildcard local part blocklist entry', async () => {
+      const client = await initExperienceClient({
+        interactionEvent: InteractionEvent.Register,
+      });
+
+      await expectRejects(
+        client.sendVerificationCode({
+          identifier: {
+            type: SignInIdentifier.Email,
+            value: 'foobar@example.com',
+          },
+          interactionEvent: InteractionEvent.Register,
+        }),
+        emailNotAllowedError
+      );
+    });
+
+    it('should reject email matched by a wildcard domain blocklist entry', async () => {
+      const client = await initExperienceClient({
+        interactionEvent: InteractionEvent.Register,
+      });
+
+      await expectRejects(
+        client.sendVerificationCode({
+          identifier: {
+            type: SignInIdentifier.Email,
+            value: 'bar@foo.dev',
+          },
+          interactionEvent: InteractionEvent.Register,
+        }),
+        emailNotAllowedError
+      );
+    });
+
+    it('should allow email that does not match any wildcard blocklist entry', async () => {
+      const client = await initExperienceClient({
+        interactionEvent: InteractionEvent.Register,
+      });
+
+      await expect(
+        client.sendVerificationCode({
+          identifier: {
+            type: SignInIdentifier.Email,
+            value: 'bar@example.com',
+          },
+          interactionEvent: InteractionEvent.Register,
+        })
+      ).resolves.toHaveProperty('verificationId');
     });
   });
 });


### PR DESCRIPTION
## Summary
Add integration coverage for email blocklist matching across registration and Account API primary email updates. The tests cover case-insensitive exact address/domain matching, wildcard local-part and domain matching, and a non-matching registration email path.

Stacked on #9147.

## Testing
Integration tests

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments