### PR TITLE
feat(core): support reset one-time token context

### DIFF
--- a/packages/core/src/libraries/one-time-token.ts
+++ b/packages/core/src/libraries/one-time-token.ts
@@ -1,4 +1,4 @@
-import { OneTimeTokenStatus } from '@logto/schemas';
+import { type InteractionEvent, OneTimeTokenStatus } from '@logto/schemas';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -22,10 +22,20 @@ export const createOneTimeTokenLibrary = (queries: Queries) => {
     return updateOneTimeTokenStatusQuery(token, status);
   };
 
-  const checkOneTimeToken = async (token: string, email: string) => {
+  const checkOneTimeToken = async (
+    token: string,
+    email: string,
+    expectedInteractionEvent?: InteractionEvent
+  ) => {
     const oneTimeToken = await getOneTimeTokenByToken(token);
 
     assertThat(oneTimeToken.email === email, 'one_time_token.email_mismatch');
+    assertThat(
+      !oneTimeToken.context.interactionEvent ||
+        !expectedInteractionEvent ||
+        oneTimeToken.context.interactionEvent === expectedInteractionEvent,
+      'one_time_token.interaction_event_mismatch'
+    );
 
     if (
       oneTimeToken.expiresAt <= Date.now() ||
@@ -46,8 +56,12 @@ export const createOneTimeTokenLibrary = (queries: Queries) => {
     return oneTimeToken;
   };
 
-  const verifyOneTimeToken = async (token: string, email: string) => {
-    await checkOneTimeToken(token, email);
+  const verifyOneTimeToken = async (
+    token: string,
+    email: string,
+    expectedInteractionEvent?: InteractionEvent
+  ) => {
+    await checkOneTimeToken(token, email, expectedInteractionEvent);
 
     return updateOneTimeTokenStatus(token, OneTimeTokenStatus.Consumed);
   };

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -1,5 +1,6 @@
 import {
   type InteractionIdentifier,
+  type InteractionEvent,
   type OneTimeTokenContext,
   type SignInIdentifier,
   type User,
@@ -76,10 +77,11 @@ export class OneTimeTokenVerification
   /**
    * Verifies if the one-time token matches the record in database with the provided email.
    */
-  async verify(token: string) {
+  async verify(token: string, expectedInteractionEvent?: InteractionEvent) {
     const tokenRecord = await this.libraries.oneTimeTokens.verifyOneTimeToken(
       token,
-      this.identifier.value
+      this.identifier.value,
+      expectedInteractionEvent
     );
     this.verified = true;
     this.context = tokenRecord.context;

--- a/packages/core/src/routes/experience/verification-routes/one-time-token.ts
+++ b/packages/core/src/routes/experience/verification-routes/one-time-token.ts
@@ -59,7 +59,7 @@ export default function oneTimeTokenVerificationRoutes<
             verificationId: oneTimeTokenVerificationRecord.id,
           },
         },
-        oneTimeTokenVerificationRecord.verify(token)
+        oneTimeTokenVerificationRecord.verify(token, experienceInteraction.interactionEvent)
       );
 
       // Skip CAPTCHA for one-time token flow

--- a/packages/core/src/routes/one-time-tokens.openapi.json
+++ b/packages/core/src/routes/one-time-tokens.openapi.json
@@ -45,7 +45,7 @@
                     "description": "The expiration time in seconds. If not provided, defaults to 10 mins (600 seconds)."
                   },
                   "context": {
-                    "description": "Additional context to store with the one-time token. This can be used to store arbitrary data that will be associated with the token."
+                    "description": "Additional context to store with the one-time token, such as JIT organization IDs or the interaction event this token is intended for."
                   }
                 }
               }

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/one-time-token.test.ts
@@ -1,6 +1,10 @@
-import { SignInIdentifier } from '@logto/schemas';
+import { InteractionEvent, OneTimeTokenStatus, SignInIdentifier } from '@logto/schemas';
 
-import { createOneTimeToken } from '#src/api/one-time-token.js';
+import {
+  createOneTimeToken,
+  deleteOneTimeTokenById,
+  getOneTimeTokenById,
+} from '#src/api/one-time-token.js';
 import { initExperienceClient } from '#src/helpers/client.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { waitFor } from '#src/utils.js';
@@ -117,5 +121,40 @@ describe('One-time token verification APIs', () => {
         status: 400,
       }
     );
+  });
+
+  it('should throw interaction_event_mismatch error when token context does not match current interaction event', async () => {
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    const oneTimeToken = await createOneTimeToken({
+      email: 'foo@logto.io',
+      context: {
+        interactionEvent: InteractionEvent.ForgotPassword,
+      },
+    });
+
+    try {
+      await expectRejects(
+        client.verifyOneTimeToken({
+          token: oneTimeToken.token,
+          identifier: {
+            type: SignInIdentifier.Email,
+            value: 'foo@logto.io',
+          },
+        }),
+        {
+          code: 'one_time_token.interaction_event_mismatch',
+          status: 400,
+        }
+      );
+
+      await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
+        status: OneTimeTokenStatus.Active,
+      });
+    } finally {
+      await deleteOneTimeTokenById(oneTimeToken.id);
+    }
   });
 });

--- a/packages/integration-tests/src/tests/api/one-time-tokens.test.ts
+++ b/packages/integration-tests/src/tests/api/one-time-tokens.test.ts
@@ -1,4 +1,4 @@
-import { OneTimeTokenStatus } from '@logto/schemas';
+import { InteractionEvent, OneTimeTokenStatus } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 
 import { authedAdminApi } from '#src/api/api.js';
@@ -48,11 +48,12 @@ describe('one-time tokens API', () => {
     await deleteOneTimeTokenById(oneTimeToken.id);
   });
 
-  it('should create one-time token with `applicationIds` and `jitOrganizationIds` configured', async () => {
+  it('should create one-time token with context configured', async () => {
     const email = `foo${generateStandardId()}@bar.com`;
     const oneTimeToken = await createOneTimeToken({
       email,
       context: {
+        interactionEvent: InteractionEvent.ForgotPassword,
         jitOrganizationIds: ['org-1'],
       },
     });
@@ -60,6 +61,7 @@ describe('one-time tokens API', () => {
     expect(oneTimeToken.status).toBe(OneTimeTokenStatus.Active);
     expect(oneTimeToken.email).toBe(email);
     expect(oneTimeToken.context).toEqual({
+      interactionEvent: InteractionEvent.ForgotPassword,
       jitOrganizationIds: ['org-1'],
     });
     expect(oneTimeToken.token.length).toBe(32);

--- a/packages/phrases/src/locales/en/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/en/errors/one-time-token.ts
@@ -5,6 +5,7 @@ const one_time_token = {
   token_consumed: 'The token has been consumed.',
   token_revoked: 'The token has been revoked.',
   cannot_reactivate_token: 'Cannot reactivate the token.',
+  interaction_event_mismatch: 'The token cannot be used for this interaction.',
 };
 
 export default Object.freeze(one_time_token);

--- a/packages/schemas/src/foundations/jsonb-types/one-time-tokens.ts
+++ b/packages/schemas/src/foundations/jsonb-types/one-time-tokens.ts
@@ -1,14 +1,23 @@
 import { type ToZodObject } from '@logto/connector-kit';
 import { z } from 'zod';
 
+import { type InteractionEvent } from '../../types/interactions.js';
+
+const interactionEvents = new Set(['SignIn', 'Register', 'ForgotPassword']);
+const oneTimeTokenInteractionEventGuard = z.custom<InteractionEvent>(
+  (value) => typeof value === 'string' && interactionEvents.has(value)
+);
+
 export type OneTimeTokenContext = {
   // Used for organization JIT provisioning.
   jitOrganizationIds?: string[];
+  interactionEvent?: InteractionEvent;
 };
 
 export const oneTimeTokenContextGuard = z
   .object({
     jitOrganizationIds: z.string().array(),
+    interactionEvent: oneTimeTokenInteractionEventGuard,
   })
   .partial() satisfies ToZodObject<OneTimeTokenContext>;
 


### PR DESCRIPTION
## Summary
Add an optional `interactionEvent` to one-time token context so reset-capable tokens can be represented with the existing `InteractionEvent.ForgotPassword` model.

Verify one-time tokens against the current Experience interaction event before consuming them, so reset-capable tokens cannot be consumed by sign-in/register one-time-token flows.

## Testing
Integration tests

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments