### PR TITLE
fix(schemas): handle hyphenated db names in applyTableRls base role lookup

### DIFF
--- a/packages/schemas/alterations/utils/1704934999-tables.ts
+++ b/packages/schemas/alterations/utils/1704934999-tables.ts
@@ -2,12 +2,33 @@ import { type CommonQueryMethods, sql } from '@silverhand/slonik';
 
 const getId = (value: string) => sql.identifier([value]);
 
+/**
+ * Returns the suffix used in the base Logto role name for the current database
+ * (`logto_tenant_<suffix>`).
+ *
+ * Historically the suffix was the raw database name (which may contain hyphens). A later
+ * convention normalised it by replacing hyphens with underscores. To remain compatible with
+ * both conventions we probe `pg_roles` for the normalised name first and fall back to the
+ * raw database name for legacy installations.
+ */
 const getDatabaseName = async (pool: CommonQueryMethods) => {
   const { currentDatabase } = await pool.one<{ currentDatabase: string }>(sql`
     select current_database();
   `);
 
-  return currentDatabase.replaceAll('-', '_');
+  const normalized = currentDatabase.replaceAll('-', '_');
+
+  if (normalized === currentDatabase) {
+    return currentDatabase;
+  }
+
+  const { exists } = await pool.one<{ exists: boolean }>(sql`
+    select exists(
+      select 1 from pg_roles where rolname = ${'logto_tenant_' + normalized}
+    ) as exists;
+  `);
+
+  return exists ? normalized : currentDatabase;
 };
 
 /**


### PR DESCRIPTION
Fixes #9060

## Problem

`applyTableRls` in `packages/schemas/alterations/utils/1704934999-tables.ts` constructs the Logto base role name as `logto_tenant_<database>` where `<database>` is the current database name with hyphens replaced by underscores. This is correct for standard installations, but fails for:

- **Managed PostgreSQL providers** (e.g. Render, Railway, Supabase) where the database name contains hyphens and the operator cannot freely create/rename roles — the base role was provisioned under the raw hyphenated name before the normalisation convention was introduced.
- **Legacy self-hosted installs** that predate the `replaceAll('-', '_')` change.

Any migration that calls `applyTableRls` (including `1.40.0-1779421396-add-application-access-control-schema.ts`) then fails at the `GRANT … TO logto_tenant_<underscored>` step with:

```
error: role "logto_tenant_pw_staging_1_auth_db" does not exist
```

even though `logto_tenant_pw-staging-1-auth-db` exists.

## Fix

When the database name contains hyphens, `getDatabaseName` now probes `pg_roles` for the normalised name first:

- **Normalised role exists** → use underscores (standard install, no behaviour change).
- **Normalised role absent** → fall back to the raw hyphenated name (legacy/managed install, fixes the bug).
- **Database name has no hyphens** → early return, no extra query (no behaviour change).

## Testing

- Standard install (no hyphens in DB name): unaffected — early return, zero extra queries.
- Standard install (hyphens, normalised role present): `pg_roles` probe returns `true`, normalised name used.
- Legacy install (hyphens, hyphenated role only): `pg_roles` probe returns `false`, raw name used, GRANT succeeds.