### PR TITLE
perf(core): skip redundant grant revocation query

### DIFF
--- a/packages/core/src/queries/oidc-model-instance.test.ts
+++ b/packages/core/src/queries/oidc-model-instance.test.ts
@@ -330,7 +330,7 @@ describe('oidc-model-instance query', () => {
     expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 
-  it('revokeInstanceByGrantId should continue until no rows are deleted', async () => {
+  it('revokeInstanceByGrantId should continue while batches are full', async () => {
     const grantId = 'grant';
     const batchSize = 1000;
 
@@ -352,7 +352,7 @@ describe('oidc-model-instance query', () => {
         expectSqlAssert(sql, expectSql.sql);
         expect(values).toEqual([instance.modelName, grantId, batchSize]);
 
-        return { rowCount: 500 };
+        return { rowCount: 1000 };
       })
       // @ts-expect-error - mock delete query
       .mockImplementationOnce(async (sql, values) => {
@@ -360,17 +360,11 @@ describe('oidc-model-instance query', () => {
         expect(values).toEqual([instance.modelName, grantId, batchSize]);
 
         return { rowCount: 200 };
-      })
-      // @ts-expect-error - mock delete query
-      .mockImplementationOnce(async (sql, values) => {
-        expectSqlAssert(sql, expectSql.sql);
-        expect(values).toEqual([instance.modelName, grantId, batchSize]);
-
-        return { rowCount: 0 };
       });
 
+    // Stops after the partial batch without issuing a trailing empty query.
     await revokeInstanceByGrantId(instance.modelName, grantId);
-    expect(mockQuery).toHaveBeenCalledTimes(3);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 
   it('findUserActiveApplicationGrants with thirdparty', async () => {

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -182,7 +182,8 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   };
 
   const revokeInstanceByGrantId = async (modelName: string, grantId: string) => {
-    // Keep deleting bounded batches until the revoke query no longer finds matches.
+    // Keep deleting bounded batches until a batch comes back not full, which means
+    // every matching row has been drained.
     for (;;) {
       // Revocation batches must run serially to keep each delete bounded.
       // eslint-disable-next-line no-await-in-loop
@@ -198,7 +199,9 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
         )
       `);
 
-      if (rowCount === 0) {
+      // A batch smaller than the limit means no more matching rows remain (the subquery
+      // and delete share one snapshot), so we can stop without a trailing empty query.
+      if (rowCount < revokeInstanceBatchSize) {
         return;
       }
     }


### PR DESCRIPTION
## Summary
On logout, `revokeInstanceByGrantId` deletes a grant's `oidc_model_instances` rows in bounded batches of 1000, looping until a batch deletes 0 rows. Because a grant almost always has far fewer than 1000 instances, the first batch removed everything and the loop still issued a second DELETE just to observe a 0 count — so every logout ran two queries where one suffices.

This stops the loop as soon as a batch comes back smaller than the limit. The subquery and delete run as a single statement on one snapshot, so a batch returning fewer than `revokeInstanceBatchSize` rows proves the match set was already drained — nothing is left behind and revocation stays complete. Net effect: one DELETE per logout instead of two, and slightly less connection-hold time on this path.

Note: this is a load/latency cleanup, not a fix for the `StatementTimeoutError` we've seen on this query. If a single DELETE is what hits `statement_timeout` (seq scan or lock wait), that still needs a separate root-cause fix.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments