### PR TITLE
fix(console): hosted email cap banner bug-bash fixes

### DIFF
--- a/packages/console/src/components/HostedEmailCapBanner/index.module.scss
+++ b/packages/console/src/components/HostedEmailCapBanner/index.module.scss
@@ -1,5 +1,24 @@
 @use '@/scss/underscore' as _;
 
 .container {
-  padding: _.unit(4) _.unit(6);
+  display: flex;
+  padding-block: _.unit(4);
+}
+
+.sidebarPlaceholder {
+  // Matches the console sidebar width (see ConsoleContent/Sidebar/index.module.scss) so the banner
+  // starts at the page content's left edge.
+  width: 248px;
+  flex-shrink: 0;
+}
+
+.content {
+  // Mirror ConsoleContent's `.main`: fill the space right of the sidebar with the same inline padding
+  // and content-width cap, so the banner sits exactly over the page content column.
+  flex-grow: 1;
+  padding-inline: _.unit(2) _.unit(6);
+
+  > * {
+    @include _.main-content-width;
+  }
 }

--- a/packages/console/src/components/HostedEmailCapBanner/index.module.scss
+++ b/packages/console/src/components/HostedEmailCapBanner/index.module.scss
@@ -1,5 +1,5 @@
 @use '@/scss/underscore' as _;
 
 .container {
-  padding: _.unit(4) _.unit(6) 0;
+  padding: _.unit(4) _.unit(6);
 }

--- a/packages/console/src/components/HostedEmailCapBanner/index.tsx
+++ b/packages/console/src/components/HostedEmailCapBanner/index.tsx
@@ -52,7 +52,8 @@ function HostedEmailCapBanner() {
   return (
     <div className={styles.container}>
       <InlineNotification
-        severity={situation === 'reached' ? 'error' : 'alert'}
+        // A cap notice is a warning, not an error — use the alert (amber) severity for both states.
+        severity="alert"
         action="general.got_it"
         onClick={() => {
           setDismissedSituation(situation);

--- a/packages/console/src/components/HostedEmailCapBanner/index.tsx
+++ b/packages/console/src/components/HostedEmailCapBanner/index.tsx
@@ -51,23 +51,27 @@ function HostedEmailCapBanner() {
 
   return (
     <div className={styles.container}>
-      <InlineNotification
-        // A cap notice is a warning, not an error — use the alert (amber) severity for both states.
-        severity="alert"
-        action="general.got_it"
-        onClick={() => {
-          setDismissedSituation(situation);
-        }}
-      >
-        <Trans
-          components={{
-            provider: <TextLink to={connectorsPasswordlessPage} />,
-            upgrade: <TextLink to={tenantSettingsPage} />,
+      {/* Empty placeholder matching the sidebar so the banner aligns with the page content column. */}
+      <div className={styles.sidebarPlaceholder} />
+      <div className={styles.content}>
+        <InlineNotification
+          // A cap notice is a warning, not an error — use the alert (amber) severity for both states.
+          severity="alert"
+          action="general.got_it"
+          onClick={() => {
+            setDismissedSituation(situation);
           }}
         >
-          {t(`connector_details.logto_email.hosted_email_usage.banner.${situation}`)}
-        </Trans>
-      </InlineNotification>
+          <Trans
+            components={{
+              provider: <TextLink to={connectorsPasswordlessPage} />,
+              upgrade: <TextLink to={tenantSettingsPage} />,
+            }}
+          >
+            {t(`connector_details.logto_email.hosted_email_usage.banner.${situation}`)}
+          </Trans>
+        </InlineNotification>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Bug-bash fixes for the hosted email cap banner (part of the Hosted Email Service & Usage work). Three independent fixes, one per commit:

- **Closes LOG-13775 — color.** The banner used the `error` (red) severity in the "reached" state. A cap notice is a warning, not an error, so it now uses the `alert` (amber) severity for both the approaching and reached states.
- **Closes LOG-13772 — bottom spacing.** The container had no bottom padding, so the banner sat flush against the page content. Added bottom padding matching the top.
- **Closes LOG-13769 — width/alignment.** The banner is rendered in the app shell, above the sidebar/content row, so it spanned the full viewport width and looked too wide. It now has an empty left placeholder matching the sidebar width and mirrors the content column's inline padding and `main-content-width` cap, so it sits exactly over the page content column (same left edge and max-width).

### Reviewer notes
- The `248px` placeholder width is coupled to the console sidebar width (`ConsoleContent/Sidebar/index.module.scss`); a comment documents the coupling. There's no shared SCSS variable for the console sidebar width today, so it's referenced by value.
- The banner is still gated behind `isDevFeaturesEnabled` (via `useHostedEmailUsage`), so no changeset.

## Testing

Tested locally

<img width="6016" height="3208" alt="image" src="https://github.com/user-attachments/assets/92e81319-3a90-404d-95ab-049df1bcde80" />


## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
