### PR TITLE
fix(console): don't show hosted email cap notice when built-in connector is unused

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/EmailUsage/use-hosted-email-usage.ts
+++ b/packages/console/src/pages/ConnectorDetails/EmailUsage/use-hosted-email-usage.ts
@@ -1,3 +1,5 @@
+import { ServiceConnector } from '@logto/connector-kit';
+import { type ConnectorResponse } from '@logto/schemas';
 import { useContext } from 'react';
 import useSWR from 'swr';
 
@@ -16,14 +18,27 @@ export const getHostedEmailUsageKey = (tenantId: string) =>
  * Fetches the per-tenant daily and monthly hosted-email usage and limits (Cloud + dev-features
  * only). Shared by the Connector Details usage card and the cap notices — SWR dedupes the request
  * so both consumers hit the endpoint once.
+ *
+ * The cap only applies to Logto's built-in email connector, so the usage request is skipped for
+ * tenants on their own email provider — leaving `data` undefined, which also hides the cap notices.
  */
 const useHostedEmailUsage = () => {
   const { currentTenantId } = useContext(TenantsContext);
   const cloudApi = useCloudApi({ hideErrorToast: true });
 
   const isEnabled = isCloud && isDevFeaturesEnabled;
+
+  // Only tenants using the built-in email connector are subject to the cap. Read it from the shared
+  // `api/connectors` SWR cache (fetched only while the feature is enabled).
+  const { data: connectors } = useSWR<ConnectorResponse[]>(isEnabled && 'api/connectors');
+  const isLogtoEmailConnectorInUse =
+    connectors?.some((connector) => connector.connectorId === ServiceConnector.Email) ?? false;
+
   const { data } = useSWR(
-    isEnabled && currentTenantId && getHostedEmailUsageKey(currentTenantId),
+    isEnabled &&
+      isLogtoEmailConnectorInUse &&
+      currentTenantId &&
+      getHostedEmailUsageKey(currentTenantId),
     async () =>
       cloudApi.get('/api/tenants/:tenantId/subscription/hosted-email-usage', {
         params: { tenantId: currentTenantId },


### PR DESCRIPTION
## Summary

Closes LOG-13774. Builds on the banner fixes from #9152 (now merged).

The hosted-email cap only applies to Logto's **built-in email connector**, but the usage request and the cap banner fired for every Cloud dev-features tenant regardless of which email connector they use — so tenants on their own email provider saw an irrelevant cap notice.

### What changed
`useHostedEmailUsage` now gates the usage request on the built-in email connector actually being in use:
- Reads the tenant's connectors from the shared `api/connectors` SWR cache (fetched only while the feature is enabled) and checks for a connector with `connectorId === ServiceConnector.Email` (`'logto-email'`).
- When it's **not** in use, the usage SWR key is falsy, so **the API is not called** (issue point 1), and the resulting `undefined` data makes the global banner's existing `if (!data) return null` **hide the banner** (issue point 2).

### Behavior notes
- The Connector Details usage **card** is unaffected: it only renders on the built-in email connector page, where the connector is in use by definition, so `isEnabled` (feature-level) is unchanged and there's no lifetime-count flash.
- Fails safe: if `api/connectors` can't load, the connector is treated as not-in-use, so nothing is fetched or shown.

## Testing

Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
