### PR TITLE
feat(experience): identify forgot password with one-time token

### DIFF
--- a/packages/experience/src/apis/experience/one-time-token.ts
+++ b/packages/experience/src/apis/experience/one-time-token.ts
@@ -3,7 +3,7 @@ import { InteractionEvent, type OneTimeTokenVerificationVerifyPayload } from '@l
 import api from '../api';
 
 import { experienceApiRoutes, type VerificationResponse } from './const';
-import { initInteraction } from './interaction';
+import { identifyUser, initInteraction } from './interaction';
 
 export const signInWithOneTimeToken = async (payload: OneTimeTokenVerificationVerifyPayload) => {
   await initInteraction(InteractionEvent.SignIn);
@@ -13,4 +13,20 @@ export const signInWithOneTimeToken = async (payload: OneTimeTokenVerificationVe
       json: payload,
     })
     .json<VerificationResponse>();
+};
+
+export const identifyForgotPasswordWithOneTimeToken = async (
+  payload: OneTimeTokenVerificationVerifyPayload
+) => {
+  await initInteraction(InteractionEvent.ForgotPassword);
+
+  const { verificationId } = await api
+    .post(`${experienceApiRoutes.verification}/one-time-token/verify`, {
+      json: payload,
+    })
+    .json<VerificationResponse>();
+
+  await identifyUser({ verificationId });
+
+  return { verificationId };
 };


### PR DESCRIPTION
## Summary
Add an Experience API helper that initializes a forgot-password interaction, verifies an email-bound one-time token, and identifies the interaction with the returned verification record.

This keeps token verification separate from the reset-password UI and leaves the existing set-password submission flow unchanged.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments