### PR TITLE
feat(experience): add reset password token mode

### DIFF
--- a/packages/experience/src/apis/experience/one-time-token.ts
+++ b/packages/experience/src/apis/experience/one-time-token.ts
@@ -3,7 +3,7 @@ import { InteractionEvent, type OneTimeTokenVerificationVerifyPayload } from '@l
 import api from '../api';
 
 import { experienceApiRoutes, type VerificationResponse } from './const';
-import { initInteraction } from './interaction';
+import { identifyUser, initInteraction } from './interaction';
 
 export const signInWithOneTimeToken = async (payload: OneTimeTokenVerificationVerifyPayload) => {
   await initInteraction(InteractionEvent.SignIn);
@@ -13,4 +13,20 @@ export const signInWithOneTimeToken = async (payload: OneTimeTokenVerificationVe
       json: payload,
     })
     .json<VerificationResponse>();
+};
+
+export const identifyForgotPasswordWithOneTimeToken = async (
+  payload: OneTimeTokenVerificationVerifyPayload
+) => {
+  await initInteraction(InteractionEvent.ForgotPassword);
+
+  const { verificationId } = await api
+    .post(`${experienceApiRoutes.verification}/one-time-token/verify`, {
+      json: payload,
+    })
+    .json<VerificationResponse>();
+
+  await identifyUser({ verificationId });
+
+  return { verificationId };
 };

--- a/packages/experience/src/pages/ResetPasswordLanding/OneTimeTokenForm.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/OneTimeTokenForm.tsx
@@ -3,13 +3,13 @@ import classNames from 'classnames';
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import { identifyForgotPasswordWithOneTimeToken } from '@/apis/experience';
 import { SmartInputField } from '@/components/InputFields';
 import useApi from '@/hooks/use-api';
 import useErrorHandler from '@/hooks/use-error-handler';
+import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import Button from '@/shared/components/Button';
 import ErrorMessage from '@/shared/components/ErrorMessage';
 import { UserFlow } from '@/types';
@@ -35,8 +35,9 @@ const emailIdentifier = [SignInIdentifier.Email];
 const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
   const { t } = useTranslation();
   const [errorMessage, setErrorMessage] = useState<string>();
+  const [isAutoSubmitting, setIsAutoSubmitting] = useState(false);
   const isAutoSubmitted = useRef(false);
-  const navigate = useNavigate();
+  const navigate = useNavigateWithPreservedSearchParams();
   const handleError = useErrorHandler();
   const asyncIdentifyForgotPasswordWithOneTimeToken = useApi(
     identifyForgotPasswordWithOneTimeToken
@@ -108,14 +109,25 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
 
     // eslint-disable-next-line @silverhand/fp/no-mutation -- React ref guards one-time auto submit
     isAutoSubmitted.current = true;
-    void submit({
-      token,
-      identifier: { type: SignInIdentifier.Email, value: loginHint },
-    });
+    setIsAutoSubmitting(true);
+    void (async () => {
+      try {
+        await submit({
+          token,
+          identifier: { type: SignInIdentifier.Email, value: loginHint },
+        });
+      } finally {
+        setIsAutoSubmitting(false);
+      }
+    })();
   }, [loginHint, submit, token]);
 
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {
+      if (isAutoSubmitting) {
+        return;
+      }
+
       await handleSubmit(async ({ identifier: { type, value } }) => {
         if (!type) {
           return;
@@ -127,8 +139,10 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
         });
       })(event);
     },
-    [handleSubmit, submit, token]
+    [handleSubmit, isAutoSubmitting, submit, token]
   );
+
+  const isVerificationPending = isSubmitting || isAutoSubmitting;
 
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
@@ -160,6 +174,7 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
             className={styles.inputField}
             {...field}
             defaultValue={defaultValues?.identifier?.value}
+            disabled={isVerificationPending}
             isDanger={!!errors.identifier}
             errorMessage={errors.identifier?.message}
             enabledTypes={emailIdentifier}
@@ -169,9 +184,9 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
 
       {errorMessage && <ErrorMessage className={styles.formErrors}>{errorMessage}</ErrorMessage>}
 
-      <Button title="action.continue" htmlType="submit" isLoading={isSubmitting} />
+      <Button title="action.continue" htmlType="submit" isLoading={isVerificationPending} />
 
-      <input hidden type="submit" />
+      <input hidden disabled={isVerificationPending} type="submit" />
     </form>
   );
 };

--- a/packages/experience/src/pages/ResetPasswordLanding/OneTimeTokenForm.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/OneTimeTokenForm.tsx
@@ -1,0 +1,179 @@
+import { SignInIdentifier, type OneTimeTokenVerificationVerifyPayload } from '@logto/schemas';
+import classNames from 'classnames';
+import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
+import { identifyForgotPasswordWithOneTimeToken } from '@/apis/experience';
+import { SmartInputField } from '@/components/InputFields';
+import useApi from '@/hooks/use-api';
+import useErrorHandler from '@/hooks/use-error-handler';
+import Button from '@/shared/components/Button';
+import ErrorMessage from '@/shared/components/ErrorMessage';
+import { UserFlow } from '@/types';
+import { getGeneralIdentifierErrorMessage, validateIdentifierField } from '@/utils/form';
+
+import styles from '../ForgotPassword/ForgotPasswordForm/index.module.scss';
+
+type Props = {
+  readonly className?: string;
+  readonly token: string;
+  readonly loginHint?: string;
+};
+
+type FormState = {
+  identifier: {
+    type?: SignInIdentifier.Email;
+    value: string;
+  };
+};
+
+const emailIdentifier = [SignInIdentifier.Email];
+
+const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
+  const { t } = useTranslation();
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const isAutoSubmitted = useRef(false);
+  const navigate = useNavigate();
+  const handleError = useErrorHandler();
+  const asyncIdentifyForgotPasswordWithOneTimeToken = useApi(
+    identifyForgotPasswordWithOneTimeToken
+  );
+  const { setForgotPasswordIdentifierInputValue } = useContext(UserInteractionContext);
+
+  const {
+    handleSubmit,
+    control,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<FormState>({
+    reValidateMode: 'onBlur',
+    defaultValues: {
+      identifier: {
+        value: loginHint,
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (!isValid) {
+      setErrorMessage(undefined);
+    }
+  }, [isValid]);
+
+  const submit = useCallback(
+    async (payload: OneTimeTokenVerificationVerifyPayload) => {
+      setErrorMessage(undefined);
+
+      const [error] = await asyncIdentifyForgotPasswordWithOneTimeToken(payload);
+
+      if (error) {
+        await handleError(error, {
+          'guard.invalid_input': () => {
+            setErrorMessage(t('error.invalid_email'));
+          },
+          global: (error) => {
+            setErrorMessage(error.message);
+          },
+        });
+        return;
+      }
+
+      const { identifier } = payload;
+      setForgotPasswordIdentifierInputValue(identifier);
+      navigate(`/${UserFlow.ForgotPassword}/reset`, { replace: true });
+    },
+    [
+      asyncIdentifyForgotPasswordWithOneTimeToken,
+      handleError,
+      navigate,
+      setForgotPasswordIdentifierInputValue,
+      t,
+    ]
+  );
+
+  useEffect(() => {
+    if (isAutoSubmitted.current) {
+      return;
+    }
+
+    if (loginHint.length === 0) {
+      return;
+    }
+
+    if (validateIdentifierField(SignInIdentifier.Email, loginHint)) {
+      return;
+    }
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- React ref guards one-time auto submit
+    isAutoSubmitted.current = true;
+    void submit({
+      token,
+      identifier: { type: SignInIdentifier.Email, value: loginHint },
+    });
+  }, [loginHint, submit, token]);
+
+  const onSubmitHandler = useCallback(
+    async (event?: React.FormEvent<HTMLFormElement>) => {
+      await handleSubmit(async ({ identifier: { type, value } }) => {
+        if (!type) {
+          return;
+        }
+
+        await submit({
+          token,
+          identifier: { type, value },
+        });
+      })(event);
+    },
+    [handleSubmit, submit, token]
+  );
+
+  return (
+    <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
+      <Controller
+        control={control}
+        name="identifier"
+        rules={{
+          validate: (identifier) => {
+            const { type, value } = identifier;
+
+            if (!type || value.length === 0) {
+              return getGeneralIdentifierErrorMessage(emailIdentifier, 'required');
+            }
+
+            const errorMessage = validateIdentifierField(type, value);
+
+            if (errorMessage) {
+              return typeof errorMessage === 'string'
+                ? t(`error.${errorMessage}`)
+                : t(`error.${errorMessage.code}`, errorMessage.data ?? {});
+            }
+
+            return true;
+          },
+        }}
+        render={({ field, formState: { defaultValues } }) => (
+          <SmartInputField
+            autoFocus
+            className={styles.inputField}
+            {...field}
+            defaultValue={defaultValues?.identifier?.value}
+            isDanger={!!errors.identifier}
+            errorMessage={errors.identifier?.message}
+            enabledTypes={emailIdentifier}
+          />
+        )}
+      />
+
+      {errorMessage && <ErrorMessage className={styles.formErrors}>{errorMessage}</ErrorMessage>}
+
+      <Button title="action.continue" htmlType="submit" isLoading={isSubmitting} />
+
+      <input hidden type="submit" />
+    </form>
+  );
+};
+
+export default OneTimeTokenForm;

--- a/packages/experience/src/pages/ResetPasswordLanding/index.test.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/index.test.tsx
@@ -1,0 +1,106 @@
+import { SignInIdentifier } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+
+import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { mockSignInExperienceSettings } from '@/__mocks__/logto';
+import { identifyForgotPasswordWithOneTimeToken } from '@/apis/experience';
+import type { SignInExperienceResponse } from '@/types';
+
+import ResetPasswordLanding from '.';
+
+const mockedIdentifyForgotPasswordWithOneTimeToken =
+  identifyForgotPasswordWithOneTimeToken as jest.MockedFunction<
+    typeof identifyForgotPasswordWithOneTimeToken
+  >;
+
+jest.mock('i18next', () => ({
+  language: 'en',
+  t: (key: string) => key,
+}));
+
+jest.mock('@/apis/experience', () => ({
+  identifyForgotPasswordWithOneTimeToken: jest.fn().mockResolvedValue({ verificationId: '123' }),
+}));
+
+describe('ResetPasswordLanding', () => {
+  const renderPage = (
+    initialEntry: string,
+    forgotPassword?: SignInExperienceResponse['forgotPassword']
+  ) =>
+    renderWithPageContext(
+      <SettingsProvider
+        settings={{
+          ...mockSignInExperienceSettings,
+          forgotPassword: {
+            ...mockSignInExperienceSettings.forgotPassword,
+            ...forgotPassword,
+          },
+        }}
+      >
+        <UserInteractionContextProvider>
+          <Routes>
+            <Route path="/reset-password" element={<ResetPasswordLanding />} />
+            <Route path="/forgot-password/reset" element={<div>set password page</div>} />
+            <Route path="/sign-in" element={<div>sign in page</div>} />
+          </Routes>
+        </UserInteractionContextProvider>
+      </SettingsProvider>,
+      { initialEntries: [initialEntry] }
+    );
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('auto verifies one-time token when login_hint is provided', async () => {
+    const { queryByText } = renderPage(
+      '/reset-password?one_time_token=token&login_hint=foo%40logto.io',
+      { email: false, phone: false }
+    );
+
+    expect(queryByText('description.reset_password_magic_link_description')).not.toBeNull();
+
+    await waitFor(() => {
+      expect(mockedIdentifyForgotPasswordWithOneTimeToken).toBeCalledWith({
+        token: 'token',
+        identifier: { type: SignInIdentifier.Email, value: 'foo@logto.io' },
+      });
+      expect(queryByText('set password page')).not.toBeNull();
+    });
+  });
+
+  it('asks for email before verifying one-time token when login_hint is missing', async () => {
+    const { container, getByText, queryByText } = renderPage(
+      '/reset-password?one_time_token=token',
+      { email: false, phone: false }
+    );
+
+    expect(queryByText('description.reset_password_magic_link_description')).not.toBeNull();
+    expect(mockedIdentifyForgotPasswordWithOneTimeToken).not.toBeCalled();
+
+    const identifierInput = container.querySelector('input[name="identifier"]');
+    assert(identifierInput, new Error('identifier input should not be null'));
+
+    fireEvent.change(identifierInput, { target: { value: 'foo@logto.io' } });
+    fireEvent.click(getByText('action.continue'));
+
+    await waitFor(() => {
+      expect(mockedIdentifyForgotPasswordWithOneTimeToken).toBeCalledWith({
+        token: 'token',
+        identifier: { type: SignInIdentifier.Email, value: 'foo@logto.io' },
+      });
+      expect(queryByText('set password page')).not.toBeNull();
+    });
+  });
+
+  it('keeps existing self-service reset fallback when one-time token is missing', () => {
+    const { queryByText } = renderPage('/reset-password', { email: false, phone: false });
+
+    expect(queryByText('sign in page')).not.toBeNull();
+    expect(queryByText('description.reset_password_magic_link_description')).toBeNull();
+  });
+});

--- a/packages/experience/src/pages/ResetPasswordLanding/index.test.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/index.test.tsx
@@ -73,6 +73,42 @@ describe('ResetPasswordLanding', () => {
     });
   });
 
+  it('keeps the form disabled while auto verifying one-time token', async () => {
+    mockedIdentifyForgotPasswordWithOneTimeToken.mockImplementationOnce(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
+
+      return { verificationId: '123' };
+    });
+
+    const { container, queryByText } = renderPage(
+      '/reset-password?one_time_token=token&login_hint=foo%40logto.io',
+      { email: false, phone: false }
+    );
+
+    await waitFor(() => {
+      expect(mockedIdentifyForgotPasswordWithOneTimeToken).toBeCalledTimes(1);
+    });
+
+    const identifierInput = container.querySelector<HTMLInputElement>('input[name="identifier"]');
+    const submitButton = container.querySelector<HTMLButtonElement>('button[type="submit"]');
+
+    assert(identifierInput, new Error('identifier input should not be null'));
+    assert(submitButton, new Error('submit button should not be null'));
+
+    expect(identifierInput.disabled).toBe(true);
+    expect(submitButton.disabled).toBe(true);
+
+    fireEvent.click(submitButton);
+
+    expect(mockedIdentifyForgotPasswordWithOneTimeToken).toBeCalledTimes(1);
+
+    await waitFor(() => {
+      expect(queryByText('set password page')).not.toBeNull();
+    });
+  });
+
   it('asks for email before verifying one-time token when login_hint is missing', async () => {
     const { container, getByText, queryByText } = renderPage(
       '/reset-password?one_time_token=token',

--- a/packages/experience/src/pages/ResetPasswordLanding/index.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/index.tsx
@@ -1,13 +1,15 @@
-import { experience } from '@logto/schemas';
+import { experience, ExtraParamsKey } from '@logto/schemas';
 import { useTranslation } from 'react-i18next';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
 
 import FocusedAuthPageLayout from '@/Layout/FocusedAuthPageLayout';
+import { isDevFeaturesEnabled } from '@/constants/env';
 import usePrefilledIdentifier from '@/hooks/use-prefilled-identifier';
 import { identifierInputDescriptionMap } from '@/utils/form';
 
 import ForgotPasswordForm from '../ForgotPassword/ForgotPasswordForm';
 
+import OneTimeTokenForm from './OneTimeTokenForm';
 import { useResetPasswordMethods } from './use-reset-password-methods';
 
 /**
@@ -32,11 +34,32 @@ import { useResetPasswordMethods } from './use-reset-password-methods';
  */
 const ResetPasswordLanding = () => {
   const { t } = useTranslation();
+  const [params] = useSearchParams();
+  const oneTimeToken = params.get(ExtraParamsKey.OneTimeToken);
+  const loginHint = params.get(ExtraParamsKey.LoginHint) ?? undefined;
   const enabledMethods = useResetPasswordMethods();
   const { value: prefilledValue } = usePrefilledIdentifier({
     enabledIdentifiers: enabledMethods,
     isForgotPassword: true,
   });
+
+  if (isDevFeaturesEnabled && oneTimeToken) {
+    return (
+      <FocusedAuthPageLayout
+        pageMeta={{
+          titleKey: 'description.reset_password',
+        }}
+        title="description.reset_password"
+        description="description.reset_password_magic_link_description"
+        authOptionsLink={{
+          to: `/${experience.routes.signIn}`,
+          text: 'description.back_to_sign_in',
+        }}
+      >
+        <OneTimeTokenForm token={oneTimeToken} loginHint={loginHint} />
+      </FocusedAuthPageLayout>
+    );
+  }
 
   // Fallback to sign-in page
   if (enabledMethods.length === 0) {

--- a/packages/phrases-experience/src/locales/ar/description.ts
+++ b/packages/phrases-experience/src/locales/ar/description.ts
@@ -35,6 +35,8 @@ const description = {
   reset_password: 'إعادة تعيين كلمة المرور',
   reset_password_description:
     'أدخل {{types, list(type: disjunction;)}} المرتبطة بحسابك، وسنرسل لك رمز التحقق لإعادة تعيين كلمة المرور.',
+  reset_password_magic_link_description:
+    'أدخل عنوان البريد الإلكتروني المرتبط بحسابك لمتابعة إعادة تعيين كلمة المرور.',
   new_password: 'كلمة المرور الجديدة',
   set_password: 'تعيين كلمة المرور',
   password_changed: 'تم تغيير كلمة المرور',

--- a/packages/phrases-experience/src/locales/cs/description.ts
+++ b/packages/phrases-experience/src/locales/cs/description.ts
@@ -36,6 +36,8 @@ const description = {
   reset_password: 'Obnovit heslo',
   reset_password_description:
     'Zadej {{types, list(type: disjunction;)}} propojené s tvým účtem a pošleme ti ověřovací kód pro obnovení hesla.',
+  reset_password_magic_link_description:
+    'Zadejte e-mailovou adresu přiřazenou k vašemu účtu, abyste mohli pokračovat v resetování hesla.',
   new_password: 'Nové heslo',
   set_password: 'Nastavit heslo',
   password_changed: 'Heslo bylo změněno',

--- a/packages/phrases-experience/src/locales/de/description.ts
+++ b/packages/phrases-experience/src/locales/de/description.ts
@@ -37,6 +37,8 @@ const description = {
   reset_password: 'Passwort vergessen',
   reset_password_description:
     'Gib die {{types, list(type: disjunction;)}} deines Kontos ein und wir senden dir einen Bestätigungscode um dein Passwort zurückzusetzen.',
+  reset_password_magic_link_description:
+    'Gib die mit deinem Konto verknüpfte E-Mail-Adresse ein, um mit dem Zurücksetzen deines Passworts fortzufahren.',
   new_password: 'Neues Passwort',
   set_password: 'Passwort setzen',
   password_changed: 'Passwort geändert',

--- a/packages/phrases-experience/src/locales/en/description.ts
+++ b/packages/phrases-experience/src/locales/en/description.ts
@@ -37,6 +37,8 @@ const description = {
   reset_password: 'Reset password',
   reset_password_description:
     'Enter the {{types, list(type: disjunction;)}} associated with your account, and we’ll send you the verification code to reset your password.',
+  reset_password_magic_link_description:
+    'Enter the email address associated with your account to continue resetting your password.',
   new_password: 'New password',
   set_password: 'Set password',
   password_changed: 'Password changed',

--- a/packages/phrases-experience/src/locales/es/description.ts
+++ b/packages/phrases-experience/src/locales/es/description.ts
@@ -37,6 +37,8 @@ const description = {
   reset_password: 'Restablecer contraseña',
   reset_password_description:
     'Ingrese los {{types, lista(type: disyunción;)}} asociados a su cuenta, y le enviaremos el código de verificación para restablecer su contraseña.',
+  reset_password_magic_link_description:
+    'Ingresa la dirección de correo electrónico asociada con tu cuenta para continuar restableciendo tu contraseña.',
   new_password: 'Nueva contraseña',
   set_password: 'Establecer contraseña',
   password_changed: 'Contraseña cambiada',

--- a/packages/phrases-experience/src/locales/fa-ir/description.ts
+++ b/packages/phrases-experience/src/locales/fa-ir/description.ts
@@ -36,6 +36,8 @@ const description = {
   reset_password: 'بازنشانی رمز عبور',
   reset_password_description:
     '{{types, list(type: disjunction;)}} مرتبط با حساب خود را وارد کنید تا کد تأیید برای بازنشانی رمز عبور ارسال شود.',
+  reset_password_magic_link_description:
+    'برای ادامه بازنشانی گذرواژه، آدرس ایمیل مرتبط با حساب خود را وارد کنید.',
   new_password: 'رمز عبور جدید',
   set_password: 'تنظیم رمز عبور',
   password_changed: 'رمز عبور تغییر یافت',

--- a/packages/phrases-experience/src/locales/fr/description.ts
+++ b/packages/phrases-experience/src/locales/fr/description.ts
@@ -37,6 +37,8 @@ const description = {
   reset_password: 'Mot de passe oublié',
   reset_password_description:
     'Entrez le {{types, list(type: disjunction;)}} associé à votre compte et nous vous enverrons le code de vérification pour réinitialiser votre mot de passe.',
+  reset_password_magic_link_description:
+    'Saisis l’adresse e-mail associée à ton compte pour continuer la réinitialisation de ton mot de passe.',
   new_password: 'Nouveau mot de passe',
   set_password: 'Définir un mot de passe',
   password_changed: 'Mot de passe modifié',

--- a/packages/phrases-experience/src/locales/it/description.ts
+++ b/packages/phrases-experience/src/locales/it/description.ts
@@ -36,6 +36,8 @@ const description = {
   reset_password: 'Resetta la password',
   reset_password_description:
     'Inserisci il {{types, list(type: disjunction;)}} associato al tuo account, e ti invieremo il codice di verifica per resettare la password.',
+  reset_password_magic_link_description:
+    "Inserisci l'indirizzo email associato al tuo account per continuare a reimpostare la password.",
   new_password: 'Nuova password',
   set_password: 'Imposta una password',
   password_changed: 'Password cambiata',

--- a/packages/phrases-experience/src/locales/ja/description.ts
+++ b/packages/phrases-experience/src/locales/ja/description.ts
@@ -37,6 +37,8 @@ const description = {
   reset_password: 'パスワードを再設定する',
   reset_password_description:
     'アカウントに関連する{{types, list(type: disjunction;)}}を入力すると、パスワードの再設定に必要な確認コードが送信されます。',
+  reset_password_magic_link_description:
+    'パスワードのリセットを続行するには、アカウントに関連付けられたメールアドレスを入力してください。',
   new_password: '新しいパスワード',
   set_password: 'パスワードを設定する',
   password_changed: 'パスワードが変更されました',

--- a/packages/phrases-experience/src/locales/ko/description.ts
+++ b/packages/phrases-experience/src/locales/ko/description.ts
@@ -34,6 +34,8 @@ const description = {
   reset_password: '비밀번호를 잊으셨나요',
   reset_password_description:
     '귀하의 계정과 연결된 {{types, list(type: disjunction;)}}를 입력하면 비밀번호 재설정을 위한 인증 코드를 보내드립니다.',
+  reset_password_magic_link_description:
+    '비밀번호 재설정을 계속하려면 계정에 연결된 이메일 주소를 입력하세요.',
   new_password: '새 비밀번호',
   set_password: '비밀번호 설정',
   password_changed: '비밀번호 변경됨',

--- a/packages/phrases-experience/src/locales/pl-pl/description.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/description.ts
@@ -36,6 +36,8 @@ const description = {
   reset_password: 'Zresetuj hasło',
   reset_password_description:
     'Wpisz {{types, lista(type: złączonych;)}} związanego z twoim kontem, a wyślemy ci kod weryfikacyjny do zresetowania hasła.',
+  reset_password_magic_link_description:
+    'Wpisz adres e-mail powiązany z kontem, aby kontynuować resetowanie hasła.',
   new_password: 'Nowe hasło',
   set_password: 'Ustaw hasło',
   password_changed: 'Hasło zmienione',

--- a/packages/phrases-experience/src/locales/pt-br/description.ts
+++ b/packages/phrases-experience/src/locales/pt-br/description.ts
@@ -36,6 +36,8 @@ const description = {
   reset_password: 'Esqueceu a senha',
   reset_password_description:
     'Digite o {{types, list(type: disjunction;)}} à sua conta e enviaremos a você o código de verificação para redefinir sua senha.',
+  reset_password_magic_link_description:
+    'Insira o endereço de e-mail associado à sua conta para continuar redefinindo sua senha.',
   new_password: 'Nova senha',
   set_password: 'Configurar senha',
   password_changed: 'Senha alterada',

--- a/packages/phrases-experience/src/locales/pt-pt/description.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/description.ts
@@ -36,6 +36,8 @@ const description = {
   reset_password: 'Esqueceu a senha',
   reset_password_description:
     'Insira os {{types, list(type: disjunction;)}} associados à sua conta e enviaremos o código de verificação para redefinir sua senha.',
+  reset_password_magic_link_description:
+    'Introduz o endereço de email associado à tua conta para continuares a repor a palavra-passe.',
   new_password: 'Nova Senha',
   set_password: 'Definir senha',
   password_changed: 'Senha alterada',

--- a/packages/phrases-experience/src/locales/ru/description.ts
+++ b/packages/phrases-experience/src/locales/ru/description.ts
@@ -36,6 +36,8 @@ const description = {
   reset_password: 'Забыли пароль',
   reset_password_description:
     'Введите {{types, list(type: disjunction;)}} от вашей учетной записи, и мы вышлем вам код для восстановления пароля.',
+  reset_password_magic_link_description:
+    'Введите адрес электронной почты, связанный с вашей учетной записью, чтобы продолжить сброс пароля.',
   new_password: 'Новый пароль',
   set_password: 'Задать пароль',
   password_changed: 'Пароль изменен',

--- a/packages/phrases-experience/src/locales/th/description.ts
+++ b/packages/phrases-experience/src/locales/th/description.ts
@@ -36,6 +36,8 @@ const description = {
   reset_password: 'รีเซ็ตรหัสผ่าน',
   reset_password_description:
     'กรอก {{types, list(type: disjunction;)}} ที่เชื่อมโยงกับบัญชีของคุณ แล้วเราจะส่งรหัสยืนยันเพื่อรีเซ็ตรหัสผ่าน',
+  reset_password_magic_link_description:
+    'ป้อนที่อยู่อีเมลที่เชื่อมโยงกับบัญชีของคุณเพื่อดำเนินการรีเซ็ตรหัสผ่านต่อ',
   new_password: 'รหัสผ่านใหม่',
   set_password: 'ตั้งรหัสผ่าน',
   password_changed: 'เปลี่ยนรหัสผ่านแล้ว',

--- a/packages/phrases-experience/src/locales/tr-tr/description.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/description.ts
@@ -35,6 +35,8 @@ const description = {
   reset_password: 'Parolanızı mı unuttunuz',
   reset_password_description:
     'Hesabınızla ilişkili {{types, list(type: disjunction;)}} girin, şifrenizi sıfırlamanız için size doğrulama kodunu göndereceğiz.',
+  reset_password_magic_link_description:
+    'Parolanızı sıfırlamaya devam etmek için hesabınızla ilişkili e-posta adresini girin.',
   new_password: 'Yeni Şifre',
   set_password: 'Şifreyi belirle',
   password_changed: 'Şifre değişti',

--- a/packages/phrases-experience/src/locales/uk-ua/description.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/description.ts
@@ -36,6 +36,8 @@ const description = {
   reset_password: 'Скинути пароль',
   reset_password_description:
     'Введіть {{types, list(type: disjunction;)}}, пов’язаний з вашим обліковим записом, і ми надішлемо вам код підтвердження для скидання пароля.',
+  reset_password_magic_link_description:
+    'Введіть адресу електронної пошти, пов’язану з вашим обліковим записом, щоб продовжити скидання пароля.',
   new_password: 'Новий пароль',
   set_password: 'Встановити пароль',
   password_changed: 'Пароль змінено',

--- a/packages/phrases-experience/src/locales/zh-cn/description.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/description.ts
@@ -32,6 +32,7 @@ const description = {
   skip_social_linking: '跳过链接现有帐户？',
   reset_password: '忘记密码',
   reset_password_description: '输入{{types, list(type: disjunction;)}}，获取验证码以重设密码。',
+  reset_password_magic_link_description: '输入与你的账号关联的邮箱地址以继续重设密码。',
   new_password: '新密码',
   set_password: '设置密码',
   password_changed: '已重置密码！',

--- a/packages/phrases-experience/src/locales/zh-hk/description.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/description.ts
@@ -32,6 +32,7 @@ const description = {
   skip_social_linking: '跳過連接現有帳戶？',
   reset_password: '忘記密碼',
   reset_password_description: '輸入{{types, list(type: disjunction;)}}，獲取驗證碼以重設密碼。',
+  reset_password_magic_link_description: '輸入與你的帳戶關聯的電子郵件地址以繼續重設密碼。',
   new_password: '新密碼',
   set_password: '設定密碼',
   password_changed: '已重置密碼！',

--- a/packages/phrases-experience/src/locales/zh-tw/description.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/description.ts
@@ -32,6 +32,7 @@ const description = {
   skip_social_linking: '跳過連接現有帳戶？',
   reset_password: '忘記密碼',
   reset_password_description: '輸入{{types, list(type: disjunction;)}}，獲取驗證碼以重設密碼。',
+  reset_password_magic_link_description: '輸入與你的帳戶關聯的電子郵件地址以繼續重設密碼。',
   new_password: '新密碼',
   set_password: '設置密碼',
   password_changed: '已重置密碼！',


### PR DESCRIPTION
## Summary
Add reset-password landing support for one-time token magic links.

The reset-password page can verify the token automatically when `login_hint` is present, or ask the user for their email before verifying the token and continuing to the existing set-password step.

Update the localized reset-password copy for this token landing flow.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments