### PR TITLE
feat(core): route reset token prompts to reset password

### DIFF
--- a/packages/core/src/middleware/koa-consent-guard.test.ts
+++ b/packages/core/src/middleware/koa-consent-guard.test.ts
@@ -1,4 +1,4 @@
-import { OneTimeTokenStatus } from '@logto/schemas';
+import { FirstScreen, OneTimeTokenStatus } from '@logto/schemas';
 import { NotFoundError } from '@silverhand/slonik';
 import { Provider } from 'oidc-provider';
 
@@ -91,6 +91,47 @@ describe('koaConsentGuard middleware', () => {
     await guard(ctx, next);
     expect(mockTenant.queries.users.findUserById).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
+  });
+
+  it('should redirect reset-password one-time token flow to reset-password page without login_hint', async () => {
+    const ctx = createContext({
+      params: {
+        first_screen: FirstScreen.ResetPassword,
+        one_time_token: 'token_value',
+      },
+      // @ts-expect-error -- Only accountId is needed by this middleware.
+      session: { accountId: 'foo' },
+    });
+    const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
+
+    await guard(ctx, next);
+
+    expect(mockTenant.queries.users.findUserById).not.toHaveBeenCalled();
+    expect(checkOneTimeToken).not.toHaveBeenCalled();
+    expect(ctx.redirect).toHaveBeenCalledWith('reset-password?one_time_token=token_value');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should redirect reset-password one-time token flow to reset-password page with login_hint', async () => {
+    const ctx = createContext({
+      params: {
+        first_screen: FirstScreen.ResetPassword,
+        one_time_token: 'token_value',
+        login_hint: 'foo@example.com',
+      },
+      // @ts-expect-error -- Only accountId is needed by this middleware.
+      session: { accountId: 'foo' },
+    });
+    const guard = koaConsentGuard(mockTenant.libraries, mockTenant.queries);
+
+    await guard(ctx, next);
+
+    expect(mockTenant.queries.users.findUserById).not.toHaveBeenCalled();
+    expect(checkOneTimeToken).not.toHaveBeenCalled();
+    expect(ctx.redirect).toHaveBeenCalledWith(
+      'reset-password?login_hint=foo%40example.com&one_time_token=token_value'
+    );
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('should redirect to switch account page if email does not match', async () => {

--- a/packages/core/src/middleware/koa-consent-guard.ts
+++ b/packages/core/src/middleware/koa-consent-guard.ts
@@ -32,39 +32,50 @@ const buildOneTimeTokenErrorUrl = (message: string) => {
 const hasLoginPrompt = (prompt: unknown) =>
   typeof prompt === 'string' && prompt.split(' ').includes(Prompt.Login);
 
-const getOneTimeTokenParams = ({
-  one_time_token: token,
-  login_hint: loginHint,
-  prompt,
-}: {
-  one_time_token?: unknown;
-  login_hint?: unknown;
-  prompt?: unknown;
-}) => {
-  if (!token || !loginHint || typeof token !== 'string' || typeof loginHint !== 'string') {
+const nonEmptyStringGuard = z.string().min(1);
+const optionalNonEmptyStringGuard = z.preprocess(
+  (value) => (value === '' ? undefined : value),
+  nonEmptyStringGuard.optional()
+);
+
+const oneTimeTokenParamsGuard = z.object({
+  one_time_token: nonEmptyStringGuard,
+  login_hint: nonEmptyStringGuard,
+  prompt: z.unknown().optional(),
+});
+
+const getOneTimeTokenParams = (params: unknown) => {
+  const result = oneTimeTokenParamsGuard.safeParse(params);
+
+  if (!result.success) {
     return;
   }
+
+  const { one_time_token: token, login_hint: loginHint, prompt } = result.data;
 
   return { token, loginHint, prompt };
 };
 
-const getOneTimeToken = ({ one_time_token: token }: { one_time_token?: unknown }) =>
-  token && typeof token === 'string' ? token : undefined;
+const resetPasswordOneTimeTokenParamsGuard = z.object({
+  first_screen: z.literal(FirstScreen.ResetPassword),
+  one_time_token: nonEmptyStringGuard,
+  login_hint: optionalNonEmptyStringGuard,
+});
 
-const getLoginHint = ({ login_hint: loginHint }: { login_hint?: unknown }) =>
-  loginHint && typeof loginHint === 'string' ? loginHint : undefined;
-
-const isResetPasswordFirstScreen = ({ first_screen: firstScreen }: { first_screen?: unknown }) =>
-  firstScreen === FirstScreen.ResetPassword;
-
-const getResetPasswordOneTimeToken = (
-  params: Parameters<typeof getOneTimeToken>[0] & Parameters<typeof isResetPasswordFirstScreen>[0]
-) => {
-  if (!EnvSet.values.isDevFeaturesEnabled || !isResetPasswordFirstScreen(params)) {
+const getResetPasswordOneTimeTokenParams = (params: unknown) => {
+  if (!EnvSet.values.isDevFeaturesEnabled) {
     return;
   }
 
-  return getOneTimeToken(params);
+  const result = resetPasswordOneTimeTokenParamsGuard.safeParse(params);
+
+  if (!result.success) {
+    return;
+  }
+
+  const { one_time_token: token, login_hint: loginHint } = result.data;
+
+  return { token, loginHint };
 };
 
 const lastSubmittedLoginGuard = z.object({
@@ -138,16 +149,12 @@ export default function koaConsentGuard<
     assertThat(session, new RequestError({ code: 'session.not_found' }));
 
     const oneTimeTokenParams = getOneTimeTokenParams(params);
-    const resetPasswordToken = getResetPasswordOneTimeToken(params);
+    const resetPasswordOneTimeTokenParams = getResetPasswordOneTimeTokenParams(params);
 
-    if (resetPasswordToken) {
-      ctx.redirect(
-        buildExperienceUrl(
-          experience.routes.resetPassword,
-          resetPasswordToken,
-          getLoginHint(params)
-        )
-      );
+    if (resetPasswordOneTimeTokenParams) {
+      const { token, loginHint } = resetPasswordOneTimeTokenParams;
+
+      ctx.redirect(buildExperienceUrl(experience.routes.resetPassword, token, loginHint));
       return;
     }
 

--- a/packages/core/src/middleware/koa-consent-guard.ts
+++ b/packages/core/src/middleware/koa-consent-guard.ts
@@ -1,20 +1,24 @@
 import { Prompt } from '@logto/js';
-import { experience, ExtraParamsKey } from '@logto/schemas';
+import { experience, ExtraParamsKey, FirstScreen } from '@logto/schemas';
 import { NotFoundError } from '@silverhand/slonik';
 import { type MiddlewareType } from 'koa';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-const buildExperienceUrl = (route: string, token: string, loginHint: string) => {
-  const searchParams = new URLSearchParams({
-    [ExtraParamsKey.LoginHint]: loginHint,
-    [ExtraParamsKey.OneTimeToken]: token,
-  });
+const buildExperienceUrl = (route: string, token: string, loginHint?: string) => {
+  const searchParams = new URLSearchParams();
+
+  if (loginHint) {
+    searchParams.append(ExtraParamsKey.LoginHint, loginHint);
+  }
+
+  searchParams.append(ExtraParamsKey.OneTimeToken, token);
 
   return `${route}?${searchParams.toString()}`;
 };
@@ -42,6 +46,25 @@ const getOneTimeTokenParams = ({
   }
 
   return { token, loginHint, prompt };
+};
+
+const getOneTimeToken = ({ one_time_token: token }: { one_time_token?: unknown }) =>
+  token && typeof token === 'string' ? token : undefined;
+
+const getLoginHint = ({ login_hint: loginHint }: { login_hint?: unknown }) =>
+  loginHint && typeof loginHint === 'string' ? loginHint : undefined;
+
+const isResetPasswordFirstScreen = ({ first_screen: firstScreen }: { first_screen?: unknown }) =>
+  firstScreen === FirstScreen.ResetPassword;
+
+const getResetPasswordOneTimeToken = (
+  params: Parameters<typeof getOneTimeToken>[0] & Parameters<typeof isResetPasswordFirstScreen>[0]
+) => {
+  if (!EnvSet.values.isDevFeaturesEnabled || !isResetPasswordFirstScreen(params)) {
+    return;
+  }
+
+  return getOneTimeToken(params);
 };
 
 const lastSubmittedLoginGuard = z.object({
@@ -115,12 +138,24 @@ export default function koaConsentGuard<
     assertThat(session, new RequestError({ code: 'session.not_found' }));
 
     const oneTimeTokenParams = getOneTimeTokenParams(params);
+    const resetPasswordToken = getResetPasswordOneTimeToken(params);
+
+    if (resetPasswordToken) {
+      ctx.redirect(
+        buildExperienceUrl(
+          experience.routes.resetPassword,
+          resetPasswordToken,
+          getLoginHint(params)
+        )
+      );
+      return;
+    }
 
     if (!oneTimeTokenParams) {
       return next();
     }
 
-    const { token, loginHint, prompt } = oneTimeTokenParams;
+    const { token: signInOneTimeToken, loginHint, prompt } = oneTimeTokenParams;
     const getPrimaryEmailByUserId = async (userId: string) => {
       const { primaryEmail } = await queries.users.findUserById(userId);
 
@@ -136,12 +171,14 @@ export default function koaConsentGuard<
     });
 
     if (primaryEmail !== loginHint && !hasLoginPrompt(prompt) && !hasMatchingLastSubmittedLogin) {
-      ctx.redirect(buildExperienceUrl(experience.routes.switchAccount, token, loginHint));
+      ctx.redirect(
+        buildExperienceUrl(experience.routes.switchAccount, signInOneTimeToken, loginHint)
+      );
       return;
     }
 
     try {
-      await libraries.oneTimeTokens.checkOneTimeToken(token, loginHint);
+      await libraries.oneTimeTokens.checkOneTimeToken(signInOneTimeToken, loginHint);
     } catch (error: unknown) {
       if (error instanceof RequestError) {
         if (
@@ -160,6 +197,6 @@ export default function koaConsentGuard<
       throw error;
     }
 
-    ctx.redirect(buildExperienceUrl(experience.routes.oneTimeToken, token, loginHint));
+    ctx.redirect(buildExperienceUrl(experience.routes.oneTimeToken, signInOneTimeToken, loginHint));
   };
 }

--- a/packages/core/src/oidc/utils.test.ts
+++ b/packages/core/src/oidc/utils.test.ts
@@ -394,6 +394,21 @@ describe('buildLoginPromptUrl', () => {
     expect(
       buildLoginPromptUrl({ one_time_token: 'token_value', login_hint: 'user@mail.com' })
     ).toBe('sign-in?one_time_token=token_value&login_hint=user%40mail.com');
+
+    expect(
+      buildLoginPromptUrl({
+        first_screen: FirstScreen.ResetPassword,
+        one_time_token: 'token_value',
+      })
+    ).toBe('reset-password?one_time_token=token_value');
+
+    expect(
+      buildLoginPromptUrl({
+        first_screen: FirstScreen.ResetPassword,
+        one_time_token: 'token_value',
+        login_hint: 'user@mail.com',
+      })
+    ).toBe('reset-password?one_time_token=token_value&login_hint=user%40mail.com');
   });
 
   it('should append shared experience params to the url', () => {


### PR DESCRIPTION
## Summary
Route reset-password OIDC prompts that include a one-time token to the existing reset-password experience page.

The routing preserves optional `login_hint` for reset-password prompts and keeps the existing one-time-token sign-in/register prompt routing unchanged.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments