### PR TITLE
fix(console): render hosted email cap banner inside the content area

### DIFF
--- a/packages/console/src/components/HostedEmailCapBanner/index.module.scss
+++ b/packages/console/src/components/HostedEmailCapBanner/index.module.scss
@@ -1,24 +1,7 @@
 @use '@/scss/underscore' as _;
 
 .container {
-  display: flex;
+  // A direct child of ConsoleContent's `.main`, so it inherits that column's content-width cap and
+  // centering; only vertical spacing is added here so it doesn't sit flush against the page content.
   padding-block: _.unit(4);
-}
-
-.sidebarPlaceholder {
-  // Matches the console sidebar width (see ConsoleContent/Sidebar/index.module.scss) so the banner
-  // starts at the page content's left edge.
-  width: 248px;
-  flex-shrink: 0;
-}
-
-.content {
-  // Mirror ConsoleContent's `.main`: fill the space right of the sidebar with the same inline padding
-  // and content-width cap, so the banner sits exactly over the page content column.
-  flex-grow: 1;
-  padding-inline: _.unit(2) _.unit(6);
-
-  > * {
-    @include _.main-content-width;
-  }
 }

--- a/packages/console/src/components/HostedEmailCapBanner/index.tsx
+++ b/packages/console/src/components/HostedEmailCapBanner/index.tsx
@@ -15,7 +15,7 @@ const bannerThreshold = 0.8;
 const connectorsPasswordlessPage = `/connectors/${ConnectorsTabs.Passwordless}`;
 
 /**
- * Global banner for the hosted email service cap, shown app-wide (below the topbar) once daily or
+ * Banner for the hosted email service cap, rendered at the top of the page content once daily or
  * monthly usage crosses {@link bannerThreshold}. Two states — approaching (>=80%) and reached (at
  * the cap, a hard block that can interrupt sign-in emails) — each offering to connect an own email
  * provider or upgrade.
@@ -51,27 +51,23 @@ function HostedEmailCapBanner() {
 
   return (
     <div className={styles.container}>
-      {/* Empty placeholder matching the sidebar so the banner aligns with the page content column. */}
-      <div className={styles.sidebarPlaceholder} />
-      <div className={styles.content}>
-        <InlineNotification
-          // A cap notice is a warning, not an error — use the alert (amber) severity for both states.
-          severity="alert"
-          action="general.got_it"
-          onClick={() => {
-            setDismissedSituation(situation);
+      <InlineNotification
+        // A cap notice is a warning, not an error — use the alert (amber) severity for both states.
+        severity="alert"
+        action="general.got_it"
+        onClick={() => {
+          setDismissedSituation(situation);
+        }}
+      >
+        <Trans
+          components={{
+            provider: <TextLink to={connectorsPasswordlessPage} />,
+            upgrade: <TextLink to={tenantSettingsPage} />,
           }}
         >
-          <Trans
-            components={{
-              provider: <TextLink to={connectorsPasswordlessPage} />,
-              upgrade: <TextLink to={tenantSettingsPage} />,
-            }}
-          >
-            {t(`connector_details.logto_email.hosted_email_usage.banner.${situation}`)}
-          </Trans>
-        </InlineNotification>
-      </div>
+          {t(`connector_details.logto_email.hosted_email_usage.banner.${situation}`)}
+        </Trans>
+      </InlineNotification>
     </div>
   );
 }

--- a/packages/console/src/containers/AppContent/index.tsx
+++ b/packages/console/src/containers/AppContent/index.tsx
@@ -4,7 +4,6 @@ import { Navigate, Outlet, useParams } from 'react-router-dom';
 
 import { type SubscriptionCountBasedUsage } from '@/cloud/types/router';
 import AppLoading from '@/components/AppLoading';
-import HostedEmailCapBanner from '@/components/HostedEmailCapBanner';
 import Topbar from '@/components/Topbar';
 import { isCloud } from '@/consts/env';
 import SubscriptionDataProvider from '@/contexts/SubscriptionDataProvider';
@@ -82,11 +81,7 @@ export default function AppContent() {
         <Topbar className={conditional(scrollTop && styles.topbarShadow)} />
         {isTenantSuspended && <TenantSuspendedPage />}
         {!isTenantSuspended && (
-          <>
-            {/* Key by tenant so the banner's per-session dismissal state resets on tenant switch. */}
-            <HostedEmailCapBanner key={currentTenant.id} />
-            <Outlet context={{ scrollableContent } satisfies AppContentOutletContext} />
-          </>
+          <Outlet context={{ scrollableContent } satisfies AppContentOutletContext} />
         )}
       </div>
       <TenantNotificationContainer />

--- a/packages/console/src/containers/ConsoleContent/index.tsx
+++ b/packages/console/src/containers/ConsoleContent/index.tsx
@@ -1,9 +1,11 @@
-import { Suspense } from 'react';
+import { Suspense, useContext } from 'react';
 import { useOutletContext, useRoutes } from 'react-router-dom';
 import { safeLazy } from 'react-safe-lazy';
 
 import DelayedSuspenseFallback from '@/components/DelayedSuspenseFallback';
+import HostedEmailCapBanner from '@/components/HostedEmailCapBanner';
 import { isDevFeaturesEnabled } from '@/consts/env';
+import { TenantsContext } from '@/contexts/TenantsProvider';
 import OverlayScrollbar from '@/ds-components/OverlayScrollbar';
 import Tag from '@/ds-components/Tag';
 import { useConsoleRoutes } from '@/hooks/use-console-routes';
@@ -19,6 +21,7 @@ const Sidebar = safeLazy(async () => import('./Sidebar'));
 
 function ConsoleContent() {
   const { scrollableContent } = useOutletContext<AppContentOutletContext>();
+  const { currentTenantId } = useContext(TenantsContext);
   const routeObjects = useConsoleRoutes();
   const routes = useRoutes(routeObjects);
 
@@ -33,6 +36,8 @@ function ConsoleContent() {
       </Suspense>
       <OverlayScrollbar className={styles.overlayScrollbarWrapper}>
         <div ref={scrollableContent} className={styles.main}>
+          {/* Key by tenant so the banner's per-session dismissal state resets on tenant switch. */}
+          <HostedEmailCapBanner key={currentTenantId} />
           <Suspense fallback={<DelayedSuspenseFallback />}>{routes}</Suspense>
         </div>
       </OverlayScrollbar>


### PR DESCRIPTION
## Summary

Follow-up to the hosted email cap banner work in #9152.

The banner was rendered in the **app shell** (`AppContent`, above the sidebar/content row), so the vertical space it took **pushed the whole row down — including the left sidebar menu**. It also needed a sidebar-width placeholder + a flex/offset structure just to line up with the page content.

### What changed
- **Moved the banner into `ConsoleContent`'s `.main`** (inside the `OverlayScrollbar`), above the routed content. It now occupies only the content column, so the sidebar stays put and only the page content shifts.
- **Removed the sidebar placeholder and the flex/offset structure.** As a direct child of `.main`, the banner inherits the same `main-content-width` cap and centering the page content uses (`.main > :not(svg)`), so it aligns with the page content automatically.
- Kept the per-tenant `key` (moved to `ConsoleContent`) so the per-session dismissal state still resets on tenant switch.

### Behavior notes
- The banner now scrolls with the page content (it lives inside the scroll area, as requested) instead of being pinned in the shell.
- Coverage is unchanged: `ConsoleContent` is the `*` route under `AppContent` (the only sibling is an instant index redirect), so the banner still shows across all console pages.

## Testing

Tested locally

<img width="4698" height="2314" alt="image" src="https://github.com/user-attachments/assets/869d513c-18cf-42cf-bff3-c14eb9d05ea2" />


## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
