### PR TITLE
test(experience): cover one-time token sign-in behavior

### DIFF
--- a/packages/experience/src/apis/experience/one-time-token.test.ts
+++ b/packages/experience/src/apis/experience/one-time-token.test.ts
@@ -1,0 +1,54 @@
+import {
+  InteractionEvent,
+  SignInIdentifier,
+  type OneTimeTokenVerificationVerifyPayload,
+} from '@logto/schemas';
+
+import api from '../api';
+
+import { experienceApiRoutes } from './const';
+import { initInteraction } from './interaction';
+import { signInWithOneTimeToken } from './one-time-token';
+
+jest.mock('../api', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('./interaction', () => ({
+  initInteraction: jest.fn(),
+  identifyUser: jest.fn(),
+}));
+
+const mockedApiPost = api.post as jest.MockedFunction<typeof api.post>;
+const mockedInitInteraction = initInteraction as jest.MockedFunction<typeof initInteraction>;
+
+describe('one-time-token experience APIs', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes a sign-in interaction before verifying one-time token sign-in', async () => {
+    const payload = {
+      token: 'token',
+      identifier: { type: SignInIdentifier.Email, value: 'foo@logto.io' },
+    } satisfies OneTimeTokenVerificationVerifyPayload;
+    const response = { verificationId: 'verification-id' };
+    const json = jest.fn().mockResolvedValue(response);
+
+    mockedApiPost.mockReturnValueOnce({ json } as unknown as ReturnType<typeof api.post>);
+
+    await expect(signInWithOneTimeToken(payload)).resolves.toEqual(response);
+
+    expect(mockedInitInteraction).toBeCalledWith(InteractionEvent.SignIn);
+    expect(mockedApiPost).toBeCalledWith(
+      `${experienceApiRoutes.verification}/one-time-token/verify`,
+      {
+        json: payload,
+      }
+    );
+    expect(json).toBeCalled();
+  });
+});

--- a/packages/experience/src/apis/experience/one-time-token.test.ts
+++ b/packages/experience/src/apis/experience/one-time-token.test.ts
@@ -43,6 +43,9 @@ describe('one-time-token experience APIs', () => {
     await expect(signInWithOneTimeToken(payload)).resolves.toEqual(response);
 
     expect(mockedInitInteraction).toBeCalledWith(InteractionEvent.SignIn);
+    expect(mockedInitInteraction.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedApiPost.mock.invocationCallOrder[0]!
+    );
     expect(mockedApiPost).toBeCalledWith(
       `${experienceApiRoutes.verification}/one-time-token/verify`,
       {

--- a/packages/experience/src/pages/OneTimeToken/index.test.tsx
+++ b/packages/experience/src/pages/OneTimeToken/index.test.tsx
@@ -1,0 +1,118 @@
+import { experience, SignInIdentifier } from '@logto/schemas';
+import { waitFor } from '@testing-library/react';
+import { HTTPError } from 'ky';
+import { Route, Routes } from 'react-router-dom';
+
+import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import {
+  identifyAndSubmitInteraction,
+  registerWithVerifiedIdentifier,
+  signInWithOneTimeToken,
+} from '@/apis/experience';
+
+import OneTimeToken from '.';
+import OneTimeTokenError from './Error';
+
+const mockRedirectTo = jest.fn();
+
+function mockUseGlobalRedirectTo() {
+  return mockRedirectTo;
+}
+
+jest.mock('i18next', () => ({
+  language: 'en',
+  t: (key: string) => key,
+}));
+
+jest.mock('@/apis/experience', () => ({
+  identifyAndSubmitInteraction: jest.fn().mockResolvedValue({ redirectTo: '/redirect' }),
+  registerWithVerifiedIdentifier: jest.fn().mockResolvedValue({ redirectTo: '/register-redirect' }),
+  signInWithOneTimeToken: jest.fn().mockResolvedValue({ verificationId: 'verification-id' }),
+}));
+
+jest.mock('@/hooks/use-global-redirect-to', () => mockUseGlobalRedirectTo);
+
+const mockedIdentifyAndSubmitInteraction = identifyAndSubmitInteraction as jest.MockedFunction<
+  typeof identifyAndSubmitInteraction
+>;
+const mockedRegisterWithVerifiedIdentifier = registerWithVerifiedIdentifier as jest.MockedFunction<
+  typeof registerWithVerifiedIdentifier
+>;
+const mockedSignInWithOneTimeToken = signInWithOneTimeToken as jest.MockedFunction<
+  typeof signInWithOneTimeToken
+>;
+
+const createRequestError = (code: string) => {
+  const response = {
+    status: 404,
+    statusText: 'Not Found',
+    json: async () => ({ code, message: code }),
+  } as unknown as Response;
+
+  return new HTTPError(response, {} as Request, {} as never);
+};
+
+describe('OneTimeToken', () => {
+  const renderPage = (initialEntry: string) =>
+    renderWithPageContext(
+      <SettingsProvider>
+        <UserInteractionContextProvider>
+          <Routes>
+            <Route path={`/${experience.routes.oneTimeToken}`} element={<OneTimeToken />} />
+            <Route
+              path={`/${experience.routes.oneTimeToken}/error`}
+              element={<OneTimeTokenError />}
+            />
+          </Routes>
+        </UserInteractionContextProvider>
+      </SettingsProvider>,
+      { initialEntries: [initialEntry] }
+    );
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits an existing one-time token with the sign-in interaction', async () => {
+    renderPage('/one-time-token?one_time_token=token&login_hint=foo%40logto.io');
+
+    await waitFor(() => {
+      expect(mockedSignInWithOneTimeToken).toBeCalledWith({
+        token: 'token',
+        identifier: { type: SignInIdentifier.Email, value: 'foo@logto.io' },
+      });
+      expect(mockedIdentifyAndSubmitInteraction).toBeCalledWith({
+        verificationId: 'verification-id',
+      });
+      expect(mockedRegisterWithVerifiedIdentifier).not.toBeCalled();
+      expect(mockRedirectTo).toBeCalledWith('/redirect');
+    });
+  });
+
+  it('falls back to register when the verified identifier does not exist', async () => {
+    mockedIdentifyAndSubmitInteraction.mockRejectedValueOnce(
+      createRequestError('user.user_not_exist')
+    );
+
+    renderPage('/one-time-token?one_time_token=token&login_hint=foo%40logto.io');
+
+    await waitFor(() => {
+      expect(mockedIdentifyAndSubmitInteraction).toBeCalledWith({
+        verificationId: 'verification-id',
+      });
+      expect(mockedRegisterWithVerifiedIdentifier).toBeCalledWith('verification-id');
+      expect(mockRedirectTo).toBeCalledWith('/register-redirect');
+    });
+  });
+
+  it('shows the one-time token error page when required parameters are missing', async () => {
+    const { queryByText } = renderPage('/one-time-token?one_time_token=token');
+
+    await waitFor(() => {
+      expect(mockedSignInWithOneTimeToken).not.toBeCalled();
+      expect(queryByText('error.invalid_link')).not.toBeNull();
+    });
+  });
+});

--- a/packages/experience/src/pages/OneTimeToken/index.test.tsx
+++ b/packages/experience/src/pages/OneTimeToken/index.test.tsx
@@ -32,7 +32,10 @@ jest.mock('@/apis/experience', () => ({
   signInWithOneTimeToken: jest.fn().mockResolvedValue({ verificationId: 'verification-id' }),
 }));
 
-jest.mock('@/hooks/use-global-redirect-to', () => mockUseGlobalRedirectTo);
+jest.mock('@/hooks/use-global-redirect-to', () => ({
+  __esModule: true,
+  default: mockUseGlobalRedirectTo,
+}));
 
 const mockedIdentifyAndSubmitInteraction = identifyAndSubmitInteraction as jest.MockedFunction<
   typeof identifyAndSubmitInteraction


### PR DESCRIPTION
## Summary
Add regression coverage for existing one-time-token sign-in/register behavior.

- Verify `/one-time-token` still verifies one-time tokens as email sign-in and submits the interaction.
- Verify the `user.user_not_exist` path still falls back to registration with the verified identifier.
- Verify the sign-in one-time-token API helper initializes `InteractionEvent.SignIn` before token verification.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments