### PR TITLE
fix(core): guard account verification codes by email blocklist

### DIFF
--- a/.changeset/tender-verifications-block.md
+++ b/.changeset/tender-verifications-block.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+prevent Account API verification codes from being sent to blocked email addresses

--- a/packages/core/src/routes/verification/index.openapi.json
+++ b/packages/core/src/routes/verification/index.openapi.json
@@ -87,6 +87,9 @@
               }
             }
           },
+          "422": {
+            "description": "The email address is restricted by the email blocklist policy."
+          },
           "501": {
             "description": "The connector for sending the verification code is not configured."
           }

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -27,6 +27,8 @@ import { SocialVerification } from '../experience/classes/verifications/social-v
 import { WebAuthnVerification } from '../experience/classes/verifications/web-authn-verification.js';
 import type { UserRouter, RouterInitArgs } from '../types.js';
 
+import { guardNewIdentifierEmailBlocklist } from './utils.js';
+
 export const verificationApiPrefix = '/verifications';
 
 export default function verificationRoutes<T extends UserRouter>(
@@ -82,7 +84,6 @@ export default function verificationRoutes<T extends UserRouter>(
     koaGuard({
       body: z.object({
         identifier: verificationCodeIdentifierGuard,
-        // Optional: explicitly specify the template type to use (limited set)
         templateType: z
           .union([
             z.literal(TemplateType.BindMfa),
@@ -91,7 +92,7 @@ export default function verificationRoutes<T extends UserRouter>(
           .optional(),
       }),
       response: z.object({ verificationRecordId: z.string(), expiresAt: z.string() }),
-      status: [201, 429, 501],
+      status: [201, 422, 429, 501],
     }),
     async (ctx, next) => {
       const { id: userId, clientId: applicationId } = ctx.auth;
@@ -105,6 +106,8 @@ export default function verificationRoutes<T extends UserRouter>(
       const templateType = isNewIdentifier
         ? TemplateType.BindNewIdentifier
         : (inputTemplateType ?? TemplateType.UserPermissionValidation);
+
+      await guardNewIdentifierEmailBlocklist(queries, identifier, isNewIdentifier);
 
       const codeVerification = createNewCodeVerificationRecord(
         libraries,

--- a/packages/core/src/routes/verification/utils.ts
+++ b/packages/core/src/routes/verification/utils.ts
@@ -1,0 +1,17 @@
+import { SignInIdentifier, type VerificationCodeIdentifier } from '@logto/schemas';
+
+import { validateEmailAgainstBlocklistPolicy } from '#src/libraries/sign-in-experience/email-blocklist-policy.js';
+import type Queries from '#src/tenants/Queries.js';
+
+export const guardNewIdentifierEmailBlocklist = async (
+  queries: Queries,
+  identifier: VerificationCodeIdentifier,
+  isNewIdentifier: boolean
+) => {
+  if (!isNewIdentifier || identifier.type !== SignInIdentifier.Email) {
+    return;
+  }
+
+  const { emailBlocklistPolicy } = await queries.signInExperiences.findDefaultSignInExperience();
+  await validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, identifier.value);
+};

--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -13,7 +13,7 @@ import {
   updatePrimaryPhone,
   updateUser,
 } from '#src/api/my-account.js';
-import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { getSignInExperience, updateSignInExperience } from '#src/api/sign-in-experience.js';
 import {
   createAndVerifyVerificationCode,
   createVerificationRecordByPassword,
@@ -37,12 +37,7 @@ const expectPrimaryEmailUpdateRejectedByBlocklist = async (
   email: string,
   customBlocklist: string[]
 ) => {
-  await updateSignInExperience({
-    emailBlocklistPolicy: {
-      customBlocklist,
-    },
-  });
-
+  const { emailBlocklistPolicy } = await getSignInExperience();
   const { user, username, password } = await createDefaultTenantUserWithPassword();
   const api = await signInAndGetUserApi(username, password, {
     scopes: [UserScope.Profile, UserScope.Email],
@@ -54,6 +49,12 @@ const expectPrimaryEmailUpdateRejectedByBlocklist = async (
       type: SignInIdentifier.Email,
       value: email,
     });
+    await updateSignInExperience({
+      emailBlocklistPolicy: {
+        ...emailBlocklistPolicy,
+        customBlocklist: [...(emailBlocklistPolicy.customBlocklist ?? []), ...customBlocklist],
+      },
+    });
 
     await expectRejects(
       updatePrimaryEmail(api, email, verificationRecordId, newVerificationRecordId),
@@ -64,9 +65,7 @@ const expectPrimaryEmailUpdateRejectedByBlocklist = async (
     );
   } finally {
     await updateSignInExperience({
-      emailBlocklistPolicy: {
-        customBlocklist: [],
-      },
+      emailBlocklistPolicy,
     });
     await deleteDefaultTenantUser(user.id);
   }
@@ -184,6 +183,44 @@ describe('account (email and phone)', () => {
       expect(userInfo).toHaveProperty('primaryEmail', newEmail);
 
       await deleteDefaultTenantUser(user.id);
+    });
+
+    it('should reject sending verification code to a blocklisted new email', async () => {
+      const email = generateEmail();
+      const { emailBlocklistPolicy } = await getSignInExperience();
+      const { user, username, password } = await createDefaultTenantUserWithPassword();
+      const api = await signInAndGetUserApi(username, password, {
+        scopes: [UserScope.Profile, UserScope.Email],
+      });
+
+      try {
+        await updateSignInExperience({
+          emailBlocklistPolicy: {
+            ...emailBlocklistPolicy,
+            customBlocklist: [...(emailBlocklistPolicy.customBlocklist ?? []), email],
+          },
+        });
+
+        await expectRejects(
+          api.post('api/verifications/verification-code', {
+            json: {
+              identifier: {
+                type: SignInIdentifier.Email,
+                value: email,
+              },
+            },
+          }),
+          {
+            code: 'session.email_blocklist.email_not_allowed',
+            status: 422,
+          }
+        );
+      } finally {
+        await updateSignInExperience({
+          emailBlocklistPolicy,
+        });
+        await deleteDefaultTenantUser(user.id);
+      }
     });
 
     it('should reject the email if the email is in the blocklist', async () => {


### PR DESCRIPTION
## Summary
Account verification-code creation now checks the email blocklist before sending a code to a new email identifier. This prevents Account Center email linking or changing from sending verification codes to blocked email addresses, while leaving security verification for an existing email untouched.

- Added a shared Account API verification-code guard for new email identifiers.
- Documented the 422 blocklist response on the verification-code endpoint.
- Added an integration regression test for blocklisted new-email verification-code sends.
- Added a core changeset.

## Testing
Integration tests

## Checklist
- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments