### PR TITLE
fix(experience): fall back to password sign-in when the email cap blocks a code send

### DIFF
--- a/packages/experience/src/components/IdentifierSignInForm/index.test.tsx
+++ b/packages/experience/src/components/IdentifierSignInForm/index.test.tsx
@@ -2,6 +2,7 @@ import type { SignIn, SsoConnectorMetadata } from '@logto/schemas';
 import { SignInIdentifier, experience } from '@logto/schemas';
 import { assert } from '@silverhand/essentials';
 import { fireEvent, act, waitFor } from '@testing-library/react';
+import { HTTPError } from 'ky';
 
 import SingleSignOnFormModeContextProvider from '@/Providers/SingleSignOnFormModeContextProvider';
 import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
@@ -26,9 +27,15 @@ jest.mock('i18next', () => ({
 
 const mockedNavigate = jest.fn();
 const getSingleSignOnConnectorsMock = jest.fn();
+const mockedSetToast = jest.fn();
 
 jest.mock('@/apis/utils', () => ({
   sendVerificationCodeApi: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  __esModule: true,
+  default: () => ({ toast: '', setToast: mockedSetToast }),
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -59,6 +66,22 @@ const renderForm = (signInMethods: SignIn['methods'], ssoConnectors: SsoConnecto
       </UserInteractionContextProvider>
     </SettingsProvider>
   );
+
+const renderFormAndSubmitEmail = (signInMethods: SignIn['methods']) => {
+  const { getByText, container } = renderForm(signInMethods);
+  const inputField = container.querySelector('input[name="identifier"]');
+  const submitButton = getByText('action.sign_in');
+
+  assert(inputField, new Error('identifier input should exist'));
+
+  act(() => {
+    fireEvent.change(inputField, { target: { value: email } });
+  });
+
+  act(() => {
+    fireEvent.submit(submitButton);
+  });
+};
 
 describe('IdentifierSignInForm', () => {
   afterEach(() => {
@@ -299,6 +322,47 @@ describe('IdentifierSignInForm', () => {
           undefined
         );
       });
+    });
+  });
+
+  describe('email service usage cap fallback', () => {
+    const usageLimitExceededError = new HTTPError(
+      {
+        json: async () => ({
+          code: 'connector.usage_limit_exceeded',
+          message: 'connector.usage_limit_exceeded',
+        }),
+      } as Response,
+      {} as Request,
+      {} as never
+    );
+
+    it('falls back to the password page when the cap is hit and password is configured', async () => {
+      (sendVerificationCodeApi as jest.Mock).mockRejectedValueOnce(usageLimitExceededError);
+
+      // Fixture [1]'s email method allows password + verification code (code primary), so the
+      // password fallback is available.
+      renderFormAndSubmitEmail(mockSignInMethodSettingsTestCases[1]!);
+
+      await waitFor(() => {
+        expect(sendVerificationCodeApi).toBeCalled();
+        expect(mockedSetToast).toBeCalledWith('error.send_verification_code_failed_use_password');
+        expect(mockedNavigate).toBeCalledWith({ pathname: '/sign-in/password' }, undefined);
+      });
+    });
+
+    it('shows the generic error and stays put when the cap is hit but no password is configured', async () => {
+      (sendVerificationCodeApi as jest.Mock).mockRejectedValueOnce(usageLimitExceededError);
+
+      // Fixture [2]'s email method allows verification code only, so there is no password fallback.
+      renderFormAndSubmitEmail(mockSignInMethodSettingsTestCases[2]!);
+
+      await waitFor(() => {
+        expect(sendVerificationCodeApi).toBeCalled();
+        expect(mockedSetToast).toBeCalledWith('error.send_verification_code_failed');
+      });
+
+      expect(mockedNavigate).not.toBeCalled();
     });
   });
 });

--- a/packages/experience/src/components/IdentifierSignInForm/use-on-submit.ts
+++ b/packages/experience/src/components/IdentifierSignInForm/use-on-submit.ts
@@ -1,6 +1,8 @@
 import type { SignIn } from '@logto/schemas';
 import { SignInIdentifier } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import { useCallback, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import useCheckSingleSignOn from '@/hooks/use-check-single-sign-on';
@@ -8,10 +10,13 @@ import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-pres
 import useSendVerificationCode from '@/hooks/use-send-verification-code';
 import { useSieMethods } from '@/hooks/use-sie';
 import useStartIdentifierPasskeySignInProcessing from '@/hooks/use-start-identifier-passkey-sign-in-processing';
+import useToast from '@/hooks/use-toast';
 import { UserFlow } from '@/types';
 
 const useOnSubmit = (signInMethods: SignIn['methods']) => {
   const navigate = useNavigateWithPreservedSearchParams();
+  const { setToast } = useToast();
+  const { t } = useTranslation();
   const { ssoConnectors, passkeySignIn } = useSieMethods();
   const { onSubmit: checkSingleSignOn } = useCheckSingleSignOn();
   const { setIdentifierInputValue } = useContext(UserInteractionContext);
@@ -80,7 +85,21 @@ const useOnSubmit = (signInMethods: SignIn['methods']) => {
       }
 
       if (verificationCode) {
-        await sendVerificationCode({ identifier, value });
+        await sendVerificationCode(
+          { identifier, value },
+          undefined,
+          // The email service usage cap blocks the code send. If this method also allows password
+          // sign-in, route to the password page instead of stranding the user on the identifier
+          // page with no way forward.
+          conditional(
+            password && {
+              'connector.usage_limit_exceeded': () => {
+                setToast(t('error.send_verification_code_failed_use_password'));
+                navigateToPasswordPage();
+              },
+            }
+          )
+        );
       }
     },
     [
@@ -92,6 +111,8 @@ const useOnSubmit = (signInMethods: SignIn['methods']) => {
       startIdentifierPasskeySignInProcessing,
       navigateToPasswordPage,
       sendVerificationCode,
+      setToast,
+      t,
     ]
   );
 

--- a/packages/experience/src/hooks/use-send-verification-code.ts
+++ b/packages/experience/src/hooks/use-send-verification-code.ts
@@ -9,7 +9,7 @@ import CaptchaContext from '@/Providers/CaptchaContextProvider/CaptchaContext';
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import { sendVerificationCodeApi } from '@/apis/utils';
 import useApi from '@/hooks/use-api';
-import useErrorHandler from '@/hooks/use-error-handler';
+import useErrorHandler, { type ErrorHandlers } from '@/hooks/use-error-handler';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import useToast from '@/hooks/use-toast';
 import {
@@ -40,7 +40,11 @@ const useSendVerificationCode = (flow: UserFlow, replaceCurrentPage?: boolean) =
   }, []);
 
   const onSubmit = useCallback(
-    async ({ identifier, value }: Payload, interactionEvent?: ContinueFlowInteractionEvent) => {
+    async (
+      { identifier, value }: Payload,
+      interactionEvent?: ContinueFlowInteractionEvent,
+      errorHandlers?: ErrorHandlers
+    ) => {
       const captchaToken = await executeCaptcha();
 
       const [error, result] = await asyncSendVerificationCode(
@@ -71,6 +75,9 @@ const useSendVerificationCode = (flow: UserFlow, replaceCurrentPage?: boolean) =
           'connector.usage_limit_exceeded': () => {
             setToast(t('error.send_verification_code_failed'));
           },
+          // Per-call overrides win over the defaults above, so a caller can react to a specific
+          // failure differently (e.g. sign-in falls back to the password page on a cap hit).
+          ...errorHandlers,
         });
 
         return;

--- a/packages/phrases-experience/src/locales/ar/error/index.ts
+++ b/packages/phrases-experience/src/locales/ar/error/index.ts
@@ -34,6 +34,8 @@ const error = {
   invalid_link_description: 'ربما يكون رمز الدخول المؤقت قد انتهى أو لم يعد صالحًا.',
   captcha_verification_failed: 'فشل التحقق من رمز التحقق.',
   send_verification_code_failed: 'فشل إرسال رمز التحقق. يرجى المحاولة لاحقًا.',
+  send_verification_code_failed_use_password:
+    'فشل إرسال رمز التحقق. يرجى تسجيل الدخول باستخدام كلمة المرور بدلاً من ذلك.',
   terms_acceptance_required: 'مطلوب قبول الشروط',
   terms_acceptance_required_description:
     'يجب أن توافق على الشروط للمتابعة. يرجى المحاولة مرة أخرى.',

--- a/packages/phrases-experience/src/locales/cs/error/index.ts
+++ b/packages/phrases-experience/src/locales/cs/error/index.ts
@@ -34,6 +34,8 @@ const error = {
   invalid_link_description: 'Tvůj jednorázový kód mohl vypršet nebo již není platný.',
   captcha_verification_failed: 'Ověření, že nejsi robot, se nezdařilo.',
   send_verification_code_failed: 'Odeslání ověřovacího kódu se nezdařilo. Zkus to prosím později.',
+  send_verification_code_failed_use_password:
+    'Odeslání ověřovacího kódu se nezdařilo. Přihlas se prosím pomocí hesla.',
   terms_acceptance_required: 'Je nutné souhlasit s podmínkami',
   terms_acceptance_required_description: 'Pro pokračování je nutné souhlasit s podmínkami.',
   something_went_wrong: 'Něco se pokazilo.',

--- a/packages/phrases-experience/src/locales/de/error/index.ts
+++ b/packages/phrases-experience/src/locales/de/error/index.ts
@@ -37,6 +37,8 @@ const error = {
   captcha_verification_failed: 'Fehler beim Captcha-Verifizierung.',
   send_verification_code_failed:
     'Bestätigungscode konnte nicht gesendet werden. Bitte versuche es später noch einmal.',
+  send_verification_code_failed_use_password:
+    'Bestätigungscode konnte nicht gesendet werden. Bitte melde dich stattdessen mit deinem Passwort an.',
   terms_acceptance_required: 'Zustimmung zu den Bedingungen erforderlich',
   terms_acceptance_required_description: 'Du musst den Bedingungen zustimmen, um fortzufahren.',
   something_went_wrong: 'Etwas ist schiefgegangen',

--- a/packages/phrases-experience/src/locales/en/error/index.ts
+++ b/packages/phrases-experience/src/locales/en/error/index.ts
@@ -35,6 +35,8 @@ const error = {
   invalid_link_description: 'Your one-time token may have expired or is no longer valid.',
   captcha_verification_failed: 'Failed to perform captcha verification.',
   send_verification_code_failed: 'Failed to send the verification code. Please try again later.',
+  send_verification_code_failed_use_password:
+    'Failed to send the verification code. Please sign in with your password instead.',
   terms_acceptance_required: 'Terms acceptance required',
   terms_acceptance_required_description: 'You must agree to the terms to continue.',
   something_went_wrong: 'Something went wrong',

--- a/packages/phrases-experience/src/locales/es/error/index.ts
+++ b/packages/phrases-experience/src/locales/es/error/index.ts
@@ -38,6 +38,8 @@ const error = {
   captcha_verification_failed: 'Error al verificar el captcha.',
   send_verification_code_failed:
     'No se pudo enviar el código de verificación. Inténtalo de nuevo más tarde.',
+  send_verification_code_failed_use_password:
+    'No se pudo enviar el código de verificación. Inicia sesión con tu contraseña en su lugar.',
   terms_acceptance_required: 'Se requiere aceptar los términos',
   terms_acceptance_required_description:
     'Debes aceptar los términos para continuar. Por favor, inténtalo de nuevo.',

--- a/packages/phrases-experience/src/locales/fa-ir/error/index.ts
+++ b/packages/phrases-experience/src/locales/fa-ir/error/index.ts
@@ -34,6 +34,8 @@ const error = {
   invalid_link_description: 'توکن یک‌بار مصرف شما ممکن است منقضی شده یا دیگر معتبر نباشد.',
   captcha_verification_failed: 'تأیید کپچا ناموفق بود.',
   send_verification_code_failed: 'ارسال کد تأیید ناموفق بود. لطفاً بعداً دوباره تلاش کنید.',
+  send_verification_code_failed_use_password:
+    'ارسال کد تأیید ناموفق بود. لطفاً به جای آن با رمز عبور وارد شوید.',
   terms_acceptance_required: 'پذیرش شرایط الزامی است',
   terms_acceptance_required_description: 'برای ادامه باید با شرایط موافقت کنید.',
   something_went_wrong: 'مشکلی پیش آمد',

--- a/packages/phrases-experience/src/locales/fr/error/index.ts
+++ b/packages/phrases-experience/src/locales/fr/error/index.ts
@@ -41,6 +41,8 @@ const error = {
   captcha_verification_failed: 'Erreur lors de la vérification du captcha.',
   send_verification_code_failed:
     "Échec de l'envoi du code de vérification. Veuillez réessayer plus tard.",
+  send_verification_code_failed_use_password:
+    "Échec de l'envoi du code de vérification. Veuillez plutôt vous connecter avec votre mot de passe.",
   terms_acceptance_required: 'Acceptation des conditions requise',
   terms_acceptance_required_description: 'Vous devez accepter les conditions pour continuer.',
   something_went_wrong: 'Quelque chose a mal tourné',

--- a/packages/phrases-experience/src/locales/it/error/index.ts
+++ b/packages/phrases-experience/src/locales/it/error/index.ts
@@ -35,6 +35,8 @@ const error = {
   invalid_link_description: 'Il tuo token monouso potrebbe essere scaduto o non è più valido.',
   captcha_verification_failed: 'Errore durante la verifica del captcha.',
   send_verification_code_failed: 'Invio del codice di verifica non riuscito. Riprova più tardi.',
+  send_verification_code_failed_use_password:
+    'Invio del codice di verifica non riuscito. Accedi invece con la tua password.',
   terms_acceptance_required: 'Accettazione dei termini richiesta',
   terms_acceptance_required_description: 'Devi accettare i termini per continuare.',
   something_went_wrong: 'Qualcosa è andato storto',

--- a/packages/phrases-experience/src/locales/ja/error/index.ts
+++ b/packages/phrases-experience/src/locales/ja/error/index.ts
@@ -37,6 +37,8 @@ const error = {
   captcha_verification_failed: 'キャプチャーの検証に失敗しました。',
   send_verification_code_failed:
     '認証コードの送信に失敗しました。しばらくしてからもう一度お試しください。',
+  send_verification_code_failed_use_password:
+    '認証コードの送信に失敗しました。代わりにパスワードでサインインしてください。',
   terms_acceptance_required: '利用規約の同意が必要です',
   terms_acceptance_required_description:
     '続行するには利用規約に同意する必要があります。もう一度お試しください。',

--- a/packages/phrases-experience/src/locales/ko/error/index.ts
+++ b/packages/phrases-experience/src/locales/ko/error/index.ts
@@ -34,6 +34,8 @@ const error = {
   invalid_link_description: '일회성 토큰이 만료되었거나 더 이상 유효하지 않을 수 있어요.',
   captcha_verification_failed: '캡차 검증에 실패했어요.',
   send_verification_code_failed: '인증 코드를 보내지 못했습니다. 잠시 후 다시 시도해주세요.',
+  send_verification_code_failed_use_password:
+    '인증 코드를 보내지 못했습니다. 대신 비밀번호로 로그인해주세요.',
   terms_acceptance_required: '약관 동의가 필요해요',
   terms_acceptance_required_description: '계속하려면 약관에 동의해야 해요.',
   something_went_wrong: '문제가 발생했어요',

--- a/packages/phrases-experience/src/locales/pl-pl/error/index.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/error/index.ts
@@ -36,6 +36,8 @@ const error = {
   captcha_verification_failed: 'Weryfikacja captcha nie powiodła się.',
   send_verification_code_failed:
     'Nie udało się wysłać kodu weryfikacyjnego. Spróbuj ponownie później.',
+  send_verification_code_failed_use_password:
+    'Nie udało się wysłać kodu weryfikacyjnego. Zaloguj się zamiast tego za pomocą hasła.',
   terms_acceptance_required: 'Wymagana akceptacja warunków',
   terms_acceptance_required_description: 'Musisz zaakceptować warunki, aby kontynuować.',
   something_went_wrong: 'Coś poszło nie tak',

--- a/packages/phrases-experience/src/locales/pt-br/error/index.ts
+++ b/packages/phrases-experience/src/locales/pt-br/error/index.ts
@@ -36,6 +36,8 @@ const error = {
   captcha_verification_failed: 'Falha na verificação do captcha.',
   send_verification_code_failed:
     'Falha ao enviar o código de verificação. Tente novamente mais tarde.',
+  send_verification_code_failed_use_password:
+    'Falha ao enviar o código de verificação. Em vez disso, faça login com sua senha.',
   terms_acceptance_required: 'Aceitação dos termos obrigatória',
   terms_acceptance_required_description: 'Você deve aceitar os termos para continuar.',
   something_went_wrong: 'Algo deu errado',

--- a/packages/phrases-experience/src/locales/pt-pt/error/index.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/error/index.ts
@@ -37,6 +37,8 @@ const error = {
   captcha_verification_failed: 'Falha na verificação do captcha.',
   send_verification_code_failed:
     'Falha ao enviar o código de verificação. Tente novamente mais tarde.',
+  send_verification_code_failed_use_password:
+    'Falha ao enviar o código de verificação. Em vez disso, inicie sessão com a sua palavra-passe.',
   terms_acceptance_required: 'Aceitação dos termos necessária',
   terms_acceptance_required_description:
     'Deves aceitar os termos para continuar. Por favor, tenta novamente.',

--- a/packages/phrases-experience/src/locales/ru/error/index.ts
+++ b/packages/phrases-experience/src/locales/ru/error/index.ts
@@ -36,6 +36,8 @@ const error = {
     'Ваш одноразовый токен мог истечь или больше не является действительным.',
   captcha_verification_failed: 'Не удалось проверить капчу.',
   send_verification_code_failed: 'Не удалось отправить код подтверждения. Попробуйте позже.',
+  send_verification_code_failed_use_password:
+    'Не удалось отправить код подтверждения. Войдите с помощью пароля.',
   terms_acceptance_required: 'Требуется согласие с условиями',
   terms_acceptance_required_description:
     'Вы должны согласиться с условиями, чтобы продолжить. Пожалуйста, попробуйте снова.',

--- a/packages/phrases-experience/src/locales/th/error/index.ts
+++ b/packages/phrases-experience/src/locales/th/error/index.ts
@@ -34,6 +34,8 @@ const error = {
   invalid_link_description: 'โทเค็นใช้ครั้งเดียวของคุณอาจหมดอายุหรือไม่ถูกต้องอีกต่อไป',
   captcha_verification_failed: 'การตรวจสอบ captcha ล้มเหลว',
   send_verification_code_failed: 'ส่งรหัสยืนยันไม่สำเร็จ โปรดลองอีกครั้งในภายหลัง',
+  send_verification_code_failed_use_password:
+    'ส่งรหัสยืนยันไม่สำเร็จ โปรดเข้าสู่ระบบด้วยรหัสผ่านแทน',
   terms_acceptance_required: 'จำเป็นต้องยอมรับเงื่อนไข',
   terms_acceptance_required_description: 'คุณต้องยอมรับเงื่อนไขเพื่อดำเนินการต่อ',
   something_went_wrong: 'เกิดข้อผิดพลาดบางอย่าง',

--- a/packages/phrases-experience/src/locales/tr-tr/error/index.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/error/index.ts
@@ -36,6 +36,8 @@ const error = {
     'Tek kullanımlık belirtecin süresi dolmuş olabilir veya artık geçerli değil.',
   captcha_verification_failed: 'Captcha doğrulama hatası.',
   send_verification_code_failed: 'Doğrulama kodu gönderilemedi. Lütfen daha sonra tekrar dene.',
+  send_verification_code_failed_use_password:
+    'Doğrulama kodu gönderilemedi. Lütfen bunun yerine şifrenle giriş yap.',
   terms_acceptance_required: 'Şartların kabulü gerekli',
   terms_acceptance_required_description: 'Devam etmek için şartları kabul etmelisiniz.',
   something_went_wrong: 'Bir şeyler yanlış gitti',

--- a/packages/phrases-experience/src/locales/uk-ua/error/index.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/error/index.ts
@@ -35,6 +35,8 @@ const error = {
   captcha_verification_failed: 'Не вдалося пройти перевірку капчі.',
   send_verification_code_failed:
     'Не вдалося надіслати код підтвердження. Спробуйте ще раз пізніше.',
+  send_verification_code_failed_use_password:
+    'Не вдалося надіслати код підтвердження. Натомість увійдіть за допомогою пароля.',
   terms_acceptance_required: 'Потрібно прийняти умови',
   terms_acceptance_required_description:
     'Ви повинні погодитися з умовами, щоб продовжити. Будь ласка, спробуйте ще раз.',

--- a/packages/phrases-experience/src/locales/zh-cn/error/index.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/error/index.ts
@@ -34,6 +34,7 @@ const error = {
   invalid_link_description: '你的一次性令牌可能已过期或不再有效。',
   captcha_verification_failed: '验证码验证失败。',
   send_verification_code_failed: '验证码发送失败，请稍后再试。',
+  send_verification_code_failed_use_password: '验证码发送失败，请改用密码登录。',
   terms_acceptance_required: '需要同意条款',
   terms_acceptance_required_description: '必须同意条款后才能继续。',
   something_went_wrong: '出现错误',

--- a/packages/phrases-experience/src/locales/zh-hk/error/index.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/error/index.ts
@@ -34,6 +34,7 @@ const error = {
   invalid_link_description: '你的一次性令牌可能已過期或失效。',
   captcha_verification_failed: '驗證碼驗證失敗。',
   send_verification_code_failed: '驗證碼傳送失敗，請稍後再試。',
+  send_verification_code_failed_use_password: '驗證碼傳送失敗，請改用密碼登錄。',
   terms_acceptance_required: '需要同意條款',
   terms_acceptance_required_description: '必須同意條款後才能繼續。',
   something_went_wrong: '出錯了',

--- a/packages/phrases-experience/src/locales/zh-tw/error/index.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/error/index.ts
@@ -34,6 +34,7 @@ const error = {
   invalid_link_description: '你的一次性令牌可能已過期或不再有效。',
   captcha_verification_failed: '驗證碼驗證失敗。',
   send_verification_code_failed: '驗證碼傳送失敗，請稍後再試。',
+  send_verification_code_failed_use_password: '驗證碼傳送失敗，請改用密碼登錄。',
   terms_acceptance_required: '需要同意條款',
   terms_acceptance_required_description: '必須同意條款後才能繼續。',
   something_went_wrong: '出了些問題',


### PR DESCRIPTION
## Summary

Part 2 of LOG-13773 (end-user UX for the built-in email cap). Part 1 (#9161) fixed the copy; this fixes the **sign-in fallback flow**.

**Problem:** With a sign-in method that allows **both** verification code and password (code primary), a user who enters their email and clicks Sign in goes straight to the code send. When the built-in email service usage cap is hit (`connector.usage_limit_exceeded`), the send fails, a toast shows, and the user is **stranded on the identifier page** — there's no path to the password form even though password sign-in is configured.

**Fix:** In the sign-in identifier flow, on `connector.usage_limit_exceeded`, if the method also has `password`, route to `/sign-in/password` with an explanatory toast. The identifier carries over via `UserInteractionContext`, so the password page renders directly.

### What changed
- `hooks/use-send-verification-code.ts` — `onSubmit` accepts an optional per-call `errorHandlers` (`ErrorHandlers`), merged **after** the defaults so a caller can override how a specific error is handled. Backward compatible; existing callers pass nothing.
- `components/IdentifierSignInForm/use-on-submit.ts` — passes an override for `connector.usage_limit_exceeded` **only when `password` is set** (`conditional(password && {...})`) that shows the toast and calls the existing `navigateToPasswordPage()`.
- New phrase `error.send_verification_code_failed_use_password` across all 20 `phrases-experience` locales.

### Scope / non-goals
- Only `connector.usage_limit_exceeded`. Input errors (`guard.invalid_input`, blocklist) still surface inline on the identifier page so the user can fix the email.
- Only when `password` is configured; otherwise the generic "try again later" toast stays and the user stays put.
- Sign-in only. Register / forgot-password / continue have no password fallback and are unchanged.
- Not surfaced on the verification-code page by design: that page is gated on a `verificationId` that only exists after a *successful* send, so a failed send has nothing to land on.

## Testing

Unit tests

Two new cases in `IdentifierSignInForm/index.test.tsx`: cap hit with password configured → navigates to `/sign-in/password` + toast; cap hit with verification-code-only → generic toast, no navigation. Full `@logto/experience` suite green (412 tests).

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
