### PR TITLE
feat(core,schemas): scope one-time tokens by interaction event

### DIFF
--- a/packages/core/src/libraries/one-time-token.ts
+++ b/packages/core/src/libraries/one-time-token.ts
@@ -1,4 +1,4 @@
-import { OneTimeTokenStatus } from '@logto/schemas';
+import { OneTimeTokenStatus, type InteractionEvent } from '@logto/schemas';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -22,7 +22,11 @@ export const createOneTimeTokenLibrary = (queries: Queries) => {
     return updateOneTimeTokenStatusQuery(token, status);
   };
 
-  const checkOneTimeToken = async (token: string, email: string) => {
+  const checkOneTimeToken = async (
+    token: string,
+    email: string,
+    expectedInteractionEvent?: InteractionEvent
+  ) => {
     const oneTimeToken = await getOneTimeTokenByToken(token);
 
     assertThat(oneTimeToken.email === email, 'one_time_token.email_mismatch');
@@ -42,12 +46,22 @@ export const createOneTimeTokenLibrary = (queries: Queries) => {
       'one_time_token.token_consumed'
     );
     assertThat(oneTimeToken.status !== OneTimeTokenStatus.Revoked, 'one_time_token.token_revoked');
+    assertThat(
+      !expectedInteractionEvent ||
+        !oneTimeToken.context.interactionEvent ||
+        oneTimeToken.context.interactionEvent === expectedInteractionEvent,
+      'one_time_token.interaction_event_mismatch'
+    );
 
     return oneTimeToken;
   };
 
-  const verifyOneTimeToken = async (token: string, email: string) => {
-    await checkOneTimeToken(token, email);
+  const verifyOneTimeToken = async (
+    token: string,
+    email: string,
+    expectedInteractionEvent?: InteractionEvent
+  ) => {
+    await checkOneTimeToken(token, email, expectedInteractionEvent);
 
     return updateOneTimeTokenStatus(token, OneTimeTokenStatus.Consumed);
   };

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -1,5 +1,6 @@
 import {
   type InteractionIdentifier,
+  type InteractionEvent,
   type OneTimeTokenContext,
   type SignInIdentifier,
   type User,
@@ -75,11 +76,13 @@ export class OneTimeTokenVerification
 
   /**
    * Verifies if the one-time token matches the record in database with the provided email.
+   * When an interaction event is provided, rejects tokens scoped to a different interaction.
    */
-  async verify(token: string) {
+  async verify(token: string, interactionEvent?: InteractionEvent) {
     const tokenRecord = await this.libraries.oneTimeTokens.verifyOneTimeToken(
       token,
-      this.identifier.value
+      this.identifier.value,
+      interactionEvent
     );
     this.verified = true;
     this.context = tokenRecord.context;

--- a/packages/core/src/routes/experience/verification-routes/one-time-token.ts
+++ b/packages/core/src/routes/experience/verification-routes/one-time-token.ts
@@ -59,7 +59,7 @@ export default function oneTimeTokenVerificationRoutes<
             verificationId: oneTimeTokenVerificationRecord.id,
           },
         },
-        oneTimeTokenVerificationRecord.verify(token)
+        oneTimeTokenVerificationRecord.verify(token, experienceInteraction.interactionEvent)
       );
 
       // Skip CAPTCHA for one-time token flow

--- a/packages/core/src/routes/one-time-tokens.openapi.json
+++ b/packages/core/src/routes/one-time-tokens.openapi.json
@@ -45,7 +45,7 @@
                     "description": "The expiration time in seconds. If not provided, defaults to 10 mins (600 seconds)."
                   },
                   "context": {
-                    "description": "Additional context to store with the one-time token. This can be used to store arbitrary data that will be associated with the token."
+                    "description": "Additional context to store with the one-time token. Set `interactionEvent` to scope the token to a specific flow, such as `ForgotPassword` for reset-password magic links."
                   }
                 }
               }

--- a/packages/core/src/routes/one-time-tokens.ts
+++ b/packages/core/src/routes/one-time-tokens.ts
@@ -131,6 +131,7 @@ export default function oneTimeTokenRoutes<T extends ManagementApiRouter>(
     async (ctx, next) => {
       const { token, email } = ctx.guard.body;
 
+      // Management API is an admin-level raw token verifier and does not bind the token to an Experience interaction.
       ctx.body = await verifyOneTimeToken(token, email);
       ctx.status = 200;
       return next();

--- a/packages/integration-tests/src/tests/api/experience-api/profile/reset-password.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/profile/reset-password.test.ts
@@ -253,7 +253,12 @@ describe('Reset Password', () => {
 
     const newPassword = generatePassword();
     const client = new ExperienceClient();
-    const oneTimeToken = await createOneTimeToken({ email: primaryEmail });
+    const oneTimeToken = await createOneTimeToken({
+      email: primaryEmail,
+      context: {
+        interactionEvent: InteractionEvent.ForgotPassword,
+      },
+    });
 
     try {
       await startResetMagicLinkAuthorization(client, oneTimeToken.token, primaryEmail);
@@ -287,7 +292,12 @@ describe('Reset Password', () => {
 
     const newPassword = generatePassword();
     const client = new ExperienceClient();
-    const oneTimeToken = await createOneTimeToken({ email: primaryEmail });
+    const oneTimeToken = await createOneTimeToken({
+      email: primaryEmail,
+      context: {
+        interactionEvent: InteractionEvent.ForgotPassword,
+      },
+    });
 
     try {
       await startResetMagicLinkAuthorization(client, oneTimeToken.token);
@@ -328,6 +338,47 @@ describe('Reset Password', () => {
         {
           status: 400,
           code: 'one_time_token.email_mismatch',
+        }
+      );
+
+      await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
+        status: OneTimeTokenStatus.Active,
+      });
+
+      const interactionData = await client.getInteractionData();
+
+      expect(interactionData.interactionEvent).toBe(InteractionEvent.ForgotPassword);
+      expect(interactionData.userId).toBeUndefined();
+      await expectRejects(client.resetPassword({ password: generatePassword() }), {
+        status: 404,
+        code: 'session.identifier_not_found',
+      });
+    } finally {
+      await deleteOneTimeTokenById(oneTimeToken.id);
+    }
+  });
+
+  it('should not consume the one-time token or identify the user if the token scope mismatches', async () => {
+    const email = generateEmail();
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.ForgotPassword,
+    });
+    const oneTimeToken = await createOneTimeToken({
+      email,
+      context: {
+        interactionEvent: InteractionEvent.SignIn,
+      },
+    });
+
+    try {
+      await expectRejects(
+        client.verifyOneTimeToken({
+          token: oneTimeToken.token,
+          identifier: { type: SignInIdentifier.Email, value: email },
+        }),
+        {
+          status: 400,
+          code: 'one_time_token.interaction_event_mismatch',
         }
       );
 

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/one-time-token.test.ts
@@ -1,7 +1,11 @@
-import { InteractionEvent, SignInIdentifier, SignInMode } from '@logto/schemas';
+import { InteractionEvent, OneTimeTokenStatus, SignInIdentifier, SignInMode } from '@logto/schemas';
 
 import { deleteUser, updateSignInExperience } from '#src/api/index.js';
-import { createOneTimeToken } from '#src/api/one-time-token.js';
+import {
+  createOneTimeToken,
+  deleteOneTimeTokenById,
+  getOneTimeTokenById,
+} from '#src/api/one-time-token.js';
 import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
 import { setEmailConnector } from '#src/helpers/connector.js';
 import { expectRejects } from '#src/helpers/index.js';
@@ -69,6 +73,43 @@ describe('Register interaction with one-time token', () => {
     const userId = await processSession(client, redirectTo);
     await logoutClient(client);
     await deleteUser(userId);
+  });
+
+  it('should not consume a forgot-password scoped one-time token for registration', async () => {
+    const email = 'foo@logto.io';
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
+    await client.updateInteractionEvent({ interactionEvent: InteractionEvent.Register });
+
+    const oneTimeToken = await createOneTimeToken({
+      email,
+      context: {
+        interactionEvent: InteractionEvent.ForgotPassword,
+      },
+    });
+
+    try {
+      await expectRejects(
+        client.verifyOneTimeToken({
+          token: oneTimeToken.token,
+          identifier: {
+            type: SignInIdentifier.Email,
+            value: email,
+          },
+        }),
+        {
+          code: 'one_time_token.interaction_event_mismatch',
+          status: 400,
+        }
+      );
+
+      await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
+        status: OneTimeTokenStatus.Active,
+      });
+    } finally {
+      await deleteOneTimeTokenById(oneTimeToken.id);
+    }
   });
 
   it('should sign-in directly when email already exists (no need to switch after verify)', async () => {

--- a/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sign-in-interaction/one-time-token.test.ts
@@ -256,6 +256,38 @@ describe('Sign-in interaction with one-time token', () => {
     );
   });
 
+  it('should not consume a forgot-password scoped one-time token for sign-in', async () => {
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.SignIn,
+    });
+
+    const oneTimeToken = await createOneTimeToken({
+      email: userProfile.primaryEmail,
+      context: {
+        interactionEvent: InteractionEvent.ForgotPassword,
+      },
+    });
+
+    try {
+      await expectRejects(
+        client.verifyOneTimeToken({
+          token: oneTimeToken.token,
+          identifier: { type: SignInIdentifier.Email, value: userProfile.primaryEmail },
+        }),
+        {
+          code: 'one_time_token.interaction_event_mismatch',
+          status: 400,
+        }
+      );
+
+      await expect(getOneTimeTokenById(oneTimeToken.id)).resolves.toMatchObject({
+        status: OneTimeTokenStatus.Active,
+      });
+    } finally {
+      await deleteOneTimeTokenById(oneTimeToken.id);
+    }
+  });
+
   it('should fail to sign-in with an expired one-time token', async () => {
     const client = await initExperienceClient({
       interactionEvent: InteractionEvent.SignIn,

--- a/packages/integration-tests/src/tests/api/one-time-tokens.test.ts
+++ b/packages/integration-tests/src/tests/api/one-time-tokens.test.ts
@@ -1,4 +1,4 @@
-import { OneTimeTokenStatus } from '@logto/schemas';
+import { InteractionEvent, OneTimeTokenStatus } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 
 import { authedAdminApi } from '#src/api/api.js';
@@ -48,12 +48,13 @@ describe('one-time tokens API', () => {
     await deleteOneTimeTokenById(oneTimeToken.id);
   });
 
-  it('should create one-time token with `applicationIds` and `jitOrganizationIds` configured', async () => {
+  it('should create one-time token with context configured', async () => {
     const email = `foo${generateStandardId()}@bar.com`;
     const oneTimeToken = await createOneTimeToken({
       email,
       context: {
         jitOrganizationIds: ['org-1'],
+        interactionEvent: InteractionEvent.ForgotPassword,
       },
     });
 
@@ -61,6 +62,7 @@ describe('one-time tokens API', () => {
     expect(oneTimeToken.email).toBe(email);
     expect(oneTimeToken.context).toEqual({
       jitOrganizationIds: ['org-1'],
+      interactionEvent: InteractionEvent.ForgotPassword,
     });
     expect(oneTimeToken.token.length).toBe(32);
 

--- a/packages/phrases/src/locales/ar/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/ar/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'الرمز {{token}} غير موجود.',
   email_mismatch: 'البريد الإلكتروني لا يتطابق مع الرمز المقدم.',
+  interaction_event_mismatch: 'لا يمكن استخدام الرمز لهذا التفاعل.',
   token_expired: 'انتهت صلاحية الرمز.',
   token_consumed: 'تم استهلاك الرمز.',
   token_revoked: 'تم إلغاء الرمز.',

--- a/packages/phrases/src/locales/de/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/de/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Token {{token}} wurde nicht gefunden.',
   email_mismatch: 'E-Mail stimmt nicht mit dem angegebenen Token überein.',
+  interaction_event_mismatch: 'Das Token kann für diese Interaktion nicht verwendet werden.',
   token_expired: 'Das Token ist abgelaufen.',
   token_consumed: 'Das Token wurde verbraucht.',
   token_revoked: 'Das Token wurde widerrufen.',

--- a/packages/phrases/src/locales/en/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/en/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Token {{token}} not found.',
   email_mismatch: 'Email mismatch with given token.',
+  interaction_event_mismatch: 'The token cannot be used for this interaction.',
   token_expired: 'The token is expired.',
   token_consumed: 'The token has been consumed.',
   token_revoked: 'The token has been revoked.',

--- a/packages/phrases/src/locales/es/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/es/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Token {{token}} no encontrado.',
   email_mismatch: 'El correo electrónico no coincide con el token proporcionado.',
+  interaction_event_mismatch: 'El token no se puede usar para esta interacción.',
   token_expired: 'El token ha expirado.',
   token_consumed: 'El token ha sido consumido.',
   token_revoked: 'El token ha sido revocado.',

--- a/packages/phrases/src/locales/fa-ir/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/fa-ir/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'توکن {{token}} یافت نشد.',
   email_mismatch: 'ایمیل با توکن داده‌شده مطابقت ندارد.',
+  interaction_event_mismatch: 'نمی‌توان از این توکن برای این تعامل استفاده کرد.',
   token_expired: 'توکن منقضی شده است.',
   token_consumed: 'توکن مصرف شده است.',
   token_revoked: 'توکن لغو شده است.',

--- a/packages/phrases/src/locales/fr/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/fr/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Jeton {{token}} introuvable.',
   email_mismatch: "L'email ne correspond pas au jeton fourni.",
+  interaction_event_mismatch: 'Le jeton ne peut pas être utilisé pour cette interaction.',
   token_expired: 'Le jeton est expiré.',
   token_consumed: 'Le jeton a été consommé.',
   token_revoked: 'Le jeton a été révoqué.',

--- a/packages/phrases/src/locales/it/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/it/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Token {{token}} non trovato.',
   email_mismatch: 'Discrepanza tra email e token fornito.',
+  interaction_event_mismatch: 'Il token non può essere utilizzato per questa interazione.',
   token_expired: 'Il token è scaduto.',
   token_consumed: 'Il token è stato consumato.',
   token_revoked: 'Il token è stato revocato.',

--- a/packages/phrases/src/locales/ja/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/ja/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'トークン {{token}} が見つかりません。',
   email_mismatch: '指定されたトークンとメールが一致しません。',
+  interaction_event_mismatch: 'このトークンはこのインタラクションには使用できません。',
   token_expired: 'トークンの有効期限が切れています。',
   token_consumed: 'トークンが既に使用されています。',
   token_revoked: 'トークンが取り消されました。',

--- a/packages/phrases/src/locales/ko/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/ko/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: '토큰 {{token}} 을(를) 찾을 수 없습니다.',
   email_mismatch: '주어진 토큰과 이메일이 일치하지 않습니다.',
+  interaction_event_mismatch: '이 토큰은 이 상호작용에 사용할 수 없습니다.',
   token_expired: '토큰이 만료되었습니다.',
   token_consumed: '토큰이 이미 사용되었습니다.',
   token_revoked: '토큰이 취소되었습니다.',

--- a/packages/phrases/src/locales/pl-pl/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Token {{token}} nie znaleziony.',
   email_mismatch: 'Adres e-mail nie pasuje do podanego tokenu.',
+  interaction_event_mismatch: 'Tego tokenu nie można użyć w tej interakcji.',
   token_expired: 'Token wygasł.',
   token_consumed: 'Token został użyty.',
   token_revoked: 'Token został unieważniony.',

--- a/packages/phrases/src/locales/pt-br/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/pt-br/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Token {{token}} não encontrado.',
   email_mismatch: 'O e-mail não corresponde ao token fornecido.',
+  interaction_event_mismatch: 'O token não pode ser usado para esta interação.',
   token_expired: 'O token expirou.',
   token_consumed: 'O token já foi utilizado.',
   token_revoked: 'O token foi revogado.',

--- a/packages/phrases/src/locales/pt-pt/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Token {{token}} não encontrado.',
   email_mismatch: 'O e-mail não corresponde ao token fornecido.',
+  interaction_event_mismatch: 'O token não pode ser usado para esta interação.',
   token_expired: 'O token expirou.',
   token_consumed: 'O token já foi utilizado.',
   token_revoked: 'O token foi revogado.',

--- a/packages/phrases/src/locales/ru/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/ru/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Токен {{token}} не найден.',
   email_mismatch: 'Электронная почта не соответствует указанному токену.',
+  interaction_event_mismatch: 'Токен нельзя использовать для этого взаимодействия.',
   token_expired: 'Токен истек.',
   token_consumed: 'Токен был использован.',
   token_revoked: 'Токен был отозван.',

--- a/packages/phrases/src/locales/th/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/th/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'ไม่พบโทเคน {{token}}',
   email_mismatch: 'อีเมลไม่ตรงกับโทเคนที่ให้มา',
+  interaction_event_mismatch: 'ไม่สามารถใช้โทเคนนี้กับการโต้ตอบนี้ได้',
   token_expired: 'โทเคนนี้หมดอายุแล้ว',
   token_consumed: 'โทเคนนี้ถูกใช้ไปแล้ว',
   token_revoked: 'โทเคนนี้ถูกเพิกถอนแล้ว',

--- a/packages/phrases/src/locales/tr-tr/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: 'Token {{token}} bulunamadı.',
   email_mismatch: 'E-posta, sağlanan token ile eşleşmiyor.',
+  interaction_event_mismatch: 'Token bu etkileşim için kullanılamaz.',
   token_expired: "Token'ın süresi doldu.",
   token_consumed: 'Token zaten kullanılmış.',
   token_revoked: 'Token iptal edilmiş.',

--- a/packages/phrases/src/locales/zh-cn/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: '令牌 {{token}} 未找到。',
   email_mismatch: '电子邮件与给定令牌不匹配。',
+  interaction_event_mismatch: '该令牌不能用于此次交互。',
   token_expired: '令牌已过期。',
   token_consumed: '令牌已被使用。',
   token_revoked: '令牌已被撤销。',

--- a/packages/phrases/src/locales/zh-hk/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: '找不到令牌 {{token}}。',
   email_mismatch: '電郵與指定令牌不匹配。',
+  interaction_event_mismatch: '此令牌不能用於此互動。',
   token_expired: '令牌已過期。',
   token_consumed: '令牌已被使用。',
   token_revoked: '令牌已被撤銷。',

--- a/packages/phrases/src/locales/zh-tw/errors/one-time-token.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/one-time-token.ts
@@ -1,6 +1,7 @@
 const one_time_token = {
   token_not_found: '找不到令牌 {{token}}。',
   email_mismatch: '電子郵件與提供的令牌不匹配。',
+  interaction_event_mismatch: '此令牌不能用於此互動。',
   token_expired: '令牌已過期。',
   token_consumed: '令牌已被使用。',
   token_revoked: '令牌已被撤銷。',

--- a/packages/schemas/src/foundations/jsonb-types/one-time-tokens.ts
+++ b/packages/schemas/src/foundations/jsonb-types/one-time-tokens.ts
@@ -1,14 +1,19 @@
 import { type ToZodObject } from '@logto/connector-kit';
 import { z } from 'zod';
 
+import { eventGuard, type InteractionEvent } from '../../types/interaction-event.js';
+
 export type OneTimeTokenContext = {
   // Used for organization JIT provisioning.
   jitOrganizationIds?: string[];
+  // Restricts this one-time token to a specific interaction event.
+  interactionEvent?: InteractionEvent;
 };
 
 export const oneTimeTokenContextGuard = z
   .object({
     jitOrganizationIds: z.string().array(),
+    interactionEvent: eventGuard,
   })
   .partial() satisfies ToZodObject<OneTimeTokenContext>;
 

--- a/packages/schemas/src/types/interaction-event.ts
+++ b/packages/schemas/src/types/interaction-event.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+/**
+ * User interaction events defined in Logto RFC 0004.
+ * @see {@link https://github.com/logto-io/rfcs | Logto RFCs} for more information.
+ */
+export enum InteractionEvent {
+  SignIn = 'SignIn',
+  Register = 'Register',
+  ForgotPassword = 'ForgotPassword',
+}
+
+export const eventGuard = z.nativeEnum(InteractionEvent);

--- a/packages/schemas/src/types/interactions.ts
+++ b/packages/schemas/src/types/interactions.ts
@@ -11,6 +11,7 @@ import {
 } from '../foundations/index.js';
 import { type ToZodObject } from '../utils/zod.js';
 
+import { InteractionEvent } from './interaction-event.js';
 import type {
   EmailVerificationCodePayload,
   PhoneVerificationCodePayload,
@@ -20,15 +21,7 @@ import {
   phoneVerificationCodePayloadGuard,
 } from './verification-code.js';
 
-/**
- * User interaction events defined in Logto RFC 0004.
- * @see {@link https://github.com/logto-io/rfcs | Logto RFCs} for more information.
- */
-export enum InteractionEvent {
-  SignIn = 'SignIn',
-  Register = 'Register',
-  ForgotPassword = 'ForgotPassword',
-}
+export { eventGuard, InteractionEvent } from './interaction-event.js';
 
 export type VerificationIdentifier = {
   type: SignInIdentifier | AdditionalIdentifier;
@@ -270,8 +263,6 @@ export const socialPhonePayloadGuard = z.object({
 });
 
 export type SocialPhonePayload = z.infer<typeof socialPhonePayloadGuard>;
-
-export const eventGuard = z.nativeEnum(InteractionEvent);
 
 export const identifierPayloadGuard = z.union([
   usernamePasswordPayloadGuard,


### PR DESCRIPTION
## Summary
Add an optional `context.interactionEvent` scope to one-time tokens and enforce it during Experience one-time-token verification before consuming the token. This keeps existing unscoped tokens backward compatible while preventing reset-password-scoped tokens from being reused by generic sign-in/register flows.

Also update reset magic link coverage to create scoped tokens, add mismatch regression coverage, and document the scoped context in the Management API OpenAPI supplement.

## Testing
Integration tests

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments