### PR TITLE
fix(experience): clean one-time token URL params

### DIFF
--- a/packages/experience/src/hooks/use-consume-one-time-token-parameters.ts
+++ b/packages/experience/src/hooks/use-consume-one-time-token-parameters.ts
@@ -1,0 +1,28 @@
+import { ExtraParamsKey } from '@logto/schemas';
+import { useLayoutEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import useLoginHint from '@/hooks/use-login-hint';
+import { removeSearchParameters } from '@/shared/utils/search-parameters';
+
+const oneTimeTokenSearchParameterKeys = Object.freeze([
+  ExtraParamsKey.OneTimeToken,
+  ExtraParamsKey.LoginHint,
+] as const);
+
+const useConsumeOneTimeTokenParameters = () => {
+  const [params] = useSearchParams();
+  const oneTimeToken = params.get(ExtraParamsKey.OneTimeToken);
+  const loginHint = useLoginHint();
+
+  useLayoutEffect(() => {
+    removeSearchParameters(oneTimeTokenSearchParameterKeys);
+  }, [params]);
+
+  return {
+    oneTimeToken,
+    loginHint,
+  };
+};
+
+export default useConsumeOneTimeTokenParameters;

--- a/packages/experience/src/pages/OneTimeToken/index.test.tsx
+++ b/packages/experience/src/pages/OneTimeToken/index.test.tsx
@@ -1,10 +1,10 @@
 import { experience, SignInIdentifier } from '@logto/schemas';
-import { waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { HTTPError } from 'ky';
-import { Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
+import PageContextProvider from '@/Providers/PageContextProvider';
 import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
-import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import {
   identifyAndSubmitInteraction,
@@ -58,34 +58,46 @@ const createRequestError = (code: string) => {
 };
 
 describe('OneTimeToken', () => {
-  const renderPage = (initialEntry: string) =>
-    renderWithPageContext(
-      <SettingsProvider>
-        <UserInteractionContextProvider>
-          <Routes>
-            <Route path={`/${experience.routes.oneTimeToken}`} element={<OneTimeToken />} />
-            <Route
-              path={`/${experience.routes.oneTimeToken}/error`}
-              element={<OneTimeTokenError />}
-            />
-          </Routes>
-        </UserInteractionContextProvider>
-      </SettingsProvider>,
-      { initialEntries: [initialEntry] }
+  const renderPage = (initialEntry: string) => {
+    window.history.pushState(window.history.state, '', initialEntry);
+
+    return render(
+      <BrowserRouter>
+        <PageContextProvider>
+          <SettingsProvider>
+            <UserInteractionContextProvider>
+              <Routes>
+                <Route path={`/${experience.routes.oneTimeToken}`} element={<OneTimeToken />} />
+                <Route
+                  path={`/${experience.routes.oneTimeToken}/error`}
+                  element={<OneTimeTokenError />}
+                />
+              </Routes>
+            </UserInteractionContextProvider>
+          </SettingsProvider>
+        </PageContextProvider>
+      </BrowserRouter>
     );
+  };
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.restoreAllMocks();
+    window.history.replaceState(window.history.state, '', '/');
   });
 
   it('submits an existing one-time token with the sign-in interaction', async () => {
-    renderPage('/one-time-token?one_time_token=token&login_hint=foo%40logto.io');
+    const initialEntry = '/one-time-token?one_time_token=token&login_hint=foo%40logto.io&foo=bar';
+
+    renderPage(initialEntry);
 
     await waitFor(() => {
       expect(mockedSignInWithOneTimeToken).toBeCalledWith({
         token: 'token',
         identifier: { type: SignInIdentifier.Email, value: 'foo@logto.io' },
       });
+      expect(window.location.href).not.toContain('one_time_token');
+      expect(window.location.href).not.toContain('login_hint');
       expect(mockedIdentifyAndSubmitInteraction).toBeCalledWith({
         verificationId: 'verification-id',
       });

--- a/packages/experience/src/pages/OneTimeToken/index.tsx
+++ b/packages/experience/src/pages/OneTimeToken/index.tsx
@@ -1,7 +1,6 @@
 import {
   AgreeToTermsPolicy,
   experience,
-  ExtraParamsKey,
   InteractionEvent,
   SignInIdentifier,
   type RequestErrorBody,
@@ -16,6 +15,7 @@ import {
   signInWithOneTimeToken,
 } from '@/apis/experience';
 import useApi from '@/hooks/use-api';
+import useConsumeOneTimeTokenParameters from '@/hooks/use-consume-one-time-token-parameters';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
@@ -25,6 +25,7 @@ import LoadingLayer from '@/shared/components/LoadingLayer';
 
 const OneTimeToken = () => {
   const [params] = useSearchParams();
+  const { oneTimeToken, loginHint } = useConsumeOneTimeTokenParameters();
   const navigate = useNavigateWithPreservedSearchParams();
   const [isLoading, setIsLoading] = useState(false);
   const hasTermsAgreed = useRef(false);
@@ -120,8 +121,6 @@ const OneTimeToken = () => {
   // Single effect: validate params, run terms gating once, then proceed to submission with idempotency
   useEffect(() => {
     (async () => {
-      const token = params.get(ExtraParamsKey.OneTimeToken);
-      const email = params.get(ExtraParamsKey.LoginHint);
       const errorMessage = params.get('errorMessage');
 
       if (errorMessage) {
@@ -132,7 +131,7 @@ const OneTimeToken = () => {
         return;
       }
 
-      if (!token || !email) {
+      if (!oneTimeToken || !loginHint) {
         navigate(`/${experience.routes.oneTimeToken}/error`, { replace: true });
         return;
       }
@@ -166,8 +165,8 @@ const OneTimeToken = () => {
 
       setIsLoading(true);
       const [error, result] = await asyncSignInWithOneTimeToken({
-        token,
-        identifier: { type: SignInIdentifier.Email, value: email },
+        token: oneTimeToken,
+        identifier: { type: SignInIdentifier.Email, value: loginHint },
       });
 
       if (error) {
@@ -190,7 +189,7 @@ const OneTimeToken = () => {
 
       // Set email identifier to the <HiddenIdentifierInput />, so that when being asked for fulfilling
       // the password later, the browser password manager can pick up both the email and the password.
-      setIdentifierInputValue({ type: SignInIdentifier.Email, value: email });
+      setIdentifierInputValue({ type: SignInIdentifier.Email, value: loginHint });
 
       await submit(result.verificationId);
       setIsLoading(false);
@@ -200,7 +199,9 @@ const OneTimeToken = () => {
     params,
     asyncSignInWithOneTimeToken,
     handleError,
+    loginHint,
     navigate,
+    oneTimeToken,
     setIdentifierInputValue,
     submit,
     termsValidation,

--- a/packages/experience/src/pages/ResetPasswordLanding/index.test.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/index.test.tsx
@@ -1,10 +1,10 @@
 import { SignInIdentifier } from '@logto/schemas';
 import { assert } from '@silverhand/essentials';
-import { fireEvent, waitFor } from '@testing-library/react';
-import { Route, Routes } from 'react-router-dom';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
+import PageContextProvider from '@/Providers/PageContextProvider';
 import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
-import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { mockSignInExperienceSettings } from '@/__mocks__/logto';
 import { identifyForgotPasswordWithOneTimeToken } from '@/apis/experience';
@@ -37,37 +37,44 @@ describe('ResetPasswordLanding', () => {
   const renderPage = (
     initialEntry: string,
     forgotPassword?: SignInExperienceResponse['forgotPassword']
-  ) =>
-    renderWithPageContext(
-      <SettingsProvider
-        settings={{
-          ...mockSignInExperienceSettings,
-          forgotPassword: {
-            ...mockSignInExperienceSettings.forgotPassword,
-            ...forgotPassword,
-          },
-        }}
-      >
-        <UserInteractionContextProvider>
-          <Routes>
-            <Route path="/reset-password" element={<ResetPasswordLanding />} />
-            <Route path="/forgot-password/reset" element={<div>set password page</div>} />
-            <Route path="/sign-in" element={<div>sign in page</div>} />
-          </Routes>
-        </UserInteractionContextProvider>
-      </SettingsProvider>,
-      { initialEntries: [initialEntry] }
+  ) => {
+    window.history.pushState(window.history.state, '', initialEntry);
+
+    return render(
+      <BrowserRouter>
+        <PageContextProvider>
+          <SettingsProvider
+            settings={{
+              ...mockSignInExperienceSettings,
+              forgotPassword: {
+                ...mockSignInExperienceSettings.forgotPassword,
+                ...forgotPassword,
+              },
+            }}
+          >
+            <UserInteractionContextProvider>
+              <Routes>
+                <Route path="/reset-password" element={<ResetPasswordLanding />} />
+                <Route path="/forgot-password/reset" element={<div>set password page</div>} />
+                <Route path="/sign-in" element={<div>sign in page</div>} />
+              </Routes>
+            </UserInteractionContextProvider>
+          </SettingsProvider>
+        </PageContextProvider>
+      </BrowserRouter>
     );
+  };
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.restoreAllMocks();
+    window.history.replaceState(window.history.state, '', '/');
   });
 
   it('auto verifies one-time token when login_hint is provided', async () => {
-    const { queryByText } = renderPage(
-      '/reset-password?one_time_token=token&login_hint=foo%40logto.io',
-      { email: false, phone: false }
-    );
+    const initialEntry = '/reset-password?one_time_token=token&login_hint=foo%40logto.io&foo=bar';
+
+    const { queryByText } = renderPage(initialEntry, { email: false, phone: false });
 
     expect(queryByText(mockResetPasswordMagicLinkDescription)).not.toBeNull();
 
@@ -137,6 +144,18 @@ describe('ResetPasswordLanding', () => {
         identifier: { type: SignInIdentifier.Email, value: 'foo@logto.io' },
       });
       expect(queryByText('set password page')).not.toBeNull();
+    });
+  });
+
+  it('removes login_hint even when one-time token is missing', async () => {
+    renderPage('/reset-password?login_hint=foo%40logto.io&foo=bar', {
+      email: true,
+      phone: false,
+    });
+
+    await waitFor(() => {
+      expect(window.location.pathname).toBe('/reset-password');
+      expect(window.location.search).toBe('?foo=bar');
     });
   });
 

--- a/packages/experience/src/pages/ResetPasswordLanding/index.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/index.tsx
@@ -1,9 +1,10 @@
-import { experience, ExtraParamsKey } from '@logto/schemas';
+import { experience } from '@logto/schemas';
 import { useTranslation } from 'react-i18next';
-import { Navigate, useSearchParams } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 
 import FocusedAuthPageLayout from '@/Layout/FocusedAuthPageLayout';
 import { isDevFeaturesEnabled } from '@/constants/env';
+import useConsumeOneTimeTokenParameters from '@/hooks/use-consume-one-time-token-parameters';
 import usePrefilledIdentifier from '@/hooks/use-prefilled-identifier';
 import { identifierInputDescriptionMap } from '@/utils/form';
 
@@ -34,9 +35,7 @@ import { useResetPasswordMethods } from './use-reset-password-methods';
  */
 const ResetPasswordLanding = () => {
   const { t } = useTranslation();
-  const [params] = useSearchParams();
-  const oneTimeToken = params.get(ExtraParamsKey.OneTimeToken);
-  const loginHint = params.get(ExtraParamsKey.LoginHint) ?? undefined;
+  const { oneTimeToken, loginHint } = useConsumeOneTimeTokenParameters();
   const enabledMethods = useResetPasswordMethods();
   const { value: prefilledValue } = usePrefilledIdentifier({
     enabledIdentifiers: enabledMethods,

--- a/packages/experience/src/shared/utils/search-parameters.test.ts
+++ b/packages/experience/src/shared/utils/search-parameters.test.ts
@@ -1,0 +1,21 @@
+import { removeSearchParameters } from './search-parameters';
+
+describe('search parameters utils', () => {
+  afterEach(() => {
+    window.history.replaceState(window.history.state, '', '/');
+  });
+
+  it('removes selected search parameters and preserves the rest', () => {
+    window.history.pushState(
+      window.history.state,
+      '',
+      '/reset-password?one_time_token=token&login_hint=foo%40logto.io&foo=bar#section'
+    );
+
+    removeSearchParameters(['one_time_token', 'login_hint']);
+
+    expect(window.location.pathname).toBe('/reset-password');
+    expect(window.location.search).toBe('?foo=bar');
+    expect(window.location.hash).toBe('#section');
+  });
+});

--- a/packages/experience/src/shared/utils/search-parameters.ts
+++ b/packages/experience/src/shared/utils/search-parameters.ts
@@ -20,6 +20,19 @@ export const searchKeys = Object.freeze({
   uiLocales: 'ui_locales',
 } satisfies Record<SearchKeysCamelCase, string>);
 
+const replaceSearchParameters = (parameters: URLSearchParams) => {
+  const parameterString = parameters.toString();
+  const conditionalParamString = condString(parameterString && `?${parameterString}`);
+
+  // Preserve the existing history state (e.g. React Router's location state) to avoid
+  // losing in-progress flow data (like Continue page's interactionEvent) on page refresh.
+  window.history.replaceState(
+    window.history.state,
+    '',
+    window.location.pathname + conditionalParamString + window.location.hash
+  );
+};
+
 export const handleSearchParametersData = () => {
   const { search } = window.location;
 
@@ -44,13 +57,26 @@ export const handleSearchParametersData = () => {
     }
   }
 
-  const conditionalParamString = condString(parameters.size > 0 && `?${parameters.toString()}`);
+  replaceSearchParameters(parameters);
+};
 
-  // Preserve the existing history state (e.g. React Router's location state) to avoid
-  // losing in-progress flow data (like Continue page's interactionEvent) on page refresh.
-  window.history.replaceState(
-    window.history.state,
-    '',
-    window.location.pathname + conditionalParamString
-  );
+export const removeSearchParameters = (keys: readonly string[]) => {
+  const { search } = window.location;
+
+  if (!search) {
+    return;
+  }
+
+  const parameters = new URLSearchParams(search);
+  const hasTargetParameter = keys.some((key) => parameters.has(key));
+
+  if (!hasTargetParameter) {
+    return;
+  }
+
+  for (const key of keys) {
+    parameters.delete(key);
+  }
+
+  replaceSearchParameters(parameters);
 };


### PR DESCRIPTION
## Summary
Remove one-time-token credentials from the browser URL after Experience pages read them. This covers both the shared one-time-token landing page and reset-password magic-link landing page, while preserving unrelated search parameters through the shared search-parameter helper.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments