### PR TITLE
fix(experience): improve reset magic link loading flow

### DIFF
--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.test.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.test.ts
@@ -1,0 +1,35 @@
+import { SignInIdentifier, VerificationType } from '@logto/schemas';
+
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+import { OneTimeTokenVerification } from './one-time-token-verification.js';
+
+const { jest } = import.meta;
+
+describe('OneTimeTokenVerification', () => {
+  it('interpolates the identifier for unknown users', async () => {
+    const email = 'foo@example.com';
+    const findUserByEmail = jest.fn().mockResolvedValue(null);
+    const tenant = new MockTenant(undefined, {
+      users: {
+        findUserByEmail,
+      },
+    });
+    const verification = new OneTimeTokenVerification(tenant.libraries, tenant.queries, {
+      id: 'mock_one_time_token_verification_id',
+      type: VerificationType.OneTimeToken,
+      identifier: {
+        type: SignInIdentifier.Email,
+        value: email,
+      },
+      verified: true,
+    });
+
+    await expect(verification.identifyUser()).rejects.toMatchObject({
+      code: 'user.user_not_exist',
+      message: `User with ${email} does not exist.`,
+      status: 404,
+    });
+    expect(findUserByEmail).toHaveBeenCalledWith(email);
+  });
+});

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -99,8 +99,14 @@ export class OneTimeTokenVerification
     assertThat(
       user,
       new RequestError(
-        { code: 'user.user_not_exist', status: 404 },
-        { identifier: this.identifier }
+        {
+          code: 'user.user_not_exist',
+          status: 404,
+          identifier: this.identifier.value,
+        },
+        {
+          identifier: this.identifier.value,
+        }
       )
     );
 

--- a/packages/experience/src/pages/ResetPasswordLanding/OneTimeTokenForm.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/OneTimeTokenForm.tsx
@@ -1,5 +1,10 @@
-import { SignInIdentifier, type OneTimeTokenVerificationVerifyPayload } from '@logto/schemas';
+import {
+  SignInIdentifier,
+  type OneTimeTokenVerificationVerifyPayload,
+  type RequestErrorBody,
+} from '@logto/schemas';
 import classNames from 'classnames';
+import { HTTPError, TimeoutError } from 'ky';
 import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -8,19 +13,21 @@ import UserInteractionContext from '@/Providers/UserInteractionContextProvider/U
 import { identifyForgotPasswordWithOneTimeToken } from '@/apis/experience';
 import { SmartInputField } from '@/components/InputFields';
 import useApi from '@/hooks/use-api';
-import useErrorHandler from '@/hooks/use-error-handler';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import Button from '@/shared/components/Button';
-import ErrorMessage from '@/shared/components/ErrorMessage';
+import LoadingLayer from '@/shared/components/LoadingLayer';
 import { UserFlow } from '@/types';
 import { getGeneralIdentifierErrorMessage, validateIdentifierField } from '@/utils/form';
 
 import styles from '../ForgotPassword/ForgotPasswordForm/index.module.scss';
 
+import type { ResetPasswordMagicLinkError } from './types';
+
 type Props = {
   readonly className?: string;
   readonly token: string;
   readonly loginHint?: string;
+  readonly onError: (error: ResetPasswordMagicLinkError) => void;
 };
 
 type FormState = {
@@ -32,13 +39,11 @@ type FormState = {
 
 const emailIdentifier = [SignInIdentifier.Email];
 
-const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
+const OneTimeTokenForm = ({ className, token, loginHint = '', onError }: Props) => {
   const { t } = useTranslation();
-  const [errorMessage, setErrorMessage] = useState<string>();
   const [isAutoSubmitting, setIsAutoSubmitting] = useState(false);
   const isAutoSubmitted = useRef(false);
   const navigate = useNavigateWithPreservedSearchParams();
-  const handleError = useErrorHandler();
   const asyncIdentifyForgotPasswordWithOneTimeToken = useApi(
     identifyForgotPasswordWithOneTimeToken
   );
@@ -47,7 +52,7 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
   const {
     handleSubmit,
     control,
-    formState: { errors, isValid, isSubmitting },
+    formState: { errors, isSubmitting },
   } = useForm<FormState>({
     reValidateMode: 'onBlur',
     defaultValues: {
@@ -57,27 +62,29 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
     },
   });
 
-  useEffect(() => {
-    if (!isValid) {
-      setErrorMessage(undefined);
-    }
-  }, [isValid]);
-
   const submit = useCallback(
     async (payload: OneTimeTokenVerificationVerifyPayload) => {
-      setErrorMessage(undefined);
-
       const [error] = await asyncIdentifyForgotPasswordWithOneTimeToken(payload);
 
       if (error) {
-        await handleError(error, {
-          'guard.invalid_input': () => {
-            setErrorMessage(t('error.invalid_email'));
-          },
-          global: (error) => {
-            setErrorMessage(error.message);
-          },
-        });
+        if (error instanceof HTTPError) {
+          try {
+            const { code, message } = await error.response.json<RequestErrorBody>();
+
+            onError(
+              code === 'guard.invalid_input'
+                ? { message: 'error.invalid_email' }
+                : { rawMessage: message }
+            );
+          } catch {
+            onError({ message: 'error.unknown' });
+          }
+        } else if (error instanceof TimeoutError) {
+          onError({ message: 'error.timeout' });
+        } else {
+          onError({ message: 'error.unknown' });
+        }
+
         return;
       }
 
@@ -87,10 +94,9 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
     },
     [
       asyncIdentifyForgotPasswordWithOneTimeToken,
-      handleError,
       navigate,
+      onError,
       setForgotPasswordIdentifierInputValue,
-      t,
     ]
   );
 
@@ -100,10 +106,6 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
     }
 
     if (loginHint.length === 0) {
-      return;
-    }
-
-    if (validateIdentifierField(SignInIdentifier.Email, loginHint)) {
       return;
     }
 
@@ -144,6 +146,10 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
 
   const isVerificationPending = isSubmitting || isAutoSubmitting;
 
+  if (loginHint) {
+    return <LoadingLayer />;
+  }
+
   return (
     <form className={classNames(styles.form, className)} onSubmit={onSubmitHandler}>
       <Controller
@@ -181,8 +187,6 @@ const OneTimeTokenForm = ({ className, token, loginHint = '' }: Props) => {
           />
         )}
       />
-
-      {errorMessage && <ErrorMessage className={styles.formErrors}>{errorMessage}</ErrorMessage>}
 
       <Button title="action.continue" htmlType="submit" isLoading={isVerificationPending} />
 

--- a/packages/experience/src/pages/ResetPasswordLanding/index.test.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/index.test.tsx
@@ -1,6 +1,7 @@
 import { SignInIdentifier } from '@logto/schemas';
 import { assert } from '@silverhand/essentials';
 import { fireEvent, render, waitFor } from '@testing-library/react';
+import { HTTPError } from 'ky';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import PageContextProvider from '@/Providers/PageContextProvider';
@@ -32,6 +33,16 @@ jest.mock('react-i18next', () => ({
 jest.mock('@/apis/experience', () => ({
   identifyForgotPasswordWithOneTimeToken: jest.fn().mockResolvedValue({ verificationId: '123' }),
 }));
+
+const createRequestError = (code: string, message = code) => {
+  const response = {
+    status: 400,
+    statusText: 'Bad Request',
+    json: async () => ({ code, message }),
+  } as unknown as Response;
+
+  return new HTTPError(response, {} as Request, {} as never);
+};
 
 describe('ResetPasswordLanding', () => {
   const renderPage = (
@@ -87,7 +98,7 @@ describe('ResetPasswordLanding', () => {
     });
   });
 
-  it('keeps the form disabled while auto verifying one-time token', async () => {
+  it('shows loading instead of the email form while auto verifying one-time token', async () => {
     mockedIdentifyForgotPasswordWithOneTimeToken.mockImplementationOnce(async () => {
       await new Promise((resolve) => {
         setTimeout(resolve, 100);
@@ -108,19 +119,49 @@ describe('ResetPasswordLanding', () => {
     const identifierInput = container.querySelector<HTMLInputElement>('input[name="identifier"]');
     const submitButton = container.querySelector<HTMLButtonElement>('button[type="submit"]');
 
-    assert(identifierInput, new Error('identifier input should not be null'));
-    assert(submitButton, new Error('submit button should not be null'));
-
-    expect(identifierInput.disabled).toBe(true);
-    expect(submitButton.disabled).toBe(true);
-
-    fireEvent.click(submitButton);
-
+    expect(identifierInput).toBeNull();
+    expect(submitButton).toBeNull();
     expect(mockedIdentifyForgotPasswordWithOneTimeToken).toBeCalledTimes(1);
 
     await waitFor(() => {
       expect(queryByText('set password page')).not.toBeNull();
     });
+  });
+
+  it('shows the reset-password error page when magic-link verification fails', async () => {
+    mockedIdentifyForgotPasswordWithOneTimeToken.mockRejectedValueOnce(
+      createRequestError('session.verification_failed', 'Verification failed')
+    );
+
+    const { container, queryByText } = renderPage(
+      '/reset-password?one_time_token=token&login_hint=foo%40logto.io',
+      { email: false, phone: false }
+    );
+
+    await waitFor(() => {
+      expect(mockedIdentifyForgotPasswordWithOneTimeToken).toBeCalledTimes(1);
+      expect(window.location.pathname).toBe('/reset-password');
+      expect(queryByText('Verification failed')).not.toBeNull();
+    });
+
+    expect(container.querySelector<HTMLInputElement>('input[name="identifier"]')).toBeNull();
+  });
+
+  it('shows the reset-password error page when magic-link verification fails with a non-HTTP error', async () => {
+    mockedIdentifyForgotPasswordWithOneTimeToken.mockRejectedValueOnce(new Error('Network down'));
+
+    const { container, queryByText } = renderPage(
+      '/reset-password?one_time_token=token&login_hint=foo%40logto.io',
+      { email: false, phone: false }
+    );
+
+    await waitFor(() => {
+      expect(mockedIdentifyForgotPasswordWithOneTimeToken).toBeCalledTimes(1);
+      expect(window.location.pathname).toBe('/reset-password');
+      expect(queryByText('error.unknown')).not.toBeNull();
+    });
+
+    expect(container.querySelector<HTMLInputElement>('input[name="identifier"]')).toBeNull();
   });
 
   it('asks for email before verifying one-time token when login_hint is missing', async () => {

--- a/packages/experience/src/pages/ResetPasswordLanding/index.tsx
+++ b/packages/experience/src/pages/ResetPasswordLanding/index.tsx
@@ -1,4 +1,5 @@
 import { experience } from '@logto/schemas';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router-dom';
 
@@ -6,11 +7,13 @@ import FocusedAuthPageLayout from '@/Layout/FocusedAuthPageLayout';
 import { isDevFeaturesEnabled } from '@/constants/env';
 import useConsumeOneTimeTokenParameters from '@/hooks/use-consume-one-time-token-parameters';
 import usePrefilledIdentifier from '@/hooks/use-prefilled-identifier';
+import ErrorPage from '@/pages/ErrorPage';
 import { identifierInputDescriptionMap } from '@/utils/form';
 
 import ForgotPasswordForm from '../ForgotPassword/ForgotPasswordForm';
 
 import OneTimeTokenForm from './OneTimeTokenForm';
+import type { ResetPasswordMagicLinkError } from './types';
 import { useResetPasswordMethods } from './use-reset-password-methods';
 
 /**
@@ -36,11 +39,23 @@ import { useResetPasswordMethods } from './use-reset-password-methods';
 const ResetPasswordLanding = () => {
   const { t } = useTranslation();
   const { oneTimeToken, loginHint } = useConsumeOneTimeTokenParameters();
+  const [magicLinkError, setMagicLinkError] = useState<ResetPasswordMagicLinkError>();
   const enabledMethods = useResetPasswordMethods();
   const { value: prefilledValue } = usePrefilledIdentifier({
     enabledIdentifiers: enabledMethods,
     isForgotPassword: true,
   });
+
+  if (magicLinkError) {
+    return (
+      <ErrorPage
+        isNavbarHidden
+        title="error.invalid_link"
+        message={magicLinkError.message ?? 'error.invalid_link_description'}
+        rawMessage={magicLinkError.rawMessage}
+      />
+    );
+  }
 
   if (isDevFeaturesEnabled && oneTimeToken) {
     return (
@@ -55,7 +70,7 @@ const ResetPasswordLanding = () => {
           text: 'description.back_to_sign_in',
         }}
       >
-        <OneTimeTokenForm token={oneTimeToken} loginHint={loginHint} />
+        <OneTimeTokenForm token={oneTimeToken} loginHint={loginHint} onError={setMagicLinkError} />
       </FocusedAuthPageLayout>
     );
   }

--- a/packages/experience/src/pages/ResetPasswordLanding/types.ts
+++ b/packages/experience/src/pages/ResetPasswordLanding/types.ts
@@ -1,0 +1,6 @@
+import type { TFuncKey } from 'i18next';
+
+export type ResetPasswordMagicLinkError = {
+  readonly message?: TFuncKey;
+  readonly rawMessage?: string;
+};


### PR DESCRIPTION
## Summary
Show a loading state instead of the email input form when a reset magic link already provides `login_hint`. For reset magic-link verification failures, whether the email came from `login_hint` or was entered manually, render the reset-password `ErrorPage` in the current route instead of showing API errors below the email field.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments