### PR TITLE
feat(schemas): add service_logs created_at index

### DIFF
--- a/packages/schemas/alterations/next-1784619793-add-service-logs-created-at-index.ts
+++ b/packages/schemas/alterations/next-1784619793-add-service-logs-created-at-index.ts
@@ -1,0 +1,33 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    // Support the age-based `service_logs` retention prune's global oldest-first scan
+    // (`where created_at < ? order by created_at asc limit ?`). The existing
+    // `(tenant_id, type, created_at)` index leads with `tenant_id`, so it can't drive a
+    // tenant-agnostic time-range scan. `concurrently` keeps the write path unlocked — this
+    // unbounded table is written on every send.
+    //
+    // No `if not exists`: fail loud if the index already exists (e.g. a leftover invalid build from a
+    // prior failed concurrent creation) instead of silently skipping.
+    await pool.query(sql`
+      create index concurrently service_logs__created_at
+        on service_logs (created_at);
+    `);
+  },
+  up: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently if exists service_logs__created_at;
+    `);
+  },
+  down: async () => {
+    /** `concurrently` cannot be used inside a transaction. */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/service_logs.sql
+++ b/packages/schemas/tables/service_logs.sql
@@ -13,4 +13,9 @@ create index service_logs__id
 create index service_logs__tenant_id__type__created_at
   on service_logs (tenant_id, type, created_at);
 
+/* Global oldest-first scan for the age-based retention prune (the composite index above leads with
+   `tenant_id`, so it can't drive a tenant-agnostic `created_at` range scan). */
+create index service_logs__created_at
+  on service_logs (created_at);
+
 /* no_after_each */


### PR DESCRIPTION
## Summary

Adds a `service_logs (created_at)` index — the schema prerequisite for the age-based `service_logs` retention prune (`Refs LOG-13740`). Split out from the prune job (Azure Functions, cloud repo), which follows.

The prune scans `service_logs` globally, oldest-first (`where created_at < ? order by created_at asc limit ?`). The existing `(tenant_id, type, created_at)` index leads with `tenant_id`, so it can't drive a tenant-agnostic time-range scan; a plain `created_at` index turns each batch into a cheap index range scan.

### What changed
- New alteration `next-1783585154-add-service-logs-created-at-index.ts` — `create index concurrently service_logs__created_at on service_logs (created_at)` (`concurrently` keeps the write path unlocked; the table is written on every hosted-email send). `down` drops it. Mirrors the existing `sentinel_activities` `created_at` index alteration.
- `tables/service_logs.sql` — the same index, so fresh installs match.

Additive and reversible; no generated-type change. `service_logs` is written only by Cloud, so on self-hosted OSS the table is empty and the index is a no-op there.

## Testing

Tested locally

`build:alterations` + `generate` (no diff) + lint clean.

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
