### PR TITLE
feat(toolkit): add email list coverage helpers

### DIFF
--- a/packages/toolkit/core-kit/src/email-blocklist.test.ts
+++ b/packages/toolkit/core-kit/src/email-blocklist.test.ts
@@ -1,49 +1,125 @@
 import { describe, expect, it } from 'vitest';
 
-import { isEmailBlocklistItem, matchesEmailBlocklistItem } from './email-blocklist.js';
+import {
+  findBlockedAllowlistItems,
+  isEmailBlocklistItem,
+  isEmailListItem,
+  isEmailListItemFullyCoveredByBlockItem,
+  matchesEmailBlocklistItem,
+  matchesEmailListItem,
+} from './email-blocklist.js';
 
-describe('email blocklist helpers', () => {
-  describe('isEmailBlocklistItem', () => {
+describe('email list helpers', () => {
+  describe('isEmailListItem', () => {
     it('validates exact email and domain items', () => {
-      expect(isEmailBlocklistItem('foo@example.com')).toBe(true);
-      expect(isEmailBlocklistItem('@example.com')).toBe(true);
+      expect(isEmailListItem('foo@example.com')).toBe(true);
+      expect(isEmailListItem('@example.com')).toBe(true);
     });
 
     it('validates wildcard email and domain items', () => {
-      expect(isEmailBlocklistItem('foo*@example.com')).toBe(true);
-      expect(isEmailBlocklistItem('*@example.com')).toBe(true);
-      expect(isEmailBlocklistItem('foo@*.example.com')).toBe(true);
-      expect(isEmailBlocklistItem('@foo.*')).toBe(true);
-      expect(isEmailBlocklistItem('@*.example.com')).toBe(true);
+      expect(isEmailListItem('foo*@example.com')).toBe(true);
+      expect(isEmailListItem('*@example.com')).toBe(true);
+      expect(isEmailListItem('foo@*.example.com')).toBe(true);
+      expect(isEmailListItem('@foo.*')).toBe(true);
+      expect(isEmailListItem('@*.example.com')).toBe(true);
     });
 
     it.each(['foo*', '@*', 'foo@*', 'foo@example', '@example', '*@*.*'])(
       'rejects malformed wildcard item: %s',
       (item) => {
-        expect(isEmailBlocklistItem(item)).toBe(false);
+        expect(isEmailListItem(item)).toBe(false);
       }
     );
   });
 
-  describe('matchesEmailBlocklistItem', () => {
+  describe('matchesEmailListItem', () => {
     it('matches exact email and domain items case-insensitively', () => {
-      expect(matchesEmailBlocklistItem('foo@example.com', 'Foo@Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('@example.com', 'foo@Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('foo@example.com', 'bar@example.com')).toBe(false);
-      expect(matchesEmailBlocklistItem('@example.com', 'foo@example.org')).toBe(false);
+      expect(matchesEmailListItem('foo@example.com', 'Foo@Example.com')).toBe(true);
+      expect(matchesEmailListItem('@example.com', 'foo@Example.com')).toBe(true);
+      expect(matchesEmailListItem('foo@example.com', 'bar@example.com')).toBe(false);
+      expect(matchesEmailListItem('@example.com', 'foo@example.org')).toBe(false);
     });
 
     it('matches wildcard email and domain items case-insensitively', () => {
-      expect(matchesEmailBlocklistItem('foo*@example.com', 'FooBar@Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('*@example.com', 'anything@Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('foo@*.example.com', 'Foo@bar.Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('@foo.*', 'bar@Foo.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('@*.example.com', 'bar@Foo.Example.com')).toBe(true);
+      expect(matchesEmailListItem('foo*@example.com', 'FooBar@Example.com')).toBe(true);
+      expect(matchesEmailListItem('*@example.com', 'anything@Example.com')).toBe(true);
+      expect(matchesEmailListItem('foo@*.example.com', 'Foo@bar.Example.com')).toBe(true);
+      expect(matchesEmailListItem('@foo.*', 'bar@Foo.com')).toBe(true);
+      expect(matchesEmailListItem('@*.example.com', 'bar@Foo.Example.com')).toBe(true);
     });
 
     it('treats regex metacharacters as literal characters in wildcard items', () => {
-      expect(matchesEmailBlocklistItem('foo.+*@example.com', 'foo.+bar@example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('foo.+*@example.com', 'fooxbar@example.com')).toBe(false);
+      expect(matchesEmailListItem('foo.+*@example.com', 'foo.+bar@example.com')).toBe(true);
+      expect(matchesEmailListItem('foo.+*@example.com', 'fooxbar@example.com')).toBe(false);
+    });
+  });
+
+  describe('isEmailListItemFullyCoveredByBlockItem', () => {
+    it('detects exact allowlist entries fully covered by exact, domain, and wildcard block items', () => {
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@email.com', 'foo@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@email.com', '@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@email.com', 'f*@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('😀@email.com', '😀@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('😀@email.com', '*@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@email.com', 'bar@email.com')).toBe(false);
+    });
+
+    it('detects wildcard allowlist entries fully covered by wider block items', () => {
+      expect(isEmailListItemFullyCoveredByBlockItem('foo*@email.com', '@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo*@email.com', 'f*@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo*@email.com', 'foo1@email.com')).toBe(
+        false
+      );
+    });
+
+    it('detects domain allowlist entries fully covered by domain or wildcard-all email block items', () => {
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('@team.email.com', '@*.email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '*@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', 'foo@email.com')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@example.com', 'bad@example.com')).toBe(false);
+    });
+
+    it('returns false for malformed allowlist or blocklist items', () => {
+      expect(isEmailListItemFullyCoveredByBlockItem('@', '@email.com')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com@foo', '@email.com')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@bar', '@bar')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@example', '@example.com')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '@')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '@email.com@foo')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', 'foo@bar')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '@example')).toBe(false);
+    });
+  });
+
+  describe('findBlockedAllowlistItems', () => {
+    it('returns allowlist entries fully covered by custom blocklist entries', () => {
+      expect(
+        findBlockedAllowlistItems(['foo@email.com', '@example.com', 'foo*@example.com'], {
+          customBlocklist: ['f*@email.com', 'bad@example.com'],
+        })
+      ).toEqual([{ allowItem: 'foo@email.com', blockedBy: 'f*@email.com' }]);
+    });
+
+    it('returns allowlist entries fully covered by subaddressing block rules', () => {
+      expect(
+        findBlockedAllowlistItems(
+          ['foo+bar@email.com', 'foo+*@email.com', 'foo*@email.com', 'foo+bar@example'],
+          {
+            blockSubaddressing: true,
+          }
+        )
+      ).toEqual([
+        { allowItem: 'foo+bar@email.com', blockedBy: 'blockSubaddressing' },
+        { allowItem: 'foo+*@email.com', blockedBy: 'blockSubaddressing' },
+      ]);
+    });
+  });
+
+  describe('blocklist compatibility exports', () => {
+    it('keeps existing blocklist helper names available', () => {
+      expect(isEmailBlocklistItem('@example.com')).toBe(true);
+      expect(matchesEmailBlocklistItem('@example.com', 'foo@example.com')).toBe(true);
     });
   });
 });

--- a/packages/toolkit/core-kit/src/email-blocklist.ts
+++ b/packages/toolkit/core-kit/src/email-blocklist.ts
@@ -1,4 +1,15 @@
 import { emailOrEmailDomainRegEx } from './regex.js';
+import { isWildcardPatternSubset } from './wildcard-pattern.js';
+
+export type EmailBlocklistPolicyShape = Readonly<{
+  blockSubaddressing?: boolean;
+  customBlocklist?: readonly string[];
+}>;
+
+export type BlockedAllowlistItem = Readonly<{
+  allowItem: string;
+  blockedBy: string | 'blockSubaddressing';
+}>;
 
 const wildcard = '*';
 const emailSeparator = '@';
@@ -6,16 +17,38 @@ const domainSeparator = '.';
 const whitespaceRegEx = /\s/u;
 const wildcardOnlyDomainRegEx = /^[*.]+$/u;
 
+/**
+ * Returns whether an email list item contains wildcard syntax.
+ */
 const hasWildcard = (value: string) => value.includes(wildcard);
 
+/**
+ * Escapes literal characters before a wildcard pattern is converted to a regular expression.
+ */
 const escapeRegExp = (value: string) => value.replaceAll(/[.+?^${}()|[\]\\]/gu, '\\$&');
 
+/**
+ * Builds an anchored regular expression for matching a wildcard email list item.
+ *
+ * Only `*` is treated as wildcard syntax; all other regular expression meta characters are
+ * escaped and matched literally.
+ */
 const buildWildcardRegExp = (pattern: string) =>
   new RegExp(`^${escapeRegExp(pattern).replaceAll(wildcard, '.*')}$`, 'u');
 
+/**
+ * Validates the local-part shape for a wildcard email list item.
+ */
 const isValidWildcardLocalPart = (localPart: string) =>
   localPart.length > 0 && !localPart.includes(emailSeparator) && !whitespaceRegEx.test(localPart);
 
+/**
+ * Validates the domain shape for a wildcard email list item.
+ *
+ * The domain must keep the same rough email-domain shape as non-wildcard entries, while allowing
+ * `*` inside labels. Pure wildcard domains such as `*` or `*.*` are rejected because they are too
+ * broad to be meaningful list entries.
+ */
 const isValidWildcardDomain = (domain: string) =>
   domain.length > 0 &&
   domain.includes(domainSeparator) &&
@@ -27,13 +60,69 @@ const isValidWildcardDomain = (domain: string) =>
   !wildcardOnlyDomainRegEx.test(domain);
 
 /**
- * Validates an email blocklist item.
+ * Splits an email list item into local-part and domain pieces.
+ *
+ * Domain-only items (`@example.com`) return only the domain. Malformed values return `undefined`.
+ * Full validation is still handled by `isEmailListItem()` before public coverage checks use these
+ * parsed parts.
+ */
+const getEmailParts = (item: string) => {
+  if (item.startsWith(emailSeparator)) {
+    const domain = item.slice(1);
+
+    if (!domain || domain.includes(emailSeparator)) {
+      return;
+    }
+
+    return { domain };
+  }
+
+  const [localPart, domain, ...rest] = item.split(emailSeparator);
+
+  if (rest.length > 0 || !localPart || !domain) {
+    return;
+  }
+
+  return { localPart, domain };
+};
+
+/**
+ * Returns whether a wildcard pattern consists only of `*` tokens.
+ */
+const isWildcardOnly = (pattern: string) =>
+  [...pattern].every((character) => character === wildcard);
+
+/**
+ * Checks whether a local part is fully denied by the block-subaddressing rule.
+ *
+ * Literal local parts are covered when they contain `+`. Wildcard local parts are covered only when
+ * their whole language is a subset of `*+*`.
+ */
+const isLocalPartCoveredBySubaddressing = (localPart: string) =>
+  hasWildcard(localPart)
+    ? isWildcardPatternSubset(localPart, `${wildcard}+${wildcard}`)
+    : localPart.includes('+');
+
+/**
+ * Checks whether an allowlist item can never pass when subaddressing is blocked.
+ */
+const isAllowItemCoveredBySubaddressing = (allowItem: string) => {
+  const allowParts = getEmailParts(allowItem);
+
+  return Boolean(allowParts?.localPart && isLocalPartCoveredBySubaddressing(allowParts.localPart));
+};
+
+/**
+ * Validates an email list item.
  *
  * An item can be either a full email address (`foo@example.com`) or a domain entry
  * prefixed with `@` (`@example.com`). `*` can be used inside the local part or
  * domain while keeping the same email/domain shapes.
+ *
+ * This helper is shared by allowlist and blocklist policies so Console and Core use the same entry
+ * format rules.
  */
-export const isEmailBlocklistItem = (value: string) => {
+export const isEmailListItem = (value: string) => {
   if (!hasWildcard(value)) {
     return emailOrEmailDomainRegEx.test(value);
   }
@@ -63,12 +152,14 @@ export const isEmailBlocklistItem = (value: string) => {
 };
 
 /**
- * Checks whether an email address matches an email blocklist item.
+ * Checks whether an email address matches an email list item.
  *
  * Matching is case-insensitive. Domain items (`@example.com`) match only the email
  * domain, while full email items match the complete email address.
+ *
+ * Wildcard items treat `*` as the only pattern syntax; all other characters are matched literally.
  */
-export const matchesEmailBlocklistItem = (item: string, email: string) => {
+export const matchesEmailListItem = (item: string, email: string) => {
   const normalizedItem = item.toLowerCase();
   const normalizedEmail = email.toLowerCase();
   const domain = normalizedEmail.split(emailSeparator)[1];
@@ -86,3 +177,70 @@ export const matchesEmailBlocklistItem = (item: string, email: string) => {
     ? buildWildcardRegExp(normalizedItem).test(normalizedEmail)
     : normalizedEmail === normalizedItem;
 };
+
+/**
+ * Checks whether every email address allowed by `allowItem` is denied by `blockItem`.
+ *
+ * This is used to reject allowlist entries that are fully shadowed by block rules. Partial overlap
+ * is allowed; the helper returns `true` only when the block item covers the whole allow item.
+ * Malformed inputs return `false` so callers do not report misleading coverage for invalid entries.
+ */
+export const isEmailListItemFullyCoveredByBlockItem = (allowItem: string, blockItem: string) => {
+  if (!isEmailListItem(allowItem) || !isEmailListItem(blockItem)) {
+    return false;
+  }
+
+  const normalizedAllowItem = allowItem.toLowerCase();
+  const normalizedBlockItem = blockItem.toLowerCase();
+  const allowParts = getEmailParts(normalizedAllowItem);
+  const blockParts = getEmailParts(normalizedBlockItem);
+
+  if (!allowParts || !blockParts) {
+    return false;
+  }
+
+  if (!blockParts.localPart) {
+    return isWildcardPatternSubset(allowParts.domain, blockParts.domain);
+  }
+
+  if (!allowParts.localPart) {
+    return (
+      isWildcardOnly(blockParts.localPart) &&
+      isWildcardPatternSubset(allowParts.domain, blockParts.domain)
+    );
+  }
+
+  return isWildcardPatternSubset(
+    `${allowParts.localPart}${emailSeparator}${allowParts.domain}`,
+    `${blockParts.localPart}${emailSeparator}${blockParts.domain}`
+  );
+};
+
+/**
+ * Finds allowlist entries that can never be used because block rules fully cover them.
+ *
+ * Invalid allowlist entries are ignored here because format validation is reported separately by
+ * policy validators. Returned items include the first block rule that fully covers each allow entry.
+ */
+export const findBlockedAllowlistItems = (
+  allowlist: readonly string[],
+  { blockSubaddressing, customBlocklist = [] }: EmailBlocklistPolicyShape
+): BlockedAllowlistItem[] =>
+  allowlist.flatMap((allowItem) => {
+    if (!isEmailListItem(allowItem)) {
+      return [];
+    }
+
+    if (blockSubaddressing && isAllowItemCoveredBySubaddressing(allowItem)) {
+      return [{ allowItem, blockedBy: 'blockSubaddressing' }];
+    }
+
+    const blockedBy = customBlocklist.find((blockItem) =>
+      isEmailListItemFullyCoveredByBlockItem(allowItem, blockItem)
+    );
+
+    return blockedBy ? [{ allowItem, blockedBy }] : [];
+  });
+
+export const isEmailBlocklistItem = isEmailListItem;
+export const matchesEmailBlocklistItem = matchesEmailListItem;

--- a/packages/toolkit/core-kit/src/wildcard-pattern.ts
+++ b/packages/toolkit/core-kit/src/wildcard-pattern.ts
@@ -1,0 +1,175 @@
+const wildcard = '*';
+const anyOtherCharacter: unique symbol = Symbol('anyOtherCharacter');
+
+type WildcardPattern = readonly string[];
+type WildcardPatternCharacter = string | typeof anyOtherCharacter;
+
+/**
+ * Returns the finite alphabet used by wildcard subset checks.
+ *
+ * The subset algorithm only needs characters that appear literally in either pattern, plus the
+ * `anyOtherCharacter` sentinel for every other possible input character.
+ */
+const getLiteralCharacters = (...patterns: string[]): ReadonlySet<string> =>
+  new Set(
+    patterns.flatMap((pattern) => [...pattern].filter((character) => character !== wildcard))
+  );
+
+/**
+ * Expands a set of NFA states through zero-length `*` transitions.
+ *
+ * In this wildcard model, `*` can either consume one input character or advance without consuming
+ * anything, which is why the closure includes the following state for every active `*` token.
+ */
+const epsilonClosure = (
+  pattern: WildcardPattern,
+  states: ReadonlySet<number>
+): ReadonlySet<number> => {
+  /* eslint-disable @silverhand/fp/no-mutating-methods -- finite automata traversal uses local queue state */
+  const closedStates = new Set(states);
+  const pendingStates = [...states];
+
+  for (const state of pendingStates) {
+    if (pattern[state] === wildcard && !closedStates.has(state + 1)) {
+      closedStates.add(state + 1);
+      pendingStates.push(state + 1);
+    }
+  }
+
+  return closedStates;
+  /* eslint-enable @silverhand/fp/no-mutating-methods */
+};
+
+/**
+ * Moves a wildcard-pattern NFA by consuming one abstract input character.
+ *
+ * A literal token only accepts the same real character. The `anyOtherCharacter` sentinel is accepted
+ * only by `*`, which lets the subset algorithm cover all characters not explicitly present in the
+ * compared patterns.
+ */
+const move = (
+  pattern: WildcardPattern,
+  states: ReadonlySet<number>,
+  character: WildcardPatternCharacter
+): ReadonlySet<number> => {
+  const nextStates = [...states].flatMap((state) => {
+    const token = pattern[state];
+
+    if (!token) {
+      return [];
+    }
+
+    if (token === wildcard) {
+      return [state];
+    }
+
+    if (character !== anyOtherCharacter && token === character) {
+      return [state + 1];
+    }
+
+    return [];
+  });
+
+  return epsilonClosure(pattern, new Set(nextStates));
+};
+
+/**
+ * Serializes a set of NFA states so paired allow/block states can be de-duplicated.
+ */
+const serializeStates = (states: ReadonlySet<number>) =>
+  [...states]
+    .slice()
+    .sort((left, right) => left - right)
+    .join(',');
+
+/**
+ * Returns whether an NFA state set has reached the end of the wildcard pattern.
+ */
+const isAccepted = (pattern: WildcardPattern, states: ReadonlySet<number>) =>
+  states.has(pattern.length);
+
+type StatePair = readonly [ReadonlySet<number>, ReadonlySet<number>];
+
+type PatternSubsetContext = Readonly<{
+  allowPattern: WildcardPattern;
+  blockPattern: WildcardPattern;
+  alphabet: readonly WildcardPatternCharacter[];
+}>;
+
+/**
+ * Searches for an input accepted by the allow pattern but not accepted by the block pattern.
+ *
+ * Returning `true` means the allow pattern is not fully covered. Returning `false` means every
+ * reachable accepted allow state is also accepted by the block pattern.
+ */
+const hasUncoveredAcceptedState = (
+  context: PatternSubsetContext,
+  initialPendingPairs: readonly StatePair[]
+): boolean => {
+  const { allowPattern, alphabet, blockPattern } = context;
+
+  /* eslint-disable @silverhand/fp/no-let, @silverhand/fp/no-mutation, @silverhand/fp/no-mutating-methods -- finite automata traversal uses local queue/set state */
+  const pendingPairs = [...initialPendingPairs];
+  const visitedPairs = new Set<string>();
+  let index = 0;
+
+  while (index < pendingPairs.length) {
+    const statePair = pendingPairs[index];
+    index += 1;
+
+    if (!statePair) {
+      continue;
+    }
+
+    const [allowStates, blockStates] = statePair;
+    const pairKey = `${serializeStates(allowStates)}|${serializeStates(blockStates)}`;
+
+    if (visitedPairs.has(pairKey)) {
+      continue;
+    }
+
+    visitedPairs.add(pairKey);
+
+    if (isAccepted(allowPattern, allowStates) && !isAccepted(blockPattern, blockStates)) {
+      return true;
+    }
+
+    const nextPairs = alphabet.flatMap((character): StatePair[] => {
+      const nextAllowStates = move(allowPattern, allowStates, character);
+
+      return nextAllowStates.size > 0
+        ? [[nextAllowStates, move(blockPattern, blockStates, character)]]
+        : [];
+    });
+
+    pendingPairs.push(...nextPairs);
+  }
+
+  return false;
+  /* eslint-enable @silverhand/fp/no-let, @silverhand/fp/no-mutation, @silverhand/fp/no-mutating-methods */
+};
+
+/**
+ * Checks whether every string matched by `allowPattern` is also matched by `blockPattern`.
+ *
+ * The supported pattern syntax is intentionally small: only `*` is special and it matches any
+ * sequence of characters. The implementation uses a small NFA subset construction over the literal
+ * characters in the two patterns plus `anyOtherCharacter`, avoiding infinite character enumeration
+ * while still covering unknown input.
+ */
+export const isWildcardPatternSubset = (allowPattern: string, blockPattern: string) => {
+  const alphabet: readonly WildcardPatternCharacter[] = [
+    ...getLiteralCharacters(allowPattern, blockPattern),
+    anyOtherCharacter,
+  ];
+  const allowPatternCharacters = [...allowPattern];
+  const blockPatternCharacters = [...blockPattern];
+  const initialAllowStates = epsilonClosure(allowPatternCharacters, new Set([0]));
+  const initialBlockStates = epsilonClosure(blockPatternCharacters, new Set([0]));
+  const initialPair = [initialAllowStates, initialBlockStates] as const;
+
+  return !hasUncoveredAcceptedState(
+    { allowPattern: allowPatternCharacters, alphabet, blockPattern: blockPatternCharacters },
+    [initialPair]
+  );
+};


### PR DESCRIPTION
## Summary

- add shared email list validation/matching helpers with wildcard support
- add allowlist-vs-blocklist coverage detection helpers for frontend/backend reuse
- keep existing email blocklist helper exports compatible

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments