### PR TITLE
feat(core): add email allowlist policy

### DIFF
--- a/packages/core/src/__mocks__/sign-in-experience.ts
+++ b/packages/core/src/__mocks__/sign-in-experience.ts
@@ -121,6 +121,7 @@ export const mockSignInExperience: SignInExperience = {
   sentinelPolicy: {},
   verificationCodePolicy: {},
   emailBlocklistPolicy: {},
+  emailAllowlistPolicy: {},
   forgotPasswordMethods: null,
   passkeySignIn: {
     enabled: false,

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -4,9 +4,12 @@ import { deduplicate } from '@silverhand/essentials';
 import RequestError from '#src/errors/RequestError/index.js';
 
 import {
+  parseEmailAllowlistPolicy,
   parseEmailBlocklistPolicy,
   validateEmailAgainstBlocklistPolicy,
   isEmailBlocklistPolicyEnabled,
+  isEmailAllowlistPolicyEnabled,
+  validateEmailAllowlistAgainstBlocklistPolicy,
 } from './email-blocklist-policy.js';
 
 const invalidCustomBlockList = ['bar', 'bar@foo', '@foo', '@foo.', 'bar@foo.'];
@@ -39,6 +42,70 @@ describe('parseEmailBlocklistPolicy', () => {
     const parsed = parseEmailBlocklistPolicy({ customBlocklist });
 
     expect(parsed).toEqual({ customBlocklist });
+  });
+});
+
+describe('parseEmailAllowlistPolicy', () => {
+  const invalidCustomAllowList = invalidCustomBlockList;
+  const validCustomAllowList = [
+    'bar@foo.com',
+    '@foo.com',
+    'abc.bar@foo.xyz',
+    'bar@foo.com',
+    'foo*@example.com',
+  ];
+
+  it.each(invalidCustomAllowList)(
+    'should throw error for invalid custom allow list item: %s',
+    (item) => {
+      const emailAllowlistPolicy = { customAllowlist: [item] };
+      expect(() => {
+        parseEmailAllowlistPolicy(emailAllowlistPolicy, {});
+      }).toMatchError(
+        new RequestError({
+          code: 'sign_in_experiences.invalid_custom_email_allowlist_format',
+          items: Array.from([item]),
+          status: 400,
+        })
+      );
+    }
+  );
+
+  it('should pass the validation with valid format, wildcard items, and deduplicate items', () => {
+    const parsed = parseEmailAllowlistPolicy({ customAllowlist: validCustomAllowList }, {});
+    expect(parsed).toEqual({ customAllowlist: deduplicate(validCustomAllowList) });
+  });
+
+  it('should reject entries fully covered by custom blocklist rules', () => {
+    expect(() => {
+      parseEmailAllowlistPolicy(
+        { customAllowlist: ['foo@email.com', 'bar@email.com'] },
+        { customBlocklist: ['f*@email.com'] }
+      );
+    }).toMatchError(
+      new RequestError({
+        code: 'sign_in_experiences.email_allowlist_entries_blocked',
+        blockedItems: [{ allowItem: 'foo@email.com', blockedBy: 'f*@email.com' }],
+        items: ['foo@email.com blocked by f*@email.com'],
+        status: 422,
+      })
+    );
+  });
+
+  it('should reject entries fully covered by subaddressing block rule', () => {
+    expect(() => {
+      validateEmailAllowlistAgainstBlocklistPolicy(
+        { customAllowlist: ['foo+bar@email.com'] },
+        { blockSubaddressing: true }
+      );
+    }).toMatchError(
+      new RequestError({
+        code: 'sign_in_experiences.email_allowlist_entries_blocked',
+        blockedItems: [{ allowItem: 'foo+bar@email.com', blockedBy: 'blockSubaddressing' }],
+        items: ['foo+bar@email.com blocked by blockSubaddressing'],
+        status: 422,
+      })
+    );
   });
 });
 
@@ -170,5 +237,13 @@ describe('isEmailBlocklistPolicyEnabled', () => {
     };
 
     expect(isEmailBlocklistPolicyEnabled(emailBlocklistPolicy)).toBe(false);
+  });
+});
+
+describe('isEmailAllowlistPolicyEnabled', () => {
+  it('returns true only when custom allowlist is non-empty', () => {
+    expect(isEmailAllowlistPolicyEnabled({ customAllowlist: ['@bar.com'] })).toBe(true);
+    expect(isEmailAllowlistPolicyEnabled({ customAllowlist: [] })).toBe(false);
+    expect(isEmailAllowlistPolicyEnabled({})).toBe(false);
   });
 });

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -1,5 +1,10 @@
-import { isEmailBlocklistItem, matchesEmailBlocklistItem } from '@logto/core-kit';
-import { type EmailBlocklistPolicy } from '@logto/schemas';
+import {
+  findBlockedAllowlistItems,
+  isEmailBlocklistItem,
+  isEmailListItem,
+  matchesEmailBlocklistItem,
+} from '@logto/core-kit';
+import { type EmailAllowlistPolicy, type EmailBlocklistPolicy } from '@logto/schemas';
 import { conditional, deduplicate } from '@silverhand/essentials';
 import { got } from 'got';
 import { z } from 'zod';
@@ -35,6 +40,21 @@ const parseCustomBlocklist = (customBlocklist: string[]) => {
   return deduplicated;
 };
 
+const parseCustomAllowlist = (customAllowlist: string[]) => {
+  const deduplicated = deduplicate(customAllowlist);
+  const invalidItems = deduplicated.filter((item) => !isEmailListItem(item));
+
+  if (invalidItems.length > 0) {
+    throw new RequestError({
+      code: 'sign_in_experiences.invalid_custom_email_allowlist_format',
+      items: invalidItems,
+      status: 400,
+    });
+  }
+
+  return deduplicated;
+};
+
 /**
  * This function will deduplicate the custom blocklist (if not undefined) and validate the format of each item.
  * If any item is invalid, it throws a RequestError with the details of the invalid items.
@@ -59,6 +79,48 @@ export const parseEmailBlocklistPolicy = (
     ...rest,
     ...conditional(customBlocklist && { customBlocklist: parseCustomBlocklist(customBlocklist) }),
   };
+};
+
+/**
+ * Validates that custom allowlist entries are not made unusable by the effective block rules.
+ */
+export const validateEmailAllowlistAgainstBlocklistPolicy = (
+  emailAllowlistPolicy: EmailAllowlistPolicy,
+  emailBlocklistPolicy: EmailBlocklistPolicy
+) => {
+  const { customAllowlist } = emailAllowlistPolicy;
+
+  if (!customAllowlist || customAllowlist.length === 0) {
+    return;
+  }
+
+  const blockedItems = findBlockedAllowlistItems(customAllowlist, emailBlocklistPolicy);
+
+  if (blockedItems.length > 0) {
+    throw new RequestError({
+      code: 'sign_in_experiences.email_allowlist_entries_blocked',
+      blockedItems,
+      items: blockedItems.map(({ allowItem, blockedBy }) => `${allowItem} blocked by ${blockedBy}`),
+      status: 422,
+    });
+  }
+};
+
+/**
+ * Deduplicates and validates the custom allowlist. Wildcards are supported for allowlist entries.
+ */
+export const parseEmailAllowlistPolicy = (
+  emailAllowlistPolicy: EmailAllowlistPolicy,
+  emailBlocklistPolicy: EmailBlocklistPolicy
+): EmailAllowlistPolicy => {
+  const { customAllowlist } = emailAllowlistPolicy;
+  const parsedPolicy = {
+    ...conditional(customAllowlist && { customAllowlist: parseCustomAllowlist(customAllowlist) }),
+  };
+
+  validateEmailAllowlistAgainstBlocklistPolicy(parsedPolicy, emailBlocklistPolicy);
+
+  return parsedPolicy;
 };
 
 const disposableEmailDomainValidationResponseGuard = z.object({
@@ -184,3 +246,6 @@ export const isEmailBlocklistPolicyEnabled = (emailBlockListPolicy: EmailBlockli
   );
   /* eslint-enable @typescript-eslint/prefer-nullish-coalescing */
 };
+
+export const isEmailAllowlistPolicyEnabled = (emailAllowlistPolicy: EmailAllowlistPolicy) =>
+  Boolean(emailAllowlistPolicy.customAllowlist && emailAllowlistPolicy.customAllowlist.length > 0);

--- a/packages/core/src/middleware/koa-guard.ts
+++ b/packages/core/src/middleware/koa-guard.ts
@@ -2,7 +2,7 @@ import { appInsights } from '@logto/app-insights/node';
 import type { Optional } from '@silverhand/essentials';
 import { has } from '@silverhand/essentials';
 import type { MiddlewareType } from 'koa';
-import { koaBody, type ScalarOrArrayFiles } from 'koa-body';
+import { koaBody } from 'koa-body';
 import type { IMiddleware, IRouterParamContext } from 'koa-router';
 import type { ZodType, ZodTypeDef } from 'zod';
 
@@ -11,6 +11,8 @@ import RequestError from '#src/errors/RequestError/index.js';
 import { ResponseBodyError, StatusCodeError } from '#src/errors/ServerError/index.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
+
+type ScalarOrArrayFiles = Record<string, unknown | unknown[]>;
 
 /** Configure what and how to guard. */
 export type GuardConfig<QueryT, BodyT, ParametersT, ResponseT, FilesT> = {

--- a/packages/core/src/queries/sign-in-experience.test.ts
+++ b/packages/core/src/queries/sign-in-experience.test.ts
@@ -44,6 +44,7 @@ describe('sign-in-experience query', () => {
     sentinelPolicy: JSON.stringify(mockSignInExperience.sentinelPolicy),
     verificationCodePolicy: JSON.stringify(mockSignInExperience.verificationCodePolicy),
     emailBlocklistPolicy: JSON.stringify(mockSignInExperience.emailBlocklistPolicy),
+    emailAllowlistPolicy: JSON.stringify(mockSignInExperience.emailAllowlistPolicy),
     forgotPasswordMethods: JSON.stringify(mockSignInExperience.forgotPasswordMethods),
     passkeySignIn: JSON.stringify(mockSignInExperience.passkeySignIn),
     signUpProfileFields: JSON.stringify(mockSignInExperience.signUpProfileFields),
@@ -53,7 +54,7 @@ describe('sign-in-experience query', () => {
   it('findDefaultSignInExperience', async () => {
     /* eslint-disable sql/no-unsafe-query */
     const expectSql = `
-      select "tenant_id", "id", "color", "branding", "hide_logto_branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "custom_ui_csp", "password_policy", "mfa", "adaptive_mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy", "email_blocklist_policy", "verification_code_policy", "forgot_password_methods", "passkey_sign_in", "sign_up_profile_fields", "password_expiration", "username_policy"
+      select "tenant_id", "id", "color", "branding", "hide_logto_branding", "language_info", "terms_of_use_url", "privacy_policy_url", "agree_to_terms_policy", "sign_in", "sign_up", "social_sign_in", "social_sign_in_connector_targets", "sign_in_mode", "custom_css", "custom_content", "custom_ui_assets", "custom_ui_csp", "password_policy", "mfa", "adaptive_mfa", "single_sign_on_enabled", "support_email", "support_website_url", "unknown_session_redirect_url", "captcha_policy", "sentinel_policy", "email_blocklist_policy", "email_allowlist_policy", "verification_code_policy", "forgot_password_methods", "passkey_sign_in", "sign_up_profile_fields", "password_expiration", "username_policy"
       from "sign_in_experiences"
       where "id"=$1
     `;

--- a/packages/core/src/routes/sign-in-experience/guard.test.ts
+++ b/packages/core/src/routes/sign-in-experience/guard.test.ts
@@ -7,6 +7,7 @@ import { MockTenant } from '#src/test-utils/tenant.js';
 const { jest } = import.meta;
 
 const validateLanguageInfo = jest.fn();
+const findDefaultSignInExperience = jest.fn().mockResolvedValue(mockSignInExperience);
 
 const tenantContext = new MockTenant(
   undefined,
@@ -18,7 +19,7 @@ const tenantContext = new MockTenant(
         ...mockSignInExperience,
         ...data,
       }),
-      findDefaultSignInExperience: jest.fn().mockResolvedValue(mockSignInExperience),
+      findDefaultSignInExperience,
     },
   },
   undefined,
@@ -49,6 +50,7 @@ const invalidBooleans = [undefined, null, 0, 1, '0', '1', 'true', 'false'];
 
 beforeEach(() => {
   jest.clearAllMocks();
+  findDefaultSignInExperience.mockResolvedValue(mockSignInExperience);
 });
 
 describe('terms of use url', () => {
@@ -136,6 +138,62 @@ describe('socialSignInConnectorTargets', () => {
       );
     }
   );
+});
+
+describe('emailAllowlistPolicy', () => {
+  it('should allow wildcard entries', async () => {
+    await expectPatchResponseStatus(
+      {
+        emailAllowlistPolicy: {
+          customAllowlist: ['foo*@bar.com', '@*.example.com'],
+        },
+      },
+      200
+    );
+  });
+
+  it('should reject invalid entries', async () => {
+    await expectPatchResponseStatus(
+      {
+        emailAllowlistPolicy: {
+          customAllowlist: ['foo@bar'],
+        },
+      },
+      400
+    );
+  });
+
+  it('should reject allowlist entries fully covered by requested blocklist rules', async () => {
+    await expectPatchResponseStatus(
+      {
+        emailAllowlistPolicy: {
+          customAllowlist: ['foo@bar.com'],
+        },
+        emailBlocklistPolicy: {
+          customBlocklist: ['@bar.com'],
+        },
+      },
+      422
+    );
+  });
+
+  it('should reject current allowlist entries fully covered by requested blocklist rules', async () => {
+    findDefaultSignInExperience.mockResolvedValueOnce({
+      ...mockSignInExperience,
+      emailAllowlistPolicy: {
+        customAllowlist: ['foo@bar.com'],
+      },
+    });
+
+    await expectPatchResponseStatus(
+      {
+        emailBlocklistPolicy: {
+          customBlocklist: ['@bar.com'],
+        },
+      },
+      422
+    );
+  });
 });
 
 describe('password expiration policy', () => {

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -21,6 +21,9 @@ import {
   validateSignIn,
   parseEmailBlocklistPolicy,
   isEmailBlocklistPolicyEnabled,
+  isEmailAllowlistPolicyEnabled,
+  parseEmailAllowlistPolicy,
+  validateEmailAllowlistAgainstBlocklistPolicy,
 } from '#src/libraries/sign-in-experience/index.js';
 import { validateMfa } from '#src/libraries/sign-in-experience/mfa.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -114,6 +117,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         body: {
           socialSignInConnectorTargets,
           emailBlocklistPolicy,
+          emailAllowlistPolicy,
           signUpProfileFields,
           customUiCsp,
           usernamePolicy,
@@ -147,6 +151,23 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         getLogtoConnectors(),
         findDefaultSignInExperience(),
       ]);
+
+      const parsedEmailBlocklistPolicy = conditional(
+        emailBlocklistPolicy && parseEmailBlocklistPolicy(emailBlocklistPolicy)
+      );
+      const effectiveEmailBlocklistPolicy =
+        parsedEmailBlocklistPolicy ?? currentSettings.emailBlocklistPolicy;
+      const parsedEmailAllowlistPolicy = conditional(
+        emailAllowlistPolicy &&
+          parseEmailAllowlistPolicy(emailAllowlistPolicy, effectiveEmailBlocklistPolicy)
+      );
+
+      if (emailBlocklistPolicy && !emailAllowlistPolicy) {
+        validateEmailAllowlistAgainstBlocklistPolicy(
+          currentSettings.emailAllowlistPolicy,
+          effectiveEmailBlocklistPolicy
+        );
+      }
 
       // Flipping usernames to case-insensitive would merge accounts that differ only by case, so
       // reject the flip while such conflicts exist. Only the actual case-sensitive ->
@@ -324,9 +345,11 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
       // - sentinelPolicy: if sentinelPolicy is not empty object, security features are guarded
       // - captchaPolicy: if captchaPolicy is enabled, security features are guarded
       // - emailBlocklistPolicy: if any of the blocklist policies are enabled, security features are guarded
+      // - emailAllowlistPolicy: if custom allowlist is non-empty, security features are guarded
       if (
         (sentinelPolicy && Object.keys(sentinelPolicy).length > 0) ||
         (emailBlocklistPolicy && isEmailBlocklistPolicyEnabled(emailBlocklistPolicy)) ||
+        (emailAllowlistPolicy && isEmailAllowlistPolicyEnabled(emailAllowlistPolicy)) ||
         captchaPolicy?.enabled
       ) {
         await quota.guardTenantUsageByKey('securityFeaturesEnabled');
@@ -384,8 +407,13 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
           }
         ),
         ...conditional(
-          emailBlocklistPolicy && {
-            emailBlocklistPolicy: parseEmailBlocklistPolicy(emailBlocklistPolicy),
+          parsedEmailBlocklistPolicy && {
+            emailBlocklistPolicy: parsedEmailBlocklistPolicy,
+          }
+        ),
+        ...conditional(
+          parsedEmailAllowlistPolicy && {
+            emailAllowlistPolicy: parsedEmailAllowlistPolicy,
           }
         ),
         ...conditional(
@@ -407,7 +435,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
 
       void quota.reportSubscriptionUpdatesUsage('mfaEnabled');
 
-      if (sentinelPolicy ?? captchaPolicy ?? emailBlocklistPolicy) {
+      if (sentinelPolicy ?? captchaPolicy ?? emailBlocklistPolicy ?? emailAllowlistPolicy) {
         void quota.reportSubscriptionUpdatesUsage('securityFeaturesEnabled');
       }
 

--- a/packages/phrases/src/locales/ar/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/ar/errors/sign-in-experiences.ts
@@ -34,6 +34,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'لا يمكن أن يكون معرف التسجيل الأساسي فارغًا.',
   invalid_custom_email_blocklist_format:
     'عناصر قائمة البريد الإلكتروني المحظورة المخصصة غير صالحة: {{items, list(type:conjunction)}}. يجب أن يكون كل عنصر عنوان بريد إلكتروني أو نطاق بريد إلكتروني صالحًا، مثلاً، foo@example.com أو @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'طريقة استرداد كلمة المرور تتطلب تكوين موصل {{method}} ملائم.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/de/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/de/errors/sign-in-experiences.ts
@@ -38,6 +38,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'Primäre Anmeldekennung darf nicht leer sein.',
   invalid_custom_email_blocklist_format:
     'Ungültige benutzerdefinierte E-Mail-Sperrlistenpunkte: {{items, list(type:conjunction)}}. Jedes Element muss eine gültige E-Mail-Adresse oder Domain sein, z. B. foo@example.com oder @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'Die Methode zum Zurücksetzen des Passworts erfordert einen entsprechenden {{method}} Connector.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/en/errors/sign-in-experiences.ts
@@ -34,6 +34,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'Primary sign-up identifier cannot be empty.',
   invalid_custom_email_blocklist_format:
     'Invalid custom email blocklist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'Forgot password method requires a corresponding {{method}} connector to be configured.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/es/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/es/errors/sign-in-experiences.ts
@@ -37,6 +37,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'El identificador de registro principal no puede estar vacío.',
   invalid_custom_email_blocklist_format:
     'Elementos no válidos de la lista de bloqueo de correos electrónicos personalizados: {{items, list(type:conjunction)}}. Cada elemento debe ser una dirección de correo electrónico o dominio de correo electrónico válido, por ejemplo, foo@ejemplo.com o @ejemplo.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'El método de recuperación de contraseña requiere que se configure un conector {{method}} correspondiente.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/fa-ir/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/fa-ir/errors/sign-in-experiences.ts
@@ -34,6 +34,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'شناسه اصلی ثبت‌نام نمی‌تواند خالی باشد.',
   invalid_custom_email_blocklist_format:
     'موارد لیست مسدود ایمیل سفارشی نامعتبر: {{items, list(type:conjunction)}}. هر مورد باید آدرس ایمیل یا دامنه ایمیل معتبر باشد، مثلاً foo@example.com یا @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'روش فراموشی رمز عبور نیاز به پیکربندی اتصال‌دهنده {{method}} متناظر دارد.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/fr/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/fr/errors/sign-in-experiences.ts
@@ -39,6 +39,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: "L'identifiant principal d'inscription ne peut pas être vide.",
   invalid_custom_email_blocklist_format:
     "Articles non valides de la liste de blocage d'e-mails personnalisés : {{items, list(type:conjunction)}}. Chaque élément doit être une adresse e-mail ou un domaine de messagerie valide, par exemple, foo@example.com ou @example.com.",
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     "La méthode de mot de passe oublié nécessite qu'un connecteur {{method}} correspondant soit configuré.",
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/it/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/it/errors/sign-in-experiences.ts
@@ -37,6 +37,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: "L'identificatore di registrazione principale non può essere vuoto.",
   invalid_custom_email_blocklist_format:
     'Formato non valido per gli elementi della lista bloccata delle email personalizzate: {{items, list(type:conjunction)}}. Ogni elemento deve essere un indirizzo email o un dominio email valido, ad es., foo@example.com o @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'Il metodo di recupero della password richiede che sia configurato un connettore {{method}} corrispondente.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/ja/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/ja/errors/sign-in-experiences.ts
@@ -37,6 +37,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: '主要なサインアップ識別子を空にすることはできません。',
   invalid_custom_email_blocklist_format:
     '無効なカスタムメールブロックリスト項目: {{items, list(type:conjunction)}} 。各項目は有効なメールアドレスまたはメールドメインである必要があります。例: foo@example.com または @example.com 。',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'パスワード忘れの方法には、対応する {{method}} コネクタの構成が必要です。',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/ko/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/ko/errors/sign-in-experiences.ts
@@ -34,6 +34,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: '기본 회원가입 식별자는 비워 둘 수 없습니다.',
   invalid_custom_email_blocklist_format:
     '잘못된 사용자 정의 이메일 차단 목록 항목: {{items, list(type:conjunction)}}. 각 항목은 유효한 이메일 주소 또는 이메일 도메인이어야 합니다. 예: foo@example.com 또는 @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     '비밀번호 찾기 방법은 해당 {{method}} 커넥터를 구성해야 합니다.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/pl-pl/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/sign-in-experiences.ts
@@ -36,6 +36,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'Podstawowy identyfikator rejestracji nie może być pusty.',
   invalid_custom_email_blocklist_format:
     'Nieprawidłowe elementy niestandardowej listy blokowanych adresów e-mail: {{items, list(type:conjunction)}}. Każdy element musi być prawidłowym adresem e-mail lub domeną, np. foo@example.com lub @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'Metoda "Zapomniałem hasła" wymaga skonfigurowania odpowiedniego łącznika {{method}}.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/pt-br/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/pt-br/errors/sign-in-experiences.ts
@@ -37,6 +37,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'O identificador principal de inscrição não pode estar vazio.',
   invalid_custom_email_blocklist_format:
     'Itens de lista de bloqueio personalizados de email inválidos: {{items, list(type:conjunction)}}. Cada item deve ser um endereço de email válido ou domínio de email, por exemplo, foo@example.com ou @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'O método de esquecimento de senha requer um conector {{method}} correspondente para ser configurado.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/pt-pt/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/sign-in-experiences.ts
@@ -37,6 +37,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'O identificador de inscrição principal não pode estar vazio.',
   invalid_custom_email_blocklist_format:
     'Itens da lista de bloqueio de email personalizada inválidos: {{items, list(type:conjunction)}}. Cada item deve ser um endereço de email ou domínio de email válido, ex.: foo@example.com ou @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'O método de recuperação de senha requer um conector {{method}} correspondente a ser configurado.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/ru/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/ru/errors/sign-in-experiences.ts
@@ -38,6 +38,10 @@ const sign_in_experiences = {
     'Основной идентификатор создания учетной записи не может быть пустым.',
   invalid_custom_email_blocklist_format:
     'Неверный формат пользовательского списка блокировки электронной почты: {{items, list(type:conjunction)}}. Каждый элемент должен быть действительным адресом электронной почты или доменом, например, foo@example.com или @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'Метод восстановления пароля требует настройки соответствующего коннектора {{method}}.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/th/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/th/errors/sign-in-experiences.ts
@@ -36,6 +36,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'ตัวระบุสมัครสมาชิกหลักต้องไม่เว้นว่าง',
   invalid_custom_email_blocklist_format:
     'รายการบล็อคอีเมลแบบกำหนดเองไม่ถูกต้อง: {{items, list(type:conjunction)}} แต่ละรายการต้องเป็นอีเมลหรือโดเมนอีเมลที่ถูกต้อง เช่น foo@example.com หรือ @example.com',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'วิธีกู้คืนรหัสผ่านต้องมีตัวเชื่อมต่อ {{method}} ที่เกี่ยวข้องกำหนดค่าไว้',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/tr-tr/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/sign-in-experiences.ts
@@ -36,6 +36,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: 'Birincil kayıt kimliği boş olamaz.',
   invalid_custom_email_blocklist_format:
     'Geçersiz özel e-posta engelleme listesi öğeleri: {{items, list(type:conjunction)}}. Her öğe, geçerli bir e-posta adresi veya e-posta alan adı olmalıdır, örneğin, foo@example.com veya @example.com.',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector:
     'Şifremi unuttum yöntemi, yapılandırılması gereken ilgili bir {{method}} bağlayıcı gerektirir.',
   password_expiration_requires_forgot_password:

--- a/packages/phrases/src/locales/zh-cn/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/sign-in-experiences.ts
@@ -28,6 +28,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: '主要的注册标识符不能为空。',
   invalid_custom_email_blocklist_format:
     '无效的自定义电子邮件黑名单项目：{{items, list(type:conjunction)}}。每个项目必须是有效的电子邮件地址或电子邮件域，例如，foo@example.com 或 @example.com。',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector: '忘记密码方法需要配置相应的 {{method}} 连接器。',
   password_expiration_requires_forgot_password:
     '密码过期需要至少配置一种带有有效连接器的忘记密码方式。',

--- a/packages/phrases/src/locales/zh-hk/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/sign-in-experiences.ts
@@ -30,6 +30,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: '主要的註冊標識符不能為空。',
   invalid_custom_email_blocklist_format:
     '無效的自定義電子郵件黑名單條目：{{items, list(type:conjunction)}}。每個條目必須是有效的電子郵件地址或電子郵件域，例如，foo@example.com 或 @example.com。',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector: '忘記密碼方法需要配置相應的 {{method}} 連接器。',
   password_expiration_requires_forgot_password:
     '密碼過期需要至少配置一種帶有有效連接器的忘記密碼方式。',

--- a/packages/phrases/src/locales/zh-tw/errors/sign-in-experiences.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/sign-in-experiences.ts
@@ -29,6 +29,10 @@ const sign_in_experiences = {
   missing_sign_up_identifiers: '主要註冊識別符不能為空。',
   invalid_custom_email_blocklist_format:
     '無效的自訂電子郵件封鎖清單項目：{{items, list(type:conjunction)}}。每個項目必須是有效的電子郵件地址或電子郵件域，例如：foo@example.com 或 @example.com。',
+  invalid_custom_email_allowlist_format:
+    'Invalid custom email allowlist items: {{items, list(type:conjunction)}}. Each item must be a valid email address or email domain, e.g., foo@example.com or @example.com.',
+  email_allowlist_entries_blocked:
+    'Some email allowlist entries are fully blocked by email blocklist rules: {{items, list(type:conjunction)}}. Remove the conflicting block rules or allowlist entries.',
   forgot_password_method_requires_connector: '忘記密碼方法需要配置對應的 {{method}} 連接器。',
   password_expiration_requires_forgot_password:
     '密碼過期需要至少配置一種帶有有效連接器的忘記密碼方式。',

--- a/packages/schemas/alterations/1.41.0-1783632000-add-email-allowlist-policy-column-to-sie-table.ts
+++ b/packages/schemas/alterations/1.41.0-1783632000-add-email-allowlist-policy-column-to-sie-table.ts
@@ -1,0 +1,19 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences
+        add column if not exists email_allowlist_policy jsonb not null default '{}'::jsonb;
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table sign_in_experiences drop column if exists email_allowlist_policy;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
@@ -350,6 +350,24 @@ export const emailBlocklistPolicyGuard = z.object({
   customBlocklist: z.string().array().optional(),
 }) satisfies ToZodObject<EmailBlocklistPolicy>;
 
+export type EmailAllowlistPolicy = {
+  /**
+   * Custom allowlist of email addresses or domains. When provided and non-empty, only matching
+   * email addresses are accepted.
+   *
+   * @example
+   * Email address: abc@xyx.com
+   *
+   * @example
+   * Domain name: @xyz.com
+   */
+  customAllowlist?: string[];
+};
+
+export const emailAllowlistPolicyGuard = z.object({
+  customAllowlist: z.string().array().optional(),
+}) satisfies ToZodObject<EmailAllowlistPolicy>;
+
 export enum ForgotPasswordMethod {
   EmailVerificationCode = 'EmailVerificationCode',
   PhoneVerificationCode = 'PhoneVerificationCode',

--- a/packages/schemas/src/types/sign-in-experience.ts
+++ b/packages/schemas/src/types/sign-in-experience.ts
@@ -31,7 +31,10 @@ export type ExperienceSocialConnector = Omit<
   'description' | 'configTemplate' | 'formItems' | 'readme' | 'customData'
 >;
 
-export type FullSignInExperience = Omit<SignInExperience, 'forgotPasswordMethods'> & {
+export type FullSignInExperience = Omit<
+  SignInExperience,
+  'emailAllowlistPolicy' | 'forgotPasswordMethods'
+> & {
   socialConnectors: ExperienceSocialConnector[];
   ssoConnectors: SsoConnectorMetadata[];
   forgotPassword: ForgotPassword;
@@ -63,7 +66,7 @@ export type FullSignInExperience = Omit<SignInExperience, 'forgotPasswordMethods
 };
 
 export const fullSignInExperienceGuard = SignInExperiences.guard
-  .omit({ forgotPasswordMethods: true })
+  .omit({ emailAllowlistPolicy: true, forgotPasswordMethods: true })
   .extend({
     socialConnectors: connectorMetadataGuard
       .omit({

--- a/packages/schemas/tables/sign_in_experiences.sql
+++ b/packages/schemas/tables/sign_in_experiences.sql
@@ -32,6 +32,7 @@ create table sign_in_experiences (
   captcha_policy jsonb /* @use CaptchaPolicy */ not null default '{}'::jsonb,
   sentinel_policy jsonb /* @use SentinelPolicy */ not null default '{}'::jsonb,
   email_blocklist_policy jsonb /* @use EmailBlocklistPolicy */ not null default '{}'::jsonb,
+  email_allowlist_policy jsonb /* @use EmailAllowlistPolicy */ not null default '{}'::jsonb,
   verification_code_policy jsonb /* @use VerificationCodePolicy */ not null default '{}'::jsonb,
   forgot_password_methods jsonb /* @use ForgotPasswordMethods */ default '[]'::jsonb,
   passkey_sign_in jsonb /* @use PasskeySignIn */ not null default '{}'::jsonb,

--- a/packages/toolkit/core-kit/src/email-blocklist.test.ts
+++ b/packages/toolkit/core-kit/src/email-blocklist.test.ts
@@ -1,49 +1,125 @@
 import { describe, expect, it } from 'vitest';
 
-import { isEmailBlocklistItem, matchesEmailBlocklistItem } from './email-blocklist.js';
+import {
+  findBlockedAllowlistItems,
+  isEmailBlocklistItem,
+  isEmailListItem,
+  isEmailListItemFullyCoveredByBlockItem,
+  matchesEmailBlocklistItem,
+  matchesEmailListItem,
+} from './email-blocklist.js';
 
-describe('email blocklist helpers', () => {
-  describe('isEmailBlocklistItem', () => {
+describe('email list helpers', () => {
+  describe('isEmailListItem', () => {
     it('validates exact email and domain items', () => {
-      expect(isEmailBlocklistItem('foo@example.com')).toBe(true);
-      expect(isEmailBlocklistItem('@example.com')).toBe(true);
+      expect(isEmailListItem('foo@example.com')).toBe(true);
+      expect(isEmailListItem('@example.com')).toBe(true);
     });
 
     it('validates wildcard email and domain items', () => {
-      expect(isEmailBlocklistItem('foo*@example.com')).toBe(true);
-      expect(isEmailBlocklistItem('*@example.com')).toBe(true);
-      expect(isEmailBlocklistItem('foo@*.example.com')).toBe(true);
-      expect(isEmailBlocklistItem('@foo.*')).toBe(true);
-      expect(isEmailBlocklistItem('@*.example.com')).toBe(true);
+      expect(isEmailListItem('foo*@example.com')).toBe(true);
+      expect(isEmailListItem('*@example.com')).toBe(true);
+      expect(isEmailListItem('foo@*.example.com')).toBe(true);
+      expect(isEmailListItem('@foo.*')).toBe(true);
+      expect(isEmailListItem('@*.example.com')).toBe(true);
     });
 
     it.each(['foo*', '@*', 'foo@*', 'foo@example', '@example', '*@*.*'])(
       'rejects malformed wildcard item: %s',
       (item) => {
-        expect(isEmailBlocklistItem(item)).toBe(false);
+        expect(isEmailListItem(item)).toBe(false);
       }
     );
   });
 
-  describe('matchesEmailBlocklistItem', () => {
+  describe('matchesEmailListItem', () => {
     it('matches exact email and domain items case-insensitively', () => {
-      expect(matchesEmailBlocklistItem('foo@example.com', 'Foo@Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('@example.com', 'foo@Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('foo@example.com', 'bar@example.com')).toBe(false);
-      expect(matchesEmailBlocklistItem('@example.com', 'foo@example.org')).toBe(false);
+      expect(matchesEmailListItem('foo@example.com', 'Foo@Example.com')).toBe(true);
+      expect(matchesEmailListItem('@example.com', 'foo@Example.com')).toBe(true);
+      expect(matchesEmailListItem('foo@example.com', 'bar@example.com')).toBe(false);
+      expect(matchesEmailListItem('@example.com', 'foo@example.org')).toBe(false);
     });
 
     it('matches wildcard email and domain items case-insensitively', () => {
-      expect(matchesEmailBlocklistItem('foo*@example.com', 'FooBar@Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('*@example.com', 'anything@Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('foo@*.example.com', 'Foo@bar.Example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('@foo.*', 'bar@Foo.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('@*.example.com', 'bar@Foo.Example.com')).toBe(true);
+      expect(matchesEmailListItem('foo*@example.com', 'FooBar@Example.com')).toBe(true);
+      expect(matchesEmailListItem('*@example.com', 'anything@Example.com')).toBe(true);
+      expect(matchesEmailListItem('foo@*.example.com', 'Foo@bar.Example.com')).toBe(true);
+      expect(matchesEmailListItem('@foo.*', 'bar@Foo.com')).toBe(true);
+      expect(matchesEmailListItem('@*.example.com', 'bar@Foo.Example.com')).toBe(true);
     });
 
     it('treats regex metacharacters as literal characters in wildcard items', () => {
-      expect(matchesEmailBlocklistItem('foo.+*@example.com', 'foo.+bar@example.com')).toBe(true);
-      expect(matchesEmailBlocklistItem('foo.+*@example.com', 'fooxbar@example.com')).toBe(false);
+      expect(matchesEmailListItem('foo.+*@example.com', 'foo.+bar@example.com')).toBe(true);
+      expect(matchesEmailListItem('foo.+*@example.com', 'fooxbar@example.com')).toBe(false);
+    });
+  });
+
+  describe('isEmailListItemFullyCoveredByBlockItem', () => {
+    it('detects exact allowlist entries fully covered by exact, domain, and wildcard block items', () => {
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@email.com', 'foo@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@email.com', '@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@email.com', 'f*@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('😀@email.com', '😀@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('😀@email.com', '*@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@email.com', 'bar@email.com')).toBe(false);
+    });
+
+    it('detects wildcard allowlist entries fully covered by wider block items', () => {
+      expect(isEmailListItemFullyCoveredByBlockItem('foo*@email.com', '@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo*@email.com', 'f*@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo*@email.com', 'foo1@email.com')).toBe(
+        false
+      );
+    });
+
+    it('detects domain allowlist entries fully covered by domain or wildcard-all email block items', () => {
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('@team.email.com', '@*.email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '*@email.com')).toBe(true);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', 'foo@email.com')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@example.com', 'bad@example.com')).toBe(false);
+    });
+
+    it('returns false for malformed allowlist or blocklist items', () => {
+      expect(isEmailListItemFullyCoveredByBlockItem('@', '@email.com')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com@foo', '@email.com')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('foo@bar', '@bar')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@example', '@example.com')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '@')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '@email.com@foo')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', 'foo@bar')).toBe(false);
+      expect(isEmailListItemFullyCoveredByBlockItem('@email.com', '@example')).toBe(false);
+    });
+  });
+
+  describe('findBlockedAllowlistItems', () => {
+    it('returns allowlist entries fully covered by custom blocklist entries', () => {
+      expect(
+        findBlockedAllowlistItems(['foo@email.com', '@example.com', 'foo*@example.com'], {
+          customBlocklist: ['f*@email.com', 'bad@example.com'],
+        })
+      ).toEqual([{ allowItem: 'foo@email.com', blockedBy: 'f*@email.com' }]);
+    });
+
+    it('returns allowlist entries fully covered by subaddressing block rules', () => {
+      expect(
+        findBlockedAllowlistItems(
+          ['foo+bar@email.com', 'foo+*@email.com', 'foo*@email.com', 'foo+bar@example'],
+          {
+            blockSubaddressing: true,
+          }
+        )
+      ).toEqual([
+        { allowItem: 'foo+bar@email.com', blockedBy: 'blockSubaddressing' },
+        { allowItem: 'foo+*@email.com', blockedBy: 'blockSubaddressing' },
+      ]);
+    });
+  });
+
+  describe('blocklist compatibility exports', () => {
+    it('keeps existing blocklist helper names available', () => {
+      expect(isEmailBlocklistItem('@example.com')).toBe(true);
+      expect(matchesEmailBlocklistItem('@example.com', 'foo@example.com')).toBe(true);
     });
   });
 });

--- a/packages/toolkit/core-kit/src/email-blocklist.ts
+++ b/packages/toolkit/core-kit/src/email-blocklist.ts
@@ -1,10 +1,24 @@
 import { emailOrEmailDomainRegEx } from './regex.js';
 
+export type EmailBlocklistPolicyShape = Readonly<{
+  blockSubaddressing?: boolean;
+  customBlocklist?: readonly string[];
+}>;
+
+export type BlockedAllowlistItem = Readonly<{
+  allowItem: string;
+  blockedBy: string | 'blockSubaddressing';
+}>;
+
 const wildcard = '*';
 const emailSeparator = '@';
 const domainSeparator = '.';
 const whitespaceRegEx = /\s/u;
 const wildcardOnlyDomainRegEx = /^[*.]+$/u;
+const anyOtherCharacter: unique symbol = Symbol('anyOtherCharacter');
+
+type WildcardPattern = readonly string[];
+type WildcardPatternCharacter = string | typeof anyOtherCharacter;
 
 const hasWildcard = (value: string) => value.includes(wildcard);
 
@@ -26,14 +40,179 @@ const isValidWildcardDomain = (domain: string) =>
   !whitespaceRegEx.test(domain) &&
   !wildcardOnlyDomainRegEx.test(domain);
 
+const getEmailParts = (item: string) => {
+  if (item.startsWith(emailSeparator)) {
+    const domain = item.slice(1);
+
+    if (!domain || domain.includes(emailSeparator)) {
+      return;
+    }
+
+    return { domain };
+  }
+
+  const [localPart, domain, ...rest] = item.split(emailSeparator);
+
+  if (rest.length > 0 || !localPart || !domain) {
+    return;
+  }
+
+  return { localPart, domain };
+};
+
+const getLiteralCharacters = (...patterns: string[]): ReadonlySet<string> =>
+  new Set(
+    patterns.flatMap((pattern) => [...pattern].filter((character) => character !== wildcard))
+  );
+
+const epsilonClosure = (
+  pattern: WildcardPattern,
+  states: ReadonlySet<number>
+): ReadonlySet<number> => {
+  /* eslint-disable @silverhand/fp/no-mutating-methods -- finite automata traversal uses local queue state */
+  const closedStates = new Set(states);
+  const pendingStates = [...states];
+
+  for (const state of pendingStates) {
+    if (pattern[state] === wildcard && !closedStates.has(state + 1)) {
+      closedStates.add(state + 1);
+      pendingStates.push(state + 1);
+    }
+  }
+
+  return closedStates;
+  /* eslint-enable @silverhand/fp/no-mutating-methods */
+};
+
+const move = (
+  pattern: WildcardPattern,
+  states: ReadonlySet<number>,
+  character: WildcardPatternCharacter
+): ReadonlySet<number> => {
+  const nextStates = [...states].flatMap((state) => {
+    const token = pattern[state];
+
+    if (!token) {
+      return [];
+    }
+
+    if (token === wildcard) {
+      return [state];
+    }
+
+    if (character !== anyOtherCharacter && token === character) {
+      return [state + 1];
+    }
+
+    return [];
+  });
+
+  return epsilonClosure(pattern, new Set(nextStates));
+};
+
+const serializeStates = (states: ReadonlySet<number>) =>
+  [...states]
+    .slice()
+    .sort((left, right) => left - right)
+    .join(',');
+
+const isAccepted = (pattern: WildcardPattern, states: ReadonlySet<number>) =>
+  states.has(pattern.length);
+
+type StatePair = readonly [ReadonlySet<number>, ReadonlySet<number>];
+
+type PatternSubsetContext = Readonly<{
+  allowPattern: WildcardPattern;
+  blockPattern: WildcardPattern;
+  alphabet: readonly WildcardPatternCharacter[];
+}>;
+
+const hasUncoveredAcceptedState = (
+  context: PatternSubsetContext,
+  initialPendingPairs: readonly StatePair[]
+): boolean => {
+  const { allowPattern, alphabet, blockPattern } = context;
+
+  /* eslint-disable @silverhand/fp/no-let, @silverhand/fp/no-mutation, @silverhand/fp/no-mutating-methods -- finite automata traversal uses local queue/set state */
+  const pendingPairs = [...initialPendingPairs];
+  const visitedPairs = new Set<string>();
+  let index = 0;
+
+  while (index < pendingPairs.length) {
+    const statePair = pendingPairs[index];
+    index += 1;
+
+    if (!statePair) {
+      continue;
+    }
+
+    const [allowStates, blockStates] = statePair;
+    const pairKey = `${serializeStates(allowStates)}|${serializeStates(blockStates)}`;
+
+    if (visitedPairs.has(pairKey)) {
+      continue;
+    }
+
+    visitedPairs.add(pairKey);
+
+    if (isAccepted(allowPattern, allowStates) && !isAccepted(blockPattern, blockStates)) {
+      return true;
+    }
+
+    const nextPairs = alphabet.flatMap((character): StatePair[] => {
+      const nextAllowStates = move(allowPattern, allowStates, character);
+
+      return nextAllowStates.size > 0
+        ? [[nextAllowStates, move(blockPattern, blockStates, character)]]
+        : [];
+    });
+
+    pendingPairs.push(...nextPairs);
+  }
+
+  return false;
+  /* eslint-enable @silverhand/fp/no-let, @silverhand/fp/no-mutation, @silverhand/fp/no-mutating-methods */
+};
+
+const isWildcardPatternSubset = (allowPattern: string, blockPattern: string) => {
+  const alphabet: readonly WildcardPatternCharacter[] = [
+    ...getLiteralCharacters(allowPattern, blockPattern),
+    anyOtherCharacter,
+  ];
+  const allowPatternCharacters = [...allowPattern];
+  const blockPatternCharacters = [...blockPattern];
+  const initialAllowStates = epsilonClosure(allowPatternCharacters, new Set([0]));
+  const initialBlockStates = epsilonClosure(blockPatternCharacters, new Set([0]));
+  const initialPair = [initialAllowStates, initialBlockStates] as const;
+
+  return !hasUncoveredAcceptedState(
+    { allowPattern: allowPatternCharacters, alphabet, blockPattern: blockPatternCharacters },
+    [initialPair]
+  );
+};
+
+const isWildcardOnly = (pattern: string) =>
+  [...pattern].every((character) => character === wildcard);
+
+const isLocalPartCoveredBySubaddressing = (localPart: string) =>
+  hasWildcard(localPart)
+    ? isWildcardPatternSubset(localPart, `${wildcard}+${wildcard}`)
+    : localPart.includes('+');
+
+const isAllowItemCoveredBySubaddressing = (allowItem: string) => {
+  const allowParts = getEmailParts(allowItem);
+
+  return Boolean(allowParts?.localPart && isLocalPartCoveredBySubaddressing(allowParts.localPart));
+};
+
 /**
- * Validates an email blocklist item.
+ * Validates an email list item.
  *
  * An item can be either a full email address (`foo@example.com`) or a domain entry
  * prefixed with `@` (`@example.com`). `*` can be used inside the local part or
  * domain while keeping the same email/domain shapes.
  */
-export const isEmailBlocklistItem = (value: string) => {
+export const isEmailListItem = (value: string) => {
   if (!hasWildcard(value)) {
     return emailOrEmailDomainRegEx.test(value);
   }
@@ -63,12 +242,12 @@ export const isEmailBlocklistItem = (value: string) => {
 };
 
 /**
- * Checks whether an email address matches an email blocklist item.
+ * Checks whether an email address matches an email list item.
  *
  * Matching is case-insensitive. Domain items (`@example.com`) match only the email
  * domain, while full email items match the complete email address.
  */
-export const matchesEmailBlocklistItem = (item: string, email: string) => {
+export const matchesEmailListItem = (item: string, email: string) => {
   const normalizedItem = item.toLowerCase();
   const normalizedEmail = email.toLowerCase();
   const domain = normalizedEmail.split(emailSeparator)[1];
@@ -86,3 +265,63 @@ export const matchesEmailBlocklistItem = (item: string, email: string) => {
     ? buildWildcardRegExp(normalizedItem).test(normalizedEmail)
     : normalizedEmail === normalizedItem;
 };
+
+/**
+ * Checks whether every email address allowed by `allowItem` is denied by `blockItem`.
+ */
+export const isEmailListItemFullyCoveredByBlockItem = (allowItem: string, blockItem: string) => {
+  if (!isEmailListItem(allowItem) || !isEmailListItem(blockItem)) {
+    return false;
+  }
+
+  const normalizedAllowItem = allowItem.toLowerCase();
+  const normalizedBlockItem = blockItem.toLowerCase();
+  const allowParts = getEmailParts(normalizedAllowItem);
+  const blockParts = getEmailParts(normalizedBlockItem);
+
+  if (!allowParts || !blockParts) {
+    return false;
+  }
+
+  if (!blockParts.localPart) {
+    return isWildcardPatternSubset(allowParts.domain, blockParts.domain);
+  }
+
+  if (!allowParts.localPart) {
+    return (
+      isWildcardOnly(blockParts.localPart) &&
+      isWildcardPatternSubset(allowParts.domain, blockParts.domain)
+    );
+  }
+
+  return isWildcardPatternSubset(
+    `${allowParts.localPart}${emailSeparator}${allowParts.domain}`,
+    `${blockParts.localPart}${emailSeparator}${blockParts.domain}`
+  );
+};
+
+/**
+ * Finds allowlist entries that can never be used because block rules fully cover them.
+ */
+export const findBlockedAllowlistItems = (
+  allowlist: readonly string[],
+  { blockSubaddressing, customBlocklist = [] }: EmailBlocklistPolicyShape
+): BlockedAllowlistItem[] =>
+  allowlist.flatMap((allowItem) => {
+    if (!isEmailListItem(allowItem)) {
+      return [];
+    }
+
+    if (blockSubaddressing && isAllowItemCoveredBySubaddressing(allowItem)) {
+      return [{ allowItem, blockedBy: 'blockSubaddressing' }];
+    }
+
+    const blockedBy = customBlocklist.find((blockItem) =>
+      isEmailListItemFullyCoveredByBlockItem(allowItem, blockItem)
+    );
+
+    return blockedBy ? [{ allowItem, blockedBy }] : [];
+  });
+
+export const isEmailBlocklistItem = isEmailListItem;
+export const matchesEmailBlocklistItem = matchesEmailListItem;


### PR DESCRIPTION
## Summary

- add the sign-in experience email allowlist policy schema, storage column, and alteration
- parse and validate allowlist entries with wildcard support through PATCH `/sign-in-exp`
- reject allowlist entries that are fully covered by effective blocklist rules

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments