### PR TITLE
feat(core): enforce email allowlist policy

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -6,6 +6,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import {
   parseEmailAllowlistPolicy,
   parseEmailBlocklistPolicy,
+  validateEmailAgainstAccessPolicy,
   validateEmailAgainstBlocklistPolicy,
   isEmailBlocklistPolicyEnabled,
   isEmailAllowlistPolicyEnabled,
@@ -196,6 +197,52 @@ describe('validateEmailAgainstBlocklistPolicy', () => {
     await expect(
       validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, 'test@bar.com')
     ).resolves.not.toThrow();
+  });
+});
+
+describe('validateEmailAgainstAccessPolicy', () => {
+  it('should pass when allowlist is empty', async () => {
+    await expect(validateEmailAgainstAccessPolicy({}, {}, 'test@bar.com')).resolves.not.toThrow();
+  });
+
+  it('should pass when email matches allowlist entry', async () => {
+    await expect(
+      validateEmailAgainstAccessPolicy(
+        { customAllowlist: ['foo*@bar.com', '@example.com'] },
+        {},
+        'FooBar@bar.com'
+      )
+    ).resolves.not.toThrow();
+  });
+
+  it('should throw if email does not match the allowlist', async () => {
+    const email = 'test@bar.com';
+    await expect(
+      validateEmailAgainstAccessPolicy({ customAllowlist: ['@example.com'] }, {}, email)
+    ).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_allowlist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
+  });
+
+  it('should still apply blocklist after allowlist passes', async () => {
+    const email = 'foo@bar.com';
+    await expect(
+      validateEmailAgainstAccessPolicy(
+        { customAllowlist: ['@bar.com'] },
+        { customBlocklist: ['foo@bar.com'] },
+        email
+      )
+    ).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
   });
 });
 

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -2,6 +2,7 @@ import {
   findBlockedAllowlistItems,
   isEmailBlocklistItem,
   isEmailListItem,
+  matchesEmailListItem,
   matchesEmailBlocklistItem,
 } from '@logto/core-kit';
 import { type EmailAllowlistPolicy, type EmailBlocklistPolicy } from '@logto/schemas';
@@ -233,6 +234,36 @@ export const validateEmailAgainstBlocklistPolicy = async (
   if (blockDisposableAddresses) {
     await validateDisposableEmailDomain(email);
   }
+};
+
+/**
+ * Guard the email address against the sign-in experience access policies.
+ *
+ * @remarks
+ * - if custom allowlist is non-empty, the email must match at least one allowlist entry
+ * - then apply the existing blocklist rules
+ */
+export const validateEmailAgainstAccessPolicy = async (
+  emailAllowlistPolicy: EmailAllowlistPolicy,
+  emailBlocklistPolicy: EmailBlocklistPolicy,
+  email: string
+) => {
+  const { customAllowlist } = emailAllowlistPolicy;
+
+  if (customAllowlist && customAllowlist.length > 0) {
+    const isAllowed = customAllowlist.some((item) => matchesEmailListItem(item, email));
+
+    assertThat(
+      isAllowed,
+      new RequestError({
+        code: 'session.email_allowlist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
+  }
+
+  await validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, email);
 };
 
 export const isEmailBlocklistPolicyEnabled = (emailBlockListPolicy: EmailBlocklistPolicy) => {

--- a/packages/core/src/routes/account/email-and-phone.ts
+++ b/packages/core/src/routes/account/email-and-phone.ts
@@ -6,7 +6,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import { assertUserHasRemainingIdentifier } from '#src/utils/user.js';
 
 import RequestError from '../../errors/RequestError/index.js';
-import { validateEmailAgainstBlocklistPolicy } from '../../libraries/sign-in-experience/email-blocklist-policy.js';
+import { validateEmailAgainstAccessPolicy } from '../../libraries/sign-in-experience/email-blocklist-policy.js';
 import { buildVerificationRecordByIdAndType } from '../../libraries/verification.js';
 import assertThat from '../../utils/assert-that.js';
 import type { UserRouter, RouterInitArgs } from '../types.js';
@@ -49,9 +49,9 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
 
       assertThat(scopes.has(UserScope.Email), 'auth.unauthorized');
 
-      // Validate email blocklist policy
-      const { emailBlocklistPolicy } = await findDefaultSignInExperience();
-      await validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, email);
+      // Validate email access policy
+      const { emailAllowlistPolicy, emailBlocklistPolicy } = await findDefaultSignInExperience();
+      await validateEmailAgainstAccessPolicy(emailAllowlistPolicy, emailBlocklistPolicy, email);
 
       // Check new identifier
       const newVerificationRecord = await buildVerificationRecordByIdAndType({

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -290,7 +290,7 @@ export default class ExperienceInteraction {
       if (verificationRecord.type !== VerificationType.EnterpriseSso) {
         await this.signInExperienceValidator.guardSsoOnlyEmailIdentifier(verificationRecord);
       }
-      await this.signInExperienceValidator.guardEmailBlocklist(verificationRecord);
+      await this.signInExperienceValidator.guardEmailAccessPolicy(verificationRecord);
 
       const identifierProfile = await getNewUserProfileFromVerificationRecord(verificationRecord);
 

--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -12,7 +12,7 @@ import {
 } from '@logto/schemas';
 
 import RequestError from '#src/errors/RequestError/index.js';
-import { validateEmailAgainstBlocklistPolicy } from '#src/libraries/sign-in-experience/index.js';
+import { validateEmailAgainstAccessPolicy } from '#src/libraries/sign-in-experience/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -372,22 +372,27 @@ export class SignInExperienceValidator {
   }
 
   /**
-   * Guard the email address is not in the blocklist.
+   * Guard the email address against the allowlist and blocklist access policies.
    *
    * @remarks
-   * Use this method to guard the email address or domain is not in the blocklist.
+   * Use this method to guard the email address against sign-in experience email access policies.
+   * - guard custom email allowlist if provided
    * - guard disposable email domain if enabled
    * - guard email subaddessing if enabled
    * - guard custom email address/domain if provided
    */
-  public async guardEmailBlocklist(verificationRecord: VerificationRecord) {
+  public async guardEmailAccessPolicy(verificationRecord: VerificationRecord) {
     const email = getEmailIdentifierFromVerificationRecord(verificationRecord);
     if (!email) {
       return;
     }
 
-    const { emailBlocklistPolicy } = await this.getSignInExperienceData();
-    await validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, email);
+    const { emailAllowlistPolicy, emailBlocklistPolicy } = await this.getSignInExperienceData();
+    await validateEmailAgainstAccessPolicy(emailAllowlistPolicy, emailBlocklistPolicy, email);
+  }
+
+  public async guardEmailBlocklist(verificationRecord: VerificationRecord) {
+    await this.guardEmailAccessPolicy(verificationRecord);
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -118,7 +118,7 @@ export class Profile {
     // Guard SSO only email identifier in verification record  (EmailVerificationCode, Social)
     await this.signInExperienceValidator.guardSsoOnlyEmailIdentifier(verificationRecord);
 
-    await this.signInExperienceValidator.guardEmailBlocklist(verificationRecord);
+    await this.signInExperienceValidator.guardEmailAccessPolicy(verificationRecord);
 
     log?.append({
       verification: verificationRecord.toJson(),

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -17,7 +17,7 @@ type MockExperienceInteraction = {
   setVerificationRecord: jest.MockedFunction<() => Promise<void>>;
   save: jest.MockedFunction<() => Promise<void>>;
   signInExperienceValidator: {
-    guardEmailBlocklist: jest.MockedFunction<() => Promise<void>>;
+    guardEmailAccessPolicy: jest.MockedFunction<() => Promise<void>>;
     isRegistrationDisabled: jest.MockedFunction<() => Promise<boolean>>;
   };
 };
@@ -55,7 +55,7 @@ describe('sendCode parameter passing', () => {
     setVerificationRecord: jest.fn().mockImplementation(resolveVoid),
     save: jest.fn().mockImplementation(resolveVoid),
     signInExperienceValidator: {
-      guardEmailBlocklist: jest.fn().mockImplementation(resolveVoid),
+      guardEmailAccessPolicy: jest.fn().mockImplementation(resolveVoid),
       // Default: registration is enabled, so delivery is never suppressed for sign-in.
       isRegistrationDisabled: jest.fn().mockResolvedValue(false),
     },

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -142,12 +142,12 @@ export const sendCode = async ({
 
   const codeVerification = createVerificationRecord();
 
-  // Pre-validate email against blocklist for registration
+  // Pre-validate email against access policies for registration
   if (
     interactionEvent === InteractionEvent.Register &&
     identifier.type === SignInIdentifier.Email
   ) {
-    await experienceInteraction.signInExperienceValidator.guardEmailBlocklist(codeVerification);
+    await experienceInteraction.signInExperienceValidator.guardEmailAccessPolicy(codeVerification);
   }
 
   const skipDelivery = await shouldSkipDelivery(

--- a/packages/core/src/routes/verification/utils.ts
+++ b/packages/core/src/routes/verification/utils.ts
@@ -1,6 +1,6 @@
 import { SignInIdentifier, type VerificationCodeIdentifier } from '@logto/schemas';
 
-import { validateEmailAgainstBlocklistPolicy } from '#src/libraries/sign-in-experience/email-blocklist-policy.js';
+import { validateEmailAgainstAccessPolicy } from '#src/libraries/sign-in-experience/email-blocklist-policy.js';
 import type Queries from '#src/tenants/Queries.js';
 
 export const guardNewIdentifierEmailBlocklist = async (
@@ -12,6 +12,11 @@ export const guardNewIdentifierEmailBlocklist = async (
     return;
   }
 
-  const { emailBlocklistPolicy } = await queries.signInExperiences.findDefaultSignInExperience();
-  await validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, identifier.value);
+  const { emailAllowlistPolicy, emailBlocklistPolicy } =
+    await queries.signInExperiences.findDefaultSignInExperience();
+  await validateEmailAgainstAccessPolicy(
+    emailAllowlistPolicy,
+    emailBlocklistPolicy,
+    identifier.value
+  );
 };

--- a/packages/phrases/src/locales/ar/errors/session.ts
+++ b/packages/phrases/src/locales/ar/errors/session.ts
@@ -60,6 +60,10 @@ const session = {
     email_subaddressing_not_allowed: 'لا يُسمح بتوجيه البريد الإلكتروني الإضافي.',
     email_not_allowed: 'عنوان البريد الإلكتروني "{{email}}" مقيد. يرجى اختيار عنوان آخر.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'عدم تطابق ملف تعريف الارتباط لخدمة Google One Tap.',
     invalid_id_token: 'رمز معرف Google غير صالح.',

--- a/packages/phrases/src/locales/de/errors/session.ts
+++ b/packages/phrases/src/locales/de/errors/session.ts
@@ -70,6 +70,10 @@ const session = {
     email_subaddressing_not_allowed: 'E-Mail-Subadressierung ist nicht erlaubt.',
     email_not_allowed: 'Die E-Mail-Adresse "{{email}}" ist eingeschränkt. Bitte wähle eine andere.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Google One Tap Cookie-Störung.',
     invalid_id_token: 'Ungültiges Google-ID-Token.',

--- a/packages/phrases/src/locales/en/errors/session.ts
+++ b/packages/phrases/src/locales/en/errors/session.ts
@@ -65,6 +65,10 @@ const session = {
     email_not_allowed:
       'The email address "{{email}}" is restricted. Please choose a different one.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Google One Tap cookie mismatch.',
     invalid_id_token: 'Invalid Google ID Token.',

--- a/packages/phrases/src/locales/es/errors/session.ts
+++ b/packages/phrases/src/locales/es/errors/session.ts
@@ -75,6 +75,10 @@ const session = {
     email_not_allowed:
       'La dirección de correo electrónico "{{email}}" está restringida. Por favor, elige otra diferente.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Incompatibilidad de cookie de Google One Tap.',
     invalid_id_token: 'Token de ID de Google no válido.',

--- a/packages/phrases/src/locales/fa-ir/errors/session.ts
+++ b/packages/phrases/src/locales/fa-ir/errors/session.ts
@@ -61,6 +61,10 @@ const session = {
     email_subaddressing_not_allowed: 'زیرآدرس ایمیل مجاز نیست.',
     email_not_allowed: 'آدرس ایمیل «{{email}}» محدود شده است. لطفاً آدرس دیگری انتخاب کنید.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'عدم تطابق کوکی Google One Tap.',
     invalid_id_token: 'توکن شناسایی Google نامعتبر است.',

--- a/packages/phrases/src/locales/fr/errors/session.ts
+++ b/packages/phrases/src/locales/fr/errors/session.ts
@@ -74,6 +74,10 @@ const session = {
     email_not_allowed:
       'L\'adresse e-mail "{{email}}" est restreinte. Veuillez en choisir une autre.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Incompatibilité des cookies Google One Tap.',
     invalid_id_token: "Jeton d'ID Google invalide.",

--- a/packages/phrases/src/locales/it/errors/session.ts
+++ b/packages/phrases/src/locales/it/errors/session.ts
@@ -69,6 +69,10 @@ const session = {
     email_not_allowed:
       'L\'indirizzo email "{{email}}" è ristretto. Si prega di sceglierne un altro.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Discrepanza dei cookie di Google One Tap.',
     invalid_id_token: 'Token ID Google non valido.',

--- a/packages/phrases/src/locales/ja/errors/session.ts
+++ b/packages/phrases/src/locales/ja/errors/session.ts
@@ -67,6 +67,10 @@ const session = {
     email_not_allowed:
       'メールアドレス "{{email}}" は制限されています。別のものを選択してください。',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Google One Tap クッキーが一致しません。',
     invalid_id_token: '無効な Google ID トークン。',

--- a/packages/phrases/src/locales/ko/errors/session.ts
+++ b/packages/phrases/src/locales/ko/errors/session.ts
@@ -63,6 +63,10 @@ const session = {
     email_subaddressing_not_allowed: '이메일 서브어드레싱은 허용되지 않아요.',
     email_not_allowed: '이메일 주소 "{{email}}" 는 제한되어 있어요. 다른 주소를 선택해 주세요.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Google One Tap 쿠키가 일치하지 않아요.',
     invalid_id_token: '유효하지 않은 Google ID 토큰이에요.',

--- a/packages/phrases/src/locales/pl-pl/errors/session.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/session.ts
@@ -68,6 +68,10 @@ const session = {
     email_subaddressing_not_allowed: 'Dodawanie subadresów do emaila nie jest dozwolone.',
     email_not_allowed: 'Adres email "{{email}}" jest zastrzeżony. Proszę wybrać inny.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Nieprawidłowe dopasowanie ciasteczek Google One Tap.',
     invalid_id_token: 'Nieprawidłowy token ID Google.',

--- a/packages/phrases/src/locales/pt-br/errors/session.ts
+++ b/packages/phrases/src/locales/pt-br/errors/session.ts
@@ -70,6 +70,10 @@ const session = {
     email_not_allowed:
       'O endereço de email "{{email}}" está restrito. Por favor, escolha um diferente.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Incompatibilidade de cookies do Google One Tap.',
     invalid_id_token: 'Token de ID do Google inválido.',

--- a/packages/phrases/src/locales/pt-pt/errors/session.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/session.ts
@@ -73,6 +73,10 @@ const session = {
     email_not_allowed:
       'O endereço de email "{{email}}" é restrito. Por favor, escolha um diferente.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Incompatibilidade do cookie do Google One Tap.',
     invalid_id_token: 'Token de ID do Google inválido.',

--- a/packages/phrases/src/locales/ru/errors/session.ts
+++ b/packages/phrases/src/locales/ru/errors/session.ts
@@ -69,6 +69,10 @@ const session = {
     email_not_allowed:
       'Адрес электронной почты "{{email}}" ограничен. Пожалуйста, выберите другой.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Несоответствие cookie Google One Tap.',
     invalid_id_token: 'Недействительный токен Google ID.',

--- a/packages/phrases/src/locales/th/errors/session.ts
+++ b/packages/phrases/src/locales/th/errors/session.ts
@@ -60,6 +60,10 @@ const session = {
     email_subaddressing_not_allowed: 'ไม่อนุญาตให้ใช้อีเมลแบบ subaddressing',
     email_not_allowed: 'อีเมล "{{email}}" ถูกจำกัด กรุณาเลือกอีเมลอื่น',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'คุกกี้ Google One Tap ไม่ตรงกัน',
     invalid_id_token: 'Google ID Token ไม่ถูกต้อง',

--- a/packages/phrases/src/locales/tr-tr/errors/session.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/session.ts
@@ -66,6 +66,10 @@ const session = {
     email_subaddressing_not_allowed: 'E-posta alt adreslemesine izin verilmiyor.',
     email_not_allowed: 'Kısıtlanmış e-posta adresi "{{email}}". Lütfen farklı bir tane seçiniz.',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Google One Tap çerezleri uyuşmuyor.',
     invalid_id_token: 'Geçersiz Google Kimliği Jetonu.',

--- a/packages/phrases/src/locales/zh-cn/errors/session.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/session.ts
@@ -54,6 +54,10 @@ const session = {
     email_subaddressing_not_allowed: '不允许电子邮件子地址。',
     email_not_allowed: '电子邮件地址 "{{email}}" 受限。请选择其他地址。',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Google One Tap cookie 不匹配。',
     invalid_id_token: '无效的 Google ID Token。',

--- a/packages/phrases/src/locales/zh-hk/errors/session.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/session.ts
@@ -54,6 +54,10 @@ const session = {
     email_subaddressing_not_allowed: '不允許使用電子郵件子地址。',
     email_not_allowed: '電子郵件地址 "{{email}}" 受限。請選擇其他地址。',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Google One Tap cookie 不匹配。',
     invalid_id_token: '無效的 Google ID Token。',

--- a/packages/phrases/src/locales/zh-tw/errors/session.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/session.ts
@@ -54,6 +54,10 @@ const session = {
     email_subaddressing_not_allowed: '不允許使用電子郵件子地址。',
     email_not_allowed: '電子郵件地址 "{{email}}" 受到限制。請選擇不同的地址。',
   },
+  email_allowlist: {
+    email_not_allowed:
+      'The email address "{{email}}" is not allowed. Please use an allowed email address.',
+  },
   google_one_tap: {
     cookie_mismatch: 'Google One Tap cookie 不匹配。',
     invalid_id_token: '無效的 Google ID token。',


### PR DESCRIPTION
## Summary

- add runtime email access policy validation that checks allowlist before existing blocklist rules
- enforce the policy in Experience registration/profile flows, verification utilities, and Account API primary-email updates
- add session error phrases for allowlist rejections

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments