### PR TITLE
chore(deps): update dependency jose to v6

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,7 @@
     "http-errors": "^2.0.0",
     "i18next": "^22.4.15",
     "iconv-lite": "0.6.3",
-    "jose": "^5.6.3",
+    "jose": "^6.2.3",
     "koa": "^3.2.1",
     "koa-body": "^8.0.0",
     "koa-compose": "^4.1.0",

--- a/packages/core/src/oidc/grants/token-exchange/account.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.ts
@@ -1,5 +1,5 @@
 import { trySafe } from '@silverhand/essentials';
-import { type JWSHeaderParameters, type FlattenedJWSInput, type KeyLike, jwtVerify } from 'jose';
+import { type CryptoKey, type JWSHeaderParameters, type FlattenedJWSInput, jwtVerify } from 'jose';
 import { type Provider, errors } from 'oidc-provider';
 
 import type Queries from '#src/tenants/Queries.js';
@@ -20,7 +20,7 @@ type ValidateSubjectTokenParams = {
     localJWKSet: (
       protectedHeader: JWSHeaderParameters,
       token: FlattenedJWSInput
-    ) => Promise<KeyLike | Uint8Array>;
+    ) => Promise<CryptoKey>;
     issuer: string;
   };
 };

--- a/packages/core/src/oidc/grants/token-exchange/account.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.ts
@@ -1,5 +1,5 @@
 import { trySafe } from '@silverhand/essentials';
-import { type CryptoKey, type JWSHeaderParameters, type FlattenedJWSInput, jwtVerify } from 'jose';
+import { type JWTVerifyGetKey, jwtVerify } from 'jose';
 import { type Provider, errors } from 'oidc-provider';
 
 import type Queries from '#src/tenants/Queries.js';
@@ -17,10 +17,7 @@ type ValidateSubjectTokenParams = {
   AccessToken: Provider['AccessToken'];
   /** For JWT access token verification. */
   jwtVerificationOptions?: {
-    localJWKSet: (
-      protectedHeader: JWSHeaderParameters,
-      token: FlattenedJWSInput
-    ) => Promise<CryptoKey>;
+    localJWKSet: JWTVerifyGetKey;
     issuer: string;
   };
 };

--- a/packages/core/src/utils/jwks.ts
+++ b/packages/core/src/utils/jwks.ts
@@ -5,7 +5,7 @@
 
 import { createHash } from 'node:crypto';
 
-import { type CryptoKey, type JWK, type KeyObject, exportJWK as joseExportJWK } from 'jose';
+import { type JWK, exportJWK as joseExportJWK } from 'jose';
 
 const getCalculateKidComponents = (jwk: JWK) => {
   switch (jwk.kty) {
@@ -43,7 +43,7 @@ const calculateKid = (jwk: JWK) => {
   return createHash('sha256').update(JSON.stringify(components)).digest().toString('base64url');
 };
 
-export const exportJWK = async (key: CryptoKey | KeyObject | Uint8Array): Promise<JWK> => {
+export const exportJWK = async (key: Parameters<typeof joseExportJWK>[0]): Promise<JWK> => {
   const jwk = await joseExportJWK(key);
 
   return {

--- a/packages/core/src/utils/jwks.ts
+++ b/packages/core/src/utils/jwks.ts
@@ -5,7 +5,7 @@
 
 import { createHash } from 'node:crypto';
 
-import { type JWK, type KeyLike, exportJWK as joseExportJWK } from 'jose';
+import { type CryptoKey, type JWK, type KeyObject, exportJWK as joseExportJWK } from 'jose';
 
 const getCalculateKidComponents = (jwk: JWK) => {
   switch (jwk.kty) {
@@ -43,7 +43,7 @@ const calculateKid = (jwk: JWK) => {
   return createHash('sha256').update(JSON.stringify(components)).digest().toString('base64url');
 };
 
-export const exportJWK = async (key: KeyLike | Uint8Array): Promise<JWK> => {
+export const exportJWK = async (key: CryptoKey | KeyObject | Uint8Array): Promise<JWK> => {
   const jwk = await joseExportJWK(key);
 
   return {

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -36,7 +36,7 @@
     "eslint": "^8.56.0",
     "i18next": "^22.4.15",
     "i18next-browser-languagedetector": "^8.0.0",
-    "jose": "^5.6.3",
+    "jose": "^6.2.3",
     "lint-staged": "^15.0.0",
     "prettier": "^3.5.3",
     "react": "^18.3.1",

--- a/packages/device-demo-app/package.json
+++ b/packages/device-demo-app/package.json
@@ -31,7 +31,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^8.56.0",
-    "jose": "^5.6.3",
+    "jose": "^6.2.3",
     "lint-staged": "^15.0.0",
     "prettier": "^3.5.3",
     "qrcode": "^1.5.4",

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -45,7 +45,7 @@
     "jest": "^29.7.0",
     "jest-matcher-specific-error": "^1.0.0",
     "jest-puppeteer": "^11.0.0",
-    "jose": "^5.6.3",
+    "jose": "^6.2.3",
     "ky": "^1.2.3",
     "lint-staged": "^15.0.0",
     "openapi-schema-validator": "^12.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4200,8 +4200,8 @@ importers:
         specifier: 0.6.3
         version: 0.6.3
       jose:
-        specifier: ^5.6.3
-        version: 5.9.6
+        specifier: ^6.2.3
+        version: 6.2.3
       koa:
         specifier: ^3.2.1
         version: 3.2.1
@@ -4477,8 +4477,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0
       jose:
-        specifier: ^5.6.3
-        version: 5.9.6
+        specifier: ^6.2.3
+        version: 6.2.3
       lint-staged:
         specifier: ^15.0.0
         version: 15.0.2
@@ -4549,8 +4549,8 @@ importers:
         specifier: ^8.56.0
         version: 8.57.0
       jose:
-        specifier: ^5.6.3
-        version: 5.9.6
+        specifier: ^6.2.3
+        version: 6.2.3
       lint-staged:
         specifier: ^15.0.0
         version: 15.0.2
@@ -4944,8 +4944,8 @@ importers:
         specifier: ^11.0.0
         version: 11.0.0(puppeteer@23.10.3(typescript@5.5.3))(typescript@5.5.3)
       jose:
-        specifier: ^5.6.3
-        version: 5.9.6
+        specifier: ^6.2.3
+        version: 6.2.3
       ky:
         specifier: ^1.2.3
         version: 1.2.3
@@ -12214,6 +12214,9 @@ packages:
 
   jose@5.9.6:
     resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -24821,6 +24824,8 @@ snapshots:
       '@sideway/pinpoint': 2.0.0
 
   jose@5.9.6: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- bump jose from v5 to v6 across core, demo apps, and integration tests
- update jose key types while preserving Node KeyObject support
- resolve LOG-13797

## Testing

- Tested locally
- Unit tests