### PR TITLE
chore(connector): upgrade jose to v6

### DIFF
--- a/.changeset/connector-jose-v6.md
+++ b/.changeset/connector-jose-v6.md
@@ -1,0 +1,10 @@
+---
+"@logto/connector-apple": patch
+"@logto/connector-google": patch
+"@logto/connector-oauth": patch
+"@logto/connector-oidc": patch
+---
+
+upgrade jose from v5 to v6
+
+These connectors now use jose 6, which runs on the Web Crypto API instead of Node's crypto module. Token signing and ID token verification behave exactly as before.

--- a/.changeset/gitlab-drop-jose.md
+++ b/.changeset/gitlab-drop-jose.md
@@ -1,0 +1,7 @@
+---
+"@logto/connector-gitlab": patch
+---
+
+remove the unused jose dependency
+
+The GitLab connector declared jose as a dependency but never imported it, so installing the connector pulled in a package it did not need.

--- a/packages/connectors/connector-apple/package.json
+++ b/packages/connectors/connector-apple/package.json
@@ -7,7 +7,7 @@
     "@logto/shared": "workspace:^",
     "@silverhand/essentials": "^2.9.1",
     "got": "^14.0.0",
-    "jose": "^5.6.3",
+    "jose": "^6.2.3",
     "snakecase-keys": "^8.0.1",
     "zod": "3.24.3"
   },

--- a/packages/connectors/connector-gitlab/package.json
+++ b/packages/connectors/connector-gitlab/package.json
@@ -7,7 +7,6 @@
     "@logto/connector-oauth": "workspace:^",
     "@logto/shared": "workspace:^",
     "@silverhand/essentials": "^2.9.1",
-    "jose": "^5.6.3",
     "ky": "^1.2.3",
     "nanoid": "^5.0.9",
     "snakecase-keys": "^8.0.1",

--- a/packages/connectors/connector-google/package.json
+++ b/packages/connectors/connector-google/package.json
@@ -7,7 +7,7 @@
     "@logto/connector-kit": "workspace:^",
     "@silverhand/essentials": "^2.9.1",
     "got": "^14.0.0",
-    "jose": "^5.6.3",
+    "jose": "^6.2.3",
     "snakecase-keys": "^8.0.1",
     "zod": "3.24.3"
   },

--- a/packages/connectors/connector-oauth2/package.json
+++ b/packages/connectors/connector-oauth2/package.json
@@ -7,7 +7,7 @@
     "@logto/connector-kit": "workspace:^",
     "@logto/shared": "workspace:^",
     "@silverhand/essentials": "^2.9.1",
-    "jose": "^5.6.3",
+    "jose": "^6.2.3",
     "ky": "^1.2.3",
     "query-string": "^9.0.0",
     "snakecase-keys": "^8.0.1",

--- a/packages/connectors/connector-oidc/package.json
+++ b/packages/connectors/connector-oidc/package.json
@@ -7,7 +7,7 @@
     "@logto/connector-oauth": "workspace:^",
     "@logto/shared": "workspace:^",
     "@silverhand/essentials": "^2.9.1",
-    "jose": "^5.6.3",
+    "jose": "^6.2.3",
     "ky": "^1.2.3",
     "nanoid": "^5.0.9",
     "snakecase-keys": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,8 +872,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       jose:
-        specifier: ^5.6.3
-        version: 5.9.6
+        specifier: ^6.2.3
+        version: 6.2.3
       snakecase-keys:
         specifier: ^8.0.1
         version: 8.0.1
@@ -1420,9 +1420,6 @@ importers:
       '@silverhand/essentials':
         specifier: ^2.9.1
         version: 2.9.2
-      jose:
-        specifier: ^5.6.3
-        version: 5.9.6
       ky:
         specifier: ^1.2.3
         version: 1.2.3
@@ -1488,8 +1485,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       jose:
-        specifier: ^5.6.3
-        version: 5.9.6
+        specifier: ^6.2.3
+        version: 6.2.3
       snakecase-keys:
         specifier: ^8.0.1
         version: 8.0.1
@@ -2474,8 +2471,8 @@ importers:
         specifier: ^2.9.1
         version: 2.9.2
       jose:
-        specifier: ^5.6.3
-        version: 5.9.6
+        specifier: ^6.2.3
+        version: 6.2.3
       ky:
         specifier: ^1.2.3
         version: 1.2.3
@@ -2544,8 +2541,8 @@ importers:
         specifier: ^2.9.1
         version: 2.9.2
       jose:
-        specifier: ^5.6.3
-        version: 5.9.6
+        specifier: ^6.2.3
+        version: 6.2.3
       ky:
         specifier: ^1.2.3
         version: 1.2.3


### PR DESCRIPTION
## Summary

Upgrade jose from v5 to v6 in the connectors.

- bump jose from v5 to v6 in `@logto/connector-apple`, `@logto/connector-google`, `@logto/connector-oauth`, and `@logto/connector-oidc`
- drop the unused jose dependency from `@logto/connector-gitlab` — it was declared in `package.json` but never imported anywhere in the package

No source changes were needed: the jose APIs these connectors use (`createRemoteJWKSet`, `jwtVerify`, `SignJWT`) keep the same signatures in v6.

Note that jose v5 remains in the dependency tree regardless, since `oidc-provider` and `@logto/client` both pin it. This PR is about keeping our own packages current, not about deduplicating jose.

## Testing

Tested locally.

The existing unit tests for `connector-apple` and `connector-oauth` mock the jose module wholesale, so they cannot catch a breaking change in jose itself. The jose v6 code paths were therefore exercised directly:

- **`connector-oauth` client_secret_jwt signing** passes `Buffer.from(clientSecret)` to `SignJWT#sign`, while jose v6 types the parameter as `Uint8Array`. Signing and verifying round-trips under HS256/HS384/HS512 on both v5 and v6, and the error raised when the key type genuinely mismatches is unchanged (`Buffer` is a `Uint8Array` subclass).
- **ID token verification** in `connector-apple`, `connector-google`, and `connector-oidc` goes through `createRemoteJWKSet` + `jwtVerify`. Verified against a local JWKS server with real keys under RS256 (what Apple and Google actually sign with), ES256, and ES384. This is the path most at risk in v6, which drops the Node-specific implementation and runs on Web Crypto only.

## Checklist

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
