### PR TITLE
fix(core): bound connector usage lookup with a timeout

### DIFF
--- a/packages/core/src/utils/connectors/index.test.ts
+++ b/packages/core/src/utils/connectors/index.test.ts
@@ -1,0 +1,52 @@
+import { type GetUsageFunction } from '@logto/connector-kit';
+
+import { mockAliyunDmConnector } from '#src/__mocks__/connector.js';
+import { type LogtoConnector } from '#src/utils/connectors/types.js';
+
+const { transpileLogtoConnector } = await import('./index.js');
+
+// `mockAliyunDmConnector` is an email (passwordless) connector; attach a `getUsage` implementation.
+const buildEmailConnector = (
+  getUsage: GetUsageFunction
+): LogtoConnector & { getUsage: GetUsageFunction } => ({
+  ...mockAliyunDmConnector,
+  getUsage,
+});
+
+// Intentionally never resolve to simulate a stuck cloud usage lookup without extra timers.
+const hang: GetUsageFunction = async () =>
+  new Promise<number>((resolve) => {
+    void resolve;
+  });
+
+describe('transpileLogtoConnector usage', () => {
+  it('includes usage when getUsage resolves in time', async () => {
+    const connector = buildEmailConnector(async () => 42);
+
+    const result = await transpileLogtoConnector(connector);
+
+    expect(result.usage).toBe(42);
+  });
+
+  it('omits usage when getUsage rejects', async () => {
+    const connector = buildEmailConnector(async () => {
+      throw new Error('cloud usage lookup failed');
+    });
+
+    const result = await transpileLogtoConnector(connector);
+
+    expect(result.usage).toBeUndefined();
+  });
+
+  it('does not block the response when getUsage hangs', async () => {
+    const connector = buildEmailConnector(hang);
+
+    const start = Date.now();
+    const result = await transpileLogtoConnector(connector);
+
+    expect(result.usage).toBeUndefined();
+    // The 3s deadline fired instead of waiting on the stuck lookup.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(2900);
+    // Generous Jest budget so the ~3s real-timer wait can't brush the default timeout under CI load.
+  }, 8000);
+});

--- a/packages/core/src/utils/connectors/index.ts
+++ b/packages/core/src/utils/connectors/index.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import { setTimeout } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 
 import type { ConnectorFactory } from '@logto/cli/lib/connector/index.js';
@@ -11,11 +12,12 @@ import {
   demoConnectorIds,
   ConnectorType,
   type EmailConnector,
+  type GetUsageFunction,
   type SmsConnector,
 } from '@logto/connector-kit';
 import type { ConnectorFactoryResponse, ConnectorResponse } from '@logto/schemas';
 import { findPackage } from '@logto/shared';
-import { conditional, deduplicate, pick, trySafe } from '@silverhand/essentials';
+import { type Optional, conditional, deduplicate, pick, trySafe } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -29,6 +31,36 @@ const isPasswordlessLogtoConnector = (
 
 const isDemoConnector = (connectorId: string) => demoConnectorIds.includes(connectorId);
 
+// `getUsage` reaches out to the Logto Cloud service, so a slow or hanging usage lookup must never
+// block the connector response.
+const getUsageTimeout = 3000;
+const usageTimeoutSentinel = Symbol('connector-usage-timeout');
+
+/**
+ * Resolve the connector's usage, bounded by a deadline. `getUsage` calls the cloud service; racing
+ * it against a timeout keeps a slow response from blocking the connector list/detail responses. On
+ * timeout or error the usage is omitted (it is best-effort) — errors are swallowed by `trySafe` and
+ * the timer is cancelled once `getUsage` settles first.
+ */
+const getUsageWithTimeout = async (
+  getUsage: GetUsageFunction,
+  startFrom: Date
+): Promise<Optional<number>> => {
+  const abortController = new AbortController();
+  const timeoutPromise = setTimeout(getUsageTimeout, usageTimeoutSentinel, {
+    // Best-effort usage lookup; the deadline timer must not keep the process alive.
+    ref: false,
+    signal: abortController.signal,
+  });
+
+  try {
+    const usage = await Promise.race([trySafe(getUsage(startFrom)), timeoutPromise]);
+    return usage === usageTimeoutSentinel ? undefined : usage;
+  } finally {
+    abortController.abort();
+  }
+};
+
 export const transpileLogtoConnector = async (
   connector: LogtoConnector,
   extraInfo?: ConnectorResponse['extraInfo']
@@ -37,7 +69,11 @@ export const transpileLogtoConnector = async (
     /** Should do the check in advance since only passwordless connectors could have `getUsage` method. */
     isPasswordlessLogtoConnector(connector) &&
       connector.getUsage && {
-        usage: await trySafe(connector.getUsage(new Date(connector.dbEntry.createdAt))),
+        usage: await getUsageWithTimeout(
+          // Bind the receiver so an implementation relying on `this` keeps the previous method-call semantics.
+          connector.getUsage.bind(connector),
+          new Date(connector.dbEntry.createdAt)
+        ),
       }
   );
   const { dbEntry, metadata, type } = connector;


### PR DESCRIPTION
## Summary

`GET /connectors` (and the connector detail endpoint) call the built-in email connector's `getUsage` while transpiling each connector. `getUsage` reaches out to the Logto Cloud service over HTTP, and the call had no timeout — a slow or hanging usage lookup blocked the entire connector response. Under a slow cloud usage query this surfaced as connector-endpoint timeouts.

Usage is best-effort (the call site already wraps it in `trySafe` and drops errors), so it should never gate the response. This races `getUsage` against a 3s deadline in `transpileLogtoConnector`; on timeout the `usage` field is simply omitted. The pattern mirrors the existing `raceWithTimeout` used for Redis cache I/O in `caches/index.ts` (sentinel + `AbortController` to cancel the timer, `ref: false` so it can't keep the process alive).

The underlying slow usage query is a cloud-side issue addressed separately; this is a defensive core-side guard.

## Testing

Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
