### PR TITLE
test(test): cover OIDC provider integration hooks

### DIFF
--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -36,6 +36,7 @@
     "@logto/shared": "workspace:^",
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/essentials": "^2.9.1",
+    "@silverhand/slonik": "31.0.0-beta.2",
     "@silverhand/ts-config": "6.0.0",
     "@types/jest": "^29.4.0",
     "@types/node": "^22.14.0",

--- a/packages/integration-tests/src/tests/api/oidc/comma-separated-resource.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/comma-separated-resource.test.ts
@@ -1,0 +1,57 @@
+import { demoAppApplicationId } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+import ky from 'ky';
+
+import { createResource, deleteResource } from '#src/api/resource.js';
+import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
+
+const codeChallenge = 'a'.repeat(43);
+
+const requestAuthorization = async (resources: string[], commaSeparated: boolean) => {
+  const resourceParameters = commaSeparated
+    ? [['resource', resources.join(',')]]
+    : resources.map((resource) => ['resource', resource]);
+  const searchParameters = new URLSearchParams([
+    ['client_id', demoAppApplicationId],
+    ['code_challenge', codeChallenge],
+    ['code_challenge_method', 'S256'],
+    ['redirect_uri', demoAppRedirectUri],
+    ['response_type', 'code'],
+    ['scope', 'openid'],
+    ...resourceParameters,
+  ]);
+  const url = new URL(`/oidc/auth?${searchParameters.toString()}`, logtoUrl);
+
+  const response = await ky.get(url, { redirect: 'manual', throwHttpErrors: false });
+  const location = response.headers.get('location');
+  assert(location, new Error('Missing authorization response location'));
+
+  return {
+    location: new URL(location, logtoUrl).pathname,
+    status: response.status,
+  };
+};
+
+describe('comma-separated resource parameter', () => {
+  it('behaves like separate resource parameters on the authorization endpoint', async () => {
+    const resources = await Promise.all([createResource(), createResource()]);
+
+    try {
+      const [separateResult, commaSeparatedResult] = await Promise.all([
+        requestAuthorization(
+          resources.map(({ indicator }) => indicator),
+          false
+        ),
+        requestAuthorization(
+          resources.map(({ indicator }) => indicator),
+          true
+        ),
+      ]);
+
+      expect(separateResult).toEqual({ location: '/sign-in', status: 303 });
+      expect(commaSeparatedResult).toEqual(separateResult);
+    } finally {
+      await Promise.all(resources.map(async ({ id }) => deleteResource(id)));
+    }
+  });
+});

--- a/packages/integration-tests/src/tests/api/oidc/rp-initiated-logout.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/rp-initiated-logout.test.ts
@@ -1,0 +1,88 @@
+import { formUrlEncodedHeaders } from '@logto/shared';
+import { assert } from '@silverhand/essentials';
+import ky from 'ky';
+
+import { deleteUser } from '#src/api/index.js';
+import { logtoUrl } from '#src/constants.js';
+import { initExperienceClient, processSession } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import { createUserByAdmin } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generatePassword, generateUsername } from '#src/utils.js';
+
+const getHtmlAttribute = (element: string, attribute: string) =>
+  new RegExp(`\\b${attribute}=["']([^"']*)["']`, 'i').exec(element)?.[1];
+
+describe('RP-initiated logout pages', () => {
+  const username = generateUsername();
+  const password = generatePassword();
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let userId = '';
+
+  beforeAll(async () => {
+    const user = await createUserByAdmin({ username, password });
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    userId = user.id;
+    await enableAllPasswordSignInMethods();
+  });
+
+  afterAll(async () => {
+    await deleteUser(userId);
+  });
+
+  it('renders the custom confirmation and localized success pages without an ID token hint', async () => {
+    const client = await initExperienceClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+    const { redirectTo } = await client.submitInteraction();
+    await processSession(client, redirectTo);
+
+    const endSessionUrl = new URL('/oidc/session/end', logtoUrl);
+    const confirmationResponse = await ky.get(endSessionUrl, {
+      headers: {
+        'accept-language': 'zh-CN',
+        cookie: client.getCookieHeader(endSessionUrl.pathname),
+      },
+      redirect: 'manual',
+    });
+    const confirmationPage = await confirmationResponse.text();
+    const form = /<form\b[^>]*id=["']op\.logoutform["'][^>]*>/i.exec(confirmationPage)?.[0];
+
+    expect(confirmationResponse.status).toBe(200);
+    expect(confirmationPage).toContain('<title>Sign Out</title>');
+    expect(confirmationPage).toContain(
+      'onload="document.getElementById(\'op.logoutForm\').submit();"'
+    );
+    expect(confirmationPage).toContain('name="logout"');
+    assert(form, new Error('Missing logout confirmation form'));
+
+    const action = getHtmlAttribute(form, 'action');
+    const xsrfInput = /<input\b[^>]*name=["']xsrf["'][^>]*>/i.exec(confirmationPage)?.[0];
+    const xsrf = xsrfInput && getHtmlAttribute(xsrfInput, 'value');
+    assert(action && xsrf, new Error('Missing logout confirmation form values'));
+
+    client.mergeRawCookies(confirmationResponse.headers.getSetCookie());
+    const confirmUrl = new URL(action, logtoUrl);
+    const confirmResponse = await ky.post(confirmUrl, {
+      body: new URLSearchParams({ logout: 'yes', xsrf }),
+      headers: {
+        ...formUrlEncodedHeaders,
+        cookie: client.getCookieHeader(confirmUrl.pathname),
+      },
+      redirect: 'manual',
+      throwHttpErrors: false,
+    });
+    const successLocation = confirmResponse.headers.get('location');
+
+    expect(confirmResponse.status).toBe(303);
+    assert(successLocation, new Error('Missing post-logout success page location'));
+
+    const successResponse = await ky.get(new URL(successLocation, logtoUrl), {
+      headers: { 'accept-language': 'zh-CN' },
+    });
+    const successPage = await successResponse.text();
+
+    expect(successResponse.status).toBe(200);
+    expect(successPage).toContain('<title>Sign Out</title>');
+    expect(successPage).toContain('你已经成功登出。');
+  });
+});

--- a/packages/integration-tests/src/tests/api/oidc/rp-initiated-logout.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/rp-initiated-logout.test.ts
@@ -39,7 +39,7 @@ describe('RP-initiated logout pages', () => {
     const endSessionUrl = new URL('/oidc/session/end', logtoUrl);
     const confirmationResponse = await ky.get(endSessionUrl, {
       headers: {
-        'accept-language': 'zh-CN',
+        'accept-language': 'en',
         cookie: client.getCookieHeader(endSessionUrl.pathname),
       },
       redirect: 'manual',
@@ -77,12 +77,12 @@ describe('RP-initiated logout pages', () => {
     assert(successLocation, new Error('Missing post-logout success page location'));
 
     const successResponse = await ky.get(new URL(successLocation, logtoUrl), {
-      headers: { 'accept-language': 'zh-CN' },
+      headers: { 'accept-language': 'en' },
     });
     const successPage = await successResponse.text();
 
     expect(successResponse.status).toBe(200);
     expect(successPage).toContain('<title>Sign Out</title>');
-    expect(successPage).toContain('你已经成功登出。');
+    expect(successPage).toContain('You have successfully signed out.');
   });
 });

--- a/packages/integration-tests/src/tests/api/oidc/token-metering.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/token-metering.test.ts
@@ -1,0 +1,148 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { ApplicationType, defaultTenantId, demoAppApplicationId } from '@logto/schemas';
+import { assert, assertEnv } from '@silverhand/essentials';
+import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
+
+import { oidcApi } from '#src/api/api.js';
+import { createApplication, deleteApplication } from '#src/api/application.js';
+import { deleteUser } from '#src/api/index.js';
+import { createResource, deleteResource } from '#src/api/resource.js';
+import { initExperienceClient, processSession } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import { createUserByAdmin } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generatePassword, generateUsername } from '#src/utils.js';
+
+type TokenUsage = {
+  userTokenUsage: number;
+  m2mTokenUsage: number;
+};
+
+const getTokenUsage = async (pool: DatabasePool) =>
+  pool.one<TokenUsage>(sql`
+    select
+      coalesce(sum(user_token_usage), 0)::integer as user_token_usage,
+      coalesce(sum(m2m_token_usage), 0)::integer as m2m_token_usage
+    from daily_token_usage
+    where tenant_id = ${defaultTenantId}
+  `);
+
+const getActiveUserCount = async (pool: DatabasePool, userId: string) =>
+  pool.oneFirst<number>(sql`
+    select count(*)::integer
+    from daily_active_users
+    where tenant_id = ${defaultTenantId} and user_id = ${userId}
+  `);
+
+const waitForValue = async <T>(
+  read: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  attempts = 50
+): Promise<T> => {
+  const value = await read();
+
+  if (predicate(value)) {
+    return value;
+  }
+
+  if (attempts === 1) {
+    throw new Error('Timed out waiting for token metering listener');
+  }
+
+  await setTimeout(100);
+  return waitForValue(read, predicate, attempts - 1);
+};
+
+describe('token metering listeners', () => {
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let pool: DatabasePool;
+
+  beforeAll(async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    pool = await createPool(assertEnv('DB_URL'), {
+      interceptors: createInterceptorsPreset(),
+    });
+    await enableAllPasswordSignInMethods();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('records user token usage and daily active users after sign-in and refresh', async () => {
+    const username = generateUsername();
+    const password = generatePassword();
+    const [user, resource] = await Promise.all([
+      createUserByAdmin({ username, password }),
+      createResource(),
+    ]);
+    const usageBefore = await getTokenUsage(pool);
+
+    try {
+      const client = await initExperienceClient({
+        config: { resources: [resource.indicator] },
+      });
+      await identifyUserWithUsernamePassword(client, username, password);
+      const { redirectTo } = await client.submitInteraction();
+      const signedInUserId = await processSession(client, redirectTo);
+      const refreshToken = await client.getRefreshToken();
+
+      expect(signedInUserId).toBe(user.id);
+      assert(refreshToken, new Error('Missing refresh token after sign-in'));
+
+      await oidcApi.post('token', {
+        body: new URLSearchParams({
+          client_id: demoAppApplicationId,
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+          resource: resource.indicator,
+        }),
+      });
+
+      const [usageAfter, activeUserCount] = await Promise.all([
+        waitForValue(
+          async () => getTokenUsage(pool),
+          ({ userTokenUsage }) => userTokenUsage >= usageBefore.userTokenUsage + 2
+        ),
+        waitForValue(
+          async () => getActiveUserCount(pool, user.id),
+          (count) => count > 0
+        ),
+      ]);
+
+      expect(usageAfter.userTokenUsage).toBeGreaterThanOrEqual(usageBefore.userTokenUsage + 2);
+      expect(activeUserCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      await Promise.all([deleteUser(user.id), deleteResource(resource.id)]);
+    }
+  });
+
+  it('records M2M token usage after a client credentials grant', async () => {
+    const [application, resource] = await Promise.all([
+      createApplication('token metering test', ApplicationType.MachineToMachine),
+      createResource(),
+    ]);
+    const usageBefore = await getTokenUsage(pool);
+
+    try {
+      await oidcApi.post('token', {
+        body: new URLSearchParams({
+          client_id: application.id,
+          client_secret: application.secret,
+          grant_type: 'client_credentials',
+          resource: resource.indicator,
+        }),
+      });
+
+      const usageAfter = await waitForValue(
+        async () => getTokenUsage(pool),
+        ({ m2mTokenUsage }) => m2mTokenUsage > usageBefore.m2mTokenUsage
+      );
+
+      expect(usageAfter.m2mTokenUsage).toBe(usageBefore.m2mTokenUsage + 1);
+    } finally {
+      await Promise.all([deleteApplication(application.id), deleteResource(resource.id)]);
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4916,6 +4916,9 @@ importers:
       '@silverhand/essentials':
         specifier: ^2.9.1
         version: 2.9.2
+      '@silverhand/slonik':
+        specifier: 31.0.0-beta.2
+        version: 31.0.0-beta.2
       '@silverhand/ts-config':
         specifier: 6.0.0
         version: 6.0.0(typescript@5.5.3)


### PR DESCRIPTION
## Summary

- cover the custom RP-initiated logout confirmation and localized success pages
- verify user and M2M token-metering listeners persist usage and daily active user rows
- verify comma-separated `resource` parameters behave like repeated parameters

These paths are sensitive to the oidc-provider v9 upgrade and previously had no integration coverage.

## Testing

Integration tests