### PR TITLE
test: cover wildcard redirects and per-client interactions

### DIFF
--- a/packages/integration-tests/src/tests/api/oidc/per-client-interaction-cookie.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/per-client-interaction-cookie.test.ts
@@ -1,0 +1,145 @@
+import { Prompt } from '@logto/js';
+import { ApplicationType, InteractionEvent, type Application } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { createApplication, deleteApplication } from '#src/api/application.js';
+import { ExperienceClient } from '#src/client/experience/index.js';
+import { initExperienceClient, processSession } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import { createUserByAdmin } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import {
+  generatePassword,
+  generateTestName,
+  generateUsername,
+  parseInteractionCookie,
+} from '#src/utils.js';
+
+const firstRedirectUri = 'https://first.example.com/callback';
+const secondRedirectUri = 'https://second.example.com/callback';
+
+const createClient = (applicationId: string) => {
+  const client = new ExperienceClient({
+    appId: applicationId,
+    prompt: Prompt.Login,
+    scopes: [],
+  });
+
+  // eslint-disable-next-line @silverhand/fp/no-mutation
+  client.extraHeaders = { 'Logto-App-Id': applicationId };
+
+  return client;
+};
+
+const startInteraction = async (client: ExperienceClient, redirectUri: string) => {
+  const response = await client.startAuthorization(redirectUri);
+
+  expect(response.status).toBe(303);
+  expect(response.headers.get('location')?.startsWith('/sign-in')).toBe(true);
+
+  client.mergeRawCookies(response.headers.getSetCookie());
+  await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
+};
+
+describe('per-client interaction cookies', () => {
+  const username = generateUsername();
+  const password = generatePassword();
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let firstApplication: Application;
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let secondApplication: Application;
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let userId = '';
+
+  beforeAll(async () => {
+    const [createdFirstApplication, createdSecondApplication, user] = await Promise.all([
+      createApplication(generateTestName(), ApplicationType.SPA, {
+        oidcClientMetadata: {
+          redirectUris: [firstRedirectUri],
+          postLogoutRedirectUris: [],
+        },
+      }),
+      createApplication(generateTestName(), ApplicationType.SPA, {
+        oidcClientMetadata: {
+          redirectUris: [secondRedirectUri],
+          postLogoutRedirectUris: [],
+        },
+      }),
+      createUserByAdmin({ username, password }),
+      enableAllPasswordSignInMethods(),
+    ]);
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    firstApplication = createdFirstApplication;
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    secondApplication = createdSecondApplication;
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    userId = user.id;
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      deleteApplication(firstApplication.id),
+      deleteApplication(secondApplication.id),
+      deleteUser(userId),
+    ]);
+  });
+
+  it('completes interleaved interactions for two applications sharing one cookie jar', async () => {
+    const firstClient = createClient(firstApplication.id);
+    await startInteraction(firstClient, firstRedirectUri);
+
+    const secondClient = createClient(secondApplication.id);
+    const secondAuthorizationResponse = await secondClient.startAuthorization(
+      secondRedirectUri,
+      {},
+      firstClient.interactionCookie
+    );
+    expect(secondAuthorizationResponse.status).toBe(303);
+    expect(secondAuthorizationResponse.headers.get('location')?.startsWith('/sign-in')).toBe(true);
+    secondClient.assignRawCookies(firstClient.rawCookies);
+    secondClient.mergeRawCookies(secondAuthorizationResponse.headers.getSetCookie());
+    firstClient.mergeRawCookies(secondClient.rawCookies);
+    await secondClient.initInteraction({ interactionEvent: InteractionEvent.SignIn });
+
+    const interactionCookie = firstClient.parsedCookies.get('_interaction');
+    assert(interactionCookie, new Error('No interaction found in shared cookie jar'));
+    const interactionIds = parseInteractionCookie(interactionCookie);
+    expect(interactionIds[firstApplication.id]).toEqual(expect.any(String));
+    expect(interactionIds[secondApplication.id]).toEqual(expect.any(String));
+    expect(interactionIds[firstApplication.id]).not.toBe(interactionIds[secondApplication.id]);
+
+    await identifyUserWithUsernamePassword(firstClient, username, password);
+    await identifyUserWithUsernamePassword(secondClient, username, password);
+
+    const { redirectTo: firstRedirectTo } = await firstClient.submitInteraction();
+    secondClient.mergeRawCookies(firstClient.rawCookies);
+    const { redirectTo: secondRedirectTo } = await secondClient.submitInteraction();
+    firstClient.mergeRawCookies(secondClient.rawCookies);
+
+    await expect(processSession(firstClient, firstRedirectTo)).resolves.toBe(userId);
+    secondClient.mergeRawCookies(firstClient.rawCookies);
+    await expect(processSession(secondClient, secondRedirectTo)).resolves.toBe(userId);
+  });
+
+  it('keeps the default interaction cookie behavior without the app ID header', async () => {
+    const client = await initExperienceClient({
+      config: {
+        appId: firstApplication.id,
+        prompt: Prompt.Login,
+        scopes: [],
+      },
+      redirectUri: firstRedirectUri,
+    });
+    const interactionCookie = client.parsedCookies.get('_interaction');
+    assert(interactionCookie, new Error('No interaction found in cookie'));
+    const interactionIds = parseInteractionCookie(interactionCookie);
+    expect(interactionIds._legacy).toBe(interactionIds[firstApplication.id]);
+
+    await identifyUserWithUsernamePassword(client, username, password);
+    const { redirectTo } = await client.submitInteraction();
+
+    await expect(processSession(client, redirectTo)).resolves.toBe(userId);
+  });
+});

--- a/packages/integration-tests/src/tests/api/oidc/wildcard-redirect-uri.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/wildcard-redirect-uri.test.ts
@@ -1,0 +1,147 @@
+import { Prompt } from '@logto/js';
+import { ApplicationType, InteractionEvent, type Application } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+import ky from 'ky';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { createApplication, deleteApplication } from '#src/api/application.js';
+import { ExperienceClient } from '#src/client/experience/index.js';
+import { discoveryUrl } from '#src/constants.js';
+import { processSession } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import { createUserByAdmin } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generatePassword, generateTestName, generateUsername } from '#src/utils.js';
+
+const wildcardRedirectUri = 'https://*.example.com/callback';
+const matchingRedirectUri = 'https://tenant.example.com/callback';
+const wildcardPostLogoutRedirectUri = 'https://*.example.com/signed-out';
+const matchingPostLogoutRedirectUri = 'https://tenant.example.com/signed-out';
+const nonMatchingRedirectUri = 'https://tenant.example.net/callback';
+const nonMatchingPostLogoutRedirectUri = 'https://tenant.example.net/signed-out';
+
+const expectInvalidRedirectResponse = async (
+  response: Response,
+  parameter: 'redirect_uri' | 'post_logout_redirect_uri'
+) => {
+  expect(response.status).toBe(400);
+  await expect(response.text()).resolves.toContain(parameter);
+};
+
+const getHtmlAttribute = (element: string, attribute: string) =>
+  new RegExp(`\\b${attribute}=(['"])(.*?)\\1`, 'i').exec(element)?.[2];
+
+const getLogoutConfirmation = (html: string) => {
+  const form = /<form\b[^>]*>/i.exec(html)?.[0];
+  assert(form, new Error('Missing logout confirmation form'));
+  const action = getHtmlAttribute(form, 'action');
+  assert(action, new Error('Missing logout confirmation form action'));
+
+  const xsrfInput = [...html.matchAll(/<input\b[^>]*>/gi)].find(
+    ([input]) => getHtmlAttribute(input, 'name') === 'xsrf'
+  )?.[0];
+  assert(xsrfInput, new Error('Missing logout confirmation XSRF input'));
+  const xsrf = getHtmlAttribute(xsrfInput, 'value');
+  assert(xsrf, new Error('Missing logout confirmation XSRF value'));
+
+  return { action, xsrf };
+};
+
+describe('wildcard redirect URI round trip', () => {
+  const username = generateUsername();
+  const password = generatePassword();
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let application: Application;
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let userId = '';
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let endSessionEndpoint = '';
+
+  beforeAll(async () => {
+    const [createdApplication, user, discovery] = await Promise.all([
+      createApplication(generateTestName(), ApplicationType.SPA, {
+        oidcClientMetadata: {
+          redirectUris: [wildcardRedirectUri],
+          postLogoutRedirectUris: [wildcardPostLogoutRedirectUri],
+        },
+      }),
+      createUserByAdmin({ username, password }),
+      ky.get(discoveryUrl).json<{ end_session_endpoint: string }>(),
+      enableAllPasswordSignInMethods(),
+    ]);
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    application = createdApplication;
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    userId = user.id;
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    endSessionEndpoint = discovery.end_session_endpoint;
+  });
+
+  afterAll(async () => {
+    await Promise.all([deleteApplication(application.id), deleteUser(userId)]);
+  });
+
+  it('completes sign-in and post-logout redirects for matching subdomains', async () => {
+    const client = new ExperienceClient({
+      appId: application.id,
+      prompt: Prompt.Login,
+      scopes: [],
+    });
+
+    await client.initSession(matchingRedirectUri);
+    await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
+    await identifyUserWithUsernamePassword(client, username, password);
+    const { redirectTo } = await client.submitInteraction();
+
+    await expect(processSession(client, redirectTo)).resolves.toBe(userId);
+
+    const logoutUrl = new URL(
+      `${endSessionEndpoint}?${new URLSearchParams({
+        client_id: application.id,
+        post_logout_redirect_uri: matchingPostLogoutRedirectUri,
+      }).toString()}`
+    );
+
+    const logoutResponse = await ky.get(logoutUrl, {
+      headers: { cookie: client.getCookieHeader(logoutUrl.pathname) },
+      redirect: 'manual',
+      throwHttpErrors: false,
+    });
+    expect(logoutResponse.status).toBe(200);
+    client.mergeRawCookies(logoutResponse.headers.getSetCookie());
+
+    const { action, xsrf } = getLogoutConfirmation(await logoutResponse.text());
+    const confirmationUrl = new URL(action, endSessionEndpoint);
+    const confirmationResponse = await ky.post(confirmationUrl, {
+      headers: { cookie: client.getCookieHeader(confirmationUrl.pathname) },
+      body: new URLSearchParams({ xsrf, logout: 'yes' }),
+      redirect: 'manual',
+      throwHttpErrors: false,
+    });
+
+    expect(confirmationResponse.status).toBe(303);
+    expect(confirmationResponse.headers.get('location')).toBe(matchingPostLogoutRedirectUri);
+  });
+
+  it('rejects non-matching hosts for sign-in and post-logout redirects', async () => {
+    const client = new ExperienceClient({
+      appId: application.id,
+      prompt: Prompt.Login,
+      scopes: [],
+    });
+
+    const authorizationResponse = await client.startAuthorization(nonMatchingRedirectUri);
+    await expectInvalidRedirectResponse(authorizationResponse, 'redirect_uri');
+
+    const logoutResponse = await ky.get(endSessionEndpoint, {
+      searchParams: {
+        client_id: application.id,
+        post_logout_redirect_uri: nonMatchingPostLogoutRedirectUri,
+      },
+      redirect: 'manual',
+      throwHttpErrors: false,
+    });
+    await expectInvalidRedirectResponse(logoutResponse, 'post_logout_redirect_uri');
+  });
+});


### PR DESCRIPTION
## Summary

- add end-to-end coverage for wildcard redirect and post-logout redirect URI matching, including rejection of non-matching hosts
- verify two applications can complete interleaved sign-in interactions through a shared cookie jar using `Logto-App-Id`
- cover the default interaction cookie fallback when the app ID header is absent

These tests pin the Logto-specific `oidc-provider` behavior needed during the provider upgrade and make regressions fail at the integration boundary.

## Testing

Integration tests