### PR TITLE
test(core): pin OIDC token and 404 response shapes

### DIFF
--- a/packages/integration-tests/src/tests/api/oidc/client-credentials-grant.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/client-credentials-grant.test.ts
@@ -188,11 +188,18 @@ describe('client credentials grant', () => {
     it('should be able to get an organization token', async () => {
       const organization = await organizationApi.create({ name: 'test-organization' });
       await organizationApi.applications.add(organization.id, [client.id]);
-      const { access_token: accessToken, scope } = await post({ organization_id: organization.id });
+      const tokenResponse = await post({ organization_id: organization.id });
 
-      expect(scope).toBe('');
+      expect(typeof tokenResponse.access_token).toBe('string');
+      expect(typeof tokenResponse.expires_in).toBe('number');
+      expect(tokenResponse).toEqual({
+        access_token: tokenResponse.access_token,
+        expires_in: tokenResponse.expires_in,
+        scope: '',
+        token_type: 'Bearer',
+      });
 
-      const verified = await jwtVerify(accessToken, jwkSet, {
+      const verified = await jwtVerify(tokenResponse.access_token, jwkSet, {
         audience: buildOrganizationUrn(organization.id),
       });
       expect(verified.payload.scope).toBe('');

--- a/packages/integration-tests/src/tests/api/oidc/content-type-json.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/content-type-json.test.ts
@@ -110,4 +110,20 @@ describe('content-type: application/json compatibility', () => {
       })
     ).resolves.toBeDefined();
   });
+
+  it('should return the current error response for an unknown OIDC route', async () => {
+    await trySafe(api.get('nonexistent'), async (error) => {
+      if (!(error instanceof HTTPError)) {
+        throw new TypeError('Error is not a HTTPError instance.');
+      }
+
+      expect(error.response.status).toBe(404);
+      expect(await error.response.json()).toEqual({
+        code: 'oidc.invalid_request',
+        error: 'invalid_request',
+        error_description: 'unrecognized route or not allowed method (GET on /nonexistent)',
+        message: 'Request is invalid.',
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Pin the successful token response shape with an empty `scope`, so the test distinguishes `scope: ""` from an omitted field.
- Pin the status and complete JSON body returned by `GET /oidc/nonexistent`.
- Record the token-response `scope` consumer inventory that justifies keeping the authorization-code, device-code, and CIBA compatibility hunks in the `node-oidc-provider` fork.

## Scope consumer inventory

Audited the 12 official SDK repositories (including the archived Java repository for completeness), in-repo callers, maintained samples, and user-facing guides on 2026-07-10.

Consumers that rely on `scope` being present:

- JavaScript SDKs model `scope` as required in authorization-code and refresh-token responses, cache it on every access token, and reject persisted access-token entries whose scope is not a string. React Native inherits this behavior from `@logto/client`.
- Kotlin/Android, Swift, Dart/Flutter, and Rust decode `scope` into required non-null strings. Missing scope fails decoding before sign-in or token refresh can complete.
- Go models `scope` as a non-pointer string and copies it into the access-token cache. Its JSON decoder falls back to an empty string instead of throwing, but its public model and cache still assume the field.
- In this repository, `@logto/api` compares the returned scope with the requested Management API scope and warns on a missing value; `@logto/tunnel` and the device-flow demo type it as required.
- The Console device-flow guide promises `scope` in both initial and refreshed token responses. The M2M guide and the public opaque-token, service delegation, and impersonation guides also show it as part of the response; the impersonation example types it as required.

Consumers checked and found tolerant:

- The .NET, PHP, and Python SDK token-response models do not read `scope`.
- Ruby accepts a missing value as `nil`; the archived Java SDK's field is nullable.
- `cli-auth` deliberately makes scope optional and preserves the previous value when a refresh omits it.
- The maintained multi-tenant SaaS, RBAC, Spring Boot, WordPress, and Experience samples either ignore token-response scope, make it optional, or inherit a tolerant SDK.

This is not a clean consumer inventory: several current SDKs fail hard when the field is absent, and published guides present it as part of Logto's response contract. The three one-line fork hunks should therefore remain when upgrading `oidc-provider`.

## Testing

Integration tests

Related: LOG-13799