### PR TITLE
fix(core): remove email blocklist policy from public SIE

### DIFF
--- a/.changeset/hide-public-email-blocklist-policy.md
+++ b/.changeset/hide-public-email-blocklist-policy.md
@@ -1,0 +1,6 @@
+---
+"@logto/core": patch
+"@logto/schemas": patch
+---
+
+remove email blocklist policy from public sign-in experience responses

--- a/packages/account/src/__mocks__/RenderWithPageContext/index.tsx
+++ b/packages/account/src/__mocks__/RenderWithPageContext/index.tsx
@@ -122,7 +122,6 @@ export const mockSignInExperienceSettings = {
   captchaPolicy: {},
   sentinelPolicy: {},
   verificationCodePolicy: {},
-  emailBlocklistPolicy: {},
   passkeySignIn: {},
   isDevelopmentTenant: false,
   signUpProfileFields: null,

--- a/packages/core/src/libraries/sign-in-experience/index.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.test.ts
@@ -87,6 +87,16 @@ const {
   new WellKnownCache('foo', new TtlCache())
 );
 
+const getPublicSignInExperience = (signInExperience: SignInExperience) => {
+  const {
+    emailBlocklistPolicy: _emailBlocklistPolicy,
+    forgotPasswordMethods: _forgotPasswordMethods,
+    ...publicSignInExperience
+  } = signInExperience;
+
+  return publicSignInExperience;
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
 });
@@ -188,7 +198,7 @@ describe('getFullSignInExperience()', () => {
     const connectorFactory = ssoConnectorFactories[wellConfiguredSsoConnector.providerName];
 
     expect(fullSignInExperience).toStrictEqual({
-      ...mockSignInExperience,
+      ...getPublicSignInExperience(mockSignInExperience),
       socialConnectors: [],
       socialSignInConnectorTargets: ['github', 'facebook', 'wechat'],
       ssoConnectors: [
@@ -209,6 +219,7 @@ describe('getFullSignInExperience()', () => {
         phone: false,
       },
     });
+    expect(fullSignInExperience).not.toHaveProperty('emailBlocklistPolicy');
   });
 
   it('should return full sign-in experience with google one tap', async () => {
@@ -226,7 +237,7 @@ describe('getFullSignInExperience()', () => {
     const connectorFactory = ssoConnectorFactories[wellConfiguredSsoConnector.providerName];
 
     expect(fullSignInExperience).toStrictEqual({
-      ...mockSignInExperience,
+      ...getPublicSignInExperience(mockSignInExperience),
       socialConnectors: [
         { ...mockGithubConnector.metadata, id: mockGithubConnector.dbEntry.id },
         { ...mockGoogleConnector.metadata, id: mockGoogleConnector.dbEntry.id },

--- a/packages/core/src/libraries/sign-in-experience/index.ts
+++ b/packages/core/src/libraries/sign-in-experience/index.ts
@@ -323,14 +323,17 @@ export const createSignInExperienceLibrary = (
       signInExperience.signUpProfileFields
     );
 
+    const {
+      emailBlocklistPolicy: _emailBlocklistPolicy,
+      forgotPasswordMethods: _forgotPasswordMethods,
+      ...publicSignInExperience
+    } = deepmerge<SignInExperience, SignInExperienceOverride>(
+      deepmerge<SignInExperience, SignInExperienceOverride>(signInExperience, appSignInExperience),
+      organizationOverride
+    );
+
     return {
-      ...deepmerge<SignInExperience, SignInExperienceOverride>(
-        deepmerge<SignInExperience, SignInExperienceOverride>(
-          signInExperience,
-          appSignInExperience
-        ),
-        organizationOverride
-      ),
+      ...publicSignInExperience,
       socialConnectors,
       ssoConnectors,
       forgotPassword: getForgotPassword(),

--- a/packages/core/src/routes/well-known/well-known.test.ts
+++ b/packages/core/src/routes/well-known/well-known.test.ts
@@ -72,7 +72,11 @@ describe('GET /.well-known/sign-in-exp', () => {
     expect(findDefaultSignInExperience).toHaveBeenCalledTimes(1);
     expect(getLogtoConnectors).toHaveBeenCalledTimes(1);
     expect(response.status).toEqual(200);
-    const { forgotPasswordMethods, ...expectedSignInExperience } = mockSignInExperience;
+    const {
+      emailBlocklistPolicy: _emailBlocklistPolicy,
+      forgotPasswordMethods: _forgotPasswordMethods,
+      ...expectedSignInExperience
+    } = mockSignInExperience;
     expect(response.body).toMatchObject({
       ...expectedSignInExperience,
       forgotPassword: {
@@ -102,5 +106,7 @@ describe('GET /.well-known/sign-in-exp', () => {
       ),
       ssoConnectors: [],
     });
+    expect(response.body).not.toHaveProperty('emailBlocklistPolicy');
+    expect(response.body).not.toHaveProperty('forgotPasswordMethods');
   });
 });

--- a/packages/experience/src/__mocks__/logto.tsx
+++ b/packages/experience/src/__mocks__/logto.tsx
@@ -179,7 +179,6 @@ export const mockSignInExperienceSettings: SignInExperienceResponse = {
   adaptiveMfa: {},
   sentinelPolicy: {},
   verificationCodePolicy: {},
-  emailBlocklistPolicy: {},
   passkeySignIn: {},
   signUpProfileFields: null,
   usernamePolicy: defaultUsernamePolicy,

--- a/packages/schemas/src/types/sign-in-experience.ts
+++ b/packages/schemas/src/types/sign-in-experience.ts
@@ -31,7 +31,10 @@ export type ExperienceSocialConnector = Omit<
   'description' | 'configTemplate' | 'formItems' | 'readme' | 'customData'
 >;
 
-export type FullSignInExperience = Omit<SignInExperience, 'forgotPasswordMethods'> & {
+export type FullSignInExperience = Omit<
+  SignInExperience,
+  'emailBlocklistPolicy' | 'forgotPasswordMethods'
+> & {
   socialConnectors: ExperienceSocialConnector[];
   ssoConnectors: SsoConnectorMetadata[];
   forgotPassword: ForgotPassword;
@@ -63,7 +66,7 @@ export type FullSignInExperience = Omit<SignInExperience, 'forgotPasswordMethods
 };
 
 export const fullSignInExperienceGuard = SignInExperiences.guard
-  .omit({ forgotPasswordMethods: true })
+  .omit({ emailBlocklistPolicy: true, forgotPasswordMethods: true })
   .extend({
     socialConnectors: connectorMetadataGuard
       .omit({


### PR DESCRIPTION
## Summary
Hide the email blocklist policy from the public full sign-in experience response.

Keep the internal sign-in experience policy available for Management API flows while returning a public-safe shape from `getFullSignInExperience()` and `fullSignInExperienceGuard`.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments