### PR TITLE
test: pin OIDC discovery and token semantics

### DIFF
--- a/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
@@ -1,0 +1,141 @@
+import ky from 'ky';
+
+import { discoveryUrl, logtoUrl } from '#src/constants.js';
+
+const normalizeEndpoint = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    return value.replaceAll(logtoUrl, '<logto-url>');
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((nestedValue) => normalizeEndpoint(nestedValue));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [key, normalizeEndpoint(nestedValue)])
+    );
+  }
+
+  return value;
+};
+
+describe('OIDC discovery', () => {
+  it('exposes the reviewed provider metadata', async () => {
+    const discovery = await ky.get(discoveryUrl).json();
+
+    expect(normalizeEndpoint(discovery)).toMatchInlineSnapshot(`
+      {
+        "authorization_endpoint": "<logto-url>/oidc/auth",
+        "authorization_response_iss_parameter_supported": true,
+        "backchannel_logout_session_supported": true,
+        "backchannel_logout_supported": true,
+        "claim_types_supported": [
+          "normal",
+        ],
+        "claims_parameter_supported": false,
+        "claims_supported": [
+          "sub",
+          "name",
+          "family_name",
+          "given_name",
+          "middle_name",
+          "nickname",
+          "preferred_username",
+          "profile",
+          "picture",
+          "website",
+          "gender",
+          "birthdate",
+          "zoneinfo",
+          "locale",
+          "updated_at",
+          "username",
+          "created_at",
+          "email",
+          "email_verified",
+          "phone_number",
+          "phone_number_verified",
+          "address",
+          "custom_data",
+          "identities",
+          "sso_identities",
+          "roles",
+          "organizations",
+          "organization_data",
+          "organization_roles",
+          "sid",
+          "auth_time",
+          "iss",
+        ],
+        "code_challenge_methods_supported": [
+          "S256",
+        ],
+        "device_authorization_endpoint": "<logto-url>/oidc/device/auth",
+        "end_session_endpoint": "<logto-url>/oidc/session/end",
+        "grant_types_supported": [
+          "implicit",
+          "authorization_code",
+          "refresh_token",
+          "client_credentials",
+          "urn:ietf:params:oauth:grant-type:device_code",
+          "urn:ietf:params:oauth:grant-type:token-exchange",
+        ],
+        "id_token_signing_alg_values_supported": [
+          "ES384",
+        ],
+        "introspection_endpoint": "<logto-url>/oidc/token/introspection",
+        "issuer": "<logto-url>/oidc",
+        "jwks_uri": "<logto-url>/oidc/jwks",
+        "pushed_authorization_request_endpoint": "<logto-url>/oidc/request",
+        "request_parameter_supported": false,
+        "request_uri_parameter_supported": false,
+        "response_modes_supported": [
+          "form_post",
+          "fragment",
+          "query",
+        ],
+        "response_types_supported": [
+          "code id_token",
+          "code",
+          "id_token",
+          "none",
+        ],
+        "revocation_endpoint": "<logto-url>/oidc/token/revocation",
+        "scopes_supported": [
+          "openid",
+          "offline_access",
+          "profile",
+          "email",
+          "phone",
+          "address",
+          "custom_data",
+          "identities",
+          "roles",
+          "urn:logto:scope:organizations",
+          "urn:logto:scope:organization_roles",
+          "urn:logto:scope:sessions",
+        ],
+        "subject_types_supported": [
+          "public",
+        ],
+        "token_endpoint": "<logto-url>/oidc/token",
+        "token_endpoint_auth_methods_supported": [
+          "client_secret_basic",
+          "client_secret_jwt",
+          "client_secret_post",
+          "private_key_jwt",
+          "none",
+        ],
+        "token_endpoint_auth_signing_alg_values_supported": [
+          "HS256",
+          "RS256",
+          "PS256",
+          "ES256",
+          "EdDSA",
+        ],
+        "userinfo_endpoint": "<logto-url>/oidc/me",
+      }
+    `);
+  });
+});

--- a/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
@@ -21,6 +21,11 @@ const normalizeEndpoint = (value: unknown): unknown => {
 };
 
 describe('OIDC discovery', () => {
+  /**
+   * The snapshot assumes the default database seed, which generates an EC signing key and thus
+   * advertises `ES384`. An instance seeded with an RSA signing key reports different
+   * `id_token_signing_alg_values_supported` and fails this snapshot.
+   */
   it('exposes the reviewed provider metadata', async () => {
     const discovery = await ky.get(discoveryUrl).json();
 

--- a/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
@@ -1,0 +1,264 @@
+import { randomBytes } from 'node:crypto';
+
+import { ApplicationType, type Application, defaultTenantId } from '@logto/schemas';
+import { formUrlEncodedHeaders } from '@logto/shared';
+import { assert, assertEnv, noop } from '@silverhand/essentials';
+import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
+import ky from 'ky';
+
+import { oidcApi } from '#src/api/api.js';
+import { createApplication, deleteApplication } from '#src/api/application.js';
+import { deleteJwtCustomizer, deleteUser } from '#src/api/index.js';
+import { createResource, deleteResource } from '#src/api/resource.js';
+import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import { createUserByAdmin } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generatePassword, generateUsername } from '#src/utils.js';
+
+type IntrospectionResponse = {
+  [key: string]: unknown;
+  active: boolean;
+};
+
+const getAuthorizationHeader = ({ id, secret }: Application) =>
+  `Basic ${Buffer.from(`${id}:${secret}`).toString('base64')}`;
+
+const introspectToken = async (application: Application, token: string, tokenType: string) =>
+  oidcApi
+    .post('token/introspection', {
+      headers: { Authorization: getAuthorizationHeader(application) },
+      body: new URLSearchParams({ token, token_type_hint: tokenType }),
+    })
+    .json<IntrospectionResponse>();
+
+const revokeToken = async (application: Application, token: string, tokenType: string) =>
+  oidcApi.post('token/revocation', {
+    headers: { Authorization: getAuthorizationHeader(application) },
+    body: new URLSearchParams({ token, token_type_hint: tokenType }),
+  });
+
+const getHtmlAttribute = (element: string, attribute: string) =>
+  new RegExp(`\\b${attribute}=["']([^"']*)["']`, 'i').exec(element)?.[1];
+
+describe('opaque user token lifecycle', () => {
+  const username = generateUsername();
+  const password = generatePassword();
+  /* eslint-disable @silverhand/fp/no-let */
+  let application: Application;
+  let userId = '';
+  /* eslint-enable @silverhand/fp/no-let */
+
+  beforeAll(async () => {
+    await deleteJwtCustomizer('access-token').catch(noop);
+
+    const [createdApplication, user] = await Promise.all([
+      createApplication('OIDC provider semantics', ApplicationType.Traditional, {
+        oidcClientMetadata: {
+          redirectUris: [demoAppRedirectUri],
+          postLogoutRedirectUris: [demoAppRedirectUri],
+        },
+        customClientMetadata: { alwaysIssueRefreshToken: true },
+      }),
+      createUserByAdmin({ username, password }),
+      enableAllPasswordSignInMethods(),
+    ]);
+
+    /* eslint-disable @silverhand/fp/no-mutation */
+    application = createdApplication;
+    userId = user.id;
+    /* eslint-enable @silverhand/fp/no-mutation */
+  });
+
+  afterAll(async () => {
+    await Promise.all([deleteApplication(application.id), deleteUser(userId)]);
+  });
+
+  const signIn = async (resources?: string[]) => {
+    const client = await initExperienceClient({
+      config: {
+        appId: application.id,
+        appSecret: application.secret,
+        resources,
+      },
+      redirectUri: demoAppRedirectUri,
+    });
+    await identifyUserWithUsernamePassword(client, username, password);
+    const { redirectTo } = await client.submitInteraction();
+    await expect(processSession(client, redirectTo)).resolves.toBe(userId);
+
+    return client;
+  };
+
+  it('round-trips opaque artifacts through authorization code, refresh, and logout', async () => {
+    const client = await signIn();
+    const authorizationCodeRefreshToken = await client.getRefreshToken();
+    assert(authorizationCodeRefreshToken, new Error('Missing refresh token after code exchange'));
+
+    await client.clearAccessToken();
+    const accessToken = await client.getAccessToken();
+    const refreshToken = await client.getRefreshToken();
+    assert(refreshToken, new Error('Missing refresh token after refresh grant'));
+
+    expect(accessToken).not.toContain('.');
+    expect(accessToken.length).toBeGreaterThanOrEqual(43);
+    expect(authorizationCodeRefreshToken).not.toContain('.');
+    expect(authorizationCodeRefreshToken.length).toBeGreaterThanOrEqual(43);
+    expect(refreshToken).not.toContain('.');
+    expect(refreshToken.length).toBeGreaterThanOrEqual(43);
+
+    const endSessionUrl = new URL('/oidc/session/end', logtoUrl);
+    const confirmationResponse = await ky.get(endSessionUrl, {
+      headers: { cookie: client.getCookieHeader(endSessionUrl.pathname) },
+      redirect: 'manual',
+    });
+    const confirmationPage = await confirmationResponse.text();
+    const form = /<form\b[^>]*id=["']op\.logoutform["'][^>]*>/i.exec(confirmationPage)?.[0];
+    assert(form, new Error('Missing logout confirmation form'));
+    const action = getHtmlAttribute(form, 'action');
+    const xsrfInput = /<input\b[^>]*name=["']xsrf["'][^>]*>/i.exec(confirmationPage)?.[0];
+    const xsrf = xsrfInput && getHtmlAttribute(xsrfInput, 'value');
+    assert(action && xsrf, new Error('Missing logout confirmation form values'));
+
+    client.mergeRawCookies(confirmationResponse.headers.getSetCookie());
+    const confirmationUrl = new URL(action, logtoUrl);
+    const logoutResponse = await ky.post(confirmationUrl, {
+      body: new URLSearchParams({ logout: 'yes', xsrf }),
+      headers: {
+        ...formUrlEncodedHeaders,
+        cookie: client.getCookieHeader(confirmationUrl.pathname),
+      },
+      redirect: 'manual',
+      throwHttpErrors: false,
+    });
+
+    expect(logoutResponse.status).toBe(303);
+    await logoutClient(client);
+  });
+
+  it('pins opaque and JWT introspection plus access-token revocation semantics', async () => {
+    const resource = await createResource();
+
+    try {
+      const client = await signIn([resource.indicator]);
+      await client.clearAccessToken();
+      const opaqueAccessToken = await client.getAccessToken();
+      const jwtAccessToken = await client.getAccessToken(resource.indicator);
+      const refreshToken = await client.getRefreshToken();
+      assert(refreshToken, new Error('Missing sibling refresh token'));
+
+      const introspection = await introspectToken(application, opaqueAccessToken, 'access_token');
+
+      expect(Object.keys(introspection).toSorted()).toEqual([
+        'active',
+        'client_id',
+        'exp',
+        'iat',
+        'iss',
+        'scope',
+        'sub',
+        'token_type',
+      ]);
+      expect(introspection).toEqual({
+        active: true,
+        client_id: application.id,
+        exp: introspection.exp,
+        iat: introspection.iat,
+        iss: `${logtoUrl}/oidc`,
+        scope: 'openid offline_access profile',
+        sub: userId,
+        token_type: 'Bearer',
+      });
+      expect(typeof introspection.exp).toBe('number');
+      expect(typeof introspection.iat).toBe('number');
+      await expect(introspectToken(application, jwtAccessToken, 'access_token')).resolves.toEqual({
+        active: false,
+      });
+
+      await revokeToken(application, opaqueAccessToken, 'access_token');
+
+      await expect(
+        introspectToken(application, opaqueAccessToken, 'access_token')
+      ).resolves.toEqual({ active: false });
+      await expect(
+        oidcApi.post('token', {
+          headers: { Authorization: getAuthorizationHeader(application) },
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+          }),
+        })
+      ).resolves.toBeDefined();
+    } finally {
+      await deleteResource(resource.id);
+    }
+  });
+});
+
+describe('opaque client-credentials revocation', () => {
+  /* eslint-disable @silverhand/fp/no-let */
+  let application: Application;
+  let pool: DatabasePool;
+  /* eslint-enable @silverhand/fp/no-let */
+
+  beforeAll(async () => {
+    /* eslint-disable @silverhand/fp/no-mutation */
+    [application, pool] = await Promise.all([
+      createApplication('Opaque client credentials', ApplicationType.MachineToMachine),
+      createPool(assertEnv('DB_URL'), { interceptors: createInterceptorsPreset() }),
+    ]);
+    /* eslint-enable @silverhand/fp/no-mutation */
+  });
+
+  afterAll(async () => {
+    await Promise.all([deleteApplication(application.id), pool.end()]);
+  });
+
+  it('destroys only the requested token', async () => {
+    const issuedAt = Math.floor(Date.now() / 1000);
+    const expiresAt = issuedAt + 3600;
+    const tokens = [
+      randomBytes(32).toString('base64url'),
+      randomBytes(32).toString('base64url'),
+    ] as const;
+    const payload = {
+      clientId: application.id,
+      exp: expiresAt,
+      iat: issuedAt,
+      kind: 'ClientCredentials',
+    };
+
+    // Logto issues M2M API tokens as JWTs. Seed oidc-provider's opaque ClientCredentials model
+    // shape directly so its revocation behavior can still be exercised through the public endpoint.
+    await pool.query(sql`
+      insert into oidc_model_instances (tenant_id, model_name, id, payload, expires_at)
+      values
+        (${defaultTenantId}, 'ClientCredentials', ${tokens[0]}, ${sql.jsonb({ ...payload, jti: tokens[0] })}, to_timestamp(${expiresAt})),
+        (${defaultTenantId}, 'ClientCredentials', ${tokens[1]}, ${sql.jsonb({ ...payload, jti: tokens[1] })}, to_timestamp(${expiresAt}))
+    `);
+
+    try {
+      await expect(
+        introspectToken(application, tokens[0], 'client_credentials')
+      ).resolves.toMatchObject({ active: true, client_id: application.id });
+      await expect(
+        introspectToken(application, tokens[1], 'client_credentials')
+      ).resolves.toMatchObject({ active: true, client_id: application.id });
+
+      await revokeToken(application, tokens[0], 'client_credentials');
+
+      await expect(introspectToken(application, tokens[0], 'client_credentials')).resolves.toEqual({
+        active: false,
+      });
+      await expect(
+        introspectToken(application, tokens[1], 'client_credentials')
+      ).resolves.toMatchObject({ active: true, client_id: application.id });
+    } finally {
+      await pool.query(sql`
+        delete from oidc_model_instances
+        where tenant_id = ${defaultTenantId} and id in (${sql.join(tokens, sql`, `)})
+      `);
+    }
+  });
+});

--- a/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
@@ -134,6 +134,23 @@ describe('opaque user token lifecycle', () => {
     });
 
     expect(logoutResponse.status).toBe(303);
+
+    /**
+     * The `offline_access` refresh token is not session-bound (the default `expiresWithSession`
+     * policy only binds tokens whose scope lacks `offline_access`), so server-side logout must
+     * leave it usable. Pin this before v9 revisits artifact destruction on logout.
+     */
+    const postLogoutTokenResponse = await oidcApi
+      .post('token', {
+        headers: { Authorization: getAuthorizationHeader(application) },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+        }),
+      })
+      .json<{ access_token: string }>();
+    expect(postLogoutTokenResponse.access_token).not.toContain('.');
+
     await logoutClient(client);
   });
 
@@ -150,28 +167,18 @@ describe('opaque user token lifecycle', () => {
 
       const introspection = await introspectToken(application, opaqueAccessToken, 'access_token');
 
-      expect(Object.keys(introspection).toSorted()).toEqual([
-        'active',
-        'client_id',
-        'exp',
-        'iat',
-        'iss',
-        'scope',
-        'sub',
-        'token_type',
-      ]);
+      /* eslint-disable @typescript-eslint/no-unsafe-assignment -- jest `expect.any` is typed as `any` */
       expect(introspection).toEqual({
         active: true,
         client_id: application.id,
-        exp: introspection.exp,
-        iat: introspection.iat,
+        exp: expect.any(Number),
+        iat: expect.any(Number),
         iss: `${logtoUrl}/oidc`,
         scope: 'openid offline_access profile',
         sub: userId,
         token_type: 'Bearer',
       });
-      expect(typeof introspection.exp).toBe('number');
-      expect(typeof introspection.iat).toBe('number');
+      /* eslint-enable @typescript-eslint/no-unsafe-assignment */
       await expect(introspectToken(application, jwtAccessToken, 'access_token')).resolves.toEqual({
         active: false,
       });
@@ -229,8 +236,14 @@ describe('opaque client-credentials revocation', () => {
       kind: 'ClientCredentials',
     };
 
-    // Logto issues M2M API tokens as JWTs. Seed oidc-provider's opaque ClientCredentials model
-    // shape directly so its revocation behavior can still be exercised through the public endpoint.
+    /**
+     * Logto issues M2M API tokens as JWTs, so opaque ClientCredentials tokens cannot be minted
+     * through the public endpoints. Seed the model shape directly instead, mirroring what the
+     * opaque format persists in v8: `iat` and `exp` plus the defined `IN_PAYLOAD` fields (`jti`,
+     * `kind`, `clientId`; `aud`/`scope`/`extra` are omitted when undefined). If this test fails
+     * after the v9 switch, first diff this seed against the new `IN_PAYLOAD` list — a mismatch
+     * there is a seeding-shape issue, not a revocation semantics change.
+     */
     await pool.query(sql`
       insert into oidc_model_instances (tenant_id, model_name, id, payload, expires_at)
       values


### PR DESCRIPTION
## Summary

- snapshot the normalized OIDC discovery document so the v9 migration requires an explicit key-by-key review
- cover the authorization-code, refresh-token, and server-side logout round trip with long opaque artifacts
- pin current opaque user-token revocation, opaque client-credentials revocation, and opaque/JWT introspection behavior

[LOG-13802](https://linear.app/silverhand/issue/LOG-13802/snapshot-the-discovery-document-and-pin-long-id-round-trip-revocation)

## Testing

Integration tests