### PR TITLE
refactor(core): add oidc-provider internals seam module

### DIFF
--- a/packages/core/src/oidc/grants/client-credentials.test.ts
+++ b/packages/core/src/oidc/grants/client-credentials.test.ts
@@ -6,18 +6,16 @@ import { MockTenant } from '#src/test-utils/tenant.js';
 
 const { jest } = import.meta;
 
-jest.unstable_mockModule('oidc-provider/lib/shared/check_resource.js', () => ({
-  default: jest.fn(),
-}));
-
-jest.unstable_mockModule('oidc-provider/lib/helpers/weak_cache.js', () => ({
-  default: jest.fn().mockReturnValue({
-    configuration: jest.fn().mockReturnValue({
-      features: {
-        mTLS: { getCertificate: jest.fn() },
-      },
-      scopes: new Set(['foo', 'bar']),
-    }),
+jest.unstable_mockModule('#src/oidc/oidc-provider-internals.js', () => ({
+  certificateThumbprint: jest.fn(),
+  checkResource: jest.fn(),
+  dpopValidate: jest.fn(),
+  epochTime: jest.fn(),
+  getProviderConfiguration: jest.fn().mockReturnValue({
+    features: {
+      mTLS: { getCertificate: jest.fn() },
+    },
+    scopes: new Set(['foo', 'bar']),
   }),
 }));
 

--- a/packages/core/src/oidc/grants/client-credentials.ts
+++ b/packages/core/src/oidc/grants/client-credentials.ts
@@ -22,10 +22,9 @@
 import { cond } from '@silverhand/essentials';
 import type { Provider } from 'oidc-provider';
 import { errors } from 'oidc-provider';
-import instance from 'oidc-provider/lib/helpers/weak_cache.js';
-import checkResource from 'oidc-provider/lib/shared/check_resource.js';
 
 import { type EnvSet } from '#src/env-set/index.js';
+import { checkResource, getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -57,7 +56,7 @@ export const buildHandler: (
       mTLS: { getCertificate },
     },
     scopes: statics,
-  } = instance(ctx.oidc.provider).configuration();
+  } = getProviderConfiguration(ctx.oidc.provider);
 
   /* === RFC 0006 === */
   // The value type is `unknown`, which will swallow other type inferences. So we have to cast it

--- a/packages/core/src/oidc/grants/index.ts
+++ b/packages/core/src/oidc/grants/index.ts
@@ -1,8 +1,8 @@
 import { GrantType } from '@logto/schemas';
 import type { Provider } from 'oidc-provider';
-import instance from 'oidc-provider/lib/helpers/weak_cache.js';
 
 import { type EnvSet } from '#src/env-set/index.js';
+import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -18,7 +18,7 @@ export const registerGrants = (
 ) => {
   const {
     features: { resourceIndicators },
-  } = instance(oidc).configuration();
+  } = getProviderConfiguration(oidc);
 
   // If resource indicators are enabled, append `resource` to the parameters and allow it to
   // be duplicated

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -4,6 +4,7 @@ import Sinon from 'sinon';
 
 import { mockApplication } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import { createOidcContext } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
@@ -129,7 +130,7 @@ const stubGrant = (
 };
 
 const stubAccount = (ctx: KoaContextWithOIDC, overrideAccountId = accountId) => {
-  return Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({
+  return Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
     accountId: overrideAccountId,
   });
 };
@@ -251,7 +252,10 @@ describe('refresh token grant', () => {
     const ctx = createOidcContext(validOidcContext);
     stubRefreshToken(ctx);
     const stubbedGrant = stubGrant(ctx);
-    const stubFindAccount = Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves();
+    const stubFindAccount = Sinon.stub(
+      getProviderConfiguration(ctx.oidc.provider),
+      'findAccount'
+    ).resolves();
     await expect(mockHandler()(ctx, noop)).rejects.toThrow(errors.InvalidGrant);
 
     stubbedGrant.resolves({ ...validGrant, accountId: 'some_other_id' });

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -23,15 +23,17 @@ import { UserScope } from '@logto/core-kit';
 import { isKeyInObject } from '@silverhand/essentials';
 import type { Provider } from 'oidc-provider';
 import { errors } from 'oidc-provider';
-import difference from 'oidc-provider/lib/helpers/_/difference.js';
-import filterClaims from 'oidc-provider/lib/helpers/filter_claims.js';
-import resolveResource from 'oidc-provider/lib/helpers/resolve_resource.js';
-import revoke from 'oidc-provider/lib/helpers/revoke.js';
-import validatePresence from 'oidc-provider/lib/helpers/validate_presence.js';
-import instance from 'oidc-provider/lib/helpers/weak_cache.js';
 
 import { type EnvSet } from '#src/env-set/index.js';
 import { assertUserHasApplicationAccessForOidc } from '#src/oidc/application-access-control.js';
+import {
+  difference,
+  filterClaims,
+  getProviderConfiguration,
+  resolveResource,
+  revoke,
+  validatePresence,
+} from '#src/oidc/oidc-provider-internals.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -74,19 +76,18 @@ type Handler = (
 
 export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx, next) => {
   const { client, params, requestParamScopes, provider } = ctx.oidc;
-  const { RefreshToken, Account, AccessToken, Grant, IdToken } = provider;
+  const { RefreshToken, AccessToken, Grant, IdToken } = provider;
 
   assertThat(params, new InvalidGrant('parameters must be available'));
   assertThat(client, new InvalidClient('client must be available'));
 
   validatePresence(ctx, ...requiredParameters);
 
-  const providerInstance = instance(provider);
   const {
     rotateRefreshToken,
     conformIdTokenClaims,
     features: { userinfo, resourceIndicators },
-  } = providerInstance.configuration();
+  } = getProviderConfiguration(provider);
 
   // @gao: I believe the presence of the param is validated by required parameters of this grant.
   // Add `String` to make TS happy.
@@ -144,9 +145,13 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx,
   ctx.oidc.entity('RefreshToken', refreshToken);
   ctx.oidc.entity('Grant', grant);
 
-  // @ts-expect-error -- code from oidc-provider. the original type definition does not include
-  // `RefreshToken` but it's actually available.
-  const account = await Account.findAccount(ctx, refreshToken.accountId, refreshToken);
+  const account = await getProviderConfiguration(provider).findAccount(
+    ctx,
+    refreshToken.accountId,
+    // @ts-expect-error -- code from oidc-provider. the original type definition does not include
+    // `RefreshToken` but it's actually available.
+    refreshToken
+  );
 
   if (!account) {
     throw new InvalidGrant('refresh token invalid (referenced account not found)');

--- a/packages/core/src/oidc/grants/token-exchange/index.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.test.ts
@@ -3,6 +3,7 @@ import { type KoaContextWithOIDC, errors } from 'oidc-provider';
 import Sinon from 'sinon';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import { createOidcContext } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
@@ -156,14 +157,14 @@ describe('token exchange', () => {
   it('should throw when account cannot be found', async () => {
     const ctx = createOidcContext(validOidcContext);
     findSubjectToken.mockResolvedValueOnce(createValidSubjectToken());
-    Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves();
+    Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves();
     await expect(mockHandler()(ctx, noop)).rejects.toThrow(errors.InvalidGrant);
   });
 
   it('should throw before creating token continuation when the user has no application access', async () => {
     const ctx = createPreparedContext();
     findSubjectToken.mockResolvedValueOnce(createValidSubjectToken());
-    Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({ accountId });
+    Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({ accountId });
     const tenant = new MockTenant(undefined, mockQueries);
     const accessError = new RequestError('oidc.access_denied');
     assertUserHasApplicationAccess.mockRejectedValueOnce(accessError);
@@ -182,7 +183,7 @@ describe('token exchange', () => {
   it('should not explode when everything looks fine', async () => {
     const ctx = createPreparedContext();
     findSubjectToken.mockResolvedValueOnce(createValidSubjectToken());
-    Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({ accountId });
+    Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({ accountId });
 
     const entityStub = Sinon.stub(ctx.oidc, 'entity');
     const noopStub = Sinon.stub().resolves();
@@ -205,7 +206,9 @@ describe('token exchange', () => {
     it('should throw if the user is not a member of the organization', async () => {
       const ctx = createPreparedOrganizationContext();
       findSubjectToken.mockResolvedValueOnce(createValidSubjectToken());
-      Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({ accountId });
+      Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
+        accountId,
+      });
 
       const tenant = new MockTenant(undefined, mockQueries);
       Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(false);
@@ -217,7 +220,9 @@ describe('token exchange', () => {
     it('should throw if the organization requires MFA but the user has not configured it', async () => {
       const ctx = createPreparedOrganizationContext();
       findSubjectToken.mockResolvedValueOnce(createValidSubjectToken());
-      Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({ accountId });
+      Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
+        accountId,
+      });
 
       const tenant = new MockTenant(undefined, mockQueries);
       Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
@@ -233,7 +238,9 @@ describe('token exchange', () => {
     it('should not explode when everything looks fine', async () => {
       const ctx = createPreparedOrganizationContext();
       findSubjectToken.mockResolvedValueOnce(createValidSubjectToken());
-      Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({ accountId });
+      Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
+        accountId,
+      });
 
       const tenant = new MockTenant(undefined, mockQueries);
       Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
@@ -308,14 +315,16 @@ describe('token exchange', () => {
     it('should throw when account cannot be found', async () => {
       const ctx = createPreparedJwtContext();
       mockJwtVerify.mockResolvedValueOnce({ payload: { sub: accountId } });
-      Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves();
+      Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves();
       await expect(mockHandler()(ctx, noop)).rejects.toThrow(errors.InvalidGrant);
     });
 
     it('should not consume the token (allow multiple exchanges)', async () => {
       const ctx = createPreparedJwtContext();
       mockJwtVerify.mockResolvedValueOnce({ payload: { sub: accountId } });
-      Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({ accountId });
+      Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
+        accountId,
+      });
 
       const entityStub = Sinon.stub(ctx.oidc, 'entity');
       const noopStub = Sinon.stub().resolves();
@@ -360,7 +369,9 @@ describe('token exchange', () => {
         accountId,
         isExpired: false,
       });
-      Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({ accountId });
+      Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
+        accountId,
+      });
 
       const entityStub = Sinon.stub(ctx.oidc, 'entity');
       const noopStub = Sinon.stub().resolves();
@@ -398,7 +409,9 @@ describe('token exchange', () => {
       Sinon.stub(ctx.oidc.provider.AccessToken, 'find').resolves();
       // Mock jwtVerify to succeed
       mockJwtVerify.mockResolvedValueOnce({ payload: { sub: accountId } });
-      Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({ accountId });
+      Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
+        accountId,
+      });
 
       const entityStub = Sinon.stub(ctx.oidc, 'entity');
       const noopStub = Sinon.stub().resolves();
@@ -438,7 +451,9 @@ describe('token exchange', () => {
     it('should validate impersonation token with explicit type', async () => {
       const ctx = createPreparedImpersonationContext();
       findSubjectToken.mockResolvedValueOnce(createValidSubjectToken());
-      Sinon.stub(ctx.oidc.provider.Account, 'findAccount').resolves({ accountId });
+      Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
+        accountId,
+      });
 
       const entityStub = Sinon.stub(ctx.oidc, 'entity');
       const noopStub = Sinon.stub().resolves();

--- a/packages/core/src/oidc/grants/token-exchange/index.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.ts
@@ -9,12 +9,14 @@ import { GrantType } from '@logto/schemas';
 import { nanoid } from 'nanoid';
 import type { Provider } from 'oidc-provider';
 import { errors } from 'oidc-provider';
-import resolveResource from 'oidc-provider/lib/helpers/resolve_resource.js';
-import validatePresence from 'oidc-provider/lib/helpers/validate_presence.js';
-import instance from 'oidc-provider/lib/helpers/weak_cache.js';
 
 import { type EnvSet } from '#src/env-set/index.js';
 import { assertUserHasApplicationAccessForOidc } from '#src/oidc/application-access-control.js';
+import {
+  getProviderConfiguration,
+  resolveResource,
+  validatePresence,
+} from '#src/oidc/oidc-provider-internals.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -64,7 +66,7 @@ type Handler = (
 
 export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx, next) => {
   const { client, params, requestParamScopes, provider } = ctx.oidc;
-  const { Account, AccessToken, Grant } = provider;
+  const { AccessToken, Grant } = provider;
 
   assertThat(params, new InvalidGrant('parameters must be available'));
   assertThat(client, new InvalidClient('client must be available'));
@@ -73,11 +75,10 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx,
 
   validatePresence(ctx, ...requiredParameters);
 
-  const providerInstance = instance(provider);
   const {
     features: { userinfo, resourceIndicators },
     scopes: oidcScopes,
-  } = providerInstance.configuration();
+  } = getProviderConfiguration(provider);
 
   const { userId, subjectTokenId } = await validateSubjectToken({
     queries,
@@ -90,7 +91,7 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx,
     },
   });
 
-  const account = await Account.findAccount(ctx, userId);
+  const account = await getProviderConfiguration(provider).findAccount(ctx, userId);
 
   if (!account) {
     throw new InvalidGrant('subject token invalid (referenced account not found)');

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -2,12 +2,14 @@ import { buildOrganizationUrn } from '@logto/core-kit';
 import { cond } from '@silverhand/essentials';
 import { errors } from 'oidc-provider';
 import type { Provider, Account, KoaContextWithOIDC } from 'oidc-provider';
-import certificateThumbprint from 'oidc-provider/lib/helpers/certificate_thumbprint.js';
-import epochTime from 'oidc-provider/lib/helpers/epoch_time.js';
-import dpopValidate from 'oidc-provider/lib/helpers/validate_dpop.js';
-import instance from 'oidc-provider/lib/helpers/weak_cache.js';
 
 import { type EnvSet } from '#src/env-set/index.js';
+import {
+  certificateThumbprint,
+  dpopValidate,
+  epochTime,
+  getProviderConfiguration,
+} from '#src/oidc/oidc-provider-internals.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -67,12 +69,11 @@ export const handleClientCertificate = async (
   const { client, provider } = ctx.oidc;
   assertThat(client, new InvalidClient('client must be available'));
 
-  const providerInstance = instance(provider);
   const {
     features: {
       mTLS: { getCertificate },
     },
-  } = providerInstance.configuration();
+  } = getProviderConfiguration(provider);
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   if (client.tlsClientCertificateBoundAccessTokens || originalToken?.['x5t#S256']) {

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -2,10 +2,10 @@ import assert from 'node:assert';
 
 import { GrantType, type Scope } from '@logto/schemas';
 import { errors, type KoaContextWithOIDC } from 'oidc-provider';
-import instance from 'oidc-provider/lib/helpers/weak_cache.js';
 
 import { mockResource } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import { mockEnvSet } from '#src/test-utils/env-set.js';
 import { createOidcContext } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -34,7 +34,7 @@ const buildScope = (id: string, name: string): Scope => ({
 });
 
 const getResourceServerInfo = async (ctx: KoaContextWithOIDC, indicator: string) => {
-  const configuration = instance(ctx.oidc.provider).configuration();
+  const configuration = getProviderConfiguration(ctx.oidc.provider);
   assert(ctx.oidc.client);
   return configuration.features.resourceIndicators.getResourceServerInfo(
     ctx,
@@ -108,7 +108,7 @@ describe('oidc provider init', () => {
   it('should allow missing application access control client metadata', async () => {
     const tenant = new MockTenant();
     const provider = createProvider(tenant);
-    const configuration = instance(provider).configuration();
+    const configuration = getProviderConfiguration(provider);
     const ctx = createOidcContext({ provider });
 
     expect(() =>
@@ -124,7 +124,7 @@ describe('oidc provider init', () => {
   it('should reject invalid application access control client metadata', async () => {
     const tenant = new MockTenant();
     const provider = createProvider(tenant);
-    const configuration = instance(provider).configuration();
+    const configuration = getProviderConfiguration(provider);
     const ctx = createOidcContext({ provider });
 
     expect(() =>
@@ -229,7 +229,7 @@ describe('oidc provider init', () => {
     });
 
     const provider = createProvider(tenant);
-    const configuration = instance(provider).configuration();
+    const configuration = getProviderConfiguration(provider);
     const ctx = createOidcContext({
       provider,
       account: { accountId },
@@ -251,7 +251,7 @@ describe('oidc provider init', () => {
 
     const provider = createProvider(tenant);
     const findGrant = mockGrantFound(provider);
-    const configuration = instance(provider).configuration();
+    const configuration = getProviderConfiguration(provider);
     const ctx = createOidcContext({
       provider,
       account: { accountId, claims: async () => ({ sub: accountId }) },
@@ -275,7 +275,7 @@ describe('oidc provider init', () => {
 
     const provider = createProvider(tenant);
     const findGrant = mockGrantFound(provider);
-    const configuration = instance(provider).configuration();
+    const configuration = getProviderConfiguration(provider);
     const ctx = createOidcContext({
       provider,
       account: { accountId, claims: async () => ({ sub: accountId }) },
@@ -302,7 +302,7 @@ describe('oidc provider init', () => {
 
     const provider = createProvider(tenant);
     const findGrant = mockGrantFound(provider);
-    const configuration = instance(provider).configuration();
+    const configuration = getProviderConfiguration(provider);
     const ctx = createOidcContext({
       provider,
       account: { accountId, claims: async () => ({ sub: accountId }) },
@@ -327,7 +327,7 @@ describe('oidc provider init', () => {
     });
 
     const provider = createProvider(tenant);
-    const configuration = instance(provider).configuration();
+    const configuration = getProviderConfiguration(provider);
     const ctx = createOidcContext({
       provider,
       account: { accountId },

--- a/packages/core/src/oidc/oidc-provider-internals.ts
+++ b/packages/core/src/oidc/oidc-provider-internals.ts
@@ -1,0 +1,19 @@
+/**
+ * @file The single module allowed to deep-import `oidc-provider` internals. All other modules
+ * must import them from here, so upgrading the `oidc-provider` fork only requires changes in
+ * this file.
+ */
+import type { Provider } from 'oidc-provider';
+import instance from 'oidc-provider/lib/helpers/weak_cache.js';
+
+export { default as difference } from 'oidc-provider/lib/helpers/_/difference.js';
+export { default as certificateThumbprint } from 'oidc-provider/lib/helpers/certificate_thumbprint.js';
+export { default as epochTime } from 'oidc-provider/lib/helpers/epoch_time.js';
+export { default as filterClaims } from 'oidc-provider/lib/helpers/filter_claims.js';
+export { default as resolveResource } from 'oidc-provider/lib/helpers/resolve_resource.js';
+export { default as revoke } from 'oidc-provider/lib/helpers/revoke.js';
+export { default as dpopValidate } from 'oidc-provider/lib/helpers/validate_dpop.js';
+export { default as validatePresence } from 'oidc-provider/lib/helpers/validate_presence.js';
+export { default as checkResource } from 'oidc-provider/lib/shared/check_resource.js';
+
+export const getProviderConfiguration = (provider: Provider) => instance(provider).configuration();


### PR DESCRIPTION
## Summary

Add `packages/core/src/oidc/oidc-provider-internals.ts` as the single module allowed to deep-import `oidc-provider` internals. It re-exports the existing deep imports (`difference`, `certificateThumbprint`, `epochTime`, `filterClaims`, `resolveResource`, `revoke`, `dpopValidate`, `validatePresence`, `checkResource`) and adds a `getProviderConfiguration(provider)` wrapper around `instance(provider).configuration()`.

Migrations onto the seam:

- The 8 `instance(provider).configuration()` call sites in `grants/` now use `getProviderConfiguration()`.
- The 2 `provider.Account.findAccount` call sites (`grants/refresh-token.ts`, `grants/token-exchange/index.ts`) now use `getProviderConfiguration(provider).findAccount`. This is behavior-identical: `provider.Account` is exactly `{ findAccount: configuration.findAccount }` (see `lib/provider.js` in the fork), so both forms call the same function reference.
- Jest mocks and Sinon stubs are repointed at the seam module accordingly.

This prepares for the oidc-provider v9 upgrade: v9 turns `.configuration()` from a method into a property and removes the `provider.Account` getter entirely. Behind the seam, both become a one-file change instead of scattered edits across the grant handlers.

No behavior change.

## Testing

Tested locally: affected unit tests (`build/oidc/grants`, `build/oidc/init.test.js`) pass.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
