### PR TITLE
fix(core): enable MFA after binding a factor via Account APIs

### DIFF
--- a/.changeset/sync-account-mfa-enabled-state.md
+++ b/.changeset/sync-account-mfa-enabled-state.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+automatically enable MFA after users bind a factor via Account APIs

--- a/packages/core/src/routes/account/mfa-verifications.test.ts
+++ b/packages/core/src/routes/account/mfa-verifications.test.ts
@@ -17,10 +17,20 @@ const { mockEsmWithActual } = createMockUtils(jest);
 
 const mockValidateTotpSecret = jest.fn();
 const mockValidateTotpToken = jest.fn();
+const { id, createdAt, ...mockWebAuthnBindMfa } = mockUserWebAuthnMfaVerification;
+
+const mockBuildVerificationRecordByIdAndType = jest.fn(async () => ({
+  isVerified: true,
+  toBindMfa: () => mockWebAuthnBindMfa,
+}));
 
 await mockEsmWithActual('#src/libraries/verification-helpers/totp-validation.js', () => ({
   validateTotpSecret: mockValidateTotpSecret,
   validateTotpToken: mockValidateTotpToken,
+}));
+
+await mockEsmWithActual('#src/libraries/verification.js', () => ({
+  buildVerificationRecordByIdAndType: mockBuildVerificationRecordByIdAndType,
 }));
 
 const mockedQueries = {
@@ -46,6 +56,13 @@ const { findUserById, updateUserById } = mockedQueries.users;
 const { findDefaultSignInExperience } = mockedQueries.signInExperiences;
 
 const accountMfaRoutes = await pickDefault(import('./mfa-verifications.js'));
+
+const getLastUpdatePayload = () => updateUserById.mock.calls.at(-1)?.[1];
+
+const expectUpdatedMfaEnabled = (enabled: boolean) => {
+  const updatePayload = getLastUpdatePayload();
+  expect(updatePayload?.logtoConfig).toMatchObject({ mfa: { enabled } });
+};
 
 describe('account mfa verification routes', () => {
   const tenantContext = new MockTenant(undefined, mockedQueries);
@@ -115,6 +132,7 @@ describe('account mfa verification routes', () => {
           mfaVerifications: [expect.any(Object)],
         })
       );
+      expectUpdatedMfaEnabled(true);
       expect(replacedTotpVerification).toEqual(
         expect.objectContaining({
           type: MfaFactor.TOTP,
@@ -148,6 +166,7 @@ describe('account mfa verification routes', () => {
           ],
         })
       );
+      expectUpdatedMfaEnabled(true);
     });
 
     it('should return 400 for an invalid totp secret', async () => {
@@ -190,10 +209,9 @@ describe('account mfa verification routes', () => {
         newIdentifierVerificationRecordId: 'fake_record_id',
       });
 
-      // Binding check passed — findDefaultSignInExperience was reached
+      expect(response.status).toBe(204);
       expect(findDefaultSignInExperience).toHaveBeenCalled();
-      // Error is from verification record lookup, not binding check
-      expect(response.body).not.toHaveProperty('code', 'session.mfa.mfa_factor_not_enabled');
+      expect(getLastUpdatePayload()).not.toHaveProperty('logtoConfig');
     });
 
     it('should reject WebAuthn binding when both mfa.factors and passkeySignIn.enabled are off', async () => {
@@ -249,10 +267,10 @@ describe('account mfa verification routes', () => {
         newIdentifierVerificationRecordId: 'fake_record_id',
       });
 
-      // Permission check passed — findDefaultSignInExperience was reached
+      expect(response.status).toBe(204);
+      expectUpdatedMfaEnabled(true);
+      // Permission check passed, and WebAuthn is treated as MFA when enabled in MFA factors.
       expect(findDefaultSignInExperience).toHaveBeenCalled();
-      // Error is from verification record lookup, not permission check
-      expect(response.body).not.toHaveProperty('code', 'account_center.field_not_editable');
     });
 
     it('should fall back to fields.mfa for non-WebAuthn types', async () => {
@@ -263,6 +281,7 @@ describe('account mfa verification routes', () => {
 
       // Uses fields.mfa which is Edit, so permission passes; TOTP is in factors
       expect(response.status).toBe(204);
+      expectUpdatedMfaEnabled(true);
     });
   });
 
@@ -393,6 +412,13 @@ describe('account mfa verification routes', () => {
 
       // Fields.mfa = Edit, so should pass
       expect(response.status).toBe(204);
+      expect(updateUserById).toHaveBeenCalledWith(
+        mockUser.id,
+        expect.objectContaining({
+          mfaVerifications: [],
+        })
+      );
+      expect(getLastUpdatePayload()).not.toHaveProperty('logtoConfig');
     });
 
     it('should reject WebAuthn deletion when passkey field is not editable', async () => {

--- a/packages/core/src/routes/account/mfa-verifications.ts
+++ b/packages/core/src/routes/account/mfa-verifications.ts
@@ -7,9 +7,11 @@ import {
   userMfaVerificationResponseGuard,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
+import { conditional } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import { buildUpdatedUserLogtoConfig } from '#src/libraries/user-logto-config.js';
 import {
   generateBackupCodes,
   validateBackupCodes,
@@ -140,16 +142,18 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
             );
           }
 
+          const mfaVerifications = [
+            ...user.mfaVerifications,
+            {
+              id: generateStandardId(),
+              createdAt: new Date().toISOString(),
+              type: MfaFactor.TOTP as const,
+              key: secret,
+            },
+          ];
           const updatedUser = await updateUserById(userId, {
-            mfaVerifications: [
-              ...user.mfaVerifications,
-              {
-                id: generateStandardId(),
-                createdAt: new Date().toISOString(),
-                type: MfaFactor.TOTP,
-                key: secret,
-              },
-            ],
+            mfaVerifications,
+            logtoConfig: buildUpdatedUserLogtoConfig(user, { mfa: { enabled: true } }),
           });
 
           ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });
@@ -184,16 +188,18 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
             })
           );
           const { codes } = ctx.guard.body;
+          const mfaVerifications = [
+            ...user.mfaVerifications,
+            {
+              id: generateStandardId(),
+              createdAt: new Date().toISOString(),
+              type: MfaFactor.BackupCode as const,
+              codes: codes.map((code) => ({ code })),
+            },
+          ];
           const updatedUser = await updateUserById(userId, {
-            mfaVerifications: [
-              ...user.mfaVerifications,
-              {
-                id: generateStandardId(),
-                createdAt: new Date().toISOString(),
-                type: MfaFactor.BackupCode,
-                codes: codes.map((code) => ({ code })),
-              },
-            ],
+            mfaVerifications,
+            logtoConfig: buildUpdatedUserLogtoConfig(user, { mfa: { enabled: true } }),
           });
 
           ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });
@@ -213,16 +219,22 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
 
           const bindMfa = newVerificationRecord.toBindMfa();
 
+          const mfaVerifications = [
+            ...user.mfaVerifications,
+            {
+              ...bindMfa,
+              id: generateStandardId(),
+              createdAt: new Date().toISOString(),
+              name,
+            },
+          ];
           const updatedUser = await updateUserById(userId, {
-            mfaVerifications: [
-              ...user.mfaVerifications,
-              {
-                ...bindMfa,
-                id: generateStandardId(),
-                createdAt: new Date().toISOString(),
-                name,
-              },
-            ],
+            mfaVerifications,
+            ...conditional(
+              mfa.factors.includes(MfaFactor.WebAuthn) && {
+                logtoConfig: buildUpdatedUserLogtoConfig(user, { mfa: { enabled: true } }),
+              }
+            ),
           });
 
           ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });
@@ -291,14 +303,15 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         ({ type }) => type === MfaFactor.TOTP
       );
 
+      const mfaVerifications = existingTotpVerification
+        ? user.mfaVerifications.map((mfaVerification) =>
+            mfaVerification.id === existingTotpVerification.id ? totpVerification : mfaVerification
+          )
+        : [...user.mfaVerifications, totpVerification];
+
       const updatedUser = await updateUserById(userId, {
-        mfaVerifications: existingTotpVerification
-          ? user.mfaVerifications.map((mfaVerification) =>
-              mfaVerification.id === existingTotpVerification.id
-                ? totpVerification
-                : mfaVerification
-            )
-          : [...user.mfaVerifications, totpVerification],
+        mfaVerifications,
+        logtoConfig: buildUpdatedUserLogtoConfig(user, { mfa: { enabled: true } }),
       });
 
       ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });
@@ -463,10 +476,11 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         'account_center.field_not_editable'
       );
 
+      const mfaVerifications = user.mfaVerifications.filter(
+        (mfaVerification) => mfaVerification.id !== ctx.guard.params.verificationId
+      );
       const updatedUser = await updateUserById(userId, {
-        mfaVerifications: user.mfaVerifications.filter(
-          (mfaVerification) => mfaVerification.id !== ctx.guard.params.verificationId
-        ),
+        mfaVerifications,
       });
 
       ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });


### PR DESCRIPTION
## Summary
Automatically enable MFA after users bind a factor via Account APIs.

Account API passkey-only WebAuthn bindings keep MFA disabled, while MFA verification methods such as TOTP, WebAuthn MFA, and backup codes mark MFA as enabled. Deleting factors no longer toggles the user MFA enabled state.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments