### PR TITLE
fix(core): resolve ReplayDetection from the provider instance and pin disabled-DPoP behavior

### DIFF
--- a/packages/core/src/include.d/oidc-provider/lib-keep/helpers/validate_dpop.d.ts
+++ b/packages/core/src/include.d/oidc-provider/lib-keep/helpers/validate_dpop.d.ts
@@ -5,5 +5,5 @@ declare module 'oidc-provider/lib/helpers/validate_dpop.js' {
 
   export default function dpopValidate(
     ctx: KoaContextWithOIDC
-  ): Promise<Optional<{ thumbprint: string; jti?: string; iat?: string }>>;
+  ): Promise<Optional<{ thumbprint: string; jti: string; iat: number }>>;
 }

--- a/packages/core/src/oidc/grants/utils.test.ts
+++ b/packages/core/src/oidc/grants/utils.test.ts
@@ -1,0 +1,124 @@
+import { type Provider, errors } from 'oidc-provider';
+
+import { createOidcContext } from '#src/test-utils/oidc-provider.js';
+
+const { jest } = import.meta;
+
+const { InvalidGrant, InvalidClient } = errors;
+
+const dpopValidate = jest.fn();
+
+jest.unstable_mockModule('#src/oidc/oidc-provider-internals.js', () => ({
+  certificateThumbprint: jest.fn(),
+  dpopValidate,
+  epochTime: () => Math.floor(Date.now() / 1000),
+  getProviderConfiguration: jest.fn(),
+}));
+
+const { handleDPoP } = await import('./utils.js');
+
+type AccessToken = InstanceType<Provider['AccessToken']>;
+type RefreshToken = InstanceType<Provider['RefreshToken']>;
+type Client = InstanceType<Provider['Client']>;
+
+const clientId = 'some_client_id';
+const thumbprint = 'dpop_key_thumbprint';
+
+const createClient = (dpopBoundAccessTokens = false): Client =>
+  // @ts-expect-error -- mock the minimal client shape used by `handleDPoP`
+  ({ clientId, dpopBoundAccessTokens });
+
+const createToken = () => {
+  const setThumbprint = jest.fn();
+  // @ts-expect-error -- `setThumbprint` exists at runtime but is not declared in the typings
+  const token: AccessToken = { setThumbprint };
+  return { token, setThumbprint };
+};
+
+/**
+ * `handleDPoP` resolves the `ReplayDetection` model from the real provider instance created by
+ * `createOidcContext()`, backed by the default memory adapter, so these tests exercise the actual
+ * static `unique()` call and its replay semantics rather than a stubbed model.
+ */
+describe('handleDPoP', () => {
+  afterEach(() => {
+    dpopValidate.mockReset();
+  });
+
+  it('should throw when the client is not available', async () => {
+    const ctx = createOidcContext();
+    const { token } = createToken();
+
+    await expect(handleDPoP(ctx, token)).rejects.toMatchError(
+      new InvalidClient('client must be available')
+    );
+  });
+
+  it('should do nothing when no DPoP proof is provided', async () => {
+    const ctx = createOidcContext({ client: createClient() });
+    const { token, setThumbprint } = createToken();
+
+    await expect(handleDPoP(ctx, token)).resolves.toBeUndefined();
+    expect(setThumbprint).not.toHaveBeenCalled();
+  });
+
+  it('should throw when the client requires DPoP but no proof is provided', async () => {
+    const ctx = createOidcContext({ client: createClient(true) });
+    const { token } = createToken();
+
+    await expect(handleDPoP(ctx, token)).rejects.toMatchError(
+      new InvalidGrant('DPoP proof JWT not provided')
+    );
+  });
+
+  it('should bind the proof thumbprint to the token when a DPoP proof is provided', async () => {
+    dpopValidate.mockResolvedValue({ thumbprint, jti: 'dpop_jti_bind', iat: 1000 });
+    const ctx = createOidcContext({ client: createClient() });
+    const { token, setThumbprint } = createToken();
+
+    await expect(handleDPoP(ctx, token)).resolves.toBeUndefined();
+    expect(setThumbprint).toHaveBeenCalledWith('jkt', thumbprint);
+  });
+
+  it('should detect a replayed DPoP proof', async () => {
+    dpopValidate.mockResolvedValue({ thumbprint, jti: 'dpop_jti_replay', iat: 1000 });
+    const ctx = createOidcContext({ client: createClient() });
+
+    await expect(handleDPoP(ctx, createToken().token)).resolves.toBeUndefined();
+    await expect(handleDPoP(ctx, createToken().token)).rejects.toMatchError(
+      new InvalidGrant('DPoP proof JWT Replay detected')
+    );
+  });
+
+  it('should throw when the original token is bound to another key', async () => {
+    dpopValidate.mockResolvedValue({ thumbprint, jti: 'dpop_jti_mismatch', iat: 1000 });
+    const ctx = createOidcContext({ client: createClient() });
+    // @ts-expect-error -- mock the minimal refresh token shape used by `handleDPoP`
+    const originalToken: RefreshToken = { jkt: 'another_key_thumbprint' };
+
+    await expect(handleDPoP(ctx, createToken().token, originalToken)).rejects.toMatchError(
+      new InvalidGrant('failed jkt verification')
+    );
+  });
+
+  it('should throw when the original token is DPoP-bound but no proof is provided', async () => {
+    const ctx = createOidcContext({ client: createClient() });
+    // @ts-expect-error -- mock the minimal refresh token shape used by `handleDPoP`
+    const originalToken: RefreshToken = { jkt: thumbprint };
+
+    await expect(handleDPoP(ctx, createToken().token, originalToken)).rejects.toMatchError(
+      new InvalidGrant('failed jkt verification')
+    );
+  });
+
+  it('should pass when the original token is bound to the same key', async () => {
+    dpopValidate.mockResolvedValue({ thumbprint, jti: 'dpop_jti_match', iat: 1000 });
+    const ctx = createOidcContext({ client: createClient() });
+    // @ts-expect-error -- mock the minimal refresh token shape used by `handleDPoP`
+    const originalToken: RefreshToken = { jkt: thumbprint };
+    const { token, setThumbprint } = createToken();
+
+    await expect(handleDPoP(ctx, token, originalToken)).resolves.toBeUndefined();
+    expect(setThumbprint).toHaveBeenCalledWith('jkt', thumbprint);
+  });
+});

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -23,6 +23,19 @@ import {
 const { InvalidGrant, InvalidClient, AccessDenied } = errors;
 
 /**
+ * The `ReplayDetection` model class with its static `unique` method. `@types/oidc-provider`
+ * declares `unique` only as an instance method, but the runtime implements it as a static method
+ * of the class. Do not declare the missing static via module augmentation: the typings export the
+ * model classes with `export type` on purpose, and a value declaration would make
+ * `import { ReplayDetection } from 'oidc-provider'` pass type checking while failing at runtime.
+ *
+ * See https://github.com/logto-io/node-oidc-provider/blob/5570006785b44e0f125ee4cb6bf540338721b1f3/lib/models/replay_detection.js
+ */
+type ReplayDetectionClass = Provider['ReplayDetection'] & {
+  unique: (iss: string, jti: string, exp?: number) => Promise<boolean>;
+};
+
+/**
  * Handle DPoP bound access tokens.
  */
 export const handleDPoP = async (
@@ -36,9 +49,9 @@ export const handleDPoP = async (
   const dPoP = await dpopValidate(ctx);
 
   if (dPoP) {
-    // @ts-expect-error -- code from oidc-provider
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    const unique: unknown = await ReplayDetection.unique(
+    const { ReplayDetection } = ctx.oidc.provider;
+    // eslint-disable-next-line no-restricted-syntax -- widen with the static method missing from the typings, see `ReplayDetectionClass`
+    const unique = await (ReplayDetection as ReplayDetectionClass).unique(
       client.clientId,
       dPoP.jti,
       epochTime() + 300

--- a/packages/integration-tests/src/tests/api/oidc/dpop-disabled.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/dpop-disabled.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert';
+
+import {
+  type Application,
+  ApplicationType,
+  GrantType,
+  demoAppApplicationId,
+  type Resource,
+} from '@logto/schemas';
+import { formUrlEncodedHeaders } from '@logto/shared';
+import { appendPath } from '@silverhand/essentials';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { oidcApi } from '#src/api/api.js';
+import {
+  createApplication,
+  deleteApplication,
+  getApplicationSecrets,
+} from '#src/api/application.js';
+import { createResource, deleteResource } from '#src/api/resource.js';
+import { createSubjectToken } from '#src/api/subject-token.js';
+import { logtoUrl } from '#src/constants.js';
+import { initExperienceClient, processSession } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import { createUserByAdmin } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import {
+  generatePassword,
+  generateResourceIndicator,
+  generateResourceName,
+  generateUsername,
+  getAccessTokenPayload,
+} from '#src/utils.js';
+
+type TokenResponse = {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  scope?: string;
+};
+
+const impersonationTokenType = 'urn:logto:token-type:impersonation_token';
+const tokenEndpoint = appendPath(new URL(logtoUrl), 'oidc/token').href;
+
+/**
+ * Create a DPoP proof JWT (RFC 9449) for the token endpoint that satisfies every check in
+ * `oidc-provider`'s `validate_dpop.js`. DPoP is disabled, so the provider must ignore the proof;
+ * if DPoP ever gets enabled unintentionally (e.g. `oidc-provider` v9 enables it by default), this
+ * valid proof would bind the issued token to the key, which the assertions below catch loudly.
+ */
+const createDpopProof = async () => {
+  const { publicKey, privateKey } = await generateKeyPair('ES256');
+
+  return new SignJWT({ htm: 'POST', htu: tokenEndpoint, jti: crypto.randomUUID() })
+    .setProtectedHeader({ alg: 'ES256', typ: 'dpop+jwt', jwk: await exportJWK(publicKey) })
+    .setIssuedAt()
+    .sign(privateKey);
+};
+
+/** Assert the response carries a plain Bearer token without a DPoP (`cnf.jkt`) binding. */
+const expectNoDpopBinding = (response: TokenResponse) => {
+  expect(response.token_type).toBe('Bearer');
+  expect(getAccessTokenPayload(response.access_token)).not.toHaveProperty('cnf');
+};
+
+describe('token requests with a DPoP proof while DPoP is disabled', () => {
+  const username = generateUsername();
+  const password = generatePassword();
+
+  /* eslint-disable @silverhand/fp/no-let */
+  let testResource: Resource;
+  let testUserId: string;
+  let m2mApplication: Application;
+  let exchangeApplication: Application;
+  let exchangeAuthorizationHeader: string;
+  /* eslint-enable @silverhand/fp/no-let */
+
+  beforeAll(async () => {
+    /* eslint-disable @silverhand/fp/no-mutation */
+    await enableAllPasswordSignInMethods();
+
+    testResource = await createResource(generateResourceName(), generateResourceIndicator());
+    ({ id: testUserId } = await createUserByAdmin({ username, password }));
+
+    m2mApplication = await createApplication(
+      'dpop-disabled-m2m-app',
+      ApplicationType.MachineToMachine
+    );
+
+    exchangeApplication = await createApplication(
+      'dpop-disabled-token-exchange-app',
+      ApplicationType.Traditional,
+      {
+        oidcClientMetadata: { redirectUris: ['http://localhost:3000'], postLogoutRedirectUris: [] },
+        customClientMetadata: { allowTokenExchange: true },
+      }
+    );
+    const secrets = await getApplicationSecrets(exchangeApplication.id);
+    exchangeAuthorizationHeader = `Basic ${Buffer.from(
+      `${exchangeApplication.id}:${secrets[0]!.value}`
+    ).toString('base64')}`;
+    /* eslint-enable @silverhand/fp/no-mutation */
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      deleteUser(testUserId),
+      deleteResource(testResource.id),
+      deleteApplication(m2mApplication.id),
+      deleteApplication(exchangeApplication.id),
+    ]);
+  });
+
+  it('should ignore the proof and issue an unbound token for the `client_credentials` grant', async () => {
+    const response = await oidcApi
+      .post('token', {
+        headers: { ...formUrlEncodedHeaders, DPoP: await createDpopProof() },
+        body: new URLSearchParams({
+          grant_type: GrantType.ClientCredentials,
+          client_id: m2mApplication.id,
+          client_secret: m2mApplication.secret,
+          resource: testResource.indicator,
+        }),
+      })
+      .json<TokenResponse>();
+
+    expectNoDpopBinding(response);
+  });
+
+  it('should ignore the proof and issue an unbound token for the `refresh_token` grant', async () => {
+    const client = await initExperienceClient({
+      config: { resources: [testResource.indicator] },
+    });
+    await identifyUserWithUsernamePassword(client, username, password);
+    const { redirectTo } = await client.submitInteraction();
+    await processSession(client, redirectTo);
+    const refreshToken = await client.getRefreshToken();
+    assert(refreshToken, new Error('No refresh token available'));
+
+    const response = await oidcApi
+      .post('token', {
+        headers: { ...formUrlEncodedHeaders, DPoP: await createDpopProof() },
+        body: new URLSearchParams({
+          grant_type: GrantType.RefreshToken,
+          client_id: demoAppApplicationId,
+          refresh_token: refreshToken,
+          resource: testResource.indicator,
+        }),
+      })
+      .json<TokenResponse>();
+
+    expectNoDpopBinding(response);
+  });
+
+  it('should ignore the proof and issue an unbound token for the token exchange grant', async () => {
+    const { subjectToken } = await createSubjectToken(testUserId);
+
+    const response = await oidcApi
+      .post('token', {
+        headers: {
+          ...formUrlEncodedHeaders,
+          Authorization: exchangeAuthorizationHeader,
+          DPoP: await createDpopProof(),
+        },
+        body: new URLSearchParams({
+          grant_type: GrantType.TokenExchange,
+          subject_token: subjectToken,
+          subject_token_type: impersonationTokenType,
+          resource: testResource.indicator,
+        }),
+      })
+      .json<TokenResponse>();
+
+    expectNoDpopBinding(response);
+  });
+});


### PR DESCRIPTION
## Summary

Part of the oidc-provider v9 upgrade preparation (LOG-13796).

**Background**: `handleDPoP` in `packages/core/src/oidc/grants/utils.ts` — shared by the `refresh_token`, `client_credentials`, and token exchange grants — was copied from oidc-provider, but the copy dropped the line that resolves `ReplayDetection` from the provider instance, leaving an undeclared variable masked by a `@ts-expect-error`. Reaching that line throws `ReferenceError: ReplayDetection is not defined`, and the token endpoint responds with HTTP 500. The branch is unreachable today because the DPoP feature is disabled, but oidc-provider v9 enables DPoP by default — so the latent bug needs to be fixed before the upgrade, and the current disabled-DPoP behavior needs a test baseline to guard the switch.

**Changes**:

- Resolve the model from the provider instance (`const { ReplayDetection } = ctx.oidc.provider;`) as the upstream implementation does, remove the masking `@ts-expect-error`, and type the static `unique` call with a local intersection type (the method is missing from `@types/oidc-provider`, which cannot be safely fixed via module augmentation).
- Correct the local `validate_dpop.js` return type — `jti` and `iat` are guaranteed by the helper's runtime checks — so the unsuppressed call type-checks.
- Add a unit test driving the DPoP branch against the real `ReplayDetection` model; it fails with the `ReferenceError` against the previous code.
- Add an integration test pinning the disabled-DPoP baseline: a valid DPoP proof (RFC 9449) is ignored on all three grants and the issued token carries no `jkt` binding. It must keep passing unchanged across the v9 switch and fails loudly if DPoP ever turns on unintentionally.

No changeset: the fixed branch is unreachable in the current configuration, so there is no end-user-visible change.

## Testing

Unit tests and integration tests.

## Checklist

- [ ] `.changeset` (not needed — no end-user-visible change)
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKDEDcBY6QZA75KmFgHTVx
