### PR TITLE
feat(core): support custom email allowlist policy

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -9,36 +9,49 @@ import {
   isEmailBlocklistPolicyEnabled,
 } from './email-blocklist-policy.js';
 
-const invalidCustomBlockList = ['bar', 'bar@foo', '@foo', '@foo.', 'bar@foo.'];
-const validCustomBlockList = ['bar@foo.com', '@foo.com', 'abc.bar@foo.xyz', 'bar@foo.com'];
+const customListKeys = ['customAllowlist', 'customBlocklist'] as const;
+const invalidCustomEmailList = ['bar', 'bar@foo', '@foo', '@foo.', 'bar@foo.'];
+const validCustomEmailList = ['bar@foo.com', '@foo.com', 'abc.bar@foo.xyz', 'bar@foo.com'];
+
+const buildPolicyWithCustomList = (
+  key: (typeof customListKeys)[number],
+  list: string[]
+): EmailBlocklistPolicy => ({
+  [key]: list,
+});
 
 describe('parseEmailBlocklistPolicy', () => {
-  it.each(invalidCustomBlockList)(
-    'should throw error for invalid custom block list item: %s',
-    (item) => {
-      const emailBlocklistPolicy = { customBlocklist: [item] };
-      expect(() => {
-        parseEmailBlocklistPolicy(emailBlocklistPolicy);
-      }).toMatchError(
-        new RequestError({
-          code: 'sign_in_experiences.invalid_custom_email_blocklist_format',
-          items: Array.from([item]),
-          status: 400,
-        })
+  it.each(customListKeys)('should throw error for invalid %s item', (key) => {
+    const emailBlocklistPolicy = buildPolicyWithCustomList(key, invalidCustomEmailList);
+
+    expect(() => {
+      parseEmailBlocklistPolicy(emailBlocklistPolicy);
+    }).toMatchError(
+      new RequestError({
+        code: 'sign_in_experiences.invalid_custom_email_blocklist_format',
+        items: invalidCustomEmailList,
+        status: 400,
+      })
+    );
+  });
+
+  it.each(customListKeys)(
+    'should pass the validation with valid %s format and deduplicate items',
+    (key) => {
+      const parsed = parseEmailBlocklistPolicy(
+        buildPolicyWithCustomList(key, validCustomEmailList)
       );
+
+      expect(parsed).toEqual({ [key]: deduplicate(validCustomEmailList) });
     }
   );
 
-  it('should pass the validation with valid format and deduplicate items', () => {
-    const parsed = parseEmailBlocklistPolicy({ customBlocklist: validCustomBlockList });
-    expect(parsed).toEqual({ customBlocklist: deduplicate(validCustomBlockList) });
-  });
-
   it('should allow wildcard items', () => {
-    const customBlocklist = ['foo*@bar.com', '*@example.com', '@foo.*', '@*.example.com'];
-    const parsed = parseEmailBlocklistPolicy({ customBlocklist });
+    const customAllowlist = ['foo*@bar.com', '*@example.com', '@foo.*', '@*.example.com'];
+    const customBlocklist = ['foo*@bar.com', '@*.example.com'];
+    const parsed = parseEmailBlocklistPolicy({ customAllowlist, customBlocklist });
 
-    expect(parsed).toEqual({ customBlocklist });
+    expect(parsed).toEqual({ customAllowlist, customBlocklist });
   });
 });
 
@@ -157,6 +170,13 @@ describe('isEmailBlocklistPolicyEnabled', () => {
     expect(
       isEmailBlocklistPolicyEnabled({
         ...emailBlocklistPolicy,
+        customAllowlist: ['@bar.com'],
+      })
+    ).toBe(true);
+
+    expect(
+      isEmailBlocklistPolicyEnabled({
+        ...emailBlocklistPolicy,
         customBlocklist: ['@bar.com'],
       })
     ).toBe(true);
@@ -166,9 +186,14 @@ describe('isEmailBlocklistPolicyEnabled', () => {
     const emailBlocklistPolicy: EmailBlocklistPolicy = {
       blockDisposableAddresses: false,
       blockSubaddressing: false,
+      customAllowlist: [],
       customBlocklist: [],
     };
 
     expect(isEmailBlocklistPolicyEnabled(emailBlocklistPolicy)).toBe(false);
+  });
+
+  it('isEmailBlocklistPolicyEnabled should return false for an empty policy', () => {
+    expect(isEmailBlocklistPolicyEnabled({})).toBe(false);
   });
 });

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -8,7 +8,7 @@ import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
-const validateCustomBlockListFormat = (list: string[]) => {
+const validateCustomEmailListFormat = (list: string[]) => {
   const invalidItems = new Set<string>();
 
   for (const item of list) {
@@ -20,9 +20,9 @@ const validateCustomBlockListFormat = (list: string[]) => {
   return invalidItems;
 };
 
-const parseCustomBlocklist = (customBlocklist: string[]) => {
-  const deduplicated = deduplicate(customBlocklist);
-  const invalidItems = validateCustomBlockListFormat(deduplicated);
+const parseCustomEmailList = (list: string[]) => {
+  const deduplicated = deduplicate(list);
+  const invalidItems = validateCustomEmailListFormat(deduplicated);
 
   if (invalidItems.size > 0) {
     throw new RequestError({
@@ -36,13 +36,13 @@ const parseCustomBlocklist = (customBlocklist: string[]) => {
 };
 
 /**
- * This function will deduplicate the custom blocklist (if not undefined) and validate the format of each item.
+ * This function will deduplicate the custom blocklist and allowlist (if not undefined) and validate the format of each item.
  * If any item is invalid, it throws a RequestError with the details of the invalid items.
  */
 export const parseEmailBlocklistPolicy = (
   emailBlocklistPolicy: EmailBlocklistPolicy
 ): EmailBlocklistPolicy => {
-  const { customBlocklist, ...rest } = emailBlocklistPolicy;
+  const { customAllowlist, customBlocklist, ...rest } = emailBlocklistPolicy;
 
   // BlockDisposableAddresses is not supported for OSS.
   if (rest.blockDisposableAddresses) {
@@ -57,7 +57,8 @@ export const parseEmailBlocklistPolicy = (
 
   return {
     ...rest,
-    ...conditional(customBlocklist && { customBlocklist: parseCustomBlocklist(customBlocklist) }),
+    ...conditional(customAllowlist && { customAllowlist: parseCustomEmailList(customAllowlist) }),
+    ...conditional(customBlocklist && { customBlocklist: parseCustomEmailList(customBlocklist) }),
   };
 };
 
@@ -174,13 +175,13 @@ export const validateEmailAgainstBlocklistPolicy = async (
 };
 
 export const isEmailBlocklistPolicyEnabled = (emailBlockListPolicy: EmailBlocklistPolicy) => {
-  const { blockDisposableAddresses, blockSubaddressing, customBlocklist } = emailBlockListPolicy;
+  const { blockDisposableAddresses, blockSubaddressing, customAllowlist, customBlocklist } =
+    emailBlockListPolicy;
 
-  /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
-  return (
-    blockDisposableAddresses ||
-    blockSubaddressing ||
-    (customBlocklist && customBlocklist.length > 0)
-  );
-  /* eslint-enable @typescript-eslint/prefer-nullish-coalescing */
+  return [
+    blockDisposableAddresses === true,
+    blockSubaddressing === true,
+    (customAllowlist?.length ?? 0) > 0,
+    (customBlocklist?.length ?? 0) > 0,
+  ].some(Boolean);
 };

--- a/packages/core/src/routes/sign-in-experience/index.openapi.json
+++ b/packages/core/src/routes/sign-in-experience/index.openapi.json
@@ -96,13 +96,17 @@
                       "description": "Custom sentinel policy settings. Use this field to customize the user lockout policy. The default value is 100 failed attempts within one hour. The user will be locked out for 60 minutes after exceeding the limit."
                     },
                     "emailBlocklistPolicy": {
-                      "description": "Define email restriction policies. Users will be prohibited from registering or linking any email addresses that are included in the blocklist.",
+                      "description": "Define email restriction policies for registering or linking email addresses.",
                       "properties": {
-                        "blockDisposableAddress": {
+                        "blockDisposableAddresses": {
                           "description": "Cloud only.  Whether to block disposable email addresses. Once enabled, Logto will check the email domain against a list of known disposable email domains. If the domain is found in the list, the email address will be blocked."
                         },
                         "blockSubaddressing": {
                           "description": "Whether to block sub-addresses. (E.g., example+shopping@test.com)"
+                        },
+                        "customAllowlist": {
+                          "description": "Dev feature. Custom allowlist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`.",
+                          "x-logto-dev-feature": true
                         },
                         "customBlocklist": {
                           "description": "Custom blocklist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`."
@@ -210,13 +214,17 @@
                     "description": "Custom sentinel policy settings. Use this field to customize the user lockout policy. The default value is 100 failed attempts within one hour. The user will be locked out for 60 minutes after exceeding the limit."
                   },
                   "emailBlocklistPolicy": {
-                    "description": "Define email restriction policies. Users will be prohibited from registering or linking any email addresses that are included in the blocklist.",
+                    "description": "Define email restriction policies for registering or linking email addresses.",
                     "properties": {
-                      "blockDisposableAddress": {
+                      "blockDisposableAddresses": {
                         "description": "Cloud only.  Whether to block disposable email addresses. Once enabled, Logto will check the email domain against a list of known disposable email domains. If the domain is found in the list, the email address will be blocked."
                       },
                       "blockSubaddressing": {
                         "description": "Whether to block sub-addresses. (E.g., example+shopping@test.com)"
+                      },
+                      "customAllowlist": {
+                        "description": "Dev feature. Custom allowlist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`.",
+                        "x-logto-dev-feature": true
                       },
                       "customBlocklist": {
                         "description": "Custom blocklist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`."

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -94,7 +94,9 @@ const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 const originalIsCloud = EnvSet.values.isCloud;
 const originalIsProduction = EnvSet.values.isProduction;
 
-const createDevFeaturesDisabledRequester = async () => {
+const createDevFeaturesDisabledRequester = async (
+  signInExperience: SignInExperience = mockSignInExperience
+) => {
   jest.resetModules();
 
   await mockEsmWithActual('#src/env-set/index.js', () => ({
@@ -110,7 +112,7 @@ const createDevFeaturesDisabledRequester = async () => {
 
   const updateDefaultSignInExperience = jest.fn(
     async (data: Partial<CreateSignInExperience>): Promise<SignInExperience> => ({
-      ...mockSignInExperience,
+      ...signInExperience,
       ...data,
     })
   );
@@ -120,7 +122,7 @@ const createDevFeaturesDisabledRequester = async () => {
     {
       signInExperiences: {
         updateDefaultSignInExperience,
-        findDefaultSignInExperience: jest.fn().mockResolvedValue(mockSignInExperience),
+        findDefaultSignInExperience: jest.fn().mockResolvedValue(signInExperience),
       },
       customPhrases: { findAllCustomLanguageTags: async () => [] },
     },
@@ -721,6 +723,28 @@ describe('PATCH /sign-in-exp', () => {
     });
   });
 
+  it('should accept custom allowlist in email blocklist policy', async () => {
+    const emailBlocklistPolicy = {
+      customAllowlist: ['foo@bar.com', '@example.com', 'foo@bar.com'],
+      customBlocklist: ['@blocked.com'],
+    };
+
+    const response = await signInExperienceRequester.patch('/sign-in-exp').send({
+      emailBlocklistPolicy,
+    });
+
+    expect(response).toMatchObject({
+      status: 200,
+      body: {
+        ...mockSignInExperience,
+        emailBlocklistPolicy: {
+          customAllowlist: ['foo@bar.com', '@example.com'],
+          customBlocklist: ['@blocked.com'],
+        },
+      },
+    });
+  });
+
   it('should reject phone forgot password method when phone connector is not available', async () => {
     mockGetLogtoConnectors.mockResolvedValueOnce([]);
 
@@ -814,6 +838,37 @@ describe('sign-in experience routes with dev features disabled', () => {
       adaptiveMfa,
       mfa,
     });
+  });
+
+  it('should omit custom allowlist from GET response', async () => {
+    const emailBlocklistPolicy = {
+      customAllowlist: ['@allowed.com'],
+      customBlocklist: ['@blocked.com'],
+    };
+    const { requester } = await createDevFeaturesDisabledRequester({
+      ...mockSignInExperience,
+      emailBlocklistPolicy,
+    });
+
+    const response = await requester.get('/sign-in-exp');
+
+    expect(response.status).toEqual(200);
+    expect(response.body.emailBlocklistPolicy).toEqual({
+      customBlocklist: emailBlocklistPolicy.customBlocklist,
+    });
+  });
+
+  it('should reject custom allowlist updates', async () => {
+    const { requester, updateDefaultSignInExperience } = await createDevFeaturesDisabledRequester();
+
+    const response = await requester.patch('/sign-in-exp').send({
+      emailBlocklistPolicy: {
+        customAllowlist: ['@allowed.com'],
+      },
+    });
+
+    expect(response.status).toEqual(400);
+    expect(updateDefaultSignInExperience).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -43,6 +43,30 @@ const isNonSkippableMfaPromptPolicy = (policy: MfaPolicy) =>
     policy
   );
 
+// Dev feature guard for the custom email allowlist configuration.
+const hasCustomAllowlistProperty = (
+  emailBlocklistPolicy: Optional<SignInExperience['emailBlocklistPolicy']>
+) => Boolean(emailBlocklistPolicy && 'customAllowlist' in emailBlocklistPolicy);
+
+const omitDevFeatureEmailBlocklistPolicyProperties = (
+  signInExperience: SignInExperience
+): SignInExperience => {
+  if (
+    EnvSet.values.isDevFeaturesEnabled ||
+    !hasCustomAllowlistProperty(signInExperience.emailBlocklistPolicy)
+  ) {
+    return signInExperience;
+  }
+
+  const { customAllowlist: _customAllowlist, ...emailBlocklistPolicy } =
+    signInExperience.emailBlocklistPolicy;
+
+  return {
+    ...signInExperience,
+    emailBlocklistPolicy,
+  };
+};
+
 const signInExperienceResponseGuard = SignInExperiences.guard;
 const signInExperienceCreateGuard = SignInExperiences.createGuard;
 
@@ -71,7 +95,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
       status: [200, 404],
     }),
     async (ctx, next) => {
-      ctx.body = await findDefaultSignInExperience();
+      ctx.body = omitDevFeatureEmailBlocklistPolicyProperties(await findDefaultSignInExperience());
 
       return next();
     }
@@ -147,6 +171,16 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         getLogtoConnectors(),
         findDefaultSignInExperience(),
       ]);
+
+      if (hasCustomAllowlistProperty(emailBlocklistPolicy)) {
+        assertThat(
+          EnvSet.values.isDevFeaturesEnabled,
+          new RequestError({
+            code: 'request.invalid_input',
+            details: 'Email allowlist configuration is not available',
+          })
+        );
+      }
 
       // Flipping usernames to case-insensitive would merge accounts that differ only by case, so
       // reject the flip while such conflicts exist. Only the actual case-sensitive ->
@@ -403,7 +437,9 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         ...conditional(verificationCodePolicy && { verificationCodePolicy }),
       };
 
-      ctx.body = await updateDefaultSignInExperience(payload);
+      ctx.body = omitDevFeatureEmailBlocklistPolicyProperties(
+        await updateDefaultSignInExperience(payload)
+      );
 
       void quota.reportSubscriptionUpdatesUsage('mfaEnabled');
 

--- a/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
+++ b/packages/schemas/src/foundations/jsonb-types/sign-in-experience.ts
@@ -327,6 +327,12 @@ export type EmailBlocklistPolicy = {
   blockDisposableAddresses?: boolean;
   blockSubaddressing?: boolean;
   /**
+   * Custom allowlist of email addresses, domains, or wildcard email address patterns.
+   *
+   * The matching semantics are the same as {@link customBlocklist}.
+   */
+  customAllowlist?: string[];
+  /**
    * Custom blocklist of email addresses, domains, or wildcard email address patterns.
    *
    * @example
@@ -347,6 +353,7 @@ export type EmailBlocklistPolicy = {
 export const emailBlocklistPolicyGuard = z.object({
   blockDisposableAddresses: z.boolean().optional(),
   blockSubaddressing: z.boolean().optional(),
+  customAllowlist: z.string().array().optional(),
   customBlocklist: z.string().array().optional(),
 }) satisfies ToZodObject<EmailBlocklistPolicy>;
 


### PR DESCRIPTION
## Summary
Extend the existing email blocklist policy shape with `customAllowlist`, reusing the same custom email list validation and deduplication rules as `customBlocklist`. Treat a non-empty custom allowlist as an enabled email access policy for security feature quota checks, and keep `PATCH /sign-in-exp` accepting and returning the extended policy.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments