### PR TITLE
feat(core): enforce custom email allowlist

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -138,6 +138,72 @@ describe('validateEmailAgainstBlocklistPolicy', () => {
     }
   });
 
+  it('should keep existing behavior when the custom allowlist is disabled', async () => {
+    await expect(
+      validateEmailAgainstBlocklistPolicy({ customAllowlist: [] }, 'foo@bar.com')
+    ).resolves.not.toThrow();
+  });
+
+  it('should throw if the email address does not match the custom allowlist', async () => {
+    const email = 'foo@bar.com';
+
+    await expect(
+      validateEmailAgainstBlocklistPolicy({ customAllowlist: ['@allowed.com'] }, email)
+    ).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
+  });
+
+  it.each([
+    { customAllowlist: ['Foo@Bar.com'], email: 'foo@bar.com' },
+    { customAllowlist: ['@bar.com'], email: 'foo@Bar.com' },
+    { customAllowlist: ['foo*@bar.com'], email: 'FooBar@bar.com' },
+    { customAllowlist: ['@*.example.com'], email: 'test@Foo.example.com' },
+  ])('should pass if the email address matches the custom allowlist: %p', async (policy) => {
+    await expect(validateEmailAgainstBlocklistPolicy(policy, policy.email)).resolves.not.toThrow();
+  });
+
+  it('should still apply custom blocklist after the email address matches the custom allowlist', async () => {
+    const email = 'foo@bar.com';
+
+    await expect(
+      validateEmailAgainstBlocklistPolicy(
+        {
+          customAllowlist: ['@bar.com'],
+          customBlocklist: ['foo@bar.com'],
+        },
+        email
+      )
+    ).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
+  });
+
+  it('should still apply subaddressing block after the email address matches the custom allowlist', async () => {
+    await expect(
+      validateEmailAgainstBlocklistPolicy(
+        {
+          blockSubaddressing: true,
+          customAllowlist: ['@bar.com'],
+        },
+        'foo+tag@bar.com'
+      )
+    ).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_subaddressing_not_allowed',
+        status: 422,
+      })
+    );
+  });
+
   it('should pass the blocklist policy validation', async () => {
     await expect(
       validateEmailAgainstBlocklistPolicy(emailBlocklistPolicy, 'test@bar.com')

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -116,11 +116,12 @@ const validateDisposableEmailDomain = async (email: string) => {
 };
 
 /**
- * Guard the email address is not in the sign-in experience blocklist. *
+ * Guard the email address with the sign-in experience email access policy.
  *
  * @remarks
+ * - guard custom allowlist if provided
  * - guard disposable email domain if enabled
- * - guard email subaddessing if enabled
+ * - guard email subaddressing if enabled
  * - guard custom email address/domain if provided
  *
  * @remarks
@@ -132,10 +133,27 @@ export const validateEmailAgainstBlocklistPolicy = async (
   emailBlocklistPolicy: EmailBlocklistPolicy,
   email: string
 ) => {
-  const { customBlocklist, blockDisposableAddresses, blockSubaddressing } = emailBlocklistPolicy;
+  const { customAllowlist, customBlocklist, blockDisposableAddresses, blockSubaddressing } =
+    emailBlocklistPolicy;
   const domain = email.split('@')[1];
 
   assertThat(domain, new RequestError('session.email_blocklist.invalid_email'));
+
+  // Guard custom allowlist if provided
+  if (customAllowlist?.length) {
+    const isCustomAllowlisted = customAllowlist.some((item) =>
+      matchesEmailBlocklistItem(item, email)
+    );
+
+    assertThat(
+      isCustomAllowlisted,
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
+  }
 
   // Guard email subaddressing if enabled
   if (blockSubaddressing) {

--- a/packages/core/src/routes/account/email-and-phone.test.ts
+++ b/packages/core/src/routes/account/email-and-phone.test.ts
@@ -1,0 +1,79 @@
+import { UserScope } from '@logto/core-kit';
+import { AccountCenterControlValue, type User } from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockSignInExperience, mockUser } from '#src/__mocks__/index.js';
+import type Queries from '#src/tenants/Queries.js';
+import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const mockedQueries = {
+  users: {
+    findUserById: jest.fn(async () => mockUser),
+    updateUserById: jest.fn(async (_userId: string, data: Partial<User>) => ({
+      ...mockUser,
+      ...data,
+    })),
+  },
+  signInExperiences: {
+    findDefaultSignInExperience: jest.fn(async () => ({
+      ...mockSignInExperience,
+      emailBlocklistPolicy: {
+        customAllowlist: ['@allowed.com'],
+      },
+    })),
+  },
+} satisfies Partial2<Queries>;
+
+const mockedLibraries = {
+  users: {
+    checkIdentifierCollision: jest.fn(),
+  },
+};
+
+const emailAndPhoneRoutes = await pickDefault(import('./email-and-phone.js'));
+
+describe('account email and phone routes', () => {
+  const tenantContext = new MockTenant(undefined, mockedQueries, undefined, mockedLibraries);
+  const accountRequest = createRequester({
+    authedRoutes: [
+      (router) => {
+        router.use(async (ctx, next) => {
+          ctx.auth = {
+            ...ctx.auth,
+            id: mockUser.id,
+            identityVerified: true,
+            scopes: new Set([UserScope.Email]),
+          };
+          ctx.accountCenter = {
+            enabled: true,
+            fields: {
+              email: AccountCenterControlValue.Edit,
+            },
+          };
+          ctx.appendDataHookContext = jest.fn();
+
+          return next();
+        });
+      },
+      emailAndPhoneRoutes as never,
+    ],
+    tenantContext,
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should reject primary email update when the email does not match the custom allowlist', async () => {
+    const response = await accountRequest.post('/my-account/primary-email').send({
+      email: 'foo@bar.com',
+      newIdentifierVerificationRecordId: 'verification-record-id',
+    });
+
+    expect(response.status).toBe(422);
+    expect(mockedQueries.users.updateUserById).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -290,7 +290,7 @@ export default class ExperienceInteraction {
       if (verificationRecord.type !== VerificationType.EnterpriseSso) {
         await this.signInExperienceValidator.guardSsoOnlyEmailIdentifier(verificationRecord);
       }
-      await this.signInExperienceValidator.guardEmailBlocklist(verificationRecord);
+      await this.signInExperienceValidator.guardEmailAccessPolicy(verificationRecord);
 
       const identifierProfile = await getNewUserProfileFromVerificationRecord(verificationRecord);
 

--- a/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sign-in-experience-validator.ts
@@ -372,15 +372,16 @@ export class SignInExperienceValidator {
   }
 
   /**
-   * Guard the email address is not in the blocklist.
+   * Guard the email address with the email access policy.
    *
    * @remarks
-   * Use this method to guard the email address or domain is not in the blocklist.
+   * Use this method to guard the email address or domain with the configured email access policy.
+   * - guard custom allowlist if provided
    * - guard disposable email domain if enabled
-   * - guard email subaddessing if enabled
+   * - guard email subaddressing if enabled
    * - guard custom email address/domain if provided
    */
-  public async guardEmailBlocklist(verificationRecord: VerificationRecord) {
+  public async guardEmailAccessPolicy(verificationRecord: VerificationRecord) {
     const email = getEmailIdentifierFromVerificationRecord(verificationRecord);
     if (!email) {
       return;

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -118,7 +118,7 @@ export class Profile {
     // Guard SSO only email identifier in verification record  (EmailVerificationCode, Social)
     await this.signInExperienceValidator.guardSsoOnlyEmailIdentifier(verificationRecord);
 
-    await this.signInExperienceValidator.guardEmailBlocklist(verificationRecord);
+    await this.signInExperienceValidator.guardEmailAccessPolicy(verificationRecord);
 
     log?.append({
       verification: verificationRecord.toJson(),

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -17,7 +17,7 @@ type MockExperienceInteraction = {
   setVerificationRecord: jest.MockedFunction<() => Promise<void>>;
   save: jest.MockedFunction<() => Promise<void>>;
   signInExperienceValidator: {
-    guardEmailBlocklist: jest.MockedFunction<() => Promise<void>>;
+    guardEmailAccessPolicy: jest.MockedFunction<() => Promise<void>>;
     isRegistrationDisabled: jest.MockedFunction<() => Promise<boolean>>;
   };
 };
@@ -55,7 +55,7 @@ describe('sendCode parameter passing', () => {
     setVerificationRecord: jest.fn().mockImplementation(resolveVoid),
     save: jest.fn().mockImplementation(resolveVoid),
     signInExperienceValidator: {
-      guardEmailBlocklist: jest.fn().mockImplementation(resolveVoid),
+      guardEmailAccessPolicy: jest.fn().mockImplementation(resolveVoid),
       // Default: registration is enabled, so delivery is never suppressed for sign-in.
       isRegistrationDisabled: jest.fn().mockResolvedValue(false),
     },

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -142,12 +142,12 @@ export const sendCode = async ({
 
   const codeVerification = createVerificationRecord();
 
-  // Pre-validate email against blocklist for registration
+  // Pre-validate email with the email access policy for registration
   if (
     interactionEvent === InteractionEvent.Register &&
     identifier.type === SignInIdentifier.Email
   ) {
-    await experienceInteraction.signInExperienceValidator.guardEmailBlocklist(codeVerification);
+    await experienceInteraction.signInExperienceValidator.guardEmailAccessPolicy(codeVerification);
   }
 
   const skipDelivery = await shouldSkipDelivery(

--- a/packages/core/src/routes/verification/utils.test.ts
+++ b/packages/core/src/routes/verification/utils.test.ts
@@ -1,0 +1,43 @@
+import { SignInIdentifier, type VerificationCodeIdentifier } from '@logto/schemas';
+
+import { mockSignInExperience } from '#src/__mocks__/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import type Queries from '#src/tenants/Queries.js';
+
+import { guardNewIdentifierEmailBlocklist } from './utils.js';
+
+const { jest } = import.meta;
+
+describe('guardNewIdentifierEmailBlocklist', () => {
+  const findDefaultSignInExperience = jest.fn(async () => ({
+    ...mockSignInExperience,
+    emailBlocklistPolicy: {
+      customAllowlist: ['@allowed.com'],
+    },
+  }));
+  const queries = {
+    signInExperiences: {
+      findDefaultSignInExperience,
+    },
+  } as unknown as Queries;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should reject a new email identifier that does not match the custom allowlist', async () => {
+    const identifier: VerificationCodeIdentifier = {
+      type: SignInIdentifier.Email,
+      value: 'foo@bar.com',
+    };
+
+    await expect(guardNewIdentifierEmailBlocklist(queries, identifier, true)).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email: identifier.value,
+      })
+    );
+    expect(findDefaultSignInExperience).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Enforce `customAllowlist` through the existing email blocklist validator. A non-empty custom allowlist rejects emails that do not match any allowlist entry, while matching emails still continue through subaddressing, custom blocklist, and disposable-address checks.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments