### PR TITLE
feat(console): add inline hooks foundation and list page

### DIFF
--- a/packages/console/src/assets/icons/code.svg
+++ b/packages/console/src/assets/icons/code.svg
@@ -1,0 +1,22 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M7.08333 5.83325L2.91667 9.99992L7.08333 14.1666"
+    stroke="currentColor"
+    stroke-width="1.66667"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M12.9167 5.83325L17.0833 9.99992L12.9167 14.1666"
+    stroke="currentColor"
+    stroke-width="1.66667"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M11.6667 3.33325L8.33333 16.6666"
+    stroke="currentColor"
+    stroke-width="1.66667"
+    stroke-linecap="round"
+  />
+</svg>

--- a/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
@@ -9,6 +9,7 @@ import Connection from '@/assets/icons/connection.svg?react';
 import Gear from '@/assets/icons/gear.svg?react';
 import Hook from '@/assets/icons/hook.svg?react';
 import JwtClaims from '@/assets/icons/jwt-claims.svg?react';
+import Lightening from '@/assets/icons/lightening.svg?react';
 import List from '@/assets/icons/list.svg?react';
 import OrganizationTemplate from '@/assets/icons/organization-template-feature.svg?react';
 import Organization from '@/assets/icons/organization.svg?react';
@@ -19,6 +20,7 @@ import SecurityLock from '@/assets/icons/security-lock.svg?react';
 import Security from '@/assets/icons/security.svg?react';
 import EnterpriseSso from '@/assets/icons/single-sign-on.svg?react';
 import Web from '@/assets/icons/web.svg?react';
+import { isDevFeaturesEnabled } from '@/consts/env';
 
 type SidebarItem = {
   Icon: FC;
@@ -127,6 +129,13 @@ export const useSidebarMenuItems = (): {
     {
       title: 'developer',
       items: [
+        {
+          Icon: Lightening,
+          title: 'inline_hooks',
+          path: 'inline-hooks',
+          // Inline hooks are still under development and should be released as one feature.
+          isHidden: !isDevFeaturesEnabled,
+        },
         {
           Icon: JwtClaims,
           title: 'customize_jwt',

--- a/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
@@ -5,11 +5,11 @@ import type { FC, ReactNode } from 'react';
 import BarGraph from '@/assets/icons/bar-graph.svg?react';
 import Bolt from '@/assets/icons/bolt.svg?react';
 import Box from '@/assets/icons/box.svg?react';
+import Code from '@/assets/icons/code.svg?react';
 import Connection from '@/assets/icons/connection.svg?react';
 import Gear from '@/assets/icons/gear.svg?react';
 import Hook from '@/assets/icons/hook.svg?react';
 import JwtClaims from '@/assets/icons/jwt-claims.svg?react';
-import Lightening from '@/assets/icons/lightening.svg?react';
 import List from '@/assets/icons/list.svg?react';
 import OrganizationTemplate from '@/assets/icons/organization-template-feature.svg?react';
 import Organization from '@/assets/icons/organization.svg?react';
@@ -130,7 +130,7 @@ export const useSidebarMenuItems = (): {
       title: 'developer',
       items: [
         {
-          Icon: Lightening,
+          Icon: Code,
           title: 'inline_hooks',
           path: 'inline-hooks',
           // Inline hooks are still under development and should be released as one feature.

--- a/packages/console/src/hooks/use-console-routes/index.tsx
+++ b/packages/console/src/hooks/use-console-routes/index.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { Navigate, useParams, type RouteObject } from 'react-router-dom';
 import { safeLazy } from 'react-safe-lazy';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
 import NotFound from '@/pages/NotFound';
 
 import { apiResources } from './routes/api-resources';
@@ -11,6 +12,7 @@ import { auditLogs } from './routes/audit-logs';
 import { connectors } from './routes/connectors';
 import { customizeJwt } from './routes/customize-jwt';
 import { enterpriseSso } from './routes/enterprise-sso';
+import { inlineHooks } from './routes/inline-hooks';
 import { mfa } from './routes/mfa';
 import { organizationTemplate } from './routes/organization-template';
 import { organizations } from './routes/organizations';
@@ -42,6 +44,7 @@ export const useConsoleRoutes = () => {
         enterpriseSso,
         security,
         webhooks,
+        ...(isDevFeaturesEnabled ? [inlineHooks] : []),
         users,
         auditLogs,
         roles,
@@ -60,7 +63,7 @@ export const useConsoleRoutes = () => {
         tenantSettings,
         customizeJwt
       ),
-    [tenantSettings]
+    [tenantId, tenantSettings]
   );
 
   return routeObjects;

--- a/packages/console/src/hooks/use-console-routes/routes/inline-hooks.tsx
+++ b/packages/console/src/hooks/use-console-routes/routes/inline-hooks.tsx
@@ -1,0 +1,9 @@
+import { type RouteObject } from 'react-router-dom';
+import { safeLazy } from 'react-safe-lazy';
+
+const InlineHooks = safeLazy(async () => import('@/pages/InlineHooks'));
+
+export const inlineHooks: RouteObject = {
+  path: 'inline-hooks',
+  children: [{ index: true, element: <InlineHooks /> }],
+};

--- a/packages/console/src/pages/InlineHooks/InlineHookCard.tsx
+++ b/packages/console/src/pages/InlineHooks/InlineHookCard.tsx
@@ -1,0 +1,75 @@
+import Lightening from '@/assets/icons/lightening.svg?react';
+import DynamicT from '@/ds-components/DynamicT';
+import Tag from '@/ds-components/Tag';
+import useTenantPathname from '@/hooks/use-tenant-pathname';
+
+import { type InlineHookCatalogItem } from './constants';
+import styles from './index.module.scss';
+import { type InlineHookConfig, InlineHookAction } from './types';
+import { getInlineHookPagePath } from './utils';
+
+type Props = InlineHookCatalogItem & {
+  readonly config?: InlineHookConfig;
+};
+
+function InlineHookCard({ hookType, name, description, config }: Props) {
+  const { navigate } = useTenantPathname();
+  const isConfigured = Boolean(config);
+  const isEnabled = config?.value.enabled === true;
+
+  return (
+    <button
+      type="button"
+      className={styles.card}
+      onClick={() => {
+        navigate(
+          getInlineHookPagePath(
+            hookType,
+            isConfigured ? InlineHookAction.Edit : InlineHookAction.Create
+          )
+        );
+      }}
+    >
+      <div className={styles.iconContainer}>
+        <Lightening className={styles.icon} />
+      </div>
+      <div className={styles.cardContent}>
+        <div className={styles.cardHeader}>
+          <div className={styles.name}>
+            <DynamicT forKey={name} />
+          </div>
+          <div className={styles.tags}>
+            {isConfigured ? (
+              <>
+                <Tag type="state" status="success" variant="plain" size="small">
+                  <DynamicT forKey="inline_hooks.status.configured" />
+                </Tag>
+                <Tag
+                  type="state"
+                  status={isEnabled ? 'success' : 'info'}
+                  variant="plain"
+                  size="small"
+                >
+                  <DynamicT
+                    forKey={
+                      isEnabled ? 'inline_hooks.status.enabled' : 'inline_hooks.status.disabled'
+                    }
+                  />
+                </Tag>
+              </>
+            ) : (
+              <Tag type="state" status="info" variant="plain" size="small">
+                <DynamicT forKey="inline_hooks.status.not_configured" />
+              </Tag>
+            )}
+          </div>
+        </div>
+        <div className={styles.description}>
+          <DynamicT forKey={description} />
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export default InlineHookCard;

--- a/packages/console/src/pages/InlineHooks/InlineHookCard.tsx
+++ b/packages/console/src/pages/InlineHooks/InlineHookCard.tsx
@@ -1,4 +1,4 @@
-import Lightening from '@/assets/icons/lightening.svg?react';
+import Code from '@/assets/icons/code.svg?react';
 import DynamicT from '@/ds-components/DynamicT';
 import Tag from '@/ds-components/Tag';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
@@ -31,7 +31,7 @@ function InlineHookCard({ hookType, name, description, config }: Props) {
       }}
     >
       <div className={styles.iconContainer}>
-        <Lightening className={styles.icon} />
+        <Code className={styles.icon} />
       </div>
       <div className={styles.cardContent}>
         <div className={styles.cardHeader}>

--- a/packages/console/src/pages/InlineHooks/Skeleton.tsx
+++ b/packages/console/src/pages/InlineHooks/Skeleton.tsx
@@ -1,0 +1,22 @@
+import Card from '@/ds-components/Card';
+
+import { inlineHookCatalog } from './constants';
+import styles from './index.module.scss';
+
+function Skeleton() {
+  return (
+    <div className={styles.cardList} role="status" aria-label="Loading...">
+      {inlineHookCatalog.map(({ hookType }) => (
+        <Card key={hookType} className={styles.skeletonCard}>
+          <div className={styles.skeletonIcon} />
+          <div className={styles.skeletonContent}>
+            <div className={styles.skeletonTitle} />
+            <div className={styles.skeletonDescription} />
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export default Skeleton;

--- a/packages/console/src/pages/InlineHooks/constants.ts
+++ b/packages/console/src/pages/InlineHooks/constants.ts
@@ -1,0 +1,21 @@
+import { type AdminConsoleKey } from '@logto/phrases';
+import { LogtoInlineHookKey } from '@logto/schemas';
+
+export type InlineHookCatalogItem = {
+  hookType: LogtoInlineHookKey;
+  name: AdminConsoleKey;
+  description: AdminConsoleKey;
+};
+
+export const inlineHookCatalog: readonly InlineHookCatalogItem[] = Object.freeze([
+  {
+    hookType: LogtoInlineHookKey.PostFirstFactorVerification,
+    name: 'inline_hooks.hooks.post_first_factor_verification.name',
+    description: 'inline_hooks.hooks.post_first_factor_verification.description',
+  },
+  {
+    hookType: LogtoInlineHookKey.PostSignIn,
+    name: 'inline_hooks.hooks.post_sign_in.name',
+    description: 'inline_hooks.hooks.post_sign_in.description',
+  },
+]);

--- a/packages/console/src/pages/InlineHooks/index.module.scss
+++ b/packages/console/src/pages/InlineHooks/index.module.scss
@@ -1,0 +1,126 @@
+@use '@/scss/underscore' as _;
+
+.content {
+  display: flex;
+  flex: 1;
+  margin-top: _.unit(4);
+}
+
+.cardList {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-content: start;
+  gap: _.unit(4);
+  width: 100%;
+}
+
+.card {
+  display: flex;
+  align-items: flex-start;
+  gap: _.unit(4);
+  min-height: 160px;
+  padding: _.unit(6);
+  text-align: start;
+  color: var(--color-text);
+  background: var(--color-layer-1);
+  border: 1px solid var(--color-divider);
+  border-radius: _.unit(4);
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+
+  &:hover {
+    border-color: var(--color-primary);
+    box-shadow: var(--shadow-1);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-focused-variant);
+    outline-offset: 2px;
+  }
+}
+
+.iconContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  color: var(--color-primary);
+  background: var(--color-primary-container);
+  border-radius: 12px;
+}
+
+.icon {
+  width: 24px;
+  height: 24px;
+}
+
+.cardContent {
+  min-width: 0;
+  flex: 1;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: _.unit(3);
+}
+
+.name {
+  font: var(--font-title-2);
+}
+
+.tags {
+  display: flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: _.unit(2);
+}
+
+.description {
+  margin-top: _.unit(3);
+  color: var(--color-text-secondary);
+  font: var(--font-body-2);
+}
+
+.skeletonCard {
+  display: flex;
+  gap: _.unit(4);
+  min-height: 160px;
+  border: 1px solid var(--color-divider);
+}
+
+.skeletonIcon {
+  flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  @include _.shimmering-animation;
+}
+
+.skeletonContent {
+  flex: 1;
+}
+
+.skeletonTitle {
+  width: 45%;
+  height: 24px;
+  @include _.shimmering-animation;
+}
+
+.skeletonDescription {
+  width: 85%;
+  height: 40px;
+  margin-top: _.unit(4);
+  @include _.shimmering-animation;
+}
+
+@media screen and (max-width: 960px) {
+  .cardList {
+    grid-template-columns: 1fr;
+  }
+}

--- a/packages/console/src/pages/InlineHooks/index.test.tsx
+++ b/packages/console/src/pages/InlineHooks/index.test.tsx
@@ -1,0 +1,149 @@
+import { LogtoInlineHookKey } from '@logto/schemas';
+import { fireEvent, render, screen } from '@testing-library/react';
+import useSWR from 'swr';
+
+import useTenantPathname from '@/hooks/use-tenant-pathname';
+
+import InlineHooks from '.';
+import { type InlineHookConfig, InlineHookAction } from './types';
+import { getInlineHookPagePath } from './utils';
+
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-tenant-pathname', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('@/scss/page-layout.module.scss', () => ({
+  container: 'container',
+  headline: 'headline',
+}));
+
+jest.mock('@/components/PageMeta', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/ds-components/CardTitle', () => ({
+  __esModule: true,
+  default: ({ title, subtitle }: { readonly title: string; readonly subtitle: string }) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+    </div>
+  ),
+}));
+
+jest.mock('@/components/RequestDataError', () => ({
+  __esModule: true,
+  default: ({ error, onRetry }: { readonly error: Error; readonly onRetry?: () => void }) => (
+    <div>
+      <span>{error.message}</span>
+      {onRetry && <button onClick={onRetry}>retry</button>}
+    </div>
+  ),
+}));
+
+const mockNavigate = jest.fn();
+const mockMutate = jest.fn();
+const mockedUseSWR = jest.mocked(useSWR);
+const mockedUseTenantPathname = jest.mocked(useTenantPathname);
+
+const buildConfig = (key: LogtoInlineHookKey, enabled: boolean): InlineHookConfig => ({
+  key,
+  value: {
+    script: 'export default () => ({})',
+    enabled,
+  },
+});
+
+describe('InlineHooks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseTenantPathname.mockReturnValue({
+      navigate: mockNavigate,
+    } as unknown as ReturnType<typeof useTenantPathname>);
+  });
+
+  it('shows every catalog hook as unconfigured and navigates to create', () => {
+    mockedUseSWR.mockReturnValue({
+      data: [],
+      mutate: mockMutate,
+    } as unknown as ReturnType<typeof useSWR>);
+
+    render(<InlineHooks />);
+
+    expect(
+      screen.getByText('admin_console.inline_hooks.hooks.post_first_factor_verification.name')
+    ).toBeTruthy();
+    expect(screen.getByText('admin_console.inline_hooks.hooks.post_sign_in.name')).toBeTruthy();
+    expect(screen.getAllByText('admin_console.inline_hooks.status.not_configured')).toHaveLength(2);
+
+    fireEvent.click(screen.getByText('admin_console.inline_hooks.hooks.post_sign_in.name'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      getInlineHookPagePath(LogtoInlineHookKey.PostSignIn, InlineHookAction.Create)
+    );
+  });
+
+  it('shows a configured but disabled hook and navigates to edit', () => {
+    mockedUseSWR.mockReturnValue({
+      data: [buildConfig(LogtoInlineHookKey.PostFirstFactorVerification, false)],
+      mutate: mockMutate,
+    } as unknown as ReturnType<typeof useSWR>);
+
+    render(<InlineHooks />);
+
+    expect(screen.getByText('admin_console.inline_hooks.status.configured')).toBeTruthy();
+    expect(screen.getByText('admin_console.inline_hooks.status.disabled')).toBeTruthy();
+    expect(screen.getByText('admin_console.inline_hooks.status.not_configured')).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByText('admin_console.inline_hooks.hooks.post_first_factor_verification.name')
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      getInlineHookPagePath(LogtoInlineHookKey.PostFirstFactorVerification, InlineHookAction.Edit)
+    );
+  });
+
+  it('shows a configured and enabled hook', () => {
+    mockedUseSWR.mockReturnValue({
+      data: [buildConfig(LogtoInlineHookKey.PostSignIn, true)],
+      mutate: mockMutate,
+    } as unknown as ReturnType<typeof useSWR>);
+
+    render(<InlineHooks />);
+
+    expect(screen.getByText('admin_console.inline_hooks.status.configured')).toBeTruthy();
+    expect(screen.getByText('admin_console.inline_hooks.status.enabled')).toBeTruthy();
+  });
+
+  it('shows the loading state before data arrives', () => {
+    mockedUseSWR.mockReturnValue({
+      mutate: mockMutate,
+    } as unknown as ReturnType<typeof useSWR>);
+
+    render(<InlineHooks />);
+
+    expect(screen.getByRole('status', { name: 'Loading...' })).toBeTruthy();
+    expect(screen.queryByText('admin_console.inline_hooks.hooks.post_sign_in.name')).toBeNull();
+  });
+
+  it('shows an error state and retries the request', () => {
+    mockedUseSWR.mockReturnValue({
+      error: new Error('request failed'),
+      mutate: mockMutate,
+    } as unknown as ReturnType<typeof useSWR>);
+
+    render(<InlineHooks />);
+
+    expect(screen.getByText('request failed')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }));
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/console/src/pages/InlineHooks/index.tsx
+++ b/packages/console/src/pages/InlineHooks/index.tsx
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+import useSWR from 'swr';
+
+import PageMeta from '@/components/PageMeta';
+import RequestDataError from '@/components/RequestDataError';
+import CardTitle from '@/ds-components/CardTitle';
+import { type RequestError } from '@/hooks/use-api';
+import pageLayout from '@/scss/page-layout.module.scss';
+
+import InlineHookCard from './InlineHookCard';
+import Skeleton from './Skeleton';
+import { inlineHookCatalog } from './constants';
+import styles from './index.module.scss';
+import { type InlineHookConfig } from './types';
+import { inlineHooksSWRKey } from './utils';
+
+function InlineHooks() {
+  const { data, error, mutate } = useSWR<InlineHookConfig[], RequestError>(inlineHooksSWRKey);
+  const isLoading = !data && !error;
+
+  const configsByHookType = useMemo(
+    () => new Map(data?.map((config) => [config.key, config])),
+    [data]
+  );
+
+  return (
+    <div className={pageLayout.container}>
+      <PageMeta titleKey="inline_hooks.page_title" />
+      <div className={pageLayout.headline}>
+        <CardTitle title="inline_hooks.title" subtitle="inline_hooks.subtitle" />
+      </div>
+      <div className={styles.content}>
+        {isLoading && <Skeleton />}
+        {error && (
+          <RequestDataError
+            error={error}
+            onRetry={() => {
+              void mutate();
+            }}
+          />
+        )}
+        {data && (
+          <div className={styles.cardList}>
+            {inlineHookCatalog.map((item) => (
+              <InlineHookCard
+                key={item.hookType}
+                {...item}
+                config={configsByHookType.get(item.hookType)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default InlineHooks;

--- a/packages/console/src/pages/InlineHooks/types.ts
+++ b/packages/console/src/pages/InlineHooks/types.ts
@@ -1,0 +1,11 @@
+import { type InlineHook, type LogtoInlineHookKey } from '@logto/schemas';
+
+export enum InlineHookAction {
+  Create = 'create',
+  Edit = 'edit',
+}
+
+export type InlineHookConfig = {
+  key: LogtoInlineHookKey;
+  value: InlineHook;
+};

--- a/packages/console/src/pages/InlineHooks/utils.test.ts
+++ b/packages/console/src/pages/InlineHooks/utils.test.ts
@@ -1,0 +1,37 @@
+import { LogtoInlineHookKey } from '@logto/schemas';
+
+import { InlineHookAction } from './types';
+import {
+  getInlineHookApiPath,
+  getInlineHookPagePath,
+  getInlineHookSWRKey,
+  inlineHooksApiPath,
+  inlineHooksPath,
+  invalidateInlineHookCache,
+  invalidateInlineHooksCache,
+} from './utils';
+
+describe('inline hook paths and cache helpers', () => {
+  it('builds list and detail paths', () => {
+    expect(getInlineHookPagePath()).toBe(inlineHooksPath);
+    expect(getInlineHookPagePath(LogtoInlineHookKey.PostSignIn, InlineHookAction.Create)).toBe(
+      `${inlineHooksPath}/${LogtoInlineHookKey.PostSignIn}/${InlineHookAction.Create}`
+    );
+    expect(getInlineHookApiPath()).toBe(inlineHooksApiPath);
+    expect(getInlineHookSWRKey(LogtoInlineHookKey.PostSignIn)).toBe(
+      `${inlineHooksApiPath}/${LogtoInlineHookKey.PostSignIn}`
+    );
+  });
+
+  it('invalidates both list and detail caches', async () => {
+    const mutate = jest.fn().mockResolvedValue(null);
+
+    await invalidateInlineHooksCache(mutate);
+
+    await invalidateInlineHookCache(mutate, LogtoInlineHookKey.PostSignIn);
+
+    expect(mutate).toHaveBeenCalledTimes(3);
+    expect(mutate).toHaveBeenCalledWith(inlineHooksApiPath);
+    expect(mutate).toHaveBeenCalledWith(`${inlineHooksApiPath}/${LogtoInlineHookKey.PostSignIn}`);
+  });
+});

--- a/packages/console/src/pages/InlineHooks/utils.ts
+++ b/packages/console/src/pages/InlineHooks/utils.ts
@@ -1,0 +1,26 @@
+import { type LogtoInlineHookKey } from '@logto/schemas';
+
+import { type InlineHookAction } from './types';
+
+export const inlineHooksPath = '/inline-hooks';
+export const inlineHooksApiPath = 'api/configs/inline-hooks';
+export const inlineHooksSWRKey = inlineHooksApiPath;
+
+export const getInlineHookPagePath = (hookType?: LogtoInlineHookKey, action?: InlineHookAction) =>
+  hookType && action ? `${inlineHooksPath}/${hookType}/${action}` : inlineHooksPath;
+
+export const getInlineHookApiPath = (hookType?: LogtoInlineHookKey) =>
+  hookType ? `${inlineHooksApiPath}/${hookType}` : inlineHooksApiPath;
+
+export const getInlineHookSWRKey = (hookType: LogtoInlineHookKey) => getInlineHookApiPath(hookType);
+
+type CacheMutator = (key: string) => Promise<unknown>;
+
+export const invalidateInlineHooksCache = async (mutate: CacheMutator) => mutate(inlineHooksSWRKey);
+
+export const invalidateInlineHookCache = async (
+  mutate: CacheMutator,
+  hookType: LogtoInlineHookKey
+) => {
+  await Promise.all([invalidateInlineHooksCache(mutate), mutate(getInlineHookSWRKey(hookType))]);
+};

--- a/packages/phrases/src/locales/ar/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/ar/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,23 @@
+const inline_hooks = {
+  page_title: 'الخطافات المضمّنة',
+  title: 'الخطافات المضمّنة',
+  subtitle: 'شغّل تعليمات برمجية مخصصة في نقاط محددة من تدفق المصادقة لتوسيع سلوك Logto.',
+  status: {
+    not_configured: 'غير مكوّن',
+    configured: 'مكوّن',
+    enabled: 'مفعّل',
+    disabled: 'معطّل',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'بعد التحقق من العامل الأول',
+      description: 'شغّل منطقًا مخصصًا بعد التحقق من عامل المصادقة الأول وقبل متابعة تسجيل الدخول.',
+    },
+    post_sign_in: {
+      name: 'بعد تسجيل الدخول',
+      description: 'شغّل منطقًا مخصصًا بعد تسجيل دخول المستخدم بنجاح.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/ar/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'الخطافات المضمّنة',
   get_started: 'البدء',
   dashboard: 'لوحة القيادة',
   applications: 'التطبيقات',

--- a/packages/phrases/src/locales/de/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/de/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,26 @@
+const inline_hooks = {
+  page_title: 'Inline-Hooks',
+  title: 'Inline-Hooks',
+  subtitle:
+    'Führe benutzerdefinierten Code an bestimmten Punkten im Authentifizierungsablauf aus, um das Verhalten von Logto zu erweitern.',
+  status: {
+    not_configured: 'Nicht konfiguriert',
+    configured: 'Konfiguriert',
+    enabled: 'Aktiviert',
+    disabled: 'Deaktiviert',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'Nach Überprüfung des ersten Faktors',
+      description:
+        'Führe benutzerdefinierte Logik aus, nachdem der erste Authentifizierungsfaktor überprüft wurde und bevor die Anmeldung fortgesetzt wird.',
+    },
+    post_sign_in: {
+      name: 'Nach der Anmeldung',
+      description:
+        'Führe benutzerdefinierte Logik aus, nachdem sich ein Benutzer erfolgreich angemeldet hat.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/de/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'Inline-Hooks',
   get_started: 'Erste Schritte',
   dashboard: 'Dashboard',
   applications: 'Anwendungen',

--- a/packages/phrases/src/locales/en/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/en/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,25 @@
+const inline_hooks = {
+  page_title: 'Inline hooks',
+  title: 'Inline hooks',
+  subtitle:
+    'Run custom code at specific points in the authentication flow to extend Logto behavior.',
+  status: {
+    not_configured: 'Not configured',
+    configured: 'Configured',
+    enabled: 'Enabled',
+    disabled: 'Disabled',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'Post first-factor verification',
+      description:
+        'Run custom logic after the first authentication factor is verified and before sign-in continues.',
+    },
+    post_sign_in: {
+      name: 'Post sign-in',
+      description: 'Run custom logic after a user signs in successfully.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/en/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/tabs.ts
@@ -8,6 +8,7 @@ const tabs = {
   enterprise_sso: 'Enterprise SSO',
   security: 'Security',
   webhooks: 'Webhooks',
+  inline_hooks: 'Inline hooks',
   organizations: 'Organizations',
   users: 'User management',
   audit_logs: 'Audit logs',

--- a/packages/phrases/src/locales/es/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/es/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,26 @@
+const inline_hooks = {
+  page_title: 'Hooks inline',
+  title: 'Hooks inline',
+  subtitle:
+    'Ejecuta código personalizado en puntos específicos del flujo de autenticación para ampliar el comportamiento de Logto.',
+  status: {
+    not_configured: 'Sin configurar',
+    configured: 'Configurado',
+    enabled: 'Habilitado',
+    disabled: 'Deshabilitado',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'Después de verificar el primer factor',
+      description:
+        'Ejecuta lógica personalizada después de verificar el primer factor de autenticación y antes de continuar con el inicio de sesión.',
+    },
+    post_sign_in: {
+      name: 'Después de iniciar sesión',
+      description:
+        'Ejecuta lógica personalizada después de que un usuario inicie sesión correctamente.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/es/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'Hooks inline',
   get_started: 'Empezar',
   dashboard: 'Tablero',
   applications: 'Aplicaciones',

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,25 @@
+const inline_hooks = {
+  page_title: 'هوک‌های درون‌خطی',
+  title: 'هوک‌های درون‌خطی',
+  subtitle:
+    'کد سفارشی را در نقاط مشخصی از جریان احراز هویت اجرا کنید تا رفتار Logto را گسترش دهید.',
+  status: {
+    not_configured: 'پیکربندی نشده',
+    configured: 'پیکربندی شده',
+    enabled: 'فعال',
+    disabled: 'غیرفعال',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'پس از تأیید عامل اول',
+      description:
+        'پس از تأیید اولین عامل احراز هویت و پیش از ادامه ورود، منطق سفارشی را اجرا کنید.',
+    },
+    post_sign_in: {
+      name: 'پس از ورود',
+      description: 'پس از ورود موفق کاربر، منطق سفارشی را اجرا کنید.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'هوک‌های درون‌خطی',
   get_started: 'شروع کنید',
   dashboard: 'داشبورد',
   applications: 'برنامه‌ها',

--- a/packages/phrases/src/locales/fr/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/fr/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,26 @@
+const inline_hooks = {
+  page_title: 'Hooks inline',
+  title: 'Hooks inline',
+  subtitle:
+    'Exécutez du code personnalisé à des étapes précises du flux d’authentification pour étendre le comportement de Logto.',
+  status: {
+    not_configured: 'Non configuré',
+    configured: 'Configuré',
+    enabled: 'Activé',
+    disabled: 'Désactivé',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'Après la vérification du premier facteur',
+      description:
+        'Exécutez une logique personnalisée après la vérification du premier facteur d’authentification et avant la poursuite de la connexion.',
+    },
+    post_sign_in: {
+      name: 'Après la connexion',
+      description:
+        'Exécutez une logique personnalisée après la connexion réussie d’un utilisateur.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/fr/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'Hooks inline',
   get_started: 'Commencez',
   dashboard: 'Tableau de bord',
   applications: 'Applications',

--- a/packages/phrases/src/locales/it/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/it/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,26 @@
+const inline_hooks = {
+  page_title: 'Hook inline',
+  title: 'Hook inline',
+  subtitle:
+    'Esegui codice personalizzato in punti specifici del flusso di autenticazione per estendere il comportamento di Logto.',
+  status: {
+    not_configured: 'Non configurato',
+    configured: 'Configurato',
+    enabled: 'Abilitato',
+    disabled: 'Disabilitato',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'Dopo la verifica del primo fattore',
+      description:
+        'Esegui logica personalizzata dopo la verifica del primo fattore di autenticazione e prima che l’accesso continui.',
+    },
+    post_sign_in: {
+      name: 'Dopo l’accesso',
+      description:
+        'Esegui logica personalizzata dopo che un utente ha effettuato correttamente l’accesso.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/it/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'Hook inline',
   get_started: 'Iniziare',
   dashboard: 'Dashboard',
   applications: 'Applicazioni',

--- a/packages/phrases/src/locales/ja/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/ja/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,24 @@
+const inline_hooks = {
+  page_title: 'インラインフック',
+  title: 'インラインフック',
+  subtitle: '認証フローの特定のポイントでカスタムコードを実行し、Logto の動作を拡張します。',
+  status: {
+    not_configured: '未設定',
+    configured: '設定済み',
+    enabled: '有効',
+    disabled: '無効',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: '第1要素の検証後',
+      description:
+        '最初の認証要素が検証されてからサインインが続行されるまでの間に、カスタムロジックを実行します。',
+    },
+    post_sign_in: {
+      name: 'サインイン後',
+      description: 'ユーザーが正常にサインインした後に、カスタムロジックを実行します。',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/ja/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'インラインフック',
   get_started: 'はじめに',
   dashboard: 'ダッシュボード',
   applications: 'アプリケーション',

--- a/packages/phrases/src/locales/ko/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/ko/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,24 @@
+const inline_hooks = {
+  page_title: '인라인 훅',
+  title: '인라인 훅',
+  subtitle: '인증 흐름의 특정 지점에서 사용자 지정 코드를 실행하여 Logto 동작을 확장합니다.',
+  status: {
+    not_configured: '구성되지 않음',
+    configured: '구성됨',
+    enabled: '활성화됨',
+    disabled: '비활성화됨',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: '첫 번째 인증 요소 확인 후',
+      description:
+        '첫 번째 인증 요소가 확인된 후 로그인 절차가 계속되기 전에 사용자 지정 로직을 실행합니다.',
+    },
+    post_sign_in: {
+      name: '로그인 후',
+      description: '사용자가 성공적으로 로그인한 후 사용자 지정 로직을 실행합니다.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/ko/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: '인라인 훅',
   get_started: '시작하기',
   dashboard: '대시보드',
   applications: '어플리케이션',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,25 @@
+const inline_hooks = {
+  page_title: 'Hooki inline',
+  title: 'Hooki inline',
+  subtitle:
+    'Uruchamiaj niestandardowy kod w określonych punktach procesu uwierzytelniania, aby rozszerzyć działanie Logto.',
+  status: {
+    not_configured: 'Nieskonfigurowany',
+    configured: 'Skonfigurowany',
+    enabled: 'Włączony',
+    disabled: 'Wyłączony',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'Po weryfikacji pierwszego czynnika',
+      description:
+        'Uruchom niestandardową logikę po zweryfikowaniu pierwszego czynnika uwierzytelniania i przed kontynuowaniem logowania.',
+    },
+    post_sign_in: {
+      name: 'Po zalogowaniu',
+      description: 'Uruchom niestandardową logikę po pomyślnym zalogowaniu się użytkownika.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'Hooki inline',
   get_started: 'Rozpocznij',
   dashboard: 'Panel',
   applications: 'Aplikacje',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,25 @@
+const inline_hooks = {
+  page_title: 'Hooks inline',
+  title: 'Hooks inline',
+  subtitle:
+    'Execute código personalizado em pontos específicos do fluxo de autenticação para estender o comportamento do Logto.',
+  status: {
+    not_configured: 'Não configurado',
+    configured: 'Configurado',
+    enabled: 'Ativado',
+    disabled: 'Desativado',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'Após a verificação do primeiro fator',
+      description:
+        'Execute lógica personalizada após a verificação do primeiro fator de autenticação e antes de o login continuar.',
+    },
+    post_sign_in: {
+      name: 'Após o login',
+      description: 'Execute lógica personalizada após um usuário entrar com sucesso.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'Hooks inline',
   get_started: 'Primeiros passos',
   dashboard: 'Painel',
   applications: 'Aplicativos',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,25 @@
+const inline_hooks = {
+  page_title: 'Hooks inline',
+  title: 'Hooks inline',
+  subtitle:
+    'Execute código personalizado em pontos específicos do fluxo de autenticação para expandir o comportamento do Logto.',
+  status: {
+    not_configured: 'Não configurado',
+    configured: 'Configurado',
+    enabled: 'Ativado',
+    disabled: 'Desativado',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'Após a verificação do primeiro fator',
+      description:
+        'Execute lógica personalizada após a verificação do primeiro fator de autenticação e antes de o início de sessão continuar.',
+    },
+    post_sign_in: {
+      name: 'Após o início de sessão',
+      description: 'Execute lógica personalizada após um utilizador iniciar sessão com sucesso.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'Hooks inline',
   get_started: 'Começar',
   dashboard: 'Painel',
   applications: 'Aplicações',

--- a/packages/phrases/src/locales/ru/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/ru/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,25 @@
+const inline_hooks = {
+  page_title: 'Inline-хуки',
+  title: 'Inline-хуки',
+  subtitle:
+    'Запускайте пользовательский код в определённых точках процесса аутентификации, чтобы расширить поведение Logto.',
+  status: {
+    not_configured: 'Не настроено',
+    configured: 'Настроено',
+    enabled: 'Включено',
+    disabled: 'Отключено',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'После проверки первого фактора',
+      description:
+        'Запускайте пользовательскую логику после проверки первого фактора аутентификации и до продолжения входа.',
+    },
+    post_sign_in: {
+      name: 'После входа',
+      description: 'Запускайте пользовательскую логику после успешного входа пользователя.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/ru/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'Inline-хуки',
   get_started: 'Начало',
   dashboard: 'Панель управления',
   applications: 'Приложения',

--- a/packages/phrases/src/locales/th/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/th/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,25 @@
+const inline_hooks = {
+  page_title: 'ฮุกแบบอินไลน์',
+  title: 'ฮุกแบบอินไลน์',
+  subtitle:
+    'เรียกใช้โค้ดที่กำหนดเอง ณ จุดที่ระบุในขั้นตอนการยืนยันตัวตน เพื่อขยายการทำงานของ Logto',
+  status: {
+    not_configured: 'ยังไม่ได้กำหนดค่า',
+    configured: 'กำหนดค่าแล้ว',
+    enabled: 'เปิดใช้งาน',
+    disabled: 'ปิดใช้งาน',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'หลังจากยืนยันปัจจัยแรก',
+      description:
+        'เรียกใช้ตรรกะที่กำหนดเองหลังจากยืนยันปัจจัยการยืนยันตัวตนแรกและก่อนดำเนินการเข้าสู่ระบบต่อ',
+    },
+    post_sign_in: {
+      name: 'หลังจากเข้าสู่ระบบ',
+      description: 'เรียกใช้ตรรกะที่กำหนดเองหลังจากผู้ใช้เข้าสู่ระบบสำเร็จ',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/th/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'ฮุกแบบอินไลน์',
   get_started: 'เริ่มต้นใช้งาน',
   dashboard: 'แดชบอร์ด',
   applications: 'แอปพลิเคชัน',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,25 @@
+const inline_hooks = {
+  page_title: 'Satır içi kancalar',
+  title: 'Satır içi kancalar',
+  subtitle:
+    'Logto davranışını genişletmek için kimlik doğrulama akışının belirli noktalarında özel kod çalıştırın.',
+  status: {
+    not_configured: 'Yapılandırılmadı',
+    configured: 'Yapılandırıldı',
+    enabled: 'Etkin',
+    disabled: 'Devre dışı',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: 'İlk faktör doğrulamasından sonra',
+      description:
+        'İlk kimlik doğrulama faktörü doğrulandıktan sonra ve oturum açma devam etmeden önce özel mantık çalıştırın.',
+    },
+    post_sign_in: {
+      name: 'Oturum açma sonrası',
+      description: 'Bir kullanıcı başarıyla oturum açtıktan sonra özel mantık çalıştırın.',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: 'Satır içi kancalar',
   get_started: 'Başla',
   dashboard: 'Gösterge Paneli',
   applications: 'Uygulamalar',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,23 @@
+const inline_hooks = {
+  page_title: '内联钩子',
+  title: '内联钩子',
+  subtitle: '在身份验证流程的特定节点运行自定义代码，以扩展 Logto 的行为。',
+  status: {
+    not_configured: '未配置',
+    configured: '已配置',
+    enabled: '已启用',
+    disabled: '已停用',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: '首个身份验证因素验证后',
+      description: '在首个身份验证因素通过验证后、登录继续前运行自定义逻辑。',
+    },
+    post_sign_in: {
+      name: '登录后',
+      description: '在用户成功登录后运行自定义逻辑。',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: '内联钩子',
   get_started: '开始上手',
   dashboard: '仪表盘',
   applications: '全部应用',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,23 @@
+const inline_hooks = {
+  page_title: '內聯鉤子',
+  title: '內聯鉤子',
+  subtitle: '在身份驗證流程的特定節點運行自定義代碼，以擴展 Logto 的行為。',
+  status: {
+    not_configured: '未配置',
+    configured: '已配置',
+    enabled: '已啟用',
+    disabled: '已停用',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: '首個身份驗證因素驗證後',
+      description: '在首個身份驗證因素通過驗證後、登錄繼續前運行自定義邏輯。',
+    },
+    post_sign_in: {
+      name: '登錄後',
+      description: '在用戶成功登錄後運行自定義邏輯。',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: '內聯鉤子',
   get_started: '開始上手',
   dashboard: '儀表板',
   applications: '全部應用',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/index.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/index.ts
@@ -17,6 +17,7 @@ import general from './general.js';
 import get_started from './get-started.js';
 import guide from './guide.js';
 import inkeep_ai_bot from './inkeep-ai-bot.js';
+import inline_hooks from './inline-hooks.js';
 import invitation from './invitation.js';
 import jwt_claims from './jwt-claims.js';
 import log_details from './log-details.js';
@@ -105,6 +106,7 @@ const admin_console = {
   protected_app,
   jwt_claims,
   invitation,
+  inline_hooks,
   signing_keys,
   organization_template,
   organization_role_details,

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/inline-hooks.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/inline-hooks.ts
@@ -1,0 +1,23 @@
+const inline_hooks = {
+  page_title: '內聯掛鉤',
+  title: '內聯掛鉤',
+  subtitle: '在驗證流程的特定節點執行自訂程式碼，以擴充 Logto 的行為。',
+  status: {
+    not_configured: '未設定',
+    configured: '已設定',
+    enabled: '已啟用',
+    disabled: '已停用',
+  },
+  hooks: {
+    post_first_factor_verification: {
+      name: '第一個驗證因素驗證後',
+      description: '在第一個驗證因素通過驗證後、登入繼續前執行自訂邏輯。',
+    },
+    post_sign_in: {
+      name: '登入後',
+      description: '在使用者成功登入後執行自訂邏輯。',
+    },
+  },
+};
+
+export default Object.freeze(inline_hooks);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/tabs.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/tabs.ts
@@ -1,4 +1,5 @@
 const tabs = {
+  inline_hooks: '內聯掛鉤',
   get_started: '開始上手',
   dashboard: '儀表板',
   applications: '全部應用',


### PR DESCRIPTION
## Summary

- add the Inline hooks catalog page and developer navigation entry
- merge configured API records with the complete hook catalog and show configuration and activation states
- add reusable page/API paths, SWR keys, cache invalidation helpers, and component coverage

Closes LOG-13714

## Testing

- Tested locally
- Unit tests

<img width="1618" height="882" alt="Screenshot 2026-07-14 at 2 29 04 PM" src="https://github.com/user-attachments/assets/1f1ea9f2-7423-4e80-a0a3-e62787307a0b" />

