### PR TITLE
fix(core): correct inline hook remote runner route

### DIFF
--- a/packages/core/src/libraries/inline-hook.test.ts
+++ b/packages/core/src/libraries/inline-hook.test.ts
@@ -1,5 +1,6 @@
 import { appInsights } from '@logto/app-insights/node';
 import { LogtoInlineHookKey } from '@logto/schemas';
+import nock from 'nock';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -40,6 +41,7 @@ describe('InlineHookLibrary', () => {
   });
 
   afterEach(() => {
+    nock.cleanAll();
     jest.restoreAllMocks();
     jest.clearAllMocks();
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after quota tests.
@@ -262,6 +264,32 @@ describe('InlineHookLibrary', () => {
         message: 'Remote inline hook runner is not configured.',
       },
     });
+  });
+
+  it('runs the script through the regional untrusted runner endpoint', async () => {
+    const endpoint = 'https://untrusted.example.com';
+    const functionKey = 'function-key';
+    const payload = {
+      hookType: LogtoInlineHookKey.PostSignIn,
+      script: 'const runInlineHook = () => ({ action: "continue" });',
+      event: {
+        key: LogtoInlineHookKey.PostSignIn,
+      },
+    };
+    const executionResult = { action: 'continue' };
+    const remoteRunner = nock(endpoint, {
+      reqheaders: {
+        'x-functions-key': functionKey,
+      },
+    })
+      .post('/api/inline-hooks', payload)
+      .reply(200, executionResult);
+
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+
+    await expect(library.runScriptRemotely(payload)).resolves.toEqual(executionResult);
+    expect(remoteRunner.isDone()).toBe(true);
   });
 
   it('blocks PostSignIn execution errors with the owning flow failure by default', async () => {

--- a/packages/core/src/libraries/inline-hook.ts
+++ b/packages/core/src/libraries/inline-hook.ts
@@ -204,7 +204,7 @@ export class InlineHookLibrary {
 
     try {
       return await got
-        .post(new URL('/api/inline-hooks/test', azureFunctionUntrustedAppEndpoint), {
+        .post(new URL('/api/inline-hooks', azureFunctionUntrustedAppEndpoint), {
           json: payload,
           headers: {
             'x-functions-key': azureFunctionUntrustedAppKey,


### PR DESCRIPTION
## Summary

- align the Core remote call with the generic regional Inline Hook runner endpoint
- cover the runner URL, function key, request payload, and response in a unit test

## Root cause

The Console-facing Management API correctly uses a `/test` suffix, but that suffix was also applied to the internal stateless Azure runner URL. Regional runners execute the script supplied in each request and use the generic `/api/inline-hooks` endpoint, matching the existing Custom JWT execution flow.

## Impact

Console Inline Hook tests can reach the regional untrusted runner instead of receiving a route-level 404.

## Related

- pairs with [logto-io/cloud#1994](https://github.com/logto-io/cloud/pull/1994), which provides the regional `/api/inline-hooks` runner

## Testing

Unit tests
