### PR TITLE
refactor(core): align OIDC event listener context types with emitted events

### DIFF
--- a/packages/core/src/event-listeners/authorization-success.ts
+++ b/packages/core/src/event-listeners/authorization-success.ts
@@ -5,8 +5,7 @@ import type { KoaContextWithOIDC, Provider } from 'oidc-provider';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { createSessionLibrary } from '#src/libraries/session/index.js';
-import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
-import type { WithLogContext } from '#src/middleware/koa-audit-log.js';
+import { assertLogContext, type LogContext } from '#src/middleware/koa-audit-log.js';
 import type Queries from '#src/tenants/Queries.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { stringifyError } from '#src/utils/format.js';
@@ -54,7 +53,7 @@ const getGrantIdsToRevokeForMaxAllowedGrants = ({
 };
 
 const enforceMaxAllowedGrantsRevocation = async (
-  ctx: KoaContextWithOIDC & WithLogContext & WithAppSecretContext,
+  ctx: KoaContextWithOIDC & LogContext,
   provider: Provider,
   queries: Queries
 ) => {
@@ -145,7 +144,8 @@ const enforceMaxAllowedGrantsRevocation = async (
 };
 
 export const createAuthorizationSuccessListener = (provider: Provider, queries: Queries) => {
-  return async (ctx: KoaContextWithOIDC & WithLogContext & WithAppSecretContext) => {
+  return async (ctx: KoaContextWithOIDC) => {
+    assertLogContext(ctx);
     await enforceMaxAllowedGrantsRevocation(ctx, provider, queries);
   };
 };

--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -33,6 +33,7 @@ const testGrantListener = (
   const ctx = {
     ...createContextWithRouteParameters(),
     createLog: log.createLog,
+    prependAllLogEntries: log.prependAllLogEntries,
     oidc: { entities, params: parameters },
     body,
   };
@@ -166,6 +167,7 @@ describe('grantRevocationListener', () => {
     const ctx = {
       ...createContextWithRouteParameters(),
       createLog: log.createLog,
+      prependAllLogEntries: log.prependAllLogEntries,
       oidc: {
         entities: { Client: client, AccessToken: accessToken },
         params: parameters,
@@ -189,6 +191,7 @@ describe('grantRevocationListener', () => {
     const ctx = {
       ...createContextWithRouteParameters(),
       createLog: log.createLog,
+      prependAllLogEntries: log.prependAllLogEntries,
       oidc: {
         entities: {
           Client: client,

--- a/packages/core/src/event-listeners/grant.ts
+++ b/packages/core/src/event-listeners/grant.ts
@@ -1,8 +1,8 @@
 import { GrantType, LogResult, token } from '@logto/schemas';
 import type { errors, KoaContextWithOIDC } from 'oidc-provider';
+import { z } from 'zod';
 
-import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
-import type { WithLogContext } from '#src/middleware/koa-audit-log.js';
+import { assertLogContext } from '#src/middleware/koa-audit-log.js';
 
 import { stringifyError } from '../utils/format.js';
 import { isEnum } from '../utils/type.js';
@@ -13,17 +13,19 @@ import { extractInteractionContext } from './utils.js';
  * @see {@link https://github.com/panva/node-oidc-provider/blob/v7.x/lib/actions/token.js#L71 Success event emission}
  * @see {@link https://github.com/panva/node-oidc-provider/blob/v7.x/lib/shared/error_handler.js OIDC Provider error handler}
  */
-export const grantListener = (
-  ctx: KoaContextWithOIDC & WithLogContext & WithAppSecretContext & { body: GrantBody },
-  error?: errors.OIDCProviderError
-) => {
+export const grantListener = (ctx: KoaContextWithOIDC, error?: errors.OIDCProviderError) => {
+  assertLogContext(ctx);
+
   const { params } = ctx.oidc;
 
   const log = ctx.createLog(
     `${token.Type.ExchangeTokenBy}.${getExchangeByType(params?.grant_type)}`
   );
 
-  const { access_token, refresh_token, id_token, scope } = ctx.body;
+  const parsedBody = grantBodyGuard.safeParse(ctx.body);
+  const { access_token, refresh_token, id_token, scope } = parsedBody.success
+    ? parsedBody.data
+    : emptyGrantBody;
   const tokenTypes = [
     access_token && token.TokenType.AccessToken,
     refresh_token && token.TokenType.RefreshToken,
@@ -40,10 +42,9 @@ export const grantListener = (
 };
 
 // The grant.revoked event is emitted at https://github.com/panva/node-oidc-provider/blob/v7.x/lib/helpers/revoke.js#L25
-export const grantRevocationListener = (
-  ctx: KoaContextWithOIDC & WithLogContext,
-  grantId: string
-) => {
+export const grantRevocationListener = (ctx: KoaContextWithOIDC, grantId: string) => {
+  assertLogContext(ctx);
+
   const {
     entities: { AccessToken, RefreshToken },
   } = ctx.oidc;
@@ -57,14 +58,20 @@ export const grantRevocationListener = (
 };
 
 /**
+ * The grant response body. Only the log-relevant fields are guarded; on the `grant.error` event
+ * the body carries an error payload instead, hence the tolerant fallback.
+ *
  * @see {@link https://github.com/panva/node-oidc-provider/tree/v7.x/lib/actions/grants grants source code} for predefined grant implementations and types.
  */
-type GrantBody = {
-  access_token?: string;
-  refresh_token?: string;
-  id_token?: string;
-  scope?: string; // AccessToken.scope
-};
+const grantBodyGuard = z.object({
+  access_token: z.string().optional(),
+  refresh_token: z.string().optional(),
+  id_token: z.string().optional(),
+  /** `AccessToken.scope` */
+  scope: z.string().optional(),
+});
+
+const emptyGrantBody: z.infer<typeof grantBodyGuard> = {};
 
 const grantTypeToExchangeByType: Record<GrantType, token.ExchangeByType> = {
   [GrantType.AuthorizationCode]: token.ExchangeByType.AuthorizationCode,

--- a/packages/core/src/event-listeners/interaction.test.ts
+++ b/packages/core/src/event-listeners/interaction.test.ts
@@ -39,6 +39,7 @@ const testInteractionListener = (
   const ctx = {
     ...createContextWithRouteParameters(),
     createLog: log.createLog,
+    prependAllLogEntries: log.prependAllLogEntries,
     oidc: { entities, params: parameters },
   };
 

--- a/packages/core/src/event-listeners/interaction.ts
+++ b/packages/core/src/event-listeners/interaction.ts
@@ -1,25 +1,24 @@
 import type { KoaContextWithOIDC, PromptDetail } from 'oidc-provider';
 
-import type { WithLogContext } from '#src/middleware/koa-audit-log.js';
+import { assertLogContext } from '#src/middleware/koa-audit-log.js';
 
 import { extractInteractionContext } from './utils.js';
 
 const interactionListener = (
   event: 'started' | 'ended',
-  ctx: KoaContextWithOIDC & WithLogContext,
+  ctx: KoaContextWithOIDC,
   prompt?: PromptDetail
 ) => {
+  assertLogContext(ctx);
+
   const log = ctx.createLog(`Interaction.${event === 'started' ? 'Create' : 'End'}`);
   log.append({ ...extractInteractionContext(ctx), prompt });
 };
 
-export const interactionStartedListener = (
-  ctx: KoaContextWithOIDC & WithLogContext,
-  prompt: PromptDetail
-) => {
+export const interactionStartedListener = (ctx: KoaContextWithOIDC, prompt: PromptDetail) => {
   interactionListener('started', ctx, prompt);
 };
 
-export const interactionEndedListener = (ctx: KoaContextWithOIDC & WithLogContext) => {
+export const interactionEndedListener = (ctx: KoaContextWithOIDC) => {
   interactionListener('ended', ctx);
 };

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -1,11 +1,10 @@
-import type { IRouterParamContext } from 'koa-router';
 import type { KoaContextWithOIDC } from 'oidc-provider';
 
 import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
 import type { LogPayload } from '#src/middleware/koa-audit-log.js';
 
 export const extractInteractionContext = (
-  ctx: IRouterParamContext & KoaContextWithOIDC & WithAppSecretContext
+  ctx: WithAppSecretContext<KoaContextWithOIDC>
 ): LogPayload => {
   const {
     entities: { Account, Session, Client, Interaction },

--- a/packages/core/src/middleware/koa-audit-log.ts
+++ b/packages/core/src/middleware/koa-audit-log.ts
@@ -112,6 +112,25 @@ export type WithLogContext<ContextT extends IRouterParamContext = IRouterParamCo
   ContextT & LogContext;
 
 /**
+ * Assert that the context has been enriched with {@link LogContext} by the audit log middleware.
+ * Useful where a context is statically typed without {@link LogContext} but is known to run
+ * downstream of the middleware, e.g. `oidc-provider` event listeners, whose contexts are emitted
+ * from within the middleware chain.
+ */
+export function assertLogContext<ContextT>(ctx: ContextT): asserts ctx is ContextT & LogContext {
+  if (
+    typeof ctx !== 'object' ||
+    ctx === null ||
+    !('createLog' in ctx) ||
+    typeof ctx.createLog !== 'function' ||
+    !('prependAllLogEntries' in ctx) ||
+    typeof ctx.prependAllLogEntries !== 'function'
+  ) {
+    throw new TypeError('The context has not been enriched by the audit log middleware.');
+  }
+}
+
+/**
  * The factory to create a new audit log middleware function.
  * It will inject a `createLog` function the context to enable audit logging.
  *

--- a/packages/core/src/middleware/koa-audit-log.ts
+++ b/packages/core/src/middleware/koa-audit-log.ts
@@ -112,6 +112,16 @@ export type WithLogContext<ContextT extends IRouterParamContext = IRouterParamCo
   ContextT & LogContext;
 
 /**
+ * Runtime `typeof` expectation for every {@link LogContext} member. The `satisfies` constraint is
+ * exhaustive over `keyof LogContext`, so extending {@link LogContext} fails compilation here until
+ * the new member is covered by {@link assertLogContext} as well.
+ */
+const logContextShape = Object.freeze({
+  createLog: 'function',
+  prependAllLogEntries: 'function',
+} as const satisfies Record<keyof LogContext, 'function'>);
+
+/**
  * Assert that the context has been enriched with {@link LogContext} by the audit log middleware.
  * Useful where a context is statically typed without {@link LogContext} but is known to run
  * downstream of the middleware, e.g. `oidc-provider` event listeners, whose contexts are emitted
@@ -120,8 +130,7 @@ export type WithLogContext<ContextT extends IRouterParamContext = IRouterParamCo
 export function assertLogContext<ContextT>(ctx: ContextT): asserts ctx is ContextT & LogContext {
   if (
     !isRecord(ctx) ||
-    typeof ctx.createLog !== 'function' ||
-    typeof ctx.prependAllLogEntries !== 'function'
+    Object.entries(logContextShape).some(([key, expectedType]) => typeof ctx[key] !== expectedType)
   ) {
     throw new TypeError('The context has not been enriched by the audit log middleware.');
   }

--- a/packages/core/src/middleware/koa-audit-log.ts
+++ b/packages/core/src/middleware/koa-audit-log.ts
@@ -119,11 +119,8 @@ export type WithLogContext<ContextT extends IRouterParamContext = IRouterParamCo
  */
 export function assertLogContext<ContextT>(ctx: ContextT): asserts ctx is ContextT & LogContext {
   if (
-    typeof ctx !== 'object' ||
-    ctx === null ||
-    !('createLog' in ctx) ||
+    !isRecord(ctx) ||
     typeof ctx.createLog !== 'function' ||
-    !('prependAllLogEntries' in ctx) ||
     typeof ctx.prependAllLogEntries !== 'function'
   ) {
     throw new TypeError('The context has not been enriched by the audit log middleware.');


### PR DESCRIPTION
## Summary

`@types/oidc-provider` v8 ships a catch-all `addListener(event: string, listener: (...args: any[]) => void)` overload, so our six OIDC event listeners (`grant.success`, `grant.error`, `grant.revoked`, `authorization.success`, `interaction.started`, `interaction.ended`) have never been checked against their event signatures. Their context parameters claim `IRouterParamContext` plus middleware enrichments — properties the emitted `KoaContextWithOIDC` cannot satisfy. The v9 types drop the catch-all, so these registrations stop compiling after the upcoming dependency flip (LOG-13811).

This PR makes the listener types truthful, version-neutrally:

- Listener signatures now match the emitted event shapes exactly (`(ctx: KoaContextWithOIDC, ...)`), which both the v8 and v9 type packages accept.
- The audit-log enrichment is recovered inside the listeners via a new runtime-checked `assertLogContext` assertion. OIDC events are emitted from within the middleware chain after `koaAuditLog` has run, so the assertion holds today — and if the chain is ever reordered, it fails loudly instead of leaving a silent `undefined` access.
- `extractInteractionContext` drops its unused `IRouterParamContext` requirement; `appSecret` remains an optional read, so no assertion is needed for it.
- `grantListener` reads the response body through a tolerant zod guard: on `grant.error` the body carries an error payload instead of tokens, which the old `{ body: GrantBody }` claim papered over.

No runtime behavior change for well-formed contexts; the previous code would have thrown a bare `TypeError` on `ctx.createLog(...)` in the same situations where the assertion now throws with a descriptive message.

Verified to compile under `@types/oidc-provider@9.5.0` as well: the only remaining v9 type errors are the two known ones owned by the dependency-flip PR (LOG-13811).

## Testing

Tested locally; covered by the existing event-listener unit tests (mocks updated to carry the full log context).

## Checklist

- [x] `.changeset` (not needed: internal type refactor, no end-user impact)
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UEH4wZLiH9MAQpsCbnGyi