### PR TITLE
feat(core): enforce custom email allowlist

### DIFF
--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -1,6 +1,7 @@
 import { type EmailBlocklistPolicy } from '@logto/schemas';
 import { deduplicate } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 
 import {
@@ -19,6 +20,12 @@ const buildPolicyWithCustomList = (
 ): EmailBlocklistPolicy => ({
   [key]: list,
 });
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+const setIsDevFeaturesEnabled = (value: boolean) => {
+  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', value);
+};
 
 describe('parseEmailBlocklistPolicy', () => {
   it.each(customListKeys)('should throw error for invalid %s item', (key) => {
@@ -61,6 +68,14 @@ describe('validateEmailAgainstBlocklistPolicy', () => {
     blockSubaddressing: true,
     customBlocklist: ['foo@bar.com', '@foo.com'],
   };
+
+  beforeAll(() => {
+    setIsDevFeaturesEnabled(true);
+  });
+
+  afterAll(() => {
+    setIsDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
 
   it('should throw if the email uses subaddressing', async () => {
     await expect(
@@ -136,6 +151,50 @@ describe('validateEmailAgainstBlocklistPolicy', () => {
         })
       );
     }
+  });
+
+  it('should throw if the email address does not match a non-empty custom allowlist', async () => {
+    const email = 'test@foo.com';
+    const policy: EmailBlocklistPolicy = {
+      customAllowlist: ['@bar.com'],
+    };
+
+    await expect(validateEmailAgainstBlocklistPolicy(policy, email)).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
+  });
+
+  it.each([
+    ['exact address', 'foo@bar.com'],
+    ['domain item', 'test@foo.com'],
+    ['wildcard local part', 'foobar@example.com'],
+    ['wildcard domain', 'test@foo.example.com'],
+  ])('should pass if the email address matches a custom allowlist %s', async (_type, email) => {
+    const policy: EmailBlocklistPolicy = {
+      customAllowlist: ['foo@bar.com', '@foo.com', 'foo*@example.com', '@*.example.com'],
+    };
+
+    await expect(validateEmailAgainstBlocklistPolicy(policy, email)).resolves.not.toThrow();
+  });
+
+  it('should still throw if the email address matches both custom allowlist and blocklist', async () => {
+    const email = 'foo@bar.com';
+    const policy: EmailBlocklistPolicy = {
+      customAllowlist: ['@bar.com'],
+      customBlocklist: [email],
+    };
+
+    await expect(validateEmailAgainstBlocklistPolicy(policy, email)).rejects.toMatchError(
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
+      })
+    );
   });
 
   it('should pass the blocklist policy validation', async () => {

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -132,7 +132,8 @@ export const validateEmailAgainstBlocklistPolicy = async (
   emailBlocklistPolicy: EmailBlocklistPolicy,
   email: string
 ) => {
-  const { customBlocklist, blockDisposableAddresses, blockSubaddressing } = emailBlocklistPolicy;
+  const { customAllowlist, customBlocklist, blockDisposableAddresses, blockSubaddressing } =
+    emailBlocklistPolicy;
   const domain = email.split('@')[1];
 
   assertThat(domain, new RequestError('session.email_blocklist.invalid_email'));
@@ -148,6 +149,22 @@ export const validateEmailAgainstBlocklistPolicy = async (
       new RequestError({
         code: 'session.email_blocklist.email_subaddressing_not_allowed',
         status: 422,
+      })
+    );
+  }
+
+  // Guard custom email allowlist if provided.
+  if (EnvSet.values.isDevFeaturesEnabled && customAllowlist && customAllowlist.length > 0) {
+    const isCustomAllowlisted = customAllowlist.some((item) =>
+      matchesEmailBlocklistItem(item, email)
+    );
+
+    assertThat(
+      isCustomAllowlisted,
+      new RequestError({
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+        email,
       })
     );
   }

--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -26,7 +26,12 @@ import {
   signInAndGetUserApi,
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { generateEmail, generatePhone, generateNationalPhoneNumber } from '#src/utils.js';
+import {
+  devFeatureTest,
+  generateEmail,
+  generatePhone,
+  generateNationalPhoneNumber,
+} from '#src/utils.js';
 
 const expectPrimaryEmailUpdateRejectedByBlocklist = async (
   email: string,
@@ -48,6 +53,44 @@ const expectPrimaryEmailUpdateRejectedByBlocklist = async (
       emailBlocklistPolicy: {
         ...emailBlocklistPolicy,
         customBlocklist: [...(emailBlocklistPolicy.customBlocklist ?? []), ...customBlocklist],
+      },
+    });
+
+    await expectRejects(
+      updatePrimaryEmail(api, email, verificationRecordId, newVerificationRecordId),
+      {
+        code: 'session.email_blocklist.email_not_allowed',
+        status: 422,
+      }
+    );
+  } finally {
+    await updateSignInExperience({
+      emailBlocklistPolicy,
+    });
+    await deleteDefaultTenantUser(user.id);
+  }
+};
+
+const expectPrimaryEmailUpdateRejectedByAllowlist = async (
+  email: string,
+  customAllowlist: string[]
+) => {
+  const { emailBlocklistPolicy } = await getSignInExperience();
+  const { user, username, password } = await createDefaultTenantUserWithPassword();
+  const api = await signInAndGetUserApi(username, password, {
+    scopes: [UserScope.Profile, UserScope.Email],
+  });
+
+  try {
+    const verificationRecordId = await createVerificationRecordByPassword(api, password);
+    const newVerificationRecordId = await createAndVerifyVerificationCode(api, {
+      type: SignInIdentifier.Email,
+      value: email,
+    });
+    await updateSignInExperience({
+      emailBlocklistPolicy: {
+        ...emailBlocklistPolicy,
+        customAllowlist,
       },
     });
 
@@ -235,6 +278,15 @@ describe('account (email and phone)', () => {
 
       await expectPrimaryEmailUpdateRejectedByBlocklist(email, ['FOO*@ACCOUNT-WILDCARD.COM']);
     });
+
+    devFeatureTest.it(
+      'should reject the email if the email does not match the allowlist',
+      async () => {
+        const email = generateEmail('account-allowlist.com');
+
+        await expectPrimaryEmailUpdateRejectedByAllowlist(email, ['@different-account-domain.com']);
+      }
+    );
   });
 
   describe('DELETE /my-account/primary-email', () => {

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
@@ -10,12 +10,18 @@ import {
   setEmailConnector,
   setSocialConnector,
 } from '#src/helpers/connector.js';
+import { signInWithPassword } from '#src/helpers/experience/index.js';
 import {
   successfullyCreateSocialVerification,
   successfullyVerifySocialAuthorization,
 } from '#src/helpers/experience/social-verification.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { generateEmail } from '#src/utils.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+} from '#src/helpers/profile.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateEmail } from '#src/utils.js';
 
 const emailNotAllowedError = {
   code: 'session.email_blocklist.email_not_allowed',
@@ -221,5 +227,155 @@ describe('should reject the email registration if the email is in the blocklist'
         })
       ).resolves.toHaveProperty('verificationId');
     });
+  });
+});
+
+devFeatureTest.describe('should enforce the email allowlist for new email registrations', () => {
+  const exactAllowedEmail = generateEmail('allowlist-exact.com');
+  const allowedDomain = 'allowlist-domain.com';
+  const wildcardLocalPartDomain = 'allowlist-local.com';
+  const wildcardDomainRoot = 'allowlist-wildcard.com';
+  const blockedAllowedEmail = `blocked@${allowedDomain}`;
+  const subaddressedAllowedEmail = `foo+bar@${allowedDomain}`;
+  const customAllowlist = [
+    exactAllowedEmail,
+    `@${allowedDomain}`,
+    `foo*@${wildcardLocalPartDomain}`,
+    `@*.${wildcardDomainRoot}`,
+  ];
+
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email]);
+    await setEmailConnector();
+    await enableAllPasswordSignInMethods({
+      identifiers: [SignInIdentifier.Email],
+      password: true,
+      verify: true,
+    });
+    await updateSignInExperience({
+      emailBlocklistPolicy: {
+        blockSubaddressing: false,
+        customAllowlist,
+        customBlocklist: [],
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await updateSignInExperience({
+      emailBlocklistPolicy: {
+        blockSubaddressing: false,
+        customAllowlist: [],
+        customBlocklist: [],
+      },
+    });
+  });
+
+  it('should reject verification code send when the email does not match the allowlist', async () => {
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.Register,
+    });
+
+    await expectRejects(
+      client.sendVerificationCode({
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: generateEmail('not-allowed.com'),
+        },
+        interactionEvent: InteractionEvent.Register,
+      }),
+      emailNotAllowedError
+    );
+  });
+
+  it.each([
+    ['exact email', exactAllowedEmail],
+    ['domain item', generateEmail(allowedDomain)],
+    ['wildcard local-part item', `foobar@${wildcardLocalPartDomain}`],
+    ['wildcard domain item', `bar@foo.${wildcardDomainRoot}`],
+  ])('should allow verification code send for an allowlist %s match', async (_label, email) => {
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.Register,
+    });
+
+    await expect(
+      client.sendVerificationCode({
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: email,
+        },
+        interactionEvent: InteractionEvent.Register,
+      })
+    ).resolves.toHaveProperty('verificationId');
+  });
+
+  it('should still reject an allowlisted email matched by a custom block rule', async () => {
+    await updateSignInExperience({
+      emailBlocklistPolicy: {
+        blockSubaddressing: false,
+        customAllowlist,
+        customBlocklist: [blockedAllowedEmail],
+      },
+    });
+
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.Register,
+    });
+
+    await expectRejects(
+      client.sendVerificationCode({
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: blockedAllowedEmail,
+        },
+        interactionEvent: InteractionEvent.Register,
+      }),
+      emailNotAllowedError
+    );
+  });
+
+  it('should still reject an allowlisted email with subaddressing when subaddressing is blocked', async () => {
+    await updateSignInExperience({
+      emailBlocklistPolicy: {
+        blockSubaddressing: true,
+        customAllowlist,
+        customBlocklist: [],
+      },
+    });
+
+    const client = await initExperienceClient({
+      interactionEvent: InteractionEvent.Register,
+    });
+
+    await expectRejects(
+      client.sendVerificationCode({
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: subaddressedAllowedEmail,
+        },
+        interactionEvent: InteractionEvent.Register,
+      }),
+      {
+        code: 'session.email_blocklist.email_subaddressing_not_allowed',
+        status: 422,
+      }
+    );
+  });
+
+  it('should allow existing users to sign in with a non-allowlisted email', async () => {
+    const primaryEmail = generateEmail('existing-user.com');
+    const { user, password } = await createDefaultTenantUserWithPassword({ primaryEmail });
+
+    try {
+      await signInWithPassword({
+        identifier: {
+          type: SignInIdentifier.Email,
+          value: primaryEmail,
+        },
+        password,
+      });
+    } finally {
+      await deleteDefaultTenantUser(user.id);
+    }
   });
 });

--- a/packages/integration-tests/src/tests/api/well-known.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.test.ts
@@ -19,7 +19,7 @@ import {
 import { createSsoConnector, deleteSsoConnectorById } from '#src/api/sso-connector.js';
 import { newOidcSsoConnectorPayload } from '#src/constants.js';
 import { setLanguage } from '#src/helpers/sign-in-experience.js';
-import { generateSsoConnectorName } from '#src/utils.js';
+import { devFeatureTest, generateSsoConnectorName } from '#src/utils.js';
 
 describe('.well-known api', () => {
   it('should return tenant endpoint URL for any given tenant id', async () => {
@@ -60,6 +60,31 @@ describe('.well-known api', () => {
     });
     expect(response).toHaveProperty('adaptiveMfa');
   });
+
+  devFeatureTest.it(
+    'should not expose email access policies in public sign-in experience',
+    async () => {
+      const { emailBlocklistPolicy } = await getSignInExperience();
+
+      try {
+        await updateSignInExperience({
+          emailBlocklistPolicy: {
+            blockSubaddressing: true,
+            customAllowlist: ['@allowed.com'],
+            customBlocklist: ['@blocked.com'],
+          },
+        });
+
+        const response = await api.get('.well-known/sign-in-exp').json<Record<string, unknown>>();
+
+        expect(response).not.toHaveProperty('emailBlocklistPolicy');
+      } finally {
+        await updateSignInExperience({
+          emailBlocklistPolicy,
+        });
+      }
+    }
+  );
 
   // Also test for Redis cache invalidation
   it('should be able to return updated phrases', async () => {


### PR DESCRIPTION
## Summary
Enforce custom email allowlist entries in the shared email blocklist policy validator, while keeping existing block rules authoritative after an allowlist match.

Add integration coverage for email allowlist enforcement across registration, Account API primary email updates, and public sign-in experience exposure.

## Testing
Unit tests
Integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments