### PR TITLE
fix(experience): persist suspended account error after SSO callback

### DIFF
--- a/.changeset/persist-sso-suspended-error.md
+++ b/.changeset/persist-sso-suspended-error.md
@@ -1,0 +1,5 @@
+---
+"@logto/experience": patch
+---
+
+persist the suspended account error on the sign-in form after enterprise SSO callback

--- a/packages/experience/src/components/IdentifierSignInForm/index.tsx
+++ b/packages/experience/src/components/IdentifierSignInForm/index.tsx
@@ -1,6 +1,6 @@
 import { AgreeToTermsPolicy, type SignIn } from '@logto/schemas';
 import classNames from 'classnames';
-import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -10,6 +10,7 @@ import LockIcon from '@/assets/icons/lock.svg?react';
 import { SmartInputField } from '@/components/InputFields';
 import CaptchaBox from '@/containers/CaptchaBox';
 import TermsAndPrivacyCheckbox from '@/containers/TermsAndPrivacyCheckbox';
+import useLocationErrorMessage from '@/hooks/use-location-error-message';
 import usePrefilledIdentifier from '@/hooks/use-prefilled-identifier';
 import useSingleSignOnWatch from '@/hooks/use-single-sign-on-watch';
 import useTerms from '@/hooks/use-terms';
@@ -34,10 +35,23 @@ type FormState = {
 
 const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
   const { t } = useTranslation();
-  const { errorMessage, clearErrorMessage, onSubmit } = useOnSubmit(signInMethods);
+  const {
+    errorMessage: submitErrorMessage,
+    clearErrorMessage: clearSubmitErrorMessage,
+    onSubmit,
+  } = useOnSubmit(signInMethods);
+  const { errorMessage: locationErrorMessage, clearErrorMessage: clearLocationErrorMessage } =
+    useLocationErrorMessage();
   const { termsValidation, agreeToTermsPolicy } = useTerms();
   const { setIdentifierInputValue } = useContext(UserInteractionContext);
   const { isPasskeyFlowProcessing } = useContext(WebAuthnContext);
+
+  const errorMessage = submitErrorMessage ?? locationErrorMessage;
+
+  const clearErrorMessage = useCallback(() => {
+    clearSubmitErrorMessage();
+    clearLocationErrorMessage();
+  }, [clearLocationErrorMessage, clearSubmitErrorMessage]);
 
   const enabledSignInMethods = useMemo(
     () => signInMethods.map(({ identifier }) => identifier),
@@ -65,10 +79,16 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
     watch('identifier')
   );
 
+  // Clear persistent errors when the form becomes invalid after it was valid
+  // (e.g. user edits the identifier). Skip the initial mount so location-state
+  // errors from SSO callbacks are not wiped before the form settles.
+  const wasValid = useRef(isValid);
   useEffect(() => {
-    if (!isValid) {
+    if (wasValid.current && !isValid) {
       clearErrorMessage();
     }
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    wasValid.current = isValid;
   }, [clearErrorMessage, isValid]);
 
   const onSubmitHandler = useCallback(

--- a/packages/experience/src/components/PasswordSignInForm/index.test.tsx
+++ b/packages/experience/src/components/PasswordSignInForm/index.test.tsx
@@ -40,7 +40,6 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockedNavigate,
 }));
-
 describe('UsernamePasswordSignInForm', () => {
   afterEach(() => {
     jest.clearAllMocks();

--- a/packages/experience/src/components/PasswordSignInForm/index.tsx
+++ b/packages/experience/src/components/PasswordSignInForm/index.tsx
@@ -1,6 +1,6 @@
 import { AgreeToTermsPolicy, type SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
-import { useCallback, useContext, useEffect } from 'react';
+import { useCallback, useContext, useEffect, useRef } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -11,6 +11,7 @@ import { SmartInputField, PasswordInputField } from '@/components/InputFields';
 import CaptchaBox from '@/containers/CaptchaBox';
 import ForgotPasswordLink from '@/containers/ForgotPasswordLink';
 import TermsAndPrivacyCheckbox from '@/containers/TermsAndPrivacyCheckbox';
+import useLocationErrorMessage from '@/hooks/use-location-error-message';
 import usePasswordSignIn from '@/hooks/use-password-sign-in';
 import usePrefilledIdentifier from '@/hooks/use-prefilled-identifier';
 import { useForgotPasswordSettings } from '@/hooks/use-sie';
@@ -38,12 +39,25 @@ export type FormState = {
 const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
   const { t } = useTranslation();
 
-  const { errorMessage, clearErrorMessage, onSubmit } = usePasswordSignIn();
+  const {
+    errorMessage: submitErrorMessage,
+    clearErrorMessage: clearSubmitErrorMessage,
+    onSubmit,
+  } = usePasswordSignIn();
+  const { errorMessage: locationErrorMessage, clearErrorMessage: clearLocationErrorMessage } =
+    useLocationErrorMessage();
   const { isForgotPasswordEnabled } = useForgotPasswordSettings();
   const { termsValidation, agreeToTermsPolicy } = useTerms();
   const { setIdentifierInputValue } = useContext(UserInteractionContext);
   const { isPasskeyFlowProcessing } = useContext(WebAuthnContext);
   const prefilledIdentifier = usePrefilledIdentifier({ enabledIdentifiers: signInMethods });
+
+  const errorMessage = submitErrorMessage ?? locationErrorMessage;
+
+  const clearErrorMessage = useCallback(() => {
+    clearSubmitErrorMessage();
+    clearLocationErrorMessage();
+  }, [clearLocationErrorMessage, clearSubmitErrorMessage]);
 
   const {
     watch,
@@ -107,10 +121,16 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
     ]
   );
 
+  // Clear persistent errors when the form becomes invalid after it was valid
+  // (e.g. user edits the identifier). Skip the initial mount so location-state
+  // errors from SSO callbacks are not wiped before SSO form mode activates.
+  const wasValid = useRef(isValid);
   useEffect(() => {
-    if (!isValid) {
+    if (wasValid.current && !isValid) {
       clearErrorMessage();
     }
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    wasValid.current = isValid;
   }, [clearErrorMessage, isValid]);
 
   return (

--- a/packages/experience/src/components/PasswordSignInForm/suspended-error.test.tsx
+++ b/packages/experience/src/components/PasswordSignInForm/suspended-error.test.tsx
@@ -1,0 +1,148 @@
+import { SignInIdentifier } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+import { act, fireEvent, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+
+import ConfirmModalProvider from '@/Providers/ConfirmModalProvider';
+import SingleSignOnFormModeContextProvider from '@/Providers/SingleSignOnFormModeContextProvider';
+import ToastProvider from '@/Providers/ToastProvider';
+import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { mockSignInExperienceSettings } from '@/__mocks__/logto';
+import useToast from '@/hooks/use-toast';
+
+import PasswordSignInForm from '.';
+
+jest.mock('react-device-detect', () => ({
+  isMobile: true,
+}));
+
+jest.mock('i18next', () => ({
+  ...jest.requireActual('i18next'),
+  language: 'en',
+  t: (key: string) => key,
+}));
+
+jest.mock('@/apis/experience', () => ({
+  signInWithPasswordIdentifier: jest.fn(async () => ({ redirectTo: '/' })),
+  getSsoAuthorizationUrl: jest.fn(),
+  getSsoConnectors: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+}));
+
+const SeedToast = ({ message }: { readonly message: string }) => {
+  const { setToast } = useToast();
+
+  useEffect(() => {
+    setToast(message);
+  }, [message, setToast]);
+
+  return null;
+};
+
+describe('PasswordSignInForm suspended account error', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('should keep suspended account form error after toast timeout', () => {
+    jest.useFakeTimers();
+
+    const suspendedMessage = 'This account is suspended.';
+
+    const { container } = renderWithPageContext(
+      <SettingsProvider settings={mockSignInExperienceSettings}>
+        <ConfirmModalProvider>
+          <ToastProvider>
+            <SeedToast message={suspendedMessage} />
+            <UserInteractionContextProvider>
+              <SingleSignOnFormModeContextProvider>
+                <PasswordSignInForm
+                  signInMethods={[SignInIdentifier.Username, SignInIdentifier.Email]}
+                />
+              </SingleSignOnFormModeContextProvider>
+            </UserInteractionContextProvider>
+          </ToastProvider>
+        </ConfirmModalProvider>
+      </SettingsProvider>,
+      {
+        initialEntries: [
+          {
+            pathname: '/sign-in',
+            state: { errorMessage: suspendedMessage },
+          },
+        ],
+      }
+    );
+
+    // Toast is portaled to document.body via ReactModal and marks the app aria-hidden
+    expect(document.querySelector('[role="toast"]')).not.toBeNull();
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(suspendedMessage);
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    // ReactModal keeps the toast in the DOM during its close animation
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    const toast = document.querySelector('[role="toast"]');
+    if (toast) {
+      fireEvent.transitionEnd(toast);
+    }
+
+    // Toast is dismissed after timeout, but the form error remains
+    expect(document.querySelector('[role="toast"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(suspendedMessage);
+  });
+
+  it('should clear suspended form error when user resubmits the form', async () => {
+    const suspendedMessage = 'This account is suspended.';
+
+    const { queryByText, getByText, container } = renderWithPageContext(
+      <SettingsProvider settings={mockSignInExperienceSettings}>
+        <ConfirmModalProvider>
+          <UserInteractionContextProvider>
+            <SingleSignOnFormModeContextProvider>
+              <PasswordSignInForm signInMethods={[SignInIdentifier.Username]} />
+            </SingleSignOnFormModeContextProvider>
+          </UserInteractionContextProvider>
+        </ConfirmModalProvider>
+      </SettingsProvider>,
+      {
+        initialEntries: [
+          {
+            pathname: '/sign-in',
+            state: { errorMessage: suspendedMessage },
+          },
+        ],
+      }
+    );
+
+    expect(queryByText(suspendedMessage)).not.toBeNull();
+
+    const identifierInput = container.querySelector('input[name="identifier"]');
+    const passwordInput = container.querySelector('input[name="password"]');
+    assert(identifierInput, new Error('identifier input should exist'));
+    assert(passwordInput, new Error('password input should exist'));
+
+    fireEvent.change(identifierInput, { target: { value: 'foo' } });
+    fireEvent.change(passwordInput, { target: { value: 'password' } });
+
+    act(() => {
+      fireEvent.submit(getByText('action.sign_in'));
+    });
+
+    await waitFor(() => {
+      expect(queryByText(suspendedMessage)).toBeNull();
+    });
+  });
+});

--- a/packages/experience/src/hooks/use-location-error-message.ts
+++ b/packages/experience/src/hooks/use-location-error-message.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { object, optional, string, validate } from 'superstruct';
+
+import useNavigateWithPreservedSearchParams from './use-navigate-with-preserved-search-params';
+
+const errorMessageStateGuard = object({
+  errorMessage: optional(string()),
+});
+
+/**
+ * Reads a one-shot `errorMessage` from the current location state (e.g. after an SSO
+ * callback redirects back to the sign-in form) and clears it from history so it is not
+ * replayed on refresh or back navigation.
+ */
+const useLocationErrorMessage = () => {
+  const { state, pathname, search } = useLocation();
+  const navigate = useNavigateWithPreservedSearchParams();
+  const [, parsed] = validate(state, errorMessageStateGuard);
+  const [errorMessage, setErrorMessage] = useState(parsed?.errorMessage);
+
+  useEffect(() => {
+    if (!parsed?.errorMessage) {
+      return;
+    }
+
+    // Clear the consumed state while keeping the user on the same URL.
+    navigate({ pathname, search }, { replace: true, state: null });
+    // Only consume location state once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const clearErrorMessage = useCallback(() => {
+    setErrorMessage(undefined);
+  }, []);
+
+  return {
+    errorMessage,
+    clearErrorMessage,
+  };
+};
+
+export default useLocationErrorMessage;

--- a/packages/experience/src/pages/SocialSignInWebCallback/sso-callback.test.tsx
+++ b/packages/experience/src/pages/SocialSignInWebCallback/sso-callback.test.tsx
@@ -1,7 +1,9 @@
-import { VerificationType } from '@logto/schemas';
+import { VerificationType, experience } from '@logto/schemas';
 import { renderHook, waitFor } from '@testing-library/react';
+import { HTTPError } from 'ky';
 import { Route, Routes, useSearchParams } from 'react-router-dom';
 
+import ToastProvider from '@/Providers/ToastProvider';
 import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
@@ -32,6 +34,15 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const mockUseSearchParameters = useSearchParams as jest.Mock;
+const mockedNavigate = jest.fn();
+
+jest.mock('@/hooks/use-navigate-with-preserved-search-params', () => ({
+  __esModule: true,
+  default: () => mockedNavigate,
+  usePreserveSearchParams: () => ({
+    getTo: (to: unknown) => to,
+  }),
+}));
 
 const verificationIdsMap = {
   [VerificationType.Social]: 'foo',
@@ -43,16 +54,25 @@ const sieSettings: SignInExperienceResponse = {
   ssoConnectors: mockSsoConnectors,
 };
 
+const createRequestError = (code: string, message: string) => {
+  const response = {
+    status: 401,
+    statusText: 'Unauthorized',
+    json: async () => ({ code, message }),
+  } as unknown as Response;
+
+  return new HTTPError(response, {} as Request, {} as never);
+};
+
 describe('SocialCallbackPage — single sign-on', () => {
   const { result } = renderHook(() => useSessionStorage());
   const { set } = result.current;
 
-  beforeAll(() => {
-    set(StorageKeys.verificationIds, verificationIdsMap);
-  });
-
   beforeEach(() => {
+    set(StorageKeys.verificationIds, verificationIdsMap);
     (signInWithSso as jest.Mock).mockClear();
+    (signInWithSso as jest.Mock).mockResolvedValue({ redirectTo: `/sign-in` });
+    mockedNavigate.mockClear();
   });
 
   describe('normal path', () => {
@@ -101,6 +121,49 @@ describe('SocialCallbackPage — single sign-on', () => {
 
       await waitFor(() => {
         expect(signInWithSso).not.toBeCalled();
+      });
+    });
+
+    it('should navigate to sign-in with persistent error state when user is suspended', async () => {
+      const suspendedMessage = 'This account is suspended.';
+      const suspendedState = generateState();
+      storeState(suspendedState, connectorId);
+
+      (signInWithSso as jest.Mock).mockRejectedValueOnce(
+        createRequestError('user.suspended', suspendedMessage)
+      );
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${suspendedState}&code=foo`),
+        jest.fn(),
+      ]);
+
+      const { queryByText } = renderWithPageContext(
+        <SettingsProvider settings={sieSettings}>
+          <ToastProvider>
+            <UserInteractionContextProvider>
+              <Routes>
+                <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+              </Routes>
+            </UserInteractionContextProvider>
+          </ToastProvider>
+        </SettingsProvider>,
+        { initialEntries: [`/callback/social/${connectorId}`] }
+      );
+
+      await waitFor(() => {
+        expect(signInWithSso).toBeCalled();
+      });
+
+      await waitFor(() => {
+        expect(mockedNavigate).toHaveBeenCalledWith('/' + experience.routes.signIn, {
+          state: { errorMessage: suspendedMessage },
+        });
+      });
+
+      await waitFor(() => {
+        expect(document.querySelector('[role="toast"]')).not.toBeNull();
+        expect(queryByText(suspendedMessage)).not.toBeNull();
       });
     });
   });

--- a/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
+++ b/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
@@ -115,6 +115,16 @@ const useSingleSignOnListener = (connectorId: string) => {
 
             await registerSingleSignOnIdentity(verificationId);
           },
+          /**
+           * Suspended users should see a persistent form error after returning to sign-in,
+           * not only a short-lived toast (see PasswordSignInForm / IdentifierSignInForm).
+           */
+          'user.suspended': async (error) => {
+            setToast(error.message);
+            navigate('/' + experience.routes.signIn, {
+              state: { errorMessage: error.message },
+            });
+          },
           // Redirect to sign-in page if error is not handled by the error handlers
           global: async (error) => {
             setToast(error.message);


### PR DESCRIPTION
## Summary
- when enterprise SSO identification returns `user.suspended`, keep showing the error on the sign-in form after redirect (in addition to the existing toast)
- reuse the API-localized message via location state and the existing form error clear rules on resubmit / invalid input

## Testing
Unit tests