### PR TITLE
fix(experience): persist suspended user error on sign-in form after SSO callback

### DIFF
--- a/.changeset/sso-suspended-error-persist.md
+++ b/.changeset/sso-suspended-error-persist.md
@@ -1,0 +1,7 @@
+---
+"@logto/experience": patch
+---
+
+keep the suspended account error message visible on the sign-in form after enterprise SSO sign-in fails
+
+Previously, when a suspended user completed the enterprise SSO flow, the error was only shown in a toast that auto-dismissed after a few seconds, leaving the sign-in form without any feedback. The error message now also persists on the sign-in form and is cleared when the user modifies the identifier input or submits the form again.

--- a/packages/experience/src/components/IdentifierSignInForm/index.test.tsx
+++ b/packages/experience/src/components/IdentifierSignInForm/index.test.tsx
@@ -51,7 +51,11 @@ const username = 'foo';
 const email = 'foo@email.com';
 const phone = '8573333333';
 
-const renderForm = (signInMethods: SignIn['methods'], ssoConnectors: SsoConnectorMetadata[] = []) =>
+const renderForm = (
+  signInMethods: SignIn['methods'],
+  ssoConnectors: SsoConnectorMetadata[] = [],
+  memoryRouterProps?: Parameters<typeof renderWithPageContext>[1]
+) =>
   renderWithPageContext(
     <SettingsProvider
       settings={{
@@ -64,7 +68,8 @@ const renderForm = (signInMethods: SignIn['methods'], ssoConnectors: SsoConnecto
           <IdentifierSignInForm signInMethods={signInMethods} />
         </SingleSignOnFormModeContextProvider>
       </UserInteractionContextProvider>
-    </SettingsProvider>
+    </SettingsProvider>,
+    memoryRouterProps
   );
 
 const renderFormAndSubmitEmail = (signInMethods: SignIn['methods']) => {
@@ -192,6 +197,63 @@ describe('IdentifierSignInForm', () => {
       });
     }
   );
+
+  describe('persistent error message from the navigation state', () => {
+    const suspendedMessage = 'This account is suspended.';
+    const memoryRouterProps = {
+      initialEntries: [{ pathname: '/sign-in', state: { errorMessage: suspendedMessage } }],
+    };
+
+    beforeEach(() => {
+      // Clear the cached identifier input value from previous tests so the
+      // identifier input is not prefilled
+      sessionStorage.clear();
+    });
+
+    test('should display the error message and clear it on resubmission', async () => {
+      const { getByText, queryByText, container } = renderForm(
+        mockSignInMethodSettingsTestCases[0]!,
+        undefined,
+        memoryRouterProps
+      );
+
+      expect(queryByText(suspendedMessage)).not.toBeNull();
+
+      const inputField = container.querySelector('input[name="identifier"]');
+      assert(inputField, new Error('identifier input should exist'));
+
+      fireEvent.change(inputField, { target: { value: username } });
+
+      act(() => {
+        fireEvent.submit(getByText('action.sign_in'));
+      });
+
+      await waitFor(() => {
+        expect(queryByText(suspendedMessage)).toBeNull();
+      });
+    });
+
+    test('should clear the error message when the identifier input is modified', async () => {
+      const { queryByText, container } = renderForm(
+        mockSignInMethodSettingsTestCases[0]!,
+        undefined,
+        memoryRouterProps
+      );
+
+      expect(queryByText(suspendedMessage)).not.toBeNull();
+
+      const inputField = container.querySelector('input[name="identifier"]');
+      assert(inputField, new Error('identifier input should exist'));
+
+      act(() => {
+        fireEvent.change(inputField, { target: { value: username } });
+      });
+
+      await waitFor(() => {
+        expect(queryByText(suspendedMessage)).toBeNull();
+      });
+    });
+  });
 
   describe('email single sign-on tests', () => {
     it('should not call check single sign-on connector when the identifier is not email', async () => {

--- a/packages/experience/src/components/IdentifierSignInForm/index.tsx
+++ b/packages/experience/src/components/IdentifierSignInForm/index.tsx
@@ -1,4 +1,5 @@
 import { AgreeToTermsPolicy, type SignIn } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
 import { useForm, Controller } from 'react-hook-form';
@@ -10,6 +11,7 @@ import LockIcon from '@/assets/icons/lock.svg?react';
 import { SmartInputField } from '@/components/InputFields';
 import CaptchaBox from '@/containers/CaptchaBox';
 import TermsAndPrivacyCheckbox from '@/containers/TermsAndPrivacyCheckbox';
+import useLocationErrorMessage from '@/hooks/use-location-error-message';
 import usePrefilledIdentifier from '@/hooks/use-prefilled-identifier';
 import useSingleSignOnWatch from '@/hooks/use-single-sign-on-watch';
 import useTerms from '@/hooks/use-terms';
@@ -35,6 +37,10 @@ type FormState = {
 const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
   const { t } = useTranslation();
   const { errorMessage, clearErrorMessage, onSubmit } = useOnSubmit(signInMethods);
+  // Persistent error message passed via the navigation state (e.g. suspended user error from
+  // the enterprise SSO callback). Follows the same clearing rules as the form's own error message.
+  const { errorMessage: locationErrorMessage, clearErrorMessage: clearLocationErrorMessage } =
+    useLocationErrorMessage();
   const { termsValidation, agreeToTermsPolicy } = useTerms();
   const { setIdentifierInputValue } = useContext(UserInteractionContext);
   const { isPasskeyFlowProcessing } = useContext(WebAuthnContext);
@@ -65,6 +71,21 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
     watch('identifier')
   );
 
+  // The submission error message takes precedence over the persistent one from the navigation
+  // state. `conditional` is needed since the cleared error message is an empty string.
+  const displayErrorMessage = conditional(errorMessage) ?? locationErrorMessage;
+
+  const { value: identifierValue } = watch('identifier');
+
+  useEffect(() => {
+    // Clear the persistent error message from the navigation state once the user modifies
+    // the identifier input. Can not rely on the `isValid`/`isDirty` form state since the
+    // identifier input emits an initial change event on mount.
+    if (identifierValue !== prefilledIdentifier.value) {
+      clearLocationErrorMessage();
+    }
+  }, [clearLocationErrorMessage, identifierValue, prefilledIdentifier.value]);
+
   useEffect(() => {
     if (!isValid) {
       clearErrorMessage();
@@ -78,6 +99,7 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
       }
 
       clearErrorMessage();
+      clearLocationErrorMessage();
 
       void handleSubmit(async ({ identifier: { type, value } }) => {
         if (!type) {
@@ -102,6 +124,7 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
     [
       agreeToTermsPolicy,
       clearErrorMessage,
+      clearLocationErrorMessage,
       handleSubmit,
       navigateToSingleSignOn,
       onSubmit,
@@ -135,7 +158,7 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
             autoFocus={autoFocus}
             className={styles.inputField}
             {...field}
-            isDanger={!!errors.identifier || !!errorMessage}
+            isDanger={!!errors.identifier || !!displayErrorMessage}
             errorMessage={errors.identifier?.message}
             enabledTypes={enabledSignInMethods}
             defaultValue={defaultValues?.identifier?.value}
@@ -143,7 +166,9 @@ const IdentifierSignInForm = ({ className, autoFocus, signInMethods }: Props) =>
         )}
       />
 
-      {errorMessage && <ErrorMessage className={styles.formErrors}>{errorMessage}</ErrorMessage>}
+      {displayErrorMessage && (
+        <ErrorMessage className={styles.formErrors}>{displayErrorMessage}</ErrorMessage>
+      )}
 
       {showSingleSignOnForm && (
         <div className={styles.message}>{t('description.single_sign_on_enabled')}</div>

--- a/packages/experience/src/components/PasswordSignInForm/index.test.tsx
+++ b/packages/experience/src/components/PasswordSignInForm/index.test.tsx
@@ -48,7 +48,8 @@ describe('UsernamePasswordSignInForm', () => {
 
   const renderPasswordSignInForm = (
     signInMethods = [SignInIdentifier.Username, SignInIdentifier.Email, SignInIdentifier.Phone],
-    settings?: Partial<SignInExperienceResponse>
+    settings?: Partial<SignInExperienceResponse>,
+    memoryRouterProps?: Parameters<typeof renderWithPageContext>[1]
   ) =>
     renderWithPageContext(
       <SettingsProvider settings={{ ...mockSignInExperienceSettings, ...settings }}>
@@ -59,7 +60,8 @@ describe('UsernamePasswordSignInForm', () => {
             </SingleSignOnFormModeContextProvider>
           </UserInteractionContextProvider>
         </ConfirmModalProvider>
-      </SettingsProvider>
+      </SettingsProvider>,
+      memoryRouterProps
     );
 
   test.each([
@@ -293,6 +295,68 @@ describe('UsernamePasswordSignInForm', () => {
     expect(mockedNavigate).not.toHaveBeenCalled();
     expect(queryByText('description.password_expired')).toBeNull();
     expect(queryByText('description.password_expiration_reset')).toBeNull();
+  });
+
+  describe('persistent error message from the navigation state', () => {
+    const suspendedMessage = 'This account is suspended.';
+    const memoryRouterProps = {
+      initialEntries: [{ pathname: '/sign-in', state: { errorMessage: suspendedMessage } }],
+    };
+
+    beforeEach(() => {
+      // Clear the cached identifier input value from previous tests so the
+      // identifier input is not prefilled
+      sessionStorage.clear();
+    });
+
+    test('should display the error message and clear it on resubmission', async () => {
+      const { getByText, queryByText, container } = renderPasswordSignInForm(
+        [SignInIdentifier.Username],
+        undefined,
+        memoryRouterProps
+      );
+
+      expect(queryByText(suspendedMessage)).not.toBeNull();
+
+      const identifierInput = container.querySelector('input[name="identifier"]');
+      const passwordInput = container.querySelector('input[name="password"]');
+
+      assert(identifierInput, new Error('identifier input should exist'));
+      assert(passwordInput, new Error('password input should exist'));
+
+      fireEvent.change(identifierInput, { target: { value: 'username' } });
+      fireEvent.change(passwordInput, { target: { value: 'password' } });
+
+      act(() => {
+        fireEvent.submit(getByText('action.sign_in'));
+      });
+
+      await waitFor(() => {
+        expect(queryByText(suspendedMessage)).toBeNull();
+        expect(signInWithPasswordIdentifier).toBeCalled();
+      });
+    });
+
+    test('should clear the error message when the identifier input is modified', async () => {
+      const { queryByText, container } = renderPasswordSignInForm(
+        [SignInIdentifier.Username],
+        undefined,
+        memoryRouterProps
+      );
+
+      expect(queryByText(suspendedMessage)).not.toBeNull();
+
+      const identifierInput = container.querySelector('input[name="identifier"]');
+      assert(identifierInput, new Error('identifier input should exist'));
+
+      act(() => {
+        fireEvent.change(identifierInput, { target: { value: 'modified-username' } });
+      });
+
+      await waitFor(() => {
+        expect(queryByText(suspendedMessage)).toBeNull();
+      });
+    });
   });
 
   test('should switch to single sign on form when single sign on is enabled for a give email', async () => {

--- a/packages/experience/src/components/PasswordSignInForm/index.tsx
+++ b/packages/experience/src/components/PasswordSignInForm/index.tsx
@@ -1,4 +1,5 @@
 import { AgreeToTermsPolicy, type SignInIdentifier } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
 import classNames from 'classnames';
 import { useCallback, useContext, useEffect } from 'react';
 import { useForm, Controller } from 'react-hook-form';
@@ -11,6 +12,7 @@ import { SmartInputField, PasswordInputField } from '@/components/InputFields';
 import CaptchaBox from '@/containers/CaptchaBox';
 import ForgotPasswordLink from '@/containers/ForgotPasswordLink';
 import TermsAndPrivacyCheckbox from '@/containers/TermsAndPrivacyCheckbox';
+import useLocationErrorMessage from '@/hooks/use-location-error-message';
 import usePasswordSignIn from '@/hooks/use-password-sign-in';
 import usePrefilledIdentifier from '@/hooks/use-prefilled-identifier';
 import { useForgotPasswordSettings } from '@/hooks/use-sie';
@@ -39,6 +41,10 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
   const { t } = useTranslation();
 
   const { errorMessage, clearErrorMessage, onSubmit } = usePasswordSignIn();
+  // Persistent error message passed via the navigation state (e.g. suspended user error from
+  // the enterprise SSO callback). Follows the same clearing rules as the form's own error message.
+  const { errorMessage: locationErrorMessage, clearErrorMessage: clearLocationErrorMessage } =
+    useLocationErrorMessage();
   const { isForgotPasswordEnabled } = useForgotPasswordSettings();
   const { termsValidation, agreeToTermsPolicy } = useTerms();
   const { setIdentifierInputValue } = useContext(UserInteractionContext);
@@ -63,6 +69,21 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
     watch('identifier')
   );
 
+  // The submission error message takes precedence over the persistent one from the navigation
+  // state. `conditional` is needed since the cleared error message is an empty string.
+  const displayErrorMessage = conditional(errorMessage) ?? locationErrorMessage;
+
+  const { value: identifierValue } = watch('identifier');
+
+  useEffect(() => {
+    // Clear the persistent error message from the navigation state once the user modifies
+    // the identifier input. Can not rely on the `isValid`/`isDirty` form state since the
+    // identifier input emits an initial change event on mount.
+    if (identifierValue !== prefilledIdentifier.value) {
+      clearLocationErrorMessage();
+    }
+  }, [clearLocationErrorMessage, identifierValue, prefilledIdentifier.value]);
+
   const onSubmitHandler = useCallback(
     async (event?: React.FormEvent<HTMLFormElement>) => {
       if (isPasskeyFlowProcessing) {
@@ -70,6 +91,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
       }
 
       clearErrorMessage();
+      clearLocationErrorMessage();
 
       await handleSubmit(async ({ identifier: { type, value }, password }) => {
         if (!type) {
@@ -97,6 +119,7 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
     [
       agreeToTermsPolicy,
       clearErrorMessage,
+      clearLocationErrorMessage,
       handleSubmit,
       navigateToSingleSignOn,
       onSubmit,
@@ -156,7 +179,9 @@ const PasswordSignInForm = ({ className, autoFocus, signInMethods }: Props) => {
         />
       )}
 
-      {errorMessage && <ErrorMessage className={styles.formErrors}>{errorMessage}</ErrorMessage>}
+      {displayErrorMessage && (
+        <ErrorMessage className={styles.formErrors}>{displayErrorMessage}</ErrorMessage>
+      )}
 
       {isForgotPasswordEnabled && !showSingleSignOnForm && (
         <ForgotPasswordLink

--- a/packages/experience/src/hooks/use-location-error-message.ts
+++ b/packages/experience/src/hooks/use-location-error-message.ts
@@ -1,0 +1,31 @@
+import { useCallback, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { is } from 'superstruct';
+
+import { persistentErrorMessageStateGuard } from '@/types/guard';
+
+/**
+ * Reads a persistent error message passed via the router navigation state.
+ *
+ * E.g. the enterprise SSO callback page redirects back to the sign-in page with the error
+ * message in the navigation state when the identified user is suspended, so the sign-in
+ * form can keep displaying the error after the global toast auto-dismisses.
+ *
+ * The error message is kept in local state so the form can clear it following its own
+ * error-clearing rules (e.g. on resubmission or when the inputs become invalid).
+ */
+const useLocationErrorMessage = () => {
+  const { state } = useLocation();
+
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    is(state, persistentErrorMessageStateGuard) ? state.errorMessage : undefined
+  );
+
+  const clearErrorMessage = useCallback(() => {
+    setErrorMessage(undefined);
+  }, []);
+
+  return { errorMessage, clearErrorMessage };
+};
+
+export default useLocationErrorMessage;

--- a/packages/experience/src/pages/SocialSignInWebCallback/sso-callback.test.tsx
+++ b/packages/experience/src/pages/SocialSignInWebCallback/sso-callback.test.tsx
@@ -1,13 +1,16 @@
 import { VerificationType } from '@logto/schemas';
 import { renderHook, waitFor } from '@testing-library/react';
+import { HTTPError } from 'ky';
 import { Route, Routes, useSearchParams } from 'react-router-dom';
 
+import ToastProvider from '@/Providers/ToastProvider';
 import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { mockSignInExperienceSettings, mockSsoConnectors } from '@/__mocks__/logto';
 import { signInWithSso } from '@/apis/experience';
 import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
+import SignIn from '@/pages/SignIn';
 import { type SignInExperienceResponse } from '@/types';
 import { generateState, storeState } from '@/utils/social-connectors';
 import { storeRedirectContext } from '@/utils/social-redirect-fallback-context';
@@ -102,6 +105,92 @@ describe('SocialCallbackPage — single sign-on', () => {
       await waitFor(() => {
         expect(signInWithSso).not.toBeCalled();
       });
+    });
+  });
+
+  describe('suspended user', () => {
+    const connectorId = mockSsoConnectors[0]!.id;
+    const suspendedMessage = 'This account is suspended.';
+
+    beforeEach(() => {
+      // The successful sign-in flow clears the interaction context session storage,
+      // so re-seed the verification ids for each test
+      set(StorageKeys.verificationIds, verificationIdsMap);
+    });
+
+    const renderCallbackAndSignInRoutes = () =>
+      renderWithPageContext(
+        <SettingsProvider settings={sieSettings}>
+          <UserInteractionContextProvider>
+            <ToastProvider>
+              <Routes>
+                <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+                <Route path="/sign-in" element={<SignIn />} />
+              </Routes>
+            </ToastProvider>
+          </UserInteractionContextProvider>
+        </SettingsProvider>,
+        { initialEntries: [`/callback/social/${connectorId}`] }
+      );
+
+    it('should keep the error message on the sign-in form after the toast disappears', async () => {
+      const state = generateState();
+      storeState(state, connectorId);
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
+        jest.fn(),
+      ]);
+
+      (signInWithSso as jest.Mock).mockRejectedValueOnce(
+        new HTTPError(
+          {
+            json: async () => ({ code: 'user.suspended', message: suspendedMessage }),
+          } as Response,
+          {} as Request,
+          {} as never
+        )
+      );
+
+      const { container } = renderCallbackAndSignInRoutes();
+
+      // Redirected back to the sign-in page with the error message displayed on the form
+      await waitFor(() => {
+        expect(container.querySelector('[role="alert"]')?.textContent).toBe(suspendedMessage);
+      });
+
+      // The toast is also displayed
+      expect(document.querySelector('[role="toast"]')?.textContent).toBe(suspendedMessage);
+
+      // Wait until the toast auto-dismisses (3s duration + closing transition)
+      await waitFor(
+        () => {
+          expect(document.querySelector('[role="toast"]')).toBeNull();
+        },
+        { timeout: 5000 }
+      );
+
+      // The error message on the sign-in form persists after the toast disappears
+      expect(container.querySelector('[role="alert"]')?.textContent).toBe(suspendedMessage);
+    }, 15_000);
+
+    it('should not show any form error message for successful single sign-on', async () => {
+      const state = generateState();
+      storeState(state, connectorId);
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
+        jest.fn(),
+      ]);
+
+      const { container } = renderCallbackAndSignInRoutes();
+
+      await waitFor(() => {
+        expect(signInWithSso).toBeCalled();
+      });
+
+      expect(container.querySelector('[role="alert"]')).toBeNull();
+      expect(document.querySelector('[role="toast"]')).toBeNull();
     });
   });
 

--- a/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
+++ b/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
@@ -13,6 +13,7 @@ import useRedirectCallbackValidation from '@/hooks/use-redirect-callback-validat
 import { useSieMethods } from '@/hooks/use-sie';
 import useTerms from '@/hooks/use-terms';
 import useToast from '@/hooks/use-toast';
+import { type PersistentErrorMessageState } from '@/types/guard';
 import { parseQueryParameters } from '@/utils';
 
 const useSingleSignOnRegister = () => {
@@ -114,6 +115,14 @@ const useSingleSignOnListener = (connectorId: string) => {
             }
 
             await registerSingleSignOnIdentity(verificationId);
+          },
+          'user.suspended': async (error) => {
+            setToast(error.message);
+            // The toast auto-dismisses after a few seconds. Persist the error message on the
+            // sign-in form via the navigation state so the user can still see why the sign-in failed.
+            navigate('/' + experience.routes.signIn, {
+              state: { errorMessage: error.message } satisfies PersistentErrorMessageState,
+            });
           },
           // Redirect to sign-in page if error is not handled by the error handlers
           global: async (error) => {

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -146,6 +146,18 @@ export const identifierInputValueGuard: s.Describe<IdentifierInputValue> = s.obj
  */
 export const identifierSearchParamGuard = s.array(identifierEnumGuard);
 
+/**
+ * Type guard for the navigation state that carries a persistent error message to display
+ * on the sign-in form. E.g. used when redirecting back to the sign-in page after the
+ * enterprise SSO callback fails with a terminal error (suspended user), so the error
+ * remains visible after the global toast disappears.
+ */
+export const persistentErrorMessageStateGuard = s.type({
+  errorMessage: s.string(),
+});
+
+export type PersistentErrorMessageState = s.Infer<typeof persistentErrorMessageStateGuard>;
+
 /* Identifier-based passkey sign-in state - only contains WebAuthn options.
  * Identifier and available methods are read from UserInteractionContext and useSieMethods(). */
 export const identifierPasskeyStateGuard = s.object({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a suspended user completes the enterprise SSO flow, `/api/experience/identification` returns `user.suspended`, but the error was only shown in a global toast that auto-dismisses after ~3 seconds. After the toast disappeared, the sign-in form showed no feedback, so users assumed nothing had happened.

This change keeps the existing toast and additionally persists the error message on the sign-in form:

- `use-single-sign-on-listener.ts` adds a dedicated `user.suspended` error handler that sets the toast and navigates back to the sign-in page with the error message in the router navigation state.
- A new `useLocationErrorMessage` hook reads the message from the navigation state (validated with a superstruct guard) and keeps it in local state so it can be cleared.
- `PasswordSignInForm` and `IdentifierSignInForm` display the persistent message with the existing `ErrorMessage` component and clear it when the user resubmits the form or modifies the identifier input.

The error message comes from the server response (already localized), so no new phrases are needed. Normal SSO, social, and password sign-in flows are unaffected.

Live demo with a suspended user completing the SSO flow against a local mock OIDC IdP (the error stays on the form after the toast is gone, and clears when the input is edited):

<a href="https://cursor.com/agents/bc-78feae3d-8f5c-424f-893b-455e903a759d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuspended_sso_error_persists_on_sign_in_form.mp4"><img src="https://cursor.com/artifacts/c/art-68a84d19-6b6d-489b-999d-f208b27865dc" alt="suspended_sso_error_persists_on_sign_in_form.mp4" /></a>

![Toast and inline form error shown together after SSO callback](https://cursor.com/artifacts/c/art-2282f406-9ff3-46a5-8919-9ed8af9f0d14)

![Inline form error persists after the toast disappears](https://cursor.com/artifacts/c/art-71c1b700-2b28-4ab4-bc84-e2c75cb18e4b)

## Testing

Tested locally

Unit tests

- SSO callback: suspended user error persists on the sign-in form after the toast auto-dismisses; successful SSO shows no form error.
- Both sign-in forms: the persistent error renders from the navigation state, clears on resubmission, and clears when the identifier input is modified.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78feae3d-8f5c-424f-893b-455e903a759d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78feae3d-8f5c-424f-893b-455e903a759d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

