### PR TITLE
fix(experience): route suspended users to a dedicated error page

### DIFF
--- a/packages/experience/src/App.tsx
+++ b/packages/experience/src/App.tsx
@@ -90,6 +90,21 @@ const App = () => {
                         path="unknown-session"
                         element={<ErrorPage message="error.invalid_session" />}
                       />
+                      <Route
+                        path="account-suspended"
+                        element={
+                          <ErrorPage
+                            isNavbarHidden
+                            title="error.account_suspended"
+                            message="error.account_suspended_description"
+                            primaryAction={{
+                              title: 'description.back_to_sign_in',
+                              to: `/${experience.routes.signIn}`,
+                              replace: true,
+                            }}
+                          />
+                        }
+                      />
 
                       {/* Sign-in */}
                       <Route path={experience.routes.signIn}>

--- a/packages/experience/src/App.tsx
+++ b/packages/experience/src/App.tsx
@@ -91,7 +91,7 @@ const App = () => {
                         element={<ErrorPage message="error.invalid_session" />}
                       />
                       <Route
-                        path="account-suspended"
+                        path={experience.routes.accountSuspended}
                         element={
                           <ErrorPage
                             isNavbarHidden

--- a/packages/experience/src/hooks/use-error-handler.test.tsx
+++ b/packages/experience/src/hooks/use-error-handler.test.tsx
@@ -1,3 +1,4 @@
+import { experience } from '@logto/schemas';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { HTTPError } from 'ky';
 import { MemoryRouter } from 'react-router-dom';
@@ -46,7 +47,7 @@ describe('useErrorHandler', () => {
 
     await waitFor(() => {
       expect(mockedNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({ pathname: '/account-suspended' }),
+        expect.objectContaining({ pathname: `/${experience.routes.accountSuspended}` }),
         { replace: true }
       );
     });
@@ -79,7 +80,7 @@ describe('useErrorHandler', () => {
 
     await waitFor(() => {
       expect(mockedNavigate).toHaveBeenCalledWith(
-        expect.objectContaining({ pathname: '/account-suspended' }),
+        expect.objectContaining({ pathname: `/${experience.routes.accountSuspended}` }),
         { replace: true }
       );
     });

--- a/packages/experience/src/hooks/use-error-handler.test.tsx
+++ b/packages/experience/src/hooks/use-error-handler.test.tsx
@@ -1,0 +1,100 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { HTTPError } from 'ky';
+import { MemoryRouter } from 'react-router-dom';
+
+import useErrorHandler from './use-error-handler';
+
+const mockedNavigate = jest.fn();
+const mockedSetToast = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate,
+}));
+
+jest.mock('./use-toast', () => ({
+  __esModule: true,
+  default: () => ({ toast: '', setToast: mockedSetToast }),
+}));
+
+const createRequestError = (code: string, message = code) => {
+  const response = {
+    status: 401,
+    statusText: 'Unauthorized',
+    json: async () => ({ code, message }),
+  } as unknown as Response;
+
+  return new HTTPError(response, {} as Request, {} as never);
+};
+
+const renderErrorHandler = () =>
+  renderHook(() => useErrorHandler(), {
+    wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+  });
+
+describe('useErrorHandler', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('navigates to the account-suspended page for user.suspended by default', async () => {
+    const { result } = renderErrorHandler();
+
+    await act(async () => {
+      await result.current(createRequestError('user.suspended', 'This account is suspended.'));
+    });
+
+    await waitFor(() => {
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: '/account-suspended' }),
+        { replace: true }
+      );
+    });
+    expect(mockedSetToast).not.toHaveBeenCalled();
+  });
+
+  it('lets a specific handler override the terminal suspended navigation', async () => {
+    const { result } = renderErrorHandler();
+    const specificHandler = jest.fn();
+
+    await act(async () => {
+      await result.current(createRequestError('user.suspended'), {
+        'user.suspended': specificHandler,
+      });
+    });
+
+    expect(specificHandler).toHaveBeenCalled();
+    expect(mockedNavigate).not.toHaveBeenCalled();
+  });
+
+  it('prefers the terminal suspended path over a global handler', async () => {
+    const { result } = renderErrorHandler();
+    const globalHandler = jest.fn();
+
+    await act(async () => {
+      await result.current(createRequestError('user.suspended'), {
+        global: globalHandler,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({ pathname: '/account-suspended' }),
+        { replace: true }
+      );
+    });
+    expect(globalHandler).not.toHaveBeenCalled();
+  });
+
+  it('falls back to toast for unhandled errors', async () => {
+    const { result } = renderErrorHandler();
+    const message = 'Something unexpected happened';
+
+    await act(async () => {
+      await result.current(createRequestError('session.invalid_credentials', message));
+    });
+
+    expect(mockedSetToast).toHaveBeenCalledWith(message);
+    expect(mockedNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/experience/src/hooks/use-error-handler.ts
+++ b/packages/experience/src/hooks/use-error-handler.ts
@@ -4,6 +4,7 @@ import { HTTPError, TimeoutError } from 'ky';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import useNavigateWithPreservedSearchParams from './use-navigate-with-preserved-search-params';
 import useToast from './use-toast';
 
 export type ErrorHandlers = {
@@ -13,9 +14,24 @@ export type ErrorHandlers = {
   global?: (error: RequestErrorBody) => void | Promise<void>;
 };
 
+/**
+ * Built-in handlers for terminal error codes that should land on a dedicated page
+ * instead of a transient toast. Specific per-call handlers still take precedence;
+ * these only run when the caller did not handle the code and before falling back
+ * to `global` / toast.
+ */
+const getTerminalErrorPath = (code: string): string | undefined => {
+  if (code === 'user.suspended') {
+    return '/account-suspended';
+  }
+
+  return undefined;
+};
+
 const useErrorHandler = () => {
   const { t } = useTranslation();
   const { setToast } = useToast();
+  const navigate = useNavigateWithPreservedSearchParams();
 
   const handleError = useCallback(
     async (error: unknown, errorHandlers?: ErrorHandlers) => {
@@ -24,8 +40,15 @@ const useErrorHandler = () => {
           const logtoError = await error.response.json<RequestErrorBody>();
 
           const { code, message } = logtoError;
+          const terminalPath = getTerminalErrorPath(code);
 
-          const handler = errorHandlers?.[code] ?? errorHandlers?.global;
+          const handler =
+            errorHandlers?.[code] ??
+            (terminalPath
+              ? () => {
+                  navigate(terminalPath, { replace: true });
+                }
+              : errorHandlers?.global);
 
           if (handler) {
             await handler(logtoError);
@@ -51,7 +74,7 @@ const useErrorHandler = () => {
       setToast(t('error.unknown'));
       console.error(error);
     },
-    [setToast, t]
+    [navigate, setToast, t]
   );
 
   return handleError;

--- a/packages/experience/src/hooks/use-error-handler.ts
+++ b/packages/experience/src/hooks/use-error-handler.ts
@@ -1,5 +1,5 @@
 import type { LogtoErrorCode } from '@logto/phrases';
-import type { RequestErrorBody } from '@logto/schemas';
+import { experience, type RequestErrorBody } from '@logto/schemas';
 import { HTTPError, TimeoutError } from 'ky';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -20,9 +20,9 @@ export type ErrorHandlers = {
  * these only run when the caller did not handle the code and before falling back
  * to `global` / toast.
  */
-const getTerminalErrorPath = (code: string): string | undefined => {
+const getTerminalErrorPath = (code: LogtoErrorCode): string | undefined => {
   if (code === 'user.suspended') {
-    return '/account-suspended';
+    return `/${experience.routes.accountSuspended}`;
   }
 
   return undefined;

--- a/packages/phrases-experience/src/locales/ar/error/index.ts
+++ b/packages/phrases-experience/src/locales/ar/error/index.ts
@@ -40,6 +40,8 @@ const error = {
   terms_acceptance_required_description:
     'يجب أن توافق على الشروط للمتابعة. يرجى المحاولة مرة أخرى.',
   something_went_wrong: 'حدث خطأ ما',
+  account_suspended: 'الحساب موقوف',
+  account_suspended_description: 'تم إيقاف هذا الحساب. يرجى الاتصال بالمسؤول للحصول على المساعدة.',
   access_denied: 'تم رفض الوصول',
   application_access_denied:
     'ليس لديك إذن للوصول إلى هذا التطبيق.\nيرجى الاتصال بالمسؤول للحصول على المساعدة.',

--- a/packages/phrases-experience/src/locales/cs/error/index.ts
+++ b/packages/phrases-experience/src/locales/cs/error/index.ts
@@ -39,6 +39,8 @@ const error = {
   terms_acceptance_required: 'Je nutné souhlasit s podmínkami',
   terms_acceptance_required_description: 'Pro pokračování je nutné souhlasit s podmínkami.',
   something_went_wrong: 'Něco se pokazilo.',
+  account_suspended: 'Účet pozastaven',
+  account_suspended_description: 'Tento účet byl pozastaven. Kontaktujte prosím administrátora.',
   access_denied: 'Přístup odepřen',
   application_access_denied:
     'Nemáš oprávnění k přístupu k této aplikaci.\nKontaktuj prosím svého administrátora pro pomoc.',

--- a/packages/phrases-experience/src/locales/de/error/index.ts
+++ b/packages/phrases-experience/src/locales/de/error/index.ts
@@ -42,6 +42,9 @@ const error = {
   terms_acceptance_required: 'Zustimmung zu den Bedingungen erforderlich',
   terms_acceptance_required_description: 'Du musst den Bedingungen zustimmen, um fortzufahren.',
   something_went_wrong: 'Etwas ist schiefgegangen',
+  account_suspended: 'Konto gesperrt',
+  account_suspended_description:
+    'Dieses Konto wurde gesperrt. Bitte wende dich an den Administrator.',
   access_denied: 'Zugriff verweigert',
   application_access_denied:
     'Sie haben keine Berechtigung, auf diese Anwendung zuzugreifen.\nBitte kontaktieren Sie Ihren Administrator um Hilfe.',

--- a/packages/phrases-experience/src/locales/en/error/index.ts
+++ b/packages/phrases-experience/src/locales/en/error/index.ts
@@ -40,6 +40,9 @@ const error = {
   terms_acceptance_required: 'Terms acceptance required',
   terms_acceptance_required_description: 'You must agree to the terms to continue.',
   something_went_wrong: 'Something went wrong',
+  account_suspended: 'Account suspended',
+  account_suspended_description:
+    'This account has been suspended. Please contact the administrator for assistance.',
   access_denied: 'Access denied',
   application_access_denied:
     'You do not have permission to access this application.\nPlease contact your administrator for assistance.',

--- a/packages/phrases-experience/src/locales/es/error/index.ts
+++ b/packages/phrases-experience/src/locales/es/error/index.ts
@@ -44,6 +44,9 @@ const error = {
   terms_acceptance_required_description:
     'Debes aceptar los términos para continuar. Por favor, inténtalo de nuevo.',
   something_went_wrong: 'Algo salió mal',
+  account_suspended: 'Cuenta suspendida',
+  account_suspended_description:
+    'Esta cuenta ha sido suspendida. Ponte en contacto con el administrador para obtener ayuda.',
   access_denied: 'Acceso denegado',
   application_access_denied:
     'No tiene permiso para acceder a esta aplicación.\nPor favor, contacte a su administrador para obtener ayuda.',

--- a/packages/phrases-experience/src/locales/fa-ir/error/index.ts
+++ b/packages/phrases-experience/src/locales/fa-ir/error/index.ts
@@ -39,6 +39,8 @@ const error = {
   terms_acceptance_required: 'پذیرش شرایط الزامی است',
   terms_acceptance_required_description: 'برای ادامه باید با شرایط موافقت کنید.',
   something_went_wrong: 'مشکلی پیش آمد',
+  account_suspended: 'حساب معلق شد',
+  account_suspended_description: 'این حساب معلق شده است. لطفاً برای کمک با مدیر تماس بگیرید.',
   access_denied: 'دسترسی رد شد',
   application_access_denied:
     'شما مجاز به دسترسی به این برنامه نیستید. لطفاً با مدیر سیستم تماس بگیرید.',

--- a/packages/phrases-experience/src/locales/fr/error/index.ts
+++ b/packages/phrases-experience/src/locales/fr/error/index.ts
@@ -46,6 +46,9 @@ const error = {
   terms_acceptance_required: 'Acceptation des conditions requise',
   terms_acceptance_required_description: 'Vous devez accepter les conditions pour continuer.',
   something_went_wrong: 'Quelque chose a mal tourné',
+  account_suspended: 'Compte suspendu',
+  account_suspended_description:
+    "Ce compte a été suspendu. Veuillez contacter l'administrateur pour obtenir de l'aide.",
   access_denied: 'Accès refusé',
   application_access_denied:
     "Vous n'avez pas la permission d'accéder à cette application.\nVeuillez contacter votre administrateur pour obtenir de l'aide.",

--- a/packages/phrases-experience/src/locales/it/error/index.ts
+++ b/packages/phrases-experience/src/locales/it/error/index.ts
@@ -40,6 +40,9 @@ const error = {
   terms_acceptance_required: 'Accettazione dei termini richiesta',
   terms_acceptance_required_description: 'Devi accettare i termini per continuare.',
   something_went_wrong: 'Qualcosa è andato storto',
+  account_suspended: 'Account sospeso',
+  account_suspended_description:
+    "Questo account è stato sospeso. Contatta l'amministratore per assistenza.",
   access_denied: 'Accesso negato',
   application_access_denied:
     'Non hai il permesso di accedere a questa applicazione.\nPer assistenza, contatta il tuo amministratore.',

--- a/packages/phrases-experience/src/locales/ja/error/index.ts
+++ b/packages/phrases-experience/src/locales/ja/error/index.ts
@@ -43,6 +43,8 @@ const error = {
   terms_acceptance_required_description:
     '続行するには利用規約に同意する必要があります。もう一度お試しください。',
   something_went_wrong: '問題が発生しました',
+  account_suspended: 'アカウントが停止されています',
+  account_suspended_description: 'このアカウントは停止されています。管理者にお問い合わせください。',
   access_denied: 'アクセスが拒否されました',
   application_access_denied:
     'このアプリケーションにアクセスする権限がありません。\n管理者にお問い合わせください。',

--- a/packages/phrases-experience/src/locales/ko/error/index.ts
+++ b/packages/phrases-experience/src/locales/ko/error/index.ts
@@ -39,6 +39,8 @@ const error = {
   terms_acceptance_required: '약관 동의가 필요해요',
   terms_acceptance_required_description: '계속하려면 약관에 동의해야 해요.',
   something_went_wrong: '문제가 발생했어요',
+  account_suspended: '계정 정지됨',
+  account_suspended_description: '이 계정은 정지되었습니다. 관리자에게 문의하세요.',
   access_denied: '접근이 거부되었어요',
   application_access_denied:
     '이 애플리케이션에 액세스할 권한이 없습니다.\n관리자에게 도움을 요청하세요.',

--- a/packages/phrases-experience/src/locales/pl-pl/error/index.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/error/index.ts
@@ -41,6 +41,9 @@ const error = {
   terms_acceptance_required: 'Wymagana akceptacja warunków',
   terms_acceptance_required_description: 'Musisz zaakceptować warunki, aby kontynuować.',
   something_went_wrong: 'Coś poszło nie tak',
+  account_suspended: 'Konto zawieszone',
+  account_suspended_description:
+    'To konto zostało zawieszone. Skontaktuj się z administratorem, aby uzyskać pomoc.',
   access_denied: 'Odmowa dostępu',
   application_access_denied:
     'Nie masz uprawnień do dostępu do tej aplikacji.\nSkontaktuj się z administratorem, aby uzyskać pomoc.',

--- a/packages/phrases-experience/src/locales/pt-br/error/index.ts
+++ b/packages/phrases-experience/src/locales/pt-br/error/index.ts
@@ -41,6 +41,9 @@ const error = {
   terms_acceptance_required: 'Aceitação dos termos obrigatória',
   terms_acceptance_required_description: 'Você deve aceitar os termos para continuar.',
   something_went_wrong: 'Algo deu errado',
+  account_suspended: 'Conta suspensa',
+  account_suspended_description:
+    'Esta conta foi suspensa. Entre em contato com o administrador para obter ajuda.',
   access_denied: 'Acesso negado',
   application_access_denied:
     'Você não tem permissão para acessar este aplicativo.\nEntre em contato com seu administrador para obter ajuda.',

--- a/packages/phrases-experience/src/locales/pt-pt/error/index.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/error/index.ts
@@ -43,6 +43,9 @@ const error = {
   terms_acceptance_required_description:
     'Deves aceitar os termos para continuar. Por favor, tenta novamente.',
   something_went_wrong: 'Algo correu mal',
+  account_suspended: 'Conta suspensa',
+  account_suspended_description:
+    'Esta conta foi suspensa. Contacte o administrador para obter assistência.',
   access_denied: 'Acesso negado',
   application_access_denied:
     'Não tem permissão para aceder a esta aplicação.\nPor favor, contacte o seu administrador para obter ajuda.',

--- a/packages/phrases-experience/src/locales/ru/error/index.ts
+++ b/packages/phrases-experience/src/locales/ru/error/index.ts
@@ -42,6 +42,9 @@ const error = {
   terms_acceptance_required_description:
     'Вы должны согласиться с условиями, чтобы продолжить. Пожалуйста, попробуйте снова.',
   something_went_wrong: 'Что-то пошло не так',
+  account_suspended: 'Аккаунт заблокирован',
+  account_suspended_description:
+    'Этот аккаунт заблокирован. Обратитесь к администратору за помощью.',
   access_denied: 'Доступ запрещен',
   application_access_denied:
     'У вас нет прав на доступ к этому приложению.\nОбратитесь к администратору за помощью.',

--- a/packages/phrases-experience/src/locales/th/error/index.ts
+++ b/packages/phrases-experience/src/locales/th/error/index.ts
@@ -39,6 +39,8 @@ const error = {
   terms_acceptance_required: 'จำเป็นต้องยอมรับเงื่อนไข',
   terms_acceptance_required_description: 'คุณต้องยอมรับเงื่อนไขเพื่อดำเนินการต่อ',
   something_went_wrong: 'เกิดข้อผิดพลาดบางอย่าง',
+  account_suspended: 'บัญชีถูกระงับ',
+  account_suspended_description: 'บัญชีนี้ถูกระงับ โปรดติดต่อผู้ดูแลระบบเพื่อขอความช่วยเหลือ',
   access_denied: 'ปฏิเสธการเข้าถึง',
   application_access_denied:
     'คุณไม่มีสิทธิ์เข้าถึงแอปพลิเคชันนี้\nกรุณาติดต่อผู้ดูแลระบบเพื่อขอความช่วยเหลือ',

--- a/packages/phrases-experience/src/locales/tr-tr/error/index.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/error/index.ts
@@ -41,6 +41,9 @@ const error = {
   terms_acceptance_required: 'Şartların kabulü gerekli',
   terms_acceptance_required_description: 'Devam etmek için şartları kabul etmelisiniz.',
   something_went_wrong: 'Bir şeyler yanlış gitti',
+  account_suspended: 'Hesap askıya alındı',
+  account_suspended_description:
+    'Bu hesap askıya alındı. Yardım için lütfen yöneticiyle iletişime geçin.',
   access_denied: 'Erişim reddedildi',
   application_access_denied:
     'Bu uygulamaya erişim izniniz yok.\nYardım için lütfen yöneticinizle iletişime geçin.',

--- a/packages/phrases-experience/src/locales/uk-ua/error/index.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/error/index.ts
@@ -41,6 +41,9 @@ const error = {
   terms_acceptance_required_description:
     'Ви повинні погодитися з умовами, щоб продовжити. Будь ласка, спробуйте ще раз.',
   something_went_wrong: 'Щось пішло не так',
+  account_suspended: 'Обліковий запис призупинено',
+  account_suspended_description:
+    'Цей обліковий запис призупинено. Зверніться до адміністратора по допомогу.',
   access_denied: 'Доступ заборонено',
   application_access_denied:
     'Ви не маєте дозволу на доступ до цього застосунку.\nЗверніться до адміністратора за допомогою.',

--- a/packages/phrases-experience/src/locales/zh-cn/error/index.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/error/index.ts
@@ -38,6 +38,8 @@ const error = {
   terms_acceptance_required: '需要同意条款',
   terms_acceptance_required_description: '必须同意条款后才能继续。',
   something_went_wrong: '出现错误',
+  account_suspended: '账户已停用',
+  account_suspended_description: '该账户已被停用，请联系管理员获取帮助。',
   access_denied: '访问被拒绝',
   application_access_denied: '您没有权限访问此应用。\n请联系管理员寻求帮助。',
   feature_not_enabled: '您没有权限访问此功能。请联系管理员寻求帮助。',

--- a/packages/phrases-experience/src/locales/zh-hk/error/index.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/error/index.ts
@@ -38,6 +38,8 @@ const error = {
   terms_acceptance_required: '需要同意條款',
   terms_acceptance_required_description: '必須同意條款後才能繼續。',
   something_went_wrong: '出錯了',
+  account_suspended: '帳戶已停用',
+  account_suspended_description: '此帳戶已被停用，請聯絡管理員以取得協助。',
   access_denied: '拒絕訪問',
   application_access_denied: '您沒有權限訪問此應用。\n請聯繫管理員尋求幫助。',
   feature_not_enabled: '您沒有權限訪問此功能。請聯繫管理員尋求幫助。',

--- a/packages/phrases-experience/src/locales/zh-tw/error/index.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/error/index.ts
@@ -38,6 +38,8 @@ const error = {
   terms_acceptance_required: '需要同意條款',
   terms_acceptance_required_description: '必須同意條款後才能繼續。',
   something_went_wrong: '出了些問題',
+  account_suspended: '帳戶已停用',
+  account_suspended_description: '此帳戶已被停用，請聯絡管理員以取得協助。',
   access_denied: '拒絕存取',
   application_access_denied: '您沒有權限存取此應用程式。\n請聯繫管理員尋求協助。',
   feature_not_enabled: '您沒有權限存取此功能。請聯繫管理員尋求協助。',

--- a/packages/schemas/src/consts/experience.ts
+++ b/packages/schemas/src/consts/experience.ts
@@ -9,6 +9,7 @@ const routes = Object.freeze({
   identifierRegister: 'identifier-register',
   switchAccount: 'switch-account',
   oneTimeToken: 'one-time-token',
+  accountSuspended: 'account-suspended',
 } as const);
 
 export const experience = Object.freeze({


### PR DESCRIPTION
## Summary

- handle `user.suspended` centrally in the experience error handler
- navigate all sign-in methods to a dedicated `/account-suspended` page
- reuse the existing `ErrorPage` layout with a back-to-sign-in action
- add localized account-suspended copy across experience languages

## Root cause

`user.suspended` is thrown by every identify path (password, verification code, social, and enterprise SSO), but the experience previously only showed a short-lived toast. Callback-based flows also navigated back to `/sign-in`, so the message disappeared after a few seconds and left no persistent state.

## Approach

Treat suspension as a terminal auth error and land on a dedicated page instead of attaching form-level state:

1. Add `/account-suspended` backed by the shared `ErrorPage`
2. Teach `useErrorHandler` to intercept `user.suspended` before toast/`global` handlers
3. Keep per-call specific handlers able to override if needed

This covers password, verification code, social, and SSO without per-flow form wiring.

## Tests

- unit tests for the default suspended navigation and override/global precedence
- local password sign-in with a suspended user lands on `/account-suspended`
- page shows the suspended title/description and back-to-sign-in action

<img width="1280" height="900" alt="account-suspended-page" src="https://github.com/user-attachments/assets/081b1068-90bf-4b0d-a18a-3f16ffa5a8f2" />
