### PR TITLE
refactor(core,test): re-sync the client-credentials grant onto upstream v9

### DIFF
--- a/packages/core/src/include.d/oidc-provider/lib-keep/helpers/grant_common.d.ts
+++ b/packages/core/src/include.d/oidc-provider/lib-keep/helpers/grant_common.d.ts
@@ -1,4 +1,4 @@
-// https://github.com/logto-io/node-oidc-provider/blob/d60ae9bd6d089e69f3a243119c6d87db25e837ce/lib/helpers/grant_common.js
+// https://github.com/logto-io/node-oidc-provider/blob/7722ac95d77cd62a41528aec4eb711b3d12589d4/lib/helpers/grant_common.js
 declare module 'oidc-provider/lib/helpers/grant_common.js' {
   import { type X509Certificate } from 'node:crypto';
 
@@ -15,6 +15,15 @@ declare module 'oidc-provider/lib/helpers/grant_common.js' {
     rar?: unknown;
     setThumbprint(name: 'jkt' | 'x5t', input: string | X509Certificate): void;
   };
+
+  /**
+   * Returns the client certificate when the client requires mTLS-bound access tokens and throws
+   * `InvalidGrant` when the certificate is missing; returns `undefined` for other clients.
+   */
+  export function checkMtlsCert(
+    ctx: KoaContextWithOIDC,
+    getCertificate: (ctx: KoaContextWithOIDC) => X509Certificate | string | undefined
+  ): X509Certificate | string | undefined;
 
   /** Throws `InvalidGrant` when the client requires DPoP-bound access tokens but no proof is given. */
   export function checkDpopRequired(ctx: KoaContextWithOIDC, dPoP: unknown): void;
@@ -61,6 +70,17 @@ declare module 'oidc-provider/lib/helpers/grant_common.js' {
 
   /** Sets the `x5t` thumbprint on the access token when a client certificate is present. */
   export function applyMtlsBinding(at: WidenedAccessToken, cert?: string | X509Certificate): void;
+
+  /**
+   * Binds the token to the DPoP proof key when a proof is present: runs replay detection
+   * (unless `allowReplay` is enabled) and sets the `jkt` thumbprint.
+   */
+  export function applyDpopBinding(
+    ctx: KoaContextWithOIDC,
+    dPoP: { jti: string; thumbprint: string } | undefined,
+    at: { setThumbprint(name: 'jkt', input: string): void },
+    allowReplay: boolean
+  ): Promise<void>;
 
   /**
    * Issues the ID token when the effective scope contains `openid`; returns `undefined`

--- a/packages/core/src/oidc/grants/client-credentials.test.ts
+++ b/packages/core/src/oidc/grants/client-credentials.test.ts
@@ -7,13 +7,17 @@ import { MockTenant } from '#src/test-utils/tenant.js';
 const { jest } = import.meta;
 
 jest.unstable_mockModule('#src/oidc/oidc-provider-internals.js', () => ({
+  applyDpopBinding: jest.fn(),
   certificateThumbprint: jest.fn(),
+  checkDpopRequired: jest.fn(),
+  checkMtlsCert: jest.fn(),
   checkResource: jest.fn(),
   dpopValidate: jest.fn(),
   epochTime: jest.fn(),
   getProviderConfiguration: jest.fn().mockReturnValue({
     features: {
       mTLS: { getCertificate: jest.fn() },
+      dPoP: { allowReplay: false },
     },
     scopes: new Set(['foo', 'bar']),
   }),
@@ -87,6 +91,14 @@ describe('client credentials grant', () => {
   it('should throw an error if the client is not available', async () => {
     const ctx = createOidcContext({ ...validOidcContext, client: undefined });
     await expect(mockHandler()(ctx)).rejects.toThrow(errors.InvalidClient);
+  });
+
+  it('should throw an error if authorization_details is provided', async () => {
+    const ctx = createOidcContext({
+      ...validOidcContext,
+      params: { ...validOidcContext.params, authorization_details: [{ type: 'foo' }] },
+    });
+    await expect(mockHandler()(ctx)).rejects.toThrow(errors.InvalidRequest);
   });
 
   it('should throw an error if the requested scope is not allowed', async () => {

--- a/packages/core/src/oidc/grants/client-credentials.ts
+++ b/packages/core/src/oidc/grants/client-credentials.ts
@@ -9,31 +9,55 @@
  * `=== End RFC 0006 ===` to indicate the changes.
  *
  * @see {@link https://github.com/logto-io/rfcs | Logto RFCs} for more information about RFC 0006.
- * @see {@link https://github.com/panva/node-oidc-provider/blob/0c52469f08b0a4a1854d90a96546a3f7aa090e5e/lib/actions/grants/client_credentials.js | Original file}.
+ * @see {@link https://github.com/logto-io/node-oidc-provider/blob/7722ac95d77cd62a41528aec4eb711b3d12589d4/lib/actions/grants/client_credentials.js | Original file}.
  *
  * @remarks
  * Since the original code is not exported, we have to copy the code here. This file should be
  * treated as a fork of the original file, which means, we should keep the code in sync with the
  * original file as much as possible.
  *
- * The commit hash of the original file is `0c52469f08b0a4a1854d90a96546a3f7aa090e5e`.
+ * The original file is from the fork's `v9` branch at commit
+ * `7722ac95d77cd62a41528aec4eb711b3d12589d4`, where it differs from the upstream v9.9.1 tag only
+ * by the fork's scope-always-present patch in the token response. Its shared helpers
+ * (`grant_common.js`) are consumed through the `oidc-provider-internals.js` seam module.
+ *
+ * Deliberate deviations from the original file:
+ *
+ * - The `ctx.oidc.resourceServers` destructure is hoisted above the scope validation so the
+ *   RFC 0006 guard (`` both `resource` and `organization_id` are not provided ``) rejects the
+ *   request before a token instance is created; the original file reads it after creating the
+ *   token.
  */
 
+import { type X509Certificate } from 'node:crypto';
+
 import { cond } from '@silverhand/essentials';
-import { errors } from 'oidc-provider';
+import { errors, type Provider } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
 import {
+  applyDpopBinding,
+  checkDpopRequired,
+  checkMtlsCert,
   checkResource,
+  dpopValidate,
   getProviderConfiguration,
   type GrantTypeHandler,
 } from '#src/oidc/oidc-provider-internals.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { handleClientCertificate, handleDPoP, handleOrganizationToken } from './utils.js';
+import { handleOrganizationToken } from './utils.js';
 
-const { AccessDenied, InvalidClient, InvalidGrant, InvalidScope, InvalidTarget } = errors;
+const { AccessDenied, InvalidClient, InvalidRequest, InvalidScope, InvalidTarget } = errors;
+
+/**
+ * The `ClientCredentials` instance widened with the `setThumbprint` model mixin missing from
+ * `@types/oidc-provider`.
+ */
+type WidenedClientCredentials = InstanceType<Provider['ClientCredentials']> & {
+  setThumbprint(name: 'jkt' | 'x5t', input: string | X509Certificate): void;
+};
 
 /**
  * The valid parameters for the `client_credentials` grant type. Note the `resource` parameter is
@@ -57,9 +81,16 @@ export const buildHandler: (
   const {
     features: {
       mTLS: { getCertificate },
+      dPoP: { allowReplay },
     },
     scopes: statics,
   } = getProviderConfiguration(ctx.oidc.provider);
+
+  const dPoP = await dpopValidate(ctx);
+
+  if (params?.authorization_details) {
+    throw new InvalidRequest('authorization_details is unsupported for this grant_type');
+  }
 
   /* === RFC 0006 === */
   // The value type is `unknown`, which will swallow other type inferences. So we have to cast it
@@ -94,9 +125,7 @@ export const buildHandler: (
     throw new InvalidTarget('both `resource` and `organization_id` are not provided');
   }
 
-  const scopes = ctx.oidc.params?.scope
-    ? [...new Set(String(ctx.oidc.params.scope).split(' '))]
-    : [];
+  const scopes = params?.scope ? [...new Set(String(params.scope).split(' '))] : [];
 
   if (client.scope) {
     const allowList = new Set(client.scope.split(' '));
@@ -108,10 +137,11 @@ export const buildHandler: (
     }
   }
 
+  // eslint-disable-next-line no-restricted-syntax -- widen with the model mixin missing from the typings, see `WidenedClientCredentials`
   const token = new ClientCredentials({
     client,
     scope: scopes.join(' ') || undefined!,
-  });
+  }) as WidenedClientCredentials;
 
   if (resourceServer) {
     if (length !== 1) {
@@ -143,19 +173,13 @@ export const buildHandler: (
     /* === End RFC 0006 === */
   }
 
-  if (client.tlsClientCertificateBoundAccessTokens) {
-    const cert = getCertificate(ctx);
-
-    if (!cert) {
-      throw new InvalidGrant('mutual TLS client certificate not provided');
-    }
-    // @ts-expect-error -- code from oidc-provider
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+  const cert = checkMtlsCert(ctx, getCertificate);
+  if (cert) {
     token.setThumbprint('x5t', cert);
   }
 
-  await handleDPoP(ctx, token);
-  await handleClientCertificate(ctx, token);
+  await applyDpopBinding(ctx, dPoP, token, allowReplay);
+  checkDpopRequired(ctx, dPoP);
 
   ctx.oidc.entity('ClientCredentials', token);
   const value = await token.save();
@@ -164,6 +188,12 @@ export const buildHandler: (
     access_token: value,
     expires_in: token.expiration,
     token_type: token.tokenType,
+    /**
+     * LOGTO PATCH(scope-always-present): always echo the token's scope in the token response.
+     * Upstream drops falsy scopes, but Logto clients rely on `scope` being present.
+     *
+     * Upstream: scope: token.scope || undefined,
+     */
     scope: token.scope,
   };
 };

--- a/packages/core/src/oidc/oidc-provider-internals.ts
+++ b/packages/core/src/oidc/oidc-provider-internals.ts
@@ -12,10 +12,12 @@ export { checkAttestBinding } from 'oidc-provider/lib/helpers/check_attest_bindi
 export { default as epochTime } from 'oidc-provider/lib/helpers/epoch_time.js';
 export { pluralize } from 'oidc-provider/lib/helpers/formatters.js';
 export {
+  applyDpopBinding,
   applyMtlsBinding,
   buildTokenResponse,
   checkAccountMismatch,
   checkDpopRequired,
+  checkMtlsCert,
   createAccessToken,
   issueIdToken,
   validateAccount,


### PR DESCRIPTION
## Summary

Re-sync the forked `client_credentials` grant (`packages/core/src/oidc/grants/client-credentials.ts`) onto the upstream v9.9.1 structure, replaying the RFC 0006 delta (organization tokens for machine-to-machine apps) on top of the new base. The file now mirrors the fork's `v9` branch file (`7722ac95`) section by section, so future re-syncs stay a straight diff.

Stacked on #9211; will be retargeted to `feat/oidc-provider-v9` once that PR merges.

Changes:

- Delegate the mTLS and DPoP handling to v9's `grant_common.js` helpers (`checkMtlsCert`, `applyDpopBinding`, `checkDpopRequired`) through the `oidc-provider-internals.js` seam module, following the v9 original: `dpopValidate` now runs at the top of the handler, and the replay check is gated by `features.dPoP.allowReplay` with the `CHALLENGE_OK_WINDOW` constant (300 seconds — the same value the v8 fork hardcoded, so the replay-detection behavior is unchanged). The grant no longer uses `handleDPoP`/`handleClientCertificate` from `grants/utils.ts`; those stay untouched until the token-exchange grant is re-synced.
- Reproduce v9's new `authorization_details` rejection (`InvalidRequest`) to keep the file aligned with upstream. The path is inert under Logto's configuration (`authorization_details` is not a registered parameter for this grant); a new unit test pins it regardless.
- Extend the `grant_common.js` type shim with the two newly consumed helpers, and add a local `WidenedClientCredentials` type for the `setThumbprint` model mixin missing from `@types/oidc-provider`, replacing the previous `@ts-expect-error` at the call site.
- One marked deviation from the upstream file: the `ctx.oidc.resourceServers` destructure stays hoisted above the scope validation so the RFC 0006 guard (``both `resource` and `organization_id` are not provided``) rejects the request before a token instance is created; the original file reads it after creating the token. Error messages and check order are otherwise preserved.
- The token response keeps `scope` unconditionally, mirroring the fork's scope-always-present patch, which lives inline in this grant's response body. Response shape is unchanged.

## Testing

- Unit tests: the existing client-credentials suite passes unchanged, plus the new `authorization_details` rejection test; the full OIDC unit sweep is green (12 suites, 138 tests).
- Integration tests: no changes needed — the existing `client-credentials-grant.test.ts` and `client-authentication.test.ts` suites cover this grant end to end.

## Checklist

- [x] `.changeset` — not needed; no end-user-visible change (deferred to the final integration-branch merge, same as #9201)
- [x] unit tests
- [x] integration tests — covered by the existing suites, no new cases needed
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y93VUpQjqE4ri9GcW4aAKx