### PR TITLE
fix(core): make start_time/end_time inclusive on GET /logs

### DIFF
--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.test.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.test.ts
@@ -1,4 +1,4 @@
-import { addDays, startOfDay } from 'date-fns';
+import { endOfDay, startOfDay } from 'date-fns';
 
 import {
   customRange,
@@ -62,30 +62,28 @@ describe('preset', () => {
     it('snaps 7d to start-of-day so day-labelled presets match the custom picker (LOG-13478)', () => {
       const window = resolveTimeWindow('7d', '', '', now);
       const rolledBack = fixedNow - 7 * 24 * 60 * 60 * 1000;
-      expect(window.startTime).toBe(startOfDay(rolledBack).getTime() - 1);
+      expect(window.startTime).toBe(startOfDay(rolledBack).getTime());
       expect(window.endTime).toBeUndefined();
     });
 
     it('snaps 30d to start-of-day', () => {
       const window = resolveTimeWindow('30d', '', '', now);
       const rolledBack = fixedNow - 30 * 24 * 60 * 60 * 1000;
-      expect(window.startTime).toBe(startOfDay(rolledBack).getTime() - 1);
+      expect(window.startTime).toBe(startOfDay(rolledBack).getTime());
       expect(window.endTime).toBeUndefined();
     });
 
     it('falls back to the default preset (7d, snapped) for an unknown range value', () => {
       const window = resolveTimeWindow('bogus', '', '', now);
       const rolledBack = fixedNow - 7 * 24 * 60 * 60 * 1000;
-      expect(window.startTime).toBe(startOfDay(rolledBack).getTime() - 1);
+      expect(window.startTime).toBe(startOfDay(rolledBack).getTime());
       expect(window.endTime).toBeUndefined();
     });
 
-    it('parses a yyyy-MM-dd custom range with bounds tuned for the API exclusive semantics', () => {
+    it('parses a yyyy-MM-dd custom range with bounds tuned for the API inclusive semantics', () => {
       const window = resolveTimeWindow(customRange, '2026-04-13', '2026-04-15', now);
-      // Start: (startOfDay - 1ms) so `>` includes midnight of the picked day.
-      expect(window.startTime).toBe(startOfDay(new Date(2026, 3, 13)).getTime() - 1);
-      // End: startOfDay of the day _after_ so `<` includes 23:59:59.999 of the picked day.
-      expect(window.endTime).toBe(startOfDay(addDays(new Date(2026, 3, 15), 1)).getTime());
+      expect(window.startTime).toBe(startOfDay(new Date(2026, 3, 13)).getTime());
+      expect(window.endTime).toBe(endOfDay(new Date(2026, 3, 15)).getTime());
     });
 
     it('drops malformed custom-range strings (regression: NaN crash)', () => {
@@ -105,7 +103,7 @@ describe('preset', () => {
     it('omits a custom bound when its raw value is empty', () => {
       const window = resolveTimeWindow(customRange, '', '2026-04-15', now);
       expect(window.startTime).toBeUndefined();
-      expect(window.endTime).toBe(startOfDay(addDays(new Date(2026, 3, 15), 1)).getTime());
+      expect(window.endTime).toBe(endOfDay(new Date(2026, 3, 15)).getTime());
     });
   });
 });

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/preset.ts
@@ -1,4 +1,4 @@
-import { addDays, isValid, parseISO, startOfDay } from 'date-fns';
+import { addDays, endOfDay, isValid, parseISO, startOfDay } from 'date-fns';
 
 /** Canonical preset names persisted in the URL (`?range=…`). */
 export const presetRanges = ['1h', '1d', '7d', '30d'] as const;
@@ -55,9 +55,8 @@ const parseDateAndTransform = (
 
 /**
  * Resolve URL state into the absolute window the API expects. Bounds are
- * exclusive (`createdAt > start_time AND createdAt < end_time`); the `±1ms`
- * / next-day biases below ensure the picked day is included. Callers should
- * memoize — the preset path snapshots `Date.now()` per call.
+ * inclusive (`createdAt >= start_time AND createdAt <= end_time`). Callers
+ * should memoize — the preset path snapshots `Date.now()` per call.
  */
 export const resolveTimeWindow = (
   range: string,
@@ -67,11 +66,8 @@ export const resolveTimeWindow = (
 ): { startTime?: number; endTime?: number } => {
   if (range === customRange) {
     return {
-      startTime: parseDateAndTransform(
-        rawStartTime,
-        (date) => new Date(startOfDay(date).getTime() - 1)
-      ),
-      endTime: parseDateAndTransform(rawEndTime, (date) => startOfDay(addDays(date, 1))),
+      startTime: parseDateAndTransform(rawStartTime, (date) => startOfDay(date)),
+      endTime: parseDateAndTransform(rawEndTime, (date) => endOfDay(date)),
     };
   }
   const presetRange: PresetRange = isPresetRange(range) ? range : defaultPresetRange;
@@ -81,6 +77,6 @@ export const resolveTimeWindow = (
   const startTime =
     daysBack === undefined
       ? now() - presetMs[presetRange]
-      : startOfDay(addDays(now(), -daysBack)).getTime() - 1;
+      : startOfDay(addDays(now(), -daysBack)).getTime();
   return { startTime, endTime: undefined };
 };

--- a/packages/console/src/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window.ts
+++ b/packages/console/src/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window.ts
@@ -86,11 +86,9 @@ const useAuditLogTimeWindow = ({
       // instead of silently broadening to the full retention window.
       // When already on `custom`, leave any existing dates intact.
       const isAlreadyCustom = range === customRange;
-      // `+ 1` undoes the day-snap preset's `-1ms` bias — without it the seed
-      // formats to the day before the preset's actual window.
       const seedStart =
         !isAlreadyCustom && startTime !== undefined
-          ? format(startTime + 1, dateInputPattern)
+          ? format(startTime, dateInputPattern)
           : undefined;
       const seedEnd = isAlreadyCustom ? undefined : format(Date.now(), dateInputPattern);
       updateSearchParameters({

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -60,6 +60,9 @@ const buildLogConditionSql = (logCondition: LogCondition) =>
           )
       ),
       conditionalSql(logKey, (logKey) => sql`${fields.key}=${logKey}`),
+      // Use `!== undefined` (not `conditionalSql`) so a legitimate `start_time=0`
+      // or `end_time=0` window still applies — `conditionalSql` treats `0` as
+      // falsy and would silently drop the filter.
       startTime === undefined
         ? sql``
         : sql`${fields.createdAt} >= to_timestamp(${startTime}::double precision / 1000)`,

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -23,7 +23,12 @@ type LogCondition = {
   payload?: { applicationId?: string; userId?: string; hookId?: string };
   /** Inclusive lower bound on `createdAt`, in unix milliseconds. */
   startTime?: number;
-  /** Inclusive upper bound on `createdAt`, in unix milliseconds. */
+  /**
+   * Inclusive upper bound on `createdAt`, in unix milliseconds. Internally the
+   * SQL adds 1ms so that rows with sub-millisecond precision (PostgreSQL stores
+   * timestamps at microsecond granularity) whose displayed `createdAt` rounds
+   * to this value are not excluded.
+   */
   endTime?: number;
   includeKeyPrefix?: AllowedKeyPrefix[];
 };
@@ -68,7 +73,7 @@ const buildLogConditionSql = (logCondition: LogCondition) =>
         : sql`${fields.createdAt} >= to_timestamp(${startTime}::double precision / 1000)`,
       endTime === undefined
         ? sql``
-        : sql`${fields.createdAt} <= to_timestamp(${endTime}::double precision / 1000)`,
+        : sql`${fields.createdAt} < to_timestamp(${endTime}::double precision / 1000) + interval '1 millisecond'`,
     ].filter(({ sql }) => sql);
 
     return subConditions.length > 0 ? sql`where ${sql.join(subConditions, sql` and `)}` : sql``;

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -21,9 +21,9 @@ type AllowedKeyPrefix = AuditLogPrefix | WebhookLogPrefix;
 type LogCondition = {
   logKey?: string;
   payload?: { applicationId?: string; userId?: string; hookId?: string };
-  /** Exclusive lower bound on `createdAt`, in unix milliseconds. */
+  /** Inclusive lower bound on `createdAt`, in unix milliseconds. */
   startTime?: number;
-  /** Exclusive upper bound on `createdAt`, in unix milliseconds. */
+  /** Inclusive upper bound on `createdAt`, in unix milliseconds. */
   endTime?: number;
   includeKeyPrefix?: AllowedKeyPrefix[];
 };
@@ -60,15 +60,12 @@ const buildLogConditionSql = (logCondition: LogCondition) =>
           )
       ),
       conditionalSql(logKey, (logKey) => sql`${fields.key}=${logKey}`),
-      // Use `!== undefined` (not `conditionalSql`) so a legitimate `start_time=0`
-      // or `end_time=0` window still applies — `conditionalSql` treats `0` as
-      // falsy and would silently drop the filter.
       startTime === undefined
         ? sql``
-        : sql`${fields.createdAt} > to_timestamp(${startTime}::double precision / 1000)`,
+        : sql`${fields.createdAt} >= to_timestamp(${startTime}::double precision / 1000)`,
       endTime === undefined
         ? sql``
-        : sql`${fields.createdAt} < to_timestamp(${endTime}::double precision / 1000)`,
+        : sql`${fields.createdAt} <= to_timestamp(${endTime}::double precision / 1000)`,
     ].filter(({ sql }) => sql);
 
     return subConditions.length > 0 ? sql`where ${sql.join(subConditions, sql` and `)}` : sql``;

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -254,11 +254,18 @@ describe('hook routes', () => {
       );
     });
 
-    it('returns 400 when start_time >= end_time', async () => {
+    it('returns 400 when start_time > end_time', async () => {
       const response = await hookRequest.get(
         `/hooks/foo/recent-logs?start_time=2000&end_time=1000`
       );
       expect(response.status).toEqual(400);
+    });
+
+    it('succeeds when start_time equals end_time (inclusive bounds)', async () => {
+      const response = await hookRequest.get(
+        `/hooks/foo/recent-logs?start_time=1000&end_time=1000`
+      );
+      expect(response.status).toEqual(200);
     });
 
     it('returns 400 when start_time is not a finite number', async () => {

--- a/packages/core/src/routes/hooks.openapi.json
+++ b/packages/core/src/routes/hooks.openapi.json
@@ -138,12 +138,12 @@
           {
             "name": "start_time",
             "in": "query",
-            "description": "Exclusive lower bound on `createdAt`, in unix milliseconds. Supplying either `start_time` or `end_time` replaces the endpoint's default 24-hour lower bound, so callers can query an arbitrary historical window. Returns `400` if `start_time >= end_time` when both are present."
+            "description": "Inclusive lower bound on `createdAt`, in unix milliseconds. Supplying either `start_time` or `end_time` replaces the endpoint's default 24-hour lower bound, so callers can query an arbitrary historical window. Returns `400` if `start_time > end_time` when both are present."
           },
           {
             "name": "end_time",
             "in": "query",
-            "description": "Exclusive upper bound on `createdAt`, in unix milliseconds. Supplying either `start_time` or `end_time` replaces the endpoint's default 24-hour lower bound."
+            "description": "Inclusive upper bound on `createdAt`, in unix milliseconds. Supplying either `start_time` or `end_time` replaces the endpoint's default 24-hour lower bound."
           },
           {
             "name": "enableCap",
@@ -153,7 +153,7 @@
         ],
         "responses": {
           "400": {
-            "description": "Returned when `start_time` or `end_time` is not a finite number, or when `start_time >= end_time`."
+            "description": "Returned when `start_time` or `end_time` is not a finite number, or when `start_time > end_time`."
           },
           "200": {
             "description": "A list of recent logs for the hook.",

--- a/packages/core/src/routes/log.openapi.json
+++ b/packages/core/src/routes/log.openapi.json
@@ -29,12 +29,12 @@
           {
             "name": "start_time",
             "in": "query",
-            "description": "Exclusive lower bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt > start_time`. Recommended for clients paginating across very large log ranges to keep query latency consistent."
+            "description": "Inclusive lower bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt >= start_time`."
           },
           {
             "name": "end_time",
             "in": "query",
-            "description": "Exclusive upper bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt < end_time`. Returns `400` if `start_time >= end_time` when both are present."
+            "description": "Inclusive upper bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt <= end_time`. Returns `400` if `start_time > end_time` when both are present."
           },
           {
             "name": "enableCap",
@@ -44,7 +44,7 @@
         ],
         "responses": {
           "400": {
-            "description": "Returned when `start_time` or `end_time` is not a finite number, or when `start_time >= end_time`."
+            "description": "Returned when `start_time` or `end_time` is not a finite number, or when `start_time > end_time`."
           },
           "200": {
             "description": "An array of logs that match the given query.",

--- a/packages/core/src/routes/log.openapi.json
+++ b/packages/core/src/routes/log.openapi.json
@@ -29,7 +29,7 @@
           {
             "name": "start_time",
             "in": "query",
-            "description": "Inclusive lower bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt >= start_time`. Recommended for clients paginating across very large log ranges to keep query latency consistent."
+            "description": "Inclusive lower bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt >= start_time`. Recommended for clients paginating across very large log ranges to keep query latency consistent. Because the bound is inclusive, when resuming pagination from the last fetched log, pass its `createdAt + 1` as `start_time` (or de-duplicate by log `id`) to avoid re-fetching the boundary log."
           },
           {
             "name": "end_time",

--- a/packages/core/src/routes/log.openapi.json
+++ b/packages/core/src/routes/log.openapi.json
@@ -29,7 +29,7 @@
           {
             "name": "start_time",
             "in": "query",
-            "description": "Inclusive lower bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt >= start_time`."
+            "description": "Inclusive lower bound on `createdAt`, in unix milliseconds. When set, returns only logs where `createdAt >= start_time`. Recommended for clients paginating across very large log ranges to keep query latency consistent."
           },
           {
             "name": "end_time",

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -137,7 +137,7 @@ describe('logRoutes', () => {
         );
       });
 
-      it('returns 400 when start_time >= end_time', async () => {
+      it('returns 400 when start_time > end_time', async () => {
         const response = await logRequest.get(`/logs?start_time=2000&end_time=1000`);
         expect(response.status).toEqual(400);
         expect(countLogs).not.toHaveBeenCalled();

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -143,9 +143,9 @@ describe('logRoutes', () => {
         expect(countLogs).not.toHaveBeenCalled();
       });
 
-      it('returns 400 when start_time equals end_time', async () => {
+      it('succeeds when start_time equals end_time (inclusive bounds)', async () => {
         const response = await logRequest.get(`/logs?start_time=1000&end_time=1000`);
-        expect(response.status).toEqual(400);
+        expect(response.status).toEqual(200);
       });
 
       it('returns 400 when start_time is not a finite number', async () => {

--- a/packages/core/src/utils/time-window.ts
+++ b/packages/core/src/utils/time-window.ts
@@ -19,11 +19,11 @@ export const parseTimestampParam = (
 };
 
 /**
- * Validate a parsed time window: when both bounds are present, `start` must be
- * strictly less than `end`. Throws 400 with `log.invalid_time_window` otherwise.
+ * Validate a parsed time window: when both bounds are present, `start` must not
+ * exceed `end`. Throws 400 with `log.invalid_time_window` otherwise.
  */
 export const validateTimeWindow = (start: number | undefined, end: number | undefined): void => {
-  if (start !== undefined && end !== undefined && start >= end) {
+  if (start !== undefined && end !== undefined && start > end) {
     throw new RequestError({ code: 'log.invalid_time_window', status: 400 });
   }
 };

--- a/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
+++ b/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
@@ -24,7 +24,7 @@ describe('GET /logs start_time / end_time params', () => {
   });
 
   describe('validation', () => {
-    it('returns 400 when start_time >= end_time', async () => {
+    it('returns 400 when start_time > end_time', async () => {
       const response = await getAuditLogsResponse(
         new URLSearchParams({ start_time: '2000', end_time: '1000' })
       ).catch((error: unknown) => error);

--- a/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
+++ b/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
@@ -162,7 +162,7 @@ describe('GET /logs end_time with sub-millisecond createdAt', () => {
         ${defaultTenantId},
         ${logId},
         ${logKey},
-        ${sql.jsonb({})},
+        ${sql.jsonb({ key: logKey, result: 'Success' })},
         to_timestamp(${subMsTimestamp}::double precision / 1000)
       )
     `);

--- a/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
+++ b/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
@@ -31,11 +31,11 @@ describe('GET /logs start_time / end_time params', () => {
       expect(response instanceof HTTPError && response.response.status).toBe(400);
     });
 
-    it('returns 400 when start_time equals end_time', async () => {
+    it('succeeds when start_time equals end_time (inclusive bounds)', async () => {
       const response = await getAuditLogsResponse(
         new URLSearchParams({ start_time: '1000', end_time: '1000' })
-      ).catch((error: unknown) => error);
-      expect(response instanceof HTTPError && response.response.status).toBe(400);
+      );
+      expect(response.status).toBe(200);
     });
 
     it('returns 400 when start_time is not a finite number', async () => {
@@ -87,7 +87,7 @@ describe('GET /logs start_time / end_time params', () => {
       const nonOverlappingWindow = await getAuditLogs(
         new URLSearchParams({
           logKey: `${interaction.prefix}.${interaction.Action.Create}`,
-          end_time: String(beforeStart),
+          end_time: String(beforeStart - 1),
         })
       );
       expect(

--- a/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
+++ b/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
@@ -143,7 +143,7 @@ describe('GET /logs end_time with sub-millisecond createdAt', () => {
   // Sub-ms timestamp ÷ 1000 = 1784217599.999500
   const subMsTimestamp = epochMs + 0.5;
   const logId = 'sub-ms-boundary-test';
-  const logKey = 'Test.SubMillisecondBoundary';
+  const logKey = `${interaction.prefix}.SubMillisecondBoundary`;
 
   /* eslint-disable @silverhand/fp/no-let */
   let pool: DatabasePool;

--- a/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
+++ b/packages/integration-tests/src/tests/api/audit-logs/time-window.test.ts
@@ -1,5 +1,6 @@
-import { InteractionEvent, SignInIdentifier, interaction } from '@logto/schemas';
-import { assert } from '@silverhand/essentials';
+import { InteractionEvent, SignInIdentifier, defaultTenantId, interaction } from '@logto/schemas';
+import { assert, assertEnv } from '@silverhand/essentials';
+import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
 import { HTTPError } from 'ky';
 
 import { deleteUser } from '#src/api/admin-user.js';
@@ -128,5 +129,59 @@ describe('GET /logs start_time / end_time params', () => {
       );
       expect(response.status).toBe(200);
     });
+  });
+});
+
+// Regression: PostgreSQL stores timestamps at microsecond precision while the
+// API exposes createdAt as a unix-millisecond integer. The SQL filter must
+// treat end_time as an inclusive millisecond bucket so that a row stored at
+// e.g. epoch 1784217599999.500 (displayed as createdAt: 1784217599999) is
+// returned when querying with end_time=1784217599999.
+describe('GET /logs end_time with sub-millisecond createdAt', () => {
+  // A millisecond boundary with a clean .5 fractional second.
+  const epochMs = 1_784_217_599_999;
+  // Sub-ms timestamp ÷ 1000 = 1784217599.999500
+  const subMsTimestamp = epochMs + 0.5;
+  const logId = 'sub-ms-boundary-test';
+  const logKey = 'Test.SubMillisecondBoundary';
+
+  /* eslint-disable @silverhand/fp/no-let */
+  let pool: DatabasePool;
+  /* eslint-enable @silverhand/fp/no-let */
+
+  beforeAll(async () => {
+    /* eslint-disable @silverhand/fp/no-mutation */
+    pool = await createPool(assertEnv('DB_URL'), {
+      interceptors: createInterceptorsPreset(),
+    });
+    /* eslint-enable @silverhand/fp/no-mutation */
+
+    await pool.query(sql`
+      insert into logs (tenant_id, id, key, payload, created_at)
+      values (
+        ${defaultTenantId},
+        ${logId},
+        ${logKey},
+        ${sql.jsonb({})},
+        to_timestamp(${subMsTimestamp}::double precision / 1000)
+      )
+    `);
+  });
+
+  afterAll(async () => {
+    await pool.query(sql`
+      delete from logs where id = ${logId}
+    `);
+    await pool.end();
+  });
+
+  it('includes a log whose displayed createdAt equals end_time despite sub-millisecond offset', async () => {
+    const logs = await getAuditLogs(new URLSearchParams({ logKey, end_time: String(epochMs) }));
+    expect(logs.some((log) => log.id === logId)).toBeTruthy();
+  });
+
+  it('excludes the same log when end_time is one millisecond earlier', async () => {
+    const logs = await getAuditLogs(new URLSearchParams({ logKey, end_time: String(epochMs - 1) }));
+    expect(logs.some((log) => log.id === logId)).toBeFalsy();
   });
 });


### PR DESCRIPTION
closes #8660 
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Changed > to >= and < to <= on createdAt filters in GET /api/logs, making start_time/end_time inclusive, with relaxed validation (start > end instead of start >= end) and updated tests.

Linked issue can be closed. The issue requests for a feature and the feature exists right now, so I just made a little changes.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
