### PR TITLE
test: finalize the integration suite for oidc-provider v9 semantics

### DIFF
--- a/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
@@ -143,4 +143,18 @@ describe('OIDC discovery', () => {
       }
     `);
   });
+
+  /**
+   * Since oidc-provider 9.2.0 the RFC 8414 `/.well-known/oauth-authorization-server` route is
+   * registered unconditionally, relative to the provider mount and backed by the same discovery
+   * handler as `/.well-known/openid-configuration`.
+   */
+  it('serves the same document at the RFC 8414 oauth-authorization-server route', async () => {
+    const [openidConfiguration, authorizationServerMetadata] = await Promise.all([
+      ky.get(discoveryUrl).json(),
+      ky.get(`${logtoUrl}/oidc/.well-known/oauth-authorization-server`).json(),
+    ]);
+
+    expect(authorizationServerMetadata).toEqual(openidConfiguration);
+  });
 });

--- a/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
@@ -4,6 +4,7 @@ import { ApplicationType, type Application, defaultTenantId } from '@logto/schem
 import { formUrlEncodedHeaders } from '@logto/shared';
 import { assert, assertEnv, noop } from '@silverhand/essentials';
 import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
+import { decodeJwt } from 'jose';
 import ky, { HTTPError } from 'ky';
 
 import { oidcApi } from '#src/api/api.js';
@@ -15,7 +16,7 @@ import { initExperienceClient, logoutClient, processSession } from '#src/helpers
 import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
 import { createUserByAdmin } from '#src/helpers/index.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { generatePassword, generateUsername } from '#src/utils.js';
+import { generatePassword, generateUsername, waitFor } from '#src/utils.js';
 
 type IntrospectionResponse = {
   [key: string]: unknown;
@@ -57,13 +58,14 @@ describe('opaque user token lifecycle', () => {
   const password = generatePassword();
   /* eslint-disable @silverhand/fp/no-let */
   let application: Application;
+  let publicApplication: Application;
   let userId = '';
   /* eslint-enable @silverhand/fp/no-let */
 
   beforeAll(async () => {
     await deleteJwtCustomizer('access-token').catch(noop);
 
-    const [createdApplication, user] = await Promise.all([
+    const [createdApplication, createdPublicApplication, user] = await Promise.all([
       createApplication('OIDC provider semantics', ApplicationType.Traditional, {
         oidcClientMetadata: {
           redirectUris: [demoAppRedirectUri],
@@ -71,18 +73,31 @@ describe('opaque user token lifecycle', () => {
         },
         customClientMetadata: { alwaysIssueRefreshToken: true },
       }),
+      /**
+       * The provider re-validates client metadata every time it loads a client, and an
+       * authorization-code client must carry at least one redirect URI to pass the schema —
+       * even when the client only ever calls the revocation endpoint.
+       */
+      createApplication('OIDC provider semantics public', ApplicationType.SPA, {
+        oidcClientMetadata: { redirectUris: [demoAppRedirectUri], postLogoutRedirectUris: [] },
+      }),
       createUserByAdmin({ username, password }),
       enableAllPasswordSignInMethods(),
     ]);
 
     /* eslint-disable @silverhand/fp/no-mutation */
     application = createdApplication;
+    publicApplication = createdPublicApplication;
     userId = user.id;
     /* eslint-enable @silverhand/fp/no-mutation */
   });
 
   afterAll(async () => {
-    await Promise.all([deleteApplication(application.id), deleteUser(userId)]);
+    await Promise.all([
+      deleteApplication(application.id),
+      deleteApplication(publicApplication.id),
+      deleteUser(userId),
+    ]);
   });
 
   const signIn = async (resources?: string[]) => {
@@ -200,6 +215,32 @@ describe('opaque user token lifecycle', () => {
           'Structured JWT Tokens cannot be introspected via the introspection_endpoint',
       });
 
+      /**
+       * Revocation rejects structured JWTs the same way since v9. The previous version answered
+       * with a silent 200 no-op, since the full JWT never matched the stored short `jti` key.
+       */
+      await expectOidcError(revokeToken(application, jwtAccessToken, 'access_token'), {
+        error: 'unsupported_token_type',
+        error_description: 'Structured JWT Tokens cannot be revoked via the revocation_endpoint',
+      });
+
+      /**
+       * The default `features.revocation.allowedPolicy` answers a public client presenting
+       * another client's token with a 200 without revoking anything, so that valid tokens
+       * cannot be guessed through the revocation endpoint.
+       */
+      const crossClientRevocation = await oidcApi.post('token/revocation', {
+        body: new URLSearchParams({
+          token: opaqueAccessToken,
+          token_type_hint: 'access_token',
+          client_id: publicApplication.id,
+        }),
+      });
+      expect(crossClientRevocation.status).toBe(200);
+      await expect(
+        introspectToken(application, opaqueAccessToken, 'access_token')
+      ).resolves.toMatchObject({ active: true });
+
       await revokeToken(application, opaqueAccessToken, 'access_token');
 
       await expect(
@@ -299,5 +340,95 @@ describe('opaque client-credentials revocation', () => {
         where tenant_id = ${defaultTenantId} and id in (${sql.join(tokens, sql`, `)})
       `);
     }
+  });
+});
+
+describe('refresh token rotation and reuse detection', () => {
+  const username = generateUsername();
+  const password = generatePassword();
+  /* eslint-disable @silverhand/fp/no-let */
+  let application: Application;
+  let userId = '';
+  /* eslint-enable @silverhand/fp/no-let */
+
+  beforeAll(async () => {
+    const [createdApplication, user] = await Promise.all([
+      createApplication('OIDC refresh token rotation', ApplicationType.SPA, {
+        oidcClientMetadata: {
+          redirectUris: [demoAppRedirectUri],
+          postLogoutRedirectUris: [demoAppRedirectUri],
+        },
+      }),
+      createUserByAdmin({ username, password }),
+      enableAllPasswordSignInMethods(),
+    ]);
+
+    /* eslint-disable @silverhand/fp/no-mutation */
+    application = createdApplication;
+    userId = user.id;
+    /* eslint-enable @silverhand/fp/no-mutation */
+  });
+
+  afterAll(async () => {
+    await Promise.all([deleteApplication(application.id), deleteUser(userId)]);
+  });
+
+  it('rotates public-client refresh tokens and revokes the whole grant on reuse', async () => {
+    const client = await initExperienceClient({
+      config: { appId: application.id },
+      redirectUri: demoAppRedirectUri,
+    });
+    await identifyUserWithUsernamePassword(client, username, password);
+    const { redirectTo } = await client.submitInteraction();
+    await expect(processSession(client, redirectTo)).resolves.toBe(userId);
+
+    const initialRefreshToken = await client.getRefreshToken();
+    assert(initialRefreshToken, new Error('Missing refresh token after code exchange'));
+
+    const exchangeRefreshToken = async (refreshToken: string) =>
+      oidcApi
+        .post('token', {
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: application.id,
+          }),
+        })
+        .json<{ refresh_token: string; id_token: string }>();
+
+    /**
+     * The default `rotateRefreshToken` policy rotates on every use for public clients whose
+     * refresh tokens are not sender-constrained, marking the presented token as consumed.
+     */
+    const rotated = await exchangeRefreshToken(initialRefreshToken);
+    expect(rotated.refresh_token).toBeTruthy();
+    expect(rotated.refresh_token).not.toBe(initialRefreshToken);
+
+    /**
+     * Since v9 the token endpoint no longer sets `at_hash` on ID tokens: the claim only guards
+     * against front-channel token substitution, so it protects nothing on this response. The
+     * official SDK sweep confirmed no SDK reads it.
+     */
+    expect(decodeJwt(rotated.id_token)).not.toHaveProperty('at_hash');
+
+    /**
+     * Logto's adapter keeps a hard-coded 3-second leeway after a rotation, during which the
+     * consumed refresh token still refreshes successfully, so that concurrent refreshes from
+     * distributed apps without shared token storage (e.g. serverless) do not race each other
+     * out of the session.
+     */
+    const leewayReplay = await exchangeRefreshToken(initialRefreshToken);
+    expect(leewayReplay.refresh_token).toBeTruthy();
+
+    /**
+     * Past the leeway, presenting a consumed refresh token is treated as reuse: the provider
+     * destroys the token and revokes the whole grant, so the freshest rotated replacement dies
+     * with it.
+     */
+    await waitFor(4000);
+    await expectOidcError(exchangeRefreshToken(initialRefreshToken), { error: 'invalid_grant' });
+    await expectOidcError(exchangeRefreshToken(leewayReplay.refresh_token), {
+      error: 'invalid_grant',
+    });
   });
 });


### PR DESCRIPTION
## Summary

Final test pass for v9 semantics. The planned baseline flips already landed in #9201; this PR adds the remaining assertions:

- The RFC 8414 `/.well-known/oauth-authorization-server` route serves the same document as `/.well-known/openid-configuration`.
- Revoking a JWT access token answers `unsupported_token_type`.
- A public client revoking another client's token is silently blocked by the default `allowedPolicy`.
- Public-client refresh tokens rotate on every use; replaying a consumed token inside Logto's 3-second reuse leeway still succeeds, and past the leeway the reuse revokes the whole grant.
- Token-endpoint ID tokens no longer carry `at_hash`.

The `scope` and POST pins stay untouched by design.

## Testing

Integration tests.

## Checklist

- [x] `.changeset` — not needed, test-only change
- [x] unit tests — N/A
- [x] integration tests
- [x] necessary TSDoc comments — N/A