### PR TITLE
feat: release custom domain verification files

### DIFF
--- a/.changeset/release-domain-verification-files.md
+++ b/.changeset/release-domain-verification-files.md
@@ -1,0 +1,10 @@
+---
+"@logto/core": minor
+"@logto/console": minor
+"@logto/schemas": minor
+"@logto/phrases": minor
+---
+
+add custom domain verification file support
+
+Admins can configure small text or JSON verification files for active custom domains. Files are limited to root-level filenames or paths under `/.well-known/`, with caps on count and content size. Exact GET and HEAD matches are served with safe content types while existing Logto routes take precedence.

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/index.tsx
@@ -1,8 +1,6 @@
 import { type CustomDomain as CustomDomainType, DomainStatus } from '@logto/schemas';
 import classNames from 'classnames';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
-
 import ActivationProcess from './ActivationProcess';
 import CustomDomainHeader from './CustomDomainHeader';
 import VerificationFiles from './VerificationFiles';
@@ -39,7 +37,7 @@ function CustomDomain({
       {customDomain.status !== DomainStatus.Active && (
         <ActivationProcess customDomain={customDomain} />
       )}
-      {isDevFeaturesEnabled && domainId && customDomain.status === DomainStatus.Active && (
+      {domainId && customDomain.status === DomainStatus.Active && (
         <VerificationFiles
           domain={customDomain.domain}
           domainId={domainId}

--- a/packages/core/src/routes/domain.openapi.json
+++ b/packages/core/src/routes/domain.openapi.json
@@ -97,7 +97,6 @@
       "get": {
         "summary": "Get domain verification files",
         "description": "Get the verification files served from the custom domain.",
-        "tags": ["Dev feature"],
         "responses": {
           "200": {
             "description": "The configured domain verification files."
@@ -110,7 +109,6 @@
       "put": {
         "summary": "Replace domain verification files",
         "description": "Replace the verification files served from the custom domain.",
-        "tags": ["Dev feature"],
         "requestBody": {
           "content": {
             "application/json": {

--- a/packages/core/src/routes/domain.ts
+++ b/packages/core/src/routes/domain.ts
@@ -108,48 +108,44 @@ export default function domainRoutes<T extends ManagementApiRouter>(
     }
   );
 
-  // Custom domain verification files are an unreleased feature and should be removed from this
-  // guard together when the feature is ready for release.
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    const verificationFilesPath = '/domains/:id/verification-files';
+  const verificationFilesPath = '/domains/:id/verification-files';
 
-    router.get(
-      verificationFilesPath,
-      koaGuard({
-        params: z.object({ id: z.string() }),
-        response: domainVerificationFilesGuard,
-        status: [200, 404],
-      }),
-      async (ctx, next) => {
-        const domain = await findDomainById(ctx.guard.params.id);
+  router.get(
+    verificationFilesPath,
+    koaGuard({
+      params: z.object({ id: z.string() }),
+      response: domainVerificationFilesGuard,
+      status: [200, 404],
+    }),
+    async (ctx, next) => {
+      const domain = await findDomainById(ctx.guard.params.id);
 
-        ctx.body = domain.verificationFiles;
+      ctx.body = domain.verificationFiles;
 
-        return next();
-      }
-    );
+      return next();
+    }
+  );
 
-    router.put(
-      verificationFilesPath,
-      koaGuard({
-        params: z.object({ id: z.string() }),
-        body: z.object({ verificationFiles: domainVerificationFilesGuard }),
-        response: domainVerificationFilesGuard,
-        status: [200, 400, 404],
-      }),
-      async (ctx, next) => {
-        const { id } = ctx.guard.params;
-        const { verificationFiles } = ctx.guard.body;
+  router.put(
+    verificationFilesPath,
+    koaGuard({
+      params: z.object({ id: z.string() }),
+      body: z.object({ verificationFiles: domainVerificationFilesGuard }),
+      response: domainVerificationFilesGuard,
+      status: [200, 400, 404],
+    }),
+    async (ctx, next) => {
+      const { id } = ctx.guard.params;
+      const { verificationFiles } = ctx.guard.body;
 
-        await findDomainById(id);
-        const domain = await updateDomainById(id, { verificationFiles });
+      await findDomainById(id);
+      const domain = await updateDomainById(id, { verificationFiles });
 
-        ctx.body = domain.verificationFiles;
+      ctx.body = domain.verificationFiles;
 
-        return next();
-      }
-    );
-  }
+      return next();
+    }
+  );
 
   router.post(
     '/domains',

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -172,9 +172,8 @@ export default class Tenant implements TenantContext {
     // Mount APIs
     app.use(mount('/api', initApis(tenantContext)));
 
-    // Custom domain verification files. Keep this response mapper behind the development feature
-    // flag until the feature is ready for release.
-    if (EnvSet.values.isDevFeaturesEnabled && this.customDomain) {
+    // Serve custom domain verification files when the request is on a custom domain.
+    if (this.customDomain) {
       app.use(koaServeDomainVerificationFiles(this.customDomain, queries));
     }
 

--- a/packages/integration-tests/src/tests/api/domains.test.ts
+++ b/packages/integration-tests/src/tests/api/domains.test.ts
@@ -9,7 +9,7 @@ import {
   getDomainVerificationFiles,
   updateDomainVerificationFiles,
 } from '#src/api/domain.js';
-import { devFeatureTest, generateDomain } from '#src/utils.js';
+import { generateDomain } from '#src/utils.js';
 
 describe('domains', () => {
   afterEach(async () => {
@@ -69,7 +69,7 @@ describe('domains', () => {
     expect(response instanceof HTTPError && response.response.status).toBe(404);
   });
 
-  devFeatureTest.describe('domain verification files', () => {
+  describe('domain verification files', () => {
     it('should get, update, and delete domain verification files', async () => {
       const domain = await createDomain();
       const verificationFiles = [


### PR DESCRIPTION
## Summary

- Remove temporary `isDevFeaturesEnabled` guards for custom domain verification files introduced in #9194.
- Always register the verification-files Management API routes and serve files on custom domains.
- Show the Console verification files UI for active custom domains.
- Drop the OpenAPI `Dev feature` tags and ungate the related integration tests.
- Add a changeset for the release.

## Testing

- [x] Confirmed no remaining verification-files `isDevFeaturesEnabled` gates
- [x] lint-staged / typecheck via pre-commit
- [ ] Unit tests
- [ ] Integration tests