### PR TITLE
refactor(console): replace reduce with native Map.groupBy in webhooks…

### DIFF
--- a/packages/console/src/consts/webhooks.ts
+++ b/packages/console/src/consts/webhooks.ts
@@ -27,14 +27,17 @@ const isDataHookSchema = (schema: string): schema is DataHookSchema =>
   Object.values(DataHookSchema).includes(schema as DataHookSchema);
 
 // Group DataHook events by schema
-// eslint-disable-next-line no-use-extend-native/no-use-extend-native
-const schemaGroupedDataHookEventsMap = Map.groupBy(
-  dataHookEvents.filter((event) => {
+const schemaGroupedDataHookEventsMap = dataHookEvents.reduce<Map<DataHookSchema, DataHookEvent[]>>(
+  (eventGroup, event) => {
     const [schema] = event.split('.');
-    return schema && isDataHookSchema(schema);
-  }),
-  // eslint-disable-next-line no-restricted-syntax
-  (event) => event.split('.')[0] as DataHookSchema
+
+    if (schema && isDataHookSchema(schema)) {
+      eventGroup.set(schema, [...(eventGroup.get(schema) ?? []), event]);
+    }
+
+    return eventGroup;
+  },
+  new Map()
 );
 
 // Sort the grouped `DataHook` events per console product design

--- a/packages/console/src/consts/webhooks.ts
+++ b/packages/console/src/consts/webhooks.ts
@@ -27,18 +27,14 @@ const isDataHookSchema = (schema: string): schema is DataHookSchema =>
   Object.values(DataHookSchema).includes(schema as DataHookSchema);
 
 // Group DataHook events by schema
-// TODO: Replace this using `groupBy` once Node v22 goes LTS
-const schemaGroupedDataHookEventsMap = dataHookEvents.reduce<Map<DataHookSchema, DataHookEvent[]>>(
-  (eventGroup, event) => {
+// eslint-disable-next-line no-use-extend-native/no-use-extend-native
+const schemaGroupedDataHookEventsMap = Map.groupBy(
+  dataHookEvents.filter((event) => {
     const [schema] = event.split('.');
-
-    if (schema && isDataHookSchema(schema)) {
-      eventGroup.set(schema, [...(eventGroup.get(schema) ?? []), event]);
-    }
-
-    return eventGroup;
-  },
-  new Map()
+    return schema && isDataHookSchema(schema);
+  }),
+  // eslint-disable-next-line no-restricted-syntax
+  (event) => event.split('.')[0] as DataHookSchema
 );
 
 // Sort the grouped `DataHook` events per console product design


### PR DESCRIPTION
… consts

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Replaced dataHookEvents.reduce(...) with native Map.groupBy(...). No behavioral change — the same filtering and grouping logic is preserved.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
