### PR TITLE
refactor(core): mount application sub-routes inside applicationRoutes

### DIFF
--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -29,7 +29,13 @@ import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 import { assertApplicationAccessControlHasRules } from './application-access-control/utils.js';
 import applicationAccessControlRoutes from './application-access-control.js';
 import applicationCustomDataRoutes from './application-custom-data.js';
-import { generateInternalSecret } from './application-secret.js';
+import applicationOrganizationRoutes from './application-organization.js';
+import applicationProtectedAppMetadataRoutes from './application-protected-app-metadata.js';
+import applicationRoleRoutes from './application-role.js';
+import applicationSecretRoutes, { generateInternalSecret } from './application-secret.js';
+import applicationSignInExperienceRoutes from './application-sign-in-experience.js';
+import applicationUserConsentOrganizationRoutes from './application-user-consent-organization.js';
+import applicationUserConsentScopeRoutes from './application-user-consent-scope.js';
 import { applicationCreateGuard, applicationPatchGuard } from './types.js';
 
 const includesInternalAdminRole = (roles: Readonly<Array<{ role: Role }>>) =>
@@ -484,5 +490,12 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
   applicationCustomDataRoutes(router, tenant);
 
   applicationAccessControlRoutes(router, tenant);
+  applicationRoleRoutes(router, tenant);
+  applicationProtectedAppMetadataRoutes(router, tenant);
+  applicationOrganizationRoutes(router, tenant);
+  applicationSecretRoutes(router, tenant);
+  applicationUserConsentScopeRoutes(router, tenant);
+  applicationSignInExperienceRoutes(router, tenant);
+  applicationUserConsentOrganizationRoutes(router, tenant);
 }
 /* eslint-enable max-lines */

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -18,13 +18,6 @@ import { accountApiPrefix } from './account/constants.js';
 import accountRoutes from './account/index.js';
 import accountCentersRoutes from './account-center/index.js';
 import adminUserRoutes from './admin-user/index.js';
-import applicationOrganizationRoutes from './applications/application-organization.js';
-import applicationProtectedAppMetadataRoutes from './applications/application-protected-app-metadata.js';
-import applicationRoleRoutes from './applications/application-role.js';
-import applicationSecretRoutes from './applications/application-secret.js';
-import applicationSignInExperienceRoutes from './applications/application-sign-in-experience.js';
-import applicationUserConsentOrganizationRoutes from './applications/application-user-consent-organization.js';
-import applicationUserConsentScopeRoutes from './applications/application-user-consent-scope.js';
 import applicationRoutes from './applications/application.js';
 import authnRoutes from './authn.js';
 import captchaProviderRoutes from './captcha-provider/index.js';
@@ -78,18 +71,7 @@ const createRouters = (tenant: TenantContext) => {
   managementRouter.use(koaTenantGuard(tenant.id, tenant.queries));
   managementRouter.use(koaManagementApiHooks(tenant.libraries.hooks));
 
-  // TODO: FIXME @sijie @darcy mount these routes in `applicationRoutes` instead
   applicationRoutes(managementRouter, tenant);
-  applicationRoleRoutes(managementRouter, tenant);
-  applicationProtectedAppMetadataRoutes(managementRouter, tenant);
-  applicationOrganizationRoutes(managementRouter, tenant);
-  applicationSecretRoutes(managementRouter, tenant);
-
-  // Third-party application related routes
-  applicationUserConsentScopeRoutes(managementRouter, tenant);
-  applicationSignInExperienceRoutes(managementRouter, tenant);
-  applicationUserConsentOrganizationRoutes(managementRouter, tenant);
-
   logtoConfigRoutes(managementRouter, tenant);
   connectorRoutes(managementRouter, tenant);
   resourceRoutes(managementRouter, tenant);


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Moves 7 application sub-route registrations from init.ts into applicationRoutes() in application.ts. This consolidates all application-related route mounting in one place, consistent with how applicationCustomDataRoutes and applicationAccessControlRoutes are already handled.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
