### PR TITLE
fix(connector): make aliyun-sms-mas signature free-text instead of dropdown

### DIFF
--- a/.changeset/aliyun-sms-mas-signature-rotation.md
+++ b/.changeset/aliyun-sms-mas-signature-rotation.md
@@ -1,0 +1,5 @@
+---
+"@logto/connector-aliyun-sms-mas": patch
+---
+
+let users enter the aliyun-sms-mas signature as free text, in case Aliyun rotates signatures again in the future

--- a/packages/connectors/connector-aliyun-sms-mas/README.md
+++ b/packages/connectors/connector-aliyun-sms-mas/README.md
@@ -43,7 +43,7 @@ Key differences:
 
 - **Domestic numbers only**: Currently only supports mobile numbers from China Mobile, China Unicom, and China Telecom (mainland China)
 - **No international support**: Does NOT support Taiwan, Hong Kong, Macau, or overseas regions
-- **No custom signatures**: As of November 12, 2025, Aliyun announced that "Due to carrier signature real-name policy control requirements, all authentication methods that use SMS verification codes under the Number Authentication product will not support using custom signatures to send SMS, specific recovery time will be notified separately."
+- **No custom signatures**: As of November 12, 2025, Aliyun announced that "Due to carrier signature real-name policy control requirements, all authentication methods that use SMS verification codes under the Number Authentication product will not support using custom signatures to send SMS, specific recovery time will be notified separately." In addition, Aliyun may occasionally rotate the provided signatures, so please pay attention to signature update emails and SMS notifications to update in time.
 
 If you need to send SMS to international numbers or regions outside mainland China, please use the [Aliyun Short Message Service connector](../connector-aliyun-sms/) instead.
 
@@ -57,12 +57,7 @@ If you need to send SMS to international numbers or regions outside mainland Chi
 ## Compose the connector JSON
 
 1. Fill out the `accessKeyId` and `accessKeySecret` with your AccessKey pair.
-2. Select a `signName` from the system-provided options:
-   - 云渚科技验证平台
-   - 云渚科技验证服务
-   - 速通互联验证码
-   - 速通互联验证平台
-   - 速通互联验证服务
+2. Enter a `signName` — copy one of the current gift signatures from your Aliyun console (号码认证 → 短信认证参数配置 → 赠送签名配置).
 3. Configure templates using system-provided template codes:
 
 | UsageType | Template Code | Description |
@@ -84,7 +79,7 @@ Example configuration:
 {
   "accessKeyId": "your-access-key-id",
   "accessKeySecret": "your-access-key-secret",
-  "signName": "速通互联验证码",
+  "signName": "<your-gift-signature>",
   "templates": [
     { "usageType": "SignIn", "templateCode": "100001" },
     { "usageType": "Register", "templateCode": "100001" },
@@ -105,7 +100,7 @@ Example configuration:
 |------|------|-------------|
 | accessKeyId | string | Aliyun Access Key ID |
 | accessKeySecret | string | Aliyun Access Key Secret |
-| signName | enum | Signature name |
+| signName | string | Signature name |
 | templates | Template[] | Array of template configurations |
 
 ## References
@@ -138,7 +133,7 @@ Example configuration:
 
 - **仅限中国大陆手机号**：目前仅支持中国移动、中国联通和中国电信的手机号码（中国大陆）
 - **不支持国际及港澳台**：不支持中国台湾、中国香港、中国澳门及海外地区使用
-- **不支持自定义签名**：自2025年11月12日起，阿里云发布[公告](https://help.aliyun.com/zh/pnvs/product-overview/sms-service-does-not-support-custom-signatures)称"因运营商签名实名制政策管控要求，即日起号码认证产品下所有使用短信验证码触达的认证方式，均不支持使用自定义签名下发短信，具体恢复时间另行通知。"
+- **不支持自定义签名**：自2025年11月12日起，阿里云发布[公告](https://help.aliyun.com/zh/pnvs/product-overview/sms-service-does-not-support-custom-signatures)称"因运营商签名实名制政策管控要求，即日起号码认证产品下所有使用短信验证码触达的认证方式，均不支持使用自定义签名下发短信，具体恢复时间另行通知"。此外阿里云可能会不定期轮换赠送签名，请留意签名更新的邮件和短信提醒，及时更新。
 
 > 如果您需要向国际号码或中国大陆以外的地区发送短信，请改用[阿里云短信服务连接器](../connector-aliyun-sms/)。
 
@@ -152,12 +147,7 @@ Example configuration:
 ## 编写连接器的 JSON
 
 1. 填写 `accessKeyId` 和 `accessKeySecret` 为你的 AccessKey 密钥对。
-2. 从系统赠送签名中选择一个填入 `signName`：
-   - 云渚科技验证平台
-   - 云渚科技验证服务
-   - 速通互联验证码
-   - 速通互联验证平台
-   - 速通互联验证服务
+2. 填入 `signName` —— 请从阿里云控制台（号码认证 → 短信认证参数配置 → 赠送签名配置）复制一个当前赠送的签名。
 3. 使用系统赠送模板代码配置模板：
 
 | UsageType | 模板 CODE | 说明 |
@@ -179,7 +169,7 @@ Example configuration:
 {
   "accessKeyId": "your-access-key-id",
   "accessKeySecret": "your-access-key-secret",
-  "signName": "速通互联验证码",
+  "signName": "<your-gift-signature>",
   "templates": [
     { "usageType": "SignIn", "templateCode": "100001" },
     { "usageType": "Register", "templateCode": "100001" },
@@ -200,7 +190,7 @@ Example configuration:
 |------|------|-------------|
 | accessKeyId | string | 阿里云 Access Key ID |
 | accessKeySecret | string | 阿里云 Access Key Secret |
-| signName | enum | 签名名称 |
+| signName | string | 签名名称 |
 | templates | Template[] | 模板配置数组 |
 
 ## 参考

--- a/packages/connectors/connector-aliyun-sms-mas/src/constant.ts
+++ b/packages/connectors/connector-aliyun-sms-mas/src/constant.ts
@@ -21,19 +21,6 @@ export const staticConfigs = {
 };
 
 /**
- * System-provided signatures for Message Authentication Service
- * These signatures are provided by Aliyun and do not require application
- * User must select one of these in the connector configuration
- */
-export const systemProvidedSignNames = [
-  '云渚科技验证平台',
-  '云渚科技验证服务',
-  '速通互联验证码',
-  '速通互联验证平台',
-  '速通互联验证服务',
-];
-
-/**
  * Connector metadata
  * This defines how the connector appears in Logto Console
  */
@@ -76,14 +63,11 @@ export const defaultMetadata: ConnectorMetadata = {
     {
       key: 'signName',
       label: 'Signature Name',
-      type: ConnectorConfigFormItemType.Select,
+      type: ConnectorConfigFormItemType.Text,
       required: true,
-      selectItems: systemProvidedSignNames.map((name) => ({
-        value: name,
-        title: name,
-      })),
+      placeholder: '<signature-name>',
       description:
-        'Select a system-provided signature. These signatures are provided by Aliyun and do not require a separate signature application.',
+        'Copy a current gift signature from your Aliyun Message Authentication Service console (号码认证 → 短信认证参数配置 → 赠送签名配置).',
     },
     {
       key: 'templates',


### PR DESCRIPTION


<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary

Aliyun deprecated the previous gift signatures for the Message Authentication Service on 2026-07-07; **they stop working after 2026-08-31**. Aliyun's notification (Chinese):

> 号码认证-短信认证服务已于7月7日上线新的赠送签名，请至[号码认证控制台-短信认证参数配置-赠送签名配置](https://dypns.console.aliyun.com/smsCertParamsConfig)中查看最新的签名列表。请您检查业务中调用短信认证 API（[SendSmsVerifyCode](https://help.aliyun.com/zh/pnvs/developer-reference/api-dypnsapi-2017-05-25-sendsmsverifycode)）的“签名”入参，尽快替换为最新的可用签名。平台将在8月31日后不再支持历史赠送签名，为保障您的业务稳定性，请您务必在8月31日前替换为最新的可用签名。

With the signatures hardcoded as a `Select` dropdown, **this signature change (and any future ones) would render the connector unusable**. This PR switches the `Select` dropdown to a free-text input for better compatibility.

**Changes:**

- `signName` form field: `Select` dropdown → free-text `Text` input. The description points users to their Aliyun console (`号码认证 → 短信认证参数配置 → 赠送签名配置`) to copy the current signature.
- Removed the hardcoded `systemProvidedSignNames` array from `src/constant.ts`. No signature values hardcoded in code or docs anymore.
- README: removed the signature lists (EN + zh-CN), pointed users to the Aliyun console, and added a one-line note about rotation alongside the existing "no custom signatures" limitation.

The zod guard `signName: z.string()` is unchanged, so the connector keeps accepting any string — existing configs continue to validate and render without error.

## Testing

Tested locally

- All 28 existing unit tests in `src/index.test.ts` and `src/utils.test.ts` pass.
- Ran the connector end-to-end against a real Aliyun MAS account with a stored legacy-signature config: the upgrade is fully backward compatible — existing configs load and render without any error, and SMS sending still works with the current signature value.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments