### PR TITLE
Update Aliyun SMS Signature Compatiblity due to provider changes

### DIFF
--- a/packages/connectors/connector-aliyun-sms-mas/src/constant.ts
+++ b/packages/connectors/connector-aliyun-sms-mas/src/constant.ts
@@ -26,11 +26,12 @@ export const staticConfigs = {
  * User must select one of these in the connector configuration
  */
 export const systemProvidedSignNames = [
-  '云渚科技验证平台',
-  '云渚科技验证服务',
-  '速通互联验证码',
-  '速通互联验证平台',
-  '速通互联验证服务',
+  '恒创联众',
+  '恒创联众科技',
+  '北京恒创联众',
+  '恒锐创岳',
+  '恒锐创岳科技',
+  '北京恒锐创岳',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Aliyun Changed Official SMS Signature for SMS Authentication Service

关于短信认证服务短信签名变更的通知 (Notification Regarding Changes to SMS Signature for SMS Authentication Service)
2026-07-16 15:46:27

号码认证-短信认证服务已于7月7日上线新的赠送签名，请至号码认证控制台-短信认证参数配置-赠送签名配置中查看最新的签名列表。请您检查业务中调用短信认证 API（SendSmsVerifyCode）的“签名”入参，尽快替换为最新的可用签名。平台将在8月31日后不再支持历史赠送签名，为保障您的业务稳定性，请您务必在8月31日前替换为最新的可用签名。

The Number Authentication - SMS Authentication service launched a new complimentary signature on July 7th. Please check the latest signature list in the Number Authentication console - SMS Authentication Parameter Configuration - Complimentary Signature Configuration. Please check the "Signature" input parameter when calling the SMS Authentication API (SendSmsVerifyCode) in your business and replace it with the latest available signature as soon as possible. The platform will no longer support historical complimentary signatures after August 31st. To ensure the stability of your business, please be sure to replace it with the latest available signature before August 31st.

## Testing

## Checklist
ONLY Changes option to meet official announcement, no checklist needed
