### PR TITLE
feat(core): webhook for max-allowed-grants evictions

### DIFF
--- a/.changeset/loud-bears-roll.md
+++ b/.changeset/loud-bears-roll.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": minor
+---
+
+fire a `Grant.LimitExceeded` webhook event when OIDC grants are evicted due to exceeding the application's max allowed grants limit

--- a/packages/console/src/components/BasicWebhookForm/index.tsx
+++ b/packages/console/src/components/BasicWebhookForm/index.tsx
@@ -31,7 +31,11 @@ const hookEventGroups: Array<CheckboxOptionGroup<HookEvent>> = [
   },
   {
     title: 'webhooks.schemas.security',
-    options: [{ value: 'Identifier.Lockout' }, { value: 'Message.RateLimited' }],
+    options: [
+      { value: 'Identifier.Lockout' },
+      { value: 'Message.RateLimited' },
+      { value: 'Grant.LimitExceeded' },
+    ],
   },
 ];
 

--- a/packages/core/src/event-listeners/authorization-success.test.ts
+++ b/packages/core/src/event-listeners/authorization-success.test.ts
@@ -171,6 +171,81 @@ describe('createAuthorizationSuccessListener', () => {
     });
   });
 
+  it('should trigger Grant.LimitExceeded webhook when grants are revoked', async () => {
+    const { provider, revokeByGrantId, destroy } = createMockProvider();
+    const findUserActiveGrantsByClientId = jest.fn(async () => [
+      {
+        id: 'grant-3',
+        payload: {
+          exp: 999_999_999,
+          iat: 30,
+          jti: 'grant-jti-3',
+          kind: 'Grant',
+          clientId: 'client-id',
+          accountId: 'user-id',
+        },
+        expiresAt: Date.now() + 1000,
+      },
+      {
+        id: 'grant-1',
+        payload: {
+          exp: 999_999_999,
+          iat: 10,
+          jti: 'grant-jti-1',
+          kind: 'Grant',
+          clientId: 'client-id',
+          accountId: 'user-id',
+        },
+        expiresAt: Date.now() + 1000,
+      },
+      {
+        id: 'grant-2',
+        payload: {
+          exp: 999_999_999,
+          iat: 20,
+          jti: 'grant-jti-2',
+          kind: 'Grant',
+          clientId: 'client-id',
+          accountId: 'user-id',
+        },
+        expiresAt: Date.now() + 1000,
+      },
+    ]);
+
+    const triggerEvent = jest.fn(async () => {
+      await Promise.resolve();
+    });
+
+    const listener = createAuthorizationSuccessListener(
+      // @ts-expect-error Provider mock is enough for unit test
+      provider,
+      new MockQueries({
+        oidcModelInstances: {
+          findUserActiveGrantsByClientId,
+          findUserActiveSessionUidByGrantId: jest.fn(async () => null),
+        },
+      }),
+      triggerEvent
+    );
+
+    const context = createMockAuthorizationSuccessContext({ maxAllowedGrants: 1 });
+    // @ts-expect-error Context mock is enough for unit test
+    await listener(context);
+
+    expect(triggerEvent).toHaveBeenCalledTimes(1);
+    expect(triggerEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      'Grant.LimitExceeded',
+      expect.objectContaining({
+        userId: 'user-id',
+        applicationId: 'client-id',
+        revokedGrantIds: ['grant-1', 'grant-2'],
+        maxAllowedGrants: 1,
+        preRevocationActiveGrantCount: 3,
+      })
+    );
+  });
+
   it('should throw when grant query fails', async () => {
     const { provider, revokeByGrantId, destroy } = createMockProvider();
     const error = new Error('query failed');

--- a/packages/core/src/event-listeners/authorization-success.test.ts
+++ b/packages/core/src/event-listeners/authorization-success.test.ts
@@ -1,5 +1,5 @@
 import { appInsights } from '@logto/app-insights/node';
-import { LogResult } from '@logto/schemas';
+import { LogResult, type ExceptionHookEvent } from '@logto/schemas';
 
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
@@ -20,6 +20,8 @@ const createMockAuthorizationSuccessContext = ({
 }) => ({
   ...createContextWithRouteParameters(),
   ...createMockLogContext(),
+  ip: '127.0.0.1',
+  headers: { 'user-agent': 'test-agent' },
   oidc: {
     entities: {
       Account: { accountId: userId },
@@ -235,14 +237,18 @@ describe('createAuthorizationSuccessListener', () => {
     expect(triggerEvent).toHaveBeenCalledTimes(1);
     expect(triggerEvent).toHaveBeenCalledWith(
       expect.anything(),
-      'Grant.LimitExceeded',
+      'Grant.LimitExceeded' satisfies ExceptionHookEvent,
       expect.objectContaining({
         userId: 'user-id',
         applicationId: 'client-id',
         revokedGrantIds: ['grant-1', 'grant-2'],
         maxAllowedGrants: 1,
         preRevocationActiveGrantCount: 3,
-      })
+      }),
+      {
+        ip: '127.0.0.1',
+        userAgent: 'test-agent',
+      }
     );
   });
 

--- a/packages/core/src/event-listeners/authorization-success.test.ts
+++ b/packages/core/src/event-listeners/authorization-success.test.ts
@@ -22,6 +22,7 @@ const createMockAuthorizationSuccessContext = ({
   ...createMockLogContext(),
   ip: '127.0.0.1',
   headers: { 'user-agent': 'test-agent' },
+  get: (field: string) => (field === 'user-agent' ? 'test-agent' : undefined),
   oidc: {
     entities: {
       Account: { accountId: userId },

--- a/packages/core/src/event-listeners/authorization-success.ts
+++ b/packages/core/src/event-listeners/authorization-success.ts
@@ -1,5 +1,6 @@
 import { appInsights } from '@logto/app-insights/node';
-import { LogResult, userApplicationGrantPayloadGuard } from '@logto/schemas';
+import { LogResult, userApplicationGrantPayloadGuard, type HookEvent } from '@logto/schemas';
+import { type ConsoleLog } from '@logto/shared';
 import { trySafe } from '@silverhand/essentials';
 import type { KoaContextWithOIDC, Provider } from 'oidc-provider';
 
@@ -12,6 +13,12 @@ import { stringifyError } from '#src/utils/format.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import { extractInteractionContext } from './utils.js';
+
+export type TriggerEvent = (
+  consoleLog: ConsoleLog,
+  event: HookEvent,
+  payload: Record<string, unknown>
+) => Promise<void>;
 
 const isDefined = <T>(value: T | undefined): value is T => value !== undefined;
 const toError = (error: unknown): Error =>
@@ -55,7 +62,8 @@ const getGrantIdsToRevokeForMaxAllowedGrants = ({
 const enforceMaxAllowedGrantsRevocation = async (
   ctx: KoaContextWithOIDC & LogContext,
   provider: Provider,
-  queries: Queries
+  queries: Queries,
+  triggerEvent?: TriggerEvent
 ) => {
   const userId = ctx.oidc.session?.accountId;
   const clientId = ctx.oidc.client?.clientId;
@@ -89,6 +97,27 @@ const enforceMaxAllowedGrantsRevocation = async (
   await trySafe(
     async () => {
       const revokeResult = await sessionLibrary.revokeUserGrantsByIds(provider, grantIdsToRevoke);
+
+      // Fire webhook unconditionally after grants are revoked,
+      // even if subsequent session cleanup or error logging fails.
+      if (triggerEvent) {
+        void trySafe(
+          triggerEvent(getConsoleLogFromContext(ctx), 'Grant.LimitExceeded', {
+            userId,
+            applicationId: clientId,
+            revokedGrantIds: grantIdsToRevoke,
+            maxAllowedGrants,
+            preRevocationActiveGrantCount: activeGrants.length,
+          }),
+          (error) => {
+            getConsoleLogFromContext(ctx).error(
+              'authorization.success max-allowed-grants webhook failed:',
+              error
+            );
+          }
+        );
+      }
+
       const cleanupResult = await sessionLibrary.removeUserSessionAuthorizationsByGrantIds(
         provider,
         userId,
@@ -139,13 +168,15 @@ const enforceMaxAllowedGrantsRevocation = async (
       throw error;
     }
   );
-
-  // TODO: Trigger a webhook event for max-allowed-grants evictions.
 };
 
-export const createAuthorizationSuccessListener = (provider: Provider, queries: Queries) => {
+export const createAuthorizationSuccessListener = (
+  provider: Provider,
+  queries: Queries,
+  triggerEvent?: TriggerEvent
+) => {
   return async (ctx: KoaContextWithOIDC) => {
     assertLogContext(ctx);
-    await enforceMaxAllowedGrantsRevocation(ctx, provider, queries);
+    await enforceMaxAllowedGrantsRevocation(ctx, provider, queries, triggerEvent);
   };
 };

--- a/packages/core/src/event-listeners/authorization-success.ts
+++ b/packages/core/src/event-listeners/authorization-success.ts
@@ -1,7 +1,6 @@
 import { appInsights } from '@logto/app-insights/node';
 import {
   LogResult,
-  type ExceptionHookEvent,
   type GrantLimitExceededEventData,
   userApplicationGrantPayloadGuard,
 } from '@logto/schemas';
@@ -21,7 +20,7 @@ import { extractInteractionContext } from './utils.js';
 
 export type TriggerEvent = (
   consoleLog: ConsoleLog,
-  event: ExceptionHookEvent,
+  event: 'Grant.LimitExceeded',
   payload: GrantLimitExceededEventData,
   metadata?: { ip?: string; userAgent?: string }
 ) => Promise<void>;
@@ -104,9 +103,9 @@ const enforceMaxAllowedGrantsRevocation = async (
     async () => {
       const revokeResult = await sessionLibrary.revokeUserGrantsByIds(provider, grantIdsToRevoke);
 
-      // Fire webhook unconditionally after grants are revoked,
-      // even if subsequent session cleanup or error logging fails.
-      if (triggerEvent) {
+      // Fire webhook after grants are revoked, even if subsequent session
+      // cleanup or error logging fails. Skip if nothing was actually revoked.
+      if (triggerEvent && revokeResult.succeededNames.length > 0) {
         void trySafe(
           triggerEvent(
             getConsoleLogFromContext(ctx),
@@ -118,7 +117,7 @@ const enforceMaxAllowedGrantsRevocation = async (
               maxAllowedGrants,
               preRevocationActiveGrantCount: activeGrants.length,
             },
-            { ip: ctx.ip, userAgent: ctx.headers['user-agent'] }
+            { ip: ctx.ip, userAgent: ctx.get('user-agent') }
           ),
           (error) => {
             getConsoleLogFromContext(ctx).error(

--- a/packages/core/src/event-listeners/authorization-success.ts
+++ b/packages/core/src/event-listeners/authorization-success.ts
@@ -1,5 +1,10 @@
 import { appInsights } from '@logto/app-insights/node';
-import { LogResult, userApplicationGrantPayloadGuard, type HookEvent } from '@logto/schemas';
+import {
+  LogResult,
+  type ExceptionHookEvent,
+  type GrantLimitExceededEventData,
+  userApplicationGrantPayloadGuard,
+} from '@logto/schemas';
 import { type ConsoleLog } from '@logto/shared';
 import { trySafe } from '@silverhand/essentials';
 import type { KoaContextWithOIDC, Provider } from 'oidc-provider';
@@ -16,8 +21,9 @@ import { extractInteractionContext } from './utils.js';
 
 export type TriggerEvent = (
   consoleLog: ConsoleLog,
-  event: HookEvent,
-  payload: Record<string, unknown>
+  event: ExceptionHookEvent,
+  payload: GrantLimitExceededEventData,
+  metadata?: { ip?: string; userAgent?: string }
 ) => Promise<void>;
 
 const isDefined = <T>(value: T | undefined): value is T => value !== undefined;
@@ -102,13 +108,18 @@ const enforceMaxAllowedGrantsRevocation = async (
       // even if subsequent session cleanup or error logging fails.
       if (triggerEvent) {
         void trySafe(
-          triggerEvent(getConsoleLogFromContext(ctx), 'Grant.LimitExceeded', {
-            userId,
-            applicationId: clientId,
-            revokedGrantIds: grantIdsToRevoke,
-            maxAllowedGrants,
-            preRevocationActiveGrantCount: activeGrants.length,
-          }),
+          triggerEvent(
+            getConsoleLogFromContext(ctx),
+            'Grant.LimitExceeded',
+            {
+              userId,
+              applicationId: clientId,
+              revokedGrantIds: revokeResult.succeededNames,
+              maxAllowedGrants,
+              preRevocationActiveGrantCount: activeGrants.length,
+            },
+            { ip: ctx.ip, userAgent: ctx.headers['user-agent'] }
+          ),
           (error) => {
             getConsoleLogFromContext(ctx).error(
               'authorization.success max-allowed-grants webhook failed:',

--- a/packages/core/src/event-listeners/index.ts
+++ b/packages/core/src/event-listeners/index.ts
@@ -6,7 +6,7 @@ import type Queries from '#src/tenants/Queries.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
-import { createAuthorizationSuccessListener } from './authorization-success.js';
+import { createAuthorizationSuccessListener, type TriggerEvent } from './authorization-success.js';
 import { grantListener, grantRevocationListener } from './grant.js';
 import { interactionEndedListener, interactionStartedListener } from './interaction.js';
 import { recordActiveUsers } from './record-active-users.js';
@@ -16,7 +16,12 @@ import { deleteSessionExtensions } from './session.js';
  * @see {@link https://github.com/panva/node-oidc-provider/blob/v7.x/docs/README.md#im-getting-a-client-authentication-failed-error-with-no-details Getting auth error with no details?}
  * @see {@link https://github.com/panva/node-oidc-provider/blob/v7.x/docs/events.md OIDC Provider events}
  */
-export const addOidcEventListeners = (tenantId: string, provider: Provider, queries: Queries) => {
+export const addOidcEventListeners = (
+  tenantId: string,
+  provider: Provider,
+  queries: Queries,
+  triggerEvent?: TriggerEvent
+) => {
   const { recordTokenUsage } = queries.dailyTokenUsage;
 
   // Listener for user access tokens (increment user_token_usage)
@@ -33,7 +38,7 @@ export const addOidcEventListeners = (tenantId: string, provider: Provider, quer
 
   provider.addListener(
     'authorization.success',
-    createAuthorizationSuccessListener(provider, queries)
+    createAuthorizationSuccessListener(provider, queries, triggerEvent)
   );
 
   provider.addListener('access_token.issued', async (token) => {

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -1,7 +1,6 @@
 import {
   LogResult,
   userInfoSelectFields,
-  type ExceptionHookEvent,
   type ExceptionHookEventPayload,
   type GrantLimitExceededEventData,
   type Hook,
@@ -300,10 +299,14 @@ export const createHookLibrary = (queries: Queries) => {
    * operate outside the middleware request context. Instead it accepts explicit metadata fields
    * and enriches the payload with application detail and standard fields (`ip`, `userAgent`)
    * to match the shape of other exception hook events.
+   *
+   * Note: the hook-matching and payload-enrichment logic here intentionally mirrors what
+   * `buildWebhooks` does, since both need the same semantics but operate on different context
+   * shapes. Keep both in sync when changing either one.
    */
   const triggerEvent = async (
     consoleLog: ConsoleLog,
-    event: ExceptionHookEvent,
+    event: 'Grant.LimitExceeded',
     payload: GrantLimitExceededEventData,
     metadata?: { ip?: string; userAgent?: string }
   ) => {
@@ -317,10 +320,7 @@ export const createHookLibrary = (queries: Queries) => {
       return;
     }
 
-    const application =
-      matchingHooks.length > 0
-        ? await trySafe(async () => findApplicationById(payload.applicationId))
-        : undefined;
+    const application = await trySafe(async () => findApplicationById(payload.applicationId));
 
     const webhookPayloads = matchingHooks.map((hook) => ({
       hook,

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -1,6 +1,9 @@
 import {
   LogResult,
   userInfoSelectFields,
+  type ExceptionHookEvent,
+  type ExceptionHookEventPayload,
+  type GrantLimitExceededEventData,
   type Hook,
   type HookConfig,
   type HookEvent,
@@ -290,17 +293,19 @@ export const createHookLibrary = (queries: Queries) => {
   }
 
   /**
-   * Trigger a hook event directly without the metadata enrichment pipeline (`buildWebhooks`).
+   * Trigger a hook event directly, enriched with standard metadata.
    *
    * Unlike `triggerInteractionHooks` / `triggerDataHooks` / `triggerExceptionHooks`, this method
-   * does not go through `buildWebhooks` because callers (e.g., OIDC event listeners) operate
-   * outside the middleware request context and therefore have no `HookContextManager` or managed
-   * metadata. The payload is passed as-is with only the event name and timestamp added.
+   * does not go through the `HookContextManager` because callers (e.g., OIDC event listeners)
+   * operate outside the middleware request context. Instead it accepts explicit metadata fields
+   * and enriches the payload with application detail and standard fields (`ip`, `userAgent`)
+   * to match the shape of other exception hook events.
    */
   const triggerEvent = async (
     consoleLog: ConsoleLog,
-    event: HookEvent,
-    payload: Record<string, unknown>
+    event: ExceptionHookEvent,
+    payload: GrantLimitExceededEventData,
+    metadata?: { ip?: string; userAgent?: string }
   ) => {
     const hooks = await findAllHooks();
     const matchingHooks = hooks.filter(
@@ -312,16 +317,23 @@ export const createHookLibrary = (queries: Queries) => {
       return;
     }
 
-    const webhookPayloads: Array<{ hook: Hook; payload: HookEventPayloadWithoutHookId }> =
-      matchingHooks.map((hook) => ({
-        hook,
-        // eslint-disable-next-line no-restricted-syntax
-        payload: {
-          event,
-          createdAt: new Date().toISOString(),
-          ...payload,
-        } as unknown as HookEventPayloadWithoutHookId,
-      }));
+    const application =
+      matchingHooks.length > 0
+        ? await trySafe(async () => findApplicationById(payload.applicationId))
+        : undefined;
+
+    const webhookPayloads = matchingHooks.map((hook) => ({
+      hook,
+      payload: {
+        event,
+        createdAt: new Date().toISOString(),
+        ...metadata,
+        ...conditional(
+          application && { application: pick(application, 'id', 'type', 'name', 'description') }
+        ),
+        ...payload,
+      } satisfies BetterOmit<ExceptionHookEventPayload, 'hookId'>,
+    }));
 
     await sendWebhooks(webhookPayloads, consoleLog);
   };

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -289,10 +289,48 @@ export const createHookLibrary = (queries: Queries) => {
     });
   }
 
+  /**
+   * Trigger a hook event directly without the metadata enrichment pipeline (`buildWebhooks`).
+   *
+   * Unlike `triggerInteractionHooks` / `triggerDataHooks` / `triggerExceptionHooks`, this method
+   * does not go through `buildWebhooks` because callers (e.g., OIDC event listeners) operate
+   * outside the middleware request context and therefore have no `HookContextManager` or managed
+   * metadata. The payload is passed as-is with only the event name and timestamp added.
+   */
+  const triggerEvent = async (
+    consoleLog: ConsoleLog,
+    event: HookEvent,
+    payload: Record<string, unknown>
+  ) => {
+    const hooks = await findAllHooks();
+    const matchingHooks = hooks.filter(
+      ({ event: hookEvent, events, enabled }) =>
+        enabled && (events.length > 0 ? events.includes(event) : event === hookEvent)
+    );
+
+    if (matchingHooks.length === 0) {
+      return;
+    }
+
+    const webhookPayloads: Array<{ hook: Hook; payload: HookEventPayloadWithoutHookId }> =
+      matchingHooks.map((hook) => ({
+        hook,
+        // eslint-disable-next-line no-restricted-syntax
+        payload: {
+          event,
+          createdAt: new Date().toISOString(),
+          ...payload,
+        } as unknown as HookEventPayloadWithoutHookId,
+      }));
+
+    await sendWebhooks(webhookPayloads, consoleLog);
+  };
+
   return {
     triggerInteractionHooks,
     triggerDataHooks,
     triggerExceptionHooks,
     triggerTestHook,
+    triggerEvent,
   };
 };

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -475,7 +475,7 @@ export default function initOidc(
   });
 
   installWildcardRedirectUriMatching(oidc);
-  addOidcEventListeners(tenantId, oidc, queries);
+  addOidcEventListeners(tenantId, oidc, queries, libraries.hooks.triggerEvent);
   registerGrants(oidc, envSet, queries, libraries);
 
   // Register first so all downstream cookie operations go through the rebound instance

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.grant-limit-exceeded.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.grant-limit-exceeded.test.ts
@@ -1,0 +1,65 @@
+import { deleteApplication, updateApplication } from '#src/api/application.js';
+import { WebHookApiTest } from '#src/helpers/hook.js';
+import { createAppAndSignInWithPassword } from '#src/helpers/session.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+
+import WebhookMockServer from './WebhookMockServer.js';
+import { assertHookLogResult } from './utils.js';
+
+const webHookMockServer = new WebhookMockServer(9998);
+const webHookApi = new WebHookApiTest();
+const hookName = 'grantLimitExceededHookEventListener';
+
+describe('trigger `Grant.LimitExceeded` exception hook', () => {
+  beforeAll(async () => {
+    await webHookMockServer.listen();
+    await enableAllPasswordSignInMethods();
+    await webHookApi.create({
+      name: hookName,
+      events: ['Grant.LimitExceeded'],
+      config: { url: webHookMockServer.endpoint },
+    });
+  });
+
+  afterAll(async () => {
+    await Promise.all([webHookApi.cleanUp(), webHookMockServer.close()]);
+  });
+
+  it('logs the `Grant.LimitExceeded` hook when maxAllowedGrants is exceeded', async () => {
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const userApi = new UserApiTest();
+    const user = await userApi.create({ username, password });
+    const { app, signIn } = await createAppAndSignInWithPassword({ username, password });
+
+    try {
+      await updateApplication(app.id, {
+        customClientMetadata: {
+          alwaysIssueRefreshToken: true,
+          maxAllowedGrants: 1,
+        },
+      });
+
+      // Grant `iat` is second-level precision. Ensure the next sign-in creates
+      // a strictly newer grant so oldest-grant selection stays deterministic.
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1100);
+      });
+
+      await signIn();
+
+      await assertHookLogResult(webHookApi.hooks.get(hookName)!, 'Grant.LimitExceeded', {
+        hookPayload: {
+          event: 'Grant.LimitExceeded',
+          userId: user.id,
+          applicationId: app.id,
+          maxAllowedGrants: 1,
+          preRevocationActiveGrantCount: 2,
+        },
+      });
+    } finally {
+      await deleteApplication(app.id);
+      await userApi.cleanUp();
+    }
+  });
+});

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.grant-limit-exceeded.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.grant-limit-exceeded.test.ts
@@ -54,6 +54,8 @@ describe('trigger `Grant.LimitExceeded` exception hook', () => {
           userId: user.id,
           applicationId: app.id,
           maxAllowedGrants: 1,
+          // Exactly 2: createAppAndSignInWithPassword mints the first grant,
+          // then signIn() mints the second, exceeding maxAllowedGrants: 1.
           preRevocationActiveGrantCount: 2,
         },
       });

--- a/packages/schemas/src/foundations/jsonb-types/hooks.ts
+++ b/packages/schemas/src/foundations/jsonb-types/hooks.ts
@@ -48,7 +48,10 @@ type CustomDataHookMutableSchema =
 type DataHookPropertyUpdateEvent =
   `${CustomDataHookMutableSchema}.${DataHookDetailMutationType.Updated}`;
 
-export type ExceptionHookEvent = 'Identifier.Lockout' | 'Message.RateLimited';
+export type ExceptionHookEvent =
+  | 'Identifier.Lockout'
+  | 'Message.RateLimited'
+  | 'Grant.LimitExceeded';
 
 export type DataHookEvent = BasicDataHookEvent | DataHookPropertyUpdateEvent;
 
@@ -82,6 +85,7 @@ export const hookEvents = Object.freeze([
   'OrganizationScope.Data.Updated',
   'Identifier.Lockout',
   'Message.RateLimited',
+  'Grant.LimitExceeded',
 ] as const satisfies Array<InteractionHookEvent | DataHookEvent | ExceptionHookEvent>);
 
 /** The type of hook event values that can be registered. */

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -97,6 +97,14 @@ export type DataHookEventPayload = {
 export type ExceptionHookEventPayload = Omit<DataHookEventPayload, 'event'> & {
   event: ExceptionHookEvent;
 };
+export type GrantLimitExceededEventData = {
+  userId: string;
+  applicationId: string;
+  revokedGrantIds: string[];
+  maxAllowedGrants: number;
+  preRevocationActiveGrantCount: number;
+};
+
 export type HookEventPayload =
   | InteractionHookEventPayload
   | DataHookEventPayload


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Trigger a `Grant.LimitExceeded`  webhook event when OIDC grants are evicted due to the application's maxAllowedGrants limit being exceeded.

## Changes

- New hook event: `Grant.LimitExceeded ` added to the webhook event catalog, selectable in the Console like any other event
- Webhook dispatch: After the oldest grants are revoked on authorization.success, the system fires this event with userId, applicationId, revokedGrantIds, maxAllowedGrants, and preRevocationActiveGrantCount
- Error-safe: Webhook dispatch is fire-and-forget via trySafe — failures are logged but never block the auth response or propagate into the revocation flow
- Capped concurrency: Uses the existing sendWebhooks with pMap concurrency of 10 to avoid connection exhaustion

## Design

- The webhook fires immediately after revokeUserGrantsByIds succeeds, before session cleanup — so it's dispatched even when subsequent cleanup partially fails
- Webhook HTTP errors are captured as TriggerHook.Grant.LimitExceeded audit log entries; unexpected errors (DB, config) are logged to console
- A triggerEvent method was added to the hook library for lightweight, metadata-free event dispatch — used here because OIDC event listeners operate outside the middleware request pipeline and have no HookContextManager
 
<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
