### PR TITLE
fix(console): constrain verification file path link hover area

### DIFF
--- a/packages/console/src/ds-components/TextLink/index.module.scss
+++ b/packages/console/src/ds-components/TextLink/index.module.scss
@@ -2,6 +2,7 @@
 
 .link {
   display: inline-flex;
+  align-items: center;
   max-width: fit-content;
   text-decoration: none;
   user-select: none;

--- a/packages/console/src/pages/InlineHooks/InlineHookDetails/utils/config.tsx
+++ b/packages/console/src/pages/InlineHooks/InlineHookDetails/utils/config.tsx
@@ -3,6 +3,8 @@ import {
   LogtoInlineHookKey,
   SignInIdentifier,
   VerificationType,
+  type HookUser,
+  type JwtCustomizerUserContext,
   type PostFirstFactorVerificationEvent,
   type PostSignInEvent,
 } from '@logto/schemas';
@@ -20,7 +22,7 @@ import {
   postSignInResultTypeDefinition,
 } from './type-definitions';
 
-const defaultHookUser = {
+const defaultHookUser: HookUser = {
   id: 'user_123',
   username: 'jane',
   primaryEmail: 'jane@example.com',
@@ -34,6 +36,22 @@ const defaultHookUser = {
     familyName: 'Doe',
     givenName: 'Jane',
   },
+};
+
+const defaultPostSignInUser: JwtCustomizerUserContext = {
+  ...defaultHookUser,
+  identities: {},
+  lastSignInAt: 1_704_067_200_000,
+  createdAt: 1_704_067_200_000,
+  updatedAt: 1_704_067_200_000,
+  applicationId: 'app_123',
+  isSuspended: false,
+  hasPassword: true,
+  ssoIdentities: [],
+  mfaVerificationFactors: [],
+  roles: [],
+  organizations: [],
+  organizationRoles: [],
 };
 
 const defaultPostFirstFactorVerificationEvent: PostFirstFactorVerificationEvent = {
@@ -51,7 +69,7 @@ const defaultPostFirstFactorVerificationEvent: PostFirstFactorVerificationEvent 
 const defaultPostSignInEvent: PostSignInEvent = {
   key: LogtoInlineHookKey.PostSignIn,
   interactionEvent: InteractionEvent.SignIn,
-  user: defaultHookUser,
+  user: defaultPostSignInUser,
 };
 
 const defaultPostFirstFactorVerificationScript = `/**

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/VerificationFiles/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/VerificationFiles/index.module.scss
@@ -60,7 +60,11 @@
 }
 
 // Higher specificity so this wins over TextLink's `max-width: fit-content`.
+// `width: fit-content` keeps the flex item from stretching under `.fileInfo`'s
+// default `align-items: stretch`; `max-width: 100%` still allows long paths to
+// truncate within the row.
 a.path {
+  width: fit-content;
   max-width: 100%;
   min-width: 0;
   font-family: 'Roboto Mono', monospace;

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/VerificationFiles/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/VerificationFiles/index.module.scss
@@ -59,13 +59,26 @@
   gap: _.unit(1);
 }
 
-.path {
-  overflow: hidden;
-  color: var(--color-text);
+// Higher specificity so this wins over TextLink's `max-width: fit-content`.
+a.path {
+  max-width: 100%;
+  min-width: 0;
   font-family: 'Roboto Mono', monospace;
   font-size: 13px;
+  line-height: 20px;
+}
+
+.pathText {
+  min-width: 0;
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.externalLinkIcon {
+  flex-shrink: 0;
+  width: _.unit(4);
+  height: _.unit(4);
 }
 
 .actions {

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/VerificationFiles/index.module.scss
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/VerificationFiles/index.module.scss
@@ -63,7 +63,7 @@
 // `width: fit-content` keeps the flex item from stretching under `.fileInfo`'s
 // default `align-items: stretch`; `max-width: 100%` still allows long paths to
 // truncate within the row.
-a.path {
+.path.path {
   width: fit-content;
   max-width: 100%;
   min-width: 0;

--- a/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/VerificationFiles/index.tsx
+++ b/packages/console/src/pages/TenantSettings/TenantDomainSettings/CustomDomain/VerificationFiles/index.tsx
@@ -11,12 +11,15 @@ import useSWR from 'swr';
 
 import Delete from '@/assets/icons/delete.svg?react';
 import Edit from '@/assets/icons/edit.svg?react';
+import ExternalLinkIcon from '@/assets/icons/external-link.svg?react';
 import Plus from '@/assets/icons/plus.svg?react';
 import Button from '@/ds-components/Button';
+import FlipOnRtl from '@/ds-components/FlipOnRtl';
 import IconButton from '@/ds-components/IconButton';
 import Select, { type Option } from '@/ds-components/Select';
 import { Ring as Spinner } from '@/ds-components/Spinner';
 import TextInput from '@/ds-components/TextInput';
+import TextLink from '@/ds-components/TextLink';
 import Textarea from '@/ds-components/Textarea';
 import useApi from '@/hooks/use-api';
 
@@ -186,14 +189,19 @@ function VerificationFiles({ domain, domainId, isReadonly }: Props) {
           {files.map((file) => (
             <div key={file.path} className={styles.fileItem}>
               <div className={styles.fileInfo}>
-                <a
+                <TextLink
+                  isTrailingIcon
+                  targetBlank
                   className={styles.path}
                   href={`https://${domain}${file.path}`}
-                  rel="noopener noreferrer"
-                  target="_blank"
+                  icon={
+                    <FlipOnRtl>
+                      <ExternalLinkIcon className={styles.externalLinkIcon} />
+                    </FlipOnRtl>
+                  }
                 >
-                  {file.path}
-                </a>
+                  <span className={styles.pathText}>{file.path}</span>
+                </TextLink>
                 <span className={styles.contentType}>
                   {contentTypeOptions.find(({ value }) => value === file.contentType)?.title ??
                     file.contentType}


### PR DESCRIPTION
## Summary

- Replace the raw verification-file path `<a>` with `TextLink` so only the path text (plus external-link icon) is clickable, instead of the full flex-stretched row.
- Add the trailing external-link icon for this external URL, matching Console link conventions.

Closes LOG-13888

## Testing

Tested locally

<img width="1436" height="634" alt="logto-verification-files-link-hover" src="https://github.com/user-attachments/assets/e4683fc4-6bfc-4433-b8e2-bba734293dcc" />
