### PR TITLE
fix(core): keep the oidc-provider SSRF protection enabled in cloud

### DIFF
--- a/packages/core/src/oidc/fetch.test.ts
+++ b/packages/core/src/oidc/fetch.test.ts
@@ -1,0 +1,40 @@
+import Sinon from 'sinon';
+
+import { EnvSet } from '#src/env-set/index.js';
+
+import providerFetch from './fetch.js';
+
+const dispatcher = Symbol('dispatcher');
+const requestInit: RequestInit & { dispatcher?: unknown } = {
+  method: 'POST',
+  dispatcher,
+};
+
+describe('providerFetch', () => {
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  it('should drop the SSRF-protecting dispatcher for self-hosted deployments', async () => {
+    Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isCloud: false });
+    const fetchStub = Sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+    await providerFetch('https://rp.example.com/backchannel-logout', requestInit);
+
+    expect(fetchStub.calledOnce).toBe(true);
+    const [, init] = fetchStub.firstCall.args;
+    expect(init).toMatchObject({ method: 'POST' });
+    expect(init).not.toHaveProperty('dispatcher');
+  });
+
+  it('should keep the SSRF-protecting dispatcher in cloud', async () => {
+    Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isCloud: true });
+    const fetchStub = Sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+    await providerFetch('https://rp.example.com/backchannel-logout', requestInit);
+
+    expect(fetchStub.calledOnce).toBe(true);
+    const [, init] = fetchStub.firstCall.args;
+    expect(init).toHaveProperty('dispatcher', dispatcher);
+  });
+});

--- a/packages/core/src/oidc/fetch.ts
+++ b/packages/core/src/oidc/fetch.ts
@@ -1,12 +1,16 @@
+import { EnvSet } from '#src/env-set/index.js';
+
 /**
  * The `fetch` implementation for the provider's outgoing requests (backchannel logout, client
  * `jwks_uri`, `sector_identifier_uri`, ...).
  *
  * Since v9, oidc-provider injects an SSRF-protecting undici dispatcher into these requests that
- * destroys connections resolving to special-use addresses such as loopback and private ranges,
- * while self-hosted Logto deployments commonly reach RPs on private networks — drop the
- * dispatcher so outgoing requests stay unrestricted as before. Revisit if we want the hardening
- * for cloud.
+ * destroys connections resolving to special-use addresses such as loopback and private ranges.
+ *
+ * Self-hosted Logto deployments commonly reach RPs on private networks, so the dispatcher is
+ * dropped there to keep outgoing requests unrestricted as before. In Cloud, these requests have
+ * no legitimate private-network targets, so the dispatcher is kept to stop tenant-controlled
+ * URIs (e.g. `backchannelLogoutUri`) from reaching internal infrastructure.
  */
 const fetchWithoutSsrfDispatcher: typeof fetch = async (input, init) => {
   // eslint-disable-next-line no-restricted-syntax -- The `dispatcher` key is an undici extension absent from `RequestInit`
@@ -14,4 +18,7 @@ const fetchWithoutSsrfDispatcher: typeof fetch = async (input, init) => {
   return fetch(input, safeInit);
 };
 
-export default fetchWithoutSsrfDispatcher;
+const providerFetch: typeof fetch = async (input, init) =>
+  EnvSet.values.isCloud ? fetch(input, init) : fetchWithoutSsrfDispatcher(input, init);
+
+export default providerFetch;

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -62,7 +62,7 @@ import {
   getExtraTokenClaimsForOrganizationApiResource,
   getExtraTokenClaimsForTokenExchange,
 } from './extra-token-claims.js';
-import fetchWithoutSsrfDispatcher from './fetch.js';
+import providerFetch from './fetch.js';
 import { registerGrants } from './grants/index.js';
 import {
   findResource,
@@ -175,7 +175,7 @@ export default function initOidc(
       introspectionSigningAlgValues: [...supportedSigningAlgs],
     },
     conformIdTokenClaims: false,
-    fetch: fetchWithoutSsrfDispatcher,
+    fetch: providerFetch,
     features: {
       userinfo: { enabled: true },
       revocation: { enabled: true },


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/logto-io/logto/pull/9219#discussion_r3610663203.

Keep oidc-provider v9's SSRF-protecting undici dispatcher for the provider's outgoing requests (backchannel logout, client `jwks_uri`, ...) in Cloud, where these requests have no legitimate private-network targets, so a tenant-controlled URI (e.g. `backchannelLogoutUri`, validated only as a URL) can no longer reach internal infrastructure. Self-hosted deployments keep the previous unrestricted behavior, since they commonly reach RPs on private networks.

Note on the review comment's redirect concern: backchannel logout never follows redirects on either version (v8 `got` sets `followRedirect: false`, v9 passes `redirect: 'manual'`), so there is no public-to-private redirect hop to test. What the dispatcher closes in Cloud is the direct case — a URI pointing straight at a special-use address — which was equally reachable on v8.

## Testing

Unit tests.

## Checklist

- [x] `.changeset` — not needed; Cloud-only behavior change, self-hosted behavior is unchanged
- [x] unit tests
- [x] integration tests — N/A (`isCloud` is not exercised by the integration environment)
- [x] necessary TSDoc comments