### PR TITLE
fix(console): align post sign-in hook type definition

### DIFF
--- a/packages/console/src/pages/InlineHooks/InlineHookDetails/utils/config.tsx
+++ b/packages/console/src/pages/InlineHooks/InlineHookDetails/utils/config.tsx
@@ -11,6 +11,7 @@ import {
 import { type EditorProps } from '@monaco-editor/react';
 
 import type { ModelSettings } from '@/components/MonacoCodeEditor';
+import { jwtCustomizerUserContextTypeDefinition } from '@/consts/jwt-customizer-type-definition';
 
 import {
   InlineHookTypeDefinitionKey,
@@ -140,8 +141,8 @@ declare type Payload = {
 };
 `;
 
-const buildSharedContextTypeDefinitions = () =>
-  `declare ${hookUserTypeDefinition}
+const buildSharedContextTypeDefinitions = (userTypeDefinition: string) =>
+  `declare ${userTypeDefinition}
 
 declare ${hookUserPatchTypeDefinition}`;
 
@@ -157,7 +158,7 @@ const postFirstFactorVerificationModel: ModelSettings = {
       filePath: 'file:///logto-inline-hook.d.ts',
     },
     {
-      content: `${buildSharedContextTypeDefinitions()}
+      content: `${buildSharedContextTypeDefinitions(hookUserTypeDefinition)}
 
 declare ${postFirstFactorVerificationEventTypeDefinition}
 
@@ -179,7 +180,7 @@ const postSignInModel: ModelSettings = {
       filePath: 'file:///logto-inline-hook.d.ts',
     },
     {
-      content: `${buildSharedContextTypeDefinitions()}
+      content: `${buildSharedContextTypeDefinitions(jwtCustomizerUserContextTypeDefinition)}
 
 declare ${postSignInEventTypeDefinition}
 

--- a/packages/console/src/pages/InlineHooks/InlineHookDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/InlineHooks/InlineHookDetails/utils/type-definitions.ts
@@ -1,5 +1,10 @@
 import { LogtoInlineHookKey } from '@logto/schemas';
 
+import {
+  JwtCustomizerTypeDefinitionKey,
+  jwtCustomizerUserContextTypeDefinition,
+} from '@/consts/jwt-customizer-type-definition';
+
 import { type InlineHookForm } from '../type';
 
 export enum InlineHookTypeDefinitionKey {
@@ -56,7 +61,7 @@ export const postFirstFactorVerificationEventTypeDefinition = `type ${InlineHook
 export const postSignInEventTypeDefinition = `type ${InlineHookTypeDefinitionKey.PostSignInEvent} = {
   key: 'inlineHook.postSignIn';
   interactionEvent: 'SignIn';
-  user: ${InlineHookTypeDefinitionKey.HookUser};
+  user: ${JwtCustomizerTypeDefinitionKey.JwtCustomizerUserContext};
 };`;
 
 export const postFirstFactorVerificationResultTypeDefinition = `type ${InlineHookTypeDefinitionKey.PostFirstFactorVerificationResult} =
@@ -100,7 +105,7 @@ export const getEventTypeDefinition = (hookType: LogtoInlineHookKey) => {
 declare ${postFirstFactorVerificationEventTypeDefinition}`;
     }
     case LogtoInlineHookKey.PostSignIn: {
-      return `declare ${hookUserTypeDefinition}
+      return `declare ${jwtCustomizerUserContextTypeDefinition}
 
 declare ${postSignInEventTypeDefinition}`;
     }


### PR DESCRIPTION
## Summary

- Reuse the generated JWT user context definition for PostSignIn Monaco hints and type documentation.
- Keep the first-factor hook on the smaller `HookUser` contract while exposing the complete PostSignIn runtime payload.

## Root cause

The PostSignIn event schema uses `JwtCustomizerUserContext`, but the Console editor definition still declared its user as the smaller `HookUser` shape. This left script autocomplete and type documentation inconsistent with the runtime event.

## Testing

Unit tests
