### PR TITLE
fix(console): add dev feature guard to allowlist console UI

### DIFF
--- a/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.test.tsx
+++ b/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.test.tsx
@@ -9,6 +9,7 @@ import BlocklistForm from '.';
 
 const mockPatch = jest.fn();
 const mockMutateGlobal = jest.fn();
+const mockIsDevFeaturesEnabled = jest.fn(() => true);
 
 jest.mock('react-hot-toast', () => ({
   toast: {
@@ -31,6 +32,9 @@ jest.mock('@/consts', () => ({
 
 jest.mock('@/consts/env', () => ({
   isCloud: true,
+  get isDevFeaturesEnabled() {
+    return mockIsDevFeaturesEnabled();
+  },
 }));
 
 jest.mock('@/consts/subscriptions', () => ({
@@ -176,6 +180,7 @@ const addCustomAllowlistValue = async (value: string) => {
 describe('BlocklistForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsDevFeaturesEnabled.mockReturnValue(true);
     mockPatch.mockReturnValue({
       json: async () => ({
         emailBlocklistPolicy: {
@@ -209,6 +214,14 @@ describe('BlocklistForm', () => {
     );
   });
 
+  it('does not render the custom allowlist section when dev features are disabled', () => {
+    mockIsDevFeaturesEnabled.mockReturnValue(false);
+    renderBlocklistForm();
+
+    expect(screen.queryByText('allowed@example.com')).toBeNull();
+    expect(screen.queryByText('security.blocklist.custom_email_allowlist.title')).toBeNull();
+  });
+
   it('sends customAllowlist in the sign-in experience patch payload', async () => {
     renderBlocklistForm();
 
@@ -229,6 +242,25 @@ describe('BlocklistForm', () => {
     });
     expect(mockMutateGlobal).toHaveBeenCalledWith('api/sign-in-exp');
     expect(toast.success).toHaveBeenCalledWith('admin_console.general.saved');
+  });
+
+  it('omits customAllowlist from the sign-in experience patch payload when dev features are disabled', async () => {
+    mockIsDevFeaturesEnabled.mockReturnValue(false);
+    renderBlocklistForm();
+
+    fireEvent.click(screen.getByText('general.save_changes'));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith('api/sign-in-exp', {
+        json: {
+          emailBlocklistPolicy: {
+            blockDisposableAddresses: false,
+            blockSubaddressing: true,
+            customBlocklist: ['@blocked.com'],
+          },
+        },
+      });
+    });
   });
 
   it('shows cheap warnings without blocking save', async () => {

--- a/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.tsx
+++ b/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.tsx
@@ -12,7 +12,7 @@ import FormCard from '@/components/FormCard';
 import MultiOptionInput from '@/components/MultiOptionInput';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { emailBlocklist } from '@/consts';
-import { isCloud } from '@/consts/env';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { latestProPlanId } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import FormField from '@/ds-components/FormField';
@@ -33,6 +33,18 @@ import styles from './index.module.scss';
 
 type Props = {
   readonly formData: EmailBlocklistPolicyFormData;
+};
+
+// Dev feature guard for the custom email allowlist configuration.
+const buildEmailBlocklistPolicyPayload = (emailBlocklistPolicy: EmailBlocklistPolicyFormData) => {
+  if (isDevFeaturesEnabled) {
+    return emailBlocklistPolicy;
+  }
+
+  const { customAllowlist: _customAllowlist, ...emailBlocklistPolicyWithoutDevFeatures } =
+    emailBlocklistPolicy;
+
+  return emailBlocklistPolicyWithoutDevFeatures;
 };
 
 function BlocklistForm({ formData }: Props) {
@@ -75,7 +87,7 @@ function BlocklistForm({ formData }: Props) {
       const { emailBlocklistPolicy: updatedEmailBlocklistPolicy } = await api
         .patch('api/sign-in-exp', {
           json: {
-            emailBlocklistPolicy,
+            emailBlocklistPolicy: buildEmailBlocklistPolicyPayload(emailBlocklistPolicy),
           },
         })
         .json<SignInExperience>();
@@ -165,57 +177,59 @@ function BlocklistForm({ formData }: Props) {
               )}
             />
           </FormField>
-          <FormField title="security.blocklist.custom_email_allowlist.title">
-            <div className={styles.fieldDescription}>
-              {t('blocklist.custom_email_allowlist.description')}
-            </div>
-            <Controller
-              name="customAllowlist"
-              control={control}
-              render={({ field: { onChange, value = [] } }) => (
-                <MultiOptionInput
-                  disabled={isFreeTenant}
-                  values={value}
-                  placeholder={t('blocklist.custom_email_allowlist.placeholder')}
-                  renderValue={(value) => value}
-                  validateInput={(input) => {
-                    if (
-                      value.some(
-                        (existingValue) => existingValue.toLowerCase() === input.toLowerCase()
-                      )
-                    ) {
-                      return t('blocklist.custom_email_allowlist.duplicate_error');
-                    }
+          {isDevFeaturesEnabled && (
+            <FormField title="security.blocklist.custom_email_allowlist.title">
+              <div className={styles.fieldDescription}>
+                {t('blocklist.custom_email_allowlist.description')}
+              </div>
+              <Controller
+                name="customAllowlist"
+                control={control}
+                render={({ field: { onChange, value = [] } }) => (
+                  <MultiOptionInput
+                    disabled={isFreeTenant}
+                    values={value}
+                    placeholder={t('blocklist.custom_email_allowlist.placeholder')}
+                    renderValue={(value) => value}
+                    validateInput={(input) => {
+                      if (
+                        value.some(
+                          (existingValue) => existingValue.toLowerCase() === input.toLowerCase()
+                        )
+                      ) {
+                        return t('blocklist.custom_email_allowlist.duplicate_error');
+                      }
 
-                    if (!isEmailBlocklistItem(input)) {
-                      return t('blocklist.custom_email_allowlist.invalid_format_error');
-                    }
+                      if (!isEmailBlocklistItem(input)) {
+                        return t('blocklist.custom_email_allowlist.invalid_format_error');
+                      }
 
-                    return { value: input };
-                  }}
-                  error={errors.customAllowlist?.message}
-                  onChange={onChange}
-                  onError={(error) => {
-                    setError('customAllowlist', { type: 'custom', message: error });
-                  }}
-                  onClearError={() => {
-                    clearErrors('customAllowlist');
-                  }}
-                />
+                      return { value: input };
+                    }}
+                    error={errors.customAllowlist?.message}
+                    onChange={onChange}
+                    onError={(error) => {
+                      setError('customAllowlist', { type: 'custom', message: error });
+                    }}
+                    onClearError={() => {
+                      clearErrors('customAllowlist');
+                    }}
+                  />
+                )}
+              />
+              {emailAllowlistWarnings.length > 0 && (
+                <InlineNotification className={styles.allowlistWarning} severity="alert">
+                  <ul className={styles.warningList}>
+                    {emailAllowlistWarnings.map((warning) => (
+                      <li key={warning}>
+                        {t(`blocklist.custom_email_allowlist.warnings.${warning}`)}
+                      </li>
+                    ))}
+                  </ul>
+                </InlineNotification>
               )}
-            />
-            {emailAllowlistWarnings.length > 0 && (
-              <InlineNotification className={styles.allowlistWarning} severity="alert">
-                <ul className={styles.warningList}>
-                  {emailAllowlistWarnings.map((warning) => (
-                    <li key={warning}>
-                      {t(`blocklist.custom_email_allowlist.warnings.${warning}`)}
-                    </li>
-                  ))}
-                </ul>
-              </InlineNotification>
-            )}
-          </FormField>
+            </FormField>
+          )}
         </FormCard>
       </DetailsForm>
       <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />


### PR DESCRIPTION
## Summary
Add the dev feature guard to the email allowlist controls in the Console Blocklist page, and omit the allowlist field from the sign-in experience patch payload when the guard is off.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments