### PR TITLE
fix(experience): improve social and SSO auth flow with blocked email

### DIFF
--- a/.changeset/short-wolves-trade.md
+++ b/.changeset/short-wolves-trade.md
@@ -4,4 +4,4 @@
 
 return users to the Logto sign-in page after blocked social or SSO registration
 
-When a social or SSO authentication callback falls back to registration and the email is rejected by email access rules, acknowledging the error now returns the user to the Logto sign-in page instead of navigating back to the external identity provider
+When a social or SSO registration flow rejects the email by email access rules, acknowledging the error now returns the user to the Logto sign-in page instead of navigating back to the external identity provider

--- a/.changeset/short-wolves-trade.md
+++ b/.changeset/short-wolves-trade.md
@@ -2,4 +2,4 @@
 "@logto/experience": patch
 ---
 
-redirect blocked social sign-up attempts back to the sign-in page
+improve the social and SSO auth flow with blocked email

--- a/.changeset/short-wolves-trade.md
+++ b/.changeset/short-wolves-trade.md
@@ -2,4 +2,6 @@
 "@logto/experience": patch
 ---
 
-improve the social and SSO auth flow with blocked email
+return users to the Logto sign-in page after blocked social or SSO registration
+
+When a social or SSO authentication callback falls back to registration and the email is rejected by email access rules, acknowledging the error now returns the user to the Logto sign-in page instead of navigating back to the external identity provider

--- a/.changeset/short-wolves-trade.md
+++ b/.changeset/short-wolves-trade.md
@@ -1,0 +1,5 @@
+---
+"@logto/experience": patch
+---
+
+redirect blocked social sign-up attempts back to the sign-in page

--- a/packages/experience/src/hooks/use-email-blocked-error-handler.ts
+++ b/packages/experience/src/hooks/use-email-blocked-error-handler.ts
@@ -6,7 +6,11 @@ import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-pres
 import { usePromiseConfirmModal } from './use-confirm-modal';
 import { type ErrorHandlers } from './use-error-handler';
 
-const useEmailBlockedErrorHandler = (): ErrorHandlers => {
+export type Options = {
+  readonly onConfirm?: () => void;
+};
+
+const useEmailBlockedErrorHandler = ({ onConfirm }: Options = {}): ErrorHandlers => {
   const navigate = useNavigateWithPreservedSearchParams();
   const { show } = usePromiseConfirmModal();
 
@@ -17,9 +21,15 @@ const useEmailBlockedErrorHandler = (): ErrorHandlers => {
         ModalContent: error.message,
         cancelText: 'action.got_it',
       });
+
+      if (onConfirm) {
+        onConfirm();
+        return;
+      }
+
       navigate(-1);
     },
-    [navigate, show]
+    [navigate, onConfirm, show]
   );
 
   return useMemo<ErrorHandlers>(

--- a/packages/experience/src/hooks/use-social-register.ts
+++ b/packages/experience/src/hooks/use-social-register.ts
@@ -10,7 +10,12 @@ import useGlobalRedirectTo from './use-global-redirect-to';
 import useSubmitInteractionErrorHandler from './use-submit-interaction-error-handler';
 import useTerms from './use-terms';
 
-const useSocialRegister = (connectorId: string, replace?: boolean) => {
+type Options = {
+  readonly replace?: boolean;
+  readonly onEmailBlocked?: () => void;
+};
+
+const useSocialRegister = (connectorId: string, { replace, onEmailBlocked }: Options = {}) => {
   const handleError = useErrorHandler();
   const asyncRegisterWithSocial = useApi(registerWithVerifiedIdentifier);
   const redirectTo = useGlobalRedirectTo();
@@ -20,6 +25,7 @@ const useSocialRegister = (connectorId: string, replace?: boolean) => {
   const preRegisterErrorHandler = useSubmitInteractionErrorHandler(InteractionEvent.Register, {
     linkSocial: connectorId,
     replace,
+    onEmailBlocked,
   });
 
   return useCallback(

--- a/packages/experience/src/hooks/use-submit-interaction-error-handler.ts
+++ b/packages/experience/src/hooks/use-submit-interaction-error-handler.ts
@@ -14,7 +14,9 @@ import useRequiredProfileErrorHandler, {
 } from './use-required-profile-error-handler';
 
 type Options = Omit<UseRequiredProfileErrorHandlerOptions, 'interactionEvent'> &
-  UseMfaVerificationErrorHandlerOptions;
+  UseMfaVerificationErrorHandlerOptions & {
+    readonly onEmailBlocked?: () => void;
+  };
 
 /**
  * Error handlers for sign-in and registration interaction submissions.
@@ -31,7 +33,7 @@ const useSubmitInteractionErrorHandler = (
    * when additional user profile information is required.
    */
   interactionEvent: ContinueFlowInteractionEvent,
-  { replace, ...rest }: Options = {}
+  { replace, onEmailBlocked, ...rest }: Options = {}
 ): ErrorHandlers => {
   const requiredProfileErrorHandler = useRequiredProfileErrorHandler({
     replace,
@@ -39,7 +41,7 @@ const useSubmitInteractionErrorHandler = (
     ...rest,
   });
   const mfaErrorHandler = useMfaErrorHandler({ replace });
-  const emailBlockedErrorHandler = useEmailBlockedErrorHandler();
+  const emailBlockedErrorHandler = useEmailBlockedErrorHandler({ onConfirm: onEmailBlocked });
   const passkeySignInErrorHandler = useMissingPasskeyErrorHandler(interactionEvent);
 
   return useMemo(

--- a/packages/experience/src/pages/SocialSignInWebCallback/social-callback.test.tsx
+++ b/packages/experience/src/pages/SocialSignInWebCallback/social-callback.test.tsx
@@ -1,17 +1,30 @@
-import { VerificationType } from '@logto/schemas';
-import { renderHook, waitFor } from '@testing-library/react';
+import { AgreeToTermsPolicy, type RequestErrorBody, VerificationType } from '@logto/schemas';
+import { fireEvent, renderHook, waitFor } from '@testing-library/react';
+import { HTTPError } from 'ky';
 import { Navigate, Route, Routes, useSearchParams } from 'react-router-dom';
 
+import ConfirmModalProvider from '@/Providers/ConfirmModalProvider';
 import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { mockSignInExperienceSettings } from '@/__mocks__/logto';
 import { socialConnectors } from '@/__mocks__/social-connectors';
-import { verifySocialVerification } from '@/apis/experience';
+import {
+  identifyAndSubmitInteraction,
+  registerWithVerifiedIdentifier,
+  verifySocialVerification,
+} from '@/apis/experience';
 import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
 import { generateState, storeState } from '@/utils/social-connectors';
 import { storeRedirectContext } from '@/utils/social-redirect-fallback-context';
 
 import SocialCallback from '.';
+
+const mockRedirectTo = jest.fn();
+
+function mockUseGlobalRedirectTo() {
+  return mockRedirectTo;
+}
 
 jest.mock('i18next', () => ({
   ...jest.requireActual('i18next'),
@@ -21,7 +34,13 @@ jest.mock('i18next', () => ({
 jest.mock('@/apis/experience', () => ({
   verifySocialVerification: jest.fn().mockResolvedValue({ verificationId: 'foo' }),
   identifyAndSubmitInteraction: jest.fn().mockResolvedValue({ redirectTo: `/sign-in` }),
+  registerWithVerifiedIdentifier: jest.fn().mockResolvedValue({ redirectTo: `/sign-in` }),
   signInWithSso: jest.fn().mockResolvedValue({ redirectTo: `/sign-in` }),
+}));
+
+jest.mock('@/hooks/use-global-redirect-to', () => ({
+  __esModule: true,
+  default: mockUseGlobalRedirectTo,
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -32,10 +51,29 @@ jest.mock('react-router-dom', () => ({
 
 const mockUseSearchParameters = useSearchParams as jest.Mock;
 const mockNavigate = Navigate as jest.Mock;
+const mockedVerifySocialVerification = verifySocialVerification as jest.MockedFunction<
+  typeof verifySocialVerification
+>;
+const mockedIdentifyAndSubmitInteraction = identifyAndSubmitInteraction as jest.MockedFunction<
+  typeof identifyAndSubmitInteraction
+>;
+const mockedRegisterWithVerifiedIdentifier = registerWithVerifiedIdentifier as jest.MockedFunction<
+  typeof registerWithVerifiedIdentifier
+>;
 
 const verificationIdsMap = {
   [VerificationType.Social]: 'foo',
   [VerificationType.EnterpriseSso]: 'bar',
+};
+
+const createRequestError = (body: RequestErrorBody) => {
+  const response = {
+    status: 400,
+    statusText: 'Bad Request',
+    json: async () => body,
+  } as unknown as Response;
+
+  return new HTTPError(response, {} as Request, {} as never);
 };
 
 describe('SocialCallbackPage — social sign-in', () => {
@@ -47,7 +85,10 @@ describe('SocialCallbackPage — social sign-in', () => {
   });
 
   beforeEach(() => {
-    (verifySocialVerification as jest.Mock).mockClear();
+    jest.clearAllMocks();
+    mockedVerifySocialVerification.mockResolvedValue({ verificationId: 'foo' });
+    mockedIdentifyAndSubmitInteraction.mockResolvedValue({ redirectTo: `/sign-in` });
+    mockedRegisterWithVerifiedIdentifier.mockResolvedValue({ redirectTo: `/sign-in` });
   });
 
   describe('fallback', () => {
@@ -116,6 +157,60 @@ describe('SocialCallbackPage — social sign-in', () => {
 
       await waitFor(() => {
         expect(verifySocialVerification).not.toBeCalled();
+      });
+    });
+
+    it('should redirect to the Logto sign-in page after blocked social registration', async () => {
+      const state = generateState();
+      storeState(state, connectorId);
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
+        jest.fn(),
+      ]);
+      mockedIdentifyAndSubmitInteraction.mockRejectedValueOnce(
+        createRequestError({
+          code: 'user.identity_not_exist',
+          message: 'User does not exist.',
+          data: {},
+        })
+      );
+      mockedRegisterWithVerifiedIdentifier.mockRejectedValueOnce(
+        createRequestError({
+          code: 'session.email_blocklist.email_not_allowed',
+          message: 'Email is blocked.',
+          data: undefined,
+        })
+      );
+
+      const { getByText, findByText } = renderWithPageContext(
+        <SettingsProvider
+          settings={{
+            ...mockSignInExperienceSettings,
+            agreeToTermsPolicy: AgreeToTermsPolicy.Automatic,
+          }}
+        >
+          <ConfirmModalProvider>
+            <UserInteractionContextProvider>
+              <Routes>
+                <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+                <Route path="/sign-in" element={<div>Sign in page</div>} />
+              </Routes>
+            </UserInteractionContextProvider>
+          </ConfirmModalProvider>
+        </SettingsProvider>,
+        {
+          initialEntries: ['/provider/continue', `/callback/social/${connectorId}`],
+          initialIndex: 1,
+        }
+      );
+
+      expect(await findByText('Email is blocked.')).not.toBeNull();
+
+      fireEvent.click(getByText('action.got_it'));
+
+      await waitFor(() => {
+        expect(getByText('Sign in page')).not.toBeNull();
       });
     });
   });

--- a/packages/experience/src/pages/SocialSignInWebCallback/sso-callback.test.tsx
+++ b/packages/experience/src/pages/SocialSignInWebCallback/sso-callback.test.tsx
@@ -1,18 +1,26 @@
-import { VerificationType } from '@logto/schemas';
-import { renderHook, waitFor } from '@testing-library/react';
+import { AgreeToTermsPolicy, type RequestErrorBody, VerificationType } from '@logto/schemas';
+import { fireEvent, renderHook, waitFor } from '@testing-library/react';
+import { HTTPError } from 'ky';
 import { Route, Routes, useSearchParams } from 'react-router-dom';
 
+import ConfirmModalProvider from '@/Providers/ConfirmModalProvider';
 import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
 import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
 import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
 import { mockSignInExperienceSettings, mockSsoConnectors } from '@/__mocks__/logto';
-import { signInWithSso } from '@/apis/experience';
+import { registerWithVerifiedIdentifier, signInWithSso } from '@/apis/experience';
 import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
 import { type SignInExperienceResponse } from '@/types';
 import { generateState, storeState } from '@/utils/social-connectors';
 import { storeRedirectContext } from '@/utils/social-redirect-fallback-context';
 
 import SocialCallback from '.';
+
+const mockRedirectTo = jest.fn();
+
+function mockUseGlobalRedirectTo() {
+  return mockRedirectTo;
+}
 
 jest.mock('i18next', () => ({
   ...jest.requireActual('i18next'),
@@ -22,7 +30,13 @@ jest.mock('i18next', () => ({
 jest.mock('@/apis/experience', () => ({
   verifySocialVerification: jest.fn().mockResolvedValue({ verificationId: 'foo' }),
   identifyAndSubmitInteraction: jest.fn().mockResolvedValue({ redirectTo: `/sign-in` }),
+  registerWithVerifiedIdentifier: jest.fn().mockResolvedValue({ redirectTo: `/sign-in` }),
   signInWithSso: jest.fn().mockResolvedValue({ redirectTo: `/sign-in` }),
+}));
+
+jest.mock('@/hooks/use-global-redirect-to', () => ({
+  __esModule: true,
+  default: mockUseGlobalRedirectTo,
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -32,6 +46,10 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const mockUseSearchParameters = useSearchParams as jest.Mock;
+const mockedRegisterWithVerifiedIdentifier = registerWithVerifiedIdentifier as jest.MockedFunction<
+  typeof registerWithVerifiedIdentifier
+>;
+const mockedSignInWithSso = signInWithSso as jest.MockedFunction<typeof signInWithSso>;
 
 const verificationIdsMap = {
   [VerificationType.Social]: 'foo',
@@ -43,6 +61,16 @@ const sieSettings: SignInExperienceResponse = {
   ssoConnectors: mockSsoConnectors,
 };
 
+const createRequestError = (body: RequestErrorBody) => {
+  const response = {
+    status: 400,
+    statusText: 'Bad Request',
+    json: async () => body,
+  } as unknown as Response;
+
+  return new HTTPError(response, {} as Request, {} as never);
+};
+
 describe('SocialCallbackPage — single sign-on', () => {
   const { result } = renderHook(() => useSessionStorage());
   const { set } = result.current;
@@ -52,7 +80,9 @@ describe('SocialCallbackPage — single sign-on', () => {
   });
 
   beforeEach(() => {
-    (signInWithSso as jest.Mock).mockClear();
+    jest.clearAllMocks();
+    mockedRegisterWithVerifiedIdentifier.mockResolvedValue({ redirectTo: `/sign-in` });
+    mockedSignInWithSso.mockResolvedValue({ redirectTo: `/sign-in` });
   });
 
   describe('normal path', () => {
@@ -101,6 +131,60 @@ describe('SocialCallbackPage — single sign-on', () => {
 
       await waitFor(() => {
         expect(signInWithSso).not.toBeCalled();
+      });
+    });
+
+    it('should redirect to the Logto sign-in page after blocked single sign-on registration', async () => {
+      const state = generateState();
+      storeState(state, connectorId);
+
+      mockUseSearchParameters.mockReturnValue([
+        new URLSearchParams(`state=${state}&code=foo`),
+        jest.fn(),
+      ]);
+      mockedSignInWithSso.mockRejectedValueOnce(
+        createRequestError({
+          code: 'user.sso_identity_not_exist',
+          message: 'SSO identity does not exist.',
+          data: undefined,
+        })
+      );
+      mockedRegisterWithVerifiedIdentifier.mockRejectedValueOnce(
+        createRequestError({
+          code: 'session.email_blocklist.email_not_allowed',
+          message: 'Email is blocked.',
+          data: undefined,
+        })
+      );
+
+      const { findByText, getByText } = renderWithPageContext(
+        <SettingsProvider
+          settings={{
+            ...sieSettings,
+            agreeToTermsPolicy: AgreeToTermsPolicy.Automatic,
+          }}
+        >
+          <ConfirmModalProvider>
+            <UserInteractionContextProvider>
+              <Routes>
+                <Route path="/callback/social/:connectorId" element={<SocialCallback />} />
+                <Route path="/sign-in" element={<div>Sign in page</div>} />
+              </Routes>
+            </UserInteractionContextProvider>
+          </ConfirmModalProvider>
+        </SettingsProvider>,
+        {
+          initialEntries: ['/provider/continue', `/callback/social/${connectorId}`],
+          initialIndex: 1,
+        }
+      );
+
+      expect(await findByText('Email is blocked.')).not.toBeNull();
+
+      fireEvent.click(getByText('action.got_it'));
+
+      await waitFor(() => {
+        expect(getByText('Sign in page')).not.toBeNull();
       });
     });
   });

--- a/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
+++ b/packages/experience/src/pages/SocialSignInWebCallback/use-single-sign-on-listener.ts
@@ -15,9 +15,13 @@ import useTerms from '@/hooks/use-terms';
 import useToast from '@/hooks/use-toast';
 import { parseQueryParameters } from '@/utils';
 
-const useSingleSignOnRegister = () => {
+type SingleSignOnRegisterOptions = {
+  readonly onEmailBlocked?: () => void;
+};
+
+const useSingleSignOnRegister = ({ onEmailBlocked }: SingleSignOnRegisterOptions = {}) => {
   const handleError = useErrorHandler();
-  const emailBlockedErrorHandler = useEmailBlockedErrorHandler();
+  const emailBlockedErrorHandler = useEmailBlockedErrorHandler({ onConfirm: onEmailBlocked });
 
   const request = useApi(registerWithVerifiedIdentifier);
   const { termsValidation, agreeToTermsPolicy } = useTerms();
@@ -89,7 +93,14 @@ const useSingleSignOnListener = (connectorId: string) => {
   const navigate = useNavigateWithPreservedSearchParams();
 
   const singleSignOnAuthorizationRequest = useApi(signInWithSso);
-  const registerSingleSignOnIdentity = useSingleSignOnRegister();
+
+  const navigateToSignIn = useCallback(() => {
+    navigate('/' + experience.routes.signIn, { replace: true });
+  }, [navigate]);
+
+  const registerSingleSignOnIdentity = useSingleSignOnRegister({
+    onEmailBlocked: navigateToSignIn,
+  });
 
   const singleSignOnHandler = useCallback(
     async (connectorId: string, verificationId: string, data: Record<string, unknown>) => {
@@ -109,7 +120,7 @@ const useSingleSignOnListener = (connectorId: string) => {
             // Should not let user register new social account under sign-in only mode
             if (signInMode === SignInMode.SignIn) {
               setToast(error.message);
-              navigate('/' + experience.routes.signIn);
+              navigateToSignIn();
               return;
             }
 
@@ -118,7 +129,7 @@ const useSingleSignOnListener = (connectorId: string) => {
           // Redirect to sign-in page if error is not handled by the error handlers
           global: async (error) => {
             setToast(error.message);
-            navigate('/' + experience.routes.signIn);
+            navigateToSignIn();
           },
         });
         return;
@@ -130,7 +141,7 @@ const useSingleSignOnListener = (connectorId: string) => {
     },
     [
       handleError,
-      navigate,
+      navigateToSignIn,
       redirectTo,
       registerSingleSignOnIdentity,
       setToast,
@@ -156,7 +167,7 @@ const useSingleSignOnListener = (connectorId: string) => {
 
     if (!result.valid) {
       setToast(t(`error.${result.error}`));
-      navigate('/' + experience.routes.signIn);
+      navigateToSignIn();
       return;
     }
 
@@ -164,7 +175,7 @@ const useSingleSignOnListener = (connectorId: string) => {
   }, [
     connectorId,
     isConsumed,
-    navigate,
+    navigateToSignIn,
     searchParameters,
     setSearchParameters,
     setToast,

--- a/packages/experience/src/pages/SocialSignInWebCallback/use-social-sign-in-listener.ts
+++ b/packages/experience/src/pages/SocialSignInWebCallback/use-social-sign-in-listener.ts
@@ -50,11 +50,19 @@ const useSocialSignInListener = (connectorId: string) => {
   const navigate = useNavigateWithPreservedSearchParams();
   const handleError = useErrorHandler();
   const bindSocialRelatedUser = useBindSocialRelatedUser();
-  const registerWithSocial = useSocialRegister(connectorId, true);
   const verifySocial = useApi(verifySocialVerification);
   const asyncSignInWithSocial = useApi(identifyAndSubmitInteraction);
   const asyncInitInteraction = useApi(initInteraction);
   const redirectTo = useGlobalRedirectTo();
+
+  const navigateToSignIn = useCallback(() => {
+    navigate('/' + experience.routes.signIn, { replace: true });
+  }, [navigate]);
+
+  const registerWithSocial = useSocialRegister(connectorId, {
+    replace: true,
+    onEmailBlocked: navigateToSignIn,
+  });
 
   const accountNotExistErrorHandler = useCallback(
     async (error: RequestErrorBody) => {
@@ -65,7 +73,7 @@ const useSocialSignInListener = (connectorId: string) => {
       // Redirect to sign-in page if the verificationId is not set properly
       if (!verificationId) {
         setToast(t('error.invalid_session'));
-        navigate('/' + experience.routes.signIn);
+        navigateToSignIn();
         return;
       }
 
@@ -85,7 +93,7 @@ const useSocialSignInListener = (connectorId: string) => {
       // Should not let user register new social account under sign-in only mode
       if (signInMode === SignInMode.SignIn) {
         setToast(error.message);
-        navigate('/' + experience.routes.signIn);
+        navigateToSignIn();
         return;
       }
 
@@ -96,6 +104,7 @@ const useSocialSignInListener = (connectorId: string) => {
       bindSocialRelatedUser,
       connectorId,
       navigate,
+      navigateToSignIn,
       registerWithSocial,
       setToast,
       signInMode,
@@ -108,13 +117,14 @@ const useSocialSignInListener = (connectorId: string) => {
   const globalErrorHandler = useCallback(
     async (error: RequestErrorBody) => {
       setToast(error.message);
-      navigate('/' + experience.routes.signIn);
+      navigateToSignIn();
     },
-    [navigate, setToast]
+    [navigateToSignIn, setToast]
   );
 
   const preSignInErrorHandler = useSubmitInteractionErrorHandler(InteractionEvent.SignIn, {
     replace: true,
+    onEmailBlocked: navigateToSignIn,
   });
 
   const signInWithSocialErrorHandlers: ErrorHandlers = useMemo(


### PR DESCRIPTION
## Summary
Improve the social and SSO auth flow so users return to the Logto sign-in page after acknowledging a blocked email error, instead of being sent back to the third-party provider page.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments