### PR TITLE
feat: release email allowlist feature

### DIFF
--- a/.changeset/release-email-allowlist.md
+++ b/.changeset/release-email-allowlist.md
@@ -1,0 +1,6 @@
+---
+"@logto/core": minor
+"@logto/console": minor
+---
+
+add email allowlist support for email registration and account email updates

--- a/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.test.tsx
+++ b/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.test.tsx
@@ -9,7 +9,6 @@ import BlocklistForm from '.';
 
 const mockPatch = jest.fn();
 const mockMutateGlobal = jest.fn();
-const mockIsDevFeaturesEnabled = jest.fn(() => true);
 
 jest.mock('react-hot-toast', () => ({
   toast: {
@@ -32,9 +31,6 @@ jest.mock('@/consts', () => ({
 
 jest.mock('@/consts/env', () => ({
   isCloud: true,
-  get isDevFeaturesEnabled() {
-    return mockIsDevFeaturesEnabled();
-  },
 }));
 
 jest.mock('@/consts/subscriptions', () => ({
@@ -180,7 +176,6 @@ const addCustomAllowlistValue = async (value: string) => {
 describe('BlocklistForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockIsDevFeaturesEnabled.mockReturnValue(true);
     mockPatch.mockReturnValue({
       json: async () => ({
         emailBlocklistPolicy: {
@@ -214,14 +209,6 @@ describe('BlocklistForm', () => {
     );
   });
 
-  it('does not render the custom allowlist section when dev features are disabled', () => {
-    mockIsDevFeaturesEnabled.mockReturnValue(false);
-    renderBlocklistForm();
-
-    expect(screen.queryByText('allowed@example.com')).toBeNull();
-    expect(screen.queryByText('security.blocklist.custom_email_allowlist.title')).toBeNull();
-  });
-
   it('sends customAllowlist in the sign-in experience patch payload', async () => {
     renderBlocklistForm();
 
@@ -242,25 +229,6 @@ describe('BlocklistForm', () => {
     });
     expect(mockMutateGlobal).toHaveBeenCalledWith('api/sign-in-exp');
     expect(toast.success).toHaveBeenCalledWith('admin_console.general.saved');
-  });
-
-  it('omits customAllowlist from the sign-in experience patch payload when dev features are disabled', async () => {
-    mockIsDevFeaturesEnabled.mockReturnValue(false);
-    renderBlocklistForm();
-
-    fireEvent.click(screen.getByText('general.save_changes'));
-
-    await waitFor(() => {
-      expect(mockPatch).toHaveBeenCalledWith('api/sign-in-exp', {
-        json: {
-          emailBlocklistPolicy: {
-            blockDisposableAddresses: false,
-            blockSubaddressing: true,
-            customBlocklist: ['@blocked.com'],
-          },
-        },
-      });
-    });
   });
 
   it('shows cheap warnings without blocking save', async () => {

--- a/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.tsx
+++ b/packages/console/src/pages/Security/Blocklist/BlocklistForm/index.tsx
@@ -12,7 +12,7 @@ import FormCard from '@/components/FormCard';
 import MultiOptionInput from '@/components/MultiOptionInput';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { emailBlocklist } from '@/consts';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { latestProPlanId } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import FormField from '@/ds-components/FormField';
@@ -33,18 +33,6 @@ import styles from './index.module.scss';
 
 type Props = {
   readonly formData: EmailBlocklistPolicyFormData;
-};
-
-// Dev feature guard for the custom email allowlist configuration.
-const buildEmailBlocklistPolicyPayload = (emailBlocklistPolicy: EmailBlocklistPolicyFormData) => {
-  if (isDevFeaturesEnabled) {
-    return emailBlocklistPolicy;
-  }
-
-  const { customAllowlist: _customAllowlist, ...emailBlocklistPolicyWithoutDevFeatures } =
-    emailBlocklistPolicy;
-
-  return emailBlocklistPolicyWithoutDevFeatures;
 };
 
 function BlocklistForm({ formData }: Props) {
@@ -87,7 +75,7 @@ function BlocklistForm({ formData }: Props) {
       const { emailBlocklistPolicy: updatedEmailBlocklistPolicy } = await api
         .patch('api/sign-in-exp', {
           json: {
-            emailBlocklistPolicy: buildEmailBlocklistPolicyPayload(emailBlocklistPolicy),
+            emailBlocklistPolicy,
           },
         })
         .json<SignInExperience>();
@@ -177,59 +165,57 @@ function BlocklistForm({ formData }: Props) {
               )}
             />
           </FormField>
-          {isDevFeaturesEnabled && (
-            <FormField title="security.blocklist.custom_email_allowlist.title">
-              <div className={styles.fieldDescription}>
-                {t('blocklist.custom_email_allowlist.description')}
-              </div>
-              <Controller
-                name="customAllowlist"
-                control={control}
-                render={({ field: { onChange, value = [] } }) => (
-                  <MultiOptionInput
-                    disabled={isFreeTenant}
-                    values={value}
-                    placeholder={t('blocklist.custom_email_allowlist.placeholder')}
-                    renderValue={(value) => value}
-                    validateInput={(input) => {
-                      if (
-                        value.some(
-                          (existingValue) => existingValue.toLowerCase() === input.toLowerCase()
-                        )
-                      ) {
-                        return t('blocklist.custom_email_allowlist.duplicate_error');
-                      }
+          <FormField title="security.blocklist.custom_email_allowlist.title">
+            <div className={styles.fieldDescription}>
+              {t('blocklist.custom_email_allowlist.description')}
+            </div>
+            <Controller
+              name="customAllowlist"
+              control={control}
+              render={({ field: { onChange, value = [] } }) => (
+                <MultiOptionInput
+                  disabled={isFreeTenant}
+                  values={value}
+                  placeholder={t('blocklist.custom_email_allowlist.placeholder')}
+                  renderValue={(value) => value}
+                  validateInput={(input) => {
+                    if (
+                      value.some(
+                        (existingValue) => existingValue.toLowerCase() === input.toLowerCase()
+                      )
+                    ) {
+                      return t('blocklist.custom_email_allowlist.duplicate_error');
+                    }
 
-                      if (!isEmailBlocklistItem(input)) {
-                        return t('blocklist.custom_email_allowlist.invalid_format_error');
-                      }
+                    if (!isEmailBlocklistItem(input)) {
+                      return t('blocklist.custom_email_allowlist.invalid_format_error');
+                    }
 
-                      return { value: input };
-                    }}
-                    error={errors.customAllowlist?.message}
-                    onChange={onChange}
-                    onError={(error) => {
-                      setError('customAllowlist', { type: 'custom', message: error });
-                    }}
-                    onClearError={() => {
-                      clearErrors('customAllowlist');
-                    }}
-                  />
-                )}
-              />
-              {emailAllowlistWarnings.length > 0 && (
-                <InlineNotification className={styles.allowlistWarning} severity="alert">
-                  <ul className={styles.warningList}>
-                    {emailAllowlistWarnings.map((warning) => (
-                      <li key={warning}>
-                        {t(`blocklist.custom_email_allowlist.warnings.${warning}`)}
-                      </li>
-                    ))}
-                  </ul>
-                </InlineNotification>
+                    return { value: input };
+                  }}
+                  error={errors.customAllowlist?.message}
+                  onChange={onChange}
+                  onError={(error) => {
+                    setError('customAllowlist', { type: 'custom', message: error });
+                  }}
+                  onClearError={() => {
+                    clearErrors('customAllowlist');
+                  }}
+                />
               )}
-            </FormField>
-          )}
+            />
+            {emailAllowlistWarnings.length > 0 && (
+              <InlineNotification className={styles.allowlistWarning} severity="alert">
+                <ul className={styles.warningList}>
+                  {emailAllowlistWarnings.map((warning) => (
+                    <li key={warning}>
+                      {t(`blocklist.custom_email_allowlist.warnings.${warning}`)}
+                    </li>
+                  ))}
+                </ul>
+              </InlineNotification>
+            )}
+          </FormField>
         </FormCard>
       </DetailsForm>
       <UnsavedChangesAlertModal hasUnsavedChanges={isDirty} />

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.test.ts
@@ -1,7 +1,6 @@
 import { type EmailBlocklistPolicy } from '@logto/schemas';
 import { deduplicate } from '@silverhand/essentials';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 
 import {
@@ -20,12 +19,6 @@ const buildPolicyWithCustomList = (
 ): EmailBlocklistPolicy => ({
   [key]: list,
 });
-
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-
-const setIsDevFeaturesEnabled = (value: boolean) => {
-  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', value);
-};
 
 describe('parseEmailBlocklistPolicy', () => {
   it.each(customListKeys)('should throw error for invalid %s item', (key) => {
@@ -68,14 +61,6 @@ describe('validateEmailAgainstBlocklistPolicy', () => {
     blockSubaddressing: true,
     customBlocklist: ['foo@bar.com', '@foo.com'],
   };
-
-  beforeAll(() => {
-    setIsDevFeaturesEnabled(true);
-  });
-
-  afterAll(() => {
-    setIsDevFeaturesEnabled(originalIsDevFeaturesEnabled);
-  });
 
   it('should throw if the email uses subaddressing', async () => {
     await expect(

--- a/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
+++ b/packages/core/src/libraries/sign-in-experience/email-blocklist-policy.ts
@@ -154,7 +154,7 @@ export const validateEmailAgainstBlocklistPolicy = async (
   }
 
   // Guard custom email allowlist if provided.
-  if (EnvSet.values.isDevFeaturesEnabled && customAllowlist && customAllowlist.length > 0) {
+  if (customAllowlist && customAllowlist.length > 0) {
     const isCustomAllowlisted = customAllowlist.some((item) =>
       matchesEmailBlocklistItem(item, email)
     );

--- a/packages/core/src/routes/sign-in-experience/index.openapi.json
+++ b/packages/core/src/routes/sign-in-experience/index.openapi.json
@@ -105,8 +105,7 @@
                           "description": "Whether to block sub-addresses. (E.g., example+shopping@test.com)"
                         },
                         "customAllowlist": {
-                          "description": "Dev feature. Custom allowlist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`.",
-                          "x-logto-dev-feature": true
+                          "description": "Custom allowlist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`."
                         },
                         "customBlocklist": {
                           "description": "Custom blocklist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`."
@@ -223,8 +222,7 @@
                         "description": "Whether to block sub-addresses. (E.g., example+shopping@test.com)"
                       },
                       "customAllowlist": {
-                        "description": "Dev feature. Custom allowlist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`.",
-                        "x-logto-dev-feature": true
+                        "description": "Custom allowlist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`."
                       },
                       "customBlocklist": {
                         "description": "Custom blocklist of email addresses, domains, or wildcard email address patterns. Examples: `bar@example.com`, `@example.com`, `foo*@example.com`, `@*.example.com`."

--- a/packages/core/src/routes/sign-in-experience/index.test.ts
+++ b/packages/core/src/routes/sign-in-experience/index.test.ts
@@ -840,7 +840,7 @@ describe('sign-in experience routes with dev features disabled', () => {
     });
   });
 
-  it('should omit custom allowlist from GET response', async () => {
+  it('should include custom allowlist in GET response', async () => {
     const emailBlocklistPolicy = {
       customAllowlist: ['@allowed.com'],
       customBlocklist: ['@blocked.com'],
@@ -853,22 +853,21 @@ describe('sign-in experience routes with dev features disabled', () => {
     const response = await requester.get('/sign-in-exp');
 
     expect(response.status).toEqual(200);
-    expect(response.body.emailBlocklistPolicy).toEqual({
-      customBlocklist: emailBlocklistPolicy.customBlocklist,
-    });
+    expect(response.body.emailBlocklistPolicy).toEqual(emailBlocklistPolicy);
   });
 
-  it('should reject custom allowlist updates', async () => {
+  it('should accept custom allowlist updates', async () => {
     const { requester, updateDefaultSignInExperience } = await createDevFeaturesDisabledRequester();
+    const emailBlocklistPolicy = {
+      customAllowlist: ['@allowed.com'],
+    };
 
     const response = await requester.patch('/sign-in-exp').send({
-      emailBlocklistPolicy: {
-        customAllowlist: ['@allowed.com'],
-      },
+      emailBlocklistPolicy,
     });
 
-    expect(response.status).toEqual(400);
-    expect(updateDefaultSignInExperience).not.toHaveBeenCalled();
+    expect(response.status).toEqual(200);
+    expect(updateDefaultSignInExperience).toHaveBeenCalledWith({ emailBlocklistPolicy });
   });
 });
 

--- a/packages/core/src/routes/sign-in-experience/index.ts
+++ b/packages/core/src/routes/sign-in-experience/index.ts
@@ -43,30 +43,6 @@ const isNonSkippableMfaPromptPolicy = (policy: MfaPolicy) =>
     policy
   );
 
-// Dev feature guard for the custom email allowlist configuration.
-const hasCustomAllowlistProperty = (
-  emailBlocklistPolicy: Optional<SignInExperience['emailBlocklistPolicy']>
-) => Boolean(emailBlocklistPolicy && 'customAllowlist' in emailBlocklistPolicy);
-
-const omitDevFeatureEmailBlocklistPolicyProperties = (
-  signInExperience: SignInExperience
-): SignInExperience => {
-  if (
-    EnvSet.values.isDevFeaturesEnabled ||
-    !hasCustomAllowlistProperty(signInExperience.emailBlocklistPolicy)
-  ) {
-    return signInExperience;
-  }
-
-  const { customAllowlist: _customAllowlist, ...emailBlocklistPolicy } =
-    signInExperience.emailBlocklistPolicy;
-
-  return {
-    ...signInExperience,
-    emailBlocklistPolicy,
-  };
-};
-
 const signInExperienceResponseGuard = SignInExperiences.guard;
 const signInExperienceCreateGuard = SignInExperiences.createGuard;
 
@@ -95,7 +71,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
       status: [200, 404],
     }),
     async (ctx, next) => {
-      ctx.body = omitDevFeatureEmailBlocklistPolicyProperties(await findDefaultSignInExperience());
+      ctx.body = await findDefaultSignInExperience();
 
       return next();
     }
@@ -171,16 +147,6 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         getLogtoConnectors(),
         findDefaultSignInExperience(),
       ]);
-
-      if (hasCustomAllowlistProperty(emailBlocklistPolicy)) {
-        assertThat(
-          EnvSet.values.isDevFeaturesEnabled,
-          new RequestError({
-            code: 'request.invalid_input',
-            details: 'Email allowlist configuration is not available',
-          })
-        );
-      }
 
       // Flipping usernames to case-insensitive would merge accounts that differ only by case, so
       // reject the flip while such conflicts exist. Only the actual case-sensitive ->
@@ -437,9 +403,7 @@ export default function signInExperiencesRoutes<T extends ManagementApiRouter>(
         ...conditional(verificationCodePolicy && { verificationCodePolicy }),
       };
 
-      ctx.body = omitDevFeatureEmailBlocklistPolicyProperties(
-        await updateDefaultSignInExperience(payload)
-      );
+      ctx.body = await updateDefaultSignInExperience(payload);
 
       void quota.reportSubscriptionUpdatesUsage('mfaEnabled');
 

--- a/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
+++ b/packages/integration-tests/src/tests/api/account/email-and-phone.test.ts
@@ -26,12 +26,7 @@ import {
   signInAndGetUserApi,
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import {
-  devFeatureTest,
-  generateEmail,
-  generatePhone,
-  generateNationalPhoneNumber,
-} from '#src/utils.js';
+import { generateEmail, generatePhone, generateNationalPhoneNumber } from '#src/utils.js';
 
 const expectPrimaryEmailUpdateRejectedByBlocklist = async (
   email: string,
@@ -279,14 +274,11 @@ describe('account (email and phone)', () => {
       await expectPrimaryEmailUpdateRejectedByBlocklist(email, ['FOO*@ACCOUNT-WILDCARD.COM']);
     });
 
-    devFeatureTest.it(
-      'should reject the email if the email does not match the allowlist',
-      async () => {
-        const email = generateEmail('account-allowlist.com');
+    it('should reject the email if the email does not match the allowlist', async () => {
+      const email = generateEmail('account-allowlist.com');
 
-        await expectPrimaryEmailUpdateRejectedByAllowlist(email, ['@different-account-domain.com']);
-      }
-    );
+      await expectPrimaryEmailUpdateRejectedByAllowlist(email, ['@different-account-domain.com']);
+    });
   });
 
   describe('DELETE /my-account/primary-email', () => {

--- a/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/register-interaction/email-blocklist.test.ts
@@ -21,7 +21,7 @@ import {
   deleteDefaultTenantUser,
 } from '#src/helpers/profile.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateEmail } from '#src/utils.js';
+import { generateEmail } from '#src/utils.js';
 
 const emailNotAllowedError = {
   code: 'session.email_blocklist.email_not_allowed',
@@ -230,7 +230,7 @@ describe('should reject the email registration if the email is in the blocklist'
   });
 });
 
-devFeatureTest.describe('should enforce the email allowlist for new email registrations', () => {
+describe('should enforce the email allowlist for new email registrations', () => {
   const exactAllowedEmail = generateEmail('allowlist-exact.com');
   const allowedDomain = 'allowlist-domain.com';
   const wildcardLocalPartDomain = 'allowlist-local.com';

--- a/packages/integration-tests/src/tests/api/well-known.test.ts
+++ b/packages/integration-tests/src/tests/api/well-known.test.ts
@@ -19,7 +19,7 @@ import {
 import { createSsoConnector, deleteSsoConnectorById } from '#src/api/sso-connector.js';
 import { newOidcSsoConnectorPayload } from '#src/constants.js';
 import { setLanguage } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateSsoConnectorName } from '#src/utils.js';
+import { generateSsoConnectorName } from '#src/utils.js';
 
 describe('.well-known api', () => {
   it('should return tenant endpoint URL for any given tenant id', async () => {
@@ -61,30 +61,27 @@ describe('.well-known api', () => {
     expect(response).toHaveProperty('adaptiveMfa');
   });
 
-  devFeatureTest.it(
-    'should not expose email access policies in public sign-in experience',
-    async () => {
-      const { emailBlocklistPolicy } = await getSignInExperience();
+  it('should not expose email access policies in public sign-in experience', async () => {
+    const { emailBlocklistPolicy } = await getSignInExperience();
 
-      try {
-        await updateSignInExperience({
-          emailBlocklistPolicy: {
-            blockSubaddressing: true,
-            customAllowlist: ['@allowed.com'],
-            customBlocklist: ['@blocked.com'],
-          },
-        });
+    try {
+      await updateSignInExperience({
+        emailBlocklistPolicy: {
+          blockSubaddressing: true,
+          customAllowlist: ['@allowed.com'],
+          customBlocklist: ['@blocked.com'],
+        },
+      });
 
-        const response = await api.get('.well-known/sign-in-exp').json<Record<string, unknown>>();
+      const response = await api.get('.well-known/sign-in-exp').json<Record<string, unknown>>();
 
-        expect(response).not.toHaveProperty('emailBlocklistPolicy');
-      } finally {
-        await updateSignInExperience({
-          emailBlocklistPolicy,
-        });
-      }
+      expect(response).not.toHaveProperty('emailBlocklistPolicy');
+    } finally {
+      await updateSignInExperience({
+        emailBlocklistPolicy,
+      });
     }
-  );
+  });
 
   // Also test for Redis cache invalidation
   it('should be able to return updated phrases', async () => {


### PR DESCRIPTION
## Summary
Enable email allowlist as a released email restriction capability across Console, Management API responses, OpenAPI docs, and email restriction enforcement.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments