### PR TITLE
fix(core): harden inline hook audit data sanitization

### DIFF
--- a/packages/core/src/libraries/inline-hook-sanitization.test.ts
+++ b/packages/core/src/libraries/inline-hook-sanitization.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildSafeInlineHookErrorSummary,
   buildSafeInlineHookTelemetryError,
   sanitizeInlineHookEvent,
   sanitizeInlineHookResult,
@@ -49,5 +50,56 @@ describe('sanitizeInlineHookResult', () => {
       message: 'execution failed for [redacted]',
     });
     expect(JSON.stringify({ sanitizedEvent, telemetryError })).not.toContain(sensitiveValue);
+  });
+
+  it('uses the shared sensitive-data policy while preserving safe metadata', () => {
+    const sanitizedEvent = sanitizeInlineHookEvent(
+      {
+        javaScript: 'private script',
+        environmentVariablesBackup: { TOKEN: 'private environment value' },
+        applicationSecret: { name: 'rotation-2' },
+        unsafeApplicationSecret: { name: 'rotation-2', value: 'private application secret' },
+        passwordVerified: true,
+      },
+      []
+    );
+
+    expect(sanitizedEvent).toEqual({
+      applicationSecret: { name: 'rotation-2' },
+      unsafeApplicationSecret: '******',
+      passwordVerified: true,
+    });
+  });
+
+  it('keeps only safe validation issue fields from wrapped runner errors', () => {
+    const sensitiveValue = 'private-field-name';
+    const summary = buildSafeInlineHookErrorSummary(
+      {
+        message: `Invalid ${sensitiveValue}`,
+        error: {
+          errors: [
+            {
+              path: ['event', sensitiveValue, 0],
+              code: 'invalid_type',
+              message: sensitiveValue,
+              received: sensitiveValue,
+            },
+            {
+              path: sensitiveValue,
+              code: `unknown-${sensitiveValue}`,
+            },
+          ],
+          request: { authorization: sensitiveValue },
+        },
+      },
+      [sensitiveValue]
+    );
+
+    expect(summary).toEqual({
+      name: 'Error',
+      message: 'Invalid [redacted]',
+      errors: [{ path: ['event', '[redacted]', 0], code: 'invalid_type' }],
+    });
+    expect(JSON.stringify(summary)).not.toContain(sensitiveValue);
   });
 });

--- a/packages/core/src/libraries/inline-hook-sanitization.test.ts
+++ b/packages/core/src/libraries/inline-hook-sanitization.test.ts
@@ -1,0 +1,53 @@
+import {
+  buildSafeInlineHookTelemetryError,
+  sanitizeInlineHookEvent,
+  sanitizeInlineHookResult,
+} from './inline-hook-sanitization.js';
+
+describe('sanitizeInlineHookResult', () => {
+  it('redacts sensitive values from untrusted property names', () => {
+    const sensitiveValue = 'environment-secret-value';
+    const sanitizedResult = sanitizeInlineHookResult(
+      {
+        [sensitiveValue]: true,
+        nested: {
+          [`prefix-${sensitiveValue}`]: 'safe value',
+        },
+      },
+      [sensitiveValue]
+    );
+
+    expect(sanitizedResult).toEqual({
+      '[redacted]': '******',
+      nested: {
+        'prefix-[redacted]': '******',
+      },
+    });
+    expect(JSON.stringify(sanitizedResult)).not.toContain(sensitiveValue);
+  });
+
+  it('redacts sensitive values from events and telemetry errors', () => {
+    const sensitiveValue = 'plain-text-password';
+    const sanitizedEvent = sanitizeInlineHookEvent(
+      {
+        password: sensitiveValue,
+        note: `received ${sensitiveValue}`,
+      },
+      [sensitiveValue]
+    );
+    const telemetryError = buildSafeInlineHookTelemetryError(
+      new Error(`execution failed for ${sensitiveValue}`),
+      [sensitiveValue]
+    );
+
+    expect(sanitizedEvent).toEqual({
+      password: '******',
+      note: 'received [redacted]',
+    });
+    expect(telemetryError).toMatchObject({
+      name: 'Error',
+      message: 'execution failed for [redacted]',
+    });
+    expect(JSON.stringify({ sanitizedEvent, telemetryError })).not.toContain(sensitiveValue);
+  });
+});

--- a/packages/core/src/libraries/inline-hook-sanitization.ts
+++ b/packages/core/src/libraries/inline-hook-sanitization.ts
@@ -1,0 +1,251 @@
+import type { InlineHookExecutionRequestBody } from '@logto/schemas';
+
+const maskedValue = '******';
+const redactedValue = '[redacted]';
+const fallbackErrorMessage = 'Inline hook execution failed.';
+const safeResultActions = new Set(['createUser', 'updateUser']);
+const safePasswordStatusKeys = new Set(['passwordverified', 'haspassword']);
+const exactSensitiveKeys = new Set(['authorization', 'xfunctionskey', 'token']);
+const sensitiveKeyFragments = [
+  'secret',
+  'password',
+  'apikey',
+  'privatekey',
+  'credential',
+  'cookie',
+];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
+
+const normalizeKey = (key: string) => key.replaceAll(/[_-]/g, '').toLowerCase();
+
+const shouldOmitKey = (key: string) => {
+  const normalizedKey = normalizeKey(key);
+
+  return normalizedKey === 'script' || normalizedKey === 'environmentvariables';
+};
+
+const isSensitiveKey = (key: string, value: unknown) => {
+  const normalizedKey = normalizeKey(key);
+  const isSafePasswordStatus =
+    safePasswordStatusKeys.has(normalizedKey) && typeof value === 'boolean';
+
+  return (
+    !isSafePasswordStatus &&
+    (exactSensitiveKeys.has(normalizedKey) ||
+      normalizedKey.endsWith('token') ||
+      sensitiveKeyFragments.some((fragment) => normalizedKey.includes(fragment)))
+  );
+};
+
+const collectStringLeaves = (value: unknown): string[] => {
+  if (typeof value === 'string') {
+    return value ? [value] : [];
+  }
+
+  if (isArray(value)) {
+    return value.flatMap((element) => collectStringLeaves(element));
+  }
+
+  if (isRecord(value)) {
+    return Object.values(value).flatMap((element) => collectStringLeaves(element));
+  }
+
+  return [];
+};
+
+const collectSensitiveValues = (value: unknown): string[] => {
+  if (isArray(value)) {
+    return value.flatMap((element) => collectSensitiveValues(element));
+  }
+
+  if (!isRecord(value)) {
+    return [];
+  }
+
+  return Object.entries(value).flatMap(([key, element]) => {
+    if (isSensitiveKey(key, element)) {
+      return collectStringLeaves(element);
+    }
+
+    return collectSensitiveValues(element);
+  });
+};
+
+export const getInlineHookSensitiveValues = ({
+  script,
+  event,
+  environmentVariables,
+}: Pick<InlineHookExecutionRequestBody, 'script' | 'event' | 'environmentVariables'>) =>
+  [
+    script,
+    ...script
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 2),
+    ...Object.values(environmentVariables ?? {}),
+    ...collectSensitiveValues(event),
+  ]
+    .filter(Boolean)
+    .filter((value, index, values) => values.indexOf(value) === index)
+    .toSorted((left, right) => right.length - left.length);
+
+const redactInlineHookSensitiveText = (value: string, sensitiveValues: readonly string[]) =>
+  sensitiveValues.reduce(
+    (redacted, sensitiveValue) => redacted.replaceAll(sensitiveValue, redactedValue),
+    value
+  );
+
+type SanitizeOptions = {
+  redactReturnedUser?: boolean;
+};
+
+const sanitizeInlineHookData = (
+  value: unknown,
+  sensitiveValues: readonly string[],
+  { redactReturnedUser = false }: SanitizeOptions = {},
+  seen = new WeakSet<Record<string, unknown> | unknown[]>()
+): unknown => {
+  if (typeof value === 'string') {
+    return redactInlineHookSensitiveText(value, sensitiveValues);
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'boolean' || value === null) {
+    return value;
+  }
+
+  if (typeof value === 'bigint') {
+    return String(value);
+  }
+
+  if (isArray(value)) {
+    if (seen.has(value)) {
+      return '[circular]';
+    }
+
+    seen.add(value);
+    return value
+      .map((element) =>
+        sanitizeInlineHookData(element, sensitiveValues, { redactReturnedUser }, seen)
+      )
+      .filter((element) => element !== undefined);
+  }
+
+  if (isRecord(value)) {
+    if (seen.has(value)) {
+      return '[circular]';
+    }
+
+    seen.add(value);
+    return Object.fromEntries(
+      Object.entries(value).flatMap(([key, element]) => {
+        if (shouldOmitKey(key)) {
+          return [];
+        }
+
+        const normalizedKey = normalizeKey(key);
+        const sanitizedKey = redactInlineHookSensitiveText(key, sensitiveValues);
+
+        if (redactReturnedUser && normalizedKey === 'user') {
+          return [[sanitizedKey, redactedValue]];
+        }
+
+        if (redactReturnedUser && normalizedKey === 'action') {
+          return [
+            [
+              sanitizedKey,
+              typeof element === 'string' && safeResultActions.has(element) ? element : 'invalid',
+            ],
+          ];
+        }
+
+        return [
+          [
+            sanitizedKey,
+            isSensitiveKey(key, element)
+              ? maskedValue
+              : sanitizeInlineHookData(element, sensitiveValues, { redactReturnedUser }, seen),
+          ],
+        ];
+      })
+    );
+  }
+};
+
+const safelySanitizeInlineHookData = (
+  value: unknown,
+  sensitiveValues: readonly string[],
+  options?: SanitizeOptions
+) => {
+  try {
+    return sanitizeInlineHookData(value, sensitiveValues, options);
+  } catch {
+    return '[unavailable]';
+  }
+};
+
+export const sanitizeInlineHookEvent = (event: unknown, sensitiveValues: readonly string[]) =>
+  safelySanitizeInlineHookData(event, sensitiveValues);
+
+export const sanitizeInlineHookResult = (result: unknown, sensitiveValues: readonly string[]) =>
+  safelySanitizeInlineHookData(result, sensitiveValues, { redactReturnedUser: true });
+
+const stringifyUnknownError = (error: unknown) => {
+  try {
+    return String(error);
+  } catch {
+    return fallbackErrorMessage;
+  }
+};
+
+type SafeInlineHookErrorSummary = {
+  name: string;
+  message: string;
+  status?: number;
+};
+
+const getNumberProperty = (record: Record<string, unknown> | undefined, key: string) => {
+  const value = record?.[key];
+  return typeof value === 'number' ? value : undefined;
+};
+
+export const buildSafeInlineHookErrorSummary = (
+  error: unknown,
+  sensitiveValues: readonly string[]
+): SafeInlineHookErrorSummary => {
+  try {
+    const errorRecord = isRecord(error) ? error : undefined;
+    const message =
+      error instanceof Error
+        ? error.message || fallbackErrorMessage
+        : stringifyUnknownError(error) || fallbackErrorMessage;
+    const status = getNumberProperty(errorRecord, 'status');
+
+    return {
+      name: 'Error',
+      message: redactInlineHookSensitiveText(message, sensitiveValues),
+      ...(status === undefined ? {} : { status }),
+    };
+  } catch {
+    return { name: 'Error', message: fallbackErrorMessage };
+  }
+};
+
+export const buildSafeInlineHookTelemetryError = (
+  error: unknown,
+  sensitiveValues: readonly string[]
+) => {
+  const summary = buildSafeInlineHookErrorSummary(error, sensitiveValues);
+  const telemetryError = new Error(summary.message);
+
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Preserve the safe error category only.
+  telemetryError.name = summary.name;
+
+  return telemetryError;
+};

--- a/packages/core/src/libraries/inline-hook-sanitization.ts
+++ b/packages/core/src/libraries/inline-hook-sanitization.ts
@@ -1,44 +1,20 @@
 import type { InlineHookExecutionRequestBody } from '@logto/schemas';
+import { z } from 'zod';
 
-const maskedValue = '******';
+import {
+  isArray,
+  isRecord,
+  isSensitiveDataKey,
+  normalizeSensitiveDataKey,
+  sensitiveDataMask,
+  shouldOmitSensitiveDataKey,
+  stripNullCharactersFromString,
+} from '#src/utils/sensitive-data.js';
+
 const redactedValue = '[redacted]';
 const fallbackErrorMessage = 'Inline hook execution failed.';
 const safeResultActions = new Set(['createUser', 'updateUser']);
-const safePasswordStatusKeys = new Set(['passwordverified', 'haspassword']);
-const exactSensitiveKeys = new Set(['authorization', 'xfunctionskey', 'token']);
-const sensitiveKeyFragments = [
-  'secret',
-  'password',
-  'apikey',
-  'privatekey',
-  'credential',
-  'cookie',
-];
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
-
-const normalizeKey = (key: string) => key.replaceAll(/[_-]/g, '').toLowerCase();
-
-const shouldOmitKey = (key: string) => {
-  const normalizedKey = normalizeKey(key);
-
-  return normalizedKey === 'script' || normalizedKey === 'environmentvariables';
-};
-
-const isSensitiveKey = (key: string, value: unknown) => {
-  const normalizedKey = normalizeKey(key);
-  const isSafePasswordStatus =
-    safePasswordStatusKeys.has(normalizedKey) && typeof value === 'boolean';
-
-  return (
-    !isSafePasswordStatus &&
-    (exactSensitiveKeys.has(normalizedKey) ||
-      normalizedKey.endsWith('token') ||
-      sensitiveKeyFragments.some((fragment) => normalizedKey.includes(fragment)))
-  );
-};
+const safeValidationIssueCodes = new Set<string>(Object.values(z.ZodIssueCode));
 
 const collectStringLeaves = (value: unknown): string[] => {
   if (typeof value === 'string') {
@@ -66,7 +42,7 @@ const collectSensitiveValues = (value: unknown): string[] => {
   }
 
   return Object.entries(value).flatMap(([key, element]) => {
-    if (isSensitiveKey(key, element)) {
+    if (shouldOmitSensitiveDataKey(key) || isSensitiveDataKey(key, element)) {
       return collectStringLeaves(element);
     }
 
@@ -88,15 +64,19 @@ export const getInlineHookSensitiveValues = ({
     ...Object.values(environmentVariables ?? {}),
     ...collectSensitiveValues(event),
   ]
+    .map((value) => stripNullCharactersFromString(value))
     .filter(Boolean)
     .filter((value, index, values) => values.indexOf(value) === index)
     .toSorted((left, right) => right.length - left.length);
 
 const redactInlineHookSensitiveText = (value: string, sensitiveValues: readonly string[]) =>
-  sensitiveValues.reduce(
-    (redacted, sensitiveValue) => redacted.replaceAll(sensitiveValue, redactedValue),
-    value
-  );
+  sensitiveValues.reduce((redacted, sensitiveValue) => {
+    const sanitizedSensitiveValue = stripNullCharactersFromString(sensitiveValue);
+
+    return sanitizedSensitiveValue
+      ? redacted.replaceAll(sanitizedSensitiveValue, redactedValue)
+      : redacted;
+  }, stripNullCharactersFromString(value));
 
 type SanitizeOptions = {
   redactReturnedUser?: boolean;
@@ -145,11 +125,11 @@ const sanitizeInlineHookData = (
     seen.add(value);
     return Object.fromEntries(
       Object.entries(value).flatMap(([key, element]) => {
-        if (shouldOmitKey(key)) {
+        if (shouldOmitSensitiveDataKey(key)) {
           return [];
         }
 
-        const normalizedKey = normalizeKey(key);
+        const normalizedKey = normalizeSensitiveDataKey(key);
         const sanitizedKey = redactInlineHookSensitiveText(key, sensitiveValues);
 
         if (redactReturnedUser && normalizedKey === 'user') {
@@ -168,8 +148,8 @@ const sanitizeInlineHookData = (
         return [
           [
             sanitizedKey,
-            isSensitiveKey(key, element)
-              ? maskedValue
+            isSensitiveDataKey(key, element)
+              ? sensitiveDataMask
               : sanitizeInlineHookData(element, sensitiveValues, { redactReturnedUser }, seen),
           ],
         ];
@@ -208,11 +188,93 @@ type SafeInlineHookErrorSummary = {
   name: string;
   message: string;
   status?: number;
+  errors?: SafeInlineHookValidationIssue[];
+};
+
+type SafeInlineHookValidationIssue = {
+  path: string | Array<string | number>;
+  code: string;
 };
 
 const getNumberProperty = (record: Record<string, unknown> | undefined, key: string) => {
   const value = record?.[key];
   return typeof value === 'number' ? value : undefined;
+};
+
+const getRecordProperty = (record: Record<string, unknown> | undefined, key: string) => {
+  const value = record?.[key];
+  return isRecord(value) ? value : undefined;
+};
+
+const getStringProperty = (record: Record<string, unknown> | undefined, key: string) => {
+  const value = record?.[key];
+  return typeof value === 'string' ? value : undefined;
+};
+
+const sanitizeInlineHookValidationPath = (
+  value: unknown,
+  sensitiveValues: readonly string[]
+): SafeInlineHookValidationIssue['path'] | undefined => {
+  if (typeof value === 'string') {
+    return redactInlineHookSensitiveText(value, sensitiveValues);
+  }
+
+  if (
+    isArray(value) &&
+    value.every(
+      (segment): segment is string | number =>
+        typeof segment === 'string' || (typeof segment === 'number' && Number.isFinite(segment))
+    )
+  ) {
+    return value.map((segment) =>
+      typeof segment === 'string'
+        ? redactInlineHookSensitiveText(segment, sensitiveValues)
+        : segment
+    );
+  }
+};
+
+const sanitizeInlineHookValidationIssue = (
+  value: unknown,
+  sensitiveValues: readonly string[]
+): SafeInlineHookValidationIssue | undefined => {
+  if (!isRecord(value)) {
+    return;
+  }
+
+  const { code } = value;
+  const path = sanitizeInlineHookValidationPath(value.path, sensitiveValues);
+
+  if (typeof code !== 'string' || !safeValidationIssueCodes.has(code) || path === undefined) {
+    return;
+  }
+
+  return { path, code };
+};
+
+const getValidationIssues = (record: Record<string, unknown> | undefined) => {
+  const nestedError = getRecordProperty(record, 'error');
+  const candidates = [record?.errors, record?.issues, nestedError?.errors, nestedError?.issues];
+
+  return candidates.find((value): value is unknown[] => isArray(value));
+};
+
+const getSafeInlineHookValidationIssues = (
+  records: Array<Record<string, unknown> | undefined>,
+  sensitiveValues: readonly string[]
+) => {
+  for (const record of records) {
+    const issues = getValidationIssues(record);
+
+    if (issues) {
+      return issues.flatMap((issue) => {
+        const sanitizedIssue = sanitizeInlineHookValidationIssue(issue, sensitiveValues);
+        return sanitizedIssue ? [sanitizedIssue] : [];
+      });
+    }
+  }
+
+  return [];
 };
 
 export const buildSafeInlineHookErrorSummary = (
@@ -221,16 +283,21 @@ export const buildSafeInlineHookErrorSummary = (
 ): SafeInlineHookErrorSummary => {
   try {
     const errorRecord = isRecord(error) ? error : undefined;
+    const errorData = getRecordProperty(errorRecord, 'data');
     const message =
-      error instanceof Error
-        ? error.message || fallbackErrorMessage
-        : stringifyUnknownError(error) || fallbackErrorMessage;
+      (error instanceof Error
+        ? (getStringProperty(errorData, 'message') ?? error.message)
+        : (getStringProperty(errorRecord, 'message') ??
+          getStringProperty(errorData, 'message') ??
+          stringifyUnknownError(error))) || fallbackErrorMessage;
     const status = getNumberProperty(errorRecord, 'status');
+    const errors = getSafeInlineHookValidationIssues([errorData, errorRecord], sensitiveValues);
 
     return {
       name: 'Error',
       message: redactInlineHookSensitiveText(message, sensitiveValues),
       ...(status === undefined ? {} : { status }),
+      ...(errors.length === 0 ? {} : { errors }),
     };
   } catch {
     return { name: 'Error', message: fallbackErrorMessage };

--- a/packages/core/src/middleware/koa-audit-log.test.ts
+++ b/packages/core/src/middleware/koa-audit-log.test.ts
@@ -364,6 +364,43 @@ describe('koaAuditLog middleware', () => {
     });
   });
 
+  it('should sanitize appended data immediately and protect reserved fields after canonicalization', async () => {
+    const ctx: TestContext = createTestContext({ 'user-agent': userAgent });
+    ctx.request.ip = ip;
+
+    const next = async () => {
+      const log = ctx.createLog(logKey);
+      const nul = String.fromCodePoint(0);
+
+      log.append({
+        [`pass${nul}word`]: 'leaked-password',
+        [`${nul}key`]: 'Attacker.Controlled.Key',
+        [`${nul}result`]: LogResult.Error,
+      });
+
+      expect(log.payload).toMatchObject({
+        password: '******',
+        key: logKey,
+        result: LogResult.Success,
+      });
+      expect(JSON.stringify(log.payload)).not.toContain('leaked-password');
+      expect(JSON.stringify(log.payload)).not.toContain('Attacker.Controlled.Key');
+    };
+
+    await koaLog(queries)(ctx, next);
+
+    expect(insertLog).toHaveBeenCalledWith({
+      id: mockId,
+      key: logKey,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+      payload: expect.objectContaining({
+        password: '******',
+        key: logKey,
+        result: LogResult.Success,
+      }),
+    });
+  });
+
   describe('should insert an error log with the error message when next() throws an error', () => {
     it('should log with error message when next throws a normal Error', async () => {
       const ctx: TestContext = createTestContext({ 'user-agent': userAgent });

--- a/packages/core/src/middleware/koa-audit-log.test.ts
+++ b/packages/core/src/middleware/koa-audit-log.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Audit log middleware behavior is covered end to end. */
 import type { LogKey } from '@logto/schemas';
 import { LogResult, VerificationType } from '@logto/schemas';
 import i18next from 'i18next';
@@ -193,18 +194,24 @@ describe('koaAuditLog middleware', () => {
     expect(insertLog).not.toBeCalled();
   });
 
-  it('should filter password sensitive data in log', async () => {
+  it('should filter sensitive data while preserving safe application secret metadata', async () => {
     const ctx: TestContext = createTestContext({ 'user-agent': userAgent });
     ctx.request.ip = ip;
 
     const additionalMockPayload = {
       password: '123456',
       interaction: { profile: { password: 123_456 } },
+      applicationSecret: { name: 'rotation-2' },
+      unsafe: {
+        applicationSecret: { name: 'rotation-2', value: 'raw-application-secret' },
+      },
     };
 
     const maskedAdditionalMockPayload = {
       password: '******',
       interaction: { profile: { password: '******' } },
+      applicationSecret: { name: 'rotation-2' },
+      unsafe: { applicationSecret: '******' },
     };
 
     const next = async () => {
@@ -227,6 +234,7 @@ describe('koaAuditLog middleware', () => {
         userAgentParsed,
       },
     });
+    expect(JSON.stringify(insertLog.mock.calls)).not.toContain('raw-application-secret');
   });
 
   it('should filter TOTP secret in log', async () => {
@@ -270,6 +278,53 @@ describe('koaAuditLog middleware', () => {
     });
   });
 
+  it('should filter sensitive data added through common log context', async () => {
+    const ctx: TestContext = createTestContext({ 'user-agent': userAgent });
+    ctx.request.ip = ip;
+
+    const next = async () => {
+      ctx.createLog(logKey);
+      ctx.prependAllLogEntries({
+        interaction: {
+          profile: {
+            Password: 'password-from-common-context',
+            clientSecret: 'secret-from-common-context',
+            Authorization: 'Bearer private-authorization',
+            passwordEncrypted: 'private-password-digest',
+            socialConnectorTokenSetSecret: 'private-token-set',
+            script: 'private-script',
+            environmentVariables: { TOKEN: 'private-environment-value' },
+            hasPassword: 'private-password-status',
+            passwordVerified: true,
+          },
+        },
+      });
+    };
+
+    await koaLog(queries)(ctx, next);
+
+    expect(insertLog).toHaveBeenCalledWith({
+      id: mockId,
+      key: logKey,
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+      payload: expect.objectContaining({
+        interaction: {
+          profile: {
+            Password: '******',
+            clientSecret: '******',
+            Authorization: '******',
+            passwordEncrypted: '******',
+            socialConnectorTokenSetSecret: '******',
+            hasPassword: '******',
+            passwordVerified: true,
+          },
+        },
+      }),
+    });
+    const serializedPayload = JSON.stringify(insertLog.mock.calls);
+    expect(serializedPayload).not.toContain('private-');
+  });
+
   it('should strip null characters so the payload is safe to store as jsonb', async () => {
     const ctx: TestContext = createTestContext({ 'user-agent': userAgent });
     ctx.request.ip = ip;
@@ -282,6 +337,8 @@ describe('koaAuditLog middleware', () => {
           grant_type: `authorization_code${nul}`,
           nested: [`a${nul}b`],
           [`field${nul}name`]: 'value',
+          [`pass${nul}word`]: 'leaked-password',
+          [`sec${nul}ret`]: 'leaked-secret',
         },
       });
     };
@@ -291,7 +348,13 @@ describe('koaAuditLog middleware', () => {
       id: mockId,
       key: logKey,
       payload: {
-        params: { grant_type: 'authorization_code', nested: ['ab'], fieldname: 'value' },
+        params: {
+          grant_type: 'authorization_code',
+          nested: ['ab'],
+          fieldname: 'value',
+          password: '******',
+          secret: '******',
+        },
         key: logKey,
         result: LogResult.Success,
         ip,
@@ -365,5 +428,41 @@ describe('koaAuditLog middleware', () => {
         },
       });
     });
+
+    it('should preserve an independent log result when the owning request later fails', async () => {
+      const ctx: TestContext = createTestContext({ 'user-agent': userAgent });
+      ctx.request.ip = ip;
+
+      const error = new Error('Owning flow failed');
+      const next = async () => {
+        const independentLog = ctx.createLog(logKey, { independent: true });
+        independentLog.append({ decision: 'updateUser' });
+        ctx.createLog(logKey);
+        throw error;
+      };
+
+      await expect(koaLog(queries)(ctx, next)).rejects.toBe(error);
+
+      expect(insertLog).toHaveBeenCalledTimes(2);
+      expect(insertLog).toHaveBeenCalledWith({
+        id: mockId,
+        key: logKey,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+        payload: expect.objectContaining({
+          decision: 'updateUser',
+          result: LogResult.Success,
+        }),
+      });
+      expect(insertLog).toHaveBeenCalledWith({
+        id: mockId,
+        key: logKey,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+        payload: expect.objectContaining({
+          result: LogResult.Error,
+          error: { message: 'Error: Owning flow failed' },
+        }),
+      });
+    });
   });
 });
+/* eslint-enable max-lines */

--- a/packages/core/src/middleware/koa-audit-log.ts
+++ b/packages/core/src/middleware/koa-audit-log.ts
@@ -9,118 +9,28 @@ import { UAParser } from 'ua-parser-js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import { getInjectedHeaderValues } from '#src/utils/injected-header-mapping.js';
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
-
-const maskedValue = '******';
-const safeSensitiveDataKeys = new Set(['passwordverified', 'haspassword']);
-const exactSensitiveDataKeys = new Set(['authorization', 'xfunctionskey', 'token']);
-const sensitiveDataKeyFragments = [
-  'secret',
-  'password',
-  'apikey',
-  'privatekey',
-  'credential',
-  'cookie',
-];
-
-const normalizeKey = (key: string) => key.replaceAll(/[_-]/g, '').toLowerCase();
-
-const shouldOmitKey = (key: string) => {
-  const normalizedKey = normalizeKey(key);
-
-  return (
-    normalizedKey.startsWith('script') ||
-    normalizedKey.endsWith('script') ||
-    normalizedKey.includes('environmentvariables')
-  );
-};
-
-const isSensitiveKey = (key: string, value: unknown) => {
-  const normalizedKey = normalizeKey(key);
-  const isSafePasswordStatus =
-    safeSensitiveDataKeys.has(normalizedKey) && typeof value === 'boolean';
-  const isSafeApplicationSecretMetadata =
-    normalizedKey === 'applicationsecret' &&
-    isRecord(value) &&
-    Object.keys(value).length === 1 &&
-    typeof value.name === 'string';
-
-  return (
-    !isSafePasswordStatus &&
-    !isSafeApplicationSecretMetadata &&
-    (exactSensitiveDataKeys.has(normalizedKey) ||
-      normalizedKey.endsWith('token') ||
-      sensitiveDataKeyFragments.some((fragment) => normalizedKey.includes(fragment)))
-  );
-};
-
-const sanitiseRecord = (value: Record<string, unknown>) =>
-  Object.fromEntries(
-    Object.entries(value).flatMap(([key, element]) => {
-      if (shouldOmitKey(key)) {
-        return [];
-      }
-
-      return [[key, isSensitiveKey(key, element) ? maskedValue : sanitise(element)]];
-    })
-  );
-
-const sanitise = (value: unknown): unknown => {
-  if (isArray(value)) {
-    return value.map((element) => sanitise(element));
-  }
-
-  if (isRecord(value)) {
-    return sanitiseRecord(value);
-  }
-
-  return value;
-};
-
-/**
- * Recursively strip null characters (U+0000) from every string in the value. PostgreSQL rejects
- * null bytes in `jsonb` (error code `22P05`), so leaving them in would make `insertLog` throw. Since
- * logs are inserted in a `finally` block, that throw would replace the original response with a 500.
- */
-const nullCharacter = String.fromCodePoint(0);
-
-const stripFromString = (value: string): string =>
-  value.includes(nullCharacter) ? value.replaceAll(nullCharacter, '') : value;
-
-function stripNullCharacters(value: string): string;
-function stripNullCharacters(value: unknown[]): unknown[];
-function stripNullCharacters(value: Record<string, unknown>): Record<string, unknown>;
-function stripNullCharacters(value: unknown): unknown;
-function stripNullCharacters(value: unknown): unknown {
-  if (typeof value === 'string') {
-    return stripFromString(value);
-  }
-
-  if (isArray(value)) {
-    return value.map((element) => stripNullCharacters(element));
-  }
-
-  if (isRecord(value)) {
-    // Strip from keys as well: PostgreSQL rejects null bytes anywhere in `jsonb`, keys included.
-    return Object.fromEntries(
-      Object.entries(value).map(([key, element]) => [
-        stripFromString(key),
-        stripNullCharacters(element),
-      ])
-    );
-  }
-
-  return value;
-}
-
-const filterSensitiveData = (data: Record<string, unknown>): Record<string, unknown> =>
-  sanitiseRecord(data);
+import {
+  isRecord,
+  sanitizeSensitiveDataRecord,
+  stripNullCharactersFromString,
+} from '#src/utils/sensitive-data.js';
 
 const removeUndefinedKeys = (object: Record<string, unknown>) =>
   Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined));
+
+/**
+ * Reapply reserved fields after canonicalizing catch-all keys, so inputs such as `\0key` cannot
+ * collide with the fields that define the log entry.
+ */
+const sanitizeLogContextPayload = ({
+  key,
+  result,
+  ...payload
+}: LogContextPayload): LogContextPayload => ({
+  ...sanitizeSensitiveDataRecord(payload),
+  key: stripNullCharactersFromString(key),
+  result,
+});
 
 export class LogEntry {
   payload: LogContextPayload;
@@ -137,22 +47,18 @@ export class LogEntry {
 
   /** Update payload by spreading `data` first, then spreading `this.payload`. */
   prepend(data: Readonly<LogPayload>) {
-    this.payload = {
+    this.payload = sanitizeLogContextPayload({
       ...removeUndefinedKeys(data),
       ...this.payload,
-    };
+    });
   }
 
   /** Update payload by spreading `this.payload` first, then spreading `data`. */
   append(data: Readonly<LogPayload>) {
-    const { key = this.payload.key, result = this.payload.result } = data;
-
-    this.payload = {
+    this.payload = sanitizeLogContextPayload({
       ...this.payload,
-      ...filterSensitiveData(removeUndefinedKeys(data)),
-      key,
-      result,
-    };
+      ...removeUndefinedKeys(data),
+    });
   }
 }
 
@@ -310,13 +216,7 @@ export default function koaAuditLog<StateT, ContextT extends IRouterParamContext
         entries.map(async ({ payload }) => {
           // Apply the recursive filter at the final insertion boundary too, so common context
           // added through `prependAllLogEntries()` can never bypass sensitive-key masking.
-          const canonicalPayload = stripNullCharacters({ ...basePayload, ...payload });
-          const sanitizedPayload = filterSensitiveData(canonicalPayload);
-          const fullPayload: LogContextPayload = {
-            ...sanitizedPayload,
-            key: payload.key,
-            result: payload.result,
-          };
+          const fullPayload = sanitizeLogContextPayload({ ...basePayload, ...payload });
           return insertLog({
             id: generateStandardId(),
             key: payload.key,

--- a/packages/core/src/middleware/koa-audit-log.ts
+++ b/packages/core/src/middleware/koa-audit-log.ts
@@ -12,20 +12,69 @@ import { getInjectedHeaderValues } from '#src/utils/injected-header-mapping.js';
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
+const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
 
-const sensitiveDataKeys = Object.freeze(['password', 'secret']);
+const maskedValue = '******';
+const safeSensitiveDataKeys = new Set(['passwordverified', 'haspassword']);
+const exactSensitiveDataKeys = new Set(['authorization', 'xfunctionskey', 'token']);
+const sensitiveDataKeyFragments = [
+  'secret',
+  'password',
+  'apikey',
+  'privatekey',
+  'credential',
+  'cookie',
+];
+
+const normalizeKey = (key: string) => key.replaceAll(/[_-]/g, '').toLowerCase();
+
+const shouldOmitKey = (key: string) => {
+  const normalizedKey = normalizeKey(key);
+
+  return (
+    normalizedKey.startsWith('script') ||
+    normalizedKey.endsWith('script') ||
+    normalizedKey.includes('environmentvariables')
+  );
+};
+
+const isSensitiveKey = (key: string, value: unknown) => {
+  const normalizedKey = normalizeKey(key);
+  const isSafePasswordStatus =
+    safeSensitiveDataKeys.has(normalizedKey) && typeof value === 'boolean';
+  const isSafeApplicationSecretMetadata =
+    normalizedKey === 'applicationsecret' &&
+    isRecord(value) &&
+    Object.keys(value).length === 1 &&
+    typeof value.name === 'string';
+
+  return (
+    !isSafePasswordStatus &&
+    !isSafeApplicationSecretMetadata &&
+    (exactSensitiveDataKeys.has(normalizedKey) ||
+      normalizedKey.endsWith('token') ||
+      sensitiveDataKeyFragments.some((fragment) => normalizedKey.includes(fragment)))
+  );
+};
+
+const sanitiseRecord = (value: Record<string, unknown>) =>
+  Object.fromEntries(
+    Object.entries(value).flatMap(([key, element]) => {
+      if (shouldOmitKey(key)) {
+        return [];
+      }
+
+      return [[key, isSensitiveKey(key, element) ? maskedValue : sanitise(element)]];
+    })
+  );
 
 const sanitise = (value: unknown): unknown => {
-  if (Array.isArray(value)) {
+  if (isArray(value)) {
     return value.map((element) => sanitise(element));
   }
 
   if (isRecord(value)) {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, element]) => {
-        return [key, sensitiveDataKeys.includes(key) ? '******' : sanitise(element)];
-      })
-    );
+    return sanitiseRecord(value);
   }
 
   return value;
@@ -41,12 +90,16 @@ const nullCharacter = String.fromCodePoint(0);
 const stripFromString = (value: string): string =>
   value.includes(nullCharacter) ? value.replaceAll(nullCharacter, '') : value;
 
-const stripNullCharacters = (value: unknown): unknown => {
+function stripNullCharacters(value: string): string;
+function stripNullCharacters(value: unknown[]): unknown[];
+function stripNullCharacters(value: Record<string, unknown>): Record<string, unknown>;
+function stripNullCharacters(value: unknown): unknown;
+function stripNullCharacters(value: unknown): unknown {
   if (typeof value === 'string') {
     return stripFromString(value);
   }
 
-  if (Array.isArray(value)) {
+  if (isArray(value)) {
     return value.map((element) => stripNullCharacters(element));
   }
 
@@ -61,15 +114,10 @@ const stripNullCharacters = (value: unknown): unknown => {
   }
 
   return value;
-};
+}
 
-const filterSensitiveData = (data: Record<string, unknown>): Record<string, unknown> => {
-  return Object.fromEntries(
-    Object.entries(data).map(([key, value]) => {
-      return [key, sensitiveDataKeys.includes(key) ? '******' : sanitise(value)];
-    })
-  );
-};
+const filterSensitiveData = (data: Record<string, unknown>): Record<string, unknown> =>
+  sanitiseRecord(data);
 
 const removeUndefinedKeys = (object: Record<string, unknown>) =>
   Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined));
@@ -77,7 +125,10 @@ const removeUndefinedKeys = (object: Record<string, unknown>) =>
 export class LogEntry {
   payload: LogContextPayload;
 
-  constructor(public readonly key: LogKey) {
+  constructor(
+    public readonly key: LogKey,
+    public readonly independent = false
+  ) {
     this.payload = {
       key,
       result: LogResult.Success,
@@ -94,17 +145,26 @@ export class LogEntry {
 
   /** Update payload by spreading `this.payload` first, then spreading `data`. */
   append(data: Readonly<LogPayload>) {
+    const { key = this.payload.key, result = this.payload.result } = data;
+
     this.payload = {
       ...this.payload,
       ...filterSensitiveData(removeUndefinedKeys(data)),
+      key,
+      result,
     };
   }
 }
 
 export type LogPayload = Partial<LogContextPayload>;
 
+export type CreateLogOptions = {
+  /** Keep this entry's own result when the remainder of the request fails. */
+  independent?: boolean;
+};
+
 export type LogContext = {
-  createLog: (key: LogKey) => LogEntry;
+  createLog: (key: LogKey, options?: CreateLogOptions) => LogEntry;
   prependAllLogEntries: (payload: LogPayload) => void;
 };
 
@@ -188,8 +248,8 @@ export default function koaAuditLog<StateT, ContextT extends IRouterParamContext
   return async (ctx, next) => {
     const entries: LogEntry[] = [];
 
-    ctx.createLog = (key: LogKey) => {
-      const entry = new LogEntry(key);
+    ctx.createLog = (key: LogKey, { independent = false } = {}) => {
+      const entry = new LogEntry(key, independent);
       // eslint-disable-next-line @silverhand/fp/no-mutating-methods
       entries.push(entry);
 
@@ -206,6 +266,10 @@ export default function koaAuditLog<StateT, ContextT extends IRouterParamContext
       await next();
     } catch (error: unknown) {
       for (const entry of entries) {
+        if (entry.independent) {
+          continue;
+        }
+
         entry.append({
           result: LogResult.Error,
           error:
@@ -244,12 +308,19 @@ export default function koaAuditLog<StateT, ContextT extends IRouterParamContext
 
       await Promise.all(
         entries.map(async ({ payload }) => {
-          const fullPayload = { ...basePayload, ...payload };
+          // Apply the recursive filter at the final insertion boundary too, so common context
+          // added through `prependAllLogEntries()` can never bypass sensitive-key masking.
+          const canonicalPayload = stripNullCharacters({ ...basePayload, ...payload });
+          const sanitizedPayload = filterSensitiveData(canonicalPayload);
+          const fullPayload: LogContextPayload = {
+            ...sanitizedPayload,
+            key: payload.key,
+            result: payload.result,
+          };
           return insertLog({
             id: generateStandardId(),
             key: payload.key,
-            // eslint-disable-next-line no-restricted-syntax -- structural identity transform preserves the payload shape
-            payload: stripNullCharacters(fullPayload) as typeof fullPayload,
+            payload: fullPayload,
           });
         })
       );

--- a/packages/core/src/routes/logto-config/inline-hook.test.ts
+++ b/packages/core/src/routes/logto-config/inline-hook.test.ts
@@ -13,6 +13,7 @@ import {
   mockLogtoConfigRows,
 } from '#src/__mocks__/index.js';
 import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import koaErrorHandler from '#src/middleware/koa-error-handler.js';
 import koaI18next from '#src/middleware/koa-i18next.js';
 import { mockLogtoConfigsLibrary } from '#src/test-utils/mock-libraries.js';
@@ -281,6 +282,14 @@ describe('configs inline hook routes', () => {
     const errorBody = {
       message: `Script failed ${script} ${environmentSecret} ${password}`,
       stack: `Error: ${script}`,
+      errors: [
+        {
+          path: ['event', password],
+          code: 'invalid_type',
+          message: `Expected string, received ${password}`,
+          received: password,
+        },
+      ],
       error: {
         request: {
           environmentVariables: { API_TOKEN: environmentSecret },
@@ -303,12 +312,54 @@ describe('configs inline hook routes', () => {
     expect(response.body.code).toEqual('inline_hook.general');
     expect(response.body.data).toEqual({
       message: 'Script failed [redacted] [redacted] [redacted]',
+      errors: [{ path: ['event', '[redacted]'], code: 'invalid_type' }],
     });
     const serializedResponse = JSON.stringify(response.body);
     expect(serializedResponse).not.toContain(script);
     expect(serializedResponse).not.toContain(environmentSecret);
     expect(serializedResponse).not.toContain(password);
     expect(serializedResponse).not.toContain('returned-patch-secret');
+  });
+
+  it('POST /configs/inline-hooks/test should preserve safe RequestError semantics', async () => {
+    const sensitiveValue = 'request-error-secret';
+    const payload: InlineHookExecutionRequestBody = {
+      ...inlineHookTestPayload,
+      environmentVariables: { API_TOKEN: sensitiveValue },
+    };
+    const requestError = new RequestError(
+      { code: 'connector.general', status: 403 },
+      {
+        message: `Runner rejected ${sensitiveValue}`,
+        errors: [
+          {
+            path: ['event', sensitiveValue],
+            code: 'invalid_type',
+            message: sensitiveValue,
+            received: sensitiveValue,
+          },
+        ],
+        request: { authorization: `Bearer ${sensitiveValue}` },
+      }
+    );
+
+    jest
+      .spyOn(tenantContext.libraries.inlineHooks, 'executeScript')
+      .mockRejectedValueOnce(requestError);
+
+    const response = await routeRequesterWithErrorHandler
+      .post('/configs/inline-hooks/test')
+      .send(payload);
+
+    expect(response.status).toEqual(403);
+    expect(response.body.code).toEqual('connector.general');
+    expect(response.body.data).toEqual({
+      message: 'Runner rejected [redacted]',
+      errors: [{ path: ['event', '[redacted]'], code: 'invalid_type' }],
+    });
+    expect(response.text).not.toContain(sensitiveValue);
+    expect(response.text).not.toContain('authorization');
+    expect(response.text).not.toContain('received');
   });
 
   it.each([

--- a/packages/core/src/routes/logto-config/inline-hook.test.ts
+++ b/packages/core/src/routes/logto-config/inline-hook.test.ts
@@ -263,11 +263,32 @@ describe('configs inline hook routes', () => {
     expect(response.status).toEqual(422);
   });
 
-  it('POST /configs/inline-hooks/test should preserve the full ResponseError body as error details', async () => {
+  it('POST /configs/inline-hooks/test should return only a redacted ResponseError summary', async () => {
+    const script = 'const privateInlineHookScript = true;';
+    const environmentSecret = 'environment-secret-value';
+    const password = 'plain-text-password';
+    const payload: InlineHookExecutionRequestBody = {
+      hookType: LogtoInlineHookKey.PostFirstFactorVerification,
+      script,
+      environmentVariables: {
+        API_TOKEN: environmentSecret,
+      },
+      event: {
+        key: LogtoInlineHookKey.PostFirstFactorVerification,
+        password,
+      },
+    };
     const errorBody = {
-      message: 'Script failed',
-      stack: 'Error: Script failed',
-      errors: [{ path: 'event.user', code: 'invalid_type' }],
+      message: `Script failed ${script} ${environmentSecret} ${password}`,
+      stack: `Error: ${script}`,
+      error: {
+        request: {
+          environmentVariables: { API_TOKEN: environmentSecret },
+        },
+        returnedUser: {
+          customData: { secret: 'returned-patch-secret' },
+        },
+      },
     };
 
     jest
@@ -276,14 +297,18 @@ describe('configs inline hook routes', () => {
 
     const response = await routeRequesterWithErrorHandler
       .post('/configs/inline-hooks/test')
-      .send(inlineHookTestPayload);
+      .send(payload);
 
     expect(response.status).toEqual(422);
     expect(response.body.code).toEqual('inline_hook.general');
     expect(response.body.data).toEqual({
-      message: 'Script failed',
-      error: errorBody,
+      message: 'Script failed [redacted] [redacted] [redacted]',
     });
+    const serializedResponse = JSON.stringify(response.body);
+    expect(serializedResponse).not.toContain(script);
+    expect(serializedResponse).not.toContain(environmentSecret);
+    expect(serializedResponse).not.toContain(password);
+    expect(serializedResponse).not.toContain('returned-patch-secret');
   });
 
   it.each([

--- a/packages/core/src/routes/logto-config/inline-hook.ts
+++ b/packages/core/src/routes/logto-config/inline-hook.ts
@@ -15,6 +15,7 @@ import {
 import koaGuard from '#src/middleware/koa-guard.js';
 import { koaQuotaGuard } from '#src/middleware/koa-quota-guard.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
+import { isRecord } from '#src/utils/sensitive-data.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
@@ -23,23 +24,37 @@ const inlineHookConfigsGuard = z.object({
   value: inlineHookGuard,
 });
 
-const inlineHookResponseErrorGuard = z.object({
-  message: z.string(),
-});
-
-const parseInlineHookResponseErrorMessage = async (error: ResponseError) => {
+const parseInlineHookResponseError = async (error: ResponseError): Promise<unknown> => {
   try {
     const responseBody: unknown = await error.response.json();
-    const errorResponseResult = inlineHookResponseErrorGuard.safeParse(responseBody);
 
-    return errorResponseResult.success ? errorResponseResult.data.message : error.message;
+    if (!isRecord(responseBody)) {
+      return error;
+    }
+
+    return {
+      ...responseBody,
+      message: typeof responseBody.message === 'string' ? responseBody.message : error.message,
+    };
   } catch {
-    return error.message;
+    return error;
   }
 };
 
 const getInlineHookResponseErrorStatus = (status: number) =>
   status === 400 || status === 403 || status === 422 ? status : 422;
+
+const buildSafeInlineHookRequestErrorData = (
+  error: unknown,
+  sensitiveValues: readonly string[]
+) => {
+  const { message, errors } = buildSafeInlineHookErrorSummary(error, sensitiveValues);
+
+  return {
+    message,
+    ...(errors ? { errors } : {}),
+  };
+};
 
 export default function logtoConfigInlineHookRoutes<T extends ManagementApiRouter>(
   ...[router, { queries, logtoConfigs, libraries }]: RouterInitArgs<T>
@@ -81,39 +96,31 @@ export default function logtoConfigInlineHookRoutes<T extends ManagementApiRoute
         const sensitiveValues = getInlineHookSensitiveValues(body);
 
         if (error instanceof ResponseError) {
-          const message = await parseInlineHookResponseErrorMessage(error);
-          const safeError = buildSafeInlineHookErrorSummary(new Error(message), sensitiveValues);
+          const responseError = await parseInlineHookResponseError(error);
 
           throw new RequestError(
             {
               code: 'inline_hook.general',
               status: getInlineHookResponseErrorStatus(error.response.status),
             },
-            { message: safeError.message }
+            buildSafeInlineHookRequestErrorData(responseError, sensitiveValues)
           );
         }
 
         if (error instanceof RequestError) {
-          const parsedErrorData = inlineHookResponseErrorGuard.safeParse(error.data);
-          const safeError = buildSafeInlineHookErrorSummary(
-            new Error(parsedErrorData.success ? parsedErrorData.data.message : error.message),
-            sensitiveValues
-          );
-
           throw new RequestError(
             {
-              code: 'inline_hook.general',
-              status: getInlineHookResponseErrorStatus(error.status),
+              code: error.code,
+              status: error.status,
+              expose: error.expose,
             },
-            { message: safeError.message }
+            buildSafeInlineHookRequestErrorData(error, sensitiveValues)
           );
         }
 
-        const safeError = buildSafeInlineHookErrorSummary(error, sensitiveValues);
-
         throw new RequestError(
           { code: 'inline_hook.general', status: 422 },
-          { message: safeError.message }
+          buildSafeInlineHookRequestErrorData(error, sensitiveValues)
         );
       }
 

--- a/packages/core/src/routes/logto-config/inline-hook.ts
+++ b/packages/core/src/routes/logto-config/inline-hook.ts
@@ -8,6 +8,10 @@ import { ResponseError } from '@withtyped/client';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
+import {
+  buildSafeInlineHookErrorSummary,
+  getInlineHookSensitiveValues,
+} from '#src/libraries/inline-hook-sanitization.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { koaQuotaGuard } from '#src/middleware/koa-quota-guard.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
@@ -23,14 +27,15 @@ const inlineHookResponseErrorGuard = z.object({
   message: z.string(),
 });
 
-const parseInlineHookResponseError = async (error: ResponseError) => {
-  const responseBody: unknown = await error.response.json();
-  const errorResponseResult = inlineHookResponseErrorGuard.safeParse(responseBody);
+const parseInlineHookResponseErrorMessage = async (error: ResponseError) => {
+  try {
+    const responseBody: unknown = await error.response.json();
+    const errorResponseResult = inlineHookResponseErrorGuard.safeParse(responseBody);
 
-  return {
-    message: errorResponseResult.success ? errorResponseResult.data.message : error.message,
-    error: responseBody,
-  };
+    return errorResponseResult.success ? errorResponseResult.data.message : error.message;
+  } catch {
+    return error.message;
+  }
 };
 
 const getInlineHookResponseErrorStatus = (status: number) =>
@@ -73,31 +78,42 @@ export default function logtoConfigInlineHookRoutes<T extends ManagementApiRoute
         ctx.body = await libraries.inlineHooks.executeScript(body);
         ctx.status = 200;
       } catch (error: unknown) {
+        const sensitiveValues = getInlineHookSensitiveValues(body);
+
         if (error instanceof ResponseError) {
-          const responseBody = await parseInlineHookResponseError(error);
-          const { message, error: originalError } = responseBody;
+          const message = await parseInlineHookResponseErrorMessage(error);
+          const safeError = buildSafeInlineHookErrorSummary(new Error(message), sensitiveValues);
 
           throw new RequestError(
             {
               code: 'inline_hook.general',
               status: getInlineHookResponseErrorStatus(error.response.status),
             },
-            { message, error: originalError }
+            { message: safeError.message }
           );
         }
 
-        // Already-normalized Management API errors (e.g. remote runner not configured).
         if (error instanceof RequestError) {
-          throw error;
+          const parsedErrorData = inlineHookResponseErrorGuard.safeParse(error.data);
+          const safeError = buildSafeInlineHookErrorSummary(
+            new Error(parsedErrorData.success ? parsedErrorData.data.message : error.message),
+            sensitiveValues
+          );
+
+          throw new RequestError(
+            {
+              code: 'inline_hook.general',
+              status: getInlineHookResponseErrorStatus(error.status),
+            },
+            { message: safeError.message }
+          );
         }
 
-        // Non-HTTP remote transport failures (e.g. Got TimeoutError) must stay within
-        // the declared 4xx contract for Console dry runs.
+        const safeError = buildSafeInlineHookErrorSummary(error, sensitiveValues);
+
         throw new RequestError(
           { code: 'inline_hook.general', status: 422 },
-          {
-            message: error instanceof Error ? error.message : String(error),
-          }
+          { message: safeError.message }
         );
       }
 

--- a/packages/core/src/utils/sensitive-data.test.ts
+++ b/packages/core/src/utils/sensitive-data.test.ts
@@ -1,0 +1,28 @@
+import { sanitizeSensitiveDataRecord } from './sensitive-data.js';
+
+describe('sanitizeSensitiveDataRecord', () => {
+  it('uses one canonical policy for omitted, masked, and explicitly safe fields', () => {
+    const nul = String.fromCodePoint(0);
+
+    expect(
+      sanitizeSensitiveDataRecord({
+        javaScript: 'private script',
+        scriptResult: 'private script result',
+        environmentVariablesBackup: { TOKEN: 'private environment value' },
+        [`pass${nul}word`]: 'private password',
+        hasPassword: true,
+        passwordVerified: 'private password status',
+        applicationSecret: { name: 'rotation-2' },
+        unsafeApplicationSecret: { name: 'rotation-2', value: 'private application secret' },
+        note: `safe${nul}value`,
+      })
+    ).toEqual({
+      password: '******',
+      hasPassword: true,
+      passwordVerified: '******',
+      applicationSecret: { name: 'rotation-2' },
+      unsafeApplicationSecret: '******',
+      note: 'safevalue',
+    });
+  });
+});

--- a/packages/core/src/utils/sensitive-data.ts
+++ b/packages/core/src/utils/sensitive-data.ts
@@ -1,0 +1,92 @@
+export const sensitiveDataMask = '******';
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
+
+const nullCharacter = String.fromCodePoint(0);
+const safeSensitiveDataKeys = new Set(['passwordverified', 'haspassword']);
+const exactSensitiveDataKeys = new Set(['authorization', 'xfunctionskey', 'token']);
+const sensitiveDataKeyFragments = [
+  'secret',
+  'password',
+  'apikey',
+  'privatekey',
+  'credential',
+  'cookie',
+];
+
+/** PostgreSQL rejects U+0000 anywhere in `jsonb`, including object keys. */
+export const stripNullCharactersFromString = (value: string): string =>
+  value.includes(nullCharacter) ? value.replaceAll(nullCharacter, '') : value;
+
+export const normalizeSensitiveDataKey = (key: string) =>
+  stripNullCharactersFromString(key).replaceAll(/[_-]/g, '').toLowerCase();
+
+export const shouldOmitSensitiveDataKey = (key: string) => {
+  const normalizedKey = normalizeSensitiveDataKey(key);
+
+  return (
+    normalizedKey.startsWith('script') ||
+    normalizedKey.endsWith('script') ||
+    normalizedKey.includes('environmentvariables')
+  );
+};
+
+export const isSensitiveDataKey = (key: string, value: unknown) => {
+  const normalizedKey = normalizeSensitiveDataKey(key);
+  const isSafePasswordStatus =
+    safeSensitiveDataKeys.has(normalizedKey) && typeof value === 'boolean';
+  const isSafeApplicationSecretMetadata =
+    normalizedKey === 'applicationsecret' &&
+    isRecord(value) &&
+    Object.keys(value).length === 1 &&
+    typeof value.name === 'string';
+
+  return (
+    !isSafePasswordStatus &&
+    !isSafeApplicationSecretMetadata &&
+    (exactSensitiveDataKeys.has(normalizedKey) ||
+      normalizedKey.endsWith('token') ||
+      sensitiveDataKeyFragments.some((fragment) => normalizedKey.includes(fragment)))
+  );
+};
+
+export const sanitizeSensitiveDataRecord = (
+  value: Record<string, unknown>
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(value).flatMap(([key, element]) => {
+      const sanitizedKey = stripNullCharactersFromString(key);
+
+      if (shouldOmitSensitiveDataKey(sanitizedKey)) {
+        return [];
+      }
+
+      return [
+        [
+          sanitizedKey,
+          isSensitiveDataKey(sanitizedKey, element)
+            ? sensitiveDataMask
+            : sanitizeSensitiveData(element),
+        ],
+      ];
+    })
+  );
+
+const sanitizeSensitiveData = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    return stripNullCharactersFromString(value);
+  }
+
+  if (isArray(value)) {
+    return value.map((element) => sanitizeSensitiveData(element));
+  }
+
+  if (isRecord(value)) {
+    return sanitizeSensitiveDataRecord(value);
+  }
+
+  return value;
+};


### PR DESCRIPTION
## Summary

- recursively mask or omit sensitive audit-log payload fields at append and final persistence boundaries
- introduce shared Inline Hook sanitization for scripts, environment variables, credentials, returned user patches, error messages, and untrusted property names
- return safe dry-run error summaries and support independent audit entries whose result is not overwritten by an outer request failure

## Review context

This PR replaces the data-safety foundation from #9231 and addresses:

- [untrusted property key leakage](https://github.com/logto-io/logto/pull/9231#discussion_r3619112326)
- [the unsafe `stripNullCharacters()` return type](https://github.com/logto-io/logto/pull/9231#discussion_r3619356122)
- [the unsafe `filterSensitiveData()` return type](https://github.com/logto-io/logto/pull/9231#discussion_r3619356132)

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
