### PR TITLE
feat(core,schemas): record inline hook execution audit logs

### DIFF
--- a/packages/core/src/libraries/inline-hook.cloud.test.ts
+++ b/packages/core/src/libraries/inline-hook.cloud.test.ts
@@ -3,6 +3,7 @@ import { ResponseError } from '@withtyped/client';
 import nock from 'nock';
 
 import { EnvSet } from '#src/env-set/index.js';
+import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 
 import { InlineHookLibrary } from './inline-hook.js';
 import type { LogtoConfigLibrary } from './logto-config.js';
@@ -30,8 +31,15 @@ const setIsCloud = (isCloud: boolean) => {
   (EnvSet.values as { isCloud: boolean }).isCloud = isCloud;
 };
 
+type RunHookInput<Event> = {
+  key: LogtoInlineHookKey;
+} & ({ event: Event } | { getEvent: () => Promise<Event> });
+
 describe('InlineHookLibrary Cloud execution routing', () => {
   const library = createLibrary();
+  const { createLog, mockAppend } = createMockLogContext();
+  const runHook = async <Event>(input: RunHookInput<Event>) =>
+    library.runHook({ ...input, auditContext: { createLog } });
 
   beforeEach(() => {
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for inline hook runtime tests.
@@ -181,13 +189,17 @@ describe('InlineHookLibrary Cloud execution routing', () => {
     const runScriptInLocalVm = jest.spyOn(InlineHookLibrary, 'runScriptInLocalVm');
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         event,
       })
     ).resolves.toEqual(executionResult);
     expect(remoteRunner.isDone()).toBe(true);
     expect(runScriptInLocalVm).not.toHaveBeenCalled();
+    expect(mockAppend).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ runtimeLocation: 'remote' })
+    );
   });
 
   it('applies allow-mode policy when Cloud remote execution fails without local fallback', async () => {
@@ -214,7 +226,7 @@ describe('InlineHookLibrary Cloud execution routing', () => {
     const runScriptInLocalVm = jest.spyOn(InlineHookLibrary, 'runScriptInLocalVm');
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         event: {},
       })
@@ -240,7 +252,7 @@ describe('InlineHookLibrary Cloud execution routing', () => {
     const runScriptInLocalVm = jest.spyOn(InlineHookLibrary, 'runScriptInLocalVm');
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         event: {},
       })
@@ -264,7 +276,7 @@ describe('InlineHookLibrary Cloud execution routing', () => {
     const runScriptInLocalVm = jest.spyOn(InlineHookLibrary, 'runScriptInLocalVm');
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostFirstFactorVerification,
         event: {
           password: 'secret-password',

--- a/packages/core/src/libraries/inline-hook.test.ts
+++ b/packages/core/src/libraries/inline-hook.test.ts
@@ -1,8 +1,10 @@
+/* eslint-disable max-lines -- Inline hook runtime, policy, and audit behavior share the same library setup. */
 import { appInsights } from '@logto/app-insights/node';
-import { LogtoInlineHookKey } from '@logto/schemas';
+import { inlineHook, LogResult, LogtoInlineHookKey } from '@logto/schemas';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 
 import { getInlineHookExecutionErrorPolicyDecision, InlineHookLibrary } from './inline-hook.js';
 import type {
@@ -34,8 +36,15 @@ const setIsCloud = (isCloud: boolean) => {
   (EnvSet.values as { isCloud: boolean }).isCloud = isCloud;
 };
 
+type RunHookInput<Event> = {
+  key: LogtoInlineHookKey;
+} & ({ event: Event } | { getEvent: () => Promise<Event> });
+
 describe('InlineHookLibrary', () => {
   const library = createLibrary();
+  const { createLog, mockAppend } = createMockLogContext();
+  const runHook = async <Event>(input: RunHookInput<Event>) =>
+    library.runHook({ ...input, auditContext: { createLog } });
 
   beforeEach(() => {
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for inline hook runtime tests.
@@ -82,7 +91,7 @@ describe('InlineHookLibrary', () => {
     });
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         getEvent,
       })
@@ -96,6 +105,180 @@ describe('InlineHookLibrary', () => {
 
     expect(getInlineHook).toHaveBeenCalledWith(LogtoInlineHookKey.PostSignIn);
     expect(getEvent).toHaveBeenCalledTimes(1);
+    expect(createLog).toHaveBeenCalledTimes(1);
+    expect(createLog).toHaveBeenCalledWith('InlineHook.PostSignIn', { independent: true });
+    expect(mockAppend).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        tenantId: 'tenant_id',
+        hookType: LogtoInlineHookKey.PostSignIn,
+        runtimeLocation: 'local',
+        onExecutionError: 'block',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+        event: expect.objectContaining({ key: LogtoInlineHookKey.PostSignIn }),
+      })
+    );
+    expect(mockAppend).toHaveBeenNthCalledWith(2, {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+      durationMs: expect.any(Number),
+      action: 'updateUser',
+      decision: 'updateUser',
+      inlineHookResult: {
+        action: 'updateUser',
+        user: '[redacted]',
+        apiType: 'undefined',
+      },
+    });
+  });
+
+  it('writes a sanitized P1 audit entry without scripts, environment values, or user patches', async () => {
+    const script = 'const privateInlineHookScript = true;';
+    const environmentSecret = 'environment-secret-value';
+    const password = 'plain-text-password';
+    const eventSecret = 'event-secret-value';
+    const apiKey = 'api-key-value';
+    const accessToken = 'access-token-value';
+    const nestedPatchEmail = 'nested-patch@example.com';
+    const event = {
+      key: LogtoInlineHookKey.PostFirstFactorVerification,
+      password,
+      nested: {
+        secret: eventSecret,
+      },
+      credentials: {
+        apiKey,
+        accessToken,
+      },
+      echoed: `${script} ${environmentSecret} ${password}`,
+    };
+    const result = {
+      action: 'createUser',
+      passwordVerified: true,
+      user: {
+        primaryEmail: 'jane@example.com',
+        customData: {
+          secret: 'returned-patch-secret',
+        },
+      },
+      nested: [{ User: { primaryEmail: nestedPatchEmail } }],
+      note: environmentSecret,
+    };
+
+    getInlineHook.mockResolvedValueOnce({
+      enabled: true,
+      script,
+      environmentVariables: {
+        API_TOKEN: environmentSecret,
+      },
+    });
+    jest.spyOn(library, 'executeScript').mockResolvedValueOnce(result);
+
+    await expect(
+      library.runHook({
+        key: LogtoInlineHookKey.PostFirstFactorVerification,
+        event,
+        auditContext: {
+          createLog,
+          sessionId: 'session-id',
+          applicationId: 'application-id',
+          userId: 'user-id',
+        },
+      })
+    ).resolves.toEqual(result);
+
+    expect(createLog).toHaveBeenCalledWith(
+      `${inlineHook.prefix}.${inlineHook.Type.PostFirstFactorVerification}`,
+      { independent: true }
+    );
+    expect(mockAppend).toHaveBeenNthCalledWith(1, {
+      sessionId: 'session-id',
+      applicationId: 'application-id',
+      userId: 'user-id',
+      tenantId: 'tenant_id',
+      hookType: LogtoInlineHookKey.PostFirstFactorVerification,
+      runtimeLocation: 'local',
+      onExecutionError: 'block',
+      event: {
+        key: LogtoInlineHookKey.PostFirstFactorVerification,
+        password: '******',
+        nested: {
+          secret: '******',
+        },
+        credentials: '******',
+        echoed: '[redacted] [redacted] [redacted]',
+      },
+    });
+    expect(mockAppend).toHaveBeenNthCalledWith(2, {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+      durationMs: expect.any(Number),
+      action: 'createUser',
+      decision: 'createUser',
+      inlineHookResult: {
+        action: 'createUser',
+        passwordVerified: true,
+        user: '[redacted]',
+        nested: [{ User: '[redacted]' }],
+        note: '[redacted]',
+      },
+    });
+
+    const serializedAuditPayload = JSON.stringify(mockAppend.mock.calls);
+    expect(serializedAuditPayload).not.toContain(script);
+    expect(serializedAuditPayload).not.toContain(environmentSecret);
+    expect(serializedAuditPayload).not.toContain(password);
+    expect(serializedAuditPayload).not.toContain(eventSecret);
+    expect(serializedAuditPayload).not.toContain(apiKey);
+    expect(serializedAuditPayload).not.toContain(accessToken);
+    expect(serializedAuditPayload).not.toContain(nestedPatchEmail);
+    expect(serializedAuditPayload).not.toContain('returned-patch-secret');
+  });
+
+  it('normalizes untrusted result actions before writing audit summaries', async () => {
+    const environmentSecret = 'environment-secret-action';
+    const passwordStatusSecret = 'password-status-secret';
+    getInlineHook.mockResolvedValueOnce({
+      enabled: true,
+      script: 'const runInlineHook = () => ({});',
+      environmentVariables: { API_TOKEN: environmentSecret },
+    });
+    jest.spyOn(library, 'executeScript').mockResolvedValueOnce({
+      action: environmentSecret,
+      passwordVerified: passwordStatusSecret,
+    });
+
+    await runHook({ key: LogtoInlineHookKey.PostSignIn, event: {} });
+
+    expect(mockAppend).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        decision: 'invalid',
+        inlineHookResult: { action: 'invalid', passwordVerified: '******' },
+      })
+    );
+    expect(JSON.stringify(mockAppend.mock.calls)).not.toContain(environmentSecret);
+    expect(JSON.stringify(mockAppend.mock.calls)).not.toContain(passwordStatusSecret);
+  });
+
+  it('keeps audit summarization failures from changing the hook result', async () => {
+    const result = {
+      action: 'updateUser',
+      get user(): never {
+        throw new Error('Untrusted getter');
+      },
+    };
+    getInlineHook.mockResolvedValueOnce({
+      enabled: true,
+      script: 'const runInlineHook = () => ({});',
+    });
+    jest.spyOn(library, 'executeScript').mockResolvedValueOnce(result);
+
+    await expect(runHook({ key: LogtoInlineHookKey.PostSignIn, event: {} })).resolves.toBe(result);
+    expect(mockAppend).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        action: 'updateUser',
+        decision: 'updateUser',
+        inlineHookResult: '[unavailable]',
+      })
+    );
   });
 
   it('does not load or run hooks when dev features are disabled', async () => {
@@ -103,7 +286,7 @@ describe('InlineHookLibrary', () => {
     (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = false;
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         event: {},
       })
@@ -111,6 +294,7 @@ describe('InlineHookLibrary', () => {
 
     expect(getInlineHook).not.toHaveBeenCalled();
     expect(getSubscriptionData).not.toHaveBeenCalled();
+    expect(createLog).not.toHaveBeenCalled();
   });
 
   it('does not run disabled hooks', async () => {
@@ -124,11 +308,13 @@ describe('InlineHookLibrary', () => {
     });
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         event: {},
       })
     ).resolves.toBeUndefined();
+
+    expect(createLog).not.toHaveBeenCalled();
   });
 
   it('does not run when inline hook config is missing', async () => {
@@ -141,13 +327,14 @@ describe('InlineHookLibrary', () => {
     );
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         getEvent,
       })
     ).resolves.toBeUndefined();
 
     expect(getEvent).not.toHaveBeenCalled();
+    expect(createLog).not.toHaveBeenCalled();
   });
 
   it('rethrows non-404 errors when loading inline hook config', async () => {
@@ -158,7 +345,7 @@ describe('InlineHookLibrary', () => {
     getInlineHook.mockRejectedValueOnce(requestError);
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         event: {},
       })
@@ -186,7 +373,7 @@ describe('InlineHookLibrary', () => {
     const runScriptRemotely = jest.spyOn(library, 'runScriptRemotely');
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         getEvent,
       })
@@ -196,6 +383,8 @@ describe('InlineHookLibrary', () => {
     expect(executeScript).not.toHaveBeenCalled();
     expect(runScriptInLocalVm).not.toHaveBeenCalled();
     expect(runScriptRemotely).not.toHaveBeenCalled();
+    expect(getEvent).not.toHaveBeenCalled();
+    expect(createLog).not.toHaveBeenCalled();
   });
 
   it('allows PostSignIn execution errors to continue without hook enrichment', async () => {
@@ -210,11 +399,19 @@ describe('InlineHookLibrary', () => {
     });
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         event: {},
       })
     ).resolves.toBeUndefined();
+
+    expect(mockAppend).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        result: LogResult.Error,
+        decision: 'continue',
+        errorPolicyOutcome: 'allow',
+      })
+    );
   });
 
   it('keeps PostFirstFactorVerification allow-mode errors from granting access', () => {
@@ -241,32 +438,53 @@ describe('InlineHookLibrary', () => {
     });
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostFirstFactorVerification,
         event: {},
       })
     ).resolves.toEqual({
       action: 'rejectInvalidCredentials',
     });
+
+    expect(mockAppend).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        result: LogResult.Error,
+        decision: 'rejectInvalidCredentials',
+        errorPolicyOutcome: 'block',
+      })
+    );
   });
 
-  it('redacts the PostFirstFactorVerification password from tracked execution errors', async () => {
+  it('redacts credentials, scripts, and environment values from tracked execution errors', async () => {
     const password = 'secret-password';
+    const script = 'const privateInlineHookScript = true;';
+    const environmentSecret = 'environment-secret-value';
+    const nestedSecret = 'nested-secret-value';
     const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
-    jest
-      .spyOn(InlineHookLibrary, 'runScriptInLocalVm')
-      .mockRejectedValueOnce(new Error(`Inline hook failed with ${password}`));
+    class SensitiveExecutionError extends Error {
+      override readonly name = environmentSecret;
+
+      readonly code = password;
+    }
+    const executionError = new SensitiveExecutionError(
+      `Inline hook failed with ${password} ${script} ${environmentSecret} ${nestedSecret}`
+    );
+    jest.spyOn(InlineHookLibrary, 'runScriptInLocalVm').mockRejectedValueOnce(executionError);
     getInlineHook.mockResolvedValueOnce({
       enabled: true,
       onExecutionError: 'allow',
-      script: '',
+      script,
+      environmentVariables: {
+        API_TOKEN: environmentSecret,
+      },
     });
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostFirstFactorVerification,
         event: {
           password,
+          nested: { secret: { value: nestedSecret } },
         },
       })
     ).resolves.toEqual({
@@ -276,9 +494,16 @@ describe('InlineHookLibrary', () => {
     const trackedError = trackException.mock.calls[0]?.[0];
     expect(trackedError).toBeInstanceOf(Error);
     expect(trackedError).toMatchObject({
-      message: 'Inline hook failed with [redacted]',
+      name: 'Error',
+      message: 'Inline hook failed with [redacted] [redacted] [redacted] [redacted]',
     });
     expect((trackedError as Error).stack).not.toContain(password);
+    expect(JSON.stringify(trackedError)).not.toContain(script);
+    expect(JSON.stringify(trackedError)).not.toContain(environmentSecret);
+    expect(JSON.stringify(mockAppend.mock.calls)).not.toContain(password);
+    expect(JSON.stringify(mockAppend.mock.calls)).not.toContain(script);
+    expect(JSON.stringify(mockAppend.mock.calls)).not.toContain(environmentSecret);
+    expect(JSON.stringify(mockAppend.mock.calls)).not.toContain(nestedSecret);
   });
 
   it('removes remote request details from tracked execution errors', async () => {
@@ -301,7 +526,7 @@ describe('InlineHookLibrary', () => {
     });
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         event: {},
       })
@@ -328,7 +553,7 @@ describe('InlineHookLibrary', () => {
     });
 
     await expect(
-      library.runHook({
+      runHook({
         key: LogtoInlineHookKey.PostSignIn,
         event: {},
       })
@@ -336,6 +561,14 @@ describe('InlineHookLibrary', () => {
       code: 'session.verification_failed',
       status: 400,
     });
+
+    expect(mockAppend).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        result: LogResult.Error,
+        decision: 'throw',
+        errorPolicyOutcome: 'block',
+      })
+    );
   });
 
   it('returns the owning flow failure for block-mode execution errors', () => {
@@ -355,3 +588,4 @@ describe('InlineHookLibrary', () => {
     });
   });
 });
+/* eslint-enable max-lines */

--- a/packages/core/src/libraries/inline-hook.ts
+++ b/packages/core/src/libraries/inline-hook.ts
@@ -1,8 +1,12 @@
+/* eslint-disable max-lines -- Inline hook runtime, policy, and audit behavior share the same library. */
 import { appInsights } from '@logto/app-insights/node';
 import {
   adminTenantId,
+  inlineHook as inlineHookLog,
+  LogResult,
   LogtoInlineHookKey,
   type InlineHookExecutionErrorPolicy,
+  type InlineHookExecutionRequestBody,
 } from '@logto/schemas';
 import { got, HTTPError } from 'got';
 import { ZodError } from 'zod';
@@ -11,12 +15,21 @@ import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import type { SubscriptionLibrary } from '#src/libraries/subscription.js';
+import type { LogContext, LogPayload } from '#src/middleware/koa-audit-log.js';
 import { parseAzureFunctionsResponseError } from '#src/utils/custom-jwt/index.js';
 import {
   buildLocalVmErrorBody,
   LocalVmError,
   runScriptFunctionInLocalVm,
 } from '#src/utils/local-vm/index.js';
+
+import {
+  buildSafeInlineHookErrorSummary,
+  buildSafeInlineHookTelemetryError,
+  getInlineHookSensitiveValues,
+  sanitizeInlineHookEvent,
+  sanitizeInlineHookResult,
+} from './inline-hook-sanitization.js';
 
 const inlineHookFunctionName = 'runInlineHook';
 const defaultInlineHookExecutionErrorPolicy = 'block' satisfies InlineHookExecutionErrorPolicy;
@@ -61,6 +74,8 @@ type InlineHookEventSource<Event> =
 
 type RunInlineHookData<Event> = InlineHookEventSource<Event> & {
   key: LogtoInlineHookKey;
+  auditContext: Pick<LogContext, 'createLog'> &
+    Pick<LogPayload, 'applicationId' | 'sessionId' | 'userId'>;
 };
 
 type InlineHookExecutionErrorHandlingData = {
@@ -68,52 +83,41 @@ type InlineHookExecutionErrorHandlingData = {
   onExecutionError?: InlineHookExecutionErrorPolicy;
 };
 
-type InlineHookExecutionErrorTelemetryData<Event> = InlineHookExecutionErrorHandlingData & {
-  event: Event;
-};
+type InlineHookExecutionOutcome =
+  | { status: 'success'; result: unknown }
+  | { status: 'error'; error: unknown };
 
-const sensitiveValueReplacement = '[redacted]';
+const inlineHookLogTypes = Object.freeze({
+  [LogtoInlineHookKey.PostFirstFactorVerification]: inlineHookLog.Type.PostFirstFactorVerification,
+  [LogtoInlineHookKey.PostSignIn]: inlineHookLog.Type.PostSignIn,
+} satisfies Record<LogtoInlineHookKey, inlineHookLog.Type>);
 
-const getPostFirstFactorVerificationPassword = (event: unknown) => {
-  if (
-    typeof event === 'object' &&
-    event !== null &&
-    'password' in event &&
-    typeof event.password === 'string'
-  ) {
-    return event.password;
+const getInlineHookLogKey = (key: LogtoInlineHookKey): inlineHookLog.LogKey =>
+  `${inlineHookLog.prefix}.${inlineHookLogTypes[key]}`;
+
+const inlineHookResultActions = Object.freeze({
+  [LogtoInlineHookKey.PostFirstFactorVerification]: ['createUser', 'updateUser'],
+  [LogtoInlineHookKey.PostSignIn]: ['updateUser'],
+} satisfies Record<LogtoInlineHookKey, readonly string[]>);
+
+const getInlineHookResultActionSummary = (key: LogtoInlineHookKey, result: unknown) => {
+  try {
+    if (typeof result !== 'object' || result === null) {
+      return { decision: 'noop' };
+    }
+
+    const rawAction: unknown = Reflect.get(result, 'action');
+
+    if (typeof rawAction !== 'string') {
+      return { decision: 'noop' };
+    }
+
+    const action = inlineHookResultActions[key].find((candidate) => candidate === rawAction);
+
+    return action ? { action, decision: action } : { decision: 'invalid' };
+  } catch {
+    return { decision: 'invalid' };
   }
-};
-
-const redactSensitiveValue = (value: string, sensitiveValue: string) =>
-  value.split(sensitiveValue).join(sensitiveValueReplacement);
-
-const buildInlineHookExecutionErrorTelemetryPayload = <Event>({
-  key,
-  event,
-  error,
-}: InlineHookExecutionErrorTelemetryData<Event> & {
-  error: unknown;
-}) => {
-  const password =
-    key === LogtoInlineHookKey.PostFirstFactorVerification
-      ? getPostFirstFactorVerificationPassword(event)
-      : undefined;
-
-  const sanitize = (value: string) => (password ? redactSensitiveValue(value, password) : value);
-
-  const telemetryError = new Error(
-    sanitize(error instanceof Error ? error.message : String(error))
-  );
-
-  if (error instanceof Error) {
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Keep the original error type on the sanitized telemetry copy.
-    telemetryError.name = error.name;
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Preserve the useful stack on the sanitized telemetry copy.
-    telemetryError.stack = error.stack && sanitize(error.stack);
-  }
-
-  return telemetryError;
 };
 
 const getInlineHookErrorFallback = (
@@ -145,9 +149,9 @@ export const getInlineHookExecutionErrorPolicyDecision = ({
   return getInlineHookErrorFallback(key);
 };
 
-const handleInlineHookExecutionError = (data: InlineHookExecutionErrorHandlingData) => {
-  const decision = getInlineHookExecutionErrorPolicyDecision(data);
-
+const applyInlineHookExecutionErrorPolicyDecision = (
+  decision: InlineHookExecutionErrorPolicyDecision
+) => {
   if (decision.action === 'throw') {
     throw decision.error;
   }
@@ -277,7 +281,12 @@ export class InlineHookLibrary {
     }
   }
 
-  async runHook<Event>({ key, ...eventSource }: RunInlineHookData<Event>): Promise<unknown> {
+  async runHook<Event>({
+    key,
+    auditContext: { createLog, ...auditContext },
+    ...eventSource
+  }: RunInlineHookData<Event>): Promise<unknown> {
+    // Inline Hooks
     if (!EnvSet.values.isDevFeaturesEnabled) {
       return;
     }
@@ -293,24 +302,64 @@ export class InlineHookLibrary {
     }
 
     const event = 'getEvent' in eventSource ? await eventSource.getEvent() : eventSource.event;
+    const executionPayload: InlineHookExecutionRequestBody = {
+      script: inlineHook.script,
+      hookType: key,
+      // Production events are always JSON-serializable payloads from Core call sites.
+      // eslint-disable-next-line no-restricted-syntax -- Generic Event is wider than Json; cast at the shared execution boundary.
+      event: event as InlineHookExecutionRequestBody['event'],
+      environmentVariables: inlineHook.environmentVariables,
+    };
+    const sensitiveValues = getInlineHookSensitiveValues(executionPayload);
+    const onExecutionError = inlineHook.onExecutionError ?? defaultInlineHookExecutionErrorPolicy;
+    const runtimeLocation = EnvSet.values.isCloud ? 'remote' : 'local';
+    const startedAt = Date.now();
+    const log = createLog(getInlineHookLogKey(key), { independent: true });
 
-    try {
-      return await this.executeScript({
-        script: inlineHook.script,
-        hookType: key,
-        event,
-        environmentVariables: inlineHook.environmentVariables,
-      });
-    } catch (error: unknown) {
-      void appInsights.trackException(
-        buildInlineHookExecutionErrorTelemetryPayload({ key, event, error })
-      );
+    log.append({
+      ...auditContext,
+      tenantId: this.tenantId,
+      hookType: key,
+      runtimeLocation,
+      onExecutionError,
+      event: sanitizeInlineHookEvent(event, sensitiveValues),
+    });
 
-      return handleInlineHookExecutionError({
-        key,
-        onExecutionError: inlineHook.onExecutionError,
+    const executionOutcome = await this.executeScript(executionPayload).then<
+      InlineHookExecutionOutcome,
+      InlineHookExecutionOutcome
+    >(
+      (result) => ({ status: 'success', result }),
+      (error: unknown) => ({ status: 'error', error })
+    );
+
+    if (executionOutcome.status === 'error') {
+      const { error } = executionOutcome;
+      const decision = getInlineHookExecutionErrorPolicyDecision({ key, onExecutionError });
+
+      log.append({
+        result: LogResult.Error,
+        durationMs: Date.now() - startedAt,
+        decision: decision.action,
+        errorPolicyOutcome: decision.action === 'continue' ? 'allow' : 'block',
+        inlineHookError: buildSafeInlineHookErrorSummary(error, sensitiveValues),
       });
+
+      void appInsights.trackException(buildSafeInlineHookTelemetryError(error, sensitiveValues));
+
+      return applyInlineHookExecutionErrorPolicyDecision(decision);
     }
+
+    const { result } = executionOutcome;
+    const actionSummary = getInlineHookResultActionSummary(key, result);
+
+    log.append({
+      durationMs: Date.now() - startedAt,
+      ...actionSummary,
+      inlineHookResult: sanitizeInlineHookResult(result, sensitiveValues),
+    });
+
+    return result;
   }
 
   private async findEnabledInlineHook(key: LogtoInlineHookKey) {
@@ -347,3 +396,4 @@ export class InlineHookLibrary {
     return quota.inlineHooksEnabled;
   }
 }
+/* eslint-enable max-lines */

--- a/packages/core/src/libraries/inline-hook.ts
+++ b/packages/core/src/libraries/inline-hook.ts
@@ -286,7 +286,6 @@ export class InlineHookLibrary {
     auditContext: { createLog, ...auditContext },
     ...eventSource
   }: RunInlineHookData<Event>): Promise<unknown> {
-    // Inline Hooks
     if (!EnvSet.values.isDevFeaturesEnabled) {
       return;
     }

--- a/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
@@ -58,6 +58,10 @@ const users = {
 };
 
 const tenant = new MockTenant(createMockProvider(), { signInExperiences, users });
+const mockInteractionDetails = {
+  jti: 'session-id',
+  params: { client_id: 'application-id' },
+} as unknown as WithHooksAndLogsContext['interactionDetails'];
 
 const ExperienceInteraction = await pickDefault(import('./experience-interaction.js'));
 
@@ -446,6 +450,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
       assignReleaseOnSuccessInteractionHookResult: jest.fn(),
       assignReleaseAnywayInteractionHookResult: jest.fn(),
       appendDataHookContext: jest.fn(),
+      interactionDetails: mockInteractionDetails,
       ...createContextWithRouteParameters({
         headers: {
           'x-logto-cf-bot-score': '10',
@@ -667,6 +672,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
       assignReleaseOnSuccessInteractionHookResult: jest.fn(),
       assignReleaseAnywayInteractionHookResult: jest.fn(),
       appendDataHookContext: jest.fn(),
+      interactionDetails: mockInteractionDetails,
       ...createContextWithRouteParameters({
         headers: {
           'x-logto-cf-bot-score': '10',
@@ -741,6 +747,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         assignReleaseOnSuccessInteractionHookResult: jest.fn(),
         assignReleaseAnywayInteractionHookResult: jest.fn(),
         appendDataHookContext: jest.fn(),
+        interactionDetails: mockInteractionDetails,
         ...createContextWithRouteParameters({
           headers: {
             'x-logto-cf-bot-score': '10',
@@ -792,6 +799,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
       assignReleaseOnSuccessInteractionHookResult: jest.fn(),
       assignReleaseAnywayInteractionHookResult: jest.fn(),
       appendDataHookContext: jest.fn(),
+      interactionDetails: mockInteractionDetails,
       ...createContextWithRouteParameters({
         headers: {
           'x-logto-cf-bot-score': '10',

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -137,7 +137,10 @@ const createSignInInteraction = ({
   );
   const runHook = jest.fn(
     async <Event>(
-      input: { key: LogtoInlineHookKey } & ({ event: Event } | { getEvent: () => Promise<Event> })
+      input: { key: LogtoInlineHookKey; auditContext: unknown } & (
+        | { event: Event }
+        | { getEvent: () => Promise<Event> }
+      )
     ): Promise<unknown> => {
       const event = 'getEvent' in input ? await input.getEvent() : input.event;
       return runHookHandler({ key: input.key, event });
@@ -173,7 +176,17 @@ const createSignInInteraction = ({
           },
         }
   );
-  // @ts-expect-error --mock test context
+  const interactionDetails = {
+    jti: 'session-id',
+    params: {
+      client_id: adminConsoleApplicationId,
+    },
+    result: {
+      interactionEvent,
+      userId: user.id,
+      ...interactionResult,
+    },
+  } as unknown as Interaction;
   const signInContext: WithHooksAndLogsContext = {
     assignReleaseOnSuccessInteractionHookResult: jest.fn(),
     assignReleaseAnywayInteractionHookResult: jest.fn(),
@@ -181,14 +194,8 @@ const createSignInInteraction = ({
     appendExceptionHookContext: jest.fn(),
     ...baseContext,
     ...logContext,
+    interactionDetails,
   };
-  const interactionDetails = {
-    result: {
-      interactionEvent,
-      userId: user.id,
-      ...interactionResult,
-    },
-  } as unknown as Interaction;
 
   const experienceInteraction = new ExperienceInteraction(
     signInContext,
@@ -298,7 +305,16 @@ describe('ExperienceInteraction class', () => {
 
       expect(getUserContext).toHaveBeenCalledWith(mockUser.id);
       const [runHookInput] = runHook.mock.calls[0]!;
-      expect(runHookInput).toMatchObject({ key: LogtoInlineHookKey.PostSignIn });
+      expect(runHookInput).toMatchObject({
+        key: LogtoInlineHookKey.PostSignIn,
+        auditContext: {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+          createLog: expect.any(Function),
+          sessionId: 'session-id',
+          applicationId: adminConsoleApplicationId,
+          userId: mockUser.id,
+        },
+      });
       expect('getEvent' in runHookInput && typeof runHookInput.getEvent).toBe('function');
       expect(runHookHandler).toHaveBeenCalledWith({
         key: LogtoInlineHookKey.PostSignIn,

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -11,7 +11,7 @@ import {
   type User,
 } from '@logto/schemas';
 import { maskEmail, maskPhone } from '@logto/shared';
-import { conditional, trySafe } from '@silverhand/essentials';
+import { conditional, conditionalString, trySafe } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -707,6 +707,7 @@ export default class ExperienceInteraction {
   }
 
   private async triggerPostSignInInlineHook(userId: string) {
+    // Inline Hooks
     if (this.#interactionEvent !== InteractionEvent.SignIn || !EnvSet.values.isDevFeaturesEnabled) {
       return;
     }
@@ -718,6 +719,12 @@ export default class ExperienceInteraction {
       userId,
       result: await inlineHooks.runHook({
         key: LogtoInlineHookKey.PostSignIn,
+        auditContext: {
+          createLog: this.ctx.createLog,
+          sessionId: this.ctx.interactionDetails.jti,
+          applicationId: conditionalString(this.ctx.interactionDetails.params.client_id),
+          userId,
+        },
         getEvent: async (): Promise<PostSignInEvent> => ({
           key: LogtoInlineHookKey.PostSignIn,
           interactionEvent: InteractionEvent.SignIn,

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -11,7 +11,7 @@ import {
   type User,
 } from '@logto/schemas';
 import { maskEmail, maskPhone } from '@logto/shared';
-import { conditional, conditionalString, trySafe } from '@silverhand/essentials';
+import { conditional, trySafe } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -707,7 +707,6 @@ export default class ExperienceInteraction {
   }
 
   private async triggerPostSignInInlineHook(userId: string) {
-    // Inline Hooks
     if (this.#interactionEvent !== InteractionEvent.SignIn || !EnvSet.values.isDevFeaturesEnabled) {
       return;
     }
@@ -722,7 +721,10 @@ export default class ExperienceInteraction {
         auditContext: {
           createLog: this.ctx.createLog,
           sessionId: this.ctx.interactionDetails.jti,
-          applicationId: conditionalString(this.ctx.interactionDetails.params.client_id),
+          applicationId: conditional(
+            typeof this.ctx.interactionDetails.params.client_id === 'string' &&
+              this.ctx.interactionDetails.params.client_id
+          ),
           userId,
         },
         getEvent: async (): Promise<PostSignInEvent> => ({

--- a/packages/core/src/routes/experience/verification-routes/password-verification.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/password-verification.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Password verification fallback scenarios share extensive route mocks. */
 import {
   InteractionEvent,
   LogtoInlineHookKey,
@@ -125,6 +126,9 @@ const runHook = jest.fn();
 const findUserByEmail = jest.fn();
 const createUser = jest.fn();
 const updateUser = jest.fn();
+const createLog = jest.fn();
+const applicationId = 'application-id';
+const sessionId = 'session-id';
 
 type PasswordVerificationRouteContext = {
   experienceInteraction: {
@@ -138,6 +142,13 @@ type PasswordVerificationRouteContext = {
   };
   verificationAuditLog: {
     append: jest.Mock;
+  };
+  createLog: typeof createLog;
+  interactionDetails: {
+    jti: string;
+    params: {
+      client_id: string;
+    };
   };
   guard: {
     body: {
@@ -186,6 +197,13 @@ const createContext = (
   },
   verificationAuditLog: {
     append: jest.fn(),
+  },
+  createLog,
+  interactionDetails: {
+    jti: sessionId,
+    params: {
+      client_id: applicationId,
+    },
   },
   guard: {
     body: {
@@ -252,6 +270,12 @@ describe('password verification route PostFirstFactorVerification fallback', () 
     await expect(getSentinelPromise()).rejects.toBe(invalidCredentialsError);
     expect(runHook).toHaveBeenCalledWith({
       key: LogtoInlineHookKey.PostFirstFactorVerification,
+      auditContext: {
+        createLog,
+        sessionId,
+        applicationId,
+        userId: undefined,
+      },
       event: {
         key: LogtoInlineHookKey.PostFirstFactorVerification,
         interactionEvent: InteractionEvent.SignIn,
@@ -368,6 +392,12 @@ describe('password verification route PostFirstFactorVerification fallback', () 
 
     expect(runHook).toHaveBeenCalledWith({
       key: LogtoInlineHookKey.PostFirstFactorVerification,
+      auditContext: {
+        createLog,
+        sessionId,
+        applicationId,
+        userId: mockUser.id,
+      },
       event: {
         key: LogtoInlineHookKey.PostFirstFactorVerification,
         interactionEvent: InteractionEvent.SignIn,
@@ -446,3 +476,4 @@ describe('password verification route PostFirstFactorVerification fallback', () 
     expect(updateUser).not.toHaveBeenCalled();
   });
 });
+/* eslint-enable max-lines */

--- a/packages/core/src/routes/experience/verification-routes/password-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/password-verification.ts
@@ -9,7 +9,7 @@ import {
   VerificationType,
 } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
-import { conditionalString } from '@silverhand/essentials';
+import { conditional } from '@silverhand/essentials';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
@@ -129,7 +129,10 @@ export default function passwordVerificationRoutes<T extends ExperienceInteracti
                 auditContext: {
                   createLog: ctx.createLog,
                   sessionId: ctx.interactionDetails.jti,
-                  applicationId: conditionalString(ctx.interactionDetails.params.client_id),
+                  applicationId: conditional(
+                    typeof ctx.interactionDetails.params.client_id === 'string' &&
+                      ctx.interactionDetails.params.client_id
+                  ),
                   userId: existingUser?.id,
                 },
               }),

--- a/packages/core/src/routes/experience/verification-routes/password-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/password-verification.ts
@@ -9,6 +9,7 @@ import {
   VerificationType,
 } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
+import { conditionalString } from '@silverhand/essentials';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
@@ -125,6 +126,12 @@ export default function passwordVerificationRoutes<T extends ExperienceInteracti
               result: await libraries.inlineHooks.runHook({
                 key: LogtoInlineHookKey.PostFirstFactorVerification,
                 event,
+                auditContext: {
+                  createLog: ctx.createLog,
+                  sessionId: ctx.interactionDetails.jti,
+                  applicationId: conditionalString(ctx.interactionDetails.params.client_id),
+                  userId: existingUser?.id,
+                },
               }),
             });
 

--- a/packages/schemas/src/types/log/index.ts
+++ b/packages/schemas/src/types/log/index.ts
@@ -1,4 +1,5 @@
 import type * as hook from './hook.js';
+import type * as inlineHook from './inline-hook.js';
 import type * as interaction from './interaction.js';
 import type * as jwtCustomizer from './jwt-customizer.js';
 import type * as saml from './saml.js';
@@ -7,6 +8,7 @@ import type * as token from './token.js';
 export * as interaction from './interaction.js';
 export * as token from './token.js';
 export * as hook from './hook.js';
+export * as inlineHook from './inline-hook.js';
 export * as jwtCustomizer from './jwt-customizer.js';
 export * as saml from './saml.js';
 
@@ -16,6 +18,7 @@ export const LogKeyUnknown = 'Unknown';
 export type InteractionLogKey = interaction.LogKey;
 export type TokenLogKey = token.LogKey;
 export type WebhookLogKey = hook.LogKey;
+export type InlineHookLogKey = inlineHook.LogKey;
 export type JwtCustomizerLogKey = jwtCustomizer.LogKey;
 export type SamlLogKey = saml.LogKey;
 
@@ -30,6 +33,7 @@ export type AuditLogKey =
   | InteractionLogKey
   | TokenLogKey
   | SamlLogKey
+  | InlineHookLogKey
   | JwtCustomizerLogKey;
 
 /**
@@ -42,6 +46,7 @@ export type AuditLogPrefix =
   | interaction.Prefix
   | token.Type
   | saml.Prefix
+  | inlineHook.Prefix
   | jwtCustomizer.Prefix
   | typeof LogKeyUnknown;
 

--- a/packages/schemas/src/types/log/inline-hook.ts
+++ b/packages/schemas/src/types/log/inline-hook.ts
@@ -1,0 +1,10 @@
+export type Prefix = 'InlineHook';
+
+export const prefix: Prefix = 'InlineHook';
+
+export enum Type {
+  PostFirstFactorVerification = 'PostFirstFactorVerification',
+  PostSignIn = 'PostSignIn',
+}
+
+export type LogKey = `${Prefix}.${Type}`;


### PR DESCRIPTION
## Summary

- add dedicated audit-log keys for PostFirstFactorVerification and PostSignIn Inline Hook executions
- record safe execution context, runtime location, latency, decisions, policy outcomes, and independent success or error results
- attach application, session, and user context at the P1 and P2 execution call sites

## Dependencies

- stacked on #9245 for audit-log persistence and Inline Hook data sanitization

## Review context

This PR replaces the execution-recording portion of #9231. The earlier #9137 and #9221 dependencies are already merged into `master`.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
