### PR TITLE
feat(core,console): expose inline hook audit log events

### DIFF
--- a/packages/console/src/consts/logs.test.ts
+++ b/packages/console/src/consts/logs.test.ts
@@ -1,0 +1,37 @@
+// eslint-disable-next-line @silverhand/fp/no-let
+let mockIsDevFeaturesEnabled = false;
+
+jest.mock('./env', () => ({
+  get isDevFeaturesEnabled() {
+    return mockIsDevFeaturesEnabled;
+  },
+}));
+
+describe('inline hook audit log event visibility', () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it.each([false, true])(
+    'exposes inline hook event titles when dev features are %s',
+    async (isDevFeaturesEnabled) => {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle the mocked build-time feature flag.
+      mockIsDevFeaturesEnabled = isDevFeaturesEnabled;
+
+      const { auditLogEventTitle } = await import('./logs');
+
+      if (isDevFeaturesEnabled) {
+        expect(auditLogEventTitle).toMatchObject({
+          'InlineHook.PostFirstFactorVerification':
+            'Execute post first-factor verification inline hook',
+          'InlineHook.PostSignIn': 'Execute post sign-in inline hook',
+        });
+        return;
+      }
+
+      expect(auditLogEventTitle).not.toHaveProperty('InlineHook.PostFirstFactorVerification');
+      expect(auditLogEventTitle).not.toHaveProperty('InlineHook.PostSignIn');
+    }
+  );
+});

--- a/packages/console/src/consts/logs.ts
+++ b/packages/console/src/consts/logs.ts
@@ -1,6 +1,8 @@
 import type { AuditLogKey, LogKey, interaction } from '@logto/schemas';
 import { type Optional } from '@silverhand/essentials';
 
+import { isDevFeaturesEnabled } from './env';
+
 export const auditLogEventTitle = Object.freeze({
   'ExchangeTokenBy.AuthorizationCode': 'Exchange token by Code',
   'ExchangeTokenBy.ClientCredentials': 'Exchange token by Client Credentials',
@@ -93,6 +95,14 @@ export const auditLogEventTitle = Object.freeze({
   'JwtCustomizer.ClientCredentials': 'Get custom M2M access token claims',
   'SamlApplication.AuthnRequest': 'Receive SAML application authentication request',
   'SamlApplication.Callback': 'Handle SAML application callback',
+  // Inline Hooks
+  ...(isDevFeaturesEnabled
+    ? {
+        'InlineHook.PostFirstFactorVerification':
+          'Execute post first-factor verification inline hook',
+        'InlineHook.PostSignIn': 'Execute post sign-in inline hook',
+      }
+    : {}),
 } satisfies Partial<Record<Exclude<AuditLogKey, interaction.DeprecatedInteractionLogKey>, string>>);
 
 export const logEventTitle: Record<string, Optional<string>> & {

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -1,7 +1,16 @@
-import { LogResult, token, interaction, LogKeyUnknown, jwtCustomizer, saml } from '@logto/schemas';
+import {
+  LogResult,
+  token,
+  interaction,
+  inlineHook,
+  LogKeyUnknown,
+  jwtCustomizer,
+  saml,
+} from '@logto/schemas';
 import type { Log } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 
+import { EnvSet } from '#src/env-set/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
@@ -20,6 +29,11 @@ const logs = {
 };
 const { countLogs, findLogs, findLogById } = logs;
 const logRoutes = await pickDefault(import('./log.js'));
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', isDevFeaturesEnabled);
+};
 
 describe('logRoutes', () => {
   const logRequest = createRequester({
@@ -29,21 +43,42 @@ describe('logRoutes', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
   });
 
   describe('GET /logs', () => {
-    it('should call countLogs and findLogs with correct parameters', async () => {
-      const userId = 'userIdValue';
-      const applicationId = 'foo';
-      const logKey = 'SignInUsernamePassword';
-      const page = 1;
-      const pageSize = 5;
+    it.each([false, true])(
+      'should call countLogs and findLogs with correct parameters when dev features are %s',
+      async (isDevFeaturesEnabled) => {
+        setDevFeaturesEnabled(isDevFeaturesEnabled);
+        const inlineHookPrefixes = isDevFeaturesEnabled ? [inlineHook.prefix] : [];
+        const userId = 'userIdValue';
+        const applicationId = 'foo';
+        const logKey = 'SignInUsernamePassword';
+        const page = 1;
+        const pageSize = 5;
 
-      await logRequest.get(
-        `/logs?userId=${userId}&applicationId=${applicationId}&logKey=${logKey}&page=${page}&page_size=${pageSize}`
-      );
-      expect(countLogs).toHaveBeenCalledWith(
-        {
+        await logRequest.get(
+          `/logs?userId=${userId}&applicationId=${applicationId}&logKey=${logKey}&page=${page}&page_size=${pageSize}`
+        );
+        expect(countLogs).toHaveBeenCalledWith(
+          {
+            payload: { userId, applicationId },
+            logKey,
+            includeKeyPrefix: [
+              token.Type.ExchangeTokenBy,
+              token.Type.RevokeToken,
+              token.Type.RevokeGrants,
+              interaction.prefix,
+              jwtCustomizer.prefix,
+              saml.prefix,
+              ...inlineHookPrefixes,
+              LogKeyUnknown,
+            ],
+          },
+          { capped: false }
+        );
+        expect(findLogs).toHaveBeenCalledWith(5, 0, {
           payload: { userId, applicationId },
           logKey,
           includeKeyPrefix: [
@@ -53,25 +88,12 @@ describe('logRoutes', () => {
             interaction.prefix,
             jwtCustomizer.prefix,
             saml.prefix,
+            ...inlineHookPrefixes,
             LogKeyUnknown,
           ],
-        },
-        { capped: false }
-      );
-      expect(findLogs).toHaveBeenCalledWith(5, 0, {
-        payload: { userId, applicationId },
-        logKey,
-        includeKeyPrefix: [
-          token.Type.ExchangeTokenBy,
-          token.Type.RevokeToken,
-          token.Type.RevokeGrants,
-          interaction.prefix,
-          jwtCustomizer.prefix,
-          saml.prefix,
-          LogKeyUnknown,
-        ],
-      });
-    });
+        });
+      }
+    );
 
     it('should return correct response', async () => {
       const response = await logRequest.get(`/logs`);

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -8,7 +8,7 @@ import {
   saml,
   type AuditLogPrefix,
 } from '@logto/schemas';
-import { yes } from '@silverhand/essentials';
+import { conditionalArray, yes } from '@silverhand/essentials';
 import { object, string } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
@@ -56,7 +56,7 @@ export default function logRoutes<T extends ManagementApiRouter>(
         jwtCustomizer.prefix,
         saml.prefix,
         // Inline Hooks
-        ...(EnvSet.values.isDevFeaturesEnabled ? [inlineHook.prefix] : []),
+        ...conditionalArray(EnvSet.values.isDevFeaturesEnabled && inlineHook.prefix),
         LogKeyUnknown,
       ];
 

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -1,5 +1,6 @@
 import {
   Logs,
+  inlineHook,
   interaction,
   token,
   LogKeyUnknown,
@@ -10,6 +11,7 @@ import {
 import { yes } from '@silverhand/essentials';
 import { object, string } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { parseTimestampParam, validateTimeWindow } from '#src/utils/time-window.js';
@@ -53,6 +55,8 @@ export default function logRoutes<T extends ManagementApiRouter>(
         interaction.prefix,
         jwtCustomizer.prefix,
         saml.prefix,
+        // Inline Hooks
+        ...(EnvSet.values.isDevFeaturesEnabled ? [inlineHook.prefix] : []),
         LogKeyUnknown,
       ];
 


### PR DESCRIPTION
## Summary

- include Inline Hook audit events in the Management API audit-log query
- map PostFirstFactorVerification and PostSignIn events to Console audit-log titles
- cover the API prefix filtering and Console event mapping

## Dependencies

- stacked on #9246, which records the Inline Hook execution audit entries

## Review context

This PR replaces the API and Console portion of #9231. Its unchanged Console diff was [previously approved](https://github.com/logto-io/logto/pull/9231#pullrequestreview-4740964080).

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

Closes LOG-13718
