### PR TITLE
feat(schemas): add saml sso connector signing keys table

### DIFF
--- a/packages/schemas/alterations/next-1784620000-add-saml-sso-connector-signing-keys-table.ts
+++ b/packages/schemas/alterations/next-1784620000-add-saml-sso-connector-signing-keys-table.ts
@@ -1,0 +1,38 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table saml_sso_connector_signing_keys (
+        id varchar(21) not null,
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        sso_connector_id varchar(128) not null
+          references sso_connectors (id) on update cascade on delete cascade,
+        private_key text not null,
+        certificate text not null,
+        created_at timestamptz not null default now(),
+        expires_at timestamptz not null,
+        active boolean not null,
+        primary key (tenant_id, sso_connector_id, id)
+      );
+
+      create unique index saml_sso_connector_signing_keys__unique_active
+        on saml_sso_connector_signing_keys (tenant_id, sso_connector_id, active)
+        where active;
+    `);
+    await applyTableRls(pool, 'saml_sso_connector_signing_keys');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'saml_sso_connector_signing_keys');
+    await pool.query(sql`
+      drop table saml_sso_connector_signing_keys;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/saml_sso_connector_signing_keys.sql
+++ b/packages/schemas/tables/saml_sso_connector_signing_keys.sql
@@ -1,0 +1,21 @@
+/* init_order = 2 */
+
+create table saml_sso_connector_signing_keys (
+  id varchar(21) not null,
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  sso_connector_id varchar(128) not null
+    references sso_connectors (id) on update cascade on delete cascade,
+  /** The SP private key (plaintext PEM) used to sign the SAML AuthnRequest. Tenant-isolated by RLS and never returned by the API. */
+  private_key text not null,
+  /** The PEM-encoded self-signed SP certificate matching the private key. Public and safe to expose. */
+  certificate text not null,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  active boolean not null,
+  primary key (tenant_id, sso_connector_id, id)
+);
+
+create unique index saml_sso_connector_signing_keys__unique_active
+  on saml_sso_connector_signing_keys (tenant_id, sso_connector_id, active)
+  where active;


### PR DESCRIPTION
## Summary
Adds the `saml_sso_connector_signing_keys` table — per-connector Service-Provider signing keys for the upcoming optional signed AuthnRequest feature on enterprise SSO SAML connectors.

**Multi-key model with an `active` flag** — a connector may hold several keys with at most one active (partial unique index `(tenant_id, sso_connector_id, active) where active`), identical in shape to the existing `saml_application_secrets` (Logto's IdP signing keys). This enables **graceful, zero-downtime SP-cert rotation** (generate new → register at IdP → activate → retire old). Private key + certificate stored as plaintext PEM, tenant-isolated by RLS, never returned by the API.

Both halves of the schema change are here so the alteration-compatibility CI can diff them:
- `packages/schemas/tables/saml_sso_connector_signing_keys.sql` — source-of-truth seed.
- `packages/schemas/alterations/next-1784620000-add-saml-sso-connector-signing-keys-table.ts` — additive migration (`next-` prefix; version assigned at release). `up` creates the table + partial unique index + applies RLS; `down` is the clean inverse.

This is a purely additive new table — no existing table, column, or row is touched, so it has zero effect on current behavior until later feature PRs read from it.

Refs LOG-13835, LOG-13836.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments