### PR TITLE
fix(core): enable OIDC provider SSRF protection by default

### DIFF
--- a/.changeset/secure-oidc-provider-fetch.md
+++ b/.changeset/secure-oidc-provider-fetch.md
@@ -3,14 +3,6 @@
 "@logto/shared": patch
 ---
 
-enable SSRF protection for OIDC provider outbound requests by default in self-hosted deployments
+strengthen OIDC provider outbound request security with SSRF protection enabled by default
 
-## Security enhancement
-
-Self-hosted OSS deployments now use the OIDC provider's built-in SSRF safeguards for outgoing requests such as client `jwks_uri`, `sector_identifier_uri`, and back-channel logout endpoints. These safeguards protect requests from destinations that resolve to loopback, private, and other special-use network addresses.
-
-## Action required for self-hosted OSS
-
-No action is required unless your Logto instance must reach trusted relying-party endpoints on a private network. In that case, set `OIDC_PROVIDER_SSRF_PROTECTION_ENABLED=false` before starting the new or upgraded deployment to retain the previous behavior.
-
-Disabling this protection permits OIDC provider outbound requests to private networks and should only be used when those endpoints are trusted. New deployments should leave the variable unset unless private-network access is required. Logto Cloud always keeps SSRF protection enabled.
+Self-hosted deployments that need to reach trusted relying-party endpoints on private networks must set `OIDC_PROVIDER_SSRF_PROTECTION_ENABLED=false` before starting Logto; otherwise, leave the variable unset.

--- a/.changeset/secure-oidc-provider-fetch.md
+++ b/.changeset/secure-oidc-provider-fetch.md
@@ -1,0 +1,16 @@
+---
+"@logto/core": patch
+"@logto/shared": patch
+---
+
+enable SSRF protection for OIDC provider outbound requests by default in self-hosted deployments
+
+## Security enhancement
+
+Self-hosted OSS deployments now use the OIDC provider's built-in SSRF safeguards for outgoing requests such as client `jwks_uri`, `sector_identifier_uri`, and back-channel logout endpoints. These safeguards protect requests from destinations that resolve to loopback, private, and other special-use network addresses.
+
+## Action required for self-hosted OSS
+
+No action is required unless your Logto instance must reach trusted relying-party endpoints on a private network. In that case, set `OIDC_PROVIDER_SSRF_PROTECTION_ENABLED=false` before starting the new or upgraded deployment to retain the previous behavior.
+
+Disabling this protection permits OIDC provider outbound requests to private networks and should only be used when those endpoints are trusted. New deployments should leave the variable unset unless private-network access is required. Logto Cloud always keeps SSRF protection enabled.

--- a/.changeset/secure-oidc-provider-fetch.md
+++ b/.changeset/secure-oidc-provider-fetch.md
@@ -5,4 +5,4 @@
 
 strengthen OIDC provider outbound request security with SSRF protection enabled by default
 
-Self-hosted deployments that need to reach trusted relying-party endpoints on private networks must set `OIDC_PROVIDER_SSRF_PROTECTION_ENABLED=false` before starting Logto; otherwise, leave the variable unset.
+Self-hosted deployments that need to reach trusted relying-party endpoints on private networks must set `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED=true` before starting Logto; otherwise, leave the variable unset.

--- a/.changeset/secure-oidc-provider-fetch.md
+++ b/.changeset/secure-oidc-provider-fetch.md
@@ -5,4 +5,6 @@
 
 strengthen OIDC provider outbound request security with SSRF protection enabled by default
 
+## Action required
+
 Self-hosted deployments that need to reach trusted relying-party endpoints on private networks must set `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED=true` before starting Logto; otherwise, leave the variable unset.

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,6 +41,8 @@ jobs:
     env:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: ${{ matrix.dev-features-enabled }}
+      # Allow Console tests to use the local backchannel logout mock server.
+      OIDC_PROVIDER_SSRF_PROTECTION_DISABLED: ${{ matrix.target == 'console' }}
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
       # Optional default grace period, in seconds, for OIDC private key rotation when the API
       # request omits `rotationGracePeriod`.
       - PRIVATE_KEY_ROTATION_GRACE_PERIOD
-      # Set to `false` only when trusted OIDC relying-party endpoints resolve to private networks.
+      # Set to `true` only when trusted OIDC relying-party endpoints resolve to private networks.
       # SSRF protection for oidc-provider outbound requests is enabled by default.
-      - OIDC_PROVIDER_SSRF_PROTECTION_ENABLED
+      - OIDC_PROVIDER_SSRF_PROTECTION_DISABLED
       # Mandatory for GitPod to map host env to the container, thus GitPod can dynamically configure the public URL of Logto;
       # Or, you can leverage it for local testing.
       - ENDPOINT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       # Optional default grace period, in seconds, for OIDC private key rotation when the API
       # request omits `rotationGracePeriod`.
       - PRIVATE_KEY_ROTATION_GRACE_PERIOD
+      # Set to `false` only when trusted OIDC relying-party endpoints resolve to private networks.
+      # SSRF protection for oidc-provider outbound requests is enabled by default.
+      - OIDC_PROVIDER_SSRF_PROTECTION_ENABLED
       # Mandatory for GitPod to map host env to the container, thus GitPod can dynamically configure the public URL of Logto;
       # Or, you can leverage it for local testing.
       - ENDPOINT

--- a/packages/core/src/oidc/fetch.test.ts
+++ b/packages/core/src/oidc/fetch.test.ts
@@ -2,7 +2,7 @@ import Sinon from 'sinon';
 
 import { EnvSet } from '#src/env-set/index.js';
 
-import providerFetch from './fetch.js';
+import fetchWithoutSsrfDispatcher, { getProviderFetchConfig } from './fetch.js';
 
 const dispatcher = Symbol('dispatcher');
 const requestInit: RequestInit & { dispatcher?: unknown } = {
@@ -10,31 +10,34 @@ const requestInit: RequestInit & { dispatcher?: unknown } = {
   dispatcher,
 };
 
-describe('providerFetch', () => {
+describe('getProviderFetchConfig', () => {
   afterEach(() => {
     Sinon.restore();
   });
 
-  it('should drop the SSRF-protecting dispatcher for self-hosted deployments', async () => {
-    Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isCloud: false });
-    const fetchStub = Sinon.stub(globalThis, 'fetch').resolves(new Response());
+  it('should preserve the provider native fetch when SSRF protection is enabled', () => {
+    Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      isOidcProviderSsrfProtectionEnabled: true,
+    });
 
-    await providerFetch('https://rp.example.com/backchannel-logout', requestInit);
+    expect(getProviderFetchConfig()).not.toHaveProperty('fetch');
+  });
+
+  it('should drop the SSRF-protecting dispatcher when protection is disabled', async () => {
+    Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      isOidcProviderSsrfProtectionEnabled: false,
+    });
+    const fetchStub = Sinon.stub(globalThis, 'fetch').resolves(new Response());
+    const config = getProviderFetchConfig();
+
+    expect(config).toHaveProperty('fetch', fetchWithoutSsrfDispatcher);
+    await config.fetch?.('https://rp.example.com/backchannel-logout', requestInit);
 
     expect(fetchStub.calledOnce).toBe(true);
     const [, init] = fetchStub.firstCall.args;
     expect(init).toMatchObject({ method: 'POST' });
     expect(init).not.toHaveProperty('dispatcher');
-  });
-
-  it('should keep the SSRF-protecting dispatcher in cloud', async () => {
-    Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isCloud: true });
-    const fetchStub = Sinon.stub(globalThis, 'fetch').resolves(new Response());
-
-    await providerFetch('https://rp.example.com/backchannel-logout', requestInit);
-
-    expect(fetchStub.calledOnce).toBe(true);
-    const [, init] = fetchStub.firstCall.args;
-    expect(init).toHaveProperty('dispatcher', dispatcher);
   });
 });

--- a/packages/core/src/oidc/fetch.test.ts
+++ b/packages/core/src/oidc/fetch.test.ts
@@ -21,7 +21,7 @@ describe('getProviderFetchConfig', () => {
       isOidcProviderSsrfProtectionEnabled: true,
     });
 
-    expect(getProviderFetchConfig()).not.toHaveProperty('fetch');
+    expect(getProviderFetchConfig()).toBeUndefined();
   });
 
   it('should drop the SSRF-protecting dispatcher when protection is disabled', async () => {
@@ -33,7 +33,7 @@ describe('getProviderFetchConfig', () => {
     const config = getProviderFetchConfig();
 
     expect(config).toHaveProperty('fetch', fetchWithoutSsrfDispatcher);
-    await config.fetch?.('https://rp.example.com/backchannel-logout', requestInit);
+    await config?.fetch('https://rp.example.com/backchannel-logout', requestInit);
 
     expect(fetchStub.calledOnce).toBe(true);
     const [, init] = fetchStub.firstCall.args;

--- a/packages/core/src/oidc/fetch.ts
+++ b/packages/core/src/oidc/fetch.ts
@@ -22,6 +22,8 @@ const fetchWithoutSsrfDispatcher: typeof fetch = async (input, init) => {
  * upstream fetch hardening is inherited automatically. Only override it for the self-hosted opt-out.
  */
 export const getProviderFetchConfig = () =>
-  EnvSet.values.isOidcProviderSsrfProtectionEnabled ? {} : { fetch: fetchWithoutSsrfDispatcher };
+  EnvSet.values.isOidcProviderSsrfProtectionEnabled
+    ? undefined
+    : { fetch: fetchWithoutSsrfDispatcher };
 
 export default fetchWithoutSsrfDispatcher;

--- a/packages/core/src/oidc/fetch.ts
+++ b/packages/core/src/oidc/fetch.ts
@@ -1,3 +1,5 @@
+import { cond } from '@silverhand/essentials';
+
 import { EnvSet } from '#src/env-set/index.js';
 
 /**
@@ -22,8 +24,6 @@ const fetchWithoutSsrfDispatcher: typeof fetch = async (input, init) => {
  * upstream fetch hardening is inherited automatically. Only override it for the self-hosted opt-out.
  */
 export const getProviderFetchConfig = () =>
-  EnvSet.values.isOidcProviderSsrfProtectionEnabled
-    ? undefined
-    : { fetch: fetchWithoutSsrfDispatcher };
+  cond(!EnvSet.values.isOidcProviderSsrfProtectionEnabled && { fetch: fetchWithoutSsrfDispatcher });
 
 export default fetchWithoutSsrfDispatcher;

--- a/packages/core/src/oidc/fetch.ts
+++ b/packages/core/src/oidc/fetch.ts
@@ -1,16 +1,15 @@
 import { EnvSet } from '#src/env-set/index.js';
 
 /**
- * The `fetch` implementation for the provider's outgoing requests (backchannel logout, client
- * `jwks_uri`, `sector_identifier_uri`, ...).
+ * The opt-out `fetch` implementation for the provider's outgoing requests (backchannel logout,
+ * client `jwks_uri`, `sector_identifier_uri`, ...).
  *
  * Since v9, oidc-provider injects an SSRF-protecting undici dispatcher into these requests that
  * destroys connections resolving to special-use addresses such as loopback and private ranges.
  *
- * Self-hosted Logto deployments commonly reach RPs on private networks, so the dispatcher is
- * dropped there to keep outgoing requests unrestricted as before. In Cloud, these requests have
- * no legitimate private-network targets, so the dispatcher is kept to stop tenant-controlled
- * URIs (e.g. `backchannelLogoutUri`) from reaching internal infrastructure.
+ * Self-hosted deployments can explicitly disable that protection when they must reach trusted RPs
+ * on private networks. In that case, this function drops the dispatcher to keep those requests
+ * unrestricted.
  */
 const fetchWithoutSsrfDispatcher: typeof fetch = async (input, init) => {
   // eslint-disable-next-line no-restricted-syntax -- The `dispatcher` key is an undici extension absent from `RequestInit`
@@ -18,7 +17,11 @@ const fetchWithoutSsrfDispatcher: typeof fetch = async (input, init) => {
   return fetch(input, safeInit);
 };
 
-const providerFetch: typeof fetch = async (input, init) =>
-  EnvSet.values.isCloud ? fetch(input, init) : fetchWithoutSsrfDispatcher(input, init);
+/**
+ * Keep oidc-provider's native fetch implementation whenever SSRF protection is enabled so future
+ * upstream fetch hardening is inherited automatically. Only override it for the self-hosted opt-out.
+ */
+export const getProviderFetchConfig = () =>
+  EnvSet.values.isOidcProviderSsrfProtectionEnabled ? {} : { fetch: fetchWithoutSsrfDispatcher };
 
-export default providerFetch;
+export default fetchWithoutSsrfDispatcher;

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -62,7 +62,7 @@ import {
   getExtraTokenClaimsForOrganizationApiResource,
   getExtraTokenClaimsForTokenExchange,
 } from './extra-token-claims.js';
-import providerFetch from './fetch.js';
+import { getProviderFetchConfig } from './fetch.js';
 import { registerGrants } from './grants/index.js';
 import {
   findResource,
@@ -175,7 +175,7 @@ export default function initOidc(
       introspectionSigningAlgValues: [...supportedSigningAlgs],
     },
     conformIdTokenClaims: false,
-    fetch: providerFetch,
+    ...getProviderFetchConfig(),
     features: {
       userinfo: { enabled: true },
       revocation: { enabled: true },

--- a/packages/shared/src/node/env/GlobalValues.test.ts
+++ b/packages/shared/src/node/env/GlobalValues.test.ts
@@ -1,6 +1,50 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { parseNonNegativeIntegerEnv, parseTimeoutEnv } from './GlobalValues.js';
+import GlobalValues, { parseNonNegativeIntegerEnv, parseTimeoutEnv } from './GlobalValues.js';
+
+const createGlobalValues = () => {
+  vi.stubEnv('DB_URL', 'postgres://postgres:password@localhost:5432/logto');
+  return new GlobalValues();
+};
+
+const unsetEnvironmentVariable = (key: string) => {
+  vi.stubEnv(key, '');
+  Reflect.deleteProperty(process.env, key);
+};
+
+describe('OIDC provider SSRF protection', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('is enabled by default in self-hosted deployments', () => {
+    unsetEnvironmentVariable('IS_CLOUD');
+    unsetEnvironmentVariable('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED');
+
+    expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(true);
+  });
+
+  it('can be disabled in self-hosted deployments', () => {
+    unsetEnvironmentVariable('IS_CLOUD');
+    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED', 'false');
+
+    expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(false);
+  });
+
+  it.each(['', 'flase'])('stays enabled for an invalid value: %s', (value) => {
+    unsetEnvironmentVariable('IS_CLOUD');
+    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED', value);
+
+    expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(true);
+  });
+
+  it('stays enabled in Cloud when the environment variable is false', () => {
+    vi.stubEnv('IS_CLOUD', 'true');
+    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED', 'false');
+
+    expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(true);
+  });
+});
 
 describe('parseTimeoutEnv', () => {
   it('returns undefined for missing, blank, or invalid values', () => {

--- a/packages/shared/src/node/env/GlobalValues.test.ts
+++ b/packages/shared/src/node/env/GlobalValues.test.ts
@@ -19,28 +19,28 @@ describe('OIDC provider SSRF protection', () => {
 
   it('is enabled by default in self-hosted deployments', () => {
     unsetEnvironmentVariable('IS_CLOUD');
-    unsetEnvironmentVariable('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED');
+    unsetEnvironmentVariable('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED');
 
     expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(true);
   });
 
   it('can be disabled in self-hosted deployments', () => {
     unsetEnvironmentVariable('IS_CLOUD');
-    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED', 'false');
+    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED', 'true');
 
     expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(false);
   });
 
-  it.each(['', 'flase'])('stays enabled for an invalid value: %s', (value) => {
+  it.each(['', 'false', 'flase'])('stays enabled when the opt-out value is: %s', (value) => {
     unsetEnvironmentVariable('IS_CLOUD');
-    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED', value);
+    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED', value);
 
     expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(true);
   });
 
-  it('stays enabled in Cloud when the environment variable is false', () => {
+  it('stays enabled in Cloud when the environment variable is true', () => {
     vi.stubEnv('IS_CLOUD', 'true');
-    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED', 'false');
+    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED', 'true');
 
     expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(true);
   });

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -156,8 +156,7 @@ export default class GlobalValues {
    * that resolve unregistered remote clients, such as CIMD, must only be enabled while this is true.
    */
   public readonly isOidcProviderSsrfProtectionEnabled =
-    this.isCloud ||
-    getEnv('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED', 'true').trim().toLowerCase() !== 'false';
+    this.isCloud || !yes(getEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED'));
 
   /** Enables protected app local development without Cloud-only behavior. */
   public readonly isProtectedAppLocalDevEnabled =

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -149,6 +149,16 @@ export default class GlobalValues {
   /** If the env explicitly indicates it's in the cloud environment. */
   public readonly isCloud = yes(getEnv('IS_CLOUD'));
 
+  /**
+   * Whether oidc-provider protects outbound requests against SSRF.
+   *
+   * Protection is enabled by default and can only be disabled in self-hosted deployments. Features
+   * that resolve unregistered remote clients, such as CIMD, must only be enabled while this is true.
+   */
+  public readonly isOidcProviderSsrfProtectionEnabled =
+    this.isCloud ||
+    getEnv('OIDC_PROVIDER_SSRF_PROTECTION_ENABLED', 'true').trim().toLowerCase() !== 'false';
+
   /** Enables protected app local development without Cloud-only behavior. */
   public readonly isProtectedAppLocalDevEnabled =
     !this.isProduction && yes(getEnv('PROTECTED_APP_LOCAL_DEV'));


### PR DESCRIPTION
## Summary

- Enable the OIDC provider's built-in SSRF protection by default for self-hosted deployments.
- Preserve the Provider's native `fetch` implementation while SSRF protection is enabled.
- Allow trusted private-network relying parties to opt out with `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED=true`.

## Testing

Unit tests