### PR TITLE
fix(core): hide internal application secrets

### DIFF
--- a/.changeset/ninety-penguins-lick.md
+++ b/.changeset/ninety-penguins-lick.md
@@ -1,0 +1,7 @@
+---
+"@logto/console": patch
+"@logto/core": patch
+"@logto/schemas": patch
+---
+
+prevent internal application secrets from being exposed through Management APIs

--- a/packages/console/src/components/RoleAssignmentModal/index.tsx
+++ b/packages/console/src/components/RoleAssignmentModal/index.tsx
@@ -1,4 +1,4 @@
-import type { RoleResponse, UserProfileResponse, Application } from '@logto/schemas';
+import type { RoleResponse, UserProfileResponse, ApplicationApiResponse } from '@logto/schemas';
 import { RoleType } from '@logto/schemas';
 import { useState } from 'react';
 import { toast } from 'react-hot-toast';
@@ -22,7 +22,7 @@ type Props = (
       type: RoleType.User;
     }
   | {
-      entity: Application;
+      entity: ApplicationApiResponse;
       type: RoleType.MachineToMachine;
     }
 ) & {

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/EndpointsAndCredentials/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/EndpointsAndCredentials/index.tsx
@@ -1,5 +1,5 @@
 import {
-  type Application,
+  type ApplicationApiResponse,
   type SnakeCaseOidcConfig,
   internalPrefix,
   hasSecrets,
@@ -41,10 +41,11 @@ import { type ApplicationSecretRow, useSecretTableColumns } from './use-secret-t
 
 export { type ApplicationSecretRow } from './use-secret-table-columns';
 
-const isLegacySecret = (secret: string) => !secret.startsWith(internalPrefix);
+const isLegacySecret = (secret?: string): secret is string =>
+  Boolean(secret && !secret.startsWith(internalPrefix));
 
 type Props = {
-  readonly app: Application;
+  readonly app: ApplicationApiResponse;
   readonly oidcConfig: SnakeCaseOidcConfig;
   readonly onApplicationUpdated: () => void;
 };

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/MachineToMachineApplicationRoles/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/MachineToMachineApplicationRoles/index.tsx
@@ -1,4 +1,4 @@
-import type { Application, Role } from '@logto/schemas';
+import type { ApplicationApiResponse, Role } from '@logto/schemas';
 import { RoleType, roleTypeToKey } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { useState } from 'react';
@@ -30,7 +30,7 @@ import styles from './index.module.scss';
 const pageSize = defaultPageSize;
 
 type Props = {
-  readonly application: Application;
+  readonly application: ApplicationApiResponse;
 };
 
 function MachineToMachineApplicationRoles({ application }: Props) {

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/components/SessionForm.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/components/SessionForm.tsx
@@ -1,4 +1,4 @@
-import { type Application, type SnakeCaseOidcConfig } from '@logto/schemas';
+import { type ApplicationApiResponse, type SnakeCaseOidcConfig } from '@logto/schemas';
 import { type ChangeEvent } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import useSWRImmutable from 'swr/immutable';
@@ -14,7 +14,7 @@ import { type ApplicationForm } from '../../utils';
 import styles from './SessionForm.module.scss';
 
 type Props = {
-  readonly data: Application;
+  readonly data: ApplicationApiResponse;
 };
 
 const maxSessionDuration = 365; // 1 year

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/ProtectedAppSettings/index.tsx
@@ -1,7 +1,7 @@
 import { isLocalhost, isValidRegEx, validateUriOrigin } from '@logto/core-kit';
 import {
   DomainStatus,
-  type Application,
+  type ApplicationApiResponse,
   type CustomDomain as CustomDomainType,
   type SnakeCaseOidcConfig,
 } from '@logto/schemas';
@@ -41,7 +41,7 @@ import SessionForm from './components/SessionForm';
 import styles from './index.module.scss';
 
 type Props = {
-  readonly data: Application;
+  readonly data: ApplicationApiResponse;
 };
 
 const routes = Object.freeze(['/register', '/sign-in', '/sign-in-callback', '/sign-out']);

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/RefreshTokenSettings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/RefreshTokenSettings.tsx
@@ -1,4 +1,9 @@
-import { type Application, ApplicationType, customClientMetadataGuard } from '@logto/schemas';
+import {
+  type Application,
+  type ApplicationApiResponse,
+  ApplicationType,
+  customClientMetadataGuard,
+} from '@logto/schemas';
 import { useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -9,7 +14,7 @@ import TextInput from '@/ds-components/TextInput';
 import TextLink from '@/ds-components/TextLink';
 
 type Props = {
-  readonly data: Application;
+  readonly data: ApplicationApiResponse;
 };
 
 function RefreshTokenSettings({ data: { type } }: Props) {

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Settings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/Settings.tsx
@@ -1,5 +1,5 @@
 import { validateRedirectUrl } from '@logto/core-kit';
-import type { Application } from '@logto/schemas';
+import type { ApplicationApiResponse } from '@logto/schemas';
 import { ApplicationType } from '@logto/schemas';
 import { useContext } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -77,7 +77,7 @@ function WildcardUriWarning() {
 }
 
 type Props = {
-  readonly data: Application;
+  readonly data: ApplicationApiResponse;
 };
 
 function Settings({ data }: Props) {

--- a/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/TokenExchangeSettings.tsx
+++ b/packages/console/src/pages/ApplicationDetails/ApplicationDetailsContent/TokenExchangeSettings.tsx
@@ -1,4 +1,4 @@
-import { type Application, ApplicationType } from '@logto/schemas';
+import { type ApplicationApiResponse, ApplicationType } from '@logto/schemas';
 import { useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
 
@@ -14,7 +14,7 @@ import styles from './index.module.scss';
 import { type ApplicationForm } from './utils';
 
 type Props = {
-  readonly data: Application;
+  readonly data: ApplicationApiResponse;
 };
 
 function TokenExchangeSettings({ data: { type, isThirdParty } }: Props) {

--- a/packages/console/src/pages/ApplicationDetails/components/Branding/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Branding/index.tsx
@@ -2,7 +2,7 @@ import { generateDarkColor } from '@logto/core-kit';
 import {
   Theme,
   defaultPrimaryColor,
-  type Application,
+  type ApplicationApiResponse,
   type ApplicationSignInExperience,
 } from '@logto/schemas';
 import { useCallback, useEffect } from 'react';
@@ -31,7 +31,7 @@ import useSignInExperienceSWR from './use-sign-in-experience-swr';
 import { type ApplicationSignInExperienceForm, formatFormToSubmitData } from './utils';
 
 type Props = {
-  readonly application: Application;
+  readonly application: ApplicationApiResponse;
   readonly isActive: boolean; // Support for conditional render UnsavedChangesAlertModal component
 };
 

--- a/packages/console/src/pages/ApplicationDetails/components/Permissions/index.tsx
+++ b/packages/console/src/pages/ApplicationDetails/components/Permissions/index.tsx
@@ -1,4 +1,4 @@
-import { type Application } from '@logto/schemas';
+import { type ApplicationApiResponse } from '@logto/schemas';
 
 import OidcPermissionsCard from './OidcPermissionsCard';
 import PermissionsCard from './PermissionsCard';
@@ -6,7 +6,7 @@ import { ScopeLevel } from './PermissionsCard/ApplicationScopesAssignmentModal/t
 import styles from './index.module.scss';
 
 type Props = {
-  readonly application: Application;
+  readonly application: ApplicationApiResponse;
 };
 
 function Permissions({ application }: Props) {

--- a/packages/core/src/routes/applications/application-response.test.ts
+++ b/packages/core/src/routes/applications/application-response.test.ts
@@ -1,0 +1,25 @@
+import { internalPrefix } from '@logto/schemas';
+
+import { mockApplication } from '#src/__mocks__/index.js';
+
+import { omitInternalApplicationSecret } from './application-response.js';
+
+describe('omitInternalApplicationSecret', () => {
+  it('omits an internal secret', () => {
+    expect(
+      omitInternalApplicationSecret({
+        ...mockApplication,
+        secret: `${internalPrefix}secret`,
+      })
+    ).not.toHaveProperty('secret');
+  });
+
+  it('preserves a legacy secret', () => {
+    expect(
+      omitInternalApplicationSecret({
+        ...mockApplication,
+        secret: 'legacy-secret',
+      })
+    ).toMatchObject({ secret: 'legacy-secret' });
+  });
+});

--- a/packages/core/src/routes/applications/application-response.ts
+++ b/packages/core/src/routes/applications/application-response.ts
@@ -1,0 +1,10 @@
+import { internalPrefix } from '@logto/schemas';
+
+type ApplicationResponse<T extends { secret?: string }> = Omit<T, 'secret'> & { secret?: string };
+
+/** Omit the internal application secret while preserving a legacy secret for migration. */
+export const omitInternalApplicationSecret = <T extends { secret?: string }>({
+  secret,
+  ...application
+}: T): ApplicationResponse<T> =>
+  !secret || secret.startsWith(internalPrefix) ? application : { ...application, secret };

--- a/packages/core/src/routes/applications/application-secret.openapi.json
+++ b/packages/core/src/routes/applications/application-secret.openapi.json
@@ -3,9 +3,9 @@
     "/api/applications/{id}/legacy-secret": {
       "delete": {
         "summary": "Delete application legacy secret",
-        "description": "Delete the legacy secret for the application and replace it with a new internal secret.\n\nNote: This operation does not \"really\" delete the legacy secret because it is still needed for internal validation. We may remove the display of the legacy secret (the `secret` field in the application response) in the future.",
+        "description": "Delete the legacy secret for the application and replace it with an internal secret used only by Logto. The internal secret is not returned by Management APIs and cannot be used for client authentication.",
         "responses": {
-          "204": {
+          "200": {
             "description": "The legacy secret was deleted successfully."
           },
           "400": {

--- a/packages/core/src/routes/applications/application-secret.test.ts
+++ b/packages/core/src/routes/applications/application-secret.test.ts
@@ -19,6 +19,12 @@ const mockApplicationSecret: ApplicationSecret = {
 };
 
 const findApplicationById = jest.fn(async (): Promise<Application> => mockProtectedApplication);
+const updateApplicationById = jest.fn(
+  async (_id: string, data: Partial<Application>): Promise<Application> => ({
+    ...mockApplication,
+    ...data,
+  })
+);
 const insert = jest.fn(async (data: Partial<ApplicationSecret>) => ({
   ...mockApplicationSecret,
   ...data,
@@ -35,6 +41,7 @@ const tenantContext = new MockTenant(
   {
     applications: {
       findApplicationById,
+      updateApplicationById,
     },
     applicationSecrets: {
       insert,
@@ -61,10 +68,25 @@ describe('application secret routes', () => {
 
   afterEach(() => {
     findApplicationById.mockClear();
+    updateApplicationById.mockClear();
     insert.mockClear();
     deleteByName.mockClear();
     update.mockClear();
     syncAppConfigsToRemote.mockClear();
+  });
+
+  it('DELETE /applications/:id/legacy-secret should omit the generated internal secret', async () => {
+    findApplicationById.mockResolvedValueOnce({ ...mockApplication, secret: 'legacy-secret' });
+
+    const response = await applicationSecretRequest.delete(
+      `/applications/${mockApplication.id}/legacy-secret`
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.body).not.toHaveProperty('secret');
+    expect(updateApplicationById).toHaveBeenCalledTimes(1);
+    expect(updateApplicationById.mock.calls[0]?.[0]).toBe(mockApplication.id);
+    expect(updateApplicationById.mock.calls[0]?.[1].secret).toMatch(/^#internal:/);
   });
 
   it('POST /applications/:id/secrets should resync protected app configs', async () => {

--- a/packages/core/src/routes/applications/application-secret.ts
+++ b/packages/core/src/routes/applications/application-secret.ts
@@ -1,4 +1,9 @@
-import { Applications, ApplicationSecrets, ApplicationType, internalPrefix } from '@logto/schemas';
+import {
+  ApplicationSecrets,
+  ApplicationType,
+  applicationResponseGuard,
+  internalPrefix,
+} from '@logto/schemas';
 import { generateStandardSecret } from '@logto/shared';
 import { z } from 'zod';
 
@@ -7,6 +12,8 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import { type ManagementApiRouter, type RouterInitArgs } from '../types.js';
+
+import { omitInternalApplicationSecret } from './application-response.js';
 
 export const generateInternalSecret = () => internalPrefix + generateStandardSecret();
 
@@ -28,7 +35,7 @@ export default function applicationSecretRoutes<T extends ManagementApiRouter>(
     '/applications/:id/legacy-secret',
     koaGuard({
       params: z.object({ id: z.string().min(1) }),
-      response: Applications.guard,
+      response: applicationResponseGuard,
       status: [200, 400, 404],
     }),
     async (ctx, next) => {
@@ -43,7 +50,9 @@ export default function applicationSecretRoutes<T extends ManagementApiRouter>(
       }
 
       const secret = generateInternalSecret();
-      ctx.body = await queries.applications.updateApplicationById(id, { secret });
+      ctx.body = omitInternalApplicationSecret(
+        await queries.applications.updateApplicationById(id, { secret })
+      );
       return next();
     }
   );

--- a/packages/core/src/routes/applications/application.openapi.json
+++ b/packages/core/src/routes/applications/application.openapi.json
@@ -10,7 +10,7 @@
       "ApplicationLegacySecret": {
         "type": "string",
         "deprecated": true,
-        "description": "The internal client secret. Note it is only used for internal validation, and the actual secrets should be retrieved from `/api/applications/{id}/secrets` endpoints."
+        "description": "The legacy client secret. This field is omitted after the legacy secret has been replaced by an internal secret. Retrieve current application secrets from the `/api/applications/{id}/secrets` endpoints."
       }
     }
   },

--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -14,7 +14,11 @@ import { mockId, mockIdGenerators } from '#src/test-utils/nanoid.js';
 import { createMockQuotaLibrary } from '#src/test-utils/quota.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
+import { omitInternalApplicationSecret } from './application-response.js';
+
 const { jest } = import.meta;
+
+const mockApplicationResponse = omitInternalApplicationSecret(mockApplication);
 
 const findApplicationById = jest.fn(async () => mockApplication);
 const deleteApplicationById = jest.fn();
@@ -98,7 +102,7 @@ describe('application route', () => {
   it('GET /applications', async () => {
     const response = await applicationRequest.get('/applications');
     expect(response.status).toEqual(200);
-    expect(response.body).toEqual([mockApplication]);
+    expect(response.body).toEqual([mockApplicationResponse]);
     expect(response.header).not.toHaveProperty('total-number');
   });
 
@@ -113,7 +117,7 @@ describe('application route', () => {
 
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
-      ...mockApplication,
+      ...mockApplicationResponse,
       id: mockId,
       name,
       description,
@@ -137,7 +141,7 @@ describe('application route', () => {
     expect(response.status).toEqual(200);
     expect(syncAppConfigsToRemote).toHaveBeenCalledWith(mockId);
     expect(response.body).toEqual({
-      ...mockApplication,
+      ...mockApplicationResponse,
       id: mockId,
       name,
       type,
@@ -158,7 +162,7 @@ describe('application route', () => {
       .send({ name, type, customClientMetadata });
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
-      ...mockApplication,
+      ...mockApplicationResponse,
       id: mockId,
       name,
       type,
@@ -213,7 +217,7 @@ describe('application route', () => {
 
     expect(response.status).toEqual(200);
     expect(response.body).toEqual({
-      ...mockApplication,
+      ...mockApplicationResponse,
       isAdmin: false,
     });
   });
@@ -226,7 +230,12 @@ describe('application route', () => {
       .patch('/applications/foo')
       .send({ name, description, customClientMetadata });
     expect(response.status).toEqual(200);
-    expect(response.body).toEqual({ ...mockApplication, name, description, customClientMetadata });
+    expect(response.body).toEqual({
+      ...mockApplicationResponse,
+      name,
+      description,
+      customClientMetadata,
+    });
   });
 
   it('PATCH /applications/:applicationId for protected app', async () => {
@@ -240,7 +249,7 @@ describe('application route', () => {
       .patch('/applications/foo')
       .send({ name, description, protectedAppMetadata: { origin, additionalScopes } });
     expect(response.status).toEqual(200);
-    expect(response.body).toEqual({ ...mockApplication, name, description });
+    expect(response.body).toEqual({ ...mockApplicationResponse, name, description });
     expect(syncAppConfigsToRemote).toHaveBeenCalledWith('foo');
     expect(updateApplicationById).toHaveBeenNthCalledWith(1, 'foo', {
       protectedAppMetadata: {
@@ -312,7 +321,7 @@ describe('application route', () => {
     expect(response.status).toEqual(200);
 
     // Should not update the secret, isThirdParty and type
-    expect(response.body).toEqual(mockApplication);
+    expect(response.body).toEqual(mockApplicationResponse);
   });
 
   it('PATCH /applications/:applicationId should save the formatted URIs as per RFC', async () => {

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -3,7 +3,6 @@
 import type { Role, Application } from '@logto/schemas';
 import {
   adminTenantId,
-  Applications,
   ApplicationType,
   buildBuiltInApplicationDataForTenant,
   defaultApplicationSecretName,
@@ -11,6 +10,7 @@ import {
   InternalRole,
   ProductEvent,
   isBuiltInApplicationId,
+  applicationResponseGuard,
 } from '@logto/schemas';
 import { generateStandardId, generateStandardSecret } from '@logto/shared';
 import { conditional } from '@silverhand/essentials';
@@ -31,6 +31,7 @@ import applicationAccessControlRoutes from './application-access-control.js';
 import applicationCustomDataRoutes from './application-custom-data.js';
 import applicationOrganizationRoutes from './application-organization.js';
 import applicationProtectedAppMetadataRoutes from './application-protected-app-metadata.js';
+import { omitInternalApplicationSecret } from './application-response.js';
 import applicationRoleRoutes from './application-role.js';
 import applicationSecretRoutes, { generateInternalSecret } from './application-secret.js';
 import applicationSignInExperienceRoutes from './application-sign-in-experience.js';
@@ -71,8 +72,11 @@ const hideOidcClientMetadataForSamlApp = (application: Application) => ({
   ),
 });
 
+const buildApplicationResponse = (application: Application) =>
+  omitInternalApplicationSecret(hideOidcClientMetadataForSamlApp(application));
+
 const hideOidcClientMetadataForSamlApps = (applications: readonly Application[]) => {
-  return applications.map((application) => hideOidcClientMetadataForSamlApp(application));
+  return applications.map((application) => buildApplicationResponse(application));
 };
 
 const applicationTypeGuard = z.nativeEnum(ApplicationType);
@@ -103,7 +107,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
         excludeOrganizationId: string().optional(),
         isThirdParty: z.union([z.literal('true'), z.literal('false')]).optional(),
       }),
-      response: z.array(Applications.guard),
+      response: z.array(applicationResponseGuard),
       status: 200,
     }),
     async (ctx, next) => {
@@ -183,7 +187,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
     '/applications',
     koaGuard({
       body: applicationCreateGuard,
-      response: Applications.guard,
+      response: applicationResponseGuard,
       status: [200, 400, 422, 403, 500],
     }),
     // eslint-disable-next-line complexity
@@ -257,7 +261,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
         }
       }
 
-      ctx.body = application;
+      ctx.body = buildApplicationResponse(application);
 
       if (rest.type === ApplicationType.MachineToMachine) {
         void quota.reportSubscriptionUpdatesUsage('machineToMachineLimit');
@@ -279,7 +283,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
     '/applications/:id',
     koaGuard({
       params: object({ id: string().min(1) }),
-      response: Applications.guard.merge(z.object({ isAdmin: z.boolean() })),
+      response: applicationResponseGuard.extend({ isAdmin: z.boolean() }),
       status: [200, 404],
     }),
     async (ctx, next) => {
@@ -291,7 +295,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
         ? buildBuiltInApplicationDataForTenant(tenantId, id)
         : undefined;
       if (builtInApplication) {
-        ctx.body = { ...builtInApplication, isAdmin: false };
+        ctx.body = { ...buildApplicationResponse(builtInApplication), isAdmin: false };
 
         return next();
       }
@@ -301,7 +305,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
         await queries.applicationsRoles.findApplicationsRolesByApplicationId(id);
 
       ctx.body = {
-        ...hideOidcClientMetadataForSamlApp(application),
+        ...buildApplicationResponse(application),
         isAdmin: includesInternalAdminRole(applicationsRoles),
       };
 
@@ -318,7 +322,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
           isAdmin: boolean().optional(),
         })
       ),
-      response: Applications.guard,
+      response: applicationResponseGuard,
       status: [200, 400, 404, 422, 500],
     }),
 
@@ -436,7 +440,7 @@ export default function applicationRoutes<T extends ManagementApiRouter>(
           ? await queries.applications.updateApplicationById(id, rest, 'replace')
           : (updatedProtectedApplication ?? pendingUpdateApplication);
 
-      ctx.body = updatedApplication;
+      ctx.body = buildApplicationResponse(updatedApplication);
 
       return next();
     }

--- a/packages/core/src/routes/organization/application/index.ts
+++ b/packages/core/src/routes/organization/application/index.ts
@@ -14,6 +14,8 @@ import type OrganizationQueries from '#src/queries/organization/index.js';
 import type SchemaRouter from '#src/utils/SchemaRouter.js';
 import { parseSearchOptions } from '#src/utils/search.js';
 
+import { omitInternalApplicationSecret } from '../../applications/application-response.js';
+
 import applicationRoleRelationRoutes from './role-relations.js';
 
 /**
@@ -151,7 +153,7 @@ export default function applicationRoutes(
         );
 
       ctx.pagination.totalCount = totalCount;
-      ctx.body = entities;
+      ctx.body = entities.map((application) => omitInternalApplicationSecret(application));
 
       return next();
     }

--- a/packages/core/src/routes/role.application.test.ts
+++ b/packages/core/src/routes/role.application.test.ts
@@ -58,6 +58,7 @@ describe('role application routes', () => {
     );
     expect(response.status).toEqual(200);
     expect(response.body[0]).toHaveProperty('id', mockApplication.id);
+    expect(response.body[0]).not.toHaveProperty('secret');
   });
 
   it('POST /roles/:id/applications', async () => {

--- a/packages/core/src/routes/role.application.ts
+++ b/packages/core/src/routes/role.application.ts
@@ -1,4 +1,4 @@
-import { Applications } from '@logto/schemas';
+import { applicationResponseGuard } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { tryThat } from '@silverhand/essentials';
 import { object, string } from 'zod';
@@ -8,6 +8,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { parseSearchParamsForSearch } from '#src/utils/search.js';
 
+import { omitInternalApplicationSecret } from './applications/application-response.js';
 import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 
 export default function roleApplicationRoutes<T extends ManagementApiRouter>(
@@ -29,7 +30,7 @@ export default function roleApplicationRoutes<T extends ManagementApiRouter>(
     koaPagination(),
     koaGuard({
       params: object({ id: string().min(1) }),
-      response: Applications.guard.array(),
+      response: applicationResponseGuard.array(),
       status: [200, 204, 400, 404],
     }),
     async (ctx, next) => {
@@ -53,7 +54,7 @@ export default function roleApplicationRoutes<T extends ManagementApiRouter>(
           ]);
 
           ctx.pagination.totalCount = count;
-          ctx.body = applications;
+          ctx.body = applications.map((application) => omitInternalApplicationSecret(application));
 
           return next();
         },

--- a/packages/integration-tests/src/api/application.ts
+++ b/packages/integration-tests/src/api/application.ts
@@ -1,3 +1,5 @@
+import assert from 'node:assert';
+
 import {
   ApplicationType,
   type Application,
@@ -33,6 +35,17 @@ export const createApplication = async (
       },
     })
     .json<Application>();
+
+/** Create an application and return its default user-facing secret for authentication tests. */
+export const createApplicationWithSecret = async (
+  ...args: Parameters<typeof createApplication>
+): Promise<Application> => {
+  const application = await createApplication(...args);
+  const [secret] = await getApplicationSecrets(application.id);
+  assert(secret);
+
+  return { ...application, secret: secret.value };
+};
 
 export const getApplications = async (
   types?: ApplicationType[],
@@ -117,17 +130,20 @@ export const deleteRoleFromApplication = async (applicationId: string, roleId: s
   authedAdminApi.delete(`applications/${applicationId}/roles/${roleId}`);
 
 export const generateM2mLog = async (applicationId: string) => {
-  const { id, secret, type, isThirdParty } = await getApplication(applicationId);
+  const { id, type, isThirdParty } = await getApplication(applicationId);
 
   if (type !== ApplicationType.MachineToMachine || isThirdParty) {
     return;
   }
 
+  const [secret] = await getApplicationSecrets(id);
+  assert(secret);
+
   // This is a token request with insufficient parameters and should fail. We make the request to generate a log for the current machine to machine app.
   return oidcApi.post('token', {
     body: new URLSearchParams({
       client_id: id,
-      client_secret: secret,
+      client_secret: secret.value,
       grant_type: 'client_credentials',
     }),
   });

--- a/packages/integration-tests/src/helpers/session.ts
+++ b/packages/integration-tests/src/helpers/session.ts
@@ -4,7 +4,7 @@ import { ApplicationType, SignInIdentifier, type GetUserSessionsResponse } from 
 import { assert } from '@silverhand/essentials';
 
 import { assignUserConsentScopes } from '#src/api/application-user-consent-scope.js';
-import { createApplication } from '#src/api/application.js';
+import { createApplication, createApplicationWithSecret } from '#src/api/application.js';
 import { consent } from '#src/api/interaction.js';
 import { defaultConfig } from '#src/client/index.js';
 import { demoAppRedirectUri } from '#src/constants.js';
@@ -90,7 +90,9 @@ export const createAppAndSignInWithPassword = async ({
   appName = generateTestName(),
   redirectUri = demoAppRedirectUri,
 }: CreateAppAndSignInOptions) => {
-  const app = await createApplication(appName, appType, {
+  const createApp =
+    appType === ApplicationType.Traditional ? createApplicationWithSecret : createApplication;
+  const app = await createApp(appName, appType, {
     isThirdParty,
     oidcClientMetadata: {
       redirectUris: [redirectUri],

--- a/packages/integration-tests/src/tests/api/admin-user.roles.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.roles.test.ts
@@ -2,7 +2,7 @@ import { createManagementApi } from '@logto/api/management';
 import { ApplicationType, RoleType, defaultTenantId } from '@logto/schemas';
 import { HTTPError } from 'ky';
 
-import { assignRolesToApplication, createApplication } from '#src/api/application.js';
+import { assignRolesToApplication, createApplicationWithSecret } from '#src/api/application.js';
 import {
   assignRolesToUser,
   getUserRoles,
@@ -96,7 +96,10 @@ describe('admin console user management (roles)', () => {
   });
 
   it('should assign and replace roles via management api client', async () => {
-    const m2mApp = await createApplication(generateTestName(), ApplicationType.MachineToMachine);
+    const m2mApp = await createApplicationWithSecret(
+      generateTestName(),
+      ApplicationType.MachineToMachine
+    );
     const [managementApiRole] = await getRoles({
       type: RoleType.MachineToMachine,
       search: '%Logto Management API access%',

--- a/packages/integration-tests/src/tests/api/application/application.roles.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application.roles.test.ts
@@ -9,6 +9,7 @@ import {
 import { oidcApi } from '#src/api/api.js';
 import {
   createApplication,
+  createApplicationWithSecret,
   getApplicationRoles,
   assignRolesToApplication,
   deleteRoleFromApplication,
@@ -170,7 +171,10 @@ describe('admin console application management (roles)', () => {
       script: clientCredentialsSampleScript,
     });
 
-    const m2mApp = await createApplication(generateStandardId(), ApplicationType.MachineToMachine);
+    const m2mApp = await createApplicationWithSecret(
+      generateStandardId(),
+      ApplicationType.MachineToMachine
+    );
     const resource = await createResource();
     const createdScope = await createScope(resource.id);
     const createdScope2 = await createScope(resource.id);

--- a/packages/integration-tests/src/tests/api/application/application.secrets.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application.secrets.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationType, hasSecrets, internalPrefix, type Application } from '@logto/schemas';
+import { ApplicationType, hasSecrets, type Application } from '@logto/schemas';
 import { cond, noop } from '@silverhand/essentials';
 import { HTTPError } from 'ky';
 
@@ -43,7 +43,7 @@ describe('application secrets', () => {
           }
         )
       );
-      expect(application.secret).toMatch(new RegExp(`^${internalPrefix}`));
+      expect(application).not.toHaveProperty('secret');
 
       // Check the default secret
       const secrets = await getApplicationSecrets(application.id);

--- a/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
@@ -4,7 +4,7 @@ import { assert } from '@silverhand/essentials';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { assignUserConsentScopes } from '#src/api/application-user-consent-scope.js';
-import { createApplication, deleteApplication } from '#src/api/application.js';
+import { createApplicationWithSecret, deleteApplication } from '#src/api/application.js';
 import { consent, getConsentInfo } from '#src/api/interaction.js';
 import { OrganizationScopeApi } from '#src/api/organization-scope.js';
 import { createResource, deleteResource } from '#src/api/resource.js';
@@ -56,7 +56,7 @@ describe('consent api', () => {
   };
 
   const bootStrapApplication = async () => {
-    const thirdPartyApplication = await createApplication(
+    const thirdPartyApplication = await createApplicationWithSecret(
       thirdPartyApplicationName,
       ApplicationType.Traditional,
       {
@@ -68,7 +68,7 @@ describe('consent api', () => {
       }
     );
 
-    const firstPartyApplication = await createApplication(
+    const firstPartyApplication = await createApplicationWithSecret(
       firstPartyApplicationName,
       ApplicationType.Traditional,
       {

--- a/packages/integration-tests/src/tests/api/oidc/client-authentication.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/client-authentication.test.ts
@@ -152,33 +152,6 @@ describe('client authentication', () => {
     );
   });
 
-  it('should pass when client credentials are valid in authorization header (legacy)', async () => {
-    await expect(
-      post({
-        authorization: `Basic ${Buffer.from(`${application.id}:${application.secret}`).toString(
-          'base64'
-        )}`,
-        body: { resource: resource.indicator },
-      })
-    ).resolves.toMatchObject({
-      token_type: 'Bearer',
-    });
-  });
-
-  it('should pass when client credentials are valid in body (legacy)', async () => {
-    await expect(
-      post({
-        body: {
-          client_id: application.id,
-          client_secret: application.secret,
-          resource: resource.indicator,
-        },
-      })
-    ).resolves.toMatchObject({
-      token_type: 'Bearer',
-    });
-  });
-
   it('should pass when client credentials are valid in authorization header', async () => {
     const application = await createApplication('application', ApplicationType.MachineToMachine);
     const secret = await createApplicationSecret({

--- a/packages/integration-tests/src/tests/api/oidc/client-credentials-grant.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/client-credentials-grant.test.ts
@@ -16,7 +16,7 @@ import { HTTPError } from 'ky';
 import { oidcApi } from '#src/api/api.js';
 import {
   assignRolesToApplication,
-  createApplication,
+  createApplicationWithSecret,
   deleteApplication,
 } from '#src/api/application.js';
 import { deleteJwtCustomizer, upsertJwtCustomizer } from '#src/api/logto-config.js';
@@ -91,7 +91,10 @@ describe('client credentials grant', () => {
 
   beforeAll(async () => {
     // eslint-disable-next-line @silverhand/fp/no-mutation
-    client = await createApplication('client credentials test', ApplicationType.MachineToMachine);
+    client = await createApplicationWithSecret(
+      'client credentials test',
+      ApplicationType.MachineToMachine
+    );
   });
 
   afterAll(async () => {

--- a/packages/integration-tests/src/tests/api/oidc/dpop-disabled.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/dpop-disabled.test.ts
@@ -15,6 +15,7 @@ import { deleteUser } from '#src/api/admin-user.js';
 import { oidcApi } from '#src/api/api.js';
 import {
   createApplication,
+  createApplicationWithSecret,
   deleteApplication,
   getApplicationSecrets,
 } from '#src/api/application.js';
@@ -83,7 +84,7 @@ describe('token requests with a DPoP proof while DPoP is disabled', () => {
     testResource = await createResource(generateResourceName(), generateResourceIndicator());
     ({ id: testUserId } = await createUserByAdmin({ username, password }));
 
-    m2mApplication = await createApplication(
+    m2mApplication = await createApplicationWithSecret(
       'dpop-disabled-m2m-app',
       ApplicationType.MachineToMachine
     );

--- a/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
@@ -8,7 +8,11 @@ import { decodeJwt } from 'jose';
 import ky, { HTTPError } from 'ky';
 
 import { oidcApi } from '#src/api/api.js';
-import { createApplication, deleteApplication } from '#src/api/application.js';
+import {
+  createApplication,
+  createApplicationWithSecret,
+  deleteApplication,
+} from '#src/api/application.js';
 import { deleteJwtCustomizer, deleteUser } from '#src/api/index.js';
 import { createResource, deleteResource } from '#src/api/resource.js';
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
@@ -66,7 +70,7 @@ describe('opaque user token lifecycle', () => {
     await deleteJwtCustomizer('access-token').catch(noop);
 
     const [createdApplication, createdPublicApplication, user] = await Promise.all([
-      createApplication('OIDC provider semantics', ApplicationType.Traditional, {
+      createApplicationWithSecret('OIDC provider semantics', ApplicationType.Traditional, {
         oidcClientMetadata: {
           redirectUris: [demoAppRedirectUri],
           postLogoutRedirectUris: [demoAppRedirectUri],
@@ -279,7 +283,7 @@ describe('opaque client-credentials revocation', () => {
   beforeAll(async () => {
     /* eslint-disable @silverhand/fp/no-mutation */
     [application, pool] = await Promise.all([
-      createApplication('Opaque client credentials', ApplicationType.MachineToMachine),
+      createApplicationWithSecret('Opaque client credentials', ApplicationType.MachineToMachine),
       createPool(assertEnv('DB_URL'), { interceptors: createInterceptorsPreset() }),
     ]);
     /* eslint-enable @silverhand/fp/no-mutation */

--- a/packages/integration-tests/src/tests/api/oidc/token-metering.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/token-metering.test.ts
@@ -5,7 +5,7 @@ import { assert, assertEnv } from '@silverhand/essentials';
 import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
 
 import { oidcApi } from '#src/api/api.js';
-import { createApplication, deleteApplication } from '#src/api/application.js';
+import { createApplicationWithSecret, deleteApplication } from '#src/api/application.js';
 import { deleteUser } from '#src/api/index.js';
 import { createResource, deleteResource } from '#src/api/resource.js';
 import { initExperienceClient, processSession } from '#src/helpers/client.js';
@@ -120,7 +120,7 @@ describe('token metering listeners', () => {
 
   it('records M2M token usage after a client credentials grant', async () => {
     const [application, resource] = await Promise.all([
-      createApplication('token metering test', ApplicationType.MachineToMachine),
+      createApplicationWithSecret('token metering test', ApplicationType.MachineToMachine),
       createResource(),
     ]);
     const usageBefore = await getTokenUsage(pool);

--- a/packages/schemas/src/types/application.ts
+++ b/packages/schemas/src/types/application.ts
@@ -10,7 +10,18 @@ import {
   ApplicationSignInExperiences,
 } from '../db-entries/index.js';
 
-export type ApplicationResponse = Application & { isAdmin: boolean };
+/**
+ * The application response returned by Management APIs.
+ *
+ * The legacy client secret is only present before it has been replaced by an internal secret.
+ */
+export const applicationResponseGuard = Applications.guard.extend({
+  secret: Applications.guard.shape.secret.optional(),
+});
+
+export type ApplicationApiResponse = z.infer<typeof applicationResponseGuard>;
+
+export type ApplicationResponse = ApplicationApiResponse & { isAdmin: boolean };
 
 /**
  * An application that is featured for display. Usually used in a list of resources that are

--- a/packages/schemas/src/types/organization.ts
+++ b/packages/schemas/src/types/organization.ts
@@ -8,10 +8,10 @@ import {
   type OrganizationInvitation,
   OrganizationInvitations,
   type Application,
-  Applications,
 } from '../db-entries/index.js';
 import { type ToZodObject } from '../utils/zod.js';
 
+import { applicationResponseGuard } from './application.js';
 import { type UserInfo, type FeaturedUser, userInfoGuard } from './user.js';
 
 /**
@@ -119,10 +119,13 @@ export type ApplicationWithOrganizationRoles = Application & {
   organizationRoles: OrganizationRoleEntity[];
 };
 
-export const applicationWithOrganizationRolesGuard: ToZodObject<ApplicationWithOrganizationRoles> =
-  Applications.guard.extend({
-    organizationRoles: organizationRoleEntityGuard.array(),
-  });
+export const applicationWithOrganizationRolesGuard = applicationResponseGuard.extend({
+  organizationRoles: organizationRoleEntityGuard.array(),
+});
+
+export type ApplicationWithOrganizationRolesResponse = z.infer<
+  typeof applicationWithOrganizationRolesGuard
+>;
 
 /**
  * The organization invitation with additional fields:


### PR DESCRIPTION
## Summary

- omit internal application secrets from Management API responses while preserving legacy secrets for migration
- keep existing token endpoint client authentication behavior to preserve SAML application code exchange
- update Console and integration-test consumers to use user-facing application secrets

## Testing

Unit tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments