### PR TITLE
test: add inline hook integration smoke tests

### DIFF
--- a/packages/integration-tests/src/api/logto-config.ts
+++ b/packages/integration-tests/src/api/logto-config.ts
@@ -10,6 +10,8 @@ import {
   type Json,
   type IdTokenConfig,
   type OidcSessionConfig,
+  type LogtoInlineHookKey,
+  type InlineHook,
 } from '@logto/schemas';
 
 import { waitFor } from '#src/utils.js';
@@ -94,6 +96,15 @@ export const testJwtCustomizer = async (payload: JwtCustomizerTestRequestBody) =
       json: payload,
     })
     .json<Json>();
+
+export const upsertInlineHook = async (key: LogtoInlineHookKey, value: InlineHook) =>
+  authedAdminApi.put(`configs/inline-hooks/${key}`, { json: value }).json<InlineHook>();
+
+export const updateInlineHook = async (key: LogtoInlineHookKey, value: Partial<InlineHook>) =>
+  authedAdminApi.patch(`configs/inline-hooks/${key}`, { json: value }).json<InlineHook>();
+
+export const deleteInlineHook = async (key: LogtoInlineHookKey) =>
+  authedAdminApi.delete(`configs/inline-hooks/${key}`);
 
 export const getIdTokenConfig = async () =>
   authedAdminApi.get('configs/id-token').json<IdTokenConfig>();

--- a/packages/integration-tests/src/tests/api/experience-api/inline-hooks/post-first-factor-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/inline-hooks/post-first-factor-verification.test.ts
@@ -1,0 +1,249 @@
+import {
+  LogtoInlineHookKey,
+  MfaFactor,
+  SignInIdentifier,
+  UsersPasswordEncryptionMethod,
+} from '@logto/schemas';
+import { trySafe } from '@silverhand/essentials';
+import { authenticator } from 'otplib';
+
+import {
+  createUserMfaVerification,
+  deleteUser,
+  getUser,
+  getUserMfaVerifications,
+} from '#src/api/admin-user.js';
+import { deleteInlineHook, updateInlineHook, upsertInlineHook } from '#src/api/logto-config.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import {
+  successfullyCreateAndVerifyTotp,
+  successfullyVerifyTotp,
+} from '#src/helpers/experience/totp-verification.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableMandatoryMfaWithTotp,
+  resetMfaSettings,
+} from '#src/helpers/sign-in-experience.js';
+import { UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest, generatePassword, generateUsername } from '#src/utils.js';
+
+const hookKey = LogtoInlineHookKey.PostFirstFactorVerification;
+
+/**
+ * Accepts unknown identifiers (user not found locally) and provisions a new user with profile,
+ * custom data, and the submitted password.
+ */
+const createUserScript = `
+const runInlineHook = ({ event }) => {
+  if (event.user) {
+    return;
+  }
+
+  return {
+    action: 'createUser',
+    user: {
+      name: 'Migrated User',
+      customData: { legacyId: 'legacy-001', migratedBy: 'p1-hook' },
+      profile: { nickname: 'legacy-nick', website: 'https://legacy.example.com' },
+    },
+    passwordVerified: true,
+  };
+};
+`;
+
+/**
+ * Treats the submitted password as verified by the legacy system for existing users and
+ * resynchronizes profile data.
+ */
+const updateUserScript = `
+const runInlineHook = ({ event }) => {
+  if (!event.user) {
+    return;
+  }
+
+  return {
+    action: 'updateUser',
+    user: {
+      name: 'Synced From Legacy',
+      customData: { legacySynced: true },
+    },
+    passwordVerified: true,
+  };
+};
+`;
+
+devFeatureTest.describe('inline hook: post first factor verification', () => {
+  const userApi = new UserApiTest();
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods({
+      identifiers: [SignInIdentifier.Username],
+      password: true,
+      verify: false,
+    });
+  });
+
+  afterEach(async () => {
+    await trySafe(deleteInlineHook(hookKey));
+    await userApi.cleanUp();
+    await resetMfaSettings();
+  });
+
+  it('should create a user for an unknown identifier accepted by the hook', async () => {
+    await upsertInlineHook(hookKey, { script: createUserScript, enabled: true });
+
+    const username = generateUsername();
+    const password = generatePassword();
+
+    const client = await initExperienceClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    const user = await getUser(userId);
+    expect(user.username).toBe(username);
+    expect(user.name).toBe('Migrated User');
+    expect(user.customData).toMatchObject({ legacyId: 'legacy-001', migratedBy: 'p1-hook' });
+    expect(user.profile).toMatchObject({
+      nickname: 'legacy-nick',
+      website: 'https://legacy.example.com',
+    });
+
+    await deleteUser(userId);
+  });
+
+  it('should not issue tokens until MFA succeeds for a hook-created user', async () => {
+    await enableMandatoryMfaWithTotp();
+    await upsertInlineHook(hookKey, { script: createUserScript, enabled: true });
+
+    const username = generateUsername();
+    const password = generatePassword();
+
+    const client = await initExperienceClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_mfa',
+      status: 422,
+    });
+    await expect(client.isAuthenticated()).resolves.toBe(false);
+
+    const totpVerificationId = await successfullyCreateAndVerifyTotp(client);
+    await client.bindMfa(MfaFactor.TOTP, totpVerificationId);
+
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    const user = await getUser(userId);
+    expect(user.username).toBe(username);
+    expect(user.customData).toMatchObject({ legacyId: 'legacy-001', migratedBy: 'p1-hook' });
+
+    const mfaVerifications = await getUserMfaVerifications(userId);
+    expect(mfaVerifications.some(({ type }) => type === MfaFactor.TOTP)).toBe(true);
+
+    await deleteUser(userId);
+  });
+
+  it('should update profile and password for an existing user whose local password fails', async () => {
+    await upsertInlineHook(hookKey, { script: updateUserScript, enabled: true });
+
+    const username = generateUsername();
+    const localPassword = generatePassword();
+    const legacyPassword = generatePassword();
+    const user = await userApi.create({ username, password: localPassword });
+
+    const client = await initExperienceClient();
+    await identifyUserWithUsernamePassword(client, username, legacyPassword);
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    expect(userId).toBe(user.id);
+
+    const updated = await getUser(user.id);
+    expect(updated.name).toBe('Synced From Legacy');
+    expect(updated.customData).toMatchObject({ legacySynced: true });
+  });
+
+  it('should store the migrated password with Argon2i and sign in locally once the hook is disabled', async () => {
+    await upsertInlineHook(hookKey, { script: updateUserScript, enabled: true });
+
+    const username = generateUsername();
+    const localPassword = generatePassword();
+    const legacyPassword = generatePassword();
+    const user = await userApi.create({ username, password: localPassword });
+
+    // Migrate the password through the hook.
+    const client = await initExperienceClient();
+    await identifyUserWithUsernamePassword(client, username, legacyPassword);
+    const { redirectTo } = await client.submitInteraction();
+    await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    const migrated = await getUser(user.id, { includePasswordHash: true });
+    expect(migrated.passwordAlgorithm).toBe(UsersPasswordEncryptionMethod.Argon2i);
+    expect(migrated.passwordDigest).toBeTruthy();
+
+    // Disable the hook and poison the script: if it were invoked again, the user would be renamed.
+    await updateInlineHook(hookKey, {
+      enabled: false,
+      script: `
+        const runInlineHook = () => ({
+          action: 'updateUser',
+          user: { name: 'Hook Was Invoked' },
+          passwordVerified: true,
+        });
+      `,
+    });
+
+    // The next sign-in succeeds through local password verification.
+    const reloginClient = await initExperienceClient();
+    await identifyUserWithUsernamePassword(reloginClient, username, legacyPassword);
+    const { redirectTo: reloginRedirectTo } = await reloginClient.submitInteraction();
+    await processSession(reloginClient, reloginRedirectTo);
+    await logoutClient(reloginClient);
+
+    const afterRelogin = await getUser(user.id);
+    expect(afterRelogin.name).toBe('Synced From Legacy');
+  });
+
+  it('should complete MFA for an existing user with seeded TOTP after hook password sync', async () => {
+    await enableMandatoryMfaWithTotp();
+    await upsertInlineHook(hookKey, { script: updateUserScript, enabled: true });
+
+    const username = generateUsername();
+    const localPassword = generatePassword();
+    const legacyPassword = generatePassword();
+    const user = await userApi.create({ username, password: localPassword });
+    const mfa = await createUserMfaVerification(user.id, MfaFactor.TOTP);
+
+    if (mfa.type !== MfaFactor.TOTP) {
+      throw new Error('unexpected mfa type');
+    }
+
+    const client = await initExperienceClient();
+    await identifyUserWithUsernamePassword(client, username, legacyPassword);
+
+    await expectRejects(client.submitInteraction(), {
+      code: 'session.mfa.require_mfa_verification',
+      status: 403,
+    });
+    await expect(client.isAuthenticated()).resolves.toBe(false);
+
+    await successfullyVerifyTotp(client, { code: authenticator.generate(mfa.secret) });
+
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    expect(userId).toBe(user.id);
+
+    const updated = await getUser(user.id);
+    expect(updated.name).toBe('Synced From Legacy');
+    expect(updated.customData).toMatchObject({ legacySynced: true });
+  });
+});

--- a/packages/integration-tests/src/tests/api/experience-api/inline-hooks/post-first-factor-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/inline-hooks/post-first-factor-verification.test.ts
@@ -55,7 +55,7 @@ const runInlineHook = ({ event }) => {
 
 /**
  * Treats the submitted password as verified by the legacy system for existing users and
- * resynchronizes profile data.
+ * resynchronizes profile, custom data, and password.
  */
 const updateUserScript = `
 const runInlineHook = ({ event }) => {
@@ -68,6 +68,7 @@ const runInlineHook = ({ event }) => {
     user: {
       name: 'Synced From Legacy',
       customData: { legacySynced: true },
+      profile: { nickname: 'legacy-synced-nick' },
     },
     passwordVerified: true,
   };
@@ -164,9 +165,13 @@ devFeatureTest.describe('inline hook: post first factor verification', () => {
 
     expect(userId).toBe(user.id);
 
-    const updated = await getUser(user.id);
+    const updated = await getUser(user.id, { includePasswordHash: true });
     expect(updated.name).toBe('Synced From Legacy');
     expect(updated.customData).toMatchObject({ legacySynced: true });
+    expect(updated.profile).toMatchObject({ nickname: 'legacy-synced-nick' });
+    // The legacy password was persisted as a fresh local credential.
+    expect(updated.passwordAlgorithm).toBe(UsersPasswordEncryptionMethod.Argon2i);
+    expect(updated.passwordDigest).toBeTruthy();
   });
 
   it('should store the migrated password with Argon2i and sign in locally once the hook is disabled', async () => {

--- a/packages/integration-tests/src/tests/api/experience-api/inline-hooks/post-sign-in.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/inline-hooks/post-sign-in.test.ts
@@ -1,0 +1,140 @@
+import { UserScope } from '@logto/core-kit';
+import { LogtoInlineHookKey, MfaFactor, SignInIdentifier } from '@logto/schemas';
+import { trySafe } from '@silverhand/essentials';
+import { authenticator } from 'otplib';
+
+import { createUserMfaVerification, deleteUser, getUser } from '#src/api/admin-user.js';
+import { deleteInlineHook, upsertInlineHook } from '#src/api/logto-config.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import { successfullyVerifyTotp } from '#src/helpers/experience/totp-verification.js';
+import { expectRejects, createUserByAdmin } from '#src/helpers/index.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableMandatoryMfaWithTotp,
+  resetMfaSettings,
+} from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest, generateName, generatePassword, generateUsername } from '#src/utils.js';
+
+const p1Key = LogtoInlineHookKey.PostFirstFactorVerification;
+const p2Key = LogtoInlineHookKey.PostSignIn;
+
+devFeatureTest.describe('inline hook: post sign-in composition', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods({
+      identifiers: [SignInIdentifier.Username],
+      password: true,
+      verify: false,
+    });
+  });
+
+  afterEach(async () => {
+    await Promise.all([trySafe(deleteInlineHook(p1Key)), trySafe(deleteInlineHook(p2Key))]);
+    await resetMfaSettings();
+  });
+
+  it('should run after MFA side effects, resynchronize a profile value, and complete before token issuance', async () => {
+    await enableMandatoryMfaWithTotp();
+    await upsertInlineHook(p2Key, {
+      script: `
+        const runInlineHook = ({ event }) => ({
+          action: 'updateUser',
+          user: {
+            name: event.user.customData.displayName,
+            customData: { p2MfaFactors: event.user.mfaVerificationFactors },
+          },
+        });
+      `,
+      enabled: true,
+    });
+
+    const username = generateUsername();
+    const password = generatePassword();
+    const displayName = generateName();
+    const user = await createUserByAdmin({
+      username,
+      password,
+      customData: { displayName },
+    });
+    const mfa = await createUserMfaVerification(user.id, MfaFactor.TOTP);
+
+    if (mfa.type !== MfaFactor.TOTP) {
+      throw new Error('unexpected mfa type');
+    }
+
+    const client = await initExperienceClient({ config: { scopes: [UserScope.Profile] } });
+    await identifyUserWithUsernamePassword(client, username, password);
+
+    await expectRejects(client.submitInteraction(), {
+      code: 'session.mfa.require_mfa_verification',
+      status: 403,
+    });
+
+    await successfullyVerifyTotp(client, { code: authenticator.generate(mfa.secret) });
+
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+    const { name: idTokenName } = await client.getIdTokenClaims();
+    await logoutClient(client);
+
+    expect(userId).toBe(user.id);
+    // The P2-updated profile value is already reflected in the issued ID token.
+    expect(idTokenName).toBe(displayName);
+
+    const updated = await getUser(user.id);
+    expect(updated.name).toBe(displayName);
+    // The hook observed the finalized user context, including the just-bound MFA factor.
+    expect(updated.customData).toMatchObject({ displayName, p2MfaFactors: [MfaFactor.TOTP] });
+
+    await deleteUser(user.id);
+  });
+
+  it('should merge custom data updates from P1 and P2 and expose P1 data to P2', async () => {
+    await upsertInlineHook(p1Key, {
+      script: `
+        const runInlineHook = ({ event }) => {
+          if (event.user) {
+            return;
+          }
+
+          return {
+            action: 'createUser',
+            user: { customData: { legacyId: 'legacy-777', p1: true } },
+            passwordVerified: true,
+          };
+        };
+      `,
+      enabled: true,
+    });
+    await upsertInlineHook(p2Key, {
+      script: `
+        const runInlineHook = ({ event }) => ({
+          action: 'updateUser',
+          user: {
+            customData: { p2: true, p2SawLegacyId: event.user.customData.legacyId },
+          },
+        });
+      `,
+      enabled: true,
+    });
+
+    const username = generateUsername();
+    const password = generatePassword();
+
+    const client = await initExperienceClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+    const { redirectTo } = await client.submitInteraction();
+    const userId = await processSession(client, redirectTo);
+    await logoutClient(client);
+
+    const created = await getUser(userId);
+    expect(created.customData).toMatchObject({
+      legacyId: 'legacy-777',
+      p1: true,
+      p2: true,
+      p2SawLegacyId: 'legacy-777',
+    });
+
+    await deleteUser(userId);
+  });
+});


### PR DESCRIPTION
## Summary

- add an API-based integration suite for inline hooks exercising the local runtime end to end
- P1 create migration: unknown identifier accepted by the script provisions a user with persisted profile/custom data and completes sign-in; in a mandatory-MFA flow no tokens are issued until MFA succeeds
- P1 update migration: existing user whose local password fails is resynchronized (profile + password) and sign-in completes
- one-shot migration: migrated password is stored with Argon2i and the next sign-in succeeds through local verification with the hook disabled
- P2 composition: P2 runs after MFA side effects with the finalized user context, resynchronizes a profile value before token issuance, and P1/P2 customData updates are preserved and merged

## Testing

Integration tests

Closes LOG-13721