### PR TITLE
feat(core): add signed authn-request fields to saml sso config guard

### DIFF
--- a/packages/core/src/sso/types/saml.test.ts
+++ b/packages/core/src/sso/types/saml.test.ts
@@ -1,0 +1,100 @@
+import { samlConnectorConfigGuard, SamlAuthnRequestSignatureAlgorithm } from './saml.js';
+
+describe('samlConnectorConfigGuard backward compatibility', () => {
+  // Every pre-existing config shape must still parse, and the newly-added optional signing
+  // fields must be absent (not defaulted/injected) so stored configs are unchanged.
+  it.each([
+    { case: 'metadata URL', config: { metadataUrl: 'https://idp.example.com/metadata' } },
+    {
+      case: 'metadata URL with attribute mapping',
+      config: {
+        metadataUrl: 'https://idp.example.com/metadata',
+        attributeMapping: { id: 'nameID', email: 'email' },
+      },
+    },
+    { case: 'metadata XML', config: { metadata: '<EntityDescriptor/>' } },
+    {
+      case: 'manual metadata',
+      config: {
+        entityId: 'urn:idp.example.com',
+        signInEndpoint: 'https://idp.example.com/sso',
+        x509Certificate: 'MIID-cert',
+      },
+    },
+    {
+      case: 'manual metadata with attribute mapping',
+      config: {
+        entityId: 'urn:idp.example.com',
+        signInEndpoint: 'https://idp.example.com/sso',
+        x509Certificate: 'MIID-cert',
+        attributeMapping: { name: 'displayName' },
+      },
+    },
+  ])('parses an existing $case config with the signing fields absent', ({ config }) => {
+    const result = samlConnectorConfigGuard.safeParse(config);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toMatchObject(config);
+      expect('signAuthnRequest' in result.data).toBe(false);
+      expect('requestSignatureAlgorithm' in result.data).toBe(false);
+    }
+  });
+});
+
+describe('samlConnectorConfigGuard signing fields', () => {
+  const baseConfigByShape = {
+    'metadata URL': { metadataUrl: 'https://idp.example.com/metadata' },
+    'metadata XML': { metadata: '<EntityDescriptor/>' },
+    manual: {
+      entityId: 'urn:idp.example.com',
+      signInEndpoint: 'https://idp.example.com/sso',
+      x509Certificate: 'MIID-cert',
+    },
+  };
+
+  // Exercise every config shape so a dropped `.merge(samlSigningConfigGuard)` on any union branch
+  // is caught (not just the metadata-URL branch).
+  it.each(Object.entries(baseConfigByShape))(
+    'accepts and preserves the signing fields on the %s shape',
+    (_shape, base) => {
+      const result = samlConnectorConfigGuard.safeParse({
+        ...base,
+        signAuthnRequest: true,
+        requestSignatureAlgorithm: SamlAuthnRequestSignatureAlgorithm.RsaSha512,
+      });
+
+      expect(result.success).toBe(true);
+      // The fields must be part of the schema, not stripped away as unknown keys.
+      if (result.success) {
+        expect(result.data).toMatchObject({
+          signAuthnRequest: true,
+          requestSignatureAlgorithm: SamlAuthnRequestSignatureAlgorithm.RsaSha512,
+        });
+      }
+    }
+  );
+
+  it.each([
+    SamlAuthnRequestSignatureAlgorithm.RsaSha256,
+    SamlAuthnRequestSignatureAlgorithm.RsaSha512,
+  ])('accepts the supported algorithm %s', (requestSignatureAlgorithm) => {
+    const result = samlConnectorConfigGuard.safeParse({
+      metadataUrl: 'https://idp.example.com/metadata',
+      signAuthnRequest: true,
+      requestSignatureAlgorithm,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid signature algorithm', () => {
+    const result = samlConnectorConfigGuard.safeParse({
+      metadata: '<EntityDescriptor/>',
+      signAuthnRequest: true,
+      requestSignatureAlgorithm: 'not-a-real-alg',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/core/src/sso/types/saml.ts
+++ b/packages/core/src/sso/types/saml.ts
@@ -53,21 +53,47 @@ export const manualSamlConnectorConfigGuard = samlIdentityProviderMetadataGuard.
   x509Certificate: true,
 });
 
+/**
+ * XML-DSig signature algorithms offered for signing the SP `AuthnRequest`. We deliberately expose
+ * only the SHA-256 and SHA-512 variants; the legacy SAML social connector additionally allows the
+ * weak RSA-SHA1, which we intentionally omit for this feature.
+ */
+export enum SamlAuthnRequestSignatureAlgorithm {
+  RsaSha256 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+  RsaSha512 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512',
+}
+
+/**
+ * Optional signed-`AuthnRequest` settings, shared across all SAML config shapes. Both fields are
+ * optional so existing connector configs remain valid; the signing behaviour is gated behind
+ * `isDevFeaturesEnabled` at the sign-in / route / console layers, not here.
+ */
+const samlSigningConfigGuard = z.object({
+  signAuthnRequest: z.boolean().optional(),
+  requestSignatureAlgorithm: z.nativeEnum(SamlAuthnRequestSignatureAlgorithm).optional(),
+});
+
 export const samlConnectorConfigGuard = z.union([
   // Config using Metadata URL
-  z.object({
-    metadataUrl: z.string(),
-    attributeMapping: customizableAttributeMapGuard.optional(),
-  }),
+  z
+    .object({
+      metadataUrl: z.string(),
+      attributeMapping: customizableAttributeMapGuard.optional(),
+    })
+    .merge(samlSigningConfigGuard),
   // Config using Metadata XML
-  z.object({
-    metadata: z.string(),
-    attributeMapping: customizableAttributeMapGuard.optional(),
-  }),
+  z
+    .object({
+      metadata: z.string(),
+      attributeMapping: customizableAttributeMapGuard.optional(),
+    })
+    .merge(samlSigningConfigGuard),
   // Config using Metadata detail
-  manualSamlConnectorConfigGuard.extend({
-    attributeMapping: customizableAttributeMapGuard.optional(),
-  }),
+  manualSamlConnectorConfigGuard
+    .extend({
+      attributeMapping: customizableAttributeMapGuard.optional(),
+    })
+    .merge(samlSigningConfigGuard),
 ]);
 export type SamlConnectorConfig = z.infer<typeof samlConnectorConfigGuard>;
 


### PR DESCRIPTION
## Summary
Adds the optional `signAuthnRequest` and `requestSignatureAlgorithm` fields — plus the `SamlAuthnRequestSignatureAlgorithm` enum (RSA-SHA256 / RSA-SHA512) — to the enterprise SSO SAML connector config guard (`samlConnectorConfigGuard`). This is the config surface for the upcoming **optional signed AuthnRequest** feature.

Both fields are optional and merged into all three config shapes (metadata URL / metadata XML / manual metadata), so existing connector configs remain valid — covered by backward-compatibility tests over every existing shape (asserting the signing fields come back absent, not defaulted). No behavior change: the signing behavior is gated behind `isDevFeaturesEnabled` at the sign-in / route / console layers in later PRs, not in the guard.

Refs LOG-13838.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments