### PR TITLE
feat(console,phrases): add user source question to cloud onboarding

### DIFF
--- a/packages/console/src/onboarding/pages/CreateTenant/HearAboutUs/index.module.scss
+++ b/packages/console/src/onboarding/pages/CreateTenant/HearAboutUs/index.module.scss
@@ -1,0 +1,12 @@
+@use '@/scss/underscore' as _;
+
+.options {
+  display: flex;
+  flex-direction: column;
+  // Radio itself keeps a unit(2) bottom margin; the row gap tops it up for a 7-item list.
+  row-gap: _.unit(1);
+}
+
+.detailInput {
+  margin-top: _.unit(3);
+}

--- a/packages/console/src/onboarding/pages/CreateTenant/HearAboutUs/index.tsx
+++ b/packages/console/src/onboarding/pages/CreateTenant/HearAboutUs/index.tsx
@@ -1,0 +1,104 @@
+import { type AdminConsoleKey } from '@logto/phrases';
+import { useTranslation } from 'react-i18next';
+
+import FormField from '@/ds-components/FormField';
+import RadioGroup, { Radio } from '@/ds-components/RadioGroup';
+import TextInput from '@/ds-components/TextInput';
+
+import styles from './index.module.scss';
+
+enum HearAboutUsSource {
+  SearchEngine = 'search_engine',
+  AiAssistant = 'ai_assistant',
+  GithubOss = 'github_oss',
+  FriendColleague = 'friend_colleague',
+  PoweredBy = 'powered_by',
+  ContentSocial = 'content_social',
+  Other = 'other',
+}
+
+export type HearAboutUsValue = {
+  source?: HearAboutUsSource;
+  detail?: string;
+};
+
+/** Sources where a free-text follow-up helps pinpoint the exact origin. */
+export const sourcesWithDetail: ReadonlySet<HearAboutUsSource> = new Set([
+  HearAboutUsSource.ContentSocial,
+  HearAboutUsSource.Other,
+]);
+
+const optionTitles = Object.freeze({
+  [HearAboutUsSource.SearchEngine]: 'cloud.create_tenant.hear_about_us.options.search_engine',
+  [HearAboutUsSource.AiAssistant]: 'cloud.create_tenant.hear_about_us.options.ai_assistant',
+  [HearAboutUsSource.GithubOss]: 'cloud.create_tenant.hear_about_us.options.github_oss',
+  [HearAboutUsSource.FriendColleague]: 'cloud.create_tenant.hear_about_us.options.friend_colleague',
+  [HearAboutUsSource.PoweredBy]: 'cloud.create_tenant.hear_about_us.options.powered_by',
+  [HearAboutUsSource.ContentSocial]: 'cloud.create_tenant.hear_about_us.options.content_social',
+  [HearAboutUsSource.Other]: 'cloud.create_tenant.hear_about_us.options.other',
+}) satisfies Record<HearAboutUsSource, AdminConsoleKey>;
+
+const isHearAboutUsSource = (value: string): value is HearAboutUsSource =>
+  Object.values<string>(HearAboutUsSource).includes(value);
+
+const shuffle = <T,>(input: readonly T[]): T[] =>
+  input
+    .map((value) => ({ value, weight: Math.random() }))
+    .slice()
+    .sort(({ weight: weightA }, { weight: weightB }) => weightA - weightB)
+    .map(({ value }) => value);
+
+// Randomize option order once per app load to avoid position bias in answers; keep "Other" last.
+const sources = Object.freeze([
+  ...shuffle(
+    Object.values(HearAboutUsSource).filter((source) => source !== HearAboutUsSource.Other)
+  ),
+  HearAboutUsSource.Other,
+]);
+
+type Props = {
+  readonly value: HearAboutUsValue;
+  readonly onChange: (value: HearAboutUsValue) => void;
+  readonly isDisabled?: boolean;
+};
+
+function HearAboutUs({ value, onChange, isDisabled }: Props) {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const showDetailInput = Boolean(value.source && sourcesWithDetail.has(value.source));
+
+  return (
+    <FormField title="cloud.create_tenant.hear_about_us.title">
+      <RadioGroup
+        name="hearAboutUsSource"
+        className={styles.options}
+        value={value.source}
+        onChange={(next) => {
+          if (!isHearAboutUsSource(next)) {
+            return;
+          }
+          onChange({
+            source: next,
+            detail: sourcesWithDetail.has(next) ? value.detail : undefined,
+          });
+        }}
+      >
+        {sources.map((source) => (
+          <Radio key={source} title={optionTitles[source]} value={source} isDisabled={isDisabled} />
+        ))}
+      </RadioGroup>
+      {showDetailInput && (
+        <TextInput
+          className={styles.detailInput}
+          placeholder={t('cloud.create_tenant.hear_about_us.detail_placeholder')}
+          value={value.detail ?? ''}
+          disabled={isDisabled}
+          onChange={({ currentTarget: { value: detail } }) => {
+            onChange({ ...value, detail });
+          }}
+        />
+      )}
+    </FormField>
+  );
+}
+
+export default HearAboutUs;

--- a/packages/console/src/onboarding/pages/CreateTenant/index.tsx
+++ b/packages/console/src/onboarding/pages/CreateTenant/index.tsx
@@ -1,6 +1,8 @@
 import { emailRegEx } from '@logto/core-kit';
 import { useLogto } from '@logto/react';
 import { TenantRole, Theme } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import { usePostHog } from 'posthog-js/react';
 import { useCallback, useContext, useMemo } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
@@ -30,10 +32,12 @@ import InviteEmailsInput from '@/pages/TenantSettings/TenantMembers/InviteEmails
 import { type InviteeEmailItem } from '@/pages/TenantSettings/TenantMembers/types';
 import { trySubmitSafe } from '@/utils/form';
 
+import HearAboutUs, { type HearAboutUsValue, sourcesWithDetail } from './HearAboutUs';
 import styles from './index.module.scss';
 
 type CreateTenantForm = Omit<CreateTenantData, 'tag'> & {
   collaboratorEmails: InviteeEmailItem[];
+  hearAboutUs: HearAboutUsValue;
 };
 
 function CreateTenant() {
@@ -42,6 +46,7 @@ function CreateTenant() {
       name: 'My project',
       regionName: defaultRegionName,
       collaboratorEmails: [],
+      hearAboutUs: {},
     },
   });
   const {
@@ -73,6 +78,7 @@ function CreateTenant() {
   const cloudApi = useCloudApi();
   const { currentTenant } = useContext(TenantsContext);
   const { regions, regionsError } = useAvailableRegions();
+  const postHog = usePostHog();
 
   const publicRegions = useMemo(
     () => regions?.filter((region) => !region.isPrivate) ?? [],
@@ -80,39 +86,58 @@ function CreateTenant() {
   );
 
   const onCreateClick = handleSubmit(
-    trySubmitSafe(async ({ name, regionName, collaboratorEmails }: CreateTenantForm) => {
-      reportToGoogle(GtagConversionId.SignUp, { transactionId: currentTenant?.id });
-      const newTenant = await cloudApi.post('/api/tenants', {
-        body: { name: name || 'My project', regionName },
-      });
-      prependTenant(newTenant);
-      toast.success(t('tenants.create_modal.tenant_created'));
+    trySubmitSafe(
+      async ({ name, regionName, collaboratorEmails, hearAboutUs }: CreateTenantForm) => {
+        reportToGoogle(GtagConversionId.SignUp, { transactionId: currentTenant?.id });
+        const newTenant = await cloudApi.post('/api/tenants', {
+          body: { name: name || 'My project', regionName },
+        });
+        prependTenant(newTenant);
+        toast.success(t('tenants.create_modal.tenant_created'));
 
-      const tenantCloudApi = createTenantApi({
-        hideErrorToast: true,
-        isAuthenticated,
-        getOrganizationToken,
-        tenantId: newTenant.id,
-        language: i18n.language,
-      });
+        const { source } = hearAboutUs;
+        const sourceDetail = conditional(
+          source && sourcesWithDetail.has(source) && hearAboutUs.detail?.trim()
+        );
+        postHog.capture('console:user_source_submit', {
+          source: source ?? 'skipped',
+          ...conditional(sourceDetail && { source_detail: sourceDetail }),
+          ...conditional(
+            source && {
+              $set_once: {
+                self_reported_source: source,
+                ...conditional(sourceDetail && { self_reported_source_detail: sourceDetail }),
+              },
+            }
+          ),
+        });
 
-      if (collaboratorEmails.length > 0) {
-        // Should not block the onboarding flow if the invitation fails.
-        try {
-          await tenantCloudApi.post('/api/tenants/:tenantId/invitations', {
-            params: { tenantId: newTenant.id },
-            body: {
-              invitee: collaboratorEmails.map(({ value }) => value),
-              roleName: TenantRole.Collaborator,
-            },
-          });
-          toast.success(t('tenant_members.messages.invitation_sent'));
-        } catch {
-          toast.error(t('tenants.create_modal.invitation_failed', { duration: 5 }));
+        const tenantCloudApi = createTenantApi({
+          hideErrorToast: true,
+          isAuthenticated,
+          getOrganizationToken,
+          tenantId: newTenant.id,
+          language: i18n.language,
+        });
+
+        if (collaboratorEmails.length > 0) {
+          // Should not block the onboarding flow if the invitation fails.
+          try {
+            await tenantCloudApi.post('/api/tenants/:tenantId/invitations', {
+              params: { tenantId: newTenant.id },
+              body: {
+                invitee: collaboratorEmails.map(({ value }) => value),
+                roleName: TenantRole.Collaborator,
+              },
+            });
+            toast.success(t('tenant_members.messages.invitation_sent'));
+          } catch {
+            toast.error(t('tenants.create_modal.invitation_failed', { duration: 5 }));
+          }
         }
+        await update({ isOnboardingDone: true });
       }
-      await update({ isOnboardingDone: true });
-    })
+    )
   );
 
   return (
@@ -185,6 +210,13 @@ function CreateTenant() {
                 )}
               />
             </FormField>
+            <Controller
+              name="hearAboutUs"
+              control={control}
+              render={({ field: { onChange, value } }) => (
+                <HearAboutUs value={value} isDisabled={isSubmitting} onChange={onChange} />
+              )}
+            />
           </FormProvider>
         </div>
       </OverlayScrollbar>

--- a/packages/phrases/src/locales/ar/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'المستأجر هو بيئة معزولة حيث يمكنك إدارة هويات المستخدمين والتطبيقات وجميع الموارد الأخرى في Logto.',
     invite_collaborators: 'ادعو مشاركيك عبر البريد الإلكتروني',
+    hear_about_us: {
+      title: 'كيف سمعت عن Logto لأول مرة؟',
+      detail_placeholder: 'أخبرنا المزيد (اختياري)',
+      options: {
+        search_engine: 'محرك بحث (Google، Bing...)',
+        ai_assistant: 'مساعد ذكاء اصطناعي (ChatGPT، Claude، Gemini...)',
+        github_oss: 'GitHub أو أدلة المصادر المفتوحة',
+        friend_colleague: 'صديق أو زميل',
+        powered_by: 'صفحة تسجيل الدخول لتطبيق يستخدم Logto',
+        content_social: 'وسائل التواصل الاجتماعي أو مقال أو فيديو (YouTube، X، Reddit...)',
+        other: 'أخرى',
+      },
+    },
   },
   social_callback: {
     title: 'لقد قمت بتسجيل الدخول بنجاح',

--- a/packages/phrases/src/locales/de/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Ein Mandant ist eine isolierte Umgebung, in der Sie Benutzeridentitäten, Anwendungen und alle anderen Logto-Ressourcen verwalten können.',
     invite_collaborators: 'Laden Sie Ihre Mitarbeiter per E-Mail ein',
+    hear_about_us: {
+      title: 'Wie haben Sie zum ersten Mal von Logto erfahren?',
+      detail_placeholder: 'Erzählen Sie uns mehr (optional)',
+      options: {
+        search_engine: 'Suchmaschine (Google, Bing...)',
+        ai_assistant: 'KI-Assistent (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub oder Open-Source-Verzeichnisse',
+        friend_colleague: 'Freund oder Kollege',
+        powered_by: 'Anmeldeseite einer App, die Logto verwendet',
+        content_social: 'Soziale Medien, Artikel oder Video (YouTube, X, Reddit...)',
+        other: 'Sonstiges',
+      },
+    },
   },
   social_callback: {
     title: 'Sie haben sich erfolgreich angemeldet',

--- a/packages/phrases/src/locales/en/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'A tenant is an isolated environment where you can manage user identities, applications, and all other Logto resources.',
     invite_collaborators: 'Invite your collaborators by email',
+    hear_about_us: {
+      title: 'How did you first hear about Logto?',
+      detail_placeholder: 'Tell us more (optional)',
+      options: {
+        search_engine: 'Search engine (Google, Bing...)',
+        ai_assistant: 'AI assistant (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub or open-source directories',
+        friend_colleague: 'A friend or colleague',
+        powered_by: 'Sign-in page of an app using Logto',
+        content_social: 'Social media, article, or video (YouTube, X, Reddit...)',
+        other: 'Other',
+      },
+    },
   },
   social_callback: {
     title: "You've successfully signed in",

--- a/packages/phrases/src/locales/es/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Un inquilino es un entorno aislado donde puedes gestionar identidades de usuarios, aplicaciones y todos los demás recursos de Logto.',
     invite_collaborators: 'Invita a tus colaboradores por correo electrónico',
+    hear_about_us: {
+      title: '¿Cómo conociste Logto por primera vez?',
+      detail_placeholder: 'Cuéntanos más (opcional)',
+      options: {
+        search_engine: 'Motor de búsqueda (Google, Bing...)',
+        ai_assistant: 'Asistente de IA (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub o directorios de código abierto',
+        friend_colleague: 'Un amigo o colega',
+        powered_by: 'Página de inicio de sesión de una aplicación que usa Logto',
+        content_social: 'Redes sociales, artículo o video (YouTube, X, Reddit...)',
+        other: 'Otro',
+      },
+    },
   },
   social_callback: {
     title: 'Ha iniciado sesión correctamente',

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'مستأجر یک محیط ایزوله است که در آن می‌توانید هویت‌های کاربری، برنامه‌ها و تمام منابع دیگر Logto را مدیریت کنید.',
     invite_collaborators: 'همکاران خود را از طریق ایمیل دعوت کنید',
+    hear_about_us: {
+      title: 'اولین بار چگونه با Logto آشنا شدید؟',
+      detail_placeholder: 'بیشتر برایمان بگویید (اختیاری)',
+      options: {
+        search_engine: 'موتور جستجو (Google، Bing...)',
+        ai_assistant: 'دستیار هوش مصنوعی (ChatGPT، Claude، Gemini...)',
+        github_oss: 'GitHub یا دایرکتوری‌های متن‌باز',
+        friend_colleague: 'دوست یا همکار',
+        powered_by: 'صفحه ورود برنامه‌ای که از Logto استفاده می‌کند',
+        content_social: 'شبکه‌های اجتماعی، مقاله یا ویدیو (YouTube، X، Reddit...)',
+        other: 'سایر',
+      },
+    },
   },
   social_callback: {
     title: 'شما با موفقیت وارد شدید',

--- a/packages/phrases/src/locales/fr/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Un locataire est un environnement isolé où vous pouvez gérer les identités des utilisateurs, les applications et toutes les autres ressources Logto.',
     invite_collaborators: 'Invitez vos collaborateurs par e-mail',
+    hear_about_us: {
+      title: 'Comment avez-vous entendu parler de Logto pour la première fois ?',
+      detail_placeholder: 'Dites-nous en plus (facultatif)',
+      options: {
+        search_engine: 'Moteur de recherche (Google, Bing...)',
+        ai_assistant: 'Assistant IA (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub ou annuaires open source',
+        friend_colleague: 'Un ami ou un collègue',
+        powered_by: "Page de connexion d'une application utilisant Logto",
+        content_social: 'Réseaux sociaux, article ou vidéo (YouTube, X, Reddit...)',
+        other: 'Autre',
+      },
+    },
   },
   social_callback: {
     title: 'Connexion réussie',

--- a/packages/phrases/src/locales/it/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Un tenant è un ambiente isolato in cui puoi gestire identità degli utenti, applicazioni e tutte le altre risorse di Logto.',
     invite_collaborators: 'Invita i tuoi collaboratori via email',
+    hear_about_us: {
+      title: 'Come hai sentito parlare di Logto per la prima volta?',
+      detail_placeholder: 'Raccontaci di più (facoltativo)',
+      options: {
+        search_engine: 'Motore di ricerca (Google, Bing...)',
+        ai_assistant: 'Assistente IA (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub o directory open source',
+        friend_colleague: 'Un amico o collega',
+        powered_by: "Pagina di accesso di un'app che utilizza Logto",
+        content_social: 'Social media, articolo o video (YouTube, X, Reddit...)',
+        other: 'Altro',
+      },
+    },
   },
   social_callback: {
     title: 'Accesso effettuato con successo',

--- a/packages/phrases/src/locales/ja/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'テナントはユーザーアイデンティティ、アプリケーション、およびその他すべての Logto リソースを管理するための独立した環境です。',
     invite_collaborators: 'メールでコラボレーターを招待',
+    hear_about_us: {
+      title: 'Logto を最初にどこで知りましたか?',
+      detail_placeholder: '詳しく教えてください(任意)',
+      options: {
+        search_engine: '検索エンジン(Google、Bing など)',
+        ai_assistant: 'AI アシスタント(ChatGPT、Claude、Gemini など)',
+        github_oss: 'GitHub またはオープンソースディレクトリ',
+        friend_colleague: '友人・同僚からの紹介',
+        powered_by: 'Logto を利用しているアプリのサインインページ',
+        content_social: 'SNS・記事・動画(YouTube、X、Reddit など)',
+        other: 'その他',
+      },
+    },
   },
   social_callback: {
     title: 'ログインが成功しました',

--- a/packages/phrases/src/locales/ko/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       '테넌트는 사용자 신원, 애플리케이션 및 기타 모든 Logto 리소스를 관리할 수 있는 독립된 환경입니다.',
     invite_collaborators: '이메일로 협력자를 초대하세요',
+    hear_about_us: {
+      title: 'Logto를 처음 어떻게 알게 되었나요?',
+      detail_placeholder: '자세히 알려주세요 (선택 사항)',
+      options: {
+        search_engine: '검색 엔진 (Google, Bing 등)',
+        ai_assistant: 'AI 어시스턴트 (ChatGPT, Claude, Gemini 등)',
+        github_oss: 'GitHub 또는 오픈 소스 디렉터리',
+        friend_colleague: '친구 또는 동료',
+        powered_by: 'Logto를 사용하는 앱의 로그인 페이지',
+        content_social: '소셜 미디어, 글 또는 영상 (YouTube, X, Reddit 등)',
+        other: '기타',
+      },
+    },
   },
   social_callback: {
     title: '성공적으로 로그인했어요',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Najemca to odizolowane środowisko, w którym możesz zarządzać tożsamościami użytkowników, aplikacjami i wszystkimi innymi zasobami Logto.',
     invite_collaborators: 'Zaproś swoich współpracowników za pomocą e-maila',
+    hear_about_us: {
+      title: 'Jak po raz pierwszy dowiedziałeś się o Logto?',
+      detail_placeholder: 'Powiedz nam więcej (opcjonalnie)',
+      options: {
+        search_engine: 'Wyszukiwarka (Google, Bing...)',
+        ai_assistant: 'Asystent AI (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub lub katalogi open source',
+        friend_colleague: 'Znajomy lub współpracownik',
+        powered_by: 'Strona logowania aplikacji korzystającej z Logto',
+        content_social: 'Media społecznościowe, artykuł lub wideo (YouTube, X, Reddit...)',
+        other: 'Inne',
+      },
+    },
   },
   social_callback: {
     title: 'Zalogowałeś się pomyślnie',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Um inquilino é um ambiente isolado onde você pode gerenciar identidades de usuário, aplicações e todos os outros recursos do Logto.',
     invite_collaborators: 'Convide seus colaboradores por e-mail',
+    hear_about_us: {
+      title: 'Como você ouviu falar do Logto pela primeira vez?',
+      detail_placeholder: 'Conte-nos mais (opcional)',
+      options: {
+        search_engine: 'Mecanismo de busca (Google, Bing...)',
+        ai_assistant: 'Assistente de IA (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub ou diretórios de código aberto',
+        friend_colleague: 'Um amigo ou colega',
+        powered_by: 'Página de login de um aplicativo que usa o Logto',
+        content_social: 'Redes sociais, artigo ou vídeo (YouTube, X, Reddit...)',
+        other: 'Outro',
+      },
+    },
   },
   social_callback: {
     title: 'Você entrou com sucesso',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Um inquilino é um ambiente isolado onde pode gerir identidades de utilizadores, aplicações e todos os demais recursos da Logto.',
     invite_collaborators: 'Convide os seus colaboradores por email',
+    hear_about_us: {
+      title: 'Como ouviu falar da Logto pela primeira vez?',
+      detail_placeholder: 'Conte-nos mais (opcional)',
+      options: {
+        search_engine: 'Motor de pesquisa (Google, Bing...)',
+        ai_assistant: 'Assistente de IA (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub ou diretórios de código aberto',
+        friend_colleague: 'Um amigo ou colega',
+        powered_by: 'Página de início de sessão de uma aplicação que usa a Logto',
+        content_social: 'Redes sociais, artigo ou vídeo (YouTube, X, Reddit...)',
+        other: 'Outro',
+      },
+    },
   },
   social_callback: {
     title: 'Entrou com Sucesso',

--- a/packages/phrases/src/locales/ru/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Арендатор – это изолированная среда, где вы можете управлять пользовательскими идентификаторами, приложениями и всеми другими ресурсами Logto.',
     invite_collaborators: 'Пригласите ваших сотрудников по электронной почте',
+    hear_about_us: {
+      title: 'Как вы впервые узнали о Logto?',
+      detail_placeholder: 'Расскажите подробнее (необязательно)',
+      options: {
+        search_engine: 'Поисковая система (Google, Bing...)',
+        ai_assistant: 'ИИ-ассистент (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub или каталоги open source',
+        friend_colleague: 'Друг или коллега',
+        powered_by: 'Страница входа приложения, использующего Logto',
+        content_social: 'Социальные сети, статья или видео (YouTube, X, Reddit...)',
+        other: 'Другое',
+      },
+    },
   },
   social_callback: {
     title: 'Вход выполнен успешно',

--- a/packages/phrases/src/locales/th/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Tenant คือสภาพแวดล้อมที่แยกออกจากกันซึ่งคุณสามารถจัดการข้อมูลตัวตนของผู้ใช้ แอปพลิเคชัน และทรัพยากรอื่น ๆ ของ Logto ได้ทั้งหมด',
     invite_collaborators: 'เชิญผู้ร่วมงานของคุณผ่านอีเมล',
+    hear_about_us: {
+      title: 'คุณรู้จัก Logto ครั้งแรกจากที่ใด?',
+      detail_placeholder: 'บอกเราเพิ่มเติม (ไม่บังคับ)',
+      options: {
+        search_engine: 'เครื่องมือค้นหา (Google, Bing...)',
+        ai_assistant: 'ผู้ช่วย AI (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub หรือไดเรกทอรีโอเพนซอร์ส',
+        friend_colleague: 'เพื่อนหรือเพื่อนร่วมงาน',
+        powered_by: 'หน้าเข้าสู่ระบบของแอปที่ใช้ Logto',
+        content_social: 'โซเชียลมีเดีย บทความ หรือวิดีโอ (YouTube, X, Reddit...)',
+        other: 'อื่น ๆ',
+      },
+    },
   },
   social_callback: {
     title: 'คุณลงชื่อเข้าใช้สำเร็จแล้ว',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/cloud.ts
@@ -8,6 +8,19 @@ const cloud = {
     description:
       'Bir kiracı, kullanıcı kimliklerini, uygulamaları ve diğer tüm Logto kaynaklarını yönetebileceğiniz izole bir ortamdır.',
     invite_collaborators: 'E-posta ile işbirlikçilerinizi davet edin',
+    hear_about_us: {
+      title: "Logto'yu ilk nereden duydunuz?",
+      detail_placeholder: 'Bize daha fazla anlatın (isteğe bağlı)',
+      options: {
+        search_engine: 'Arama motoru (Google, Bing...)',
+        ai_assistant: 'Yapay zeka asistanı (ChatGPT, Claude, Gemini...)',
+        github_oss: 'GitHub veya açık kaynak dizinleri',
+        friend_colleague: 'Bir arkadaş veya iş arkadaşı',
+        powered_by: 'Logto kullanan bir uygulamanın oturum açma sayfası',
+        content_social: 'Sosyal medya, makale veya video (YouTube, X, Reddit...)',
+        other: 'Diğer',
+      },
+    },
   },
   social_callback: {
     title: 'Başarıyla giriş yaptınız',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/cloud.ts
@@ -7,6 +7,19 @@ const cloud = {
     title: '创建你的第一个租户',
     description: '租户是一个隔离的环境，你可以在其中管理用户身份、应用程序和所有其他 Logto 资源。',
     invite_collaborators: '通过电子邮件邀请你的合作者',
+    hear_about_us: {
+      title: '你最初是从哪里了解到 Logto 的?',
+      detail_placeholder: '告诉我们更多(可选)',
+      options: {
+        search_engine: '搜索引擎(Google、Bing 等)',
+        ai_assistant: 'AI 助手(ChatGPT、Claude、Gemini 等)',
+        github_oss: 'GitHub 或开源目录',
+        friend_colleague: '朋友或同事推荐',
+        powered_by: '某个使用 Logto 的应用的登录页',
+        content_social: '社交媒体、文章或视频(YouTube、X、Reddit 等)',
+        other: '其他',
+      },
+    },
   },
   social_callback: {
     title: '你已成功登录',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/cloud.ts
@@ -7,6 +7,19 @@ const cloud = {
     title: '創建你的第一個租戶',
     description: '租戶是一個獨立的環境，在這裡你可以管理用戶身份、應用程式和所有其他 Logto 資源。',
     invite_collaborators: '通過電子郵件邀請你的合作者',
+    hear_about_us: {
+      title: '你最初是從哪裡認識 Logto 的?',
+      detail_placeholder: '告訴我們更多(可選)',
+      options: {
+        search_engine: '搜尋引擎(Google、Bing 等)',
+        ai_assistant: 'AI 助手(ChatGPT、Claude、Gemini 等)',
+        github_oss: 'GitHub 或開源目錄',
+        friend_colleague: '朋友或同事推薦',
+        powered_by: '某個使用 Logto 的應用程式的登入頁',
+        content_social: '社交媒體、文章或影片(YouTube、X、Reddit 等)',
+        other: '其他',
+      },
+    },
   },
   social_callback: {
     title: '你已成功登錄',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/cloud.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/cloud.ts
@@ -7,6 +7,19 @@ const cloud = {
     title: '創建你的第一個租戶',
     description: '租戶是一個隔離的環境，你可以在其中管理用戶身份、應用程式和所有其他 Logto 資源。',
     invite_collaborators: '通過電子郵件邀請你的合作者',
+    hear_about_us: {
+      title: '你最初是從哪裡認識 Logto 的?',
+      detail_placeholder: '告訴我們更多(可選)',
+      options: {
+        search_engine: '搜尋引擎(Google、Bing 等)',
+        ai_assistant: 'AI 助手(ChatGPT、Claude、Gemini 等)',
+        github_oss: 'GitHub 或開源目錄',
+        friend_colleague: '朋友或同事推薦',
+        powered_by: '某個使用 Logto 的應用程式的登入頁',
+        content_social: '社交媒體、文章或影片(YouTube、X、Reddit 等)',
+        other: '其他',
+      },
+    },
   },
   social_callback: {
     title: '你已成功登錄',


### PR DESCRIPTION
## Summary

Adds an optional "How did you first hear about Logto?" question to the cloud onboarding create-tenant page (MKT-551), so we can attribute new signups to channels that first-touch attribution cannot see (AI assistants, word of mouth, third-party content, etc.).

- Single-select radio list with 7 options; order is randomized per app load to avoid position bias, with "Other" pinned last.
- "Social media, article, or video" and "Other" reveal an optional free-text follow-up input to capture the exact origin.
- On tenant creation, reports a `console:user_source_submit` event to PostHog with `source` / `source_detail` properties (`source: 'skipped'` when unanswered, so response rate is directly measurable), and sets `self_reported_source` / `self_reported_source_detail` person properties via `$set_once` for cross-analysis with channel attribution.
- The answer is intentionally stored in PostHog only; no schema or database changes.
- The question is not required and does not block the onboarding flow.
- All 19 locales translated.

Cloud-only surface (OSS onboarding is a separate flow and is untouched), so no changeset.

## Screenshots

Default state:

<img width="1512" height="800" alt="Default state of the question in the create-tenant form" src="https://github.com/user-attachments/assets/752b854f-bd72-4da9-9ac7-502a0a7ff23f" />

Selecting "Social media, article, or video" (or "Other") reveals an optional follow-up input:

<img width="1512" height="800" alt="Optional follow-up input revealed after selecting an option" src="https://github.com/user-attachments/assets/5eed9954-b3b4-454e-b858-e6a9a285ddb5" />

Full onboarding layout with the action bar pinned to the bottom:

<img width="1512" height="744" alt="Full onboarding layout with pinned action bar" src="https://github.com/user-attachments/assets/ed8d2348-ad97-43d0-9734-2d112ef2642a" />

## Testing

Tested locally: rendered the cloud onboarding page and exercised option selection, follow-up input reveal, and detail reset when switching to options without follow-up.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i5aMSDhDFUj55TNcXioD5
