### PR TITLE
feat(console): surface hosted-email usage + cap notices for read/display release

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/ConnectorContent/index.tsx
@@ -16,7 +16,7 @@ import DetailsForm from '@/components/DetailsForm';
 import FormCard from '@/components/FormCard';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
 import { connectors, emailConnectors } from '@/consts';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 import useApi from '@/hooks/use-api';
 import { useConnectorFormConfigParser } from '@/hooks/use-connector-form-config-parser';
@@ -113,7 +113,7 @@ function ConnectorContent({ isDeleted, connectorData, onConnectorUpdated }: Prop
   const updateUsage = useCallback(() => {
     // A hosted-email test send consumes the daily/monthly quota; refresh that display even when the
     // lifetime count is unavailable (core wraps `getUsage` in `trySafe`, so `usage` may be undefined).
-    if (isCloud && isDevFeaturesEnabled && isEmailServiceConnector && currentTenantId) {
+    if (isCloud && isEmailServiceConnector && currentTenantId) {
       void mutate(getHostedEmailUsageKey(currentTenantId));
     }
     if (connectorData.usage !== undefined) {

--- a/packages/console/src/pages/ConnectorDetails/EmailUsage/use-hosted-email-usage.ts
+++ b/packages/console/src/pages/ConnectorDetails/EmailUsage/use-hosted-email-usage.ts
@@ -4,7 +4,7 @@ import { useContext } from 'react';
 import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { TenantsContext } from '@/contexts/TenantsProvider';
 
 /**
@@ -15,9 +15,9 @@ export const getHostedEmailUsageKey = (tenantId: string) =>
   `/api/tenants/${tenantId}/subscription/hosted-email-usage`;
 
 /**
- * Fetches the per-tenant daily and monthly hosted-email usage and limits (Cloud + dev-features
- * only). Shared by the Connector Details usage card and the cap notices — SWR dedupes the request
- * so both consumers hit the endpoint once.
+ * Fetches the per-tenant daily and monthly hosted-email usage and limits (Cloud only). Shared by
+ * the Connector Details usage card and the cap notices — SWR dedupes the request so both consumers
+ * hit the endpoint once.
  *
  * The cap only applies to Logto's built-in email connector, so the usage request is skipped for
  * tenants on their own email provider — leaving `data` undefined, which also hides the cap notices.
@@ -26,7 +26,7 @@ const useHostedEmailUsage = () => {
   const { currentTenantId } = useContext(TenantsContext);
   const cloudApi = useCloudApi({ hideErrorToast: true });
 
-  const isEnabled = isCloud && isDevFeaturesEnabled;
+  const isEnabled = isCloud;
 
   // Only tenants using the built-in email connector are subject to the cap. Read it from the shared
   // `api/connectors` SWR cache (fetched only while the feature is enabled).


### PR DESCRIPTION
## Summary
Part of the Phase 1.9 phased release ([LOG-13656](https://linear.app/silverhand/issue/LOG-13656)). Ships the console **read/display + notices** half of the hosted-email usage caps: removes the `isDevFeaturesEnabled` gate on the hosted-email usage hook so Cloud tenants see the windowed daily + monthly usage-vs-limit display and the "approaching 80% / at cap" notices. The send-blocking hard cap stays gated cloud-side and ships separately ([cloud#2016](https://github.com/logto-io/cloud/pull/2016) un-gates the usage endpoint this hook reads; enforcement is [LOG-13895](https://linear.app/silverhand/issue/LOG-13895)).

Lets us run the in-console usage display + notices in production for a soak period before any send is blocked.

### What changed
- `packages/console/src/pages/ConnectorDetails/EmailUsage/use-hosted-email-usage.ts` — `isEnabled` is now `isCloud` (was `isCloud && isDevFeaturesEnabled`); this single flag drives the usage SWR fetch, the `HostedEmailCapBanner` notices, and the windowed-vs-lifetime display swap in `EmailUsage`. Removed the now-unused `isDevFeaturesEnabled` import and updated the stale "Cloud + dev-features only" doc.

### Expected result
- Cloud tenants on the built-in Logto email connector see daily + monthly usage and the cap notices (previously dev-features-only). No behavior change for self-hosted (`isCloud` is false) and for tenants on their own email provider (display/notices stay hidden).

## Testing
Tested locally

## Checklist
- [ ] `.changeset` — not needed: cloud-only behavior (`isCloud`-gated); no OSS-user-facing change
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
