### PR TITLE
feat(core): add saml-sso-connector signing-key library

### DIFF
--- a/packages/core/src/libraries/saml-sso-connector-signing-key.test.ts
+++ b/packages/core/src/libraries/saml-sso-connector-signing-key.test.ts
@@ -1,0 +1,115 @@
+import {
+  type CreateSamlSsoConnectorSigningKey,
+  type SamlSsoConnectorSigningKey,
+} from '@logto/schemas';
+import { type Nullable } from '@silverhand/essentials';
+
+import { MockQueries } from '#src/test-utils/tenant.js';
+import { type OmitAutoSetFields } from '#src/utils/sql.js';
+
+import { createSamlSsoConnectorSigningKeyLibrary } from './saml-sso-connector-signing-key.js';
+
+const { jest } = import.meta;
+
+const ssoConnectorId = 'sso-connector-id';
+
+type SigningKeyInsert = Omit<OmitAutoSetFields<CreateSamlSsoConnectorSigningKey>, 'active'>;
+
+const buildKey = (data: SigningKeyInsert, active: boolean): SamlSsoConnectorSigningKey => ({
+  tenantId: 'tenant-id',
+  createdAt: 1_700_000_000_000,
+  active,
+  ...data,
+});
+
+const mockActiveKey: SamlSsoConnectorSigningKey = {
+  id: 'key-id',
+  tenantId: 'tenant-id',
+  ssoConnectorId,
+  privateKey: 'private-key',
+  certificate: 'certificate',
+  createdAt: 1_700_000_000_000,
+  expiresAt: 1_800_000_000_000,
+  active: true,
+};
+
+const insertInactiveSigningKey = jest.fn(async (data: SigningKeyInsert) => buildKey(data, false));
+const insertActiveSigningKey = jest.fn(async (data: SigningKeyInsert) => buildKey(data, true));
+const findActiveSigningKeyBySsoConnectorId = jest.fn(
+  async (): Promise<Nullable<SamlSsoConnectorSigningKey>> => null
+);
+const deleteSigningKeysBySsoConnectorId = jest.fn();
+
+const createLibrary = () =>
+  createSamlSsoConnectorSigningKeyLibrary(
+    new MockQueries({
+      samlSsoConnectorSigningKeys: {
+        insertInactiveSigningKey,
+        insertActiveSigningKey,
+        findActiveSigningKeyBySsoConnectorId,
+        deleteSigningKeysBySsoConnectorId,
+      },
+    })
+  );
+
+describe('createSamlSsoConnectorSigningKeyLibrary()', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createSigningKey()', () => {
+    it('should generate a key pair and insert it as active', async () => {
+      await createLibrary().createSigningKey({ ssoConnectorId, isActive: true });
+
+      expect(insertActiveSigningKey).toHaveBeenCalledTimes(1);
+      expect(insertInactiveSigningKey).not.toHaveBeenCalled();
+
+      const [data] = insertActiveSigningKey.mock.calls[0]!;
+      expect(data.ssoConnectorId).toBe(ssoConnectorId);
+      expect(data.privateKey).toContain('PRIVATE KEY');
+      expect(data.certificate).toContain('CERTIFICATE');
+      expect(typeof data.id).toBe('string');
+      // Certificate validity should be the default 3 years out (allow a wide tolerance for leap years / runtime).
+      const threeYearsInMs = 3 * 365 * 24 * 60 * 60 * 1000;
+      expect(data.expiresAt).toBeGreaterThan(Date.now() + threeYearsInMs - 2 * 24 * 60 * 60 * 1000);
+      expect(data.expiresAt).toBeLessThan(Date.now() + threeYearsInMs + 2 * 24 * 60 * 60 * 1000);
+    });
+
+    it('should generate a key pair and insert it as inactive', async () => {
+      await createLibrary().createSigningKey({ ssoConnectorId });
+
+      expect(insertInactiveSigningKey).toHaveBeenCalledTimes(1);
+      expect(insertActiveSigningKey).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ensureActiveSigningKey()', () => {
+    it('should reuse the existing active key', async () => {
+      findActiveSigningKeyBySsoConnectorId.mockResolvedValueOnce(mockActiveKey);
+
+      const result = await createLibrary().ensureActiveSigningKey(ssoConnectorId);
+
+      expect(findActiveSigningKeyBySsoConnectorId).toHaveBeenCalledWith(ssoConnectorId);
+      expect(result).toStrictEqual(mockActiveKey);
+      expect(insertActiveSigningKey).not.toHaveBeenCalled();
+      expect(insertInactiveSigningKey).not.toHaveBeenCalled();
+    });
+
+    it('should generate and insert an active key when none is active', async () => {
+      const result = await createLibrary().ensureActiveSigningKey(ssoConnectorId);
+
+      expect(findActiveSigningKeyBySsoConnectorId).toHaveBeenCalledWith(ssoConnectorId);
+      expect(insertActiveSigningKey).toHaveBeenCalledTimes(1);
+      expect(result.active).toBe(true);
+      expect(result.ssoConnectorId).toBe(ssoConnectorId);
+    });
+  });
+
+  describe('deleteSigningKeys()', () => {
+    it('should delete all keys for the connector', async () => {
+      await createLibrary().deleteSigningKeys(ssoConnectorId);
+
+      expect(deleteSigningKeysBySsoConnectorId).toHaveBeenCalledWith(ssoConnectorId);
+    });
+  });
+});

--- a/packages/core/src/libraries/saml-sso-connector-signing-key.ts
+++ b/packages/core/src/libraries/saml-sso-connector-signing-key.ts
@@ -1,0 +1,52 @@
+import { generateStandardId } from '@logto/shared';
+
+import type Queries from '#src/tenants/Queries.js';
+
+import { generateKeyPairAndCertificate } from './saml-application/utils.js';
+
+const signingKeyLifeSpanInYears = 3;
+
+export const createSamlSsoConnectorSigningKeyLibrary = (queries: Queries) => {
+  const {
+    samlSsoConnectorSigningKeys: {
+      insertInactiveSigningKey,
+      insertActiveSigningKey,
+      findActiveSigningKeyBySsoConnectorId,
+      deleteSigningKeysBySsoConnectorId,
+    },
+  } = queries;
+
+  /** Generate a fresh SP key pair (plaintext PEM) and store it — active, or inactive for rotation. */
+  const createSigningKey = async ({
+    ssoConnectorId,
+    isActive = false,
+  }: {
+    ssoConnectorId: string;
+    isActive?: boolean;
+  }) => {
+    const { privateKey, certificate, notAfter } =
+      await generateKeyPairAndCertificate(signingKeyLifeSpanInYears);
+
+    const data = {
+      id: generateStandardId(),
+      ssoConnectorId,
+      privateKey,
+      certificate,
+      expiresAt: notAfter.getTime(),
+    };
+
+    return isActive ? insertActiveSigningKey(data) : insertInactiveSigningKey(data);
+  };
+
+  /** Return the connector's active SP signing key, generating one if none is active (idempotent). */
+  const ensureActiveSigningKey = async (ssoConnectorId: string) => {
+    const active = await findActiveSigningKeyBySsoConnectorId(ssoConnectorId);
+    return active ?? createSigningKey({ ssoConnectorId, isActive: true });
+  };
+
+  const deleteSigningKeys = async (ssoConnectorId: string) => {
+    await deleteSigningKeysBySsoConnectorId(ssoConnectorId);
+  };
+
+  return { createSigningKey, ensureActiveSigningKey, deleteSigningKeys };
+};

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -17,6 +17,7 @@ import { createProtectedAppLibrary } from '#src/libraries/protected-app.js';
 import { QuotaLibrary } from '#src/libraries/quota.js';
 import { createRoleScopeLibrary } from '#src/libraries/role-scope.js';
 import { createSamlApplicationsLibrary } from '#src/libraries/saml-application/saml-applications.js';
+import { createSamlSsoConnectorSigningKeyLibrary } from '#src/libraries/saml-sso-connector-signing-key.js';
 import { createScopeLibrary } from '#src/libraries/scope.js';
 import { createSessionLibrary } from '#src/libraries/session/index.js';
 import { createSignInExperienceLibrary } from '#src/libraries/sign-in-experience/index.js';
@@ -48,6 +49,7 @@ export default class Libraries {
   applications = createApplicationLibrary(this.queries);
   verificationStatuses = createVerificationStatusLibrary(this.queries);
   samlApplications = createSamlApplicationsLibrary(this.queries);
+  samlSsoConnectorSigningKeys = createSamlSsoConnectorSigningKeyLibrary(this.queries);
   roleScopes = createRoleScopeLibrary(this.queries);
   domains = createDomainLibrary(this.queries);
   protectedApps = createProtectedAppLibrary(this.queries);


### PR DESCRIPTION
## Summary
Task 7 of the SAML enterprise SSO signed-AuthnRequest feature (Refs LOG-13841). Adds `createSamlSsoConnectorSigningKeyLibrary`, the library layer over the signing-key query module (Task 6), for managing a connector's SP signing keys under the multi-key/`active` model.

### What changed
- New `packages/core/src/libraries/saml-sso-connector-signing-key.ts`:
  - `createSigningKey({ ssoConnectorId, isActive })` — generates an SP key pair via `generateKeyPairAndCertificate` (plaintext PEM, 3-year cert validity) and inserts it as active or inactive.
  - `ensureActiveSigningKey(ssoConnectorId)` — returns the current active key or generates one if none is active (idempotent enable path).
  - `deleteSigningKeys(ssoConnectorId)` — removes all keys for a connector (disable path).
- Registered on `Libraries.ts` as `samlSsoConnectorSigningKeys`.
- Co-located unit test covering both `createSigningKey` branches, both `ensureActiveSigningKey` branches (reuse existing vs generate), and delete.

Mirrors `createSamlApplicationsLibrary` / `createSamlApplicationSecret`; the SP private key is stored plaintext (Logto-generated, sign-only) by design. Rotation itself is driven from the console/routes (later tasks) via the query methods directly — this library covers enable, key generation, and disable.

### Reviewer notes
- Stacked on #9254 (Task 6 query module); review/merge that first.
- `expiresAt` is the certificate's `notAfter` (epoch ms). Nothing yet enforces expiry on the read path — that is deferred to the route/console tasks (enable/list surface the expiry for renewal).

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments