### PR TITLE
feat(core): sign saml authnrequest when enabled with an sp credential

### DIFF
--- a/packages/core/src/sso/SamlConnector/index.ts
+++ b/packages/core/src/sso/SamlConnector/index.ts
@@ -3,6 +3,8 @@ import { conditional, type Optional } from '@silverhand/essentials';
 import { XMLValidator } from 'fast-xml-parser';
 import * as saml from 'samlify';
 
+import { EnvSet } from '#src/env-set/index.js';
+
 import {
   SsoConnectorConfigErrorCodes,
   SsoConnectorError,
@@ -14,6 +16,7 @@ import {
   type SamlServiceProviderMetadata,
   type SamlIdentityProviderMetadata,
   manualSamlConnectorConfigGuard,
+  SamlAuthnRequestSignatureAlgorithm,
 } from '../types/saml.js';
 
 import {
@@ -25,6 +28,47 @@ import {
   buildAssertionConsumerServiceUrl,
   attributeMappingPostProcessor,
 } from './utils.js';
+
+/**
+ * Force the IdP metadata's `WantAuthnRequestsSigned` to match our `signAuthnRequest` flag on the
+ * `<IDPSSODescriptor>` element. `samlify` requires `SP.AuthnRequestsSigned === IdP.WantAuthnRequestsSigned`
+ * and reads both from metadata (ignoring constructor options), so this keeps the two in sync and lets
+ * our toggle — not the customer's metadata — drive signing.
+ */
+const alignWantAuthnRequestsSigned = (metadataXml: string, enabled: boolean): string => {
+  // Real IdP metadata always has an IDPSSODescriptor; if it's absent the metadata is invalid and
+  // fails downstream in samlify anyway, so just leave it untouched here. The optional prefix accepts
+  // any namespace-prefix form (e.g. `md:`, `saml-md:`), matching samlify's namespace-agnostic parsing.
+  const descriptorTag = metadataXml.match(/<(?:[\w.-]+:)?IDPSSODescriptor\b[^>]*>/g)?.[0];
+
+  if (!descriptorTag) {
+    return metadataXml;
+  }
+
+  // XML attribute names are case-sensitive; SAML metadata uses this exact casing. Match either quote
+  // style and any value so an existing attribute is replaced (not duplicated). A replacement function
+  // keeps `$`-sequences in customer metadata from being interpreted.
+  const existingAttribute = /\s+WantAuthnRequestsSigned\s*=\s*(?:"[^"]*"|'[^']*')/;
+
+  if (existingAttribute.test(descriptorTag)) {
+    const rewritten = descriptorTag.replace(
+      existingAttribute,
+      ` WantAuthnRequestsSigned="${String(enabled)}"`
+    );
+    return metadataXml.replace(descriptorTag, () => rewritten);
+  }
+
+  // Attribute absent: it defaults to false, so only an enabled connector needs it inserted.
+  if (!enabled) {
+    return metadataXml;
+  }
+
+  const rewritten = descriptorTag.replace(
+    /(<(?:[\w.-]+:)?IDPSSODescriptor\b)/,
+    '$1 WantAuthnRequestsSigned="true"'
+  );
+  return metadataXml.replace(descriptorTag, () => rewritten);
+};
 
 /**
  * SAML connector
@@ -53,6 +97,7 @@ class SamlConnector {
 
   private _samlIdpMetadata: Optional<SamlIdentityProviderMetadata>;
   private _identityProvider: Optional<saml.IdentityProviderInstance>;
+  private _spSigningCredential?: { privateKey: string; certificate: string };
 
   // Allow _idpConfig input to be undefined when constructing the connector.
   constructor(
@@ -68,6 +113,11 @@ class SamlConnector {
       entityId: spEntityId,
       assertionConsumerServiceUrl,
     };
+  }
+
+  /** Inject the SP signing key pair — done by the sign-in flow only when `signAuthnRequest` is on. */
+  setServiceProviderSigningCredential(credential: { privateKey: string; certificate: string }) {
+    this._spSigningCredential = credential;
   }
 
   /**
@@ -140,13 +190,51 @@ class SamlConnector {
     const { x509Certificate } = await this.getSamlIdpMetadata();
     const { entityId, assertionConsumerServiceUrl } = this.serviceProviderMetadata;
 
+    const signingCredential = this._spSigningCredential;
+    // Gated behind dev features until GA: with the gate off, `signAuthnRequest` is inert and the
+    // released signing behavior below is preserved verbatim. getIdentityProvider reads the same
+    // gated value, so the SP and IdP signing flags never disagree.
+    const { isDevFeaturesEnabled } = EnvSet.values;
+    const signAuthnRequestEnabled =
+      isDevFeaturesEnabled && Boolean(this._idpConfig?.signAuthnRequest);
+
+    // Fail-closed: if signing is enabled but no SP credential was injected, refuse rather than
+    // silently send an unsigned request. The sign-in layer injects the credential and maps signing
+    // failures to a friendly error + audit log.
+    if (signAuthnRequestEnabled && !signingCredential) {
+      throw new SsoConnectorError(SsoConnectorErrorCodes.InvalidConfig, {
+        config: this._idpConfig,
+        message: SsoConnectorConfigErrorCodes.InvalidConnectorConfig,
+      });
+    }
+
+    // Drive `authnRequestsSigned` off our explicit flag rather than the IdP's `WantAuthnRequestsSigned`,
+    // so samlify never advertises a signed request without a private key. When signing, use the SP's
+    // own key/cert; when not, samlify ignores `signingCert` for a redirect request. With the dev gate
+    // off, keep the released behavior of mirroring the IdP metadata flag.
+    const signingServiceProviderOptions =
+      signAuthnRequestEnabled && signingCredential
+        ? {
+            signingCert: signingCredential.certificate,
+            authnRequestsSigned: true,
+            privateKey: signingCredential.privateKey,
+            requestSignatureAlgorithm:
+              this._idpConfig?.requestSignatureAlgorithm ??
+              SamlAuthnRequestSignatureAlgorithm.RsaSha256,
+          }
+        : {
+            signingCert: x509Certificate,
+            authnRequestsSigned: isDevFeaturesEnabled
+              ? false
+              : identityProvider.entityMeta.isWantAuthnRequestsSigned(), // Should align with IdP setting.
+          };
+
     try {
       // eslint-disable-next-line new-cap
       const serviceProvider = saml.ServiceProvider({
         entityID: entityId,
         relayState,
-        signingCert: x509Certificate,
-        authnRequestsSigned: identityProvider.entityMeta.isWantAuthnRequestsSigned(), // Should align with IdP setting.
+        ...signingServiceProviderOptions,
         assertionConsumerService: [
           {
             Location: assertionConsumerServiceUrl,
@@ -234,6 +322,13 @@ class SamlConnector {
       return this._identityProvider;
     }
 
+    // Drive signing from our flag — align the IdP side on both construction paths below
+    // (see alignWantAuthnRequestsSigned). With the dev gate off, the released behavior is preserved:
+    // the metadata is passed through untouched.
+    const { isDevFeaturesEnabled } = EnvSet.values;
+    const signAuthnRequestEnabled =
+      isDevFeaturesEnabled && Boolean(this._idpConfig?.signAuthnRequest);
+
     // If `metadataUrl` or `metadata` is provided, we use it to construct the identity provider.
     const idpMetadataXml = await this.getIdpMetadataXml();
 
@@ -256,7 +351,9 @@ class SamlConnector {
       this._identityProvider =
         // eslint-disable-next-line new-cap
         saml.IdentityProvider({
-          metadata: idpMetadataXml,
+          metadata: isDevFeaturesEnabled
+            ? alignWantAuthnRequestsSigned(idpMetadataXml, signAuthnRequestEnabled)
+            : idpMetadataXml,
         });
       return this._identityProvider;
     }
@@ -268,6 +365,8 @@ class SamlConnector {
     this._identityProvider = saml.IdentityProvider({
       entityID,
       signingCert: x509Certificate,
+      // No metadata XML here, so this option is honored (not overwritten by parsed metadata).
+      wantAuthnRequestsSigned: signAuthnRequestEnabled,
       /**
        * When `metadata` is not provided, `signInEndpoint` and `x509Certificate` are ensured by previous guard.
        * We only support redirect binding for now when sending SAML auth request.

--- a/packages/core/src/sso/SamlConnector/sign.test.ts
+++ b/packages/core/src/sso/SamlConnector/sign.test.ts
@@ -1,0 +1,220 @@
+import { EnvSet } from '#src/env-set/index.js';
+import { generateKeyPairAndCertificate } from '#src/libraries/saml-application/utils.js';
+
+import { SamlAuthnRequestSignatureAlgorithm } from '../types/saml.js';
+
+import SamlConnector from './index.js';
+
+const setDevFeaturesEnabled = (enabled: boolean) => {
+  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', enabled);
+};
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+// Minimal IdP metadata with a redirect SSO endpoint and a signing cert. Pass a namespace `prefix`
+// (e.g. `md`, `saml-md`) to exercise prefixed elements; default is the un-prefixed default namespace.
+const buildIdpMetadataXml = (cert: string, prefix = '') => {
+  const body = cert
+    .replace('-----BEGIN CERTIFICATE-----', '')
+    .replace('-----END CERTIFICATE-----', '')
+    .replaceAll(/\s/g, '');
+  const tag = prefix ? `${prefix}:` : '';
+  const namespace = prefix
+    ? `xmlns:${prefix}="urn:oasis:names:tc:SAML:2.0:metadata"`
+    : 'xmlns="urn:oasis:names:tc:SAML:2.0:metadata"';
+  return `<?xml version="1.0"?>
+<${tag}EntityDescriptor ${namespace} entityID="https://idp.example.com">
+  <${tag}IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <${tag}KeyDescriptor use="signing"><KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"><X509Data><X509Certificate>${body}</X509Certificate></X509Data></KeyInfo></${tag}KeyDescriptor>
+    <${tag}SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.example.com/sso"/>
+  </${tag}IDPSSODescriptor>
+</${tag}EntityDescriptor>`;
+};
+
+describe('SamlConnector signed AuthnRequest', () => {
+  const endpoint = new URL('https://logto.example.com');
+
+  beforeEach(() => {
+    setDevFeaturesEnabled(true);
+  });
+
+  afterAll(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
+  it('omits Signature when signAuthnRequest is off', async () => {
+    const { certificate } = await generateKeyPairAndCertificate(1);
+    const connector = new SamlConnector(endpoint, 'conn-1', {
+      metadata: buildIdpMetadataXml(certificate),
+    });
+    const url = await connector.getSingleSignOnUrl('relay-1');
+    expect(url).not.toContain('Signature=');
+  });
+
+  it('signs when enabled and a credential is set', async () => {
+    const idp = await generateKeyPairAndCertificate(1);
+    const sp = await generateKeyPairAndCertificate(1);
+    const connector = new SamlConnector(endpoint, 'conn-2', {
+      metadata: buildIdpMetadataXml(idp.certificate),
+      signAuthnRequest: true,
+      requestSignatureAlgorithm: SamlAuthnRequestSignatureAlgorithm.RsaSha256,
+    });
+    connector.setServiceProviderSigningCredential({
+      privateKey: sp.privateKey,
+      certificate: sp.certificate,
+    });
+    const url = await connector.getSingleSignOnUrl('relay-2');
+    expect(url).toContain('Signature=');
+    expect(url).toContain('SigAlg=');
+  });
+
+  it('throws (fail-closed) when enabled with no credential', async () => {
+    const idp = await generateKeyPairAndCertificate(1);
+    const connector = new SamlConnector(endpoint, 'conn-3', {
+      metadata: buildIdpMetadataXml(idp.certificate),
+      signAuthnRequest: true,
+    });
+    await expect(connector.getSingleSignOnUrl('relay-3')).rejects.toThrow();
+  });
+
+  it('stays unsigned when off despite metadata wanting it', async () => {
+    // Regression: samlify throws ERR_METADATA_CONFLICT / "not private key" if the IdP advertises
+    // WantAuthnRequestsSigned="true" while we send unsigned. Our flag drives both sides, so an
+    // off connector yields a clean unsigned request regardless of the metadata.
+    const { certificate } = await generateKeyPairAndCertificate(1);
+    const metadata = buildIdpMetadataXml(certificate).replace(
+      '<IDPSSODescriptor',
+      '<IDPSSODescriptor WantAuthnRequestsSigned="true"'
+    );
+    const connector = new SamlConnector(endpoint, 'conn-4', { metadata });
+    const url = await connector.getSingleSignOnUrl('relay-4');
+    expect(url).not.toContain('Signature=');
+  });
+
+  it('signs on the manual-config path (no metadata XML)', async () => {
+    const idp = await generateKeyPairAndCertificate(1);
+    const sp = await generateKeyPairAndCertificate(1);
+    const connector = new SamlConnector(endpoint, 'conn-5', {
+      entityId: 'https://idp.example.com',
+      signInEndpoint: 'https://idp.example.com/sso',
+      x509Certificate: idp.certificate,
+      signAuthnRequest: true,
+    });
+    connector.setServiceProviderSigningCredential({
+      privateKey: sp.privateKey,
+      certificate: sp.certificate,
+    });
+    const url = await connector.getSingleSignOnUrl('relay-5');
+    expect(url).toContain('Signature=');
+  });
+
+  it('uses the configured RSA-SHA512 algorithm', async () => {
+    const idp = await generateKeyPairAndCertificate(1);
+    const sp = await generateKeyPairAndCertificate(1);
+    const connector = new SamlConnector(endpoint, 'conn-6', {
+      metadata: buildIdpMetadataXml(idp.certificate),
+      signAuthnRequest: true,
+      requestSignatureAlgorithm: SamlAuthnRequestSignatureAlgorithm.RsaSha512,
+    });
+    connector.setServiceProviderSigningCredential({
+      privateKey: sp.privateKey,
+      certificate: sp.certificate,
+    });
+    const url = await connector.getSingleSignOnUrl('relay-6');
+    expect(url).toContain('rsa-sha512');
+  });
+
+  it('defaults to RSA-SHA256 when no algorithm is configured', async () => {
+    const idp = await generateKeyPairAndCertificate(1);
+    const sp = await generateKeyPairAndCertificate(1);
+    const connector = new SamlConnector(endpoint, 'conn-7', {
+      metadata: buildIdpMetadataXml(idp.certificate),
+      signAuthnRequest: true,
+    });
+    connector.setServiceProviderSigningCredential({
+      privateKey: sp.privateKey,
+      certificate: sp.certificate,
+    });
+    const url = await connector.getSingleSignOnUrl('relay-7');
+    expect(url).toContain('rsa-sha256');
+  });
+
+  it('rewrites WantAuthnRequestsSigned="false" when enabled', async () => {
+    const idp = await generateKeyPairAndCertificate(1);
+    const sp = await generateKeyPairAndCertificate(1);
+    const metadata = buildIdpMetadataXml(idp.certificate).replace(
+      '<IDPSSODescriptor',
+      '<IDPSSODescriptor WantAuthnRequestsSigned="false"'
+    );
+    const connector = new SamlConnector(endpoint, 'conn-8', {
+      metadata,
+      signAuthnRequest: true,
+    });
+    connector.setServiceProviderSigningCredential({
+      privateKey: sp.privateKey,
+      certificate: sp.certificate,
+    });
+    const url = await connector.getSingleSignOnUrl('relay-8');
+    expect(url).toContain('Signature=');
+  });
+
+  it('throws when enabled and metadata has no IDPSSODescriptor', async () => {
+    const sp = await generateKeyPairAndCertificate(1);
+    const metadata =
+      '<?xml version="1.0"?><EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.example.com"></EntityDescriptor>';
+    const connector = new SamlConnector(endpoint, 'conn-9', {
+      metadata,
+      signAuthnRequest: true,
+    });
+    connector.setServiceProviderSigningCredential({
+      privateKey: sp.privateKey,
+      certificate: sp.certificate,
+    });
+    await expect(connector.getSingleSignOnUrl('relay-9')).rejects.toThrow();
+  });
+
+  it('signs when the IdP metadata uses a hyphenated namespace prefix', async () => {
+    const idp = await generateKeyPairAndCertificate(1);
+    const sp = await generateKeyPairAndCertificate(1);
+    const connector = new SamlConnector(endpoint, 'conn-11', {
+      metadata: buildIdpMetadataXml(idp.certificate, 'saml-md'),
+      signAuthnRequest: true,
+    });
+    connector.setServiceProviderSigningCredential({
+      privateKey: sp.privateKey,
+      certificate: sp.certificate,
+    });
+    const url = await connector.getSingleSignOnUrl('relay-11');
+    expect(url).toContain('Signature=');
+  });
+
+  it('does not sign when dev features are off', async () => {
+    setDevFeaturesEnabled(false);
+    const idp = await generateKeyPairAndCertificate(1);
+    const sp = await generateKeyPairAndCertificate(1);
+    const connector = new SamlConnector(endpoint, 'conn-10', {
+      metadata: buildIdpMetadataXml(idp.certificate),
+      signAuthnRequest: true,
+    });
+    connector.setServiceProviderSigningCredential({
+      privateKey: sp.privateKey,
+      certificate: sp.certificate,
+    });
+    const url = await connector.getSingleSignOnUrl('relay-10');
+    expect(url).not.toContain('Signature=');
+  });
+
+  it('preserves the released mirror behavior when dev features are off', async () => {
+    setDevFeaturesEnabled(false);
+    // Released behavior mirrors the IdP metadata flag onto the SP, so an IdP advertising
+    // WantAuthnRequestsSigned="true" makes samlify attempt to sign without a private key and
+    // throw. The dev gate keeps that behavior (raw metadata, mirrored flag) until GA.
+    const { certificate } = await generateKeyPairAndCertificate(1);
+    const metadata = buildIdpMetadataXml(certificate).replace(
+      '<IDPSSODescriptor',
+      '<IDPSSODescriptor WantAuthnRequestsSigned="true"'
+    );
+    const connector = new SamlConnector(endpoint, 'conn-12', { metadata });
+    await expect(connector.getSingleSignOnUrl('relay-12')).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Task 8 of the SAML enterprise SSO signed-AuthnRequest feature (Refs LOG-13842). The connector can now sign the `AuthnRequest` it sends to the IdP, driven by the connector config's `signAuthnRequest` flag — **gated behind `isDevFeaturesEnabled`**.

### What changed
- `packages/core/src/sso/SamlConnector/index.ts`
  - New `setServiceProviderSigningCredential` — the sign-in layer (Task 9) injects the SP key pair when signing is enabled.
  - `getSingleSignOnUrl` — when signing is enabled: fail-closed (throws if no credential was injected — never sends a silently-unsigned request), signs with the SP's own key/cert, `requestSignatureAlgorithm` from config (default RSA-SHA256).
  - New `alignWantAuthnRequestsSigned` — samlify requires `SP.AuthnRequestsSigned === IdP.WantAuthnRequestsSigned` and reads both from metadata (constructor options are overwritten), so when signing is enabled the in-memory copy of the IdP metadata is aligned to the flag; the manual-config path passes `wantAuthnRequestsSigned` as an option (honored there — no metadata to override it). Namespace-prefixed (`md:`, `saml-md:`) descriptors are handled.
- `sign.test.ts` — 12 tests: signing on/off, fail-closed, both construction paths, both algorithms + default, metadata-flag rewrite, namespace prefixes, and both dev-gate-off behaviors.

### Expected result
- **Dev features off (production): behavior is unchanged, verbatim.** The metadata is passed through untouched and the SP flag keeps mirroring `isWantAuthnRequestsSigned()` — including the pre-existing throw when an IdP advertises `WantAuthnRequestsSigned="true"` (no SP key exists). A dedicated test locks this.
- **Dev features on:** the developer's `signAuthnRequest` flag drives signing (industry norm — Auth0/WorkOS/Okta gate on an SP-side toggle, not the IdP metadata flag). Toggle on → signed redirect request (`Signature=` + `SigAlg=`); toggle off → unsigned, regardless of the metadata flag.

### Reviewer notes
- Signing needs only the SP `privateKey` for the redirect binding (samlify signs the query string); the SP cert is delivered out-of-band via the console in later tasks.
- The metadata rewrite operates on the in-memory copy only — stored config and customer metadata are never mutated.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments