### PR TITLE
fix(console): ensure action env var key validation runs when value is present

### DIFF
--- a/packages/console/src/pages/Actions/ActionDetails/MainContent/SettingsSection/EnvironmentVariablesField.tsx
+++ b/packages/console/src/pages/Actions/ActionDetails/MainContent/SettingsSection/EnvironmentVariablesField.tsx
@@ -45,8 +45,8 @@ function EnvironmentVariablesField({ className }: Props) {
       }
 
       const correspondValue = getValues(`environmentVariables.${index}.value`);
-      if (correspondValue) {
-        return Boolean(key) || t('webhook_details.settings.key_missing_error');
+      if (correspondValue && !key) {
+        return t('webhook_details.settings.key_missing_error');
       }
 
       if (Boolean(key) && !isValidKey(key)) {


### PR DESCRIPTION
## Summary

Fixes key validation in `EnvironmentVariablesField` for Actions configuration. Previously, when an environment variable entry had a non-empty value (e.g. `foo`), `keyValidator` evaluated `Boolean(key)` and returned early, bypassing the `isValidKey` check. This allowed invalid keys containing hyphens or spaces (such as `BAD-KEY`) to pass form validation.

This change ensures that `isValidKey` is always evaluated even when a value is provided.

## Testing

- Unit tests
- Tested locally