### PR TITLE
feat(core): load sp signing key into saml connector at sign-in

### DIFF
--- a/packages/core/src/libraries/verification-helpers/single-sign-on.test.ts
+++ b/packages/core/src/libraries/verification-helpers/single-sign-on.test.ts
@@ -41,6 +41,14 @@ const getAvailableSsoConnectorsMock = jest.fn();
 const findIdpInitiatedSamlSsoSessionMock = jest.fn();
 const deleteIdpInitiatedSamlSsoSessionMock = jest.fn();
 
+const findActiveSigningKeyBySsoConnectorIdMock = jest.fn();
+const setSigningCredentialMock = jest.fn();
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+const setDevFeaturesEnabled = (enabled: boolean) => {
+  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', enabled);
+};
+
 class MockOidcSsoConnector extends OidcSsoConnector {
   override getAuthorizationUrl = getAuthorizationUrlMock;
   override getIssuer = getIssuerMock;
@@ -51,6 +59,7 @@ class MockSamlSsoConnector extends SamlSsoConnector {
   override getAuthorizationUrl = getAuthorizationUrlMock;
   override getIssuer = getIssuerMock;
   override getUserInfo = getUserInfoMock;
+  override setServiceProviderSigningCredential = setSigningCredentialMock;
 }
 
 const {
@@ -108,6 +117,9 @@ describe('Single sign on util methods tests', () => {
       ssoConnectors: {
         findIdpInitiatedSamlSsoSessionById: findIdpInitiatedSamlSsoSessionMock,
         deleteIdpInitiatedSamlSsoSessionById: deleteIdpInitiatedSamlSsoSessionMock,
+      },
+      samlSsoConnectorSigningKeys: {
+        findActiveSigningKeyBySsoConnectorId: findActiveSigningKeyBySsoConnectorIdMock,
       },
     },
     undefined,
@@ -519,6 +531,122 @@ describe('Single sign on util methods tests', () => {
         }
       );
       expect(deleteIdpInitiatedSamlSsoSessionMock).toBeCalledWith(samlSsoSessionId);
+    });
+  });
+
+  describe('getSsoAuthorizationUrl tests with signed AuthnRequest', () => {
+    const payload = {
+      state: 'state',
+      redirectUri: 'https://example.com',
+    };
+
+    const samlAuthorizationUrl = 'https://saml-connector/sso';
+
+    const signingSamlSsoConnector = {
+      ...mockSamlSsoConnector,
+      config: { ...mockSamlSsoConnector.config, signAuthnRequest: true },
+    };
+
+    const mockSigningKey = {
+      id: 'signing-key-id',
+      tenantId: 'mock-tenant',
+      ssoConnectorId: signingSamlSsoConnector.id,
+      privateKey: 'mock-private-key',
+      certificate: 'mock-certificate',
+      createdAt: 1_700_000_000_000,
+      expiresAt: 1_800_000_000_000,
+      active: true,
+    };
+
+    beforeEach(() => {
+      setDevFeaturesEnabled(true);
+      // Reset drains `mockResolvedValueOnce` values queued (but unconsumed) by earlier describe
+      // blocks — `jest.clearAllMocks()` does not.
+      getAuthorizationUrlMock.mockReset().mockResolvedValueOnce(samlAuthorizationUrl);
+    });
+
+    afterAll(() => {
+      setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+    });
+
+    it('should inject the active signing key when signAuthnRequest is on', async () => {
+      findActiveSigningKeyBySsoConnectorIdMock.mockResolvedValueOnce(mockSigningKey);
+
+      await expect(
+        getSsoAuthorizationUrl(mockContext, tenant, signingSamlSsoConnector, payload)
+      ).resolves.toBe(samlAuthorizationUrl);
+
+      expect(findActiveSigningKeyBySsoConnectorIdMock).toBeCalledWith(signingSamlSsoConnector.id);
+      expect(setSigningCredentialMock).toBeCalledWith({
+        certificate: mockSigningKey.certificate,
+        privateKey: mockSigningKey.privateKey,
+      });
+      // The credential must be injected before the authorization URL (AuthnRequest) is built.
+      expect(setSigningCredentialMock.mock.invocationCallOrder[0]).toBeLessThan(
+        getAuthorizationUrlMock.mock.invocationCallOrder[0]!
+      );
+    });
+
+    it('should fail closed when signAuthnRequest is on but no active key exists', async () => {
+      findActiveSigningKeyBySsoConnectorIdMock.mockResolvedValueOnce(null);
+
+      await expect(
+        getSsoAuthorizationUrl(mockContext, tenant, signingSamlSsoConnector, payload)
+      ).rejects.toThrow(
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        expect.objectContaining({ status: 500, code: 'single_sign_on.sso_signing_unavailable' })
+      );
+
+      expect(mockContext.mockAppend).toBeCalledWith({
+        ssoConnectorId: signingSamlSsoConnector.id,
+        reason: 'sp_signing_key_missing',
+      });
+      expect(setSigningCredentialMock).not.toBeCalled();
+      expect(getAuthorizationUrlMock).not.toBeCalled();
+    });
+
+    it('should not load the signing key when signAuthnRequest is off', async () => {
+      await expect(
+        getSsoAuthorizationUrl(mockContext, tenant, mockSamlSsoConnector, payload)
+      ).resolves.toBe(samlAuthorizationUrl);
+
+      expect(findActiveSigningKeyBySsoConnectorIdMock).not.toBeCalled();
+      expect(setSigningCredentialMock).not.toBeCalled();
+    });
+  });
+
+  describe('getSsoAuthorizationUrl signed AuthnRequest with dev features off', () => {
+    const payload = {
+      state: 'state',
+      redirectUri: 'https://example.com',
+    };
+
+    beforeEach(() => {
+      setDevFeaturesEnabled(false);
+      getAuthorizationUrlMock.mockReset();
+    });
+
+    afterAll(() => {
+      setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+    });
+
+    it('should not load the signing key even when signAuthnRequest is on', async () => {
+      getAuthorizationUrlMock.mockResolvedValueOnce('https://saml-connector/sso');
+
+      await expect(
+        getSsoAuthorizationUrl(
+          mockContext,
+          tenant,
+          {
+            ...mockSamlSsoConnector,
+            config: { ...mockSamlSsoConnector.config, signAuthnRequest: true },
+          },
+          payload
+        )
+      ).resolves.toBe('https://saml-connector/sso');
+
+      expect(findActiveSigningKeyBySsoConnectorIdMock).not.toBeCalled();
+      expect(setSigningCredentialMock).not.toBeCalled();
     });
   });
 });

--- a/packages/core/src/libraries/verification-helpers/single-sign-on.ts
+++ b/packages/core/src/libraries/verification-helpers/single-sign-on.ts
@@ -17,11 +17,11 @@ import { idpInitiatedSamlSsoSessionCookieName } from '#src/constants/index.js';
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type HookContextManager } from '#src/libraries/hook/context-manager.js';
-import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
+import { type LogEntry, type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import OidcConnector from '#src/sso/OidcConnector/index.js';
 import SamlConnector from '#src/sso/SamlConnector/index.js';
 import { ssoConnectorFactories, type SingleSignOnConnectorSession } from '#src/sso/index.js';
-import { type ExtendedSocialUserInfo } from '#src/sso/types/saml.js';
+import { type ExtendedSocialUserInfo, samlConnectorConfigGuard } from '#src/sso/types/saml.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { safeParseUnknownJson } from '#src/utils/json.js';
@@ -44,6 +44,47 @@ export const authorizationUrlPayloadGuard = z.object({
 });
 type AuthorizationUrlPayload = z.infer<typeof authorizationUrlPayloadGuard>;
 
+/**
+ * Load and inject the SP signing credential when signed AuthnRequest is enabled for the SAML
+ * connector. Fails closed rather than falling back to unsigned: if no active key exists, stop
+ * sign-in with a friendly error and record connector-level detail in the audit log. No-op for
+ * every other connector type and for unsigned SAML connectors.
+ */
+const injectSamlSigningCredential = async (
+  connectorInstance: unknown,
+  connectorData: SupportedSsoConnector,
+  queries: TenantContext['queries'],
+  log: LogEntry
+) => {
+  if (!(connectorInstance instanceof SamlConnector)) {
+    return;
+  }
+
+  const parsedConfig = samlConnectorConfigGuard.safeParse(connectorData.config);
+
+  // A parse failure implies a broken connector config: the constructor parses the same guard and
+  // falls back to an undefined config, which throws on first config access before any request is
+  // sent — so returning here can never produce an unsigned request.
+  if (!parsedConfig.success || !parsedConfig.data.signAuthnRequest) {
+    return;
+  }
+
+  const signingKey = await queries.samlSsoConnectorSigningKeys.findActiveSigningKeyBySsoConnectorId(
+    connectorData.id
+  );
+
+  if (!signingKey) {
+    log.append({ ssoConnectorId: connectorData.id, reason: 'sp_signing_key_missing' });
+    throw new RequestError({ code: 'single_sign_on.sso_signing_unavailable', status: 500 });
+  }
+
+  // The private key is stored as plaintext PEM — used directly, no decryption involved.
+  connectorInstance.setServiceProviderSigningCredential({
+    certificate: signingKey.certificate,
+    privateKey: signingKey.privateKey,
+  });
+};
+
 export const getSsoAuthorizationUrl = async (
   ctx: WithLogContext,
   { provider, queries, envSet }: TenantContext,
@@ -62,7 +103,8 @@ export const getSsoAuthorizationUrl = async (
   });
 
   try {
-    // Will throw ConnectorError if the config is invalid
+    // May throw ConnectorError on an invalid config — at construction or deferred to first use
+    // (SAML connectors fall back to an undefined config and throw on first config access).
     const connectorInstance = new ssoConnectorFactories[providerName].constructor(
       connectorData,
       envSet.endpoint
@@ -117,6 +159,11 @@ export const getSsoAuthorizationUrl = async (
           return url.toString();
         }
       }
+    }
+
+    // TODO: Remove the dev features check when the signed AuthnRequest feature is ready.
+    if (EnvSet.values.isDevFeaturesEnabled) {
+      await injectSamlSigningCredential(connectorInstance, connectorData, queries, log);
     }
 
     return await connectorInstance.getAuthorizationUrl(

--- a/packages/phrases/src/locales/ar/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/ar/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'لم يتم تسجيل redirect_uri. يرجى التحقق من إعدادات التطبيق.',
   idp_initiated_authentication_client_callback_uri_not_found:
     'لم يتم العثور على URI لاستدعاء المصادقة الذي بدأه العميل IdP. يرجى التحقق من إعدادات الموصل.',
+  sso_signing_unavailable:
+    'تعذر إكمال تسجيل الدخول عبر موفر الهوية الخاص بك. يرجى التواصل مع المسؤول.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/de/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/de/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'Die redirect_uri ist nicht registriert. Bitte überprüfe die Anwendungseinstellungen.',
   idp_initiated_authentication_client_callback_uri_not_found:
     'Die Client-IdP-initiierte Authentifizierungs-Callback-URI wurde nicht gefunden. Bitte überprüfe die Connector-Einstellungen.',
+  sso_signing_unavailable:
+    'Die Anmeldung über Ihren Identitätsanbieter konnte nicht abgeschlossen werden. Bitte wenden Sie sich an Ihren Administrator.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/en/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/en/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'The redirect_uri is not registered. Please check the application settings.',
   idp_initiated_authentication_client_callback_uri_not_found:
     'The client IdP-initiated authentication callback URI is not found. Please check the connector settings.',
+  sso_signing_unavailable:
+    "We couldn't complete sign-in with your identity provider. Please contact your administrator.",
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/es/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/es/errors/single-sign-on.ts
@@ -12,6 +12,8 @@ const single_sign_on = {
     'El redirect_uri no está registrado. Por favor verifica la configuración de la aplicación.',
   idp_initiated_authentication_client_callback_uri_not_found:
     'No se encuentra el URI de callback de autenticación iniciada por IdP del cliente. Por favor verifica la configuración del conector.',
+  sso_signing_unavailable:
+    'No se pudo completar el inicio de sesión con su proveedor de identidad. Póngase en contacto con su administrador.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/fa-ir/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/fa-ir/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'redirect_uri ثبت نشده است. لطفاً تنظیمات برنامه را بررسی کنید.',
   idp_initiated_authentication_client_callback_uri_not_found:
     'URI callback احراز هویت آغازشده توسط IdP کلاینت یافت نشد. لطفاً تنظیمات اتصال‌دهنده را بررسی کنید.',
+  sso_signing_unavailable:
+    'ورود از طریق ارائه‌دهنده هویت شما تکمیل نشد. لطفاً با مدیر خود تماس بگیرید.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/fr/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/fr/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     "L'URI de redirection n'est pas enregistrée. Veuillez vérifier les paramètres de l'application.",
   idp_initiated_authentication_client_callback_uri_not_found:
     "L'URI de rappel d'authentification initiée par le client IdP n'est pas trouvée. Veuillez vérifier les paramètres du connecteur.",
+  sso_signing_unavailable:
+    "Impossible de terminer la connexion avec votre fournisseur d'identité. Veuillez contacter votre administrateur.",
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/it/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/it/errors/single-sign-on.ts
@@ -12,6 +12,8 @@ const single_sign_on = {
     "Il redirect_uri non è registrato. Si prega di controllare le impostazioni dell'applicazione.",
   idp_initiated_authentication_client_callback_uri_not_found:
     "L'URI di callback dell'autenticazione iniziata dal client IdP non è stato trovato. Controlla le impostazioni del connettore.",
+  sso_signing_unavailable:
+    "Impossibile completare l'accesso con il tuo provider di identità. Contatta il tuo amministratore.",
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/ja/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/ja/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'redirect_uri は登録されていません。アプリケーション設定を確認してください。',
   idp_initiated_authentication_client_callback_uri_not_found:
     'クライアントの IdP 開始認証コールバック URI が見つかりません。コネクタ設定を確認してください。',
+  sso_signing_unavailable:
+    'ID プロバイダーでのサインインを完了できませんでした。管理者にお問い合わせください。',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/ko/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/ko/errors/single-sign-on.ts
@@ -10,6 +10,7 @@ const single_sign_on = {
     'redirect_uri가 등록되지 않았습니다. 애플리케이션 설정을 확인해 주세요.',
   idp_initiated_authentication_client_callback_uri_not_found:
     '클라이언트 IdP 시작 인증 콜백 URI를 찾을 수 없습니다. 커넥터 설정을 확인해 주세요.',
+  sso_signing_unavailable: 'ID 공급자를 통한 로그인을 완료할 수 없습니다. 관리자에게 문의하세요.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/pl-pl/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'redirect_uri nie jest zarejestrowany. Proszę sprawdzić ustawienia aplikacji.',
   idp_initiated_authentication_client_callback_uri_not_found:
     'Nie znaleziono URI zwrotnego uwierzytelniania IdP-initiated klienta. Proszę sprawdzić ustawienia łącznika.',
+  sso_signing_unavailable:
+    'Nie udało się dokończyć logowania za pomocą dostawcy tożsamości. Skontaktuj się z administratorem.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/pt-br/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/pt-br/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'O redirect_uri não está registrado. Por favor, verifique as configurações do aplicativo.',
   idp_initiated_authentication_client_callback_uri_not_found:
     'O URI de callback da autenticação iniciada pelo cliente IdP não foi encontrado. Por favor, verifique as configurações do conector.',
+  sso_signing_unavailable:
+    'Não foi possível concluir o login com seu provedor de identidade. Entre em contato com seu administrador.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/pt-pt/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'O redirect_uri não está registado. Por favor, verifique as definições da aplicação.',
   idp_initiated_authentication_client_callback_uri_not_found:
     'O URI de callback de autenticação iniciada pelo IdP no cliente não foi encontrado. Por favor, verifique as definições do conector.',
+  sso_signing_unavailable:
+    'Não foi possível concluir o início de sessão com o seu fornecedor de identidade. Contacte o seu administrador.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/ru/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/ru/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'redirect_uri не зарегистрирован. Пожалуйста, проверьте настройки приложения.',
   idp_initiated_authentication_client_callback_uri_not_found:
     'URI обратного вызова для аутентификации, инициированной клиентом IdP, не найден. Пожалуйста, проверьте настройки коннектора.',
+  sso_signing_unavailable:
+    'Не удалось завершить вход через вашего поставщика удостоверений. Обратитесь к администратору.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/th/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/th/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'redirect_uri ยังไม่ได้ลงทะเบียน กรุณาตรวจสอบการตั้งค่าแอปพลิเคชัน',
   idp_initiated_authentication_client_callback_uri_not_found:
     'ไม่พบ URI callback สำหรับการรับรองความถูกต้อง IdP-initiated ของ client กรุณาตรวจสอบการตั้งค่าคอนเนกเตอร์',
+  sso_signing_unavailable:
+    'ไม่สามารถเข้าสู่ระบบผ่านผู้ให้บริการข้อมูลประจำตัวของคุณได้ โปรดติดต่อผู้ดูแลระบบ',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/tr-tr/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/single-sign-on.ts
@@ -11,6 +11,8 @@ const single_sign_on = {
     'redirect_uri kaydedilmemiş. Lütfen uygulama ayarlarını kontrol edin.',
   idp_initiated_authentication_client_callback_uri_not_found:
     "İstemci IdP başlatılan kimlik doğrulama geri dönüş URI'si bulunamadı. Lütfen bağlayıcı ayarlarını kontrol edin.",
+  sso_signing_unavailable:
+    'Kimlik sağlayıcınızla oturum açma tamamlanamadı. Lütfen yöneticinizle iletişime geçin.',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/zh-cn/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/single-sign-on.ts
@@ -10,6 +10,7 @@ const single_sign_on = {
     'redirect_uri 未注册。请检查应用程序设置。',
   idp_initiated_authentication_client_callback_uri_not_found:
     '未找到客户端 IdP 发起的身份验证回调 URI。请检查连接器设置。',
+  sso_signing_unavailable: '无法通过你的身份提供商完成登录。请联系管理员。',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/zh-hk/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/single-sign-on.ts
@@ -8,6 +8,7 @@ const single_sign_on = {
   idp_initiated_authentication_redirect_uri_not_registered: 'redirect_uri 未註冊。請檢查應用設置。',
   idp_initiated_authentication_client_callback_uri_not_found:
     '找不到客戶端 IdP 發起的身份驗證回調 URI。請檢查連接器設置。',
+  sso_signing_unavailable: '無法透過你的身分提供者完成登入。請聯絡管理員。',
 };
 
 export default Object.freeze(single_sign_on);

--- a/packages/phrases/src/locales/zh-tw/errors/single-sign-on.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/single-sign-on.ts
@@ -10,6 +10,7 @@ const single_sign_on = {
     '未註冊的 redirect_uri。請檢查應用程式設定。',
   idp_initiated_authentication_client_callback_uri_not_found:
     '未找到客戶端 IdP 發起的身份驗證回調 URI。請檢查連接器設定。',
+  sso_signing_unavailable: '無法透過您的身分提供者完成登入。請聯絡管理員。',
 };
 
 export default Object.freeze(single_sign_on);


### PR DESCRIPTION
## Summary
Task 9 of the SAML enterprise SSO signed-AuthnRequest feature (Refs LOG-13843). Wires the Task 8 signing capability into the sign-in flow: when a SAML connector has `signAuthnRequest` enabled, the connector's **active** SP signing key is loaded and injected before the authorization URL (AuthnRequest) is built — gated behind `isDevFeaturesEnabled`.

### What changed
- `packages/core/src/libraries/verification-helpers/single-sign-on.ts`
  - New `injectSamlSigningCredential` helper, called from `getSsoAuthorizationUrl` right before `getAuthorizationUrl` (after the IdP-initiated early-return path, which never sends an AuthnRequest). No-op for non-SAML connectors and unsigned SAML configs.
  - **Fail-closed**: if `signAuthnRequest` is on but no active key exists (out-of-band API edit — the enable flow in a later task guarantees a key), sign-in stops with `single_sign_on.sso_signing_unavailable` (500) and `{ ssoConnectorId, reason: 'sp_signing_key_missing' }` goes to the interaction audit log. An unsigned request is never sent.
- `packages/phrases/src/locales/*/errors/single-sign-on.ts` — new `sso_signing_unavailable` phrase in all 18 locales; end-user friendly, no key/crypto detail.
- `single-sign-on.test.ts` — 4 new tests: inject + injection-before-URL ordering, fail-closed (error code + audit-log entry + no URL built), no-op when the flag is off, inert when dev features are off.

### Expected result
- Dev features off (production): the block is skipped entirely — no query, no behavior change.
- Dev features on: signing connectors get their credential injected transparently; a signing connector without a key fails closed with the friendly error instead of silently sending unsigned.

### Reviewer notes
- Depends on #9259 (Task 8, adds the `setServiceProviderSigningCredential` setter) — merged; this PR now targets master directly.
- A config that fails the SAML guard makes the helper return without injecting — safe because the connector constructor parses the same guard and falls back to an undefined config, which throws on first config access before any request is built (comment in code).

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
