### PR TITLE
fix(core,console): handle Action no-op results

### DIFF
--- a/packages/console/src/pages/Actions/ActionDetails/MainContent/ScriptSection/use-test-handler.test.tsx
+++ b/packages/console/src/pages/Actions/ActionDetails/MainContent/ScriptSection/use-test-handler.test.tsx
@@ -1,0 +1,74 @@
+import { LogtoActionKey } from '@logto/schemas';
+import { act, renderHook } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import useApi from '@/hooks/use-api';
+
+import { type ActionForm } from '../../type';
+
+import useTestHandler from './use-test-handler';
+
+jest.mock('@/hooks/use-api', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockedUseApi = jest.mocked(useApi);
+const mockPost = jest.fn();
+
+function Wrapper({ children }: { readonly children: ReactNode }) {
+  const methods = useForm<ActionForm>({
+    defaultValues: {
+      actionType: LogtoActionKey.PostSignIn,
+      script: 'const runAction = () => undefined;',
+      enabled: true,
+      onExecutionError: 'block',
+      environmentVariables: [{ key: '', value: '' }],
+      contextSample: JSON.stringify({
+        key: LogtoActionKey.PostSignIn,
+        interactionEvent: 'SignIn',
+        user: { id: 'user-id' },
+      }),
+    },
+  });
+
+  return <FormProvider {...methods}>{children}</FormProvider>;
+}
+
+describe('useTestHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseApi.mockReturnValue({
+      post: mockPost,
+    } as unknown as ReturnType<typeof useApi>);
+  });
+
+  it('renders an undefined result for a successful no-content response', async () => {
+    const json = jest.fn();
+    mockPost.mockResolvedValue({
+      status: 204,
+      json,
+    });
+    const { result } = renderHook(() => useTestHandler(), { wrapper: Wrapper });
+
+    await act(result.current.onTestHandler);
+
+    expect(json).not.toHaveBeenCalled();
+    expect(result.current.testResult).toEqual({ payload: 'undefined' });
+  });
+
+  it('renders a null JSON result', async () => {
+    const json = jest.fn().mockResolvedValue(null);
+    mockPost.mockResolvedValue({
+      status: 200,
+      json,
+    });
+    const { result } = renderHook(() => useTestHandler(), { wrapper: Wrapper });
+
+    await act(result.current.onTestHandler);
+
+    expect(json).toHaveBeenCalledTimes(1);
+    expect(result.current.testResult).toEqual({ payload: 'null' });
+  });
+});

--- a/packages/console/src/pages/Actions/ActionDetails/MainContent/ScriptSection/use-test-handler.ts
+++ b/packages/console/src/pages/Actions/ActionDetails/MainContent/ScriptSection/use-test-handler.ts
@@ -1,4 +1,4 @@
-import { type JsonObject, type RequestErrorBody } from '@logto/schemas';
+import { type Json, type RequestErrorBody } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 import { HTTPError } from 'ky';
 import { useCallback, useState } from 'react';
@@ -19,6 +19,9 @@ export type TestResultData = {
   payload?: string;
 };
 
+const formatTestResult = (result: unknown) =>
+  result === undefined ? 'undefined' : JSON.stringify(result, null, 2);
+
 const useTestHandler = () => {
   const [testResult, setTestResult] = useState<TestResultData>();
   const [isLoading, setIsLoading] = useState(false);
@@ -37,11 +40,15 @@ const useTestHandler = () => {
     const payload = getValues();
     setIsLoading(true);
 
-    const result = await api
+    await api
       .post(testEndpointPath, {
         json: formatFormDataToTestRequestPayload(payload),
       })
-      .json<JsonObject>()
+      .then(async (response) => {
+        const result = response.status === 204 ? undefined : await response.json<Json>();
+
+        setTestResult({ payload: formatTestResult(result) });
+      })
       .catch(async (error: unknown) => {
         if (error instanceof HTTPError) {
           const { response } = error;
@@ -88,10 +95,6 @@ const useTestHandler = () => {
       .finally(() => {
         setIsLoading(false);
       });
-
-    if (result) {
-      setTestResult({ payload: JSON.stringify(result, null, 2) });
-    }
   }, [api, getValues, trigger]);
 
   return { testResult, isLoading, onTestHandler, setTestResult };

--- a/packages/core/src/libraries/action.test.ts
+++ b/packages/core/src/libraries/action.test.ts
@@ -447,7 +447,7 @@ describe('ActionLibrary', () => {
     expect(JSON.stringify(mockAppend.mock.calls)).not.toContain(passwordStatusSecret);
   });
 
-  it('keeps audit summarization failures from changing the action result', async () => {
+  it('records accessor-only effects as no-op without changing the action result', async () => {
     const result = {
       action: 'updateUser',
       get user(): never {
@@ -461,13 +461,12 @@ describe('ActionLibrary', () => {
     jest.spyOn(library, 'executeScript').mockResolvedValueOnce(result);
 
     await expect(runAction({ key: LogtoActionKey.PostSignIn, event: {} })).resolves.toBe(result);
-    expect(mockAppend).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        action: 'updateUser',
-        decision: 'updateUser',
-        actionResult: '[unavailable]',
-      })
-    );
+    expect(mockAppend).toHaveBeenLastCalledWith({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+      durationMs: expect.any(Number),
+      decision: 'noop',
+      actionResult: '[unavailable]',
+    });
   });
 
   it('continues to run stored scripts that use the legacy entry point', async () => {

--- a/packages/core/src/libraries/action.test.ts
+++ b/packages/core/src/libraries/action.test.ts
@@ -159,7 +159,7 @@ describe('ActionLibrary', () => {
     });
   });
 
-  it('emits no-op metrics for a PostSignIn result without a user patch', async () => {
+  it('records a no-op decision for a PostSignIn result without a user patch', async () => {
     getAction.mockResolvedValueOnce({
       enabled: true,
       script: 'const runAction = () => ({ action: "updateUser" });',
@@ -172,6 +172,14 @@ describe('ActionLibrary', () => {
       })
     ).resolves.toEqual({ action: 'updateUser' });
 
+    expect(mockAppend).toHaveBeenLastCalledWith({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+      durationMs: expect.any(Number),
+      decision: 'noop',
+      actionResult: {
+        action: 'updateUser',
+      },
+    });
     expectActionMetrics({
       actionType: 'PostSignIn',
       runtimeLocation: 'local',

--- a/packages/core/src/libraries/action.test.ts
+++ b/packages/core/src/libraries/action.test.ts
@@ -159,7 +159,32 @@ describe('ActionLibrary', () => {
     });
   });
 
-  it('records a no-op decision for a PostSignIn result without a user patch', async () => {
+  it.each([
+    [LogtoActionKey.PostFirstFactorVerification, 'createUser'],
+    [LogtoActionKey.PostFirstFactorVerification, 'updateUser'],
+    [LogtoActionKey.PostSignIn, 'updateUser'],
+  ] as const)(
+    'records a no-op decision for %s results that declare %s without its effect',
+    async (key, resultAction) => {
+      getAction.mockResolvedValueOnce({
+        enabled: true,
+        script: `const runAction = () => ({ action: "${resultAction}" });`,
+      });
+
+      await expect(runAction({ key, event: {} })).resolves.toEqual({ action: resultAction });
+
+      expect(mockAppend).toHaveBeenLastCalledWith({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+        durationMs: expect.any(Number),
+        decision: 'noop',
+        actionResult: {
+          action: resultAction,
+        },
+      });
+    }
+  );
+
+  it('emits no-op metrics for a PostSignIn result without a user patch', async () => {
     getAction.mockResolvedValueOnce({
       enabled: true,
       script: 'const runAction = () => ({ action: "updateUser" });',
@@ -172,14 +197,6 @@ describe('ActionLibrary', () => {
       })
     ).resolves.toEqual({ action: 'updateUser' });
 
-    expect(mockAppend).toHaveBeenLastCalledWith({
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
-      durationMs: expect.any(Number),
-      decision: 'noop',
-      actionResult: {
-        action: 'updateUser',
-      },
-    });
     expectActionMetrics({
       actionType: 'PostSignIn',
       runtimeLocation: 'local',

--- a/packages/core/src/libraries/action.test.ts
+++ b/packages/core/src/libraries/action.test.ts
@@ -160,12 +160,12 @@ describe('ActionLibrary', () => {
   });
 
   it.each([
-    [LogtoActionKey.PostFirstFactorVerification, 'createUser'],
-    [LogtoActionKey.PostFirstFactorVerification, 'updateUser'],
-    [LogtoActionKey.PostSignIn, 'updateUser'],
+    ['invalid', LogtoActionKey.PostFirstFactorVerification, 'createUser'],
+    ['invalid', LogtoActionKey.PostFirstFactorVerification, 'updateUser'],
+    ['noop', LogtoActionKey.PostSignIn, 'updateUser'],
   ] as const)(
-    'records a no-op decision for %s results that declare %s without its effect',
-    async (key, resultAction) => {
+    'records a %s decision for %s results that declare %s without its effect',
+    async (decision, key, resultAction) => {
       getAction.mockResolvedValueOnce({
         enabled: true,
         script: `const runAction = () => ({ action: "${resultAction}" });`,
@@ -176,7 +176,7 @@ describe('ActionLibrary', () => {
       expect(mockAppend).toHaveBeenLastCalledWith({
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
         durationMs: expect.any(Number),
-        decision: 'noop',
+        decision,
         actionResult: {
           action: resultAction,
         },

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -104,15 +104,20 @@ const actionLogTypes = Object.freeze({
 const getActionLogKey = (key: LogtoActionKey): actionLog.LogKey =>
   `${actionLog.prefix}.${actionLogTypes[key]}`;
 
+type ActionResultEffect = {
+  fields: readonly string[];
+  missingDecision: 'invalid' | 'noop';
+};
+
 const actionResultEffects: Readonly<
-  Record<LogtoActionKey, Readonly<Record<string, readonly string[]>>>
+  Record<LogtoActionKey, Readonly<Record<string, ActionResultEffect>>>
 > = Object.freeze({
   [LogtoActionKey.PostFirstFactorVerification]: {
-    createUser: ['user'],
-    updateUser: ['user'],
+    createUser: { fields: ['user'], missingDecision: 'invalid' },
+    updateUser: { fields: ['user'], missingDecision: 'invalid' },
   },
   [LogtoActionKey.PostSignIn]: {
-    updateUser: ['user'],
+    updateUser: { fields: ['user'], missingDecision: 'noop' },
   },
 });
 
@@ -137,19 +142,17 @@ const getActionResultActionSummary = (key: LogtoActionKey, result: unknown) => {
       return { decision: 'noop' };
     }
 
-    const action = Object.keys(actionResultEffects[key]).find(
-      (candidate) => candidate === rawAction
-    );
+    const effect = actionResultEffects[key][rawAction];
 
-    if (!action) {
+    if (!effect) {
       return { decision: 'invalid' };
     }
 
-    if (!hasActionResultEffect(result, actionResultEffects[key][action] ?? [])) {
-      return { decision: 'noop' };
+    if (!hasActionResultEffect(result, effect.fields)) {
+      return { decision: effect.missingDecision };
     }
 
-    return { action, decision: action };
+    return { action: rawAction, decision: rawAction };
   } catch {
     return { decision: 'invalid' };
   }

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -122,7 +122,7 @@ const hasActionResultEffect = (result: unknown, effectFields: readonly string[])
   effectFields.some((field) => {
     const descriptor = Object.getOwnPropertyDescriptor(result, field);
 
-    return descriptor !== undefined && (!('value' in descriptor) || descriptor.value !== undefined);
+    return descriptor !== undefined && 'value' in descriptor && descriptor.value !== undefined;
   });
 
 const getActionResultActionSummary = (key: LogtoActionKey, result: unknown) => {

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -123,7 +123,22 @@ const getActionResultActionSummary = (key: LogtoActionKey, result: unknown) => {
 
     const action = actionResultActions[key].find((candidate) => candidate === rawAction);
 
-    return action ? { action, decision: action } : { decision: 'invalid' };
+    if (!action) {
+      return { decision: 'invalid' };
+    }
+
+    if (key === LogtoActionKey.PostSignIn && action === 'updateUser') {
+      const userDescriptor = Object.getOwnPropertyDescriptor(result, 'user');
+
+      if (
+        userDescriptor === undefined ||
+        ('value' in userDescriptor && userDescriptor.value === undefined)
+      ) {
+        return { decision: 'noop' };
+      }
+    }
+
+    return { action, decision: action };
   } catch {
     return { decision: 'invalid' };
   }

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -104,10 +104,26 @@ const actionLogTypes = Object.freeze({
 const getActionLogKey = (key: LogtoActionKey): actionLog.LogKey =>
   `${actionLog.prefix}.${actionLogTypes[key]}`;
 
-const actionResultActions = Object.freeze({
-  [LogtoActionKey.PostFirstFactorVerification]: ['createUser', 'updateUser'],
-  [LogtoActionKey.PostSignIn]: ['updateUser'],
-} satisfies Record<LogtoActionKey, readonly string[]>);
+const actionResultEffects: Readonly<
+  Record<LogtoActionKey, Readonly<Record<string, readonly string[]>>>
+> = Object.freeze({
+  [LogtoActionKey.PostFirstFactorVerification]: {
+    createUser: ['user'],
+    updateUser: ['user'],
+  },
+  [LogtoActionKey.PostSignIn]: {
+    updateUser: ['user'],
+  },
+});
+
+const hasActionResultEffect = (result: unknown, effectFields: readonly string[]) =>
+  typeof result === 'object' &&
+  result !== null &&
+  effectFields.some((field) => {
+    const descriptor = Object.getOwnPropertyDescriptor(result, field);
+
+    return descriptor !== undefined && (!('value' in descriptor) || descriptor.value !== undefined);
+  });
 
 const getActionResultActionSummary = (key: LogtoActionKey, result: unknown) => {
   try {
@@ -121,21 +137,16 @@ const getActionResultActionSummary = (key: LogtoActionKey, result: unknown) => {
       return { decision: 'noop' };
     }
 
-    const action = actionResultActions[key].find((candidate) => candidate === rawAction);
+    const action = Object.keys(actionResultEffects[key]).find(
+      (candidate) => candidate === rawAction
+    );
 
     if (!action) {
       return { decision: 'invalid' };
     }
 
-    if (key === LogtoActionKey.PostSignIn && action === 'updateUser') {
-      const userDescriptor = Object.getOwnPropertyDescriptor(result, 'user');
-
-      if (
-        userDescriptor === undefined ||
-        ('value' in userDescriptor && userDescriptor.value === undefined)
-      ) {
-        return { decision: 'noop' };
-      }
+    if (!hasActionResultEffect(result, actionResultEffects[key][action] ?? [])) {
+      return { decision: 'noop' };
     }
 
     return { action, decision: action };

--- a/packages/core/src/routes/logto-config/action.test.ts
+++ b/packages/core/src/routes/logto-config/action.test.ts
@@ -232,6 +232,30 @@ describe('configs action routes', () => {
     expect(mockQuotaLibrary.guardTenantUsageByKey).toHaveBeenCalledWith('inlineHooksEnabled');
   });
 
+  it('POST /configs/actions/test should distinguish undefined and null results', async () => {
+    jest
+      .spyOn(tenantContext.libraries.actions, 'executeScript')
+      .mockImplementationOnce(async () => {
+        await Promise.resolve();
+      })
+      .mockResolvedValueOnce(null);
+    const payload: ActionExecutionRequestBody = {
+      actionType: LogtoActionKey.PostSignIn,
+      script: 'const runAction = () => undefined;',
+      event: {
+        key: LogtoActionKey.PostSignIn,
+      },
+    };
+
+    const undefinedResponse = await routeRequester.post('/configs/actions/test').send(payload);
+    const nullResponse = await routeRequester.post('/configs/actions/test').send(payload);
+
+    expect(undefinedResponse.status).toEqual(204);
+    expect(undefinedResponse.text).toBe('');
+    expect(nullResponse.status).toEqual(200);
+    expect(nullResponse.body).toBeNull();
+  });
+
   it('POST /configs/actions/test should map general execution errors to 422', async () => {
     const payload: ActionExecutionRequestBody = {
       actionType: LogtoActionKey.PostSignIn,

--- a/packages/core/src/routes/logto-config/action.test.ts
+++ b/packages/core/src/routes/logto-config/action.test.ts
@@ -232,13 +232,14 @@ describe('configs action routes', () => {
     expect(mockQuotaLibrary.guardTenantUsageByKey).toHaveBeenCalledWith('inlineHooksEnabled');
   });
 
-  it('POST /configs/actions/test should distinguish undefined and null results', async () => {
+  it('POST /configs/actions/test should serialize undefined, null, and string results', async () => {
     jest
       .spyOn(tenantContext.libraries.actions, 'executeScript')
       .mockImplementationOnce(async () => {
         await Promise.resolve();
       })
-      .mockResolvedValueOnce(null);
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('foo');
     const payload: ActionExecutionRequestBody = {
       actionType: LogtoActionKey.PostSignIn,
       script: 'const runAction = () => undefined;',
@@ -249,11 +250,13 @@ describe('configs action routes', () => {
 
     const undefinedResponse = await routeRequester.post('/configs/actions/test').send(payload);
     const nullResponse = await routeRequester.post('/configs/actions/test').send(payload);
+    const stringResponse = await routeRequester.post('/configs/actions/test').send(payload);
 
     expect(undefinedResponse.status).toEqual(204);
     expect(undefinedResponse.text).toBe('');
     expect(nullResponse.status).toEqual(200);
     expect(nullResponse.body).toBeNull();
+    expect(stringResponse).toMatchObject({ status: 200, type: 'application/json', body: 'foo' });
   });
 
   it('POST /configs/actions/test should map general execution errors to 422', async () => {

--- a/packages/core/src/routes/logto-config/action.ts
+++ b/packages/core/src/routes/logto-config/action.ts
@@ -82,7 +82,7 @@ export default function logtoConfigActionRoutes<T extends ManagementApiRouter>(
     koaGuard({
       body: actionExecutionRequestBodyGuard,
       response: jsonGuard.optional(),
-      status: [200, 400, 403, 422],
+      status: [200, 204, 400, 403, 422],
     }),
     koaQuotaGuard({ key: actionQuotaKey, quota: libraries.quota }),
     async (ctx, next) => {
@@ -92,15 +92,18 @@ export default function logtoConfigActionRoutes<T extends ManagementApiRouter>(
         // Share the same Cloud/local execution selection as production `runAction()`.
         const result = await libraries.actions.executeScript(body);
 
-        if (result === null) {
+        if (result === undefined) {
+          ctx.status = 204;
+        } else if (result === null) {
           // Koa treats a null body as no content. Serialize it explicitly so dry runs can
           // distinguish a returned null from an undefined result.
           ctx.type = 'application/json';
           ctx.body = 'null';
+          ctx.status = 200;
         } else {
           ctx.body = result;
+          ctx.status = 200;
         }
-        ctx.status = 200;
       } catch (error: unknown) {
         const sensitiveValues = getActionSensitiveValues(body);
 

--- a/packages/core/src/routes/logto-config/action.ts
+++ b/packages/core/src/routes/logto-config/action.ts
@@ -90,7 +90,16 @@ export default function logtoConfigActionRoutes<T extends ManagementApiRouter>(
 
       try {
         // Share the same Cloud/local execution selection as production `runAction()`.
-        ctx.body = await libraries.actions.executeScript(body);
+        const result = await libraries.actions.executeScript(body);
+
+        if (result === null) {
+          // Koa treats a null body as no content. Serialize it explicitly so dry runs can
+          // distinguish a returned null from an undefined result.
+          ctx.type = 'application/json';
+          ctx.body = 'null';
+        } else {
+          ctx.body = result;
+        }
         ctx.status = 200;
       } catch (error: unknown) {
         const sensitiveValues = getActionSensitiveValues(body);

--- a/packages/core/src/routes/logto-config/action.ts
+++ b/packages/core/src/routes/logto-config/action.ts
@@ -100,6 +100,12 @@ export default function logtoConfigActionRoutes<T extends ManagementApiRouter>(
           ctx.type = 'application/json';
           ctx.body = 'null';
           ctx.status = 200;
+        } else if (typeof result === 'string') {
+          // Koa sends strings as plain text by default. Serialize them explicitly so the
+          // Console can parse every successful dry-run result as JSON.
+          ctx.type = 'application/json';
+          ctx.body = JSON.stringify(result);
+          ctx.status = 200;
         } else {
           ctx.body = result;
           ctx.status = 200;

--- a/packages/core/src/routes/logto-config/logto-config.openapi.json
+++ b/packages/core/src/routes/logto-config/logto-config.openapi.json
@@ -506,6 +506,9 @@
           "200": {
             "description": "The result of the action script testing."
           },
+          "204": {
+            "description": "The action script returned no result."
+          },
           "400": {
             "description": "The request body or response body is invalid."
           },


### PR DESCRIPTION
## Summary

- render successful `undefined` Action dry-run results instead of leaving the result dashboard unchanged
- keep `null` dry-run results distinguishable from `undefined`
- record Post sign-in results without a user patch as `noop` in audit logs
- add regression coverage for Console dry runs, the test endpoint, and Action audit summaries

## Root cause

The Console only updated its result dashboard for truthy JSON values, so a `204` response produced by an `undefined` result was silently ignored. Separately, the audit summary treated any supported `action` string as a write decision without checking whether Post sign-in supplied a `user` patch.

## Testing

Unit tests