### PR TITLE
feat(core): manage sp signing key on signAuthnRequest toggle

### DIFF
--- a/packages/core/src/libraries/saml-sso-connector-signing-key.test.ts
+++ b/packages/core/src/libraries/saml-sso-connector-signing-key.test.ts
@@ -38,7 +38,6 @@ const insertActiveSigningKey = jest.fn(async (data: SigningKeyInsert) => buildKe
 const findActiveSigningKeyBySsoConnectorId = jest.fn(
   async (): Promise<Nullable<SamlSsoConnectorSigningKey>> => null
 );
-const deleteSigningKeysBySsoConnectorId = jest.fn();
 
 const createLibrary = () =>
   createSamlSsoConnectorSigningKeyLibrary(
@@ -47,7 +46,6 @@ const createLibrary = () =>
         insertInactiveSigningKey,
         insertActiveSigningKey,
         findActiveSigningKeyBySsoConnectorId,
-        deleteSigningKeysBySsoConnectorId,
       },
     })
   );
@@ -102,14 +100,6 @@ describe('createSamlSsoConnectorSigningKeyLibrary()', () => {
       expect(insertActiveSigningKey).toHaveBeenCalledTimes(1);
       expect(result.active).toBe(true);
       expect(result.ssoConnectorId).toBe(ssoConnectorId);
-    });
-  });
-
-  describe('deleteSigningKeys()', () => {
-    it('should delete all keys for the connector', async () => {
-      await createLibrary().deleteSigningKeys(ssoConnectorId);
-
-      expect(deleteSigningKeysBySsoConnectorId).toHaveBeenCalledWith(ssoConnectorId);
     });
   });
 });

--- a/packages/core/src/libraries/saml-sso-connector-signing-key.ts
+++ b/packages/core/src/libraries/saml-sso-connector-signing-key.ts
@@ -12,7 +12,6 @@ export const createSamlSsoConnectorSigningKeyLibrary = (queries: Queries) => {
       insertInactiveSigningKey,
       insertActiveSigningKey,
       findActiveSigningKeyBySsoConnectorId,
-      deleteSigningKeysBySsoConnectorId,
     },
   } = queries;
 
@@ -44,9 +43,5 @@ export const createSamlSsoConnectorSigningKeyLibrary = (queries: Queries) => {
     return active ?? createSigningKey({ ssoConnectorId, isActive: true });
   };
 
-  const deleteSigningKeys = async (ssoConnectorId: string) => {
-    await deleteSigningKeysBySsoConnectorId(ssoConnectorId);
-  };
-
-  return { createSigningKey, ensureActiveSigningKey, deleteSigningKeys };
+  return { createSigningKey, ensureActiveSigningKey };
 };

--- a/packages/core/src/queries/saml-sso-connector-signing-key.ts
+++ b/packages/core/src/queries/saml-sso-connector-signing-key.ts
@@ -103,13 +103,6 @@ export const createSamlSsoConnectorSigningKeyQueries = (pool: CommonQueryMethods
     }
   };
 
-  const deleteSigningKeysBySsoConnectorId = async (ssoConnectorId: string) => {
-    await pool.query(sql`
-      delete from ${table}
-      where ${fields.ssoConnectorId} = ${ssoConnectorId}
-    `);
-  };
-
   return {
     insertInactiveSigningKey,
     insertActiveSigningKey,
@@ -118,6 +111,5 @@ export const createSamlSsoConnectorSigningKeyQueries = (pool: CommonQueryMethods
     findSigningKeyBySsoConnectorIdAndId,
     updateSigningKeyStatusBySsoConnectorIdAndId,
     deleteSigningKeyById,
-    deleteSigningKeysBySsoConnectorId,
   };
 };

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -26,8 +26,10 @@ import { type ManagementApiRouter, type RouterInitArgs } from '../types.js';
 import ssoConnectorIdpInitiatedAuthConfigRoutes from './idp-initiated-auth-config.js';
 import {
   fetchConnectorProviderDetails,
+  isSignAuthnRequestEnabled,
   parseConnectorConfig,
   parseFactoryDetail,
+  stripGatedSigningConfigFields,
   validateConnectorConfigConnectionStatus,
   validateConnectorDomains,
 } from './utils.js';
@@ -43,6 +45,7 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
       libraries: {
         quota,
         ssoConnectors: { getSsoConnectorById, getSsoConnectors },
+        samlSsoConnectorSigningKeys: { ensureActiveSigningKey },
       },
       envSet,
     },
@@ -106,7 +109,8 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
       }
 
       // Validate the connector config if it's provided
-      const parsedConfig = config && parseConnectorConfig(providerName, config);
+      const parsedConfig =
+        config && stripGatedSigningConfigFields(parseConnectorConfig(providerName, config));
 
       // Validate the connector name is unique
       if (connectorName) {
@@ -153,6 +157,12 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
         ...conditional(domains && { domains }),
         ...rest,
       });
+
+      // Generate the first active SP signing key on creation with signed AuthnRequest enabled
+      // (the flag is stripped when dev features are off, so this cannot fire in production).
+      if (isSignAuthnRequestEnabled(parsedConfig)) {
+        await ensureActiveSigningKey(connector.id);
+      }
 
       ctx.body = connector;
 
@@ -294,7 +304,8 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
       }
 
       // Validate the connector config if it's provided
-      const parsedConfig = config && parseConnectorConfig(providerName, config);
+      const parsedConfig =
+        config && stripGatedSigningConfigFields(parseConnectorConfig(providerName, config));
 
       // Check the connection status of the connector config if it's provided
       if (parsedConfig) {
@@ -340,6 +351,17 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
             ...rest,
           })
         : originalConnector;
+
+      // Disabling (or omitting) the flag only stops signing — key deletion is exclusive to the
+      // dedicated signing-key routes.
+      // TODO: @simeng Remove the dev features check when the signed AuthnRequest feature is ready.
+      if (
+        EnvSet.values.isDevFeaturesEnabled &&
+        providerType === SsoProviderType.SAML &&
+        isSignAuthnRequestEnabled(parsedConfig)
+      ) {
+        await ensureActiveSigningKey(id);
+      }
 
       // Make the typescript happy
       assert(

--- a/packages/core/src/routes/sso-connector/utils.test.ts
+++ b/packages/core/src/routes/sso-connector/utils.test.ts
@@ -14,8 +14,14 @@ await mockEsmWithActual('#src/sso/OidcConnector/utils.js', () => ({
 }));
 
 const { ssoConnectorFactories } = await import('#src/sso/index.js');
-const { parseFactoryDetail, fetchConnectorProviderDetails, validateConnectorDomains } =
-  await import('./utils.js');
+const {
+  parseFactoryDetail,
+  fetchConnectorProviderDetails,
+  validateConnectorDomains,
+  parseConnectorConfig,
+  isSignAuthnRequestEnabled,
+  stripGatedSigningConfigFields,
+} = await import('./utils.js');
 
 const mockTenantId = 'mock_tenant_id';
 
@@ -157,5 +163,50 @@ describe('validateConnectorDomains', () => {
         }
       )
     );
+  });
+});
+
+describe('signed AuthnRequest config helpers', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+  const setDevFeaturesEnabled = (enabled: boolean) => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', enabled);
+  };
+
+  const samlSigningConfig = {
+    metadata: 'mock-metadata',
+    signAuthnRequest: true,
+    requestSignatureAlgorithm: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+  };
+
+  afterAll(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
+  describe('isSignAuthnRequestEnabled', () => {
+    it('is true only when the config explicitly enables it', () => {
+      expect(
+        isSignAuthnRequestEnabled(parseConnectorConfig(SsoProviderName.SAML, samlSigningConfig))
+      ).toBe(true);
+      expect(
+        isSignAuthnRequestEnabled(
+          parseConnectorConfig(SsoProviderName.SAML, { metadata: 'mock-metadata' })
+        )
+      ).toBe(false);
+      expect(isSignAuthnRequestEnabled()).toBe(false);
+    });
+  });
+
+  describe('stripGatedSigningConfigFields', () => {
+    it('passes the config through when dev features are on', () => {
+      setDevFeaturesEnabled(true);
+      const parsed = parseConnectorConfig(SsoProviderName.SAML, samlSigningConfig);
+      expect(stripGatedSigningConfigFields(parsed)).toEqual(parsed);
+    });
+
+    it('strips the signing fields when dev features are off', () => {
+      setDevFeaturesEnabled(false);
+      const parsed = parseConnectorConfig(SsoProviderName.SAML, samlSigningConfig);
+      expect(stripGatedSigningConfigFields(parsed)).toEqual({ metadata: 'mock-metadata' });
+    });
   });
 });

--- a/packages/core/src/routes/sso-connector/utils.ts
+++ b/packages/core/src/routes/sso-connector/utils.ts
@@ -8,6 +8,7 @@ import type {
 import { findDuplicatedOrBlockedEmailDomains } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import SamlConnector from '#src/sso/SamlConnector/index.js';
 import { type SingleSignOnFactory, ssoConnectorFactories } from '#src/sso/index.js';
@@ -53,6 +54,31 @@ export const parseConnectorConfig = (providerName: SsoProviderName, config: Json
   }
 
   return result.data;
+};
+
+type ParsedConnectorConfig = ReturnType<typeof parseConnectorConfig>;
+
+export const isSignAuthnRequestEnabled = (config?: ParsedConnectorConfig): boolean =>
+  Boolean(config && 'signAuthnRequest' in config && config.signAuthnRequest === true);
+
+/**
+ * The signed-AuthnRequest config fields are dev-gated: strip them before persisting so they
+ * cannot be stored in production until the feature is ready.
+ * TODO: @simeng Remove when the signed AuthnRequest feature is ready.
+ */
+export const stripGatedSigningConfigFields = (
+  config: ParsedConnectorConfig
+): ParsedConnectorConfig => {
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    return config;
+  }
+
+  if ('signAuthnRequest' in config || 'requestSignatureAlgorithm' in config) {
+    const { signAuthnRequest, requestSignatureAlgorithm, ...rest } = config;
+    return rest;
+  }
+
+  return config;
 };
 
 export const fetchConnectorProviderDetails = async (

--- a/packages/integration-tests/src/tests/api/sso-connectors/sso-connector-signed-authn-request.test.ts
+++ b/packages/integration-tests/src/tests/api/sso-connectors/sso-connector-signed-authn-request.test.ts
@@ -1,0 +1,114 @@
+import { SsoProviderName } from '@logto/schemas';
+
+import { metadataXml } from '#src/__mocks__/sso-connectors-mock.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { SsoConnectorApi } from '#src/api/sso-connector.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import { devFeatureDisabledTest, devFeatureTest, randomString } from '#src/utils.js';
+
+describe('SAML SSO signed AuthnRequest', () => {
+  const ssoConnectorApi = new SsoConnectorApi();
+  const domain = `foo${randomString()}.com`;
+  const state = 'signed_authn_request_state';
+  const redirectUri = 'http://localhost:3000/redirect';
+
+  const getAuthorizationUri = async (connectorId = ssoConnectorApi.firstConnectorId!) => {
+    const client = await initExperienceClient();
+    const { authorizationUri } = await client.getEnterpriseSsoAuthorizationUri(connectorId, {
+      redirectUri,
+      state,
+    });
+    return authorizationUri;
+  };
+
+  beforeAll(async () => {
+    await ssoConnectorApi.createMockSamlConnector([domain]);
+    await updateSignInExperience({ singleSignOnEnabled: true });
+  });
+
+  afterAll(async () => {
+    await ssoConnectorApi.cleanUp();
+  });
+
+  devFeatureTest.describe('with dev features enabled', () => {
+    devFeatureTest.it('should not sign the AuthnRequest by default', async () => {
+      expect(await getAuthorizationUri()).not.toContain('Signature=');
+    });
+
+    devFeatureTest.it('should sign the AuthnRequest after enabling signAuthnRequest', async () => {
+      await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+        config: { metadata: metadataXml, signAuthnRequest: true },
+      });
+
+      const authorizationUri = await getAuthorizationUri();
+      expect(authorizationUri).toContain('Signature=');
+      expect(authorizationUri).toContain('SigAlg=');
+    });
+
+    devFeatureTest.it('should keep signing when a patch does not touch the config', async () => {
+      await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+        connectorName: `test-saml-renamed-${randomString()}`,
+      });
+
+      expect(await getAuthorizationUri()).toContain('Signature=');
+    });
+
+    devFeatureTest.it('should stop signing after disabling signAuthnRequest', async () => {
+      await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+        config: { metadata: metadataXml, signAuthnRequest: false },
+      });
+
+      expect(await getAuthorizationUri()).not.toContain('Signature=');
+    });
+
+    devFeatureTest.it(
+      'should treat a config patch that omits the flag as disabling, and resume signing on re-enable',
+      async () => {
+        // Re-enable signing (the previous test disabled it).
+        await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+          config: { metadata: metadataXml, signAuthnRequest: true },
+        });
+        expect(await getAuthorizationUri()).toContain('Signature=');
+
+        // A config-bearing patch without the flag replaces the whole config, so signing turns off;
+        // the keys are retained (deletion only happens via the dedicated signing-key routes).
+        await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+          config: { metadata: metadataXml },
+        });
+        expect(await getAuthorizationUri()).not.toContain('Signature=');
+
+        // Re-enabling resumes signing with the retained key.
+        await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+          config: { metadata: metadataXml, signAuthnRequest: true },
+        });
+        expect(await getAuthorizationUri()).toContain('Signature=');
+      }
+    );
+
+    devFeatureTest.it('should sign for a connector created with signAuthnRequest on', async () => {
+      const { id } = await ssoConnectorApi.create({
+        providerName: SsoProviderName.SAML,
+        connectorName: `test-saml-signed-${randomString()}`,
+        domains: [`bar${randomString()}.com`],
+        config: { metadata: metadataXml, signAuthnRequest: true },
+        syncProfile: true,
+      });
+
+      expect(await getAuthorizationUri(id)).toContain('Signature=');
+    });
+  });
+
+  devFeatureDisabledTest.describe('with dev features disabled', () => {
+    devFeatureDisabledTest.it(
+      'should strip the signing fields from the config and keep the request unsigned',
+      async () => {
+        const updated = await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+          config: { metadata: metadataXml, signAuthnRequest: true },
+        });
+
+        expect(updated.config).not.toHaveProperty('signAuthnRequest');
+        expect(await getAuthorizationUri()).not.toContain('Signature=');
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Part of the optional signed SAML AuthnRequest feature for enterprise SSO connectors. Base of the signing-key management routes PR (stacked next).

### What changed
- `routes/sso-connector/index.ts`: when a SAML connector is created or patched with `config.signAuthnRequest` enabled (dev-features-gated), ensure an active SP signing key exists via the idempotent `ensureActiveSigningKey`. Disabling the flag — explicitly or by omitting it in a config-bearing patch — only stops signing: **the config endpoints never delete key material**. Key deletion happens exclusively through the dedicated signing-key routes (next PR in the stack).
- `routes/sso-connector/utils.ts`: `stripGatedSigningConfigFields` removes the dev-gated signing fields (`signAuthnRequest`, `requestSignatureAlgorithm`) from POST/PATCH payloads when dev features are off, so nothing can be persisted in production.
- Removed the now-dead `deleteSigningKeys` library method and `deleteSigningKeysBySsoConnectorId` query.
- New integration suite (`sso-connector-signed-authn-request.test.ts`): authorization URI signed/unsigned across enable/disable, config-untouched patch keeps signing, flag-omitting patch disables and re-enabling resumes signing, plus a dev-features-off leg proving the write-gate strips the fields and requests stay unsigned.

### Expected result
- Dev features on: the `signAuthnRequest` toggle drives signing. Enabling auto-generates the first active key; disabling (or omitting the flag) leaves all keys in place, so re-enabling resumes with the same IdP-registered certificate.
- Production (dev features off): unchanged — the signing fields are stripped before persistence and no signing code path runs.

### Reviewer notes
- Addresses the earlier review finding on this PR: a config-bearing PATCH that omits `signAuthnRequest` no longer deletes the connector's keys — there is no key-deletion path left in the config endpoints at all. The toggle and the key material are deliberately independent, so a connector can keep its registered keys while signing is off.
- Follow-up in the next stacked PR: the signing-key routes flip `signAuthnRequest` off when the last active key is deactivated, keeping the toggle truthful.

## Testing
Unit tests, integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
