### PR TITLE
fix(toolkit): anchor dateRegEx so trailing input is rejected

### DIFF
--- a/.changeset/anchor-date-regex.md
+++ b/.changeset/anchor-date-regex.md
@@ -1,0 +1,5 @@
+---
+"@logto/core-kit": patch
+---
+
+fix date validation regex to match the complete string, rejecting trailing input after a valid date

--- a/packages/toolkit/core-kit/src/regex.test.ts
+++ b/packages/toolkit/core-kit/src/regex.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { domainRegEx, emailOrEmailDomainRegEx } from './regex.js';
+import { dateRegEx, domainRegEx, emailOrEmailDomainRegEx } from './regex.js';
 
 describe('Regular expressions should work as expected', () => {
   it('should allow valid domains that consists of 3 parts. E.g. foo.bar.com', () => {
@@ -71,6 +71,19 @@ describe('Regular expressions should work as expected', () => {
       expect(emailOrEmailDomainRegEx.test('@example..com')).toBe(false);
       expect(emailOrEmailDomainRegEx.test('@example_.com')).toBe(false);
       expect(emailOrEmailDomainRegEx.test('@example.com extra')).toBe(false);
+    });
+  });
+
+  describe('dateRegEx', () => {
+    it('should allow a full yyyy-MM-dd date', () => {
+      expect(dateRegEx.test('2020-01-01')).toBe(true);
+      expect(dateRegEx.test('1999-12-31')).toBe(true);
+    });
+
+    it('should not allow a valid date prefix followed by trailing input', () => {
+      expect(dateRegEx.test('2020-01-01xyz')).toBe(false);
+      expect(dateRegEx.test('2020-01-01T00:00:00Z')).toBe(false);
+      expect(dateRegEx.test('2020-01-01 ')).toBe(false);
     });
   });
 });

--- a/packages/toolkit/core-kit/src/regex.ts
+++ b/packages/toolkit/core-kit/src/regex.ts
@@ -8,7 +8,7 @@ export const usernameRegEx = /^[A-Z_a-z]\w*$/;
 export const webRedirectUriProtocolRegEx = /^https?:$/;
 export const mobileUriSchemeProtocolRegEx = /^(?!http(s)?:)[a-z][\d+_a-z-]*(\.[\d+_a-z-]+)*:$/;
 export const hexColorRegEx = /^#[\da-f]{3}([\da-f]{3})?$/i;
-export const dateRegEx = /^\d{4}(-\d{2}){2}/;
+export const dateRegEx = /^\d{4}(-\d{2}){2}$/;
 export const noSpaceRegEx = /^\S+$/;
 /** Full domain that consists of at least 3 parts, e.g. foo.bar.com or example-foo.bar.com */
 export const domainRegEx =


### PR DESCRIPTION
`dateRegEx` in `core-kit` is missing its end anchor:

```ts
export const dateRegEx = /^\d{4}(-\d{2}){2}/;
```

With no `$`, it only checks the prefix, so a valid date followed by anything passes. For example `dateRegEx.test('2020-01-01xyz')` returns `true`.

The one consumer is the `/dashboard/users/active` route guard in `packages/core/src/routes/dashboard.ts`, which passes the value straight to `new Date(date)`. `new Date('2020-01-01xyz')` is an `Invalid Date`, so input that clears the guard becomes NaN timestamps downstream instead of being rejected at the boundary. This isn't an injection concern (the string only ever becomes a `Date` and then numeric timestamps for the parameterized query), just looser validation than intended.

Adding the `$` makes the whole string match a `yyyy-MM-dd` date, which is the format the route actually expects (the same one `getDateString` emits). Values with a trailing time component like `2020-01-01T00:00:00Z` are rejected now too, consistent with the date-only contract.

I added a couple of cases to `regex.test.ts`. Reverting just the anchor makes the new trailing-input case fail:

```
× dateRegEx > should not allow a valid date prefix followed by trailing input
  expect(dateRegEx.test('2020-01-01xyz')).toBe(false)
  AssertionError: expected true to be false
```

With the anchor in place the package suite passes:

```
Test Files  6 passed (6)
     Tests  91 passed (91)
```
