### PR TITLE
fix(console): hide Actions without quota

### DIFF
--- a/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/hook.tsx
@@ -20,7 +20,7 @@ import SecurityLock from '@/assets/icons/security-lock.svg?react';
 import Security from '@/assets/icons/security.svg?react';
 import EnterpriseSso from '@/assets/icons/single-sign-on.svg?react';
 import Web from '@/assets/icons/web.svg?react';
-import { isDevFeaturesEnabled } from '@/consts/env';
+import useIsActionsEnabled from '@/hooks/use-is-actions-enabled';
 
 type SidebarItem = {
   Icon: FC;
@@ -51,6 +51,7 @@ export const useSidebarMenuItems = (): {
   sections: SidebarSection[];
   firstItem: Optional<SidebarItem>;
 } => {
+  const isActionsEnabled = useIsActionsEnabled();
   const allSections: SidebarSection[] = [
     {
       title: 'overview',
@@ -134,7 +135,7 @@ export const useSidebarMenuItems = (): {
           title: 'actions',
           path: 'actions',
           // Actions are still under development and should be released as one feature.
-          isHidden: !isDevFeaturesEnabled,
+          isHidden: !isActionsEnabled,
         },
         {
           Icon: JwtClaims,

--- a/packages/console/src/hooks/use-console-routes/index.tsx
+++ b/packages/console/src/hooks/use-console-routes/index.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { Navigate, useParams, type RouteObject } from 'react-router-dom';
 import { safeLazy } from 'react-safe-lazy';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
+import useIsActionsEnabled from '@/hooks/use-is-actions-enabled';
 import NotFound from '@/pages/NotFound';
 
 import { actions } from './routes/actions';
@@ -28,6 +28,7 @@ const GetStarted = safeLazy(async () => import('@/pages/GetStarted'));
 
 export const useConsoleRoutes = () => {
   const tenantSettings = useTenantSettings();
+  const isActionsEnabled = useIsActionsEnabled();
   const { tenantId } = useParams();
 
   const routeObjects: RouteObject[] = useMemo(
@@ -44,7 +45,7 @@ export const useConsoleRoutes = () => {
         enterpriseSso,
         security,
         webhooks,
-        ...(isDevFeaturesEnabled ? [actions] : []),
+        ...(isActionsEnabled ? [actions] : []),
         users,
         auditLogs,
         roles,
@@ -63,7 +64,7 @@ export const useConsoleRoutes = () => {
         tenantSettings,
         customizeJwt
       ),
-    [tenantId, tenantSettings]
+    [isActionsEnabled, tenantId, tenantSettings]
   );
 
   return routeObjects;

--- a/packages/console/src/hooks/use-is-actions-enabled.ts
+++ b/packages/console/src/hooks/use-is-actions-enabled.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
+import { isActionsEnabled } from '@/utils/actions';
+
+const useIsActionsEnabled = () => {
+  const {
+    currentSubscriptionQuota: { inlineHooksEnabled },
+  } = useContext(SubscriptionDataContext);
+
+  return isActionsEnabled({ isCloud, isDevFeaturesEnabled, inlineHooksEnabled });
+};
+
+export default useIsActionsEnabled;

--- a/packages/console/src/utils/actions.test.ts
+++ b/packages/console/src/utils/actions.test.ts
@@ -1,0 +1,41 @@
+import { isActionsEnabled } from './actions';
+
+describe('isActionsEnabled', () => {
+  it.each([
+    {
+      isCloud: true,
+      isDevFeaturesEnabled: true,
+      inlineHooksEnabled: true,
+      expected: true,
+    },
+    {
+      isCloud: true,
+      isDevFeaturesEnabled: true,
+      inlineHooksEnabled: false,
+      expected: false,
+    },
+    {
+      isCloud: true,
+      isDevFeaturesEnabled: false,
+      inlineHooksEnabled: true,
+      expected: false,
+    },
+    {
+      isCloud: false,
+      isDevFeaturesEnabled: true,
+      inlineHooksEnabled: false,
+      expected: true,
+    },
+    {
+      isCloud: false,
+      isDevFeaturesEnabled: false,
+      inlineHooksEnabled: true,
+      expected: false,
+    },
+  ])(
+    'returns $expected when cloud=$isCloud, dev features=$isDevFeaturesEnabled, and quota=$inlineHooksEnabled',
+    ({ expected, ...input }) => {
+      expect(isActionsEnabled(input)).toBe(expected);
+    }
+  );
+});

--- a/packages/console/src/utils/actions.ts
+++ b/packages/console/src/utils/actions.ts
@@ -1,0 +1,11 @@
+type ActionsAvailability = {
+  isCloud: boolean;
+  isDevFeaturesEnabled: boolean;
+  inlineHooksEnabled: boolean;
+};
+
+export const isActionsEnabled = ({
+  isCloud,
+  isDevFeaturesEnabled,
+  inlineHooksEnabled,
+}: ActionsAvailability) => isDevFeaturesEnabled && (!isCloud || inlineHooksEnabled);


### PR DESCRIPTION
## Summary

- Hide the Actions sidebar entry when the current Cloud subscription does not include Actions
- Exclude Actions routes under the same eligibility check so direct URLs are unavailable
- Preserve Actions availability for OSS environments

## Context

The Console exposed Actions navigation without checking the subscription entitlement, while the Management API correctly rejected Actions operations. This made unavailable functionality appear accessible until the user attempted to test or save an Action.

## Testing

Unit tests