### PR TITLE
style(console): align Get started item text

### DIFF
--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -16,7 +16,6 @@
 .subtitle {
   font: var(--font-body-2);
   color: var(--color-text-secondary);
-  margin-bottom: _.unit(-3);
 }
 
 .bodyText {
@@ -28,6 +27,10 @@
   display: flex;
   flex-direction: column;
   gap: _.unit(1);
+
+  .subtitle {
+    margin-bottom: _.unit(-3);
+  }
 }
 
 .developActions {


### PR DESCRIPTION
## Summary

Scoped the Get Started page subtitle negative margin to the page header only, so repeated action items use their natural text block height when vertically centered.

This fixes the visual downward drift in items such as the sign-in experience live preview action.

## Testing

Tested locally

- `pnpm --filter @logto/console stylelint`
- `git diff --check`