### PR TITLE
refactor(core): rename remote Actions runner route to /api/actions

### DIFF
--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -110,7 +110,7 @@ describe('ActionLibrary Cloud execution routing', () => {
         'x-functions-key': functionKey,
       },
     })
-      .post('/api/inline-hooks', matchLegacyRunnerPayload)
+      .post('/api/actions', matchLegacyRunnerPayload)
       .reply(200, executionResult);
 
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
@@ -199,7 +199,7 @@ describe('ActionLibrary Cloud execution routing', () => {
         'x-functions-key': functionKey,
       },
     })
-      .post('/api/inline-hooks', matchLegacyRunnerPayload)
+      .post('/api/actions', matchLegacyRunnerPayload)
       .reply(200, executionResult);
 
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
@@ -267,7 +267,7 @@ describe('ActionLibrary Cloud execution routing', () => {
         'x-functions-key': functionKey,
       },
     })
-      .post('/api/inline-hooks')
+      .post('/api/actions')
       .reply(500, {
         message: 'Remote runner failed',
       });

--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -104,13 +104,13 @@ describe('ActionLibrary Cloud execution routing', () => {
       },
     };
     const executionResult = { action: 'continue' };
-    const matchLegacyRunnerPayload = jest.fn((_body: unknown) => true);
+    const matchRunnerPayload = jest.fn((_body: unknown) => true);
     const remoteRunner = nock(endpoint, {
       reqheaders: {
         'x-functions-key': functionKey,
       },
     })
-      .post('/api/actions', matchLegacyRunnerPayload)
+      .post('/api/actions', matchRunnerPayload)
       .reply(200, executionResult);
 
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
@@ -118,9 +118,9 @@ describe('ActionLibrary Cloud execution routing', () => {
 
     await expect(library.runScriptRemotely(payload)).resolves.toEqual(executionResult);
     expect(remoteRunner.isDone()).toBe(true);
-    const requestBody = matchLegacyRunnerPayload.mock.calls[0]?.[0];
+    const requestBody = matchRunnerPayload.mock.calls[0]?.[0];
     expect(requestBody).toMatchObject({
-      hookType: payload.actionType,
+      actionType: payload.actionType,
       event: payload.event,
     });
     if (
@@ -129,7 +129,7 @@ describe('ActionLibrary Cloud execution routing', () => {
       !('script' in requestBody) ||
       typeof requestBody.script !== 'string'
     ) {
-      throw new TypeError('Expected the legacy runner request body to contain a script');
+      throw new TypeError('Expected the runner request body to contain a script');
     }
     expect(requestBody.script).toContain(payload.script);
     expect(requestBody.script).toContain('runInlineHook');
@@ -193,13 +193,13 @@ describe('ActionLibrary Cloud execution routing', () => {
         name: 'Bar',
       },
     };
-    const matchLegacyRunnerPayload = jest.fn((_body: unknown) => true);
+    const matchRunnerPayload = jest.fn((_body: unknown) => true);
     const remoteRunner = nock(endpoint, {
       reqheaders: {
         'x-functions-key': functionKey,
       },
     })
-      .post('/api/actions', matchLegacyRunnerPayload)
+      .post('/api/actions', matchRunnerPayload)
       .reply(200, executionResult);
 
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
@@ -218,9 +218,9 @@ describe('ActionLibrary Cloud execution routing', () => {
       })
     ).resolves.toEqual(executionResult);
     expect(remoteRunner.isDone()).toBe(true);
-    const requestBody = matchLegacyRunnerPayload.mock.calls[0]?.[0];
+    const requestBody = matchRunnerPayload.mock.calls[0]?.[0];
     expect(requestBody).toMatchObject({
-      hookType: LogtoActionKey.PostSignIn,
+      actionType: LogtoActionKey.PostSignIn,
       event,
       environmentVariables,
     });
@@ -230,7 +230,7 @@ describe('ActionLibrary Cloud execution routing', () => {
       !('script' in requestBody) ||
       typeof requestBody.script !== 'string'
     ) {
-      throw new TypeError('Expected the legacy runner request body to contain a script');
+      throw new TypeError('Expected the runner request body to contain a script');
     }
     expect(requestBody.script).toContain(script);
     expect(runScriptInLocalVm).not.toHaveBeenCalled();

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -298,11 +298,10 @@ export class ActionLibrary {
 
     try {
       return await got
-        // Keep the legacy payload field until the external Azure runner migrates.
         .post(new URL('/api/actions', azureFunctionUntrustedAppEndpoint), {
           json: {
             script: wrapActionScriptForLegacyRunner(script),
-            hookType: actionType,
+            actionType,
             event,
             environmentVariables,
           },

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -298,8 +298,8 @@ export class ActionLibrary {
 
     try {
       return await got
-        // Keep the legacy endpoint and payload field until the external Azure runner migrates.
-        .post(new URL('/api/inline-hooks', azureFunctionUntrustedAppEndpoint), {
+        // Keep the legacy payload field until the external Azure runner migrates.
+        .post(new URL('/api/actions', azureFunctionUntrustedAppEndpoint), {
           json: {
             script: wrapActionScriptForLegacyRunner(script),
             hookType: actionType,


### PR DESCRIPTION
## Summary

- Update Cloud remote Action execution to call `/api/actions` instead of `/api/inline-hooks`
- Update Cloud routing unit tests to assert the renamed endpoint

Deploy together with the matching Cloud Azure Functions change that exposes `/api/actions`.

## Testing

Unit tests