### PR TITLE
fix(console): align env var Monaco types with usable form values

### DIFF
--- a/packages/console/src/pages/Actions/ActionDetails/MainContent/SettingsSection/EnvironmentVariablesField.tsx
+++ b/packages/console/src/pages/Actions/ActionDetails/MainContent/SettingsSection/EnvironmentVariablesField.tsx
@@ -4,12 +4,9 @@ import { useTranslation } from 'react-i18next';
 
 import FormField from '@/ds-components/FormField';
 import KeyValueInputField from '@/ds-components/KeyValueInputField';
+import { isValidEnvironmentVariableKey } from '@/utils/validator';
 
 import { type ActionForm } from '../../type';
-
-const isValidKey = (key: string) => {
-  return /^\w+$/.test(key);
-};
 
 type Props = {
   readonly className?: string;
@@ -49,7 +46,7 @@ function EnvironmentVariablesField({ className }: Props) {
         return t('webhook_details.settings.key_missing_error');
       }
 
-      if (Boolean(key) && !isValidKey(key)) {
+      if (Boolean(key) && !isValidEnvironmentVariableKey(key)) {
         return t('webhook_details.settings.invalid_key_error');
       }
 

--- a/packages/console/src/pages/Actions/ActionDetails/MainContent/SettingsSection/EnvironmentVariablesField.tsx
+++ b/packages/console/src/pages/Actions/ActionDetails/MainContent/SettingsSection/EnvironmentVariablesField.tsx
@@ -37,16 +37,24 @@ function EnvironmentVariablesField({ className }: Props) {
         return true;
       }
 
-      if (envVariables.filter(({ key: _key }) => _key.length > 0 && _key === key).length > 1) {
+      // Match request formatting / Monaco typing, which trim keys before use.
+      const trimmedKey = key.trim();
+
+      if (
+        envVariables.filter(({ key: _key }) => {
+          const trimmed = _key.trim();
+          return trimmed.length > 0 && trimmed === trimmedKey;
+        }).length > 1
+      ) {
         return t('webhook_details.settings.key_duplicated_error');
       }
 
       const correspondValue = getValues(`environmentVariables.${index}.value`);
-      if (correspondValue && !key) {
+      if (correspondValue && !trimmedKey) {
         return t('webhook_details.settings.key_missing_error');
       }
 
-      if (Boolean(key) && !isValidEnvironmentVariableKey(key)) {
+      if (Boolean(trimmedKey) && !isValidEnvironmentVariableKey(trimmedKey)) {
         return t('webhook_details.settings.invalid_key_error');
       }
 
@@ -57,7 +65,7 @@ function EnvironmentVariablesField({ className }: Props) {
 
   const valueValidator = useCallback(
     (value: string, index: number) => {
-      return getValues(`environmentVariables.${index}.key`)
+      return getValues(`environmentVariables.${index}.key`).trim()
         ? Boolean(value) || t('webhook_details.settings.value_missing_error')
         : true;
     },

--- a/packages/console/src/pages/Actions/ActionDetails/utils/format.test.ts
+++ b/packages/console/src/pages/Actions/ActionDetails/utils/format.test.ts
@@ -87,6 +87,19 @@ describe('action form formatters', () => {
     });
   });
 
+  it('trims environment variable keys when submitting', () => {
+    const payload = formatFormDataToRequestData({
+      actionType: LogtoActionKey.PostSignIn,
+      script: 'script',
+      enabled: true,
+      onExecutionError: 'block',
+      environmentVariables: [{ key: ' API_KEY ', value: 'secret' }],
+      contextSample: undefined,
+    });
+
+    expect(payload.environmentVariables).toEqual({ API_KEY: 'secret' });
+  });
+
   it('parses valid context sample JSON for the request body', () => {
     const payload = formatFormDataToRequestData({
       actionType: LogtoActionKey.PostSignIn,

--- a/packages/console/src/pages/Actions/ActionDetails/utils/format.ts
+++ b/packages/console/src/pages/Actions/ActionDetails/utils/format.ts
@@ -25,7 +25,9 @@ const formatEnvVariablesFormDataToRequest = (envVariables: ActionForm['environme
     return;
   }
 
-  const entries = envVariables.filter(({ key, value }) => key && value);
+  const entries = envVariables
+    .map(({ key, value }) => ({ key: key.trim(), value }))
+    .filter(({ key, value }) => key && value);
 
   if (entries.length === 0) {
     return;

--- a/packages/console/src/pages/Actions/ActionDetails/utils/type-definitions.test.ts
+++ b/packages/console/src/pages/Actions/ActionDetails/utils/type-definitions.test.ts
@@ -1,0 +1,35 @@
+import {
+  ActionTypeDefinitionKey,
+  buildEnvironmentVariablesTypeDefinition,
+} from './type-definitions';
+
+describe('buildEnvironmentVariablesTypeDefinition', () => {
+  it('returns undefined when environment variables are missing', () => {
+    expect(buildEnvironmentVariablesTypeDefinition()).toBe(
+      `declare type ${ActionTypeDefinitionKey.EnvironmentVariables} = undefined`
+    );
+  });
+
+  it('types only env vars that have a valid key and a non-empty value', () => {
+    expect(
+      buildEnvironmentVariablesTypeDefinition([
+        { key: '', value: '' },
+        { key: 'LEGACY_PASSWORD', value: 'pa$sw0ld' },
+        { key: 'MISSING_VALUE', value: '' },
+        { key: 'BAD-KEY', value: 'secret' },
+        { key: 'LEGACY_IDENTIFIER', value: 'testuser' },
+      ])
+    ).toBe(`declare type ${ActionTypeDefinitionKey.EnvironmentVariables} = {
+  "LEGACY_PASSWORD": string;
+"LEGACY_IDENTIFIER": string
+    }`);
+  });
+
+  it('trims keys before validating and typing them', () => {
+    expect(
+      buildEnvironmentVariablesTypeDefinition([{ key: ' LEGACY_PASSWORD ', value: 'pa$sw0ld' }])
+    ).toBe(`declare type ${ActionTypeDefinitionKey.EnvironmentVariables} = {
+  "LEGACY_PASSWORD": string
+    }`);
+  });
+});

--- a/packages/console/src/pages/Actions/ActionDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/Actions/ActionDetails/utils/type-definitions.ts
@@ -4,6 +4,7 @@ import {
   JwtCustomizerTypeDefinitionKey,
   jwtCustomizerUserContextTypeDefinition,
 } from '@/consts/jwt-customizer-type-definition';
+import { isValidEnvironmentVariableKey } from '@/utils/validator';
 
 import { type ActionForm } from '../type';
 
@@ -83,8 +84,6 @@ export const postSignInResultTypeDefinition = `type ${ActionTypeDefinitionKey.Po
   user?: ${ActionTypeDefinitionKey.ActionUserPatch};
 };`;
 
-const isValidEnvironmentVariableKey = (key: string) => /^\w+$/.test(key);
-
 export const buildEnvironmentVariablesTypeDefinition = (
   envVariables?: ActionForm['environmentVariables']
 ) => {
@@ -92,12 +91,12 @@ export const buildEnvironmentVariablesTypeDefinition = (
     ? `{
   ${envVariables
     // Align with request payload filtering (`key && value`) and form key validation
-    // (`/^\w+$/`) so Monaco only types env vars that can actually be used at runtime.
+    // so Monaco only types env vars that can actually be used at runtime.
     .map(({ key, value }) => ({ key: key.trim(), value }))
     .filter(
       ({ key, value }) => Boolean(key) && Boolean(value) && isValidEnvironmentVariableKey(key)
     )
-    // Quote keys so values like `0FOO` stay valid TypeScript property names.
+    // Quote keys so keys like `0FOO` stay valid TypeScript property names.
     .map(({ key }) => `${JSON.stringify(key)}: string`)
     .join(';\n')}
     }`

--- a/packages/console/src/pages/Actions/ActionDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/Actions/ActionDetails/utils/type-definitions.ts
@@ -83,13 +83,20 @@ export const postSignInResultTypeDefinition = `type ${ActionTypeDefinitionKey.Po
   user?: ${ActionTypeDefinitionKey.ActionUserPatch};
 };`;
 
+const isValidEnvironmentVariableKey = (key: string) => /^\w+$/.test(key);
+
 export const buildEnvironmentVariablesTypeDefinition = (
   envVariables?: ActionForm['environmentVariables']
 ) => {
   const typeDefinition = envVariables
     ? `{
   ${envVariables
-    .filter(({ key }) => Boolean(key))
+    // Align with request payload filtering (`key && value`) and form key validation
+    // (`/^\w+$/`) so Monaco only types env vars that can actually be used at runtime.
+    .map(({ key, value }) => ({ key: key.trim(), value }))
+    .filter(
+      ({ key, value }) => Boolean(key) && Boolean(value) && isValidEnvironmentVariableKey(key)
+    )
     // Quote keys so values like `0FOO` stay valid TypeScript property names.
     .map(({ key }) => `${JSON.stringify(key)}: string`)
     .join(';\n')}

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/EnvironmentVariablesField.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/EnvironmentVariablesField.tsx
@@ -37,21 +37,29 @@ function EnvironmentVariablesField({ className }: Props) {
         return true;
       }
 
+      // Match request formatting / Monaco typing, which trim keys before use.
+      const trimmedKey = key.trim();
+
       // Unique key validation
-      if (envVariables.filter(({ key: _key }) => _key.length > 0 && _key === key).length > 1) {
+      if (
+        envVariables.filter(({ key: _key }) => {
+          const trimmed = _key.trim();
+          return trimmed.length > 0 && trimmed === trimmedKey;
+        }).length > 1
+      ) {
         // Reuse the same error phrase key from webhook settings
         return t('webhook_details.settings.key_duplicated_error');
       }
 
       // Empty key validation (if value is present)
       const correspondValue = getValues(`environmentVariables.${index}.value`);
-      if (correspondValue) {
+      if (correspondValue && !trimmedKey) {
         // Reuse the same error phrase key from webhook settings
-        return Boolean(key) || t('webhook_details.settings.key_missing_error');
+        return t('webhook_details.settings.key_missing_error');
       }
 
       // Key format validation
-      if (Boolean(key) && !isValidEnvironmentVariableKey(key)) {
+      if (Boolean(trimmedKey) && !isValidEnvironmentVariableKey(trimmedKey)) {
         // Reuse the same error phrase key from webhook settings
         return t('webhook_details.settings.invalid_key_error');
       }
@@ -63,7 +71,7 @@ function EnvironmentVariablesField({ className }: Props) {
 
   const valueValidator = useCallback(
     (value: string, index: number) => {
-      return getValues(`environmentVariables.${index}.key`)
+      return getValues(`environmentVariables.${index}.key`).trim()
         ? Boolean(value) || t('webhook_details.settings.value_missing_error')
         : true;
     },

--- a/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/EnvironmentVariablesField.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/MainContent/SettingsSection/InstructionTab/EnvironmentVariablesField.tsx
@@ -5,10 +5,7 @@ import { useTranslation } from 'react-i18next';
 import FormField from '@/ds-components/FormField';
 import KeyValueInputField from '@/ds-components/KeyValueInputField';
 import { type JwtCustomizerForm } from '@/pages/CustomizeJwtDetails/type';
-
-const isValidKey = (key: string) => {
-  return /^\w+$/.test(key);
-};
+import { isValidEnvironmentVariableKey } from '@/utils/validator';
 
 type Props = {
   readonly className?: string;
@@ -54,7 +51,7 @@ function EnvironmentVariablesField({ className }: Props) {
       }
 
       // Key format validation
-      if (Boolean(key) && !isValidKey(key)) {
+      if (Boolean(key) && !isValidEnvironmentVariableKey(key)) {
         // Reuse the same error phrase key from webhook settings
         return t('webhook_details.settings.invalid_key_error');
       }

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/format.test.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/format.test.ts
@@ -2,7 +2,7 @@ import { LogtoJwtTokenKeyType } from '@logto/schemas';
 
 import { Action } from '../../CustomizeJwt/utils/type';
 
-import { formatResponseDataToFormData } from './format';
+import { formatFormDataToRequestData, formatResponseDataToFormData } from './format';
 
 jest.mock('./config', () => ({
   defaultAccessTokenJwtCustomizerCode: 'default-access-script',
@@ -52,5 +52,22 @@ describe('formatResponseDataToFormData', () => {
     );
 
     expect(result.blockIssuanceOnError).toBe(true);
+  });
+});
+
+describe('formatFormDataToRequestData', () => {
+  it('trims environment variable keys when submitting', () => {
+    const payload = formatFormDataToRequestData({
+      tokenType: LogtoJwtTokenKeyType.AccessToken,
+      script: 'return token;',
+      blockIssuanceOnError: true,
+      environmentVariables: [{ key: ' API_KEY ', value: 'secret' }],
+      testSample: {
+        tokenSample: undefined,
+        contextSample: undefined,
+      },
+    });
+
+    expect(payload.environmentVariables).toEqual({ API_KEY: 'secret' });
   });
 });

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/format.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/format.ts
@@ -30,7 +30,9 @@ const formatEnvVariablesFormDataToRequest = (
     return;
   }
 
-  const entries = envVariables.filter(({ key, value }) => key && value);
+  const entries = envVariables
+    .map(({ key, value }) => ({ key: key.trim(), value }))
+    .filter(({ key, value }) => key && value);
 
   if (entries.length === 0) {
     return;

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.test.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.test.ts
@@ -1,0 +1,33 @@
+import { JwtCustomizerTypeDefinitionKey } from '@/consts/jwt-customizer-type-definition';
+
+import { buildEnvironmentVariablesTypeDefinition } from './type-definitions';
+
+describe('buildEnvironmentVariablesTypeDefinition', () => {
+  it('returns undefined when environment variables are missing', () => {
+    expect(buildEnvironmentVariablesTypeDefinition()).toBe(
+      `declare type ${JwtCustomizerTypeDefinitionKey.EnvironmentVariables} = undefined`
+    );
+  });
+
+  it('types only env vars that have a valid key and a non-empty value', () => {
+    expect(
+      buildEnvironmentVariablesTypeDefinition([
+        { key: '', value: '' },
+        { key: 'API_KEY', value: 'secret' },
+        { key: 'MISSING_VALUE', value: '' },
+        { key: 'BAD-KEY', value: 'secret' },
+        { key: 'ENDPOINT', value: 'https://example.com' },
+      ])
+    ).toBe(`declare type ${JwtCustomizerTypeDefinitionKey.EnvironmentVariables} = {
+  "API_KEY": string;
+"ENDPOINT": string
+    }`);
+  });
+
+  it('trims keys before validating and typing them', () => {
+    expect(buildEnvironmentVariablesTypeDefinition([{ key: ' API_KEY ', value: 'secret' }]))
+      .toBe(`declare type ${JwtCustomizerTypeDefinitionKey.EnvironmentVariables} = {
+  "API_KEY": string
+    }`);
+  });
+});

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
@@ -9,6 +9,7 @@ import {
   jwtCustomizerOrganizationContextTypeDefinition,
   jwtCustomizerApiContextTypeDefinition,
 } from '@/consts/jwt-customizer-type-definition';
+import { isValidEnvironmentVariableKey } from '@/utils/validator';
 
 import { type JwtCustomizerForm } from '../type';
 
@@ -46,8 +47,6 @@ export const buildClientCredentialsJwtCustomizerContextTsDefinition = () =>
 
   declare ${jwtCustomizerApiContextTypeDefinition}`;
 
-const isValidEnvironmentVariableKey = (key: string) => /^\w+$/.test(key);
-
 export const buildEnvironmentVariablesTypeDefinition = (
   envVariables?: JwtCustomizerForm['environmentVariables']
 ) => {
@@ -55,12 +54,12 @@ export const buildEnvironmentVariablesTypeDefinition = (
     ? `{
   ${envVariables
     // Align with request payload filtering (`key && value`) and form key validation
-    // (`/^\w+$/`) so Monaco only types env vars that can actually be used at runtime.
+    // so Monaco only types env vars that can actually be used at runtime.
     .map(({ key, value }) => ({ key: key.trim(), value }))
     .filter(
       ({ key, value }) => Boolean(key) && Boolean(value) && isValidEnvironmentVariableKey(key)
     )
-    // Quote keys so values like `0FOO` stay valid TypeScript property names.
+    // Quote keys so keys like `0FOO` stay valid TypeScript property names.
     .map(({ key }) => `${JSON.stringify(key)}: string`)
     .join(';\n')}
     }`

--- a/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
+++ b/packages/console/src/pages/CustomizeJwtDetails/utils/type-definitions.ts
@@ -46,14 +46,22 @@ export const buildClientCredentialsJwtCustomizerContextTsDefinition = () =>
 
   declare ${jwtCustomizerApiContextTypeDefinition}`;
 
+const isValidEnvironmentVariableKey = (key: string) => /^\w+$/.test(key);
+
 export const buildEnvironmentVariablesTypeDefinition = (
   envVariables?: JwtCustomizerForm['environmentVariables']
 ) => {
   const typeDefinition = envVariables
     ? `{
   ${envVariables
-    .filter(({ key }) => Boolean(key))
-    .map(({ key }) => `${key}: string`)
+    // Align with request payload filtering (`key && value`) and form key validation
+    // (`/^\w+$/`) so Monaco only types env vars that can actually be used at runtime.
+    .map(({ key, value }) => ({ key: key.trim(), value }))
+    .filter(
+      ({ key, value }) => Boolean(key) && Boolean(value) && isValidEnvironmentVariableKey(key)
+    )
+    // Quote keys so values like `0FOO` stay valid TypeScript property names.
+    .map(({ key }) => `${JSON.stringify(key)}: string`)
     .join(';\n')}
     }`
     : 'undefined';

--- a/packages/console/src/utils/validator.ts
+++ b/packages/console/src/utils/validator.ts
@@ -23,3 +23,6 @@ export const jsonValidator = (value: string) => {
 
   return true;
 };
+
+/** Environment variable keys accepted by Actions / Custom JWT form validation. */
+export const isValidEnvironmentVariableKey = (key: string) => /^\w+$/.test(key);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Actions and Custom JWT script editor IntelliSense for environment variables.

Monaco previously typed every non-empty env var key from the form, including keys that fail `/^\w+$/` validation and keys without a value. Those entries are never sent in the request payload (`key && value`), so the editor could claim a property exists when it would not be available at runtime — or, after quoting invalid keys, claim a differently spelled property than the one used in the script.

`buildEnvironmentVariablesTypeDefinition` now trims keys and only includes entries that have a valid key and a non-empty value. Request formatting also trims keys so the typed names stay aligned with the payload. The same change is applied to Custom JWT.

Missing or invalid env vars still surface as TypeScript property errors in the editor.

## Testing

- Unit tests
- Tested locally

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe7a87e9-1335-4010-ba49-bacdbb7d6eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe7a87e9-1335-4010-ba49-bacdbb7d6eed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

