### PR TITLE
chore(core): schema router status codes updated

### DIFF
--- a/packages/core/src/utils/SchemaRouter.ts
+++ b/packages/core/src/utils/SchemaRouter.ts
@@ -404,7 +404,7 @@ export default class SchemaRouter<
           // @ts-expect-error -- `.omit()` doesn't play well with generics
           body: schema.createGuard.omit({ id: true }),
           response: entityGuard ?? schema.guard,
-          status: this.#collectRouteStatuses('post', [201]), // TODO: 409/422 for conflict?
+          status: this.#collectRouteStatuses('post', [201, 422]),
         }),
         this.#assembleQualifiedMiddlewares('post'),
         async (ctx, next) => {
@@ -443,7 +443,7 @@ export default class SchemaRouter<
           params: z.object({ id: z.string().min(1) }),
           body: schema.updateGuard,
           response: entityGuard ?? schema.guard,
-          status: this.#collectRouteStatuses('patch', [200, 404]), // TODO: 409/422 for conflict?
+          status: this.#collectRouteStatuses('patch', [200, 404, 422]),
         }),
         this.#assembleQualifiedMiddlewares('patch'),
         async (ctx, next) => {


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
The globally-applied `koa-slonik-error-handler` middleware converts database constraint violations into `RequestError` with `status: 422`. The base SchemaRouter POST and PATCH routes did not include 422 in their `koaGuard` status lists.

This adds `422` to the status arrays for both routes and removes the stale TODO comments.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
