### PR TITLE
fix(core): made the replace connector transactional

### DIFF
--- a/.changeset/calm-cooks-smile.md
+++ b/.changeset/calm-cooks-smile.md
@@ -1,0 +1,7 @@
+---
+'@logto/core': patch
+---
+
+atomic passwordless connector insert and old cleanup in a transaction
+
+Previously, creating a new email or SMS connector ran the INSERT and the DELETE of old connectors as two separate statements. A crash between them left duplicate connectors. Now both operations are wrapped in a single database transaction, so either both succeed or neither does.

--- a/packages/core/src/queries/connector.ts
+++ b/packages/core/src/queries/connector.ts
@@ -1,5 +1,6 @@
-import type { Connector } from '@logto/schemas';
+import type { Connector, CreateConnector } from '@logto/schemas';
 import { Connectors } from '@logto/schemas';
+import { has } from '@silverhand/essentials';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
 
@@ -8,9 +9,16 @@ import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import { type ConnectorWellKnown } from '#src/utils/connectors/types.js';
-import { convertToIdentifiers, manyRows } from '#src/utils/sql.js';
+import {
+  convertToIdentifiers,
+  convertToPrimitiveOrSql,
+  excludeAutoSetFields,
+  manyRows,
+  type OmitAutoSetFields,
+} from '#src/utils/sql.js';
 
 const { table, fields } = convertToIdentifiers(Connectors);
+const insertKeys = excludeAutoSetFields(Connectors.fieldKeys);
 
 export const createConnectorQueries = (
   pool: CommonQueryMethods,
@@ -83,6 +91,37 @@ export const createConnectorQueries = (
     'connectors-well-known',
   ]);
 
+  const replaceConnectorsByType = wellKnownCache.mutate(
+    async (
+      newConnectorData: OmitAutoSetFields<CreateConnector>,
+      connectorIdsOfSameType: string[]
+    ): Promise<void> => {
+      return pool.transaction(async (connection) => {
+        const insertingKeys = insertKeys.filter((key) => has(newConnectorData, key));
+
+        await connection.query(sql`
+          insert into ${table} (${sql.join(
+            insertingKeys.map((key) => fields[key]),
+            sql`, `
+          )})
+          values (${sql.join(
+            insertingKeys.map((key) => convertToPrimitiveOrSql(key, newConnectorData[key])),
+            sql`, `
+          )})
+        `);
+
+        if (connectorIdsOfSameType.length > 0) {
+          await connection.query(sql`
+            delete from ${table}
+            where ${fields.connectorId} in (${sql.join(connectorIdsOfSameType, sql`, `)})
+            and ${fields.id} != ${newConnectorData.id}
+          `);
+        }
+      });
+    },
+    ['connectors-well-known']
+  );
+
   return {
     findAllConnectors,
     /** Find all connectors from database with no sensitive info. */
@@ -92,6 +131,7 @@ export const createConnectorQueries = (
     deleteConnectorById,
     deleteConnectorByIds,
     insertConnector,
+    replaceConnectorsByType,
     updateConnector,
   };
 };

--- a/packages/core/src/queries/connector.ts
+++ b/packages/core/src/queries/connector.ts
@@ -105,7 +105,7 @@ export const createConnectorQueries = (
             sql`, `
           )})
           values (${sql.join(
-            insertingKeys.map((key) => convertToPrimitiveOrSql(key, newConnectorData[key])),
+            insertingKeys.map((key) => convertToPrimitiveOrSql(key, newConnectorData[key] ?? null)),
             sql`, `
           )})
         `);

--- a/packages/core/src/routes/connector/index.post.test.ts
+++ b/packages/core/src/routes/connector/index.post.test.ts
@@ -248,6 +248,14 @@ describe('connector data route', () => {
       ]);
       validateConfig.mockReturnValueOnce(null);
       buildRawConnector.mockResolvedValueOnce({ rawConnector: { configGuard: any() } });
+      getLogtoConnectors.mockResolvedValueOnce([
+        {
+          dbEntry: { ...mockConnector, connectorId: 'id0' },
+          metadata: { ...mockMetadata, id: 'id0' },
+          type: ConnectorType.Sms,
+          ...mockLogtoConnector,
+        },
+      ]);
       await connectorRequest.post('/connectors').send({
         connectorId: 'id1',
         config: { cliend_id: 'client_id', client_secret: 'client_secret' },

--- a/packages/core/src/routes/connector/index.post.test.ts
+++ b/packages/core/src/routes/connector/index.post.test.ts
@@ -26,8 +26,9 @@ const connectorQueries = {
   countConnectorByConnectorId: jest.fn(),
   deleteConnectorByIds: jest.fn(),
   insertConnector: jest.fn(async (body) => body as Connector),
+  replaceConnectorsByType: jest.fn(),
 } satisfies Partial<Queries['connectors']>;
-const { countConnectorByConnectorId, deleteConnectorByIds, insertConnector } = connectorQueries;
+const { countConnectorByConnectorId, insertConnector, replaceConnectorsByType } = connectorQueries;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 const getLogtoConnectors = jest.fn<Promise<LogtoConnector[]>, []>();
@@ -245,31 +246,24 @@ describe('connector data route', () => {
           metadata: { ...mockConnectorFactory.metadata, id: 'id1' },
         },
       ]);
-      getLogtoConnectors.mockResolvedValueOnce([
-        {
-          dbEntry: { ...mockConnector, connectorId: 'id0' },
-          metadata: { ...mockMetadata, id: 'id0' },
-          type: ConnectorType.Sms,
-          ...mockLogtoConnector,
-        },
-      ]);
-      countConnectorByConnectorId.mockResolvedValueOnce({ count: 0 });
       validateConfig.mockReturnValueOnce(null);
       buildRawConnector.mockResolvedValueOnce({ rawConnector: { configGuard: any() } });
       await connectorRequest.post('/connectors').send({
         connectorId: 'id1',
         config: { cliend_id: 'client_id', client_secret: 'client_secret' },
       });
-      expect(insertConnector).toHaveBeenCalledWith(
+      expect(replaceConnectorsByType).toHaveBeenCalledWith(
         expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          id: expect.any(String),
           connectorId: 'id1',
           config: {
             cliend_id: 'client_id',
             client_secret: 'client_secret',
           },
-        })
+        }),
+        ['id1']
       );
-      expect(deleteConnectorByIds).toHaveBeenCalledWith(['id']);
     });
 
     it('throws when add more than 1 social connector instance with same target and platform (add from standard connector)', async () => {

--- a/packages/core/src/routes/connector/index.ts
+++ b/packages/core/src/routes/connector/index.ts
@@ -55,6 +55,7 @@ export default function connectorRoutes<T extends ManagementApiRouter>(
     deleteConnectorById,
     deleteConnectorByIds,
     insertConnector,
+    replaceConnectorsByType,
     updateConnector,
   } = tenant.queries.connectors;
   const { getLogtoConnectorById, getLogtoConnectors, getLogtoConnectorByTargetAndPlatform } =
@@ -172,29 +173,23 @@ export default function connectorRoutes<T extends ManagementApiRouter>(
 
       const insertConnectorId = proposedId ?? generateStandardShortId();
 
-      await insertConnector({
-        id: insertConnectorId,
-        connectorId,
-        ...cleanDeep({ syncProfile, config, metadata, enableTokenStorage }),
-      });
-
       /**
        * We can have only one working email/sms connector:
        * once we insert a new one, old connectors with same type should be deleted.
-       * TODO: should using transaction to ensure the atomicity of the operation. LOG-7260
        */
       if (passwordlessConnector.has(connectorFactory.type)) {
-        const logtoConnectors = await getLogtoConnectors();
-        const conflictingConnectorIds = logtoConnectors
-          .filter(
-            ({ dbEntry: { id }, type }) =>
-              type === connectorFactory.type && id !== insertConnectorId
-          )
-          .map(({ dbEntry: { id } }) => id);
+        const connectorIdsOfSameType = connectorFactories
+          .filter(({ type }) => type === connectorFactory.type)
+          .map(({ metadata: { id } }) => id);
 
-        if (conflictingConnectorIds.length > 0) {
-          await deleteConnectorByIds(conflictingConnectorIds);
-        }
+        await replaceConnectorsByType(
+          {
+            id: insertConnectorId,
+            connectorId,
+            ...cleanDeep({ syncProfile, config, metadata, enableTokenStorage }),
+          },
+          connectorIdsOfSameType
+        );
 
         captureEvent(
           { tenantId: tenant.id, request: ctx.req },
@@ -202,6 +197,12 @@ export default function connectorRoutes<T extends ManagementApiRouter>(
           pickFactoryProperties(connectorFactory)
         );
       } else {
+        await insertConnector({
+          id: insertConnectorId,
+          connectorId,
+          ...cleanDeep({ syncProfile, config, metadata, enableTokenStorage }),
+        });
+
         captureEvent(
           { tenantId: tenant.id, request: ctx.req },
           ProductEvent.SocialConnectorCreated,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Make passwordless connector insert + old connector cleanup atomic in a transaction.

## Changes
packages/core/src/queries/connector.ts: Added replaceConnectorsByType that wraps both INSERT and DELETE in a pool.transaction. Uses pre-computed insertKeys at module scope to avoid re-computing schema metadata on every call. The DELETE targets connector_id IN (...) AND id != $newId instead of relying on pre-fetched row IDs, eliminating the stale-read race.
packages/core/src/routes/connector/index.ts: Route now computes connectorIdsOfSameType from the in-memory connectorFactories (loaded once, never stale) instead of calling getLogtoConnectors() outside a transaction. Calls replaceConnectorsByType instead of separate insertConnector + deleteConnectorByIds.
packages/core/src/routes/connector/index.post.test.ts: Updated passwordless connector test to mock and assert replaceConnectorsByType instead of the separate insert/delete calls.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->
- [x] .changeset
- [x] unit tests
- [x] necessary TSDoc comments