### PR TITLE
refactor(core,console): remove legacy inlineHooksEnabled quota compatibility

### DIFF
--- a/packages/console/src/cloud/types/router.ts
+++ b/packages/console/src/cloud/types/router.ts
@@ -7,8 +7,6 @@ type GetTenantAuthRoutes = RouterRoutes<typeof tenantAuthRouter>['get'];
 
 export type GetArrayElementType<T> = T extends Array<infer U> ? U : never;
 
-type CloudLogtoSkuResponse = GetArrayElementType<GuardedResponse<GetRoutes['/api/skus']>>;
-
 export type Subscription = GuardedResponse<GetRoutes['/api/tenants/:tenantId/subscription']>;
 
 export type TenantUsageAddOnSkus = GuardedResponse<
@@ -23,28 +21,16 @@ export type SubscriptionUsageResponse = GuardedResponse<
 
 export type SubscriptionQuota = Omit<
   SubscriptionUsageResponse['quota'],
-  // Logto uses `actionsEnabled` as the canonical Actions quota key. Keep the legacy Cloud
-  // compatibility field out of the Console subscription types.
-  | 'inlineHooksEnabled'
   // Since we are deprecating the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the quota keys for now to avoid confusion.
-  | 'organizationsEnabled'
+  'organizationsEnabled'
 >;
 
-export type LogtoSkuResponse = Omit<CloudLogtoSkuResponse, 'quota'> & {
-  quota: Omit<CloudLogtoSkuResponse['quota'], 'inlineHooksEnabled'> & {
-    // Cloud keeps returning the legacy key for backward compatibility. It is removed when
-    // normalizing the response at the Console boundary.
-    inlineHooksEnabled?: boolean;
-  };
-};
+export type LogtoSkuResponse = GetArrayElementType<GuardedResponse<GetRoutes['/api/skus']>>;
 
 export type SubscriptionCountBasedUsage = Omit<
   SubscriptionUsageResponse['usage'],
-  // Logto uses `actionsEnabled` as the canonical Actions quota key. Keep the legacy Cloud
-  // compatibility field out of the Console subscription usage types.
-  | 'inlineHooksEnabled'
   // Since we are deprecating the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
-  | 'organizationsEnabled'
+  'organizationsEnabled'
 >;
 export type SubscriptionResourceScopeUsage = SubscriptionUsageResponse['resources'];
 export type SubscriptionRoleScopeUsage = Omit<

--- a/packages/console/src/cloud/types/router.ts
+++ b/packages/console/src/cloud/types/router.ts
@@ -21,16 +21,29 @@ export type SubscriptionUsageResponse = GuardedResponse<
 
 export type SubscriptionQuota = Omit<
   SubscriptionUsageResponse['quota'],
+  // Drop once `@logto/cloud` no longer declares the legacy Actions quota key.
+  | 'inlineHooksEnabled'
   // Since we are deprecating the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the quota keys for now to avoid confusion.
-  'organizationsEnabled'
+  | 'organizationsEnabled'
 >;
 
-export type LogtoSkuResponse = GetArrayElementType<GuardedResponse<GetRoutes['/api/skus']>>;
+export type LogtoSkuResponse = Omit<
+  GetArrayElementType<GuardedResponse<GetRoutes['/api/skus']>>,
+  'quota'
+> & {
+  // Drop the legacy key once `@logto/cloud` stops declaring it on SKU quotas.
+  quota: Omit<
+    GetArrayElementType<GuardedResponse<GetRoutes['/api/skus']>>['quota'],
+    'inlineHooksEnabled'
+  >;
+};
 
 export type SubscriptionCountBasedUsage = Omit<
   SubscriptionUsageResponse['usage'],
+  // Drop once `@logto/cloud` no longer declares the legacy Actions quota key.
+  | 'inlineHooksEnabled'
   // Since we are deprecating the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
-  'organizationsEnabled'
+  | 'organizationsEnabled'
 >;
 export type SubscriptionResourceScopeUsage = SubscriptionUsageResponse['resources'];
 export type SubscriptionRoleScopeUsage = Omit<

--- a/packages/console/src/utils/actions.test.ts
+++ b/packages/console/src/utils/actions.test.ts
@@ -18,7 +18,9 @@ describe('normalizeActionsQuota', () => {
   });
 
   it('uses the fallback when the Actions quota key is absent', () => {
-    const quota = { applicationsLimit: 3 };
+    const quota: { actionsEnabled?: boolean; applicationsLimit: number } = {
+      applicationsLimit: 3,
+    };
 
     expect(normalizeActionsQuota(quota, { fallback: false })).toEqual({
       actionsEnabled: false,

--- a/packages/console/src/utils/actions.test.ts
+++ b/packages/console/src/utils/actions.test.ts
@@ -14,13 +14,13 @@ describe('normalizeActionsQuota', () => {
   });
 
   it('rejects a Cloud response without the Actions quota key', () => {
-    expect(() => normalizeActionsQuota({})).toThrow(
-      'Cloud response is missing the Actions quota.'
-    );
+    expect(() => normalizeActionsQuota({})).toThrow('Cloud response is missing the Actions quota.');
   });
 
   it('uses the fallback when the Actions quota key is absent', () => {
-    expect(normalizeActionsQuota({ applicationsLimit: 3 }, { fallback: false })).toEqual({
+    const quota = { applicationsLimit: 3 };
+
+    expect(normalizeActionsQuota(quota, { fallback: false })).toEqual({
       actionsEnabled: false,
       applicationsLimit: 3,
     });

--- a/packages/console/src/utils/actions.test.ts
+++ b/packages/console/src/utils/actions.test.ts
@@ -1,11 +1,10 @@
 import { isActionsEnabled, normalizeActionsQuota } from './actions';
 
 describe('normalizeActionsQuota', () => {
-  it('uses the Actions quota key when both names are present', () => {
+  it('returns the Actions quota key when present', () => {
     expect(
       normalizeActionsQuota({
         actionsEnabled: false,
-        inlineHooksEnabled: true,
         applicationsLimit: 3,
       })
     ).toEqual({
@@ -15,15 +14,13 @@ describe('normalizeActionsQuota', () => {
   });
 
   it('rejects a Cloud response without the Actions quota key', () => {
-    expect(() => normalizeActionsQuota({ inlineHooksEnabled: true })).toThrow(
+    expect(() => normalizeActionsQuota({})).toThrow(
       'Cloud response is missing the Actions quota.'
     );
   });
 
   it('uses the fallback when the Actions quota key is absent', () => {
-    expect(
-      normalizeActionsQuota({ inlineHooksEnabled: true, applicationsLimit: 3 }, { fallback: false })
-    ).toEqual({
+    expect(normalizeActionsQuota({ applicationsLimit: 3 }, { fallback: false })).toEqual({
       actionsEnabled: false,
       applicationsLimit: 3,
     });

--- a/packages/console/src/utils/actions.ts
+++ b/packages/console/src/utils/actions.ts
@@ -6,7 +6,6 @@ type ActionsAvailability = {
 
 type ActionsQuotaData = {
   actionsEnabled?: boolean;
-  inlineHooksEnabled?: boolean;
 };
 
 type NormalizeActionsQuotaOptions = {
@@ -22,8 +21,7 @@ type NormalizeActionsQuotaOptions = {
 };
 
 /**
- * Drop the legacy `inlineHooksEnabled` key from a Cloud quota payload and return it with a
- * guaranteed `actionsEnabled` boolean.
+ * Return a Cloud quota payload with a guaranteed `actionsEnabled` boolean.
  */
 export const normalizeActionsQuota = <Quota extends ActionsQuotaData>(
   quota: Quota,
@@ -35,9 +33,7 @@ export const normalizeActionsQuota = <Quota extends ActionsQuotaData>(
     throw new TypeError('Cloud response is missing the Actions quota.');
   }
 
-  const { inlineHooksEnabled: _, ...rest } = quota;
-
-  return { ...rest, actionsEnabled };
+  return { ...quota, actionsEnabled };
 };
 
 export const isActionsEnabled = ({

--- a/packages/core/src/utils/subscription/index.test.ts
+++ b/packages/core/src/utils/subscription/index.test.ts
@@ -20,28 +20,23 @@ describe('getTenantSubscription', () => {
       getTenantSubscription(
         createCloudConnection({
           ...mockSubscriptionData,
-          quota: {
-            ...quota,
-            inlineHooksEnabled: true,
-          },
+          quota,
         })
       )
     ).rejects.toThrow('Cloud subscription response is missing the Actions quota.');
   });
 
-  it('uses the Actions quota key and omits the legacy key', async () => {
+  it('uses the Actions quota key', async () => {
     const subscription = await getTenantSubscription(
       createCloudConnection({
         ...mockSubscriptionData,
         quota: {
           ...mockSubscriptionData.quota,
           actionsEnabled: false,
-          inlineHooksEnabled: true,
         },
       })
     );
 
     expect(subscription.quota.actionsEnabled).toBe(false);
-    expect(subscription.quota).not.toHaveProperty('inlineHooksEnabled');
   });
 });

--- a/packages/core/src/utils/subscription/index.ts
+++ b/packages/core/src/utils/subscription/index.ts
@@ -25,11 +25,8 @@ export const getTenantSubscription = async (
     throw new TypeError('Cloud subscription response is missing the Actions quota.');
   }
 
-  const { inlineHooksEnabled: _, ...quota } = rest.quota;
-
   return {
     ...rest,
-    quota,
     currentPeriodStart: new Date(currentPeriodStart).toISOString(),
     currentPeriodEnd: new Date(currentPeriodEnd).toISOString(),
   };

--- a/packages/core/src/utils/subscription/types.ts
+++ b/packages/core/src/utils/subscription/types.ts
@@ -19,6 +19,8 @@ export const actionQuotaKey = 'actionsEnabled' satisfies keyof CompleteSubscript
 export type SubscriptionQuota = Omit<
   CompleteSubscriptionUsage['quota'],
   | 'auditLogsRetentionDays'
+  // Drop once `@logto/cloud` no longer declares the legacy Actions quota key.
+  | 'inlineHooksEnabled'
   // Since we are deprecating the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
   | 'organizationsEnabled'
 >;
@@ -46,8 +48,10 @@ export type Subscription = Omit<
 
 export type SubscriptionUsage = Omit<
   CompleteSubscriptionUsage['usage'],
+  // Drop once `@logto/cloud` no longer declares the legacy Actions quota key.
+  | 'inlineHooksEnabled'
   // Since we are deprecating the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
-  'organizationsEnabled'
+  | 'organizationsEnabled'
 >;
 
 export type ReportSubscriptionUpdatesUsageKey = Exclude<

--- a/packages/core/src/utils/subscription/types.ts
+++ b/packages/core/src/utils/subscription/types.ts
@@ -19,7 +19,6 @@ export const actionQuotaKey = 'actionsEnabled' satisfies keyof CompleteSubscript
 export type SubscriptionQuota = Omit<
   CompleteSubscriptionUsage['quota'],
   | 'auditLogsRetentionDays'
-  | 'inlineHooksEnabled'
   // Since we are deprecating the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
   | 'organizationsEnabled'
 >;
@@ -47,9 +46,8 @@ export type Subscription = Omit<
 
 export type SubscriptionUsage = Omit<
   CompleteSubscriptionUsage['usage'],
-  | 'inlineHooksEnabled'
   // Since we are deprecating the `organizationsEnabled` key soon (use `organizationsLimit` instead), we exclude it from the usage keys for now to avoid confusion.
-  | 'organizationsEnabled'
+  'organizationsEnabled'
 >;
 
 export type ReportSubscriptionUpdatesUsageKey = Exclude<


### PR DESCRIPTION
## Summary

- Remove remaining `inlineHooksEnabled` compatibility shims now that Cloud will stop returning this legacy quota field.
- Keep `actionsEnabled` as the only Actions quota key in core subscription handling and Console quota normalization/types.
- Update unit tests to cover the `actionsEnabled`-only path.

## Testing

Unit tests