### PR TITLE
feat(core,console): release Actions

### DIFF
--- a/packages/console/src/consts/logs.test.ts
+++ b/packages/console/src/consts/logs.test.ts
@@ -1,36 +1,10 @@
-// eslint-disable-next-line @silverhand/fp/no-let
-let mockIsDevFeaturesEnabled = false;
+import { auditLogEventTitle } from './logs';
 
-jest.mock('./env', () => ({
-  get isDevFeaturesEnabled() {
-    return mockIsDevFeaturesEnabled;
-  },
-}));
-
-describe('action audit log event visibility', () => {
-  afterEach(() => {
-    jest.resetModules();
-    jest.clearAllMocks();
+describe('action audit log event titles', () => {
+  it('exposes action event titles', () => {
+    expect(auditLogEventTitle).toMatchObject({
+      'Action.PostFirstFactorVerification': 'Execute post first-factor verification action',
+      'Action.PostSignIn': 'Execute post sign-in action',
+    });
   });
-
-  it.each([false, true])(
-    'exposes action event titles when dev features are %s',
-    async (isDevFeaturesEnabled) => {
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle the mocked build-time feature flag.
-      mockIsDevFeaturesEnabled = isDevFeaturesEnabled;
-
-      const { auditLogEventTitle } = await import('./logs');
-
-      if (isDevFeaturesEnabled) {
-        expect(auditLogEventTitle).toMatchObject({
-          'Action.PostFirstFactorVerification': 'Execute post first-factor verification action',
-          'Action.PostSignIn': 'Execute post sign-in action',
-        });
-        return;
-      }
-
-      expect(auditLogEventTitle).not.toHaveProperty('Action.PostFirstFactorVerification');
-      expect(auditLogEventTitle).not.toHaveProperty('Action.PostSignIn');
-    }
-  );
 });

--- a/packages/console/src/consts/logs.ts
+++ b/packages/console/src/consts/logs.ts
@@ -1,8 +1,6 @@
 import type { AuditLogKey, LogKey, interaction } from '@logto/schemas';
 import { type Optional } from '@silverhand/essentials';
 
-import { isDevFeaturesEnabled } from './env';
-
 export const auditLogEventTitle = Object.freeze({
   'ExchangeTokenBy.AuthorizationCode': 'Exchange token by Code',
   'ExchangeTokenBy.ClientCredentials': 'Exchange token by Client Credentials',
@@ -95,13 +93,8 @@ export const auditLogEventTitle = Object.freeze({
   'JwtCustomizer.ClientCredentials': 'Get custom M2M access token claims',
   'SamlApplication.AuthnRequest': 'Receive SAML application authentication request',
   'SamlApplication.Callback': 'Handle SAML application callback',
-  // Actions
-  ...(isDevFeaturesEnabled
-    ? {
-        'Action.PostFirstFactorVerification': 'Execute post first-factor verification action',
-        'Action.PostSignIn': 'Execute post sign-in action',
-      }
-    : {}),
+  'Action.PostFirstFactorVerification': 'Execute post first-factor verification action',
+  'Action.PostSignIn': 'Execute post sign-in action',
 } satisfies Partial<Record<Exclude<AuditLogKey, interaction.DeprecatedInteractionLogKey>, string>>);
 
 export const logEventTitle: Record<string, Optional<string>> & {

--- a/packages/console/src/hooks/use-is-actions-enabled.ts
+++ b/packages/console/src/hooks/use-is-actions-enabled.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { isActionsEnabled } from '@/utils/actions';
 
@@ -9,7 +9,7 @@ const useIsActionsEnabled = () => {
     currentSubscriptionQuota: { actionsEnabled },
   } = useContext(SubscriptionDataContext);
 
-  return isActionsEnabled({ isCloud, isDevFeaturesEnabled, actionsEnabled });
+  return isActionsEnabled({ isCloud, actionsEnabled });
 };
 
 export default useIsActionsEnabled;

--- a/packages/console/src/utils/actions.test.ts
+++ b/packages/console/src/utils/actions.test.ts
@@ -40,36 +40,26 @@ describe('isActionsEnabled', () => {
   it.each([
     {
       isCloud: true,
-      isDevFeaturesEnabled: true,
       actionsEnabled: true,
       expected: true,
     },
     {
       isCloud: true,
-      isDevFeaturesEnabled: true,
       actionsEnabled: false,
       expected: false,
     },
     {
-      isCloud: true,
-      isDevFeaturesEnabled: false,
-      actionsEnabled: true,
-      expected: false,
-    },
-    {
       isCloud: false,
-      isDevFeaturesEnabled: true,
       actionsEnabled: false,
       expected: true,
     },
     {
       isCloud: false,
-      isDevFeaturesEnabled: false,
       actionsEnabled: true,
-      expected: false,
+      expected: true,
     },
   ])(
-    'returns $expected when cloud=$isCloud, dev features=$isDevFeaturesEnabled, and quota=$actionsEnabled',
+    'returns $expected when cloud=$isCloud and quota=$actionsEnabled',
     ({ expected, ...input }) => {
       expect(isActionsEnabled(input)).toBe(expected);
     }

--- a/packages/console/src/utils/actions.ts
+++ b/packages/console/src/utils/actions.ts
@@ -1,6 +1,5 @@
 type ActionsAvailability = {
   isCloud: boolean;
-  isDevFeaturesEnabled: boolean;
   actionsEnabled: boolean;
 };
 
@@ -40,8 +39,5 @@ export const normalizeActionsQuota = <Quota extends ActionsQuotaData>(
   return { ...rest, actionsEnabled };
 };
 
-export const isActionsEnabled = ({
-  isCloud,
-  isDevFeaturesEnabled,
-  actionsEnabled,
-}: ActionsAvailability) => isDevFeaturesEnabled && (!isCloud || actionsEnabled);
+export const isActionsEnabled = ({ isCloud, actionsEnabled }: ActionsAvailability) =>
+  !isCloud || actionsEnabled;

--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -28,7 +28,6 @@ const createLibrary = (tenantId = 'tenant_id') =>
   );
 
 const originalIsCloud = EnvSet.values.isCloud;
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 
 const setIsCloud = (isCloud: boolean) => {
   // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for Cloud/local selection tests.
@@ -51,8 +50,6 @@ describe('ActionLibrary Cloud execution routing', () => {
       trackMetric,
       trackException: jest.fn(),
     } as unknown as NonNullable<typeof appInsights.client>;
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for action runtime tests.
-    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
     getSubscriptionData.mockResolvedValue({
       quota: {
         actionsEnabled: true,
@@ -67,9 +64,6 @@ describe('ActionLibrary Cloud execution routing', () => {
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the shared AppInsights singleton.
     appInsights.client = originalAppInsightsClient;
     setIsCloud(originalIsCloud);
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after dev feature tests.
-    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
-      originalIsDevFeaturesEnabled;
   });
 
   it('throws an action error when the remote runner is not configured', async () => {

--- a/packages/core/src/libraries/action.test.ts
+++ b/packages/core/src/libraries/action.test.ts
@@ -51,7 +51,6 @@ const createLibrary = (tenantId = 'tenant_id') =>
   );
 
 const originalIsCloud = EnvSet.values.isCloud;
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 
 const setIsCloud = (isCloud: boolean) => {
   // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for Cloud/local selection tests.
@@ -74,8 +73,6 @@ describe('ActionLibrary', () => {
       trackMetric,
       trackException: jest.fn(),
     } as unknown as NonNullable<typeof appInsights.client>;
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for action runtime tests.
-    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
     getSubscriptionData.mockResolvedValue({
       quota: {
         actionsEnabled: true,
@@ -89,9 +86,6 @@ describe('ActionLibrary', () => {
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the shared AppInsights singleton.
     appInsights.client = originalAppInsightsClient;
     setIsCloud(originalIsCloud);
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore EnvSet after dev feature tests.
-    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
-      originalIsDevFeaturesEnabled;
   });
 
   it('loads action config and runs the enabled script in the local VM', async () => {
@@ -480,23 +474,6 @@ describe('ActionLibrary', () => {
       decision: 'noop',
       actionResult: '[unavailable]',
     });
-  });
-
-  it('does not load or run actions when dev features are disabled', async () => {
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for dev feature gate test.
-    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = false;
-
-    await expect(
-      runAction({
-        key: LogtoActionKey.PostSignIn,
-        event: {},
-      })
-    ).resolves.toBeUndefined();
-
-    expect(getAction).not.toHaveBeenCalled();
-    expect(getSubscriptionData).not.toHaveBeenCalled();
-    expect(createLog).not.toHaveBeenCalled();
-    expect(trackMetric).not.toHaveBeenCalled();
   });
 
   it('does not run disabled actions', async () => {

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -320,10 +320,6 @@ export class ActionLibrary {
     auditContext: { createLog, ...auditContext },
     ...eventSource
   }: RunActionData<Event>): Promise<unknown> {
-    if (!EnvSet.values.isDevFeaturesEnabled) {
-      return;
-    }
-
     const action = await this.findEnabledAction(key);
 
     if (!action) {

--- a/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
@@ -851,6 +851,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
       assignReleaseOnSuccessInteractionHookResult: jest.fn(),
       assignReleaseAnywayInteractionHookResult: jest.fn(),
       appendDataHookContext: jest.fn(),
+      interactionDetails: mockInteractionDetails,
       ...createContextWithRouteParameters({
         headers: {
           'x-logto-cf-bot-score': '10',

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -351,16 +351,6 @@ describe('ExperienceInteraction class', () => {
       expect(runAction).not.toHaveBeenCalled();
     });
 
-    it('does not run PostSignIn action when dev features are disabled', async () => {
-      setDevFeaturesEnabled(false);
-      const { experienceInteraction, runAction, getUserContext } = createSignInInteraction();
-
-      await experienceInteraction.submit();
-
-      expect(getUserContext).not.toHaveBeenCalled();
-      expect(runAction).not.toHaveBeenCalled();
-    });
-
     it('updates user when PostSignIn action returns updateUser', async () => {
       const { experienceInteraction, runActionHandler } = createSignInInteraction();
       const updateUser = jest.spyOn(experienceInteraction.provisionLibrary, 'updateUser');

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -13,7 +13,6 @@ import {
 import { maskEmail, maskPhone } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayload } from '#src/libraries/user.utils.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
@@ -707,7 +706,7 @@ export default class ExperienceInteraction {
   }
 
   private async triggerPostSignInAction(userId: string) {
-    if (this.#interactionEvent !== InteractionEvent.SignIn || !EnvSet.values.isDevFeaturesEnabled) {
+    if (this.#interactionEvent !== InteractionEvent.SignIn) {
       return;
     }
 

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -54,6 +54,8 @@ describe('logRoutes', () => {
         {
           payload: { userId, applicationId },
           logKey,
+          startTime: undefined,
+          endTime: undefined,
           includeKeyPrefix: [
             token.Type.ExchangeTokenBy,
             token.Type.RevokeToken,
@@ -70,6 +72,8 @@ describe('logRoutes', () => {
       expect(findLogs).toHaveBeenCalledWith(5, 0, {
         payload: { userId, applicationId },
         logKey,
+        startTime: undefined,
+        endTime: undefined,
         includeKeyPrefix: [
           token.Type.ExchangeTokenBy,
           token.Type.RevokeToken,

--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -10,7 +10,6 @@ import {
 import type { Log } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 
-import { EnvSet } from '#src/env-set/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
@@ -29,11 +28,6 @@ const logs = {
 };
 const { countLogs, findLogs, findLogById } = logs;
 const logRoutes = await pickDefault(import('./log.js'));
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-
-const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
-  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', isDevFeaturesEnabled);
-};
 
 describe('logRoutes', () => {
   const logRequest = createRequester({
@@ -43,42 +37,21 @@ describe('logRoutes', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
   });
 
   describe('GET /logs', () => {
-    it.each([false, true])(
-      'should call countLogs and findLogs with correct parameters when dev features are %s',
-      async (isDevFeaturesEnabled) => {
-        setDevFeaturesEnabled(isDevFeaturesEnabled);
-        const actionPrefixes = isDevFeaturesEnabled ? [action.prefix] : [];
-        const userId = 'userIdValue';
-        const applicationId = 'foo';
-        const logKey = 'SignInUsernamePassword';
-        const page = 1;
-        const pageSize = 5;
+    it('should call countLogs and findLogs with correct parameters', async () => {
+      const userId = 'userIdValue';
+      const applicationId = 'foo';
+      const logKey = 'SignInUsernamePassword';
+      const page = 1;
+      const pageSize = 5;
 
-        await logRequest.get(
-          `/logs?userId=${userId}&applicationId=${applicationId}&logKey=${logKey}&page=${page}&page_size=${pageSize}`
-        );
-        expect(countLogs).toHaveBeenCalledWith(
-          {
-            payload: { userId, applicationId },
-            logKey,
-            includeKeyPrefix: [
-              token.Type.ExchangeTokenBy,
-              token.Type.RevokeToken,
-              token.Type.RevokeGrants,
-              interaction.prefix,
-              jwtCustomizer.prefix,
-              saml.prefix,
-              ...actionPrefixes,
-              LogKeyUnknown,
-            ],
-          },
-          { capped: false }
-        );
-        expect(findLogs).toHaveBeenCalledWith(5, 0, {
+      await logRequest.get(
+        `/logs?userId=${userId}&applicationId=${applicationId}&logKey=${logKey}&page=${page}&page_size=${pageSize}`
+      );
+      expect(countLogs).toHaveBeenCalledWith(
+        {
           payload: { userId, applicationId },
           logKey,
           includeKeyPrefix: [
@@ -88,12 +61,27 @@ describe('logRoutes', () => {
             interaction.prefix,
             jwtCustomizer.prefix,
             saml.prefix,
-            ...actionPrefixes,
+            action.prefix,
             LogKeyUnknown,
           ],
-        });
-      }
-    );
+        },
+        { capped: false }
+      );
+      expect(findLogs).toHaveBeenCalledWith(5, 0, {
+        payload: { userId, applicationId },
+        logKey,
+        includeKeyPrefix: [
+          token.Type.ExchangeTokenBy,
+          token.Type.RevokeToken,
+          token.Type.RevokeGrants,
+          interaction.prefix,
+          jwtCustomizer.prefix,
+          saml.prefix,
+          action.prefix,
+          LogKeyUnknown,
+        ],
+      });
+    });
 
     it('should return correct response', async () => {
       const response = await logRequest.get(`/logs`);

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -8,10 +8,9 @@ import {
   saml,
   type AuditLogPrefix,
 } from '@logto/schemas';
-import { conditionalArray, yes } from '@silverhand/essentials';
+import { yes } from '@silverhand/essentials';
 import { object, string } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import { parseTimestampParam, validateTimeWindow } from '#src/utils/time-window.js';
@@ -55,8 +54,7 @@ export default function logRoutes<T extends ManagementApiRouter>(
         interaction.prefix,
         jwtCustomizer.prefix,
         saml.prefix,
-        // Actions
-        ...conditionalArray(EnvSet.values.isDevFeaturesEnabled && action.prefix),
+        action.prefix,
         LogKeyUnknown,
       ];
 

--- a/packages/core/src/routes/logto-config/action.test.ts
+++ b/packages/core/src/routes/logto-config/action.test.ts
@@ -8,7 +8,6 @@ import {
   mockActionConfigForPostSignIn,
   mockLogtoConfigRows,
 } from '#src/__mocks__/index.js';
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaErrorHandler from '#src/middleware/koa-error-handler.js';
 import koaI18next from '#src/middleware/koa-i18next.js';
@@ -18,12 +17,6 @@ import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
 const { jest } = import.meta;
-
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-
-const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
-  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', isDevFeaturesEnabled);
-};
 
 const createResponseError = (status: number, body: Record<string, unknown>) =>
   new ResponseError(
@@ -50,8 +43,6 @@ const logtoConfigQueries = {
 
 const mockQuotaLibrary = createMockQuotaLibrary();
 
-setDevFeaturesEnabled(true);
-
 const settingRoutes = await pickDefault(import('./index.js'));
 
 describe('configs action routes', () => {
@@ -76,11 +67,6 @@ describe('configs action routes', () => {
   afterEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
-    setDevFeaturesEnabled(true);
-  });
-
-  afterAll(() => {
-    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
   });
 
   it('GET /configs/actions should return all records', async () => {
@@ -440,24 +426,5 @@ describe('configs action routes', () => {
     expect(response.body.data).toEqual({
       message: 'Socket closed',
     });
-  });
-
-  it('should not register action routes when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
-
-    const requester = createRequester({
-      authedRoutes: settingRoutes,
-      tenantContext: new MockTenant(
-        undefined,
-        { logtoConfigs: logtoConfigQueries },
-        undefined,
-        { quota: mockQuotaLibrary },
-        mockLogtoConfigsLibrary
-      ),
-    });
-
-    const response = await requester.get('/configs/actions');
-
-    expect(response.status).toEqual(404);
   });
 });

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -230,8 +230,5 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
 
   logtoConfigJwtCustomizerRoutes(router, tenant);
   idTokenRoutes(router, tenant);
-
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    logtoConfigActionRoutes(router, tenant);
-  }
+  logtoConfigActionRoutes(router, tenant);
 }

--- a/packages/core/src/routes/logto-config/logto-config.openapi.json
+++ b/packages/core/src/routes/logto-config/logto-config.openapi.json
@@ -323,7 +323,6 @@
       "get": {
         "summary": "Get all actions",
         "description": "Get all action configurations for the tenant.",
-        "tags": ["Dev feature"],
         "responses": {
           "200": {
             "description": "The action configurations."
@@ -335,7 +334,6 @@
       "put": {
         "summary": "Create or update action",
         "description": "Create or update an action configuration for the given action type.",
-        "tags": ["Dev feature"],
         "parameters": [
           {
             "in": "path",
@@ -386,7 +384,6 @@
       "patch": {
         "summary": "Update action",
         "description": "Update the action configuration for the given action type.",
-        "tags": ["Dev feature"],
         "parameters": [
           {
             "in": "path",
@@ -437,7 +434,6 @@
       "get": {
         "summary": "Get action",
         "description": "Get the action configuration for the given action type.",
-        "tags": ["Dev feature"],
         "parameters": [
           {
             "in": "path",
@@ -457,7 +453,6 @@
       "delete": {
         "summary": "Delete action",
         "description": "Delete the action configuration for the given action type.",
-        "tags": ["Dev feature"],
         "parameters": [
           {
             "in": "path",
@@ -479,7 +474,6 @@
       "post": {
         "summary": "Test action",
         "description": "Test an action script with a sample context.",
-        "tags": ["Dev feature"],
         "requestBody": {
           "content": {
             "application/json": {

--- a/packages/core/src/routes/swagger/utils/operation-id.test.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.test.ts
@@ -1,20 +1,8 @@
 import { OpenAPIV3 } from 'openapi-types';
 
-import { EnvSet } from '#src/env-set/index.js';
-
-import { buildOperationId, customRoutes, throwByDifference } from './operation-id.js';
+import { buildOperationId, customRoutes } from './operation-id.js';
 
 describe('buildOperationId', () => {
-  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-  const originalIsProduction = EnvSet.values.isProduction;
-  const originalIsUnitTest = EnvSet.values.isUnitTest;
-
-  afterEach(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
-    Reflect.set(EnvSet.values, 'isProduction', originalIsProduction);
-    Reflect.set(EnvSet.values, 'isUnitTest', originalIsUnitTest);
-  });
-
   it('should return the custom operation id if it exists', () => {
     for (const [path, operationId] of Object.entries(customRoutes)) {
       const [method, pathSegments] = path.split(' ');
@@ -57,19 +45,5 @@ describe('buildOperationId', () => {
     expect(buildOperationId(OpenAPIV3.HttpMethods.GET, '/footballs/:footballId/bars')).toBe(
       'ListFootballBars'
     );
-  });
-
-  it('should ignore dev feature custom routes when dev features are disabled', () => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
-    Reflect.set(EnvSet.values, 'isProduction', false);
-    Reflect.set(EnvSet.values, 'isUnitTest', false);
-
-    const builtCustomRoutes = new Set(
-      Object.keys(customRoutes).filter((route) => !route.includes('/configs/actions'))
-    );
-
-    expect(() => {
-      throwByDifference(builtCustomRoutes);
-    }).not.toThrow();
   });
 });

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -27,15 +27,6 @@ const methodToVerb = Object.freeze({
 
 type RouteDictionary = Record<`${OpenAPIV3.HttpMethods} ${string}`, string>;
 
-const devFeatureCustomRoutes: Readonly<RouteDictionary> = Object.freeze({
-  'get /configs/actions': 'ListActions',
-  'put /configs/actions/:actionType': 'UpsertAction',
-  'patch /configs/actions/:actionType': 'UpdateAction',
-  'get /configs/actions/:actionType': 'GetAction',
-  'delete /configs/actions/:actionType': 'DeleteAction',
-  'post /configs/actions/test': 'TestAction',
-});
-
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   // Authn
   'get /authn/hasura': 'GetHasuraAuth',
@@ -116,7 +107,12 @@ export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   'get /configs/oidc/session': 'GetOidcSessionConfig',
   'patch /configs/oidc/session': 'UpdateOidcSessionConfig',
   // Actions
-  ...(EnvSet.values.isDevFeaturesEnabled ? devFeatureCustomRoutes : {}),
+  'get /configs/actions': 'ListActions',
+  'put /configs/actions/:actionType': 'UpsertAction',
+  'patch /configs/actions/:actionType': 'UpdateAction',
+  'get /configs/actions/:actionType': 'GetAction',
+  'delete /configs/actions/:actionType': 'DeleteAction',
+  'post /configs/actions/test': 'TestAction',
 } satisfies RouteDictionary); // Key assertion doesn't work without `satisfies`
 
 /**
@@ -129,9 +125,7 @@ export const throwByDifference = (builtCustomRoutes: Set<string>) => {
     return;
   }
 
-  const expectedRoutes = Object.entries(customRoutes).filter(
-    ([path]) => EnvSet.values.isDevFeaturesEnabled || !(path in devFeatureCustomRoutes)
-  );
+  const expectedRoutes = Object.entries(customRoutes);
 
   if (shouldThrow() && builtCustomRoutes.size !== expectedRoutes.length) {
     const missingRoutes = expectedRoutes.filter(([path]) => !builtCustomRoutes.has(path));

--- a/packages/integration-tests/src/tests/api/experience-api/actions/post-first-factor-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/actions/post-first-factor-verification.test.ts
@@ -27,7 +27,7 @@ import {
   resetMfaSettings,
 } from '#src/helpers/sign-in-experience.js';
 import { UserApiTest } from '#src/helpers/user.js';
-import { devFeatureTest, generatePassword, generateUsername } from '#src/utils.js';
+import { generatePassword, generateUsername } from '#src/utils.js';
 
 const actionKey = LogtoActionKey.PostFirstFactorVerification;
 
@@ -75,7 +75,7 @@ const runAction = ({ event }) => {
 };
 `;
 
-devFeatureTest.describe('action: post first factor verification', () => {
+describe('action: post first factor verification', () => {
   const userApi = new UserApiTest();
 
   beforeAll(async () => {

--- a/packages/integration-tests/src/tests/api/experience-api/actions/post-sign-in.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/actions/post-sign-in.test.ts
@@ -14,12 +14,12 @@ import {
   enableMandatoryMfaWithTotp,
   resetMfaSettings,
 } from '#src/helpers/sign-in-experience.js';
-import { devFeatureTest, generateName, generatePassword, generateUsername } from '#src/utils.js';
+import { generateName, generatePassword, generateUsername } from '#src/utils.js';
 
 const p1Key = LogtoActionKey.PostFirstFactorVerification;
 const p2Key = LogtoActionKey.PostSignIn;
 
-devFeatureTest.describe('action: post sign-in composition', () => {
+describe('action: post sign-in composition', () => {
   beforeAll(async () => {
     await enableAllPasswordSignInMethods({
       identifiers: [SignInIdentifier.Username],


### PR DESCRIPTION
## Summary

Release the Actions feature (formerly inline hooks) by removing all `isDevFeaturesEnabled` gates related to it.

### Core

- `ActionLibrary.runAction()` no longer early-returns when dev features are disabled.
- `/configs/actions` routes are now always mounted.
- `GET /logs` always includes the `Action` log key prefix.
- The post sign-in action trigger in `ExperienceInteraction` is no longer dev-gated.
- Actions endpoints are exposed in the OpenAPI docs (removed `Dev feature` tags and moved the custom operation IDs into `customRoutes`).

### Console

- `isActionsEnabled` now only depends on the Cloud quota (`actionsEnabled`); OSS always has Actions enabled.
- Action audit log event titles are always registered.

### Tests

- Removed dev-feature toggling from the related unit tests.
- Actions integration tests now run unconditionally (`devFeatureTest.describe` → `describe`).

No changeset by design for this release PR.