### PR TITLE
perf(core): skip signing-key rotation lock when no rotation is due

### DIFF
--- a/packages/core/src/libraries/logto-config.test.ts
+++ b/packages/core/src/libraries/logto-config.test.ts
@@ -1,4 +1,4 @@
-import { LogtoActionKey, type LogtoAction } from '@logto/schemas';
+import { LogtoActionKey, type LogtoAction, type SigningKeyRotationState } from '@logto/schemas';
 import { ConsoleLog } from '@logto/shared';
 
 import { createLogtoConfigLibrary } from './logto-config.js';
@@ -10,13 +10,18 @@ const queryUpsertAction = jest.fn(async (key: LogtoActionKey, value: LogtoAction
   key,
   value,
 }));
+const getSigningKeyRotationState = jest.fn<Promise<SigningKeyRotationState | undefined>, never[]>();
+const poolTransaction = jest.fn();
 
 const createLibrary = () =>
   createLogtoConfigLibrary({
     logtoConfigs: {
       getRowsByKeys,
       upsertAction: queryUpsertAction,
+      getSigningKeyRotationState,
     },
+    pool: { transaction: poolTransaction },
+    wellKnownCache: {},
   } as unknown as Parameters<typeof createLogtoConfigLibrary>[0]);
 
 const action: LogtoAction = {
@@ -105,5 +110,44 @@ describe('Logto config Action', () => {
       ...action,
       enabled: false,
     });
+  });
+});
+
+describe('promoteScheduledSigningKeyRotation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips the locking transaction when no rotation is scheduled', async () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined -- undefined is the query's no-row result under test
+    getSigningKeyRotationState.mockResolvedValueOnce(undefined);
+
+    await createLibrary().promoteScheduledSigningKeyRotation();
+
+    expect(poolTransaction).not.toHaveBeenCalled();
+  });
+
+  it('skips the locking transaction when the rotation state has no scheduled time', async () => {
+    getSigningKeyRotationState.mockResolvedValueOnce({ tenantCacheExpiresAt: Date.now() });
+
+    await createLibrary().promoteScheduledSigningKeyRotation();
+
+    expect(poolTransaction).not.toHaveBeenCalled();
+  });
+
+  it('skips the locking transaction when the scheduled rotation is in the future', async () => {
+    getSigningKeyRotationState.mockResolvedValueOnce({ signingKeyRotationAt: Date.now() + 60_000 });
+
+    await createLibrary().promoteScheduledSigningKeyRotation();
+
+    expect(poolTransaction).not.toHaveBeenCalled();
+  });
+
+  it('opens the locking transaction when a scheduled rotation is due', async () => {
+    getSigningKeyRotationState.mockResolvedValueOnce({ signingKeyRotationAt: Date.now() - 60_000 });
+
+    await createLibrary().promoteScheduledSigningKeyRotation();
+
+    expect(poolTransaction).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/libraries/logto-config.ts
+++ b/packages/core/src/libraries/logto-config.ts
@@ -267,6 +267,18 @@ export const createLogtoConfigLibrary = ({
    * This function is intended to be called before accessing OIDC configs to ensure the key statuses are up-to-date.
    */
   const promoteScheduledSigningKeyRotation = async () => {
+    // Lock-free pre-check so the common bootstrap path skips the `FOR UPDATE` transaction below.
+    // Safe because staged rotations are always scheduled in the future, and the authoritative
+    // check + mutation still runs under the lock.
+    const scheduledRotationState = await getSigningKeyRotationState();
+
+    if (
+      !scheduledRotationState?.signingKeyRotationAt ||
+      scheduledRotationState.signingKeyRotationAt > Date.now()
+    ) {
+      return;
+    }
+
     await pool.transaction(async (connection) => {
       const transactionalQueries = createLogtoConfigQueries(connection, wellKnownCache);
       await transactionalQueries.lockPrivateSigningKeysAndRotationState();


### PR DESCRIPTION
## Summary
Relates to LOG-13872.

`promoteScheduledSigningKeyRotation` runs on every tenant bootstrap (`env-set/index.ts`) and, before this change, always opened a `pool.transaction` and took a `SELECT … FOR UPDATE` on `logto_configs` just to check whether a signing-key rotation was due. A rotation is almost never due, so every bootstrap paid a write-lock transaction for nothing — during a recent EU incident this lock, multiplied across a tenant re-initialization storm, contributed to database CPU saturation.

This adds a cheap lock-free read of the rotation state first, and only enters the locking transaction when `signingKeyRotationAt` is set and due (`<= now`). The authoritative check and mutation are unchanged and still run under the lock.

### Why it's safe
- Staged rotations are always scheduled in the future (`rotatePrivateSigningKeys(..., gracePeriod > 0)`), so the lock-free pre-check can never skip a rotation that just became due.
- Concurrent bootstraps still serialize on the `FOR UPDATE` lock inside the transaction; the second reader re-checks under the lock and no-ops, so promotion stays exactly-once.
- `signingKeyRotationAt` is only read, never modified — it remains load-bearing for tenant-cache invalidation in `isTenantHealthy`.

No changeset: this is an internal performance change with no user-facing behavior difference.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
