### PR TITLE
test(core): harden saml signed authn request coverage

### DIFF
--- a/packages/core/src/routes/sso-connector/signing-key.openapi.json
+++ b/packages/core/src/routes/sso-connector/signing-key.openapi.json
@@ -75,7 +75,7 @@
       },
       "delete": {
         "summary": "Delete an SP signing key",
-        "description": "Delete the given Service Provider signing key. The active key cannot be deleted — activate another key or deactivate this key first.",
+        "description": "Delete the given Service Provider signing key. The active key cannot be deleted — activate a replacement key first, or disable signed authentication requests and deactivate this key.",
         "responses": {
           "204": {
             "description": "The SP signing key was deleted."

--- a/packages/integration-tests/src/tests/api/sso-connectors/sso-connector-signed-authn-request.test.ts
+++ b/packages/integration-tests/src/tests/api/sso-connectors/sso-connector-signed-authn-request.test.ts
@@ -1,4 +1,7 @@
+import { createVerify, X509Certificate } from 'node:crypto';
+
 import { SsoProviderName } from '@logto/schemas';
+import { HTTPError } from 'ky';
 
 import { metadataXml } from '#src/__mocks__/sso-connectors-mock.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -6,6 +9,37 @@ import { SsoConnectorApi } from '#src/api/sso-connector.js';
 import { initExperienceClient } from '#src/helpers/client.js';
 import { expectRejects } from '#src/helpers/index.js';
 import { devFeatureDisabledTest, devFeatureTest, randomString } from '#src/utils.js';
+
+const rsaSha256AlgorithmUri = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+const rsaSha512AlgorithmUri = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
+
+const digestAlgorithms = new Map([
+  [rsaSha256AlgorithmUri, 'RSA-SHA256'],
+  [rsaSha512AlgorithmUri, 'RSA-SHA512'],
+]);
+
+/**
+ * Verify the SAML redirect-binding signature of the authorization URI against a certificate. The
+ * signed octet string is `SAMLRequest=..[&RelayState=..]&SigAlg=..` (URL-encoded, in that order,
+ * `&Signature=` appended after it); the signature is RSASSA-PKCS1-v1_5 with the `SigAlg` digest.
+ */
+const verifyRedirectSignature = (authorizationUri: string, certificate: string): boolean => {
+  const [signedUrl, encodedSignature] = authorizationUri.split('&Signature=');
+  const signatureAlgorithm = new URL(authorizationUri).searchParams.get('SigAlg');
+  const digestAlgorithm = signatureAlgorithm ? digestAlgorithms.get(signatureAlgorithm) : undefined;
+
+  if (!signedUrl || !encodedSignature || !digestAlgorithm) {
+    return false;
+  }
+
+  return createVerify(digestAlgorithm)
+    .update(signedUrl.slice(signedUrl.indexOf('SAMLRequest=')))
+    .verify(
+      new X509Certificate(certificate).publicKey,
+      decodeURIComponent(encodedSignature),
+      'base64'
+    );
+};
 
 describe('SAML SSO signed AuthnRequest', () => {
   const ssoConnectorApi = new SsoConnectorApi();
@@ -21,6 +55,9 @@ describe('SAML SSO signed AuthnRequest', () => {
     });
     return authorizationUri;
   };
+
+  const patchSigningKey = async (keyId: string, active: boolean) =>
+    ssoConnectorApi.updateSigningKeyStatus(ssoConnectorApi.firstConnectorId!, keyId, active);
 
   beforeAll(async () => {
     await ssoConnectorApi.createMockSamlConnector([domain]);
@@ -116,6 +153,21 @@ describe('SAML SSO signed AuthnRequest', () => {
       );
     });
 
+    devFeatureTest.it(
+      'should create a connector with signAuthnRequest explicitly off',
+      async () => {
+        const created = await ssoConnectorApi.create({
+          providerName: SsoProviderName.SAML,
+          connectorName: `test-saml-unsigned-${randomString()}`,
+          domains: [`bar${randomString()}.com`],
+          config: { metadata: metadataXml, signAuthnRequest: false },
+          syncProfile: true,
+        });
+
+        expect(created.config).toHaveProperty('signAuthnRequest', false);
+      }
+    );
+
     devFeatureTest.it('should support graceful rotation via the signing-key routes', async () => {
       const connectorId = ssoConnectorApi.firstConnectorId!;
       // Re-enable signing — the key created earlier is still active, so the validation passes.
@@ -166,11 +218,17 @@ describe('SAML SSO signed AuthnRequest', () => {
 
     devFeatureTest.it('should return 404 for a non-SAML connector', async () => {
       const { id } = await ssoConnectorApi.createMockOidcConnector([`oidc${randomString()}.com`]);
+      const expectedError = { code: 'connector.not_found', status: 404 };
 
-      await expectRejects(ssoConnectorApi.getSigningKeys(id), {
-        code: 'connector.not_found',
-        status: 404,
-      });
+      await Promise.all([
+        expectRejects(ssoConnectorApi.getSigningKeys(id), expectedError),
+        expectRejects(ssoConnectorApi.createSigningKey(id, true), expectedError),
+        expectRejects(
+          ssoConnectorApi.updateSigningKeyStatus(id, 'unknown-key-id', true),
+          expectedError
+        ),
+        expectRejects(ssoConnectorApi.deleteSigningKey(id, 'unknown-key-id'), expectedError),
+      ]);
     });
 
     devFeatureTest.it(
@@ -263,6 +321,120 @@ describe('SAML SSO signed AuthnRequest', () => {
         expect(await getAuthorizationUri()).toContain('Signature=');
       }
     );
+
+    devFeatureTest.it('should treat a same-state signing-key patch as a no-op', async () => {
+      const connectorId = ssoConnectorApi.firstConnectorId!;
+      const [activeKey] = await ssoConnectorApi.getSigningKeys(connectorId);
+      expect(activeKey?.active).toBe(true);
+
+      // Re-activating the active key succeeds without a state change.
+      const { active: reactivated } = await patchSigningKey(activeKey!.id, true);
+      expect(reactivated).toBe(true);
+
+      // Deactivating an already-inactive key while signing is enabled must not trip the in-use
+      // guard — the guard only protects the active key.
+      const stagedKey = await ssoConnectorApi.createSigningKey(connectorId);
+      const { active: stagedActive } = await patchSigningKey(stagedKey.id, false);
+      expect(stagedActive).toBe(false);
+
+      await ssoConnectorApi.deleteSigningKey(connectorId, stagedKey.id);
+      expect(await getAuthorizationUri()).toContain('Signature=');
+    });
+
+    devFeatureTest.it('should return 404 for an unknown or foreign key id', async () => {
+      const connectorId = ssoConnectorApi.firstConnectorId!;
+      const [activeKey] = await ssoConnectorApi.getSigningKeys(connectorId);
+      const expectedError = { code: 'entity.not_found', status: 404 };
+
+      await Promise.all([
+        expectRejects(
+          ssoConnectorApi.updateSigningKeyStatus(connectorId, 'unknown-key-id', true),
+          expectedError
+        ),
+        expectRejects(
+          ssoConnectorApi.deleteSigningKey(connectorId, 'unknown-key-id'),
+          expectedError
+        ),
+      ]);
+
+      // A key must not be reachable through another connector's path.
+      const { id: otherConnectorId } = await ssoConnectorApi.createMockSamlConnector([
+        `baz${randomString()}.com`,
+      ]);
+      expect(await ssoConnectorApi.getSigningKeys(otherConnectorId)).toEqual([]);
+      await Promise.all([
+        expectRejects(
+          ssoConnectorApi.updateSigningKeyStatus(otherConnectorId, activeKey!.id, false),
+          expectedError
+        ),
+        expectRejects(
+          ssoConnectorApi.deleteSigningKey(otherConnectorId, activeKey!.id),
+          expectedError
+        ),
+      ]);
+    });
+
+    devFeatureTest.it('should sign with the configured signature algorithm', async () => {
+      const connectorId = ssoConnectorApi.firstConnectorId!;
+
+      await ssoConnectorApi.update(connectorId, {
+        config: {
+          metadata: metadataXml,
+          signAuthnRequest: true,
+          requestSignatureAlgorithm: rsaSha512AlgorithmUri,
+        },
+      });
+      const [activeKey] = await ssoConnectorApi.getSigningKeys(connectorId);
+      const sha512AuthorizationUri = await getAuthorizationUri();
+      expect(new URL(sha512AuthorizationUri).searchParams.get('SigAlg')).toBe(
+        rsaSha512AlgorithmUri
+      );
+      expect(verifyRedirectSignature(sha512AuthorizationUri, activeKey!.certificate)).toBe(true);
+
+      // A config patch omitting the field removes it and falls back to the default algorithm.
+      await ssoConnectorApi.update(connectorId, {
+        config: { metadata: metadataXml, signAuthnRequest: true },
+      });
+      expect(new URL(await getAuthorizationUri()).searchParams.get('SigAlg')).toBe(
+        rsaSha256AlgorithmUri
+      );
+    });
+
+    devFeatureTest.it('should reject a signature algorithm outside the allowlist', async () => {
+      await expectRejects(
+        ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+          config: {
+            metadata: metadataXml,
+            signAuthnRequest: true,
+            requestSignatureAlgorithm: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+          },
+        }),
+        { code: 'connector.invalid_config', status: 400 }
+      );
+    });
+
+    devFeatureTest.it(
+      'should produce a signature that verifies against the served certificate, also after rotation',
+      async () => {
+        const connectorId = ssoConnectorApi.firstConnectorId!;
+        const [[activeKey], authorizationUri] = await Promise.all([
+          ssoConnectorApi.getSigningKeys(connectorId),
+          getAuthorizationUri(),
+        ]);
+        expect(activeKey?.active).toBe(true);
+        expect(verifyRedirectSignature(authorizationUri, activeKey!.certificate)).toBe(true);
+
+        // A create-active takeover switches signing to the new key immediately.
+        const takeoverKey = await ssoConnectorApi.createSigningKey(connectorId, true);
+        const rotatedAuthorizationUri = await getAuthorizationUri();
+        expect(verifyRedirectSignature(rotatedAuthorizationUri, takeoverKey.certificate)).toBe(
+          true
+        );
+        expect(verifyRedirectSignature(rotatedAuthorizationUri, activeKey!.certificate)).toBe(
+          false
+        );
+      }
+    );
   });
 
   devFeatureDisabledTest.describe('with dev features disabled', () => {
@@ -270,12 +442,49 @@ describe('SAML SSO signed AuthnRequest', () => {
       'should strip the signing fields from the config and keep the request unsigned',
       async () => {
         const updated = await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
-          config: { metadata: metadataXml, signAuthnRequest: true },
+          config: {
+            metadata: metadataXml,
+            signAuthnRequest: true,
+            requestSignatureAlgorithm: rsaSha512AlgorithmUri,
+          },
         });
 
         expect(updated.config).not.toHaveProperty('signAuthnRequest');
+        expect(updated.config).not.toHaveProperty('requestSignatureAlgorithm');
         expect(await getAuthorizationUri()).not.toContain('Signature=');
       }
     );
+
+    devFeatureDisabledTest.it(
+      'should strip the signing fields when creating a connector',
+      async () => {
+        // With dev features enabled the same request is rejected instead (no active key exists).
+        const created = await ssoConnectorApi.create({
+          providerName: SsoProviderName.SAML,
+          connectorName: `test-saml-dev-off-${randomString()}`,
+          domains: [`qux${randomString()}.com`],
+          config: {
+            metadata: metadataXml,
+            signAuthnRequest: true,
+            requestSignatureAlgorithm: rsaSha512AlgorithmUri,
+          },
+          syncProfile: true,
+        });
+
+        expect(created.config).not.toHaveProperty('signAuthnRequest');
+        expect(created.config).not.toHaveProperty('requestSignatureAlgorithm');
+      }
+    );
+
+    devFeatureDisabledTest.it('should not mount the signing-key routes', async () => {
+      // An unmounted route 404s with no Logto error body (which `expectRejects` would need); a
+      // mounted route would return 200 here.
+      const response = await ssoConnectorApi
+        .getSigningKeys(ssoConnectorApi.firstConnectorId!)
+        .catch((error: unknown) => error);
+
+      expect(response).toBeInstanceOf(HTTPError);
+      expect(response instanceof HTTPError && response.response.status).toBe(404);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Completeness pass on the signed-AuthnRequest integration contract suite ahead of bugbash (Refs LOG-13849), plus one openapi wording fix. Stacked on #9287.

### What changed
- `packages/integration-tests/src/tests/api/sso-connectors/sso-connector-signed-authn-request.test.ts`
  - New `verifyRedirectSignature` helper: cryptographically verifies the SAML redirect-binding signature (RSASSA-PKCS1-v1_5 over `SAMLRequest=..[&RelayState=..]&SigAlg=..`) with `node:crypto`, independent of samlify.
  - New dev-features-on cases: signature verifies against the certificate served by `GET /signing-keys`, and after a create-active takeover it verifies against the new certificate but no longer the retired one; same-state signing-key PATCH no-ops in both directions (including toggle-on + already-inactive key, which must not trip the in-use guard); unknown and cross-connector `keyId` → `entity.not_found` 404 for PATCH/DELETE; `requestSignatureAlgorithm` end-to-end (SHA-512 `SigAlg` reflected and cryptographically verified, omission falls back to SHA-256); non-allowlisted algorithm (RSA-SHA1) → `connector.invalid_config` 400; creating a connector with `signAuthnRequest: false` explicitly passes.
  - Extended the non-SAML 404 case from GET to all four verbs.
  - New dev-features-off cases: POST create strips the gated config fields (`requestSignatureAlgorithm` also added to the existing PATCH strip case), and the signing-key routes are not mounted (plain 404).
- `packages/core/src/routes/sso-connector/signing-key.openapi.json`: the DELETE description now names both legal unblock paths (activate a replacement key, or disable signed authentication requests and deactivate).

### Reviewer notes
- The suite runs sequentially against one shared connector; each new test preserves the exact entry state the next test assumes.
- The dev-features-off legs (field strip, routes not mounted) will fail by design when the dev gate is removed — updating them is an explicit step of the gate-removal task (LOG-13894).

## Testing
Integration tests

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments