### PR TITLE
fix(core): close the tenant eviction dispose-before-claim race

### DIFF
--- a/packages/core/src/tenants/index.dispose.test.ts
+++ b/packages/core/src/tenants/index.dispose.test.ts
@@ -1,0 +1,65 @@
+import { createMockUtils } from '@logto/shared/esm';
+
+const { jest } = import.meta;
+const { mockEsm } = createMockUtils(jest);
+
+const tenantCreate = jest.fn();
+const graceResolvers: Array<() => void> = [];
+const graceDelay = jest.fn(
+  async () =>
+    new Promise<void>((resolve) => {
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- capture resolvers to release the grace deterministically
+      graceResolvers.push(resolve);
+    })
+);
+
+mockEsm('node:timers/promises', () => ({ setTimeout: graceDelay }));
+
+mockEsm('#src/caches/index.js', () => ({
+  redisCache: {},
+}));
+
+mockEsm('#src/env-set/index.js', () => ({
+  // Size 1 so a single extra `get` triggers an LRU eviction.
+  EnvSet: { values: { tenantPoolSize: 1 } },
+}));
+
+mockEsm('./Tenant.js', () => ({
+  default: { create: tenantCreate },
+}));
+
+const { tenantPool } = await import('./index.js');
+
+const createMockTenant = () => ({
+  requestStart: jest.fn<boolean, never[]>(() => true),
+  requestEnd: jest.fn(),
+  checkHealth: jest.fn(async () => true),
+  dispose: jest.fn(async () => true),
+});
+
+describe('TenantPool eviction disposal grace', () => {
+  it('defers disposal until the grace elapses without delaying acquisition', async () => {
+    const evicted = createMockTenant();
+    const replacement = createMockTenant();
+    tenantCreate.mockResolvedValueOnce(evicted).mockResolvedValue(replacement);
+
+    await expect(tenantPool.get('tenant-grace-disposal')).resolves.toBe(evicted);
+    // Acquiring the replacement evicts the first entry, yet resolves while that entry's grace
+    // is still pending: the grace never sits on the acquisition path.
+    await expect(tenantPool.get('tenant-grace-neighbor')).resolves.toBe(replacement);
+
+    expect(graceDelay).toHaveBeenCalledWith(expect.any(Number), undefined, { ref: false });
+    expect(evicted.dispose).not.toHaveBeenCalled();
+
+    for (const resolve of graceResolvers) {
+      resolve();
+    }
+    // Yield a macrotask so the released disposal continuation runs.
+    await new Promise((resolve) => {
+      setImmediate(resolve);
+    });
+
+    expect(evicted.dispose).toHaveBeenCalledTimes(1);
+    expect(replacement.dispose).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/tenants/index.test.ts
+++ b/packages/core/src/tenants/index.test.ts
@@ -1,0 +1,129 @@
+import { createMockUtils } from '@logto/shared/esm';
+
+const { jest } = import.meta;
+const { mockEsm } = createMockUtils(jest);
+
+const tenantCreate = jest.fn();
+
+mockEsm('#src/caches/index.js', () => ({
+  redisCache: {},
+}));
+
+mockEsm('#src/env-set/index.js', () => ({
+  // Size 1 so a single extra `get` triggers an LRU eviction (see the eviction race test).
+  EnvSet: { values: { tenantPoolSize: 1 } },
+}));
+
+mockEsm('./Tenant.js', () => ({
+  default: { create: tenantCreate },
+}));
+
+const { tenantPool } = await import('./index.js');
+
+const createMockTenant = () => ({
+  requestStart: jest.fn<boolean, never[]>(() => true),
+  requestEnd: jest.fn(),
+  checkHealth: jest.fn(async () => true),
+  dispose: jest.fn(async () => true),
+});
+
+// The pool is a module-level singleton, so each test uses a distinct tenant id.
+describe('TenantPool.get', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reserves a slot and returns the instance', async () => {
+    const tenant = createMockTenant();
+    tenantCreate.mockResolvedValue(tenant);
+
+    await expect(tenantPool.get('tenant-happy-path')).resolves.toBe(tenant);
+
+    expect(tenantCreate).toHaveBeenCalledTimes(1);
+    expect(tenant.requestStart).toHaveBeenCalledTimes(1);
+    expect(tenant.requestEnd).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds once when the request slot is lost', async () => {
+    const disposed = createMockTenant();
+    disposed.requestStart.mockReturnValue(false);
+    const healthy = createMockTenant();
+
+    tenantCreate.mockResolvedValueOnce(disposed).mockResolvedValue(healthy);
+
+    await expect(tenantPool.get('tenant-lost-slot')).resolves.toBe(healthy);
+
+    expect(tenantCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('releases the reserved slot when the health check throws', async () => {
+    const tenant = createMockTenant();
+    tenant.checkHealth.mockRejectedValue(new Error('health check failed'));
+    tenantCreate.mockResolvedValue(tenant);
+
+    await expect(tenantPool.get('tenant-health-throw')).rejects.toThrow('health check failed');
+
+    expect(tenant.requestStart).toHaveBeenCalledTimes(1);
+    expect(tenant.requestEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers after a rejected creation is evicted', async () => {
+    const healthy = createMockTenant();
+    tenantCreate.mockRejectedValueOnce(new Error('bootstrap failed')).mockResolvedValue(healthy);
+
+    await expect(tenantPool.get('tenant-create-rejected')).rejects.toThrow('bootstrap failed');
+    await expect(tenantPool.get('tenant-create-rejected')).resolves.toBe(healthy);
+
+    expect(tenantCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps an evicted instance claimable until its requester takes the slot', async () => {
+    const evicted = createMockTenant();
+    // Mirror the real instance: once disposed, new request slots are refused.
+    evicted.dispose.mockImplementation(async () => {
+      evicted.requestStart.mockReturnValue(false);
+
+      return true;
+    });
+    const neighbor = createMockTenant();
+    tenantCreate.mockResolvedValueOnce(evicted).mockResolvedValue(neighbor);
+
+    // Push the entry out of the size-1 LRU while the first request is still between its cache
+    // read and its claim. Without the disposal grace period, the eviction hook disposes the
+    // instance first and the tenant is rebuilt.
+    const promise = tenantPool.get('tenant-evicted-before-claim');
+    const neighborPromise = tenantPool.get('tenant-eviction-neighbor');
+
+    await expect(promise).resolves.toBe(evicted);
+    await expect(neighborPromise).resolves.toBe(neighbor);
+
+    // The evicted instance is claimed, not rebuilt.
+    expect(tenantCreate).toHaveBeenCalledTimes(2);
+    expect(evicted.requestStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves a cached instance when reloads never settle', async () => {
+    const createdTenants: Array<ReturnType<typeof createMockTenant>> = [];
+    tenantCreate.mockImplementation(async () => {
+      const tenant = createMockTenant();
+      tenant.checkHealth.mockResolvedValue(false);
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- collect test doubles to assert slot release
+      createdTenants.push(tenant);
+
+      return tenant;
+    });
+
+    // An unhealthy instance reloads rather than losing its slot, so acquisition reaches the
+    // fallback and serves without a health check instead of throwing.
+    const served = await tenantPool.get('tenant-reload');
+
+    expect(tenantCreate).toHaveBeenCalledTimes(11);
+    expect(served).toBe(createdTenants.at(-1));
+
+    // Every stale instance released its probe slot; the served one keeps its slot for the caller.
+    for (const tenant of createdTenants.slice(0, -1)) {
+      expect(tenant.requestEnd).toHaveBeenCalledTimes(1);
+    }
+    expect(served.requestEnd).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/tenants/index.ts
+++ b/packages/core/src/tenants/index.ts
@@ -1,3 +1,5 @@
+import { setTimeout } from 'node:timers/promises';
+
 import { ConsoleLog } from '@logto/shared';
 import chalk from 'chalk';
 import { LRUCache } from 'lru-cache';
@@ -16,16 +18,36 @@ const consoleLog = new ConsoleLog(chalk.magenta('tenant'));
  */
 const maxTenantAcquireAttempts = 10;
 
+/**
+ * How long an evicted tenant instance waits before disposal so requests already holding its
+ * cached promise can reserve their slot first: pending claims are microtasks while this grace
+ * elapses on a timer, so the claims always win. Without it the disposal continuation
+ * deterministically beats the requester's, and an instance evicted before it is claimed is
+ * always rebuilt. Each evicted instance keeps its idle pool open at most this much longer.
+ */
+const evictionDisposeGracePeriod = 1000;
+
 class TenantPool {
   protected cache = new LRUCache<string, Promise<Tenant>>({
     max: EnvSet.values.tenantPoolSize,
-    dispose: (entry) => {
+    dispose: (entry, key, reason) => {
+      // Eviction pressure is a leading incident indicator; keep it observable.
+      consoleLog.info('Dispose cached tenant:', key, 'Reason:', reason);
       void (async () => {
         try {
           const tenant = await entry;
 
+          // `undefined` is the timer's resolution value, present only to reach the options;
+          // the `ref: false` timer cannot keep the process alive on shutdown.
+          await setTimeout(evictionDisposeGracePeriod, undefined, { ref: false });
+
           try {
-            await tenant.dispose();
+            if ((await tenant.dispose()) === 'timeout') {
+              consoleLog.warn(
+                'Tenant disposal drain timed out; pool closed with requests in flight:',
+                key
+              );
+            }
           } catch (error: unknown) {
             consoleLog.warn('Failed to dispose tenant:', error);
           }
@@ -77,6 +99,14 @@ class TenantPool {
     // request uses it, closing the dispose-before-request race.
     if (!tenant.requestStart()) {
       this.deleteCachedTenant(cacheKey, tenantPromise);
+      consoleLog.warn(
+        'Lost tenant request slot; instance was disposed before use:',
+        tenantId,
+        'Custom domain:',
+        customDomain,
+        'Attempt:',
+        attempt
+      );
 
       return this.getWithAttempts(cacheKey, tenantId, customDomain, attempt + 1);
     }
@@ -117,6 +147,12 @@ class TenantPool {
 
     if (!tenant.requestStart()) {
       this.deleteCachedTenant(cacheKey, tenantPromise);
+      consoleLog.warn(
+        'Lost tenant request slot; instance was disposed before use:',
+        tenantId,
+        'Custom domain:',
+        customDomain
+      );
 
       return this.getAfterAttemptLimit(cacheKey, tenantId, customDomain);
     }


### PR DESCRIPTION
## Summary

The tenant LRU cache stores pending `Promise<Tenant>` entries, and the eviction dispose hook awaits the same promise as the requester. When an entry is evicted before it is claimed, the hook's continuation reaches `dispose()` one await hop before the requester reaches `requestStart()`, so the claim is lost deterministically: the entry is deleted and the tenant rebuilt, and each rebuild evicts another live entry. Under eviction pressure this feeds itself (2026-07-28 EU incident: 10-12 tenant inits per arriving request on the affected instance, with most requests never completing).

### What changed

- `packages/core/src/tenants/index.ts`: the eviction dispose hook now waits a short unref'd grace (`evictionDisposeGracePeriod = 1000` ms) after the evicted entry resolves before disposing it. Pending claims are microtasks and the grace is a macrotask timer, so claims always win; `dispose()` then defers to its existing request drain as usual. Also adds a warn on the previously silent `requestStart()`-false paths, an info log per cache disposal with the LRU reason (`evict` / `set` / `delete`), and a warn when a disposal drain times out with requests still in flight.
- `packages/core/src/tenants/index.test.ts` / `index.dispose.test.ts`: unit tests covering the eviction race (the key test fails without the grace), disposal being deferred rather than cancelled (with the `ref: false` timer pinned via a mocked timer), slot release on health-check throw and on reload, and recovery after a rejected creation.

### Expected result

- The happy path (cache hit → claim → serve) is untouched; the dispose hook does not run on it.
- An instance evicted between its cache read and its claim is now claimed instead of rebuilt, so eviction pressure no longer amplifies into a rebuild storm.
- Cost: an evicted instance keeps its idle pool open up to 1s longer (roughly one idle connection each); `endAll()` and the 130s drain timeout are unchanged.

### Reviewer notes

- Retry bounds for the lost-slot paths are deliberately out of scope and tracked in LOG-13938; this PR only adds visibility on those paths.
- No changeset: the practical impact is cloud multi-tenant deployments.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments