### PR TITLE
fix(core): bound tenant rebuilds with a dedicated slot-loss budget

### DIFF
--- a/packages/core/src/tenants/index.test.ts
+++ b/packages/core/src/tenants/index.test.ts
@@ -56,6 +56,118 @@ describe('TenantPool.get', () => {
     expect(tenantCreate).toHaveBeenCalledTimes(2);
   });
 
+  it('gives up when the slot is lost on every attempt', async () => {
+    tenantCreate.mockImplementation(async () => {
+      const tenant = createMockTenant();
+      tenant.requestStart.mockReturnValue(false);
+
+      return tenant;
+    });
+
+    // The full message pins the cache-key identity and the loss count.
+    await expect(tenantPool.get('tenant-budget-exhausted')).rejects.toThrow(
+      'Failed to acquire a usable tenant instance: tenant-budget-exhausted-default (lost slots: 4)'
+    );
+
+    // The initial build plus `maxTenantRebuildAttempts` rebuilds, and no more.
+    expect(tenantCreate).toHaveBeenCalledTimes(4);
+  });
+
+  it('terminates when the fallback keeps losing the slot', async () => {
+    tenantCreate.mockImplementation(async () => {
+      const tenant = createMockTenant();
+
+      // Reloads drive acquisition to the fallback, which then keeps losing the slot.
+      if (tenantCreate.mock.calls.length > 10) {
+        tenant.requestStart.mockReturnValue(false);
+      } else {
+        tenant.checkHealth.mockResolvedValue(false);
+      }
+
+      return tenant;
+    });
+
+    await expect(tenantPool.get('tenant-fallback-lost-slot')).rejects.toThrow(
+      /Failed to acquire a usable tenant instance/
+    );
+
+    // The initial build, 10 health-check reloads, then 3 bounded rebuilds in the fallback.
+    expect(tenantCreate).toHaveBeenCalledTimes(14);
+  });
+
+  it('recovers in the fallback when a lost slot settles on the next build', async () => {
+    const createdTenants: Array<ReturnType<typeof createMockTenant>> = [];
+    tenantCreate.mockImplementation(async () => {
+      const tenant = createMockTenant();
+      const call = tenantCreate.mock.calls.length;
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- collect test doubles to assert the served instance
+      createdTenants.push(tenant);
+
+      // Reloads exhaust the acquire budget, the fallback loses its first slot, then recovers.
+      if (call === 11) {
+        tenant.requestStart.mockReturnValue(false);
+      } else if (call <= 10) {
+        tenant.checkHealth.mockResolvedValue(false);
+      }
+
+      return tenant;
+    });
+
+    const served = await tenantPool.get('tenant-fallback-recovery');
+
+    // The initial build, 10 health-check reloads, then one rebuild after the lost slot.
+    expect(tenantCreate).toHaveBeenCalledTimes(12);
+    expect(served).toBe(createdTenants.at(-1));
+    // The fallback serves without consulting the health check.
+    expect(served.checkHealth).not.toHaveBeenCalled();
+  });
+
+  it('grants the fallback a fresh rebuild budget', async () => {
+    tenantCreate.mockImplementation(async () => {
+      const tenant = createMockTenant();
+      const call = tenantCreate.mock.calls.length;
+
+      // Two early losses, then reloads until the acquire budget runs out, then losses again:
+      // the fallback must not inherit the main path's spent losses.
+      if (call <= 2 || call >= 11) {
+        tenant.requestStart.mockReturnValue(false);
+      } else {
+        tenant.checkHealth.mockResolvedValue(false);
+      }
+
+      return tenant;
+    });
+
+    await expect(tenantPool.get('tenant-fallback-budget')).rejects.toThrow(
+      /Failed to acquire a usable tenant instance/
+    );
+
+    // Two lost builds, a fresh build plus 8 reloads, then 3 fallback rebuilds: the fallback
+    // restarted the loss budget at zero.
+    expect(tenantCreate).toHaveBeenCalledTimes(14);
+  });
+
+  it('keeps the rebuild budget when reloads precede a lost slot', async () => {
+    tenantCreate.mockImplementation(async () => {
+      const tenant = createMockTenant();
+      const call = tenantCreate.mock.calls.length;
+
+      // Three stale instances, then one lost slot, then a healthy instance: reloads must not
+      // consume the rebuild budget, so the lost slot still gets its retry.
+      if (call <= 3) {
+        tenant.checkHealth.mockResolvedValue(false);
+      } else if (call === 4) {
+        tenant.requestStart.mockReturnValue(false);
+      }
+
+      return tenant;
+    });
+
+    await expect(tenantPool.get('tenant-reloads-then-loss')).resolves.toBeTruthy();
+
+    expect(tenantCreate).toHaveBeenCalledTimes(5);
+  });
+
   it('releases the reserved slot when the health check throws', async () => {
     const tenant = createMockTenant();
     tenant.checkHealth.mockRejectedValue(new Error('health check failed'));

--- a/packages/core/src/tenants/index.ts
+++ b/packages/core/src/tenants/index.ts
@@ -19,6 +19,15 @@ const consoleLog = new ConsoleLog(chalk.magenta('tenant'));
 const maxTenantAcquireAttempts = 10;
 
 /**
+ * Safety cap on rebuilds after losing the request slot, applied per phase (the attempt-limit
+ * fallback restarts its own count). Only slot losses consume it; health-check reloads spend
+ * the shared {@link maxTenantAcquireAttempts} budget instead. The eviction disposal grace
+ * makes losing a slot exceptional, so this is the backstop that bounds one acquisition to at
+ * most 14 builds (a pure loss storm fails after 4) instead of recursing forever.
+ */
+const maxTenantRebuildAttempts = 3;
+
+/**
  * How long an evicted tenant instance waits before disposal so requests already holding its
  * cached promise can reserve their slot first: pending claims are microtasks while this grace
  * elapses on a timer, so the claims always win. Without it the disposal continuation
@@ -67,7 +76,7 @@ class TenantPool {
   async get(tenantId: string, customDomain?: string): Promise<Tenant> {
     const cacheKey = `${tenantId}-${customDomain ?? 'default'}`;
 
-    return this.getWithAttempts(cacheKey, tenantId, customDomain, 0);
+    return this.getWithAttempts(cacheKey, tenantId, customDomain, 0, 0);
   }
 
   async endAll(): Promise<void> {
@@ -80,14 +89,22 @@ class TenantPool {
     );
   }
 
+  /**
+   * @param attempt Acquisition attempts spent so far, incremented by reloads and slot losses.
+   * @param lostSlots Request slots lost so far; {@link maxTenantRebuildAttempts} bounds the
+   * rebuilds they trigger.
+   */
+  // eslint-disable-next-line max-params -- two separate retry budgets plus the cache identity
   private async getWithAttempts(
     cacheKey: string,
     tenantId: string,
     customDomain: string | undefined,
-    attempt: number
+    attempt: number,
+    lostSlots: number
   ): Promise<Tenant> {
     if (attempt >= maxTenantAcquireAttempts) {
-      return this.getAfterAttemptLimit(cacheKey, tenantId, customDomain);
+      // The fallback counts its own slot losses from zero.
+      return this.getAfterAttemptLimit(cacheKey, tenantId, customDomain, 0);
     }
 
     const { tenantPromise } = this.getOrCreateTenant(cacheKey, tenantId, customDomain);
@@ -105,10 +122,18 @@ class TenantPool {
         'Custom domain:',
         customDomain,
         'Attempt:',
-        attempt
+        attempt,
+        'Lost slots:',
+        lostSlots + 1
       );
 
-      return this.getWithAttempts(cacheKey, tenantId, customDomain, attempt + 1);
+      if (lostSlots >= maxTenantRebuildAttempts) {
+        throw new Error(
+          `Failed to acquire a usable tenant instance: ${cacheKey} (lost slots: ${lostSlots + 1})`
+        );
+      }
+
+      return this.getWithAttempts(cacheKey, tenantId, customDomain, attempt + 1, lostSlots + 1);
     }
 
     // If the current LRU cached tenant instance is still healthy, return it (slot held).
@@ -132,13 +157,19 @@ class TenantPool {
       this.createAndCacheTenant(cacheKey, tenantId, customDomain, 'Reload');
     }
 
-    return this.getWithAttempts(cacheKey, tenantId, customDomain, attempt + 1);
+    // Reloads consume the shared acquire budget but not the rebuild budget.
+    return this.getWithAttempts(cacheKey, tenantId, customDomain, attempt + 1, lostSlots);
   }
 
+  /**
+   * @param lostSlots Request slots lost in the fallback; {@link maxTenantRebuildAttempts}
+   * bounds the rebuilds they trigger.
+   */
   private async getAfterAttemptLimit(
     cacheKey: string,
     tenantId: string,
-    customDomain: string | undefined
+    customDomain: string | undefined,
+    lostSlots: number
   ): Promise<Tenant> {
     // Attempt limit reached: reserve a slot on whatever is cached, dropping a disposed instance
     // with an identity check so a racing replacement is not removed accidentally.
@@ -151,10 +182,18 @@ class TenantPool {
         'Lost tenant request slot; instance was disposed before use:',
         tenantId,
         'Custom domain:',
-        customDomain
+        customDomain,
+        'Fallback lost slots:',
+        lostSlots + 1
       );
 
-      return this.getAfterAttemptLimit(cacheKey, tenantId, customDomain);
+      if (lostSlots >= maxTenantRebuildAttempts) {
+        throw new Error(
+          `Failed to acquire a usable tenant instance: ${cacheKey} (lost slots: ${lostSlots + 1})`
+        );
+      }
+
+      return this.getAfterAttemptLimit(cacheKey, tenantId, customDomain, lostSlots + 1);
     }
 
     consoleLog.warn(


### PR DESCRIPTION
## Summary

Stacked on #9299; restores the termination guarantees split out of that PR, with the counter semantics its review demanded: a dedicated slot-loss budget instead of the shared attempt counter.

### What changed

- `packages/core/src/tenants/index.ts`: threads a `lostSlots` counter through `getWithAttempts` alongside the shared `attempt` counter and bounds both lost-slot paths at `maxTenantRebuildAttempts = 3`. Health-check reloads consume only the shared acquire budget, so reload churn can never trigger the bound. The attempt-limit fallback, previously able to recurse without bound, restarts its own loss budget and throws after exhausting it. Warns and thrown errors carry the cache key and the inclusive loss count.
- `packages/core/src/tenants/index.test.ts`: restores the two termination tests (4 and 14 builds), and adds three pins: mixed ordering (3 reloads + 1 lost slot recovers instead of throwing, the defect that kept the bound out of #9299), fallback loss-then-recovery (serves without a health check after one lost slot), and the fallback's fresh budget after main-path losses.

### Expected result

Worst-case budgets per acquisition, by failure mix:

| Scenario | Builds before failing |
| --- | --- |
| Pure slot-loss storm | 4 (initial + 3 rebuilds; throws on the 4th loss, never reaches the acquire limit) |
| Reloads exhaust the acquire budget, then fallback losses | 14 (1 init + 10 reloads + 3 fallback rebuilds) — the global maximum |
| Loss-driven rebuilds specifically | at most 3 + 3 = 6 across the two phases |

- The throw surfaces through `trySafe` in `app/init.ts` as a logged 500 with an appInsights exception; it cannot crash the process, and no request slot is held when it fires.
- Reload-heavy acquisition and the happy path are unchanged.
- With #9299's disposal grace underneath, losing a slot should be near-impossible; these bounds are the backstop that converts the previous infinite-recursion hang into bounded work plus a visible error.

### Reviewer notes

- The two lost-slot warns are distinguishable ('Attempt' + 'Lost slots' on the main path, 'Fallback lost slots' in the fallback), so logs can tell which loop is spinning.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments