### PR TITLE
fix(core): negative-cache unknown tenants to protect the shared pool

### DIFF
--- a/packages/core/src/tenants/index.test.ts
+++ b/packages/core/src/tenants/index.test.ts
@@ -18,7 +18,7 @@ mockEsm('./Tenant.js', () => ({
   default: { create: tenantCreate },
 }));
 
-const { tenantPool } = await import('./index.js');
+const { tenantPool, TenantNotFoundError } = await import('./index.js');
 
 const createMockTenant = () => ({
   requestStart: jest.fn<boolean, never[]>(() => true),
@@ -30,6 +30,7 @@ const createMockTenant = () => ({
 // The pool is a module-level singleton, so each test uses a distinct tenant id.
 describe('TenantPool.get', () => {
   afterEach(() => {
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -166,6 +167,58 @@ describe('TenantPool.get', () => {
     await expect(tenantPool.get('tenant-reloads-then-loss')).resolves.toBeTruthy();
 
     expect(tenantCreate).toHaveBeenCalledTimes(5);
+  });
+
+  it('serves repeated unknown-tenant requests from the negative cache', async () => {
+    const healthy = createMockTenant();
+    tenantCreate.mockImplementation(async ({ id }: { id: string }) => {
+      if (id === 'tenant-unknown') {
+        throw new TenantNotFoundError('Cannot find valid tenant credentials for ID tenant-unknown');
+      }
+
+      return healthy;
+    });
+
+    await expect(tenantPool.get('tenant-unknown')).rejects.toThrow(TenantNotFoundError);
+    // Cache-served rejections stay distinguishable from fresh lookups in logs.
+    await expect(tenantPool.get('tenant-unknown')).rejects.toThrow(
+      'Cannot find valid tenant credentials for ID tenant-unknown (negative cache)'
+    );
+    // The negative entry covers the tenant across custom domains as well.
+    await expect(tenantPool.get('tenant-unknown', 'https://x.io')).rejects.toThrow(
+      TenantNotFoundError
+    );
+
+    // Only the first unknown-tenant request performs a lookup (and logs `Init tenant`).
+    expect(tenantCreate).toHaveBeenCalledTimes(1);
+
+    // Other tenants are unaffected while the negative entry is live.
+    await expect(tenantPool.get('tenant-unknown-neighbor')).resolves.toBe(healthy);
+    expect(tenantCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries an unknown tenant after the negative entry expires', async () => {
+    const healthy = createMockTenant();
+    tenantCreate
+      .mockRejectedValueOnce(
+        new TenantNotFoundError('Cannot find valid tenant credentials for ID tenant-provisioned')
+      )
+      .mockResolvedValue(healthy);
+
+    await expect(tenantPool.get('tenant-provisioned')).rejects.toThrow(TenantNotFoundError);
+
+    const realNow = Date.now();
+    const nowSpy = jest.spyOn(Date, 'now');
+
+    // Still cached just inside the TTL.
+    nowSpy.mockReturnValue(realNow + 59_000);
+    await expect(tenantPool.get('tenant-provisioned')).rejects.toThrow(TenantNotFoundError);
+    expect(tenantCreate).toHaveBeenCalledTimes(1);
+
+    // A tenant provisioned within the TTL becomes reachable once the entry expires.
+    nowSpy.mockReturnValue(realNow + 61_000);
+    await expect(tenantPool.get('tenant-provisioned')).resolves.toBe(healthy);
+    expect(tenantCreate).toHaveBeenCalledTimes(2);
   });
 
   it('releases the reserved slot when the health check throws', async () => {

--- a/packages/core/src/tenants/index.ts
+++ b/packages/core/src/tenants/index.ts
@@ -8,6 +8,7 @@ import { redisCache } from '#src/caches/index.js';
 import { EnvSet } from '#src/env-set/index.js';
 
 import Tenant from './Tenant.js';
+import { TenantNotFoundError } from './utils.js';
 
 const consoleLog = new ConsoleLog(chalk.magenta('tenant'));
 
@@ -35,6 +36,23 @@ const maxTenantRebuildAttempts = 3;
  * always rebuilt. Each evicted instance keeps its idle pool open at most this much longer.
  */
 const evictionDisposeGracePeriod = 1000;
+
+/**
+ * How long a {@link TenantNotFoundError} outcome is served from memory before the shared
+ * `tenants` table is consulted again. Unknown-tenant probes are unauthenticated and would
+ * otherwise cost a shared-pool query (plus an `Init tenant` log) per request; the answer is
+ * deterministic (it changes only when the tenant is provisioned), so a short TTL caps that
+ * load while keeping a newly provisioned tenant reachable promptly. A tenant whose id was
+ * probed before its insert committed — possible when the id is user-chosen rather than
+ * generated — can keep serving 404 for up to this long after creation.
+ */
+const tenantNotFoundCacheTtl = 60_000;
+
+/**
+ * Upper bound on tracked unknown-tenant ids. The key space is unauthenticated and
+ * attacker-supplied, so this cap is what bounds memory under an id-spraying probe flood.
+ */
+const tenantNotFoundCacheSize = 1000;
 
 class TenantPool {
   protected cache = new LRUCache<string, Promise<Tenant>>({
@@ -68,12 +86,35 @@ class TenantPool {
   });
 
   /**
+   * Expiry timestamps for tenant ids that recently failed with {@link TenantNotFoundError},
+   * keyed by tenant id rather than cache key since existence is domain-independent. Expiry is
+   * checked manually against `Date.now()` — lru-cache's built-in `ttl` runs on
+   * `performance.now()`, which the expiry test cannot drive.
+   */
+  protected notFoundCache = new LRUCache<string, number>({ max: tenantNotFoundCacheSize });
+
+  /**
    * Resolve a tenant instance and atomically reserve a request slot on it (see
    * {@link Tenant.requestStart}). The caller owns the slot and must call
    * {@link Tenant.requestEnd} exactly once when the request finishes. Acquisition retries to
-   * converge on a healthy instance, with a capped fallback to avoid looping forever.
+   * converge on a healthy instance, with a capped fallback to avoid looping forever. Tenant
+   * ids that recently failed with {@link TenantNotFoundError} rethrow from a short-lived
+   * negative cache without a new lookup.
    */
   async get(tenantId: string, customDomain?: string): Promise<Tenant> {
+    const notFoundExpiresAt = this.notFoundCache.get(tenantId);
+
+    if (notFoundExpiresAt !== undefined) {
+      if (Date.now() < notFoundExpiresAt) {
+        // The suffix keeps cache-served rejections distinguishable in logs and telemetry.
+        throw new TenantNotFoundError(
+          `Cannot find valid tenant credentials for ID ${tenantId} (negative cache)`
+        );
+      }
+
+      this.notFoundCache.delete(tenantId);
+    }
+
     const cacheKey = `${tenantId}-${customDomain ?? 'default'}`;
 
     return this.getWithAttempts(cacheKey, tenantId, customDomain, 0, 0);
@@ -108,7 +149,7 @@ class TenantPool {
     }
 
     const { tenantPromise } = this.getOrCreateTenant(cacheKey, tenantId, customDomain);
-    const tenant = await this.resolveCachedTenant(cacheKey, tenantPromise);
+    const tenant = await this.resolveCachedTenant(cacheKey, tenantId, tenantPromise);
 
     // Reserve a request slot *before* the async health check. If the instance has been
     // disposed concurrently, `requestStart()` returns `false` and we retry to acquire a
@@ -174,7 +215,7 @@ class TenantPool {
     // Attempt limit reached: reserve a slot on whatever is cached, dropping a disposed instance
     // with an identity check so a racing replacement is not removed accidentally.
     const { tenantPromise } = this.getOrCreateTenant(cacheKey, tenantId, customDomain);
-    const tenant = await this.resolveCachedTenant(cacheKey, tenantPromise);
+    const tenant = await this.resolveCachedTenant(cacheKey, tenantId, tenantPromise);
 
     if (!tenant.requestStart()) {
       this.deleteCachedTenant(cacheKey, tenantPromise);
@@ -241,6 +282,7 @@ class TenantPool {
 
   private async resolveCachedTenant(
     cacheKey: string,
+    tenantId: string,
     tenantPromise: Promise<Tenant>
   ): Promise<Tenant> {
     try {
@@ -248,6 +290,12 @@ class TenantPool {
     } catch (error: unknown) {
       if (this.cache.get(cacheKey) === tenantPromise) {
         this.cache.delete(cacheKey);
+      }
+
+      // Only the deterministic "tenant does not exist" outcome is negative-cached;
+      // transient creation failures stay uncached so the next request retries.
+      if (error instanceof TenantNotFoundError) {
+        this.notFoundCache.set(tenantId, Date.now() + tenantNotFoundCacheTtl);
       }
 
       throw error;

--- a/packages/core/src/tenants/utils.ts
+++ b/packages/core/src/tenants/utils.ts
@@ -13,7 +13,9 @@ import { z } from 'zod';
 import { EnvSet } from '#src/env-set/index.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 
-export class TenantNotFoundError extends Error {}
+export class TenantNotFoundError extends Error {
+  name = 'TenantNotFoundError';
+}
 
 const { table: logtoConfigsTable, fields: logtoConfigFields } = convertToIdentifiers(LogtoConfigs);
 


### PR DESCRIPTION
## Summary

Stacked on #9300. Requests for tenants that do not exist re-ran the full bootstrap on every request, forever: an `Init tenant` log, a query against the shared `tenants` table, and a pool-creation attempt (~100-500 per 15 minutes steady-state). An unauthenticated caller probing `https://<random>.logto.app/...` drives unbounded shared-pool load at zero cost to itself.

### What changed

- `packages/core/src/tenants/index.ts`: `TenantPool` gains a bounded negative cache (1,000 entries, 60s TTL) of tenant ids whose creation failed with `TenantNotFoundError`. `get()` short-circuits an unexpired entry with a fresh `TenantNotFoundError` carrying a `(negative cache)` message suffix, so cached rejections stay distinguishable in logs and App Insights. Keyed by tenant id, since existence is domain-independent - one entry covers all custom-domain variants. Expiry is a manual `Date.now()` check: lru-cache's built-in `ttl` runs on `performance.now()`, which the expiry test cannot drive. Only `TenantNotFoundError` populates the cache; transient failures keep today's retry behavior.
- `packages/core/src/tenants/utils.ts`: `TenantNotFoundError` now sets `name`, so telemetry groups it as its own type instead of generic `Error` (newly relevant with a second construction site).
- `packages/core/src/tenants/index.test.ts`: cache-served rejections (message, custom-domain coverage, cross-tenant isolation) and both TTL boundaries via a `Date.now` spy.

### Expected result

- Repeated unknown-tenant probes cost one shared-pool lookup per 60s window instead of one per request. Cached 404s still emit the per-request error log and App Insights exception, but no `Init tenant` line - init metrics stay meaningful.
- A tenant provisioned while its id is negative-cached becomes reachable within 60s of creation.
- The happy path is unchanged (one LRU read added before the tenant-cache lookup).

### Reviewer notes

- User-chosen tenant ids (Private Cloud) can be probed before their insert commits; the new tenant then 404s for up to the 60s TTL. This is documented in the TTL JSDoc. The region-lookup worker re-fans-out until the entry expires (it never caches failures), so the window is TTL-bounded. Plumbing a status-API-key bypass into `tenantPool.get` was considered and deliberately left out to keep this surgical.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments