### PR TITLE
fix(console): download saml certificates with a pem extension

### DIFF
--- a/packages/console/src/components/SamlCertificateTable/CertificateActionMenu.tsx
+++ b/packages/console/src/components/SamlCertificateTable/CertificateActionMenu.tsx
@@ -30,7 +30,9 @@ function CertificateActionMenu({
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   const onDownload = useCallback(() => {
-    downloadText(certificate, buildDownloadFilename(id), 'application/x-x509-ca-cert');
+    // The explicit `.pem` extension keeps the file acceptable to IdP certificate-upload pickers
+    // (e.g. Okta rejects the browser-invented extension of an extension-less download).
+    downloadText(certificate, `${buildDownloadFilename(id)}.pem`, 'application/x-x509-ca-cert');
   }, [buildDownloadFilename, certificate, id]);
 
   return (

--- a/packages/console/src/components/SamlCertificateTable/index.tsx
+++ b/packages/console/src/components/SamlCertificateTable/index.tsx
@@ -31,6 +31,7 @@ type Props = {
   readonly data: CertificateData[];
   readonly isLoading: boolean;
   readonly errorMessage?: string;
+  /** Builds the certificate download filename (without extension) for the given key id. */
   readonly buildDownloadFilename: (id: string) => string;
   readonly onDelete: (id: string) => void;
   readonly onActivate: (id: string) => void;


### PR DESCRIPTION
## Summary
Relates to LOG-13939 (bug-bash finding). SAML certificate downloads from the console had no file extension, so the browser invented one from the MIME type and identity-provider certificate upload pickers (e.g. Okta's Signature Certificate field) rejected the file, even though the content is valid PEM.

The fix appends `.pem` once at the shared download call site in `SamlCertificateTable/CertificateActionMenu.tsx`, covering both consumers — the SAML application certificates page and the (dev-gated) enterprise SSO signing-key table. The `buildDownloadFilename` prop is documented as returning the base name without extension.

## Testing
Tested locally — a `.pem`-named download of the same content was verified accepted by Okta's certificate upload during the bug bash.

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments