### PR TITLE
fix(core): keep OIDC interaction redirects under the endpoint base path

### DIFF
--- a/.changeset/oidc-interaction-base-path.md
+++ b/.changeset/oidc-interaction-base-path.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+keep OIDC interaction redirects under the endpoint base path
+
+When Logto is served under a sub-path endpoint (for example `ENDPOINT=https://my.host/logto`), the sign-in and consent interaction redirects no longer escape to the host root. Root-mounted endpoints are unchanged.

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -37,6 +37,7 @@ import postgresAdapter from '#src/oidc/adapter.js';
 import {
   buildSharedExperienceCookie,
   buildConsentPromptUrl,
+  buildInteractionRedirectPath,
   buildLoginPromptUrl,
   isOriginAllowed,
   readOptionalQueryString,
@@ -265,13 +266,21 @@ export default function initOidc(
           );
         }
 
+        // Prefix the endpoint's base path so the interaction redirect stays under a
+        // sub-path deployment (e.g. ENDPOINT=https://my.host/logto) instead of escaping
+        // to the host root. Root-mounted endpoints resolve to the same path as before.
+        const { pathname: endpointPathname } = envSet.endpoint;
+
         switch (prompt.name) {
           case 'login': {
-            return '/' + buildLoginPromptUrl(params, sharedParams);
+            return buildInteractionRedirectPath(
+              endpointPathname,
+              buildLoginPromptUrl(params, sharedParams)
+            );
           }
 
           case 'consent': {
-            return '/' + buildConsentPromptUrl(appId);
+            return buildInteractionRedirectPath(endpointPathname, buildConsentPromptUrl(appId));
           }
 
           default: {

--- a/packages/core/src/oidc/utils.test.ts
+++ b/packages/core/src/oidc/utils.test.ts
@@ -15,6 +15,7 @@ import {
   getConstantClientMetadata,
   validateCustomClientMetadata,
   buildLoginPromptUrl,
+  buildInteractionRedirectPath,
   parseSharedExperienceParams,
 } from './utils.js';
 
@@ -432,5 +433,23 @@ describe('parseSharedExperienceParams', () => {
     ).toEqual({
       organizationId: 'org_123',
     });
+  });
+});
+
+describe('buildInteractionRedirectPath', () => {
+  it('leaves a root-mounted endpoint unchanged', () => {
+    expect(buildInteractionRedirectPath('/', 'sign-in?app_id=foo')).toBe('/sign-in?app_id=foo');
+    expect(buildInteractionRedirectPath('', 'consent')).toBe('/consent');
+  });
+
+  it('prefixes a sub-path endpoint', () => {
+    expect(buildInteractionRedirectPath('/logto', 'sign-in')).toBe('/logto/sign-in');
+    expect(buildInteractionRedirectPath('/logto', 'sign-in?app_id=foo')).toBe(
+      '/logto/sign-in?app_id=foo'
+    );
+  });
+
+  it('normalises a trailing slash on the base path', () => {
+    expect(buildInteractionRedirectPath('/logto/', 'register')).toBe('/logto/register');
   });
 });

--- a/packages/core/src/oidc/utils.ts
+++ b/packages/core/src/oidc/utils.ts
@@ -389,3 +389,19 @@ export const buildConsentPromptUrl = (appId?: unknown): string => {
 
   return experience.routes.consent + searchParamString;
 };
+
+/**
+ * Prefix an interaction prompt path (e.g. `sign-in?app_id=foo` from
+ * {@link buildLoginPromptUrl} / {@link buildConsentPromptUrl}) with the
+ * endpoint's base path, so the OIDC provider's interaction redirect stays under
+ * a sub-path deployment (e.g. `ENDPOINT=https://my.host/logto`) instead of
+ * escaping to the host root. Returns a root-relative path; a root-mounted
+ * endpoint (pathname `/`) is unchanged, keeping existing deployments identical.
+ *
+ * @param endpointPathname The endpoint URL pathname, i.e. `EnvSet.endpoint.pathname`.
+ * @param promptPath The relative prompt path (no leading slash).
+ */
+export const buildInteractionRedirectPath = (
+  endpointPathname: string,
+  promptPath: string
+): string => `${endpointPathname.replace(/\/+$/, '')}/${promptPath}`;


### PR DESCRIPTION
## Summary

When Logto is served under a sub-path endpoint (for example `ENDPOINT=https://my.host/logto`), the OIDC provider's `interactions.url` returns root-absolute paths (`/sign-in`, `/consent`), ignoring the endpoint's base path. The interaction flow then redirects to the host root and escapes the sub-path, so sign-in cannot complete.

This is an inconsistency rather than a missing capability: the OIDC issuer already honours a sub-path endpoint (`env-set` builds it via `appendPath(endpoint, '/oidc')`), so discovery and authorize work under the sub-path, but the interaction redirect does not follow.

## What this changes

- Adds a small helper `buildInteractionRedirectPath(endpointPathname, promptPath)` in `packages/core/src/oidc/utils.ts` that prefixes the endpoint's base path.
- Uses it at the two `interactions.url` call sites in `packages/core/src/oidc/init.ts` (`login` and `consent`).
- Adds unit tests for the helper (root-mounted, sub-path, trailing-slash cases).
- Adds a changeset (`@logto/core` patch).

Backward compatible: a root-mounted endpoint (pathname `/`) produces exactly the same paths as before (`/sign-in`, `/consent`), so existing deployments are unchanged. The base-path branch only activates when `ENDPOINT` actually contains a path.

## Scope

This is a focused fix for the interaction-redirect layer only. Full "deploy under a sub-path" (#1969) additionally needs the Admin Console and experience SPA asset base to honour the endpoint path, which is a separate change and intentionally not included here, to keep this PR small and safe. This is a self-contained step in that direction.

I am aware #1969 is currently labelled `status/not-planned`, so I am opening this as a draft for maintainer feedback. Happy to adjust the approach, split it further, or close it if the direction is not wanted. If it is a fit, I am also glad to look at the asset-base piece as a follow-up.

Refs #1969.

## Testing

Added unit tests in `packages/core/src/oidc/utils.test.ts` covering the new helper. Left as a draft so CI can validate the full suite. Happy to add an integration test for the sub-path interaction redirect if you would like one.
