### PR TITLE
feat(core): support a runtime Admin Console base path

### DIFF
--- a/.changeset/runtime-console-base.md
+++ b/.changeset/runtime-console-base.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+support a runtime Admin Console base path
+
+The console's asset base is baked in at build time via `CONSOLE_PUBLIC_URL` (Vite `base`), so a prebuilt image cannot be served under a different sub-path without a rebuild. When built with `--build-arg console_runtime_base=true`, the console is built with a sentinel base that the container entrypoint rewrites to the runtime `CONSOLE_PUBLIC_URL` (default `/console`) at startup. Default builds are unaffected and the entrypoint is a no-op for them. This covers the asset base only; serving the console under a non-default path also requires core's mount path to match, which is out of scope here.

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,17 @@ ENV APPLICATIONINSIGHTS_CONNECTION_STRING=${applicationinsights_connection_strin
 ARG logto_oss_survey_endpoint=
 ENV LOGTO_OSS_SURVEY_ENDPOINT=${logto_oss_survey_endpoint}
 
-RUN pnpm -r build
+### Optionally build the Admin Console with a runtime-substitutable base ###
+# `CONSOLE_PUBLIC_URL` is Vite's `base`, baked in at build time. Building with a
+# sentinel base lets docker-entrypoint.sh rewrite it to the runtime value, so a
+# single prebuilt image (e.g. a hardened, third-party-built one) can be served
+# under any base path. Default builds are unaffected.
+ARG console_runtime_base=
+RUN if [ -n "$console_runtime_base" ]; then \
+      CONSOLE_PUBLIC_URL=/__LOGTO_CONSOLE_BASE__ pnpm -r build; \
+    else \
+      pnpm -r build; \
+    fi
 
 ### Add official connectors ###
 ARG additional_connector_args
@@ -55,5 +65,9 @@ ENV PRIVATE_KEY_ROTATION_GRACE_PERIOD=${private_key_rotation_grace_period}
 COPY --from=builder /etc/logto .
 RUN mkdir -p /etc/logto/packages/cli/alteration-scripts && chmod g+w /etc/logto/packages/cli/alteration-scripts
 EXPOSE 3001
-ENTRYPOINT ["npm", "run"]
+RUN chmod +x docker-entrypoint.sh
+# The entrypoint rewrites the Admin Console's sentinel base to the runtime
+# CONSOLE_PUBLIC_URL (no-op unless built with --build-arg console_runtime_base=true),
+# then execs `npm run <cmd>`.
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["start"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Logto container entrypoint.
+#
+# Runtime Admin Console base path. The console is a Vite SPA whose asset base is
+# baked in at build time (`CONSOLE_PUBLIC_URL` -> Vite `base`), which prevents a
+# single prebuilt image from being served under different sub-paths (a real
+# constraint when the image is produced by a third party, e.g. a hardened-image
+# supplier, and only consumed downstream).
+#
+# When the image is built with `--build-arg console_runtime_base=true`, the
+# console is built with a sentinel base instead. This entrypoint rewrites that
+# sentinel to the runtime `CONSOLE_PUBLIC_URL` (default `/console`) before the
+# server starts, so one image works under any base path. Default images are not
+# built with the sentinel, so this is a no-op for them.
+set -e
+
+sentinel="/__LOGTO_CONSOLE_BASE__"
+console_dist="node_modules/@logto/console/dist"
+runtime_base="${CONSOLE_PUBLIC_URL:-/console}"
+# Vite's sentinel base carries no trailing slash; normalise the runtime value to match.
+runtime_base="${runtime_base%/}"
+
+if [ -d "$console_dist" ] && grep -rlq "$sentinel" "$console_dist" 2>/dev/null; then
+  echo "[entrypoint] Setting Admin Console base path: ${runtime_base}"
+  # The base only appears in the emitted text assets (JS/CSS/HTML), including the
+  # `import.meta.env.BASE_URL` string the router basename derives from.
+  find "$console_dist" -type f \( -name '*.js' -o -name '*.css' -o -name '*.html' \) \
+    -exec sed -i "s#${sentinel}#${runtime_base}#g" {} +
+  # koa-send serves pre-compressed .br/.gz variants when present, and sed cannot
+  # edit those, so they would still carry the sentinel. Drop them so the rewritten
+  # uncompressed assets are served instead. (Re-compressing after the rewrite would
+  # preserve on-the-wire size but needs brotli/gzip in the image; left as a follow-up.)
+  find "$console_dist" -type f \( -name '*.br' -o -name '*.gz' \) -delete
+fi
+
+exec npm run "$@"


### PR DESCRIPTION
## Summary

`CONSOLE_PUBLIC_URL` sets the Admin Console's Vite `base`, which is baked into the build (asset URLs, the dynamic-import chunk loader, and `import.meta.env.BASE_URL`, which the router basename derives from). It is read only at build time, so a **prebuilt image cannot be served under a different base path without a rebuild**. That is a real constraint when the image is produced by a third party (for example a hardened-image supplier) and only consumed downstream.

## What this changes

- Adds an opt-in build arg `console_runtime_base`. When set, the console is built with a sentinel base (`/__LOGTO_CONSOLE_BASE__`).
- Adds `docker-entrypoint.sh`, which at container start:
  1. rewrites that sentinel to the runtime `CONSOLE_PUBLIC_URL` (default `/console`) across the built console assets, then
  2. drops the stale pre-compressed `.br`/`.gz` variants (`koa-send` serves those by default and they cannot be edited in place, so they would otherwise carry the old base), then
  3. execs the original command.
- Default builds do not set the sentinel, so the entrypoint is a no-op for them and existing images are unchanged.

Result: one prebuilt image can be served under any Admin Console asset base by setting `CONSOLE_PUBLIC_URL` at container start.

## Scope and a known coupling

This covers the **asset base only**. Serving the console under a non-default path also requires core's **serving mount** to match: today the console is mounted at a hardcoded `/console` (`AdminApps.Console`) in `Tenant.ts`, plus the `koaSpaProxy` prefix, the CSP path matching in `koa-security-headers`, and `mountedApps`. Making the full serving path runtime-configurable is a larger change and intentionally out of scope here. On an own-host deployment (console at `/console` on its own host) the default already works and this change is not needed.

## Verified locally

Built the console with the sentinel base, then applied the entrypoint logic:
- The sentinel lands in every emitted text asset (1 html, 4 css, 12 js); all `index.html` asset URLs use it; `import.meta.env.BASE_URL` is baked as the sentinel 41 times (so the router basename follows).
- Risk check found zero root-absolute `/assets` or `/console` refs that do not use the sentinel, so the rewrite surface is complete.
- After rewriting to `/logto-admin/console` and dropping the 672 `.br`/`.gz` variants: zero sentinels remain, zero compressed variants remain, and all asset URLs and `BASE_URL` occurrences point at the runtime base.

Not yet run through a full `docker build` in CI; happy to add a build-and-run check.

## Open questions

Opening as a draft for maintainer feedback on the approach:
- Sentinel plus entrypoint rewrite (this PR) vs a serve-time HTML rewrite in `koa-spa-proxy`, vs Vite `experimental.renderBuiltUrl` with a runtime global.
- Dropping the pre-compressed variants trades on-the-wire size for correctness; re-compressing after the rewrite would preserve it but needs brotli/gzip in the image. Happy to add if preferred.
- A read-only root filesystem would need the console dist on a writable path for the in-place rewrite.

Refs #1969. Companion to #9303 (OIDC interaction redirects under a base path).
