### PR TITLE
test(connector): add sendMessage test cases for SMSAero

### DIFF
--- a/packages/connectors/connector-smsaero/src/index.test.ts
+++ b/packages/connectors/connector-smsaero/src/index.test.ts
@@ -1,12 +1,156 @@
+import got from 'got';
+import nock from 'nock';
+
+import { ConnectorErrorCodes, TemplateType } from '@logto/connector-kit';
+
+import { endpoint } from './constant.js';
 import createConnector from './index.js';
 import { mockedConfig } from './mock.js';
 
-const getConfig = vi.fn().mockResolvedValue(mockedConfig);
+const getConfig = vi.fn();
+const createSendMessage = async () => {
+  const connector = await createConnector({ getConfig });
+
+  return connector.sendMessage;
+};
 
 describe('SMSAero SMS connector', () => {
   it('init without throwing errors', async () => {
     await expect(createConnector({ getConfig })).resolves.not.toThrow();
   });
 
-  // TODO: add test cases
+  describe('sendMessage()', () => {
+    beforeAll(() => {
+      nock.disableNetConnect();
+    });
+
+    afterAll(() => {
+      nock.enableNetConnect();
+    });
+
+    beforeEach(() => {
+      getConfig.mockReset();
+      getConfig.mockResolvedValue(mockedConfig);
+    });
+
+    afterEach(() => {
+      nock.cleanAll();
+      vi.restoreAllMocks();
+    });
+
+    it('should send message successfully', async () => {
+      const sendMessage = await createSendMessage();
+      const scope = nock(endpoint)
+        .post('', {
+          number: '13800138000',
+          sign: mockedConfig.senderName,
+          text: 'This is for testing purposes only. Your verification code is 1234.',
+        })
+        .basicAuth({ user: mockedConfig.email, pass: mockedConfig.apiKey })
+        .reply(200, { id: 1, from: mockedConfig.senderName, number: '13800138000', status: 0 });
+
+      await expect(
+        sendMessage({
+          to: '13800138000',
+          type: TemplateType.Generic,
+          payload: { code: '1234' },
+        })
+      ).resolves.not.toThrow();
+
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('should send message with custom config', async () => {
+      const sendMessage = await createSendMessage();
+      const customConfig = {
+        ...mockedConfig,
+        senderName: 'custom-sender',
+      };
+      const scope = nock(endpoint)
+        .post('', {
+          number: '13800138000',
+          sign: 'custom-sender',
+          text: 'This is for testing purposes only. Your verification code is 5678.',
+        })
+        .reply(200, { id: 2, status: 0 });
+
+      await expect(
+        sendMessage(
+          {
+            to: '13800138000',
+            type: TemplateType.Generic,
+            payload: { code: '5678' },
+          },
+          customConfig
+        )
+      ).resolves.not.toThrow();
+
+      expect(getConfig).not.toHaveBeenCalled();
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('should throw TemplateNotFound when template is not configured', async () => {
+      const sendMessage = await createSendMessage();
+
+      await expect(
+        sendMessage({
+          to: '13800138000',
+          type: TemplateType.SignIn,
+          payload: { code: '1234' },
+        })
+      ).rejects.toMatchObject({ code: ConnectorErrorCodes.TemplateNotFound });
+    });
+
+    it('should throw TemplateNotFound when custom config lacks the template', async () => {
+      const sendMessage = await createSendMessage();
+
+      await expect(
+        sendMessage(
+          {
+            to: '13800138000',
+            type: TemplateType.SignIn,
+            payload: { code: '1234' },
+          },
+          {
+            ...mockedConfig,
+            templates: [{ usageType: 'Register', content: 'register {{code}}' }],
+          }
+        )
+      ).rejects.toMatchObject({ code: ConnectorErrorCodes.TemplateNotFound });
+    });
+
+    it('should throw General error for HTTP error response', async () => {
+      const sendMessage = await createSendMessage();
+
+      const scope = nock(endpoint).post('').reply(400, 'some error body');
+
+      await expect(
+        sendMessage({
+          to: '13800138000',
+          type: TemplateType.Generic,
+          payload: { code: '1234' },
+        })
+      ).rejects.toMatchObject({
+        code: ConnectorErrorCodes.General,
+        data: { message: 'some error body' },
+      });
+
+      expect(scope.isDone()).toBeTruthy();
+    });
+
+    it('should rethrow unknown error', async () => {
+      const sendMessage = await createSendMessage();
+      const error = new Error('unknown error');
+
+      vi.spyOn(got, 'post').mockRejectedValueOnce(error);
+
+      await expect(
+        sendMessage({
+          to: '13800138000',
+          type: TemplateType.Generic,
+          payload: { code: '1234' },
+        })
+      ).rejects.toThrow(error);
+    });
+  });
 });

--- a/packages/connectors/connector-smsaero/src/index.test.ts
+++ b/packages/connectors/connector-smsaero/src/index.test.ts
@@ -95,7 +95,7 @@ describe('SMSAero SMS connector', () => {
       await expect(
         sendMessage({
           to: '13800138000',
-          type: TemplateType.SignIn,
+          type: TemplateType.OrganizationInvitation,
           payload: { code: '1234' },
         })
       ).rejects.toMatchObject({ code: ConnectorErrorCodes.TemplateNotFound });
@@ -108,12 +108,17 @@ describe('SMSAero SMS connector', () => {
         sendMessage(
           {
             to: '13800138000',
-            type: TemplateType.SignIn,
+            type: TemplateType.OrganizationInvitation,
             payload: { code: '1234' },
           },
           {
             ...mockedConfig,
-            templates: [{ usageType: 'Register', content: 'register {{code}}' }],
+            templates: [
+              { usageType: 'Register', content: 'register {{code}}' },
+              { usageType: 'SignIn', content: 'sign in {{code}}' },
+              { usageType: 'ForgotPassword', content: 'forgot password {{code}}' },
+              { usageType: 'Generic', content: 'generic {{code}}' },
+            ],
           }
         )
       ).rejects.toMatchObject({ code: ConnectorErrorCodes.TemplateNotFound });

--- a/packages/connectors/connector-smsaero/src/index.test.ts
+++ b/packages/connectors/connector-smsaero/src/index.test.ts
@@ -1,4 +1,4 @@
-import got from 'got';
+import { got } from 'got';
 import nock from 'nock';
 
 import { ConnectorErrorCodes, TemplateType } from '@logto/connector-kit';

--- a/packages/connectors/connector-smsaero/src/mock.ts
+++ b/packages/connectors/connector-smsaero/src/mock.ts
@@ -10,6 +10,19 @@ export const mockedConfig: SmsAeroConfig = {
   senderName: mockedSenderName,
   templates: [
     {
+      usageType: 'SignIn',
+      content: 'This is for testing purposes only. Your sign-in verification code is {{code}}.',
+    },
+    {
+      usageType: 'Register',
+      content: 'This is for testing purposes only. Your sign-up verification code is {{code}}.',
+    },
+    {
+      usageType: 'ForgotPassword',
+      content:
+        'This is for testing purposes only. Your password change verification code is {{code}}.',
+    },
+    {
       usageType: 'Generic',
       content: 'This is for testing purposes only. Your verification code is {{code}}.',
     },


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add comprehensive sendMessage() test suites for the SMSAero SMS connector covering:

Successful message send with full HTTP payload and auth header verification
Custom config override (inputConfig path) with assertion that getConfig is not called
TemplateNotFound when the required template is missing from the connector config
TemplateNotFound when a custom config lacks the template
General error on HTTP error response with raw body propagation
Unknown (non-HTTP) error rethrown as-is
Also fixes dead-code initialization of the getConfig mock (vi.fn().mockResolvedValue(...) → vi.fn()) — the resolved value was immediately overwritten in beforeEach.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Unit tests

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] unit tests
