### PR TITLE
ci: disable OIDC SSRF protection for console target in alteration tests

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -70,6 +70,8 @@ jobs:
     env:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: false
+      # Allow Console tests to use the local backchannel logout mock server.
+      OIDC_PROVIDER_SSRF_PROTECTION_DISABLED: ${{ matrix.target == 'console' }}
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres


### PR DESCRIPTION
## Summary

#9249 enabled OIDC provider SSRF protection by default and added the `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED` env to the integration test workflow so that Console tests can reach the local backchannel logout mock server. The alteration compatibility integration test workflow runs the same Console test target but was missing this env, so all its runs fail.

This PR adds the same env to the alteration compatibility workflow.

## Testing

N/A (workflow-only change; this workflow only runs on PRs containing alteration changes)

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)