### PR TITLE
feat(core,schemas): add CIMD permission ceiling tables

### DIFF
--- a/packages/core/src/queries/cimd.ts
+++ b/packages/core/src/queries/cimd.ts
@@ -1,0 +1,165 @@
+import { type UserScope } from '@logto/core-kit';
+import {
+  CimdOrganizationResourceScopes,
+  CimdOrganizationScopes,
+  CimdResourceScopes,
+  CimdUserScopes,
+  OrganizationScopes,
+  Resources,
+  Scopes,
+  type OrganizationScope,
+  type Scope,
+} from '@logto/schemas';
+import { sql, type CommonQueryMethods } from '@silverhand/slonik';
+
+import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
+import { DeletionError } from '#src/errors/SlonikError/index.js';
+import { convertToIdentifiers } from '#src/utils/sql.js';
+
+/**
+ * Queries for the tenant-level client ID metadata document (CIMD) permission ceiling relations.
+ * All tables are tenant-owned; row-level security scopes every query to the current tenant.
+ */
+export const createCimdQueries = (pool: CommonQueryMethods) => {
+  const insertUserScopes = buildInsertIntoWithPool(pool)(CimdUserScopes, {
+    onConflict: { ignore: true },
+  });
+  const insertResourceScopes = buildInsertIntoWithPool(pool)(CimdResourceScopes, {
+    onConflict: { ignore: true },
+  });
+  const insertOrganizationScopes = buildInsertIntoWithPool(pool)(CimdOrganizationScopes, {
+    onConflict: { ignore: true },
+  });
+  const insertOrganizationResourceScopes = buildInsertIntoWithPool(pool)(
+    CimdOrganizationResourceScopes,
+    { onConflict: { ignore: true } }
+  );
+
+  const findAllUserScopes = async (): Promise<UserScope[]> => {
+    const { table, fields } = convertToIdentifiers(CimdUserScopes);
+    const rows = await pool.any<{ userScope: UserScope }>(sql`
+      select ${fields.userScope}
+      from ${table}
+    `);
+    return rows.map(({ userScope }) => userScope);
+  };
+
+  const deleteUserScope = async (userScope: string) => {
+    const { table, fields } = convertToIdentifiers(CimdUserScopes);
+    const { rowCount } = await pool.query(sql`
+      delete from ${table}
+      where ${fields.userScope} = ${userScope}
+    `);
+    if (rowCount < 1) {
+      throw new DeletionError(CimdUserScopes.table);
+    }
+  };
+
+  const findAllResourceScopes = async (): Promise<readonly Scope[]> => {
+    const relation = convertToIdentifiers(CimdResourceScopes, true);
+    const scopes = convertToIdentifiers(Scopes, true);
+    return pool.any<Scope>(sql`
+      select ${scopes.table}.*
+      from ${relation.table}
+      join ${scopes.table} on ${scopes.fields.id} = ${relation.fields.scopeId}
+    `);
+  };
+
+  const findAllOrganizationResourceScopes = async (): Promise<readonly Scope[]> => {
+    const relation = convertToIdentifiers(CimdOrganizationResourceScopes, true);
+    const scopes = convertToIdentifiers(Scopes, true);
+    return pool.any<Scope>(sql`
+      select ${scopes.table}.*
+      from ${relation.table}
+      join ${scopes.table} on ${scopes.fields.id} = ${relation.fields.scopeId}
+    `);
+  };
+
+  const findResourceScopesByIndicator = async (indicator: string): Promise<readonly Scope[]> => {
+    const relation = convertToIdentifiers(CimdResourceScopes, true);
+    const scopes = convertToIdentifiers(Scopes, true);
+    const resources = convertToIdentifiers(Resources, true);
+    return pool.any<Scope>(sql`
+      select ${scopes.table}.*
+      from ${relation.table}
+      join ${scopes.table} on ${scopes.fields.id} = ${relation.fields.scopeId}
+      join ${resources.table} on ${resources.fields.id} = ${scopes.fields.resourceId}
+      where ${resources.fields.indicator} = ${indicator}
+    `);
+  };
+
+  const findOrganizationResourceScopesByIndicator = async (
+    indicator: string
+  ): Promise<readonly Scope[]> => {
+    const relation = convertToIdentifiers(CimdOrganizationResourceScopes, true);
+    const scopes = convertToIdentifiers(Scopes, true);
+    const resources = convertToIdentifiers(Resources, true);
+    return pool.any<Scope>(sql`
+      select ${scopes.table}.*
+      from ${relation.table}
+      join ${scopes.table} on ${scopes.fields.id} = ${relation.fields.scopeId}
+      join ${resources.table} on ${resources.fields.id} = ${scopes.fields.resourceId}
+      where ${resources.fields.indicator} = ${indicator}
+    `);
+  };
+
+  const deleteResourceScope = async (scopeId: string) => {
+    const { table, fields } = convertToIdentifiers(CimdResourceScopes);
+    const { rowCount } = await pool.query(sql`
+      delete from ${table}
+      where ${fields.scopeId} = ${scopeId}
+    `);
+    if (rowCount < 1) {
+      throw new DeletionError(CimdResourceScopes.table);
+    }
+  };
+
+  const findAllOrganizationScopes = async (): Promise<readonly OrganizationScope[]> => {
+    const relation = convertToIdentifiers(CimdOrganizationScopes, true);
+    const organizationScopes = convertToIdentifiers(OrganizationScopes, true);
+    return pool.any<OrganizationScope>(sql`
+      select ${organizationScopes.table}.*
+      from ${relation.table}
+      join ${organizationScopes.table} on ${organizationScopes.fields.id} = ${relation.fields.organizationScopeId}
+    `);
+  };
+
+  const deleteOrganizationScope = async (organizationScopeId: string) => {
+    const { table, fields } = convertToIdentifiers(CimdOrganizationScopes);
+    const { rowCount } = await pool.query(sql`
+      delete from ${table}
+      where ${fields.organizationScopeId} = ${organizationScopeId}
+    `);
+    if (rowCount < 1) {
+      throw new DeletionError(CimdOrganizationScopes.table);
+    }
+  };
+
+  const deleteOrganizationResourceScope = async (scopeId: string) => {
+    const { table, fields } = convertToIdentifiers(CimdOrganizationResourceScopes);
+    const { rowCount } = await pool.query(sql`
+      delete from ${table}
+      where ${fields.scopeId} = ${scopeId}
+    `);
+    if (rowCount < 1) {
+      throw new DeletionError(CimdOrganizationResourceScopes.table);
+    }
+  };
+
+  return {
+    insertUserScopes,
+    insertResourceScopes,
+    insertOrganizationScopes,
+    insertOrganizationResourceScopes,
+    findAllUserScopes,
+    deleteUserScope,
+    findAllResourceScopes,
+    findAllOrganizationResourceScopes,
+    findResourceScopesByIndicator,
+    findOrganizationResourceScopesByIndicator,
+    deleteResourceScope,
+    findAllOrganizationScopes,
+    deleteOrganizationScope,
+    deleteOrganizationResourceScope,
+  };
+};

--- a/packages/core/src/tenants/Queries.ts
+++ b/packages/core/src/tenants/Queries.ts
@@ -6,6 +6,7 @@ import { ApplicationSecretQueries } from '#src/queries/application-secrets.js';
 import createApplicationSignInExperienceQueries from '#src/queries/application-sign-in-experience.js';
 import { createApplicationQueries } from '#src/queries/application.js';
 import { createApplicationsRolesQueries } from '#src/queries/applications-roles.js';
+import { createCimdQueries } from '#src/queries/cimd.js';
 import { createConnectorQueries } from '#src/queries/connector.js';
 import { createCustomPhraseQueries } from '#src/queries/custom-phrase.js';
 import { createCustomProfileFieldsQueries } from '#src/queries/custom-profile-fields.js';
@@ -96,6 +97,7 @@ export default class Queries {
   sentinelActivities = createSentinelActivitiesQueries(this.pool);
   oidcSessionExtensions = new OidcSessionExtensionsQueries(this.pool);
   secrets = new SecretQuery(this.pool);
+  cimd = createCimdQueries(this.pool);
 
   constructor(
     public readonly pool: CommonQueryMethods,

--- a/packages/schemas/alterations/next-1785382818-add-cimd-permission-ceiling-tables.ts
+++ b/packages/schemas/alterations/next-1785382818-add-cimd-permission-ceiling-tables.ts
@@ -1,0 +1,89 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    // Support tenant-aware composite foreign keys from tenant-owned scope relations.
+    await pool.query(sql`
+      alter table scopes
+        add constraint scopes__tenant_id_id
+          unique (tenant_id, id);
+
+      alter table organization_scopes
+        add constraint organization_scopes__tenant_id_id
+          unique (tenant_id, id);
+    `);
+
+    await pool.query(sql`
+      create table cimd_user_scopes (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        user_scope varchar(64) not null,
+        primary key (tenant_id, user_scope)
+      );
+    `);
+    await applyTableRls(pool, 'cimd_user_scopes');
+
+    await pool.query(sql`
+      create table cimd_resource_scopes (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        scope_id varchar(21) not null,
+        primary key (tenant_id, scope_id),
+        foreign key (tenant_id, scope_id)
+          references scopes (tenant_id, id)
+          on update cascade on delete cascade
+      );
+    `);
+    await applyTableRls(pool, 'cimd_resource_scopes');
+
+    await pool.query(sql`
+      create table cimd_organization_scopes (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        organization_scope_id varchar(21) not null,
+        primary key (tenant_id, organization_scope_id),
+        foreign key (tenant_id, organization_scope_id)
+          references organization_scopes (tenant_id, id)
+          on update cascade on delete cascade
+      );
+    `);
+    await applyTableRls(pool, 'cimd_organization_scopes');
+
+    await pool.query(sql`
+      create table cimd_organization_resource_scopes (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        scope_id varchar(21) not null,
+        primary key (tenant_id, scope_id),
+        foreign key (tenant_id, scope_id)
+          references scopes (tenant_id, id)
+          on update cascade on delete cascade
+      );
+    `);
+    await applyTableRls(pool, 'cimd_organization_resource_scopes');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'cimd_organization_resource_scopes');
+    await dropTableRls(pool, 'cimd_organization_scopes');
+    await dropTableRls(pool, 'cimd_resource_scopes');
+    await dropTableRls(pool, 'cimd_user_scopes');
+    await pool.query(sql`
+      drop table cimd_organization_resource_scopes;
+      drop table cimd_organization_scopes;
+      drop table cimd_resource_scopes;
+      drop table cimd_user_scopes;
+
+      alter table organization_scopes
+        drop constraint organization_scopes__tenant_id_id;
+
+      alter table scopes
+        drop constraint scopes__tenant_id_id;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/cimd_organization_resource_scopes.sql
+++ b/packages/schemas/tables/cimd_organization_resource_scopes.sql
@@ -1,0 +1,14 @@
+/* init_order = 3 */
+
+/** The organization API resource scopes (permissions) that client ID metadata document (CIMD) clients of the tenant can request. The scopes are granted to users through organization roles. */
+create table cimd_organization_resource_scopes (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  /** The globally unique identifier of the API resource scope. */
+  scope_id varchar(21) not null,
+  primary key (tenant_id, scope_id),
+  /** The tenant-aware composite foreign key guarantees the referenced scope belongs to the same tenant. */
+  foreign key (tenant_id, scope_id)
+    references scopes (tenant_id, id)
+    on update cascade on delete cascade
+);

--- a/packages/schemas/tables/cimd_organization_scopes.sql
+++ b/packages/schemas/tables/cimd_organization_scopes.sql
@@ -1,0 +1,14 @@
+/* init_order = 2 */
+
+/** The organization scopes (permissions) that client ID metadata document (CIMD) clients of the tenant can request. */
+create table cimd_organization_scopes (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  /** The globally unique identifier of the organization scope. */
+  organization_scope_id varchar(21) not null,
+  primary key (tenant_id, organization_scope_id),
+  /** The tenant-aware composite foreign key guarantees the referenced organization scope belongs to the same tenant. */
+  foreign key (tenant_id, organization_scope_id)
+    references organization_scopes (tenant_id, id)
+    on update cascade on delete cascade
+);

--- a/packages/schemas/tables/cimd_resource_scopes.sql
+++ b/packages/schemas/tables/cimd_resource_scopes.sql
@@ -1,0 +1,14 @@
+/* init_order = 3 */
+
+/** The API resource scopes (permissions) that client ID metadata document (CIMD) clients of the tenant can request. */
+create table cimd_resource_scopes (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  /** The globally unique identifier of the API resource scope. */
+  scope_id varchar(21) not null,
+  primary key (tenant_id, scope_id),
+  /** The tenant-aware composite foreign key guarantees the referenced scope belongs to the same tenant. */
+  foreign key (tenant_id, scope_id)
+    references scopes (tenant_id, id)
+    on update cascade on delete cascade
+);

--- a/packages/schemas/tables/cimd_user_scopes.sql
+++ b/packages/schemas/tables/cimd_user_scopes.sql
@@ -1,0 +1,10 @@
+/* init_order = 2 */
+
+/** The user scopes (permissions) that client ID metadata document (CIMD) clients of the tenant can request. */
+create table cimd_user_scopes (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  /** The unique UserScope enum value @see (@logto/core-kit/open-id.js) for more details */
+  user_scope varchar(64) not null,
+  primary key (tenant_id, user_scope)
+);

--- a/packages/schemas/tables/organization_scopes.sql
+++ b/packages/schemas/tables/organization_scopes.sql
@@ -12,7 +12,10 @@ create table organization_scopes (
   description varchar(256),
   primary key (id),
   constraint organization_scopes__name
-    unique (tenant_id, name)
+    unique (tenant_id, name),
+  /** Support tenant-aware composite foreign keys from tenant-owned scope relations. */
+  constraint organization_scopes__tenant_id_id
+    unique (tenant_id, id)
 );
 
 create index organization_scopes__id

--- a/packages/schemas/tables/scopes.sql
+++ b/packages/schemas/tables/scopes.sql
@@ -11,7 +11,10 @@ create table scopes (
   created_at timestamptz not null default(now()),
   primary key (id),
   constraint scopes__resource_id_name
-    unique (tenant_id, resource_id, name)
+    unique (tenant_id, resource_id, name),
+  /** Support tenant-aware composite foreign keys from tenant-owned scope relations. */
+  constraint scopes__tenant_id_id
+    unique (tenant_id, id)
 );
 
 create index scopes__id


### PR DESCRIPTION
## Summary

Add the tenant-wide permission ceiling data model for CIMD (OAuth Client ID Metadata Documents) clients. CIMD clients are not registered in Logto, so there is no per-client object to attach consent configuration to — the ceiling is defined per tenant and shared by all CIMD clients of that tenant.

- Four relation tables mirroring the third-party `application_user_consent_*` family, with the owner switched from application to tenant: `cimd_user_scopes`, `cimd_resource_scopes`, `cimd_organization_scopes`, and `cimd_organization_resource_scopes`. They reference `tenants` and the scope tables directly (not the CIMD config row), so disabling CIMD later will not wipe permission settings.
- New `(tenant_id, id)` unique constraints on `scopes` and `organization_scopes` to back tenant-aware composite foreign keys: a referenced scope is guaranteed to belong to the same tenant, and ceiling rows cascade on scope deletion.
- Alteration script (with standard tenant RLS) and the `cimd` query factory in core. The queries store scope IDs; the OAuth runtime will resolve them to scope names via joins in follow-up PRs.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
