### PR TITLE
feat: add cimd management api for feature switch and consent scopes

### DIFF
--- a/packages/core/src/queries/cimd.ts
+++ b/packages/core/src/queries/cimd.ts
@@ -11,26 +11,19 @@ import {
 } from '@logto/schemas';
 import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 
+import { buildBatchInsertIntoWithPool } from '#src/database/insert-into.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 
 const cimdUserScopes = convertToIdentifiers(CimdUserScopes, true);
 
 const createUserScopeQueries = (pool: CommonQueryMethods) => {
-  const insert = async (userScopes: readonly UserScope[]) => {
-    if (userScopes.length === 0) {
-      return;
-    }
+  const batchInsert = buildBatchInsertIntoWithPool(pool)(CimdUserScopes, {
+    onConflict: { ignore: true },
+  });
 
-    await pool.query(sql`
-      insert into ${cimdUserScopes.table} (${sql.identifier([CimdUserScopes.fields.userScope])})
-      values ${sql.join(
-        userScopes.map((userScope) => sql`(${userScope})`),
-        sql`, `
-      )}
-      on conflict do nothing
-    `);
-  };
+  const insert = async (userScopes: readonly UserScope[]) =>
+    batchInsert(userScopes.map((userScope) => ({ userScope })));
 
   const findAll = async (): Promise<UserScope[]> => {
     const rows = await pool.any<{ userScope: UserScope }>(sql`
@@ -57,20 +50,12 @@ const cimdResourceScopes = convertToIdentifiers(CimdResourceScopes, true);
 const scopes = convertToIdentifiers(Scopes, true);
 
 const createResourceScopeQueries = (pool: CommonQueryMethods) => {
-  const insert = async (scopeIds: readonly string[]) => {
-    if (scopeIds.length === 0) {
-      return;
-    }
+  const batchInsert = buildBatchInsertIntoWithPool(pool)(CimdResourceScopes, {
+    onConflict: { ignore: true },
+  });
 
-    await pool.query(sql`
-      insert into ${cimdResourceScopes.table} (${sql.identifier([CimdResourceScopes.fields.scopeId])})
-      values ${sql.join(
-        scopeIds.map((scopeId) => sql`(${scopeId})`),
-        sql`, `
-      )}
-      on conflict do nothing
-    `);
-  };
+  const insert = async (scopeIds: readonly string[]) =>
+    batchInsert(scopeIds.map((scopeId) => ({ scopeId })));
 
   const findAll = async (): Promise<readonly Scope[]> =>
     pool.any<Scope>(sql`
@@ -96,22 +81,12 @@ const cimdOrganizationScopes = convertToIdentifiers(CimdOrganizationScopes, true
 const organizationScopes = convertToIdentifiers(OrganizationScopes, true);
 
 const createOrganizationScopeQueries = (pool: CommonQueryMethods) => {
-  const insert = async (organizationScopeIds: readonly string[]) => {
-    if (organizationScopeIds.length === 0) {
-      return;
-    }
+  const batchInsert = buildBatchInsertIntoWithPool(pool)(CimdOrganizationScopes, {
+    onConflict: { ignore: true },
+  });
 
-    await pool.query(sql`
-      insert into ${cimdOrganizationScopes.table} (${sql.identifier([
-        CimdOrganizationScopes.fields.organizationScopeId,
-      ])})
-      values ${sql.join(
-        organizationScopeIds.map((organizationScopeId) => sql`(${organizationScopeId})`),
-        sql`, `
-      )}
-      on conflict do nothing
-    `);
-  };
+  const insert = async (organizationScopeIds: readonly string[]) =>
+    batchInsert(organizationScopeIds.map((organizationScopeId) => ({ organizationScopeId })));
 
   const findAll = async (): Promise<readonly OrganizationScope[]> =>
     pool.any<OrganizationScope>(sql`
@@ -136,22 +111,12 @@ const createOrganizationScopeQueries = (pool: CommonQueryMethods) => {
 const cimdOrganizationResourceScopes = convertToIdentifiers(CimdOrganizationResourceScopes, true);
 
 const createOrganizationResourceScopeQueries = (pool: CommonQueryMethods) => {
-  const insert = async (scopeIds: readonly string[]) => {
-    if (scopeIds.length === 0) {
-      return;
-    }
+  const batchInsert = buildBatchInsertIntoWithPool(pool)(CimdOrganizationResourceScopes, {
+    onConflict: { ignore: true },
+  });
 
-    await pool.query(sql`
-      insert into ${cimdOrganizationResourceScopes.table} (${sql.identifier([
-        CimdOrganizationResourceScopes.fields.scopeId,
-      ])})
-      values ${sql.join(
-        scopeIds.map((scopeId) => sql`(${scopeId})`),
-        sql`, `
-      )}
-      on conflict do nothing
-    `);
-  };
+  const insert = async (scopeIds: readonly string[]) =>
+    batchInsert(scopeIds.map((scopeId) => ({ scopeId })));
 
   const findAll = async (): Promise<readonly Scope[]> =>
     pool.any<Scope>(sql`

--- a/packages/core/src/queries/cimd.ts
+++ b/packages/core/src/queries/cimd.ts
@@ -11,16 +11,26 @@ import {
 } from '@logto/schemas';
 import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 
-import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 
 const cimdUserScopes = convertToIdentifiers(CimdUserScopes, true);
 
 const createUserScopeQueries = (pool: CommonQueryMethods) => {
-  const insert = buildInsertIntoWithPool(pool)(CimdUserScopes, {
-    onConflict: { ignore: true },
-  });
+  const insert = async (userScopes: readonly UserScope[]) => {
+    if (userScopes.length === 0) {
+      return;
+    }
+
+    await pool.query(sql`
+      insert into ${cimdUserScopes.table} (${sql.identifier([CimdUserScopes.fields.userScope])})
+      values ${sql.join(
+        userScopes.map((userScope) => sql`(${userScope})`),
+        sql`, `
+      )}
+      on conflict do nothing
+    `);
+  };
 
   const findAll = async (): Promise<UserScope[]> => {
     const rows = await pool.any<{ userScope: UserScope }>(sql`
@@ -47,9 +57,20 @@ const cimdResourceScopes = convertToIdentifiers(CimdResourceScopes, true);
 const scopes = convertToIdentifiers(Scopes, true);
 
 const createResourceScopeQueries = (pool: CommonQueryMethods) => {
-  const insert = buildInsertIntoWithPool(pool)(CimdResourceScopes, {
-    onConflict: { ignore: true },
-  });
+  const insert = async (scopeIds: readonly string[]) => {
+    if (scopeIds.length === 0) {
+      return;
+    }
+
+    await pool.query(sql`
+      insert into ${cimdResourceScopes.table} (${sql.identifier([CimdResourceScopes.fields.scopeId])})
+      values ${sql.join(
+        scopeIds.map((scopeId) => sql`(${scopeId})`),
+        sql`, `
+      )}
+      on conflict do nothing
+    `);
+  };
 
   const findAll = async (): Promise<readonly Scope[]> =>
     pool.any<Scope>(sql`
@@ -75,9 +96,22 @@ const cimdOrganizationScopes = convertToIdentifiers(CimdOrganizationScopes, true
 const organizationScopes = convertToIdentifiers(OrganizationScopes, true);
 
 const createOrganizationScopeQueries = (pool: CommonQueryMethods) => {
-  const insert = buildInsertIntoWithPool(pool)(CimdOrganizationScopes, {
-    onConflict: { ignore: true },
-  });
+  const insert = async (organizationScopeIds: readonly string[]) => {
+    if (organizationScopeIds.length === 0) {
+      return;
+    }
+
+    await pool.query(sql`
+      insert into ${cimdOrganizationScopes.table} (${sql.identifier([
+        CimdOrganizationScopes.fields.organizationScopeId,
+      ])})
+      values ${sql.join(
+        organizationScopeIds.map((organizationScopeId) => sql`(${organizationScopeId})`),
+        sql`, `
+      )}
+      on conflict do nothing
+    `);
+  };
 
   const findAll = async (): Promise<readonly OrganizationScope[]> =>
     pool.any<OrganizationScope>(sql`
@@ -102,9 +136,22 @@ const createOrganizationScopeQueries = (pool: CommonQueryMethods) => {
 const cimdOrganizationResourceScopes = convertToIdentifiers(CimdOrganizationResourceScopes, true);
 
 const createOrganizationResourceScopeQueries = (pool: CommonQueryMethods) => {
-  const insert = buildInsertIntoWithPool(pool)(CimdOrganizationResourceScopes, {
-    onConflict: { ignore: true },
-  });
+  const insert = async (scopeIds: readonly string[]) => {
+    if (scopeIds.length === 0) {
+      return;
+    }
+
+    await pool.query(sql`
+      insert into ${cimdOrganizationResourceScopes.table} (${sql.identifier([
+        CimdOrganizationResourceScopes.fields.scopeId,
+      ])})
+      values ${sql.join(
+        scopeIds.map((scopeId) => sql`(${scopeId})`),
+        sql`, `
+      )}
+      on conflict do nothing
+    `);
+  };
 
   const findAll = async (): Promise<readonly Scope[]> =>
     pool.any<Scope>(sql`

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -4,6 +4,9 @@ import {
   LogtoConfigs,
   LogtoTenantConfigKey,
   type AdminConsoleData,
+  type CimdConfig,
+  cimdConfigGuard,
+  defaultCimdConfig,
   type IdTokenConfig,
   type LogtoConfig,
   type LogtoConfigKey,
@@ -258,6 +261,28 @@ export const createLogtoConfigQueries = (
     ['id-token-config']
   );
 
+  // DEV: CIMD (client ID metadata document) support
+  const getCimdConfig = async (): Promise<CimdConfig> => {
+    const { rows } = await getRowsByKeys([LogtoTenantConfigKey.Cimd]);
+
+    if (rows.length === 0) {
+      return defaultCimdConfig;
+    }
+
+    return cimdConfigGuard.parse(rows[0]?.value);
+  };
+
+  // DEV: CIMD (client ID metadata document) support
+  const upsertCimdConfig = async (value: CimdConfig) =>
+    pool.query(sql`
+      insert into ${table} (${fields.key}, ${fields.value})
+        values (${LogtoTenantConfigKey.Cimd}, ${sql.jsonb(value)})
+        on conflict (${fields.tenantId}, ${fields.key}) do update set ${fields.value} = ${sql.jsonb(
+          value
+        )}
+        returning *
+    `);
+
   // Internal, ops-only per-tenant override of the system message send-rate-limit policy. There is
   // intentionally no upsert counterpart: the key is set by direct DB write only (no API), so the
   // cache picks it up on its next expiry (or tenant restart).
@@ -291,6 +316,8 @@ export const createLogtoConfigQueries = (
     deleteAction,
     getIdTokenConfig,
     upsertIdTokenConfig,
+    getCimdConfig,
+    upsertCimdConfig,
     getMessageRateLimitOverride,
   };
 };

--- a/packages/core/src/routes/cimd.openapi.json
+++ b/packages/core/src/routes/cimd.openapi.json
@@ -1,0 +1,61 @@
+{
+  "tags": [
+    {
+      "name": "CIMD",
+      "description": "Endpoints for managing the tenant-wide permission ceiling of OAuth Client ID Metadata Document (CIMD) clients. CIMD clients are unregistered, so the ceiling applies to all of them; the enablement switch itself lives under `/api/configs/cimd`."
+    },
+    {
+      "name": "Dev feature"
+    }
+  ],
+  "paths": {
+    "/api/cimd/user-consent-scopes": {
+      "get": {
+        "summary": "List CIMD user consent scopes",
+        "description": "List the tenant-level permission ceiling for CIMD clients: user scopes, API resource scopes, organization scopes, and organization API resource scopes.",
+        "responses": {
+          "200": {
+            "description": "The configured scopes."
+          }
+        }
+      },
+      "post": {
+        "summary": "Assign CIMD user consent scopes",
+        "description": "Add scopes to the tenant-level permission ceiling for CIMD clients. Database-backed scopes are referenced by ID; Management API scopes can never be selected.",
+        "responses": {
+          "201": {
+            "description": "The scopes were assigned."
+          },
+          "422": {
+            "description": "Some scopes do not exist or are not allowed."
+          }
+        }
+      }
+    },
+    "/api/cimd/user-consent-scopes/{scopeType}/{scopeId}": {
+      "delete": {
+        "summary": "Delete a CIMD user consent scope",
+        "description": "Remove a scope from the tenant-level permission ceiling for CIMD clients.",
+        "parameters": [
+          {
+            "name": "scopeType",
+            "in": "path",
+            "description": "The scope type.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The scope was removed."
+          },
+          "404": {
+            "description": "The scope relation was not found."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/cimd.test.ts
+++ b/packages/core/src/routes/cimd.test.ts
@@ -1,0 +1,144 @@
+import { UserScope } from '@logto/core-kit';
+import { ApplicationUserConsentScopeType } from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { MockTenant } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const mockResource = Object.freeze({
+  id: 'resource_id',
+  tenantId: 'mock_id',
+  name: 'API resource',
+  indicator: 'https://api.example.com',
+  isDefault: false,
+  accessTokenTtl: 3600,
+});
+
+const mockResourceScope = Object.freeze({
+  id: 'scope_id',
+  tenantId: 'mock_id',
+  resourceId: mockResource.id,
+  name: 'read:data',
+  description: null,
+  createdAt: 1_785_000_000_000,
+});
+
+const cimdQueries = {
+  userScopes: {
+    insert: jest.fn(),
+    findAll: jest.fn(async () => [UserScope.Profile]),
+    delete: jest.fn(),
+  },
+  resourceScopes: {
+    insert: jest.fn(),
+    findAll: jest.fn(async () => [mockResourceScope]),
+    delete: jest.fn(),
+  },
+  organizationScopes: {
+    insert: jest.fn(),
+    findAll: jest.fn(async () => []),
+    delete: jest.fn(),
+  },
+  organizationResourceScopes: {
+    insert: jest.fn(),
+    findAll: jest.fn(async () => []),
+    delete: jest.fn(),
+  },
+};
+
+const resourceQueries = {
+  findResourceById: jest.fn(async () => mockResource),
+};
+
+const validateApplicationUserConsentScopes = jest.fn();
+
+const cimdRoutes = await pickDefault(import('./cimd.js'));
+
+describe('CIMD user consent scope routes', () => {
+  const tenantContext = new MockTenant(
+    undefined,
+    {
+      cimd: cimdQueries,
+      resources: resourceQueries,
+    },
+    undefined,
+    { applications: { validateApplicationUserConsentScopes } }
+  );
+
+  const routeRequester = createRequester({
+    authedRoutes: cimdRoutes,
+    tenantContext,
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /cimd/user-consent-scopes', () => {
+    it('returns the configured scopes grouped by resource', async () => {
+      const response = await routeRequester.get('/cimd/user-consent-scopes');
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        userScopes: [UserScope.Profile],
+        organizationScopes: [],
+        resourceScopes: [
+          {
+            resource: {
+              id: mockResource.id,
+              name: mockResource.name,
+              indicator: mockResource.indicator,
+            },
+            scopes: [
+              {
+                id: mockResourceScope.id,
+                name: mockResourceScope.name,
+                description: mockResourceScope.description,
+              },
+            ],
+          },
+        ],
+        organizationResourceScopes: [],
+      });
+    });
+  });
+
+  describe('POST /cimd/user-consent-scopes', () => {
+    it('validates the scopes and inserts the relations', async () => {
+      const response = await routeRequester
+        .post('/cimd/user-consent-scopes')
+        .send({ userScopes: [UserScope.Email], resourceScopes: [mockResourceScope.id] });
+
+      expect(response.status).toEqual(201);
+      expect(validateApplicationUserConsentScopes).toHaveBeenCalledWith(
+        { userScopes: [UserScope.Email], resourceScopes: [mockResourceScope.id] },
+        'mock_id'
+      );
+      expect(cimdQueries.userScopes.insert).toHaveBeenCalledWith({ userScope: UserScope.Email });
+      expect(cimdQueries.resourceScopes.insert).toHaveBeenCalledWith({
+        scopeId: mockResourceScope.id,
+      });
+    });
+  });
+
+  describe('DELETE /cimd/user-consent-scopes/:scopeType/:scopeId', () => {
+    it('deletes the relation for the given scope type', async () => {
+      const response = await routeRequester.delete(
+        `/cimd/user-consent-scopes/${ApplicationUserConsentScopeType.ResourceScopes}/${mockResourceScope.id}`
+      );
+
+      expect(response.status).toEqual(204);
+      expect(cimdQueries.resourceScopes.delete).toHaveBeenCalledWith(mockResourceScope.id);
+    });
+
+    it('rejects an unknown scope type with 400', async () => {
+      const response = await routeRequester.delete(
+        '/cimd/user-consent-scopes/unknown-type/some-id'
+      );
+
+      expect(response.status).toEqual(400);
+    });
+  });
+});

--- a/packages/core/src/routes/cimd.test.ts
+++ b/packages/core/src/routes/cimd.test.ts
@@ -116,10 +116,8 @@ describe('CIMD user consent scope routes', () => {
         { userScopes: [UserScope.Email], resourceScopes: [mockResourceScope.id] },
         'mock_id'
       );
-      expect(cimdQueries.userScopes.insert).toHaveBeenCalledWith({ userScope: UserScope.Email });
-      expect(cimdQueries.resourceScopes.insert).toHaveBeenCalledWith({
-        scopeId: mockResourceScope.id,
-      });
+      expect(cimdQueries.userScopes.insert).toHaveBeenCalledWith([UserScope.Email]);
+      expect(cimdQueries.resourceScopes.insert).toHaveBeenCalledWith([mockResourceScope.id]);
     });
   });
 

--- a/packages/core/src/routes/cimd.ts
+++ b/packages/core/src/routes/cimd.ts
@@ -1,0 +1,159 @@
+import { UserScope } from '@logto/core-kit';
+import {
+  ApplicationUserConsentScopeType,
+  applicationUserConsentScopesResponseGuard,
+} from '@logto/schemas';
+import { z } from 'zod';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import koaGuard from '#src/middleware/koa-guard.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import type { ManagementApiRouter, RouterInitArgs } from './types.js';
+
+/**
+ * Routes for the tenant-wide permission ceiling of OAuth Client ID Metadata Document (CIMD)
+ * clients. Unlike third-party applications, CIMD clients are unregistered and have no per-client
+ * record to attach consent scopes to, so the ceiling is tenant-level.
+ */
+export default function cimdRoutes<T extends ManagementApiRouter>(
+  ...[router, tenant]: RouterInitArgs<T>
+) {
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
+  const { queries, libraries } = tenant;
+  const {
+    resources: { findResourceById },
+  } = queries;
+  const {
+    applications: { validateApplicationUserConsentScopes },
+  } = libraries;
+
+  const groupScopesByResource = async (scopes: ReadonlyArray<{ resourceId: string }>) => {
+    const resourceIds = [...new Set(scopes.map(({ resourceId }) => resourceId))];
+    return Promise.all(
+      resourceIds.map(async (resourceId) => ({
+        resource: await findResourceById(resourceId),
+        scopes: scopes.filter((scope) => scope.resourceId === resourceId),
+      }))
+    );
+  };
+
+  // DEV: CIMD (client ID metadata document) support
+  router.get(
+    '/cimd/user-consent-scopes',
+    koaGuard({
+      response: applicationUserConsentScopesResponseGuard,
+      status: [200],
+    }),
+    async (ctx, next) => {
+      const [userScopes, resourceScopes, organizationScopes, organizationResourceScopes] =
+        await Promise.all([
+          queries.cimd.userScopes.findAll(),
+          queries.cimd.resourceScopes.findAll(),
+          queries.cimd.organizationScopes.findAll(),
+          queries.cimd.organizationResourceScopes.findAll(),
+        ]);
+
+      // The queries return full data schemas; the response guard filters out unneeded fields.
+      ctx.body = {
+        userScopes,
+        organizationScopes: [...organizationScopes],
+        resourceScopes: await groupScopesByResource(resourceScopes),
+        organizationResourceScopes: await groupScopesByResource(organizationResourceScopes),
+      };
+
+      return next();
+    }
+  );
+
+  // DEV: CIMD (client ID metadata document) support
+  router.post(
+    '/cimd/user-consent-scopes',
+    koaGuard({
+      body: z.object({
+        organizationScopes: z.string().array().optional(),
+        resourceScopes: z.string().array().optional(),
+        organizationResourceScopes: z.string().array().optional(),
+        userScopes: z.nativeEnum(UserScope).array().optional(),
+      }),
+      status: [201, 422],
+    }),
+    async (ctx, next) => {
+      const { body } = ctx.guard;
+      const { organizationScopes, resourceScopes, organizationResourceScopes, userScopes } = body;
+
+      // The shared third-party application validation also rejects Management API scopes.
+      await validateApplicationUserConsentScopes(body, tenant.id);
+
+      await Promise.all([
+        ...(userScopes ?? []).map(async (userScope) =>
+          queries.cimd.userScopes.insert({ userScope })
+        ),
+        ...(resourceScopes ?? []).map(async (scopeId) =>
+          queries.cimd.resourceScopes.insert({ scopeId })
+        ),
+        ...(organizationScopes ?? []).map(async (organizationScopeId) =>
+          queries.cimd.organizationScopes.insert({ organizationScopeId })
+        ),
+        ...(organizationResourceScopes ?? []).map(async (scopeId) =>
+          queries.cimd.organizationResourceScopes.insert({ scopeId })
+        ),
+      ]);
+
+      ctx.status = 201;
+
+      return next();
+    }
+  );
+
+  // DEV: CIMD (client ID metadata document) support
+  router.delete(
+    '/cimd/user-consent-scopes/:scopeType/:scopeId',
+    koaGuard({
+      params: z.object({
+        scopeType: z.nativeEnum(ApplicationUserConsentScopeType),
+        scopeId: z.string(),
+      }),
+      status: [204, 404],
+    }),
+    async (ctx, next) => {
+      const {
+        params: { scopeType, scopeId },
+      } = ctx.guard;
+
+      switch (scopeType) {
+        case ApplicationUserConsentScopeType.UserScopes: {
+          const userScope = z.nativeEnum(UserScope).safeParse(scopeId);
+          // An unknown scope name cannot exist in the ceiling table, so it is the same 404 as
+          // deleting a missing row rather than a guard-level 400.
+          assertThat(
+            userScope.success,
+            new RequestError({ code: 'entity.not_found', status: 404 })
+          );
+          await queries.cimd.userScopes.delete(userScope.data);
+          break;
+        }
+        case ApplicationUserConsentScopeType.ResourceScopes: {
+          await queries.cimd.resourceScopes.delete(scopeId);
+          break;
+        }
+        case ApplicationUserConsentScopeType.OrganizationScopes: {
+          await queries.cimd.organizationScopes.delete(scopeId);
+          break;
+        }
+        case ApplicationUserConsentScopeType.OrganizationResourceScopes: {
+          await queries.cimd.organizationResourceScopes.delete(scopeId);
+          break;
+        }
+      }
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/cimd.ts
+++ b/packages/core/src/routes/cimd.ts
@@ -89,20 +89,21 @@ export default function cimdRoutes<T extends ManagementApiRouter>(
       // The shared third-party application validation also rejects Management API scopes.
       await validateApplicationUserConsentScopes(body, tenant.id);
 
-      await Promise.all([
-        ...(userScopes ?? []).map(async (userScope) =>
-          queries.cimd.userScopes.insert({ userScope })
-        ),
-        ...(resourceScopes ?? []).map(async (scopeId) =>
-          queries.cimd.resourceScopes.insert({ scopeId })
-        ),
-        ...(organizationScopes ?? []).map(async (organizationScopeId) =>
-          queries.cimd.organizationScopes.insert({ organizationScopeId })
-        ),
-        ...(organizationResourceScopes ?? []).map(async (scopeId) =>
-          queries.cimd.organizationResourceScopes.insert({ scopeId })
-        ),
-      ]);
+      if (userScopes) {
+        await queries.cimd.userScopes.insert(userScopes);
+      }
+
+      if (resourceScopes) {
+        await queries.cimd.resourceScopes.insert(resourceScopes);
+      }
+
+      if (organizationScopes) {
+        await queries.cimd.organizationScopes.insert(organizationScopes);
+      }
+
+      if (organizationResourceScopes) {
+        await queries.cimd.organizationResourceScopes.insert(organizationResourceScopes);
+      }
 
       ctx.status = 201;
 

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -21,6 +21,7 @@ import adminUserRoutes from './admin-user/index.js';
 import applicationRoutes from './applications/application.js';
 import authnRoutes from './authn.js';
 import captchaProviderRoutes from './captcha-provider/index.js';
+import cimdRoutes from './cimd.js';
 import connectorRoutes from './connector/index.js';
 import customPhraseRoutes from './custom-phrase.js';
 import customProfileFieldsRoutes from './custom-profile-fields.js';
@@ -99,6 +100,8 @@ const createRouters = (tenant: TenantContext) => {
   sentinelActivitiesRoutes(managementRouter, tenant);
   customProfileFieldsRoutes(managementRouter, tenant);
   secretsRoutes(managementRouter, tenant);
+  // DEV: CIMD (client ID metadata document) support
+  cimdRoutes(managementRouter, tenant);
 
   // General anonymous router for publicly accessible APIs
   const anonymousRouter: AnonymousRouter = new Router();

--- a/packages/core/src/routes/logto-config/cimd.test.ts
+++ b/packages/core/src/routes/logto-config/cimd.test.ts
@@ -1,5 +1,6 @@
 import { defaultCimdConfig, type CimdConfig } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
+import Sinon from 'sinon';
 
 import { EnvSet } from '#src/env-set/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -22,15 +23,9 @@ describe('CIMD config routes', () => {
     tenantContext,
   });
 
-  const originalSsrfProtectionEnabled = EnvSet.values.isOidcProviderSsrfProtectionEnabled;
-
   afterEach(() => {
     jest.clearAllMocks();
-    Reflect.set(
-      EnvSet.values,
-      'isOidcProviderSsrfProtectionEnabled',
-      originalSsrfProtectionEnabled
-    );
+    Sinon.restore();
   });
 
   describe('GET /configs/cimd', () => {
@@ -61,7 +56,10 @@ describe('CIMD config routes', () => {
     });
 
     it('rejects enabling with 422 while the SSRF protection is disabled', async () => {
-      Reflect.set(EnvSet.values, 'isOidcProviderSsrfProtectionEnabled', false);
+      Sinon.stub(EnvSet, 'values').value({
+        ...EnvSet.values,
+        isOidcProviderSsrfProtectionEnabled: false,
+      });
 
       const response = await routeRequester.patch('/configs/cimd').send({ enabled: true });
 
@@ -70,7 +68,10 @@ describe('CIMD config routes', () => {
     });
 
     it('allows disabling while the SSRF protection is disabled', async () => {
-      Reflect.set(EnvSet.values, 'isOidcProviderSsrfProtectionEnabled', false);
+      Sinon.stub(EnvSet, 'values').value({
+        ...EnvSet.values,
+        isOidcProviderSsrfProtectionEnabled: false,
+      });
       logtoConfigQueries.getCimdConfig.mockResolvedValueOnce({ enabled: true });
 
       const response = await routeRequester.patch('/configs/cimd').send({ enabled: false });

--- a/packages/core/src/routes/logto-config/cimd.test.ts
+++ b/packages/core/src/routes/logto-config/cimd.test.ts
@@ -1,0 +1,82 @@
+import { defaultCimdConfig, type CimdConfig } from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { EnvSet } from '#src/env-set/index.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const logtoConfigQueries = {
+  getCimdConfig: jest.fn(async (): Promise<CimdConfig> => defaultCimdConfig),
+  upsertCimdConfig: jest.fn(),
+};
+
+const settingRoutes = await pickDefault(import('./index.js'));
+
+describe('CIMD config routes', () => {
+  const tenantContext = new MockTenant(undefined, { logtoConfigs: logtoConfigQueries });
+
+  const routeRequester = createRequester({
+    authedRoutes: settingRoutes,
+    tenantContext,
+  });
+
+  const originalSsrfProtectionEnabled = EnvSet.values.isOidcProviderSsrfProtectionEnabled;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    Reflect.set(
+      EnvSet.values,
+      'isOidcProviderSsrfProtectionEnabled',
+      originalSsrfProtectionEnabled
+    );
+  });
+
+  describe('GET /configs/cimd', () => {
+    it('resolves a missing config row to the disabled state', async () => {
+      const response = await routeRequester.get('/configs/cimd');
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({ enabled: false });
+    });
+
+    it('returns the stored config', async () => {
+      logtoConfigQueries.getCimdConfig.mockResolvedValueOnce({ enabled: true });
+
+      const response = await routeRequester.get('/configs/cimd');
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({ enabled: true });
+    });
+  });
+
+  describe('PATCH /configs/cimd', () => {
+    it('merges the patch onto the current config and upserts the whole object', async () => {
+      const response = await routeRequester.patch('/configs/cimd').send({ enabled: true });
+
+      expect(response.status).toEqual(200);
+      expect(logtoConfigQueries.upsertCimdConfig).toHaveBeenCalledWith({ enabled: true });
+      expect(response.body).toEqual({ enabled: true });
+    });
+
+    it('rejects enabling with 422 while the SSRF protection is disabled', async () => {
+      Reflect.set(EnvSet.values, 'isOidcProviderSsrfProtectionEnabled', false);
+
+      const response = await routeRequester.patch('/configs/cimd').send({ enabled: true });
+
+      expect(response.status).toEqual(422);
+      expect(logtoConfigQueries.upsertCimdConfig).not.toHaveBeenCalled();
+    });
+
+    it('allows disabling while the SSRF protection is disabled', async () => {
+      Reflect.set(EnvSet.values, 'isOidcProviderSsrfProtectionEnabled', false);
+      logtoConfigQueries.getCimdConfig.mockResolvedValueOnce({ enabled: true });
+
+      const response = await routeRequester.patch('/configs/cimd').send({ enabled: false });
+
+      expect(response.status).toEqual(200);
+      expect(logtoConfigQueries.upsertCimdConfig).toHaveBeenCalledWith({ enabled: false });
+    });
+  });
+});

--- a/packages/core/src/routes/logto-config/cimd.ts
+++ b/packages/core/src/routes/logto-config/cimd.ts
@@ -1,0 +1,75 @@
+import { cimdConfigGuard } from '@logto/schemas';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import koaGuard from '#src/middleware/koa-guard.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
+
+/**
+ * Routes for the OAuth Client ID Metadata Document (CIMD) enablement switch, stored as the
+ * optional `cimd` tenant config object.
+ */
+export default function logtoConfigCimdRoutes<T extends ManagementApiRouter>(
+  ...[router, tenant]: RouterInitArgs<T>
+) {
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
+  const { getCimdConfig, upsertCimdConfig } = tenant.queries.logtoConfigs;
+
+  // DEV: CIMD (client ID metadata document) support
+  router.get(
+    '/configs/cimd',
+    koaGuard({
+      response: cimdConfigGuard,
+      status: [200],
+    }),
+    async (ctx, next) => {
+      ctx.body = await getCimdConfig();
+
+      return next();
+    }
+  );
+
+  // DEV: CIMD (client ID metadata document) support
+  router.patch(
+    '/configs/cimd',
+    koaGuard({
+      body: cimdConfigGuard.partial(),
+      response: cimdConfigGuard,
+      status: [200, 422],
+    }),
+    async (ctx, next) => {
+      const { body } = ctx.guard;
+
+      /**
+       * Fail fast so enabling never looks successful while the protection is off. This is not the
+       * authoritative gate: the env can be flipped after the config is stored, so provider
+       * construction applies the same condition (LOG-13920).
+       */
+      assertThat(
+        !body.enabled || EnvSet.values.isOidcProviderSsrfProtectionEnabled,
+        new RequestError(
+          { code: 'request.invalid_input', status: 422 },
+          {
+            details:
+              'CIMD requires the OIDC provider SSRF protection. Remove `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED` to enable CIMD.',
+          }
+        )
+      );
+
+      const updated = { ...(await getCimdConfig()), ...body };
+      await upsertCimdConfig(updated);
+
+      ctx.body = updated;
+
+      // The switch is applied at provider construction; rebuild the tenant on the next request.
+      void tenant.invalidateCache();
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -21,6 +21,7 @@ import { getConsoleLogFromContext } from '#src/utils/console.js';
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 
 import logtoConfigActionRoutes from './action.js';
+import logtoConfigCimdRoutes from './cimd.js';
 import idTokenRoutes from './id-token.js';
 import logtoConfigJwtCustomizerRoutes from './jwt-customizer.js';
 
@@ -231,4 +232,6 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
   logtoConfigJwtCustomizerRoutes(router, tenant);
   idTokenRoutes(router, tenant);
   logtoConfigActionRoutes(router, tenant);
+  // DEV: CIMD (client ID metadata document) support
+  logtoConfigCimdRoutes(router, tenant);
 }

--- a/packages/core/src/routes/logto-config/logto-config.openapi.json
+++ b/packages/core/src/routes/logto-config/logto-config.openapi.json
@@ -553,6 +553,31 @@
           }
         }
       }
+    },
+    "/api/configs/cimd": {
+      "get": {
+        "tags": ["Dev feature"],
+        "summary": "Get CIMD config",
+        "description": "Get the tenant-level OAuth Client ID Metadata Document (CIMD) configuration. A missing configuration resolves to the disabled state.",
+        "responses": {
+          "200": {
+            "description": "The CIMD configuration."
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Dev feature"],
+        "summary": "Update CIMD config",
+        "description": "Update the tenant-level OAuth Client ID Metadata Document (CIMD) switch. Enabling requires the OIDC provider SSRF protection to be active.",
+        "responses": {
+          "200": {
+            "description": "The updated CIMD configuration."
+          },
+          "422": {
+            "description": "The OIDC provider SSRF protection is disabled, so CIMD cannot be enabled."
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/swagger/utils/general.ts
+++ b/packages/core/src/routes/swagger/utils/general.ts
@@ -43,7 +43,8 @@ const tagMap = new Map([
 ]);
 
 if (EnvSet.values.isDevFeaturesEnabled) {
-  // TagMap.set('foo-bar', 'Foo bar');
+  // DEV: CIMD (client ID metadata document) support
+  tagMap.set('cimd', 'CIMD');
 }
 
 /**

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -27,6 +27,15 @@ const methodToVerb = Object.freeze({
 
 type RouteDictionary = Record<`${OpenAPIV3.HttpMethods} ${string}`, string>;
 
+const devFeatureCustomRoutes: Readonly<RouteDictionary> = Object.freeze({
+  // DEV: CIMD (client ID metadata document) support
+  'get /configs/cimd': 'GetCimdConfig',
+  'patch /configs/cimd': 'UpdateCimdConfig',
+  'get /cimd/user-consent-scopes': 'ListCimdUserConsentScopes',
+  'post /cimd/user-consent-scopes': 'AssignCimdUserConsentScopes',
+  'delete /cimd/user-consent-scopes/:scopeType/:scopeId': 'DeleteCimdUserConsentScope',
+});
+
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   // Authn
   'get /authn/hasura': 'GetHasuraAuth',
@@ -113,6 +122,7 @@ export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   'get /configs/actions/:actionType': 'GetAction',
   'delete /configs/actions/:actionType': 'DeleteAction',
   'post /configs/actions/test': 'TestAction',
+  ...(EnvSet.values.isDevFeaturesEnabled ? devFeatureCustomRoutes : {}),
 } satisfies RouteDictionary); // Key assertion doesn't work without `satisfies`
 
 /**
@@ -125,7 +135,9 @@ export const throwByDifference = (builtCustomRoutes: Set<string>) => {
     return;
   }
 
-  const expectedRoutes = Object.entries(customRoutes);
+  const expectedRoutes = Object.entries(customRoutes).filter(
+    ([path]) => EnvSet.values.isDevFeaturesEnabled || !(path in devFeatureCustomRoutes)
+  );
 
   if (shouldThrow() && builtCustomRoutes.size !== expectedRoutes.length) {
     const missingRoutes = expectedRoutes.filter(([path]) => !builtCustomRoutes.has(path));

--- a/packages/integration-tests/src/api/cimd.ts
+++ b/packages/integration-tests/src/api/cimd.ts
@@ -1,0 +1,21 @@
+import {
+  type ApplicationUserConsentScopesResponse,
+  type ApplicationUserConsentScopeType,
+} from '@logto/schemas';
+
+import { authedAdminApi } from './api.js';
+
+export const getCimdUserConsentScopes = async () =>
+  authedAdminApi.get('cimd/user-consent-scopes').json<ApplicationUserConsentScopesResponse>();
+
+export const assignCimdUserConsentScopes = async (payload: {
+  organizationScopes?: string[];
+  resourceScopes?: string[];
+  organizationResourceScopes?: string[];
+  userScopes?: string[];
+}) => authedAdminApi.post('cimd/user-consent-scopes', { json: payload });
+
+export const deleteCimdUserConsentScope = async (
+  scopeType: ApplicationUserConsentScopeType,
+  scopeId: string
+) => authedAdminApi.delete(`cimd/user-consent-scopes/${scopeType}/${scopeId}`);

--- a/packages/integration-tests/src/api/cimd.ts
+++ b/packages/integration-tests/src/api/cimd.ts
@@ -1,3 +1,4 @@
+import { type UserScope } from '@logto/core-kit';
 import {
   type ApplicationUserConsentScopesResponse,
   type ApplicationUserConsentScopeType,
@@ -12,7 +13,7 @@ export const assignCimdUserConsentScopes = async (payload: {
   organizationScopes?: string[];
   resourceScopes?: string[];
   organizationResourceScopes?: string[];
-  userScopes?: string[];
+  userScopes?: UserScope[];
 }) => authedAdminApi.post('cimd/user-consent-scopes', { json: payload });
 
 export const deleteCimdUserConsentScope = async (

--- a/packages/integration-tests/src/api/logto-config.ts
+++ b/packages/integration-tests/src/api/logto-config.ts
@@ -4,6 +4,7 @@ import {
   type OidcConfigKeysResponse,
   type LogtoOidcConfigKeyType,
   type AccessTokenJwtCustomizer,
+  type CimdConfig,
   type ClientCredentialsJwtCustomizer,
   type JwtCustomizerConfigs,
   type JwtCustomizerTestRequestBody,
@@ -125,4 +126,14 @@ export const updateSessionConfig = async (payload: Partial<OidcSessionConfig>) =
     .json<OidcSessionConfig & { ttl: number }>();
   await waitForTenantCacheInvalidation();
   return sessionConfig;
+};
+
+export const getCimdConfig = async () => authedAdminApi.get('configs/cimd').json<CimdConfig>();
+
+export const updateCimdConfig = async (payload: Partial<CimdConfig>) => {
+  const cimdConfig = await authedAdminApi
+    .patch('configs/cimd', { json: payload })
+    .json<CimdConfig>();
+  await waitForTenantCacheInvalidation();
+  return cimdConfig;
 };

--- a/packages/integration-tests/src/tests/api/cimd.test.ts
+++ b/packages/integration-tests/src/tests/api/cimd.test.ts
@@ -1,0 +1,216 @@
+import { UserScope } from '@logto/core-kit';
+import { ApplicationUserConsentScopeType } from '@logto/schemas';
+
+import { authedAdminApi } from '#src/api/api.js';
+import {
+  assignCimdUserConsentScopes,
+  deleteCimdUserConsentScope,
+  getCimdUserConsentScopes,
+} from '#src/api/cimd.js';
+import { OrganizationScopeApi } from '#src/api/organization-scope.js';
+import { createResource, deleteResource } from '#src/api/resource.js';
+import { createScope } from '#src/api/scope.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { devFeatureDisabledTest, devFeatureTest } from '#src/utils.js';
+
+devFeatureTest.describe('CIMD user consent scopes', () => {
+  const organizationScopes = new Map<string, string>();
+  const resourceScopes = new Map<string, string>();
+  const organizationResourceScopes = new Map<string, string>();
+  const resourceIds = new Set<string>();
+
+  const organizationScopeApi = new OrganizationScopeApi();
+
+  beforeAll(async () => {
+    const organizationScope1 = await organizationScopeApi.create({
+      name: 'cimd-organization-scope-1',
+    });
+    const organizationScope2 = await organizationScopeApi.create({
+      name: 'cimd-organization-scope-2',
+    });
+
+    organizationScopes.set('organizationScope1', organizationScope1.id);
+    organizationScopes.set('organizationScope2', organizationScope2.id);
+
+    const resource = await createResource();
+    resourceIds.add(resource.id);
+
+    const resourceScope1 = await createScope(resource.id);
+    const resourceScope2 = await createScope(resource.id);
+
+    resourceScopes.set('resourceScope1', resourceScope1.id);
+    resourceScopes.set('resourceScope2', resourceScope2.id);
+
+    const resourceScope3 = await createScope(resource.id);
+
+    organizationResourceScopes.set('resourceScope1', resourceScope3.id);
+  });
+
+  afterAll(async () => {
+    // Deleting the resources and organization scopes cascades to the CIMD relations.
+    await Promise.all(
+      Array.from(resourceIds).map(async (resourceId) => deleteResource(resourceId))
+    );
+    await Promise.all(
+      Array.from(organizationScopes.values()).map(async (organizationScopeId) =>
+        organizationScopeApi.delete(organizationScopeId)
+      )
+    );
+    await deleteCimdUserConsentScope(
+      ApplicationUserConsentScopeType.UserScopes,
+      UserScope.Profile
+    ).catch(() => {
+      // The scope may already be removed by individual tests.
+    });
+  });
+
+  it('should return empty consent scopes when nothing is assigned', async () => {
+    const result = await getCimdUserConsentScopes();
+
+    expect(result.organizationScopes.length).toBe(0);
+    expect(result.resourceScopes.length).toBe(0);
+    expect(result.organizationResourceScopes.length).toBe(0);
+    expect(result.userScopes.length).toBe(0);
+  });
+
+  it('should throw error when trying to assign a non-existing scope', async () => {
+    await expectRejects(
+      assignCimdUserConsentScopes({ organizationScopes: ['non-existing-organization-scope'] }),
+      {
+        code: 'application.user_consent_scopes_not_found',
+        status: 422,
+      }
+    );
+
+    await expectRejects(assignCimdUserConsentScopes({ resourceScopes: ['non-existing-scope'] }), {
+      code: 'application.user_consent_scopes_not_found',
+      status: 422,
+    });
+
+    await expectRejects(
+      assignCimdUserConsentScopes({ organizationResourceScopes: ['non-existing-scope'] }),
+      {
+        code: 'application.user_consent_scopes_not_found',
+        status: 422,
+      }
+    );
+  });
+
+  it('should assign consent scopes successfully and idempotently', async () => {
+    await expect(
+      assignCimdUserConsentScopes({
+        organizationScopes: Array.from(organizationScopes.values()),
+        resourceScopes: Array.from(resourceScopes.values()),
+        organizationResourceScopes: Array.from(organizationResourceScopes.values()),
+        userScopes: [UserScope.Profile, UserScope.Email],
+      })
+    ).resolves.not.toThrow();
+
+    // Re-assigning existing scopes does not throw.
+    await expect(
+      assignCimdUserConsentScopes({
+        organizationScopes: [organizationScopes.get('organizationScope1')!],
+        resourceScopes: [resourceScopes.get('resourceScope1')!],
+        userScopes: [UserScope.Profile],
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it('should return the assigned scopes grouped by resource', async () => {
+    const result = await getCimdUserConsentScopes();
+
+    expect(result.organizationScopes.length).toBe(organizationScopes.size);
+    for (const organizationScopeId of organizationScopes.values()) {
+      expect(result.organizationScopes.some(({ id }) => id === organizationScopeId)).toBeTruthy();
+    }
+
+    expect(result.resourceScopes.length).toBe(1);
+    expect(result.resourceScopes[0]!.resource.id).toBe(Array.from(resourceIds)[0]);
+    expect(result.resourceScopes[0]!.scopes.length).toBe(resourceScopes.size);
+
+    expect(result.organizationResourceScopes.length).toBe(1);
+    expect(result.organizationResourceScopes[0]!.scopes.length).toBe(
+      organizationResourceScopes.size
+    );
+
+    expect(result.userScopes.length).toBe(2);
+    expect(result.userScopes.includes(UserScope.Profile)).toBeTruthy();
+    expect(result.userScopes.includes(UserScope.Email)).toBeTruthy();
+  });
+
+  it('should return 404 when trying to delete a non-existing consent scope', async () => {
+    await expectRejects(
+      deleteCimdUserConsentScope(
+        ApplicationUserConsentScopeType.OrganizationScopes,
+        'non-existing-organization-scope'
+      ),
+      {
+        code: 'entity.not_found',
+        status: 404,
+      }
+    );
+
+    await expectRejects(
+      deleteCimdUserConsentScope(
+        ApplicationUserConsentScopeType.UserScopes,
+        'non-existing-user-scope'
+      ),
+      {
+        code: 'entity.not_found',
+        status: 404,
+      }
+    );
+  });
+
+  it('should delete consent scopes of every type successfully', async () => {
+    await expect(
+      deleteCimdUserConsentScope(
+        ApplicationUserConsentScopeType.OrganizationScopes,
+        organizationScopes.get('organizationScope1')!
+      )
+    ).resolves.not.toThrow();
+
+    await expect(
+      deleteCimdUserConsentScope(
+        ApplicationUserConsentScopeType.ResourceScopes,
+        resourceScopes.get('resourceScope1')!
+      )
+    ).resolves.not.toThrow();
+
+    await expect(
+      deleteCimdUserConsentScope(
+        ApplicationUserConsentScopeType.OrganizationResourceScopes,
+        organizationResourceScopes.get('resourceScope1')!
+      )
+    ).resolves.not.toThrow();
+
+    await expect(
+      deleteCimdUserConsentScope(ApplicationUserConsentScopeType.UserScopes, UserScope.Email)
+    ).resolves.not.toThrow();
+
+    const result = await getCimdUserConsentScopes();
+
+    expect(
+      result.organizationScopes.some(
+        ({ id }) => id === organizationScopes.get('organizationScope1')!
+      )
+    ).toBeFalsy();
+    expect(
+      result.resourceScopes[0]!.scopes.some(
+        ({ id }) => id === resourceScopes.get('resourceScope1')!
+      )
+    ).toBeFalsy();
+    expect(result.organizationResourceScopes.length).toBe(0);
+    expect(result.userScopes.includes(UserScope.Email)).toBeFalsy();
+  });
+});
+
+devFeatureDisabledTest.describe('CIMD routes when dev features are disabled', () => {
+  it('should not expose the CIMD user consent scope routes', async () => {
+    const response = await authedAdminApi.get('cimd/user-consent-scopes', {
+      throwHttpErrors: false,
+    });
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/integration-tests/src/tests/api/logto-config-cimd.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config-cimd.test.ts
@@ -1,0 +1,33 @@
+import { authedAdminApi } from '#src/api/api.js';
+import { getCimdConfig, updateCimdConfig } from '#src/api/logto-config.js';
+import { devFeatureDisabledTest, devFeatureTest } from '#src/utils.js';
+
+devFeatureTest.describe('CIMD config', () => {
+  afterAll(async () => {
+    // Leave the tenant with the default-off state so other suites see a clean provider config.
+    await updateCimdConfig({ enabled: false });
+  });
+
+  it('should resolve a missing config row to the disabled state', async () => {
+    await expect(getCimdConfig()).resolves.toEqual({ enabled: false });
+  });
+
+  it('should enable and disable the feature via merge + upsert', async () => {
+    // The API integration test environment keeps the SSRF protection on, so enabling passes.
+    await expect(updateCimdConfig({ enabled: true })).resolves.toEqual({ enabled: true });
+
+    await expect(getCimdConfig()).resolves.toEqual({ enabled: true });
+
+    await expect(updateCimdConfig({})).resolves.toEqual({ enabled: true });
+
+    await expect(updateCimdConfig({ enabled: false })).resolves.toEqual({ enabled: false });
+  });
+});
+
+devFeatureDisabledTest.describe('CIMD config routes when dev features are disabled', () => {
+  it('should not expose the CIMD config routes', async () => {
+    const response = await authedAdminApi.get('configs/cimd', { throwHttpErrors: false });
+
+    expect(response.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Add the tenant-level Management API for the client ID metadata document (CIMD) feature (LOG-13914). All routes are dev-feature-guarded (not mounted at all unless dev features are enabled).

The API splits across two prefixes, following the existing conventions:

- **`/api/configs/cimd`** — the enablement switch. It reads/writes the `cimd` key in `logto_configs`, so it belongs to the `/configs` family (every `/configs/*` route is backed by that table). It sits outside `/configs/oidc/` because the greedy `/configs/oidc/:keyType` param route captures any literal sibling segment.
  - `GET` → `{ enabled }`; a missing config row resolves to disabled.
  - `PATCH` → merge + upsert. Enabling is the only gate: it responds 422 when the OIDC provider SSRF protection is disabled, instead of accepting and silently ignoring. Once the switch is on, the stored config is the single source of truth for the runtime. Toggling triggers `tenant.invalidateCache()` since the feature is applied at provider construction.
- **`/api/cimd/user-consent-scopes`** — the tenant-wide permission ceiling. It is backed by the four `cimd_*_scopes` relation tables (not `logto_configs`), so it gets its own top-level route like other table-backed tenant settings. `GET`/`POST` plus `DELETE .../:scopeType/:scopeId` reuse the third-party application guards, response shape, and validation (scopes must exist in the tenant; Management API scopes can never be selected). Writes do not invalidate the tenant cache — the ceiling tables are read per request.

The dev-feature custom operation ID mechanism is restored in `operation-id.ts` (removed when Actions graduated), and all routes carry `Dev feature`-tagged OpenAPI docs.

Stacked on #9309 — review only the last commit; the base branch carries the ceiling tables and queries.

No changeset — dev-feature-gated, no end-user-visible behavior change.

## Testing

Unit tests and integration tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

