### PR TITLE
fix(schemas): add account id indexes for token revocation

### DIFF
--- a/packages/schemas/alterations/next-1785393731-add-oidc-model-instances-account-id-partial-index.ts
+++ b/packages/schemas/alterations/next-1785393731-add-oidc-model-instances-account-id-partial-index.ts
@@ -1,0 +1,33 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    // Add index to optimize revoking access tokens and refresh tokens by accountId.
+    // See the index comment in tables/oidc_model_instances.sql for the predicate rationale.
+    await pool.query(sql`
+      create index concurrently oidc_model_instances__model_name_payload_account_id_partial
+        on oidc_model_instances (tenant_id, model_name, (payload->>'accountId'))
+        where payload ? 'accountId';
+    `);
+
+    // Collect expression statistics right away instead of waiting for autovacuum.
+    await pool.query(sql`
+      analyze oidc_model_instances;
+    `);
+  },
+  up: async () => {
+    /** 'concurrently' cannot be used inside a transaction, so this up is intentionally left empty. */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently oidc_model_instances__model_name_payload_account_id_partial;
+    `);
+  },
+  down: async () => {
+    /** 'concurrently' cannot be used inside a transaction, so this down is intentionally left empty. */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/oidc_model_instances.sql
+++ b/packages/schemas/tables/oidc_model_instances.sql
@@ -42,6 +42,11 @@ create index oidc_model_instances__grant_payload_account_id_expires_at
   on oidc_model_instances (tenant_id, (payload->>'accountId'), expires_at)
   WHERE model_name = 'Grant';
 
+/* Partial on payload key existence so rows without accountId (e.g. client credentials tokens) stay out of the index. The parameter-free predicate stays provable under generic query plans, but matching queries must include the payload ? 'accountId' clause. */
+create index oidc_model_instances__model_name_payload_account_id_partial
+  on oidc_model_instances (tenant_id, model_name, (payload->>'accountId'))
+  where payload ? 'accountId';
+
 alter table oidc_model_instances set (
   autovacuum_vacuum_scale_factor = 0.05,
   autovacuum_analyze_scale_factor = 0.02,


### PR DESCRIPTION
## Summary

Production `StatementTimeoutError`s were traced to the delete/suspend user APIs: `signOutUser` runs `delete from oidc_model_instances where model_name = $1 and payload->>'accountId' = $2` for `AccessToken`, `RefreshToken` and `Session`. Of those three, only `Session` has an index covering `accountId` (`oidc_model_instances__session_payload_account_id_expires_at`) — the `AccessToken` and `RefreshToken` deletes have nothing to use, so each one scans every row in the tenant and the cost grows with tenant size regardless of how many rows match.

### What changed
- New index `oidc_model_instances__model_name_payload_account_id_partial` on `(tenant_id, model_name, (payload->>'accountId')) where payload ? 'accountId'` — alteration + seed.
- `analyze oidc_model_instances` after the concurrent build so expression statistics are available immediately instead of waiting for autovacuum.
- The build runs `create index concurrently` in `beforeUp` with empty transactional `up`, mirroring the released Session/Grant index alterations.

### Index shape rationale
- **Partial on `payload ? 'accountId'`** (the `grantId`-index precedent): keeps accountId-less rows (client credentials tokens, most interactions) out of the index, and the parameter-free predicate stays provable under generic query plans. The size saving is proportional to the share of rows that carry no `accountId` — check it for a given deployment with `select count(*) filter (where not payload ? 'accountId') * 100.0 / count(*) from oidc_model_instances`. The consuming revoke query includes the matching `payload ? 'accountId'` clause (#9318), so this PR should land together with it — on its own the index is write cost with no reader.
  - Alternative considered: `where (payload->>'accountId') is not null`, which the planner can prove from the existing `payload->>'accountId' = $2` clause without any query change. Measured identical in index size and scan cost, so the `?` form was kept for consistency with the `grantId` index.
- This is the seventh secondary index on the highest-write-volume table; the partial predicate keeps maintenance cost to rows that actually carry `accountId`, and token writes already maintain the uid/userCode expression indexes.
- **Not partial on `model_name`**: one index then serves all three revoked models instead of needing one per model. A `where model_name = '…'` predicate is also only provable when the planner can see the value — true for the custom plans node-postgres produces (unnamed statements are planned at Bind with the parameter values), but not under a generic plan. The parameter-free `payload ? 'accountId'` predicate is provable either way. The existing Session/Grant partials keep working, both for their literal-`model_name` queries and for the parameterized revoke whenever a custom plan is chosen.

### Expected result
Token revocation on user deletion/suspension becomes an index lookup on the target user's rows instead of a full model scan. `expires_at` is intentionally omitted — the revoke deletes carry no expiry filter.

Synthetic local probe (1M rows, single 500-row revoke batch, everything warm in shared buffers): seq scan 149 ms with 1,000,000 rows discarded by the filter, versus a 4 ms index scan touching 92 buffers. The gap is far wider in production, where the scan is I/O bound and grows with tenant size, and it compounds once #9318 batches the delete — without an index every batch repeats the full scan.

### Reviewer notes
- Hard-fail semantics (no `if not exists`), matching the #8427 review ruling. A cancelled `create index concurrently` leaves an INVALID index that must be dropped manually before rerun — run the alteration without a statement timeout (`DATABASE_STATEMENT_TIMEOUT` unset or `DISABLE_TIMEOUT`) and check `pg_index where not indisvalid` on failure.
- `analyze oidc_model_instances` takes a SHARE UPDATE EXCLUSIVE lock, which conflicts with autovacuum on a table that has deliberately aggressive autovacuum thresholds. With the statement timeout disabled that wait is unbounded, so watch it rather than assuming a hang is the index build.
- Open question from the incident: `findUserActiveApplicationGrants` timed out in prod despite its covering Grant index existing since 1.38.0 — worth checking `select indexrelid::regclass, indisvalid from pg_index` for that index in prod before attributing incident #1 to a missing index.
- Follow-up (stacked PRs): #9318 batches `revokeInstanceByUserId`; #9319 indexes `oidc_session_extensions.account_id`.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
