### PR TITLE
feat: release signed saml authn request feature

### DIFF
--- a/.changeset/release-saml-signed-authn-request.md
+++ b/.changeset/release-saml-signed-authn-request.md
@@ -1,0 +1,8 @@
+---
+"@logto/core": minor
+"@logto/console": minor
+---
+
+add optional signed SAML authentication requests for enterprise SSO connectors
+
+Enterprise SSO SAML connectors can now sign the SAML authentication request (AuthnRequest) sent to the identity provider. Generate a service-provider signing key on the connector, download its certificate and register it at the identity provider, then enable "Sign authentication request". RSA-SHA256 (default) and RSA-SHA512 are supported, and staged keys allow graceful, zero-downtime certificate rotation. Identity-provider metadata advertising `WantAuthnRequestsSigned` no longer breaks SAML sign-in when signing is disabled.

--- a/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlConnectorForm.tsx
+++ b/packages/console/src/pages/EnterpriseSsoDetails/Connection/SamlConnectorForm.tsx
@@ -10,7 +10,6 @@ import { useTranslation } from 'react-i18next';
 import DetailsForm from '@/components/DetailsForm';
 import FormCard from '@/components/FormCard';
 import UnsavedChangesAlertModal from '@/components/UnsavedChangesAlertModal';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import useApi from '@/hooks/use-api';
 import {
   samlConnectorConfigGuard,
@@ -61,9 +60,7 @@ function SamlConnectorForm({ isDeleted, data, onUpdated }: Props) {
 
     // Normalize the toggle to a real boolean: with an absent field the switch would compare
     // `false` against `undefined` after toggling on and off again, leaving the form stuck dirty.
-    return isDevFeaturesEnabled
-      ? { ...result.data, signAuthnRequest: Boolean(result.data.signAuthnRequest) }
-      : result.data;
+    return { ...result.data, signAuthnRequest: Boolean(result.data.signAuthnRequest) };
   }, [config]);
 
   // Guard the provider config data
@@ -139,7 +136,7 @@ function SamlConnectorForm({ isDeleted, data, onUpdated }: Props) {
           }}
         >
           <SamlConnectorSpInfo samlProviderConfig={samlProviderConfig} />
-          {isDevFeaturesEnabled && <SamlSigningKeySection connectorId={connectorId} />}
+          <SamlSigningKeySection connectorId={connectorId} />
         </FormCard>
         <FormCard
           title="enterprise_sso_details.attribute_mapping_title"

--- a/packages/core/src/libraries/verification-helpers/single-sign-on.test.ts
+++ b/packages/core/src/libraries/verification-helpers/single-sign-on.test.ts
@@ -44,11 +44,6 @@ const deleteIdpInitiatedSamlSsoSessionMock = jest.fn();
 const findActiveSigningKeyBySsoConnectorIdMock = jest.fn();
 const setSigningCredentialMock = jest.fn();
 
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-const setDevFeaturesEnabled = (enabled: boolean) => {
-  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', enabled);
-};
-
 class MockOidcSsoConnector extends OidcSsoConnector {
   override getAuthorizationUrl = getAuthorizationUrlMock;
   override getIssuer = getIssuerMock;
@@ -559,14 +554,9 @@ describe('Single sign on util methods tests', () => {
     };
 
     beforeEach(() => {
-      setDevFeaturesEnabled(true);
       // Reset drains `mockResolvedValueOnce` values queued (but unconsumed) by earlier describe
       // blocks — `jest.clearAllMocks()` does not.
       getAuthorizationUrlMock.mockReset().mockResolvedValueOnce(samlAuthorizationUrl);
-    });
-
-    afterAll(() => {
-      setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
     });
 
     it('should inject the active signing key when signAuthnRequest is on', async () => {
@@ -609,41 +599,6 @@ describe('Single sign on util methods tests', () => {
       await expect(
         getSsoAuthorizationUrl(mockContext, tenant, mockSamlSsoConnector, payload)
       ).resolves.toBe(samlAuthorizationUrl);
-
-      expect(findActiveSigningKeyBySsoConnectorIdMock).not.toBeCalled();
-      expect(setSigningCredentialMock).not.toBeCalled();
-    });
-  });
-
-  describe('getSsoAuthorizationUrl signed AuthnRequest with dev features off', () => {
-    const payload = {
-      state: 'state',
-      redirectUri: 'https://example.com',
-    };
-
-    beforeEach(() => {
-      setDevFeaturesEnabled(false);
-      getAuthorizationUrlMock.mockReset();
-    });
-
-    afterAll(() => {
-      setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
-    });
-
-    it('should not load the signing key even when signAuthnRequest is on', async () => {
-      getAuthorizationUrlMock.mockResolvedValueOnce('https://saml-connector/sso');
-
-      await expect(
-        getSsoAuthorizationUrl(
-          mockContext,
-          tenant,
-          {
-            ...mockSamlSsoConnector,
-            config: { ...mockSamlSsoConnector.config, signAuthnRequest: true },
-          },
-          payload
-        )
-      ).resolves.toBe('https://saml-connector/sso');
 
       expect(findActiveSigningKeyBySsoConnectorIdMock).not.toBeCalled();
       expect(setSigningCredentialMock).not.toBeCalled();

--- a/packages/core/src/libraries/verification-helpers/single-sign-on.ts
+++ b/packages/core/src/libraries/verification-helpers/single-sign-on.ts
@@ -161,10 +161,7 @@ export const getSsoAuthorizationUrl = async (
       }
     }
 
-    // TODO: Remove the dev features check when the signed AuthnRequest feature is ready.
-    if (EnvSet.values.isDevFeaturesEnabled) {
-      await injectSamlSigningCredential(connectorInstance, connectorData, queries, log);
-    }
+    await injectSamlSigningCredential(connectorInstance, connectorData, queries, log);
 
     return await connectorInstance.getAuthorizationUrl(
       { jti, ...payload, connectorId },

--- a/packages/core/src/routes/sso-connector/index.ts
+++ b/packages/core/src/routes/sso-connector/index.ts
@@ -30,7 +30,6 @@ import {
   fetchConnectorProviderDetails,
   parseConnectorConfig,
   parseFactoryDetail,
-  stripGatedSigningConfigFields,
   validateConnectorConfigConnectionStatus,
   validateConnectorDomains,
 } from './utils.js';
@@ -113,8 +112,7 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
       }
 
       // Validate the connector config if it's provided
-      const parsedConfig =
-        config && stripGatedSigningConfigFields(parseConnectorConfig(providerName, config));
+      const parsedConfig = config && parseConnectorConfig(providerName, config);
 
       // A new connector has no signing keys, so an enabled signAuthnRequest is always rejected.
       await assertActiveSigningKeyForSignAuthnRequest(parsedConfig);
@@ -305,8 +303,7 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
       }
 
       // Validate the connector config if it's provided
-      const parsedConfig =
-        config && stripGatedSigningConfigFields(parseConnectorConfig(providerName, config));
+      const parsedConfig = config && parseConnectorConfig(providerName, config);
 
       // Check the connection status of the connector config if it's provided
       if (parsedConfig) {
@@ -376,9 +373,10 @@ export default function singleSignOnConnectorsRoutes<T extends ManagementApiRout
     }
   );
 
-  // TODO: @simeng Remove when IdP initiated SSO / signed AuthnRequest are ready for production
+  samlSsoConnectorSigningKeyRoutes(...args);
+
+  // TODO: @simeng Remove when IdP initiated SSO is ready for production
   if (EnvSet.values.isDevFeaturesEnabled) {
     ssoConnectorIdpInitiatedAuthConfigRoutes(...args);
-    samlSsoConnectorSigningKeyRoutes(...args);
   }
 }

--- a/packages/core/src/routes/sso-connector/signing-key.openapi.json
+++ b/packages/core/src/routes/sso-connector/signing-key.openapi.json
@@ -1,9 +1,4 @@
 {
-  "tags": [
-    {
-      "name": "Dev feature"
-    }
-  ],
   "paths": {
     "/api/sso-connectors/{id}/signing-keys": {
       "get": {

--- a/packages/core/src/routes/sso-connector/utils.test.ts
+++ b/packages/core/src/routes/sso-connector/utils.test.ts
@@ -20,7 +20,6 @@ const {
   validateConnectorDomains,
   parseConnectorConfig,
   isSignAuthnRequestEnabled,
-  stripGatedSigningConfigFields,
   assertActiveSigningKeyForSignAuthnRequest,
 } = await import('./utils.js');
 
@@ -168,20 +167,11 @@ describe('validateConnectorDomains', () => {
 });
 
 describe('signed AuthnRequest config helpers', () => {
-  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-  const setDevFeaturesEnabled = (enabled: boolean) => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', enabled);
-  };
-
   const samlSigningConfig = {
     metadata: 'mock-metadata',
     signAuthnRequest: true,
     requestSignatureAlgorithm: 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
   };
-
-  afterAll(() => {
-    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
-  });
 
   describe('isSignAuthnRequestEnabled', () => {
     it('is true only when the config explicitly enables it', () => {
@@ -197,20 +187,6 @@ describe('signed AuthnRequest config helpers', () => {
     });
   });
 
-  describe('stripGatedSigningConfigFields', () => {
-    it('passes the config through when dev features are on', () => {
-      setDevFeaturesEnabled(true);
-      const parsed = parseConnectorConfig(SsoProviderName.SAML, samlSigningConfig);
-      expect(stripGatedSigningConfigFields(parsed)).toEqual(parsed);
-    });
-
-    it('strips the signing fields when dev features are off', () => {
-      setDevFeaturesEnabled(false);
-      const parsed = parseConnectorConfig(SsoProviderName.SAML, samlSigningConfig);
-      expect(stripGatedSigningConfigFields(parsed)).toEqual({ metadata: 'mock-metadata' });
-    });
-  });
-
   describe('assertActiveSigningKeyForSignAuthnRequest', () => {
     it('is a no-op when the config does not enable signing', async () => {
       const findActiveSigningKey = jest.fn();
@@ -223,7 +199,6 @@ describe('signed AuthnRequest config helpers', () => {
     });
 
     it('rejects enabling on creation (no finder) or without an active key', async () => {
-      setDevFeaturesEnabled(true);
       const enabledConfig = parseConnectorConfig(SsoProviderName.SAML, samlSigningConfig);
 
       await expect(assertActiveSigningKeyForSignAuthnRequest(enabledConfig)).rejects.toMatchObject({
@@ -236,7 +211,6 @@ describe('signed AuthnRequest config helpers', () => {
     });
 
     it('passes when an active key exists', async () => {
-      setDevFeaturesEnabled(true);
       const enabledConfig = parseConnectorConfig(SsoProviderName.SAML, samlSigningConfig);
 
       await expect(

--- a/packages/core/src/routes/sso-connector/utils.ts
+++ b/packages/core/src/routes/sso-connector/utils.ts
@@ -8,7 +8,6 @@ import type {
 import { findDuplicatedOrBlockedEmailDomains } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import SamlConnector from '#src/sso/SamlConnector/index.js';
 import { type SingleSignOnFactory, ssoConnectorFactories } from '#src/sso/index.js';
@@ -66,7 +65,7 @@ export const isSignAuthnRequestEnabled = (config?: ParsedConnectorConfig): boole
  * Enabling signed AuthnRequest requires an active SP signing key — the config endpoints never
  * create keys (the signing-key routes own the lifecycle), so the flag must not claim signing that
  * no key can perform. POST passes no finder: a new connector can never have keys, so an enabled
- * flag is always rejected. Inert when dev features are off (the flag is stripped from payloads).
+ * flag is always rejected.
  */
 export const assertActiveSigningKeyForSignAuthnRequest = async (
   parsedConfig?: ParsedConnectorConfig,
@@ -80,26 +79,6 @@ export const assertActiveSigningKeyForSignAuthnRequest = async (
     await findActiveSigningKey?.(),
     new RequestError({ code: 'single_sign_on.active_signing_key_required', status: 400 })
   );
-};
-
-/**
- * The signed-AuthnRequest config fields are dev-gated: strip them before persisting so they
- * cannot be stored in production until the feature is ready.
- * TODO: @simeng Remove when the signed AuthnRequest feature is ready.
- */
-export const stripGatedSigningConfigFields = (
-  config: ParsedConnectorConfig
-): ParsedConnectorConfig => {
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    return config;
-  }
-
-  if ('signAuthnRequest' in config || 'requestSignatureAlgorithm' in config) {
-    const { signAuthnRequest, requestSignatureAlgorithm, ...rest } = config;
-    return rest;
-  }
-
-  return config;
 };
 
 export const fetchConnectorProviderDetails = async (

--- a/packages/core/src/sso/SamlConnector/index.ts
+++ b/packages/core/src/sso/SamlConnector/index.ts
@@ -3,8 +3,6 @@ import { conditional, type Optional } from '@silverhand/essentials';
 import { XMLValidator } from 'fast-xml-parser';
 import * as saml from 'samlify';
 
-import { EnvSet } from '#src/env-set/index.js';
-
 import {
   SsoConnectorConfigErrorCodes,
   SsoConnectorError,
@@ -191,12 +189,9 @@ class SamlConnector {
     const { entityId, assertionConsumerServiceUrl } = this.serviceProviderMetadata;
 
     const signingCredential = this._spSigningCredential;
-    // Gated behind dev features until GA: with the gate off, `signAuthnRequest` is inert and the
-    // released signing behavior below is preserved verbatim. getIdentityProvider reads the same
-    // gated value, so the SP and IdP signing flags never disagree.
-    const { isDevFeaturesEnabled } = EnvSet.values;
-    const signAuthnRequestEnabled =
-      isDevFeaturesEnabled && Boolean(this._idpConfig?.signAuthnRequest);
+    // The IdP side derives the same flag in `getIdentityProvider`, so the SP's
+    // `authnRequestsSigned` and the IdP's `WantAuthnRequestsSigned` never disagree.
+    const signAuthnRequestEnabled = Boolean(this._idpConfig?.signAuthnRequest);
 
     // Fail-closed: if signing is enabled but no SP credential was injected, refuse rather than
     // silently send an unsigned request. The sign-in layer injects the credential and maps signing
@@ -210,8 +205,7 @@ class SamlConnector {
 
     // Drive `authnRequestsSigned` off our explicit flag rather than the IdP's `WantAuthnRequestsSigned`,
     // so samlify never advertises a signed request without a private key. When signing, use the SP's
-    // own key/cert; when not, samlify ignores `signingCert` for a redirect request. With the dev gate
-    // off, keep the released behavior of mirroring the IdP metadata flag.
+    // own key/cert; when not, samlify ignores `signingCert` for a redirect request.
     const signingServiceProviderOptions =
       signAuthnRequestEnabled && signingCredential
         ? {
@@ -224,9 +218,7 @@ class SamlConnector {
           }
         : {
             signingCert: x509Certificate,
-            authnRequestsSigned: isDevFeaturesEnabled
-              ? false
-              : identityProvider.entityMeta.isWantAuthnRequestsSigned(), // Should align with IdP setting.
+            authnRequestsSigned: false,
           };
 
     try {
@@ -322,12 +314,10 @@ class SamlConnector {
       return this._identityProvider;
     }
 
-    // Drive signing from our flag — align the IdP side on both construction paths below
-    // (see alignWantAuthnRequestsSigned). With the dev gate off, the released behavior is preserved:
-    // the metadata is passed through untouched.
-    const { isDevFeaturesEnabled } = EnvSet.values;
-    const signAuthnRequestEnabled =
-      isDevFeaturesEnabled && Boolean(this._idpConfig?.signAuthnRequest);
+    // Drive signing from our flag — the IdP side is aligned on both construction paths below
+    // (metadata XML via `alignWantAuthnRequestsSigned`; manual config via the
+    // `wantAuthnRequestsSigned` option).
+    const signAuthnRequestEnabled = Boolean(this._idpConfig?.signAuthnRequest);
 
     // If `metadataUrl` or `metadata` is provided, we use it to construct the identity provider.
     const idpMetadataXml = await this.getIdpMetadataXml();
@@ -351,9 +341,7 @@ class SamlConnector {
       this._identityProvider =
         // eslint-disable-next-line new-cap
         saml.IdentityProvider({
-          metadata: isDevFeaturesEnabled
-            ? alignWantAuthnRequestsSigned(idpMetadataXml, signAuthnRequestEnabled)
-            : idpMetadataXml,
+          metadata: alignWantAuthnRequestsSigned(idpMetadataXml, signAuthnRequestEnabled),
         });
       return this._identityProvider;
     }

--- a/packages/core/src/sso/SamlConnector/sign.test.ts
+++ b/packages/core/src/sso/SamlConnector/sign.test.ts
@@ -1,15 +1,8 @@
-import { EnvSet } from '#src/env-set/index.js';
 import { generateKeyPairAndCertificate } from '#src/libraries/saml-application/utils.js';
 
 import { SamlAuthnRequestSignatureAlgorithm } from '../types/saml.js';
 
 import SamlConnector from './index.js';
-
-const setDevFeaturesEnabled = (enabled: boolean) => {
-  Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', enabled);
-};
-
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 
 // Minimal IdP metadata with a redirect SSO endpoint and a signing cert. Pass a namespace `prefix`
 // (e.g. `md`, `saml-md`) to exercise prefixed elements; default is the un-prefixed default namespace.
@@ -33,14 +26,6 @@ const buildIdpMetadataXml = (cert: string, prefix = '') => {
 
 describe('SamlConnector signed AuthnRequest', () => {
   const endpoint = new URL('https://logto.example.com');
-
-  beforeEach(() => {
-    setDevFeaturesEnabled(true);
-  });
-
-  afterAll(() => {
-    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
-  });
 
   it('omits Signature when signAuthnRequest is off', async () => {
     const { certificate } = await generateKeyPairAndCertificate(1);
@@ -188,33 +173,14 @@ describe('SamlConnector signed AuthnRequest', () => {
     expect(url).toContain('Signature=');
   });
 
-  it('does not sign when dev features are off', async () => {
-    setDevFeaturesEnabled(false);
-    const idp = await generateKeyPairAndCertificate(1);
-    const sp = await generateKeyPairAndCertificate(1);
-    const connector = new SamlConnector(endpoint, 'conn-10', {
-      metadata: buildIdpMetadataXml(idp.certificate),
-      signAuthnRequest: true,
-    });
-    connector.setServiceProviderSigningCredential({
-      privateKey: sp.privateKey,
-      certificate: sp.certificate,
-    });
-    const url = await connector.getSingleSignOnUrl('relay-10');
-    expect(url).not.toContain('Signature=');
-  });
-
-  it('preserves the released mirror behavior when dev features are off', async () => {
-    setDevFeaturesEnabled(false);
-    // Released behavior mirrors the IdP metadata flag onto the SP, so an IdP advertising
-    // WantAuthnRequestsSigned="true" makes samlify attempt to sign without a private key and
-    // throw. The dev gate keeps that behavior (raw metadata, mirrored flag) until GA.
+  it('stays unsigned on the manual-config path when off', async () => {
     const { certificate } = await generateKeyPairAndCertificate(1);
-    const metadata = buildIdpMetadataXml(certificate).replace(
-      '<IDPSSODescriptor',
-      '<IDPSSODescriptor WantAuthnRequestsSigned="true"'
-    );
-    const connector = new SamlConnector(endpoint, 'conn-12', { metadata });
-    await expect(connector.getSingleSignOnUrl('relay-12')).rejects.toThrow();
+    const connector = new SamlConnector(endpoint, 'conn-12', {
+      entityId: 'https://idp.example.com',
+      signInEndpoint: 'https://idp.example.com/sso',
+      x509Certificate: certificate,
+    });
+    const url = await connector.getSingleSignOnUrl('relay-12');
+    expect(url).not.toContain('Signature=');
   });
 });

--- a/packages/core/src/sso/types/saml.ts
+++ b/packages/core/src/sso/types/saml.ts
@@ -65,8 +65,8 @@ export enum SamlAuthnRequestSignatureAlgorithm {
 
 /**
  * Optional signed-`AuthnRequest` settings, shared across all SAML config shapes. Both fields are
- * optional so existing connector configs remain valid; the signing behaviour is gated behind
- * `isDevFeaturesEnabled` at the sign-in / route / console layers, not here.
+ * optional so existing connector configs remain valid; enabling `signAuthnRequest` is validated at
+ * the route layer (an active signing key must exist), not here.
  */
 const samlSigningConfigGuard = z.object({
   signAuthnRequest: z.boolean().optional(),

--- a/packages/integration-tests/src/tests/api/sso-connectors/sso-connector-signed-authn-request.test.ts
+++ b/packages/integration-tests/src/tests/api/sso-connectors/sso-connector-signed-authn-request.test.ts
@@ -1,14 +1,13 @@
 import { createVerify, X509Certificate } from 'node:crypto';
 
 import { SsoProviderName } from '@logto/schemas';
-import { HTTPError } from 'ky';
 
 import { metadataXml } from '#src/__mocks__/sso-connectors-mock.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { SsoConnectorApi } from '#src/api/sso-connector.js';
 import { initExperienceClient } from '#src/helpers/client.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { devFeatureDisabledTest, devFeatureTest, randomString } from '#src/utils.js';
+import { randomString } from '#src/utils.js';
 
 const rsaSha256AlgorithmUri = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
 const rsaSha512AlgorithmUri = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
@@ -68,423 +67,340 @@ describe('SAML SSO signed AuthnRequest', () => {
     await ssoConnectorApi.cleanUp();
   });
 
-  devFeatureTest.describe('with dev features enabled', () => {
-    devFeatureTest.it('should not sign the AuthnRequest by default', async () => {
-      expect(await getAuthorizationUri()).not.toContain('Signature=');
-    });
+  it('should not sign the AuthnRequest by default', async () => {
+    expect(await getAuthorizationUri()).not.toContain('Signature=');
+  });
 
-    devFeatureTest.it('should reject enabling signAuthnRequest without an active key', async () => {
-      await expectRejects(
-        ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
-          config: { metadata: metadataXml, signAuthnRequest: true },
-        }),
-        { code: 'single_sign_on.active_signing_key_required', status: 400 }
-      );
-    });
-
-    devFeatureTest.it(
-      'should sign the AuthnRequest after enabling with an active key',
-      async () => {
-        const connectorId = ssoConnectorApi.firstConnectorId!;
-        const key = await ssoConnectorApi.createSigningKey(connectorId, true);
-        expect(key.active).toBe(true);
-
-        await ssoConnectorApi.update(connectorId, {
-          config: { metadata: metadataXml, signAuthnRequest: true },
-        });
-
-        const authorizationUri = await getAuthorizationUri();
-        expect(authorizationUri).toContain('Signature=');
-        expect(authorizationUri).toContain('SigAlg=');
-      }
-    );
-
-    devFeatureTest.it('should keep signing when a patch does not touch the config', async () => {
-      await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
-        connectorName: `test-saml-renamed-${randomString()}`,
-      });
-
-      expect(await getAuthorizationUri()).toContain('Signature=');
-    });
-
-    devFeatureTest.it('should stop signing after disabling signAuthnRequest', async () => {
-      await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
-        config: { metadata: metadataXml, signAuthnRequest: false },
-      });
-
-      expect(await getAuthorizationUri()).not.toContain('Signature=');
-    });
-
-    devFeatureTest.it(
-      'should treat a config patch that omits the flag as disabling, and resume signing on re-enable',
-      async () => {
-        // Re-enable signing (the previous test disabled it).
-        await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
-          config: { metadata: metadataXml, signAuthnRequest: true },
-        });
-        expect(await getAuthorizationUri()).toContain('Signature=');
-
-        // A config-bearing patch without the flag replaces the whole config, so signing turns off;
-        // the keys are retained (deletion only happens via the dedicated signing-key routes).
-        await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
-          config: { metadata: metadataXml },
-        });
-        expect(await getAuthorizationUri()).not.toContain('Signature=');
-
-        // Re-enabling resumes signing with the retained key.
-        await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
-          config: { metadata: metadataXml, signAuthnRequest: true },
-        });
-        expect(await getAuthorizationUri()).toContain('Signature=');
-      }
-    );
-
-    devFeatureTest.it('should reject creating a connector with signAuthnRequest on', async () => {
-      // A new connector cannot have signing keys yet, so the flag can never be enabled on create.
-      await expectRejects(
-        ssoConnectorApi.create({
-          providerName: SsoProviderName.SAML,
-          connectorName: `test-saml-signed-${randomString()}`,
-          domains: [`bar${randomString()}.com`],
-          config: { metadata: metadataXml, signAuthnRequest: true },
-          syncProfile: true,
-        }),
-        { code: 'single_sign_on.active_signing_key_required', status: 400 }
-      );
-    });
-
-    devFeatureTest.it(
-      'should create a connector with signAuthnRequest explicitly off',
-      async () => {
-        const created = await ssoConnectorApi.create({
-          providerName: SsoProviderName.SAML,
-          connectorName: `test-saml-unsigned-${randomString()}`,
-          domains: [`bar${randomString()}.com`],
-          config: { metadata: metadataXml, signAuthnRequest: false },
-          syncProfile: true,
-        });
-
-        expect(created.config).toHaveProperty('signAuthnRequest', false);
-      }
-    );
-
-    devFeatureTest.it('should support graceful rotation via the signing-key routes', async () => {
-      const connectorId = ssoConnectorApi.firstConnectorId!;
-      // Re-enable signing — the key created earlier is still active, so the validation passes.
-      await ssoConnectorApi.update(connectorId, {
+  it('should reject enabling signAuthnRequest without an active key', async () => {
+    await expectRejects(
+      ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
         config: { metadata: metadataXml, signAuthnRequest: true },
-      });
-
-      const [initialKey, ...restKeys] = await ssoConnectorApi.getSigningKeys(connectorId);
-      expect(restKeys).toHaveLength(0);
-      expect(initialKey?.active).toBe(true);
-      expect(initialKey).not.toHaveProperty('privateKey');
-      expect(initialKey?.fingerprints.sha256.formatted).toBeTruthy();
-
-      // Stage: create an inactive key alongside the active one; signing is uninterrupted.
-      const stagedKey = await ssoConnectorApi.createSigningKey(connectorId);
-      expect(stagedKey.active).toBe(false);
-      expect(await ssoConnectorApi.getSigningKeys(connectorId)).toHaveLength(2);
-      expect(await getAuthorizationUri()).toContain('Signature=');
-
-      // Switch: activating the staged key deactivates the old one; signing continues.
-      const activatedKey = await ssoConnectorApi.updateSigningKeyStatus(
-        connectorId,
-        stagedKey.id,
-        true
-      );
-      expect(activatedKey.active).toBe(true);
-      const keysAfterSwitch = await ssoConnectorApi.getSigningKeys(connectorId);
-      expect(keysAfterSwitch.find(({ id }) => id === initialKey?.id)?.active).toBe(false);
-      expect(await getAuthorizationUri()).toContain('Signature=');
-
-      // Retire: the old inactive key can be deleted; the active key cannot.
-      await ssoConnectorApi.deleteSigningKey(connectorId, initialKey!.id);
-      expect(await ssoConnectorApi.getSigningKeys(connectorId)).toHaveLength(1);
-      await expectRejects(ssoConnectorApi.deleteSigningKey(connectorId, stagedKey.id), {
-        code: 'single_sign_on.can_not_delete_active_signing_key',
-        status: 400,
-      });
-
-      // Create-active: atomically takes over from the currently active key.
-      const takeoverKey = await ssoConnectorApi.createSigningKey(connectorId, true);
-      expect(takeoverKey.active).toBe(true);
-      const finalKeys = await ssoConnectorApi.getSigningKeys(connectorId);
-      expect(finalKeys.find(({ id }) => id === stagedKey.id)?.active).toBe(false);
-      await ssoConnectorApi.deleteSigningKey(connectorId, stagedKey.id);
-      expect(await ssoConnectorApi.getSigningKeys(connectorId)).toHaveLength(1);
-      expect(await getAuthorizationUri()).toContain('Signature=');
-    });
-
-    devFeatureTest.it('should return 404 for a non-SAML connector', async () => {
-      const { id } = await ssoConnectorApi.createMockOidcConnector([`oidc${randomString()}.com`]);
-      const expectedError = { code: 'connector.not_found', status: 404 };
-
-      await Promise.all([
-        expectRejects(ssoConnectorApi.getSigningKeys(id), expectedError),
-        expectRejects(ssoConnectorApi.createSigningKey(id, true), expectedError),
-        expectRejects(
-          ssoConnectorApi.updateSigningKeyStatus(id, 'unknown-key-id', true),
-          expectedError
-        ),
-        expectRejects(ssoConnectorApi.deleteSigningKey(id, 'unknown-key-id'), expectedError),
-      ]);
-    });
-
-    devFeatureTest.it(
-      'should keep the active key when the toggle is turned off and reuse it on re-enable',
-      async () => {
-        const connectorId = ssoConnectorApi.firstConnectorId!;
-        await ssoConnectorApi.update(connectorId, {
-          config: { metadata: metadataXml, signAuthnRequest: true },
-        });
-        const [keyBefore] = await ssoConnectorApi.getSigningKeys(connectorId);
-
-        // Toggle off: signing stops but the key stays active — the IdP-registered cert is kept.
-        await ssoConnectorApi.update(connectorId, {
-          config: { metadata: metadataXml, signAuthnRequest: false },
-        });
-        const [keyWhileOff] = await ssoConnectorApi.getSigningKeys(connectorId);
-        expect(keyWhileOff?.id).toBe(keyBefore?.id);
-        expect(keyWhileOff?.active).toBe(true);
-        expect(await getAuthorizationUri()).not.toContain('Signature=');
-
-        // Re-enable: signing resumes with the same key.
-        await ssoConnectorApi.update(connectorId, {
-          config: { metadata: metadataXml, signAuthnRequest: true },
-        });
-        const [keyAfter] = await ssoConnectorApi.getSigningKeys(connectorId);
-        expect(keyAfter?.id).toBe(keyBefore?.id);
-        expect(await getAuthorizationUri()).toContain('Signature=');
-      }
-    );
-
-    devFeatureTest.it(
-      'should reject deactivating the active key while signing is enabled',
-      async () => {
-        const connectorId = ssoConnectorApi.firstConnectorId!;
-        // Explicit setup so the guard is exercised regardless of the previous test's state.
-        await ssoConnectorApi.update(connectorId, {
-          config: { metadata: metadataXml, signAuthnRequest: true },
-        });
-        const [key] = await ssoConnectorApi.getSigningKeys(connectorId);
-        expect(key?.active).toBe(true);
-
-        await expectRejects(ssoConnectorApi.updateSigningKeyStatus(connectorId, key!.id, false), {
-          code: 'single_sign_on.can_not_deactivate_signing_key_in_use',
-          status: 400,
-        });
-
-        // The toggle and the key are untouched, and signing continues.
-        const { config } = await ssoConnectorApi.getSsoConnectorById(connectorId);
-        expect(config).toHaveProperty('signAuthnRequest', true);
-        const [keyAfter] = await ssoConnectorApi.getSigningKeys(connectorId);
-        expect(keyAfter?.active).toBe(true);
-        expect(await getAuthorizationUri()).toContain('Signature=');
-      }
-    );
-
-    devFeatureTest.it(
-      'should deactivate after disabling signing, and gate re-enabling on activation',
-      async () => {
-        const connectorId = ssoConnectorApi.firstConnectorId!;
-        // Disable signing first — then the still-active key can be deactivated.
-        await ssoConnectorApi.update(connectorId, {
-          config: { metadata: metadataXml, signAuthnRequest: false },
-        });
-        const [key] = await ssoConnectorApi.getSigningKeys(connectorId);
-        const deactivatedKey = await ssoConnectorApi.updateSigningKeyStatus(
-          connectorId,
-          key!.id,
-          false
-        );
-        expect(deactivatedKey.active).toBe(false);
-
-        // Re-enabling is rejected while no key is active — the config never creates keys.
-        await expectRejects(
-          ssoConnectorApi.update(connectorId, {
-            config: { metadata: metadataXml, signAuthnRequest: true },
-          }),
-          { code: 'single_sign_on.active_signing_key_required', status: 400 }
-        );
-
-        // Activating the retained key (same IdP-registered certificate) unblocks the toggle.
-        await ssoConnectorApi.updateSigningKeyStatus(connectorId, key!.id, true);
-        await ssoConnectorApi.update(connectorId, {
-          config: { metadata: metadataXml, signAuthnRequest: true },
-        });
-
-        const keys = await ssoConnectorApi.getSigningKeys(connectorId);
-        expect(keys).toHaveLength(1);
-        expect(keys[0]?.id).toBe(key?.id);
-        expect(keys[0]?.active).toBe(true);
-        expect(await getAuthorizationUri()).toContain('Signature=');
-      }
-    );
-
-    devFeatureTest.it('should treat a same-state signing-key patch as a no-op', async () => {
-      const connectorId = ssoConnectorApi.firstConnectorId!;
-      const [activeKey] = await ssoConnectorApi.getSigningKeys(connectorId);
-      expect(activeKey?.active).toBe(true);
-
-      // Re-activating the active key succeeds without a state change.
-      const { active: reactivated } = await patchSigningKey(activeKey!.id, true);
-      expect(reactivated).toBe(true);
-
-      // Deactivating an already-inactive key while signing is enabled must not trip the in-use
-      // guard — the guard only protects the active key.
-      const stagedKey = await ssoConnectorApi.createSigningKey(connectorId);
-      const { active: stagedActive } = await patchSigningKey(stagedKey.id, false);
-      expect(stagedActive).toBe(false);
-
-      await ssoConnectorApi.deleteSigningKey(connectorId, stagedKey.id);
-      expect(await getAuthorizationUri()).toContain('Signature=');
-    });
-
-    devFeatureTest.it('should return 404 for an unknown or foreign key id', async () => {
-      const connectorId = ssoConnectorApi.firstConnectorId!;
-      const [activeKey] = await ssoConnectorApi.getSigningKeys(connectorId);
-      const expectedError = { code: 'entity.not_found', status: 404 };
-
-      await Promise.all([
-        expectRejects(
-          ssoConnectorApi.updateSigningKeyStatus(connectorId, 'unknown-key-id', true),
-          expectedError
-        ),
-        expectRejects(
-          ssoConnectorApi.deleteSigningKey(connectorId, 'unknown-key-id'),
-          expectedError
-        ),
-      ]);
-
-      // A key must not be reachable through another connector's path.
-      const { id: otherConnectorId } = await ssoConnectorApi.createMockSamlConnector([
-        `baz${randomString()}.com`,
-      ]);
-      expect(await ssoConnectorApi.getSigningKeys(otherConnectorId)).toEqual([]);
-      await Promise.all([
-        expectRejects(
-          ssoConnectorApi.updateSigningKeyStatus(otherConnectorId, activeKey!.id, false),
-          expectedError
-        ),
-        expectRejects(
-          ssoConnectorApi.deleteSigningKey(otherConnectorId, activeKey!.id),
-          expectedError
-        ),
-      ]);
-    });
-
-    devFeatureTest.it('should sign with the configured signature algorithm', async () => {
-      const connectorId = ssoConnectorApi.firstConnectorId!;
-
-      await ssoConnectorApi.update(connectorId, {
-        config: {
-          metadata: metadataXml,
-          signAuthnRequest: true,
-          requestSignatureAlgorithm: rsaSha512AlgorithmUri,
-        },
-      });
-      const [activeKey] = await ssoConnectorApi.getSigningKeys(connectorId);
-      const sha512AuthorizationUri = await getAuthorizationUri();
-      expect(new URL(sha512AuthorizationUri).searchParams.get('SigAlg')).toBe(
-        rsaSha512AlgorithmUri
-      );
-      expect(verifyRedirectSignature(sha512AuthorizationUri, activeKey!.certificate)).toBe(true);
-
-      // A config patch omitting the field removes it and falls back to the default algorithm.
-      await ssoConnectorApi.update(connectorId, {
-        config: { metadata: metadataXml, signAuthnRequest: true },
-      });
-      expect(new URL(await getAuthorizationUri()).searchParams.get('SigAlg')).toBe(
-        rsaSha256AlgorithmUri
-      );
-    });
-
-    devFeatureTest.it('should reject a signature algorithm outside the allowlist', async () => {
-      await expectRejects(
-        ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
-          config: {
-            metadata: metadataXml,
-            signAuthnRequest: true,
-            requestSignatureAlgorithm: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
-          },
-        }),
-        { code: 'connector.invalid_config', status: 400 }
-      );
-    });
-
-    devFeatureTest.it(
-      'should produce a signature that verifies against the served certificate, also after rotation',
-      async () => {
-        const connectorId = ssoConnectorApi.firstConnectorId!;
-        const [[activeKey], authorizationUri] = await Promise.all([
-          ssoConnectorApi.getSigningKeys(connectorId),
-          getAuthorizationUri(),
-        ]);
-        expect(activeKey?.active).toBe(true);
-        expect(verifyRedirectSignature(authorizationUri, activeKey!.certificate)).toBe(true);
-
-        // A create-active takeover switches signing to the new key immediately.
-        const takeoverKey = await ssoConnectorApi.createSigningKey(connectorId, true);
-        const rotatedAuthorizationUri = await getAuthorizationUri();
-        expect(verifyRedirectSignature(rotatedAuthorizationUri, takeoverKey.certificate)).toBe(
-          true
-        );
-        expect(verifyRedirectSignature(rotatedAuthorizationUri, activeKey!.certificate)).toBe(
-          false
-        );
-      }
+      }),
+      { code: 'single_sign_on.active_signing_key_required', status: 400 }
     );
   });
 
-  devFeatureDisabledTest.describe('with dev features disabled', () => {
-    devFeatureDisabledTest.it(
-      'should strip the signing fields from the config and keep the request unsigned',
-      async () => {
-        const updated = await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
-          config: {
-            metadata: metadataXml,
-            signAuthnRequest: true,
-            requestSignatureAlgorithm: rsaSha512AlgorithmUri,
-          },
-        });
+  it('should sign the AuthnRequest after enabling with an active key', async () => {
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+    const key = await ssoConnectorApi.createSigningKey(connectorId, true);
+    expect(key.active).toBe(true);
 
-        expect(updated.config).not.toHaveProperty('signAuthnRequest');
-        expect(updated.config).not.toHaveProperty('requestSignatureAlgorithm');
-        expect(await getAuthorizationUri()).not.toContain('Signature=');
-      }
-    );
-
-    devFeatureDisabledTest.it(
-      'should strip the signing fields when creating a connector',
-      async () => {
-        // With dev features enabled the same request is rejected instead (no active key exists).
-        const created = await ssoConnectorApi.create({
-          providerName: SsoProviderName.SAML,
-          connectorName: `test-saml-dev-off-${randomString()}`,
-          domains: [`qux${randomString()}.com`],
-          config: {
-            metadata: metadataXml,
-            signAuthnRequest: true,
-            requestSignatureAlgorithm: rsaSha512AlgorithmUri,
-          },
-          syncProfile: true,
-        });
-
-        expect(created.config).not.toHaveProperty('signAuthnRequest');
-        expect(created.config).not.toHaveProperty('requestSignatureAlgorithm');
-      }
-    );
-
-    devFeatureDisabledTest.it('should not mount the signing-key routes', async () => {
-      // An unmounted route 404s with no Logto error body (which `expectRejects` would need); a
-      // mounted route would return 200 here.
-      const response = await ssoConnectorApi
-        .getSigningKeys(ssoConnectorApi.firstConnectorId!)
-        .catch((error: unknown) => error);
-
-      expect(response).toBeInstanceOf(HTTPError);
-      expect(response instanceof HTTPError && response.response.status).toBe(404);
+    await ssoConnectorApi.update(connectorId, {
+      config: { metadata: metadataXml, signAuthnRequest: true },
     });
+
+    const authorizationUri = await getAuthorizationUri();
+    expect(authorizationUri).toContain('Signature=');
+    expect(authorizationUri).toContain('SigAlg=');
+  });
+
+  it('should keep signing when a patch does not touch the config', async () => {
+    await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+      connectorName: `test-saml-renamed-${randomString()}`,
+    });
+
+    expect(await getAuthorizationUri()).toContain('Signature=');
+  });
+
+  it('should stop signing after disabling signAuthnRequest', async () => {
+    await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+      config: { metadata: metadataXml, signAuthnRequest: false },
+    });
+
+    expect(await getAuthorizationUri()).not.toContain('Signature=');
+  });
+
+  it('should treat a config patch that omits the flag as disabling, and resume signing on re-enable', async () => {
+    // Re-enable signing (the previous test disabled it).
+    await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+      config: { metadata: metadataXml, signAuthnRequest: true },
+    });
+    expect(await getAuthorizationUri()).toContain('Signature=');
+
+    // A config-bearing patch without the flag replaces the whole config, so signing turns off;
+    // the keys are retained (deletion only happens via the dedicated signing-key routes).
+    await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+      config: { metadata: metadataXml },
+    });
+    expect(await getAuthorizationUri()).not.toContain('Signature=');
+
+    // Re-enabling resumes signing with the retained key.
+    await ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+      config: { metadata: metadataXml, signAuthnRequest: true },
+    });
+    expect(await getAuthorizationUri()).toContain('Signature=');
+  });
+
+  it('should reject creating a connector with signAuthnRequest on', async () => {
+    // A new connector cannot have signing keys yet, so the flag can never be enabled on create.
+    await expectRejects(
+      ssoConnectorApi.create({
+        providerName: SsoProviderName.SAML,
+        connectorName: `test-saml-signed-${randomString()}`,
+        domains: [`bar${randomString()}.com`],
+        config: { metadata: metadataXml, signAuthnRequest: true },
+        syncProfile: true,
+      }),
+      { code: 'single_sign_on.active_signing_key_required', status: 400 }
+    );
+  });
+
+  it('should create a connector with signAuthnRequest explicitly off', async () => {
+    const created = await ssoConnectorApi.create({
+      providerName: SsoProviderName.SAML,
+      connectorName: `test-saml-unsigned-${randomString()}`,
+      domains: [`bar${randomString()}.com`],
+      config: { metadata: metadataXml, signAuthnRequest: false },
+      syncProfile: true,
+    });
+
+    expect(created.config).toHaveProperty('signAuthnRequest', false);
+  });
+
+  it('should support graceful rotation via the signing-key routes', async () => {
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+    // Re-enable signing — the key created earlier is still active, so the validation passes.
+    await ssoConnectorApi.update(connectorId, {
+      config: { metadata: metadataXml, signAuthnRequest: true },
+    });
+
+    const [initialKey, ...restKeys] = await ssoConnectorApi.getSigningKeys(connectorId);
+    expect(restKeys).toHaveLength(0);
+    expect(initialKey?.active).toBe(true);
+    expect(initialKey).not.toHaveProperty('privateKey');
+    expect(initialKey?.fingerprints.sha256.formatted).toBeTruthy();
+
+    // Stage: create an inactive key alongside the active one; signing is uninterrupted.
+    const stagedKey = await ssoConnectorApi.createSigningKey(connectorId);
+    expect(stagedKey.active).toBe(false);
+    expect(await ssoConnectorApi.getSigningKeys(connectorId)).toHaveLength(2);
+    expect(await getAuthorizationUri()).toContain('Signature=');
+
+    // Switch: activating the staged key deactivates the old one; signing continues.
+    const activatedKey = await ssoConnectorApi.updateSigningKeyStatus(
+      connectorId,
+      stagedKey.id,
+      true
+    );
+    expect(activatedKey.active).toBe(true);
+    const keysAfterSwitch = await ssoConnectorApi.getSigningKeys(connectorId);
+    expect(keysAfterSwitch.find(({ id }) => id === initialKey?.id)?.active).toBe(false);
+    expect(await getAuthorizationUri()).toContain('Signature=');
+
+    // Retire: the old inactive key can be deleted; the active key cannot.
+    await ssoConnectorApi.deleteSigningKey(connectorId, initialKey!.id);
+    expect(await ssoConnectorApi.getSigningKeys(connectorId)).toHaveLength(1);
+    await expectRejects(ssoConnectorApi.deleteSigningKey(connectorId, stagedKey.id), {
+      code: 'single_sign_on.can_not_delete_active_signing_key',
+      status: 400,
+    });
+
+    // Create-active: atomically takes over from the currently active key.
+    const takeoverKey = await ssoConnectorApi.createSigningKey(connectorId, true);
+    expect(takeoverKey.active).toBe(true);
+    const finalKeys = await ssoConnectorApi.getSigningKeys(connectorId);
+    expect(finalKeys.find(({ id }) => id === stagedKey.id)?.active).toBe(false);
+    await ssoConnectorApi.deleteSigningKey(connectorId, stagedKey.id);
+    expect(await ssoConnectorApi.getSigningKeys(connectorId)).toHaveLength(1);
+    expect(await getAuthorizationUri()).toContain('Signature=');
+  });
+
+  it('should return 404 for a non-SAML connector', async () => {
+    const { id } = await ssoConnectorApi.createMockOidcConnector([`oidc${randomString()}.com`]);
+    const expectedError = { code: 'connector.not_found', status: 404 };
+
+    await Promise.all([
+      expectRejects(ssoConnectorApi.getSigningKeys(id), expectedError),
+      expectRejects(ssoConnectorApi.createSigningKey(id, true), expectedError),
+      expectRejects(
+        ssoConnectorApi.updateSigningKeyStatus(id, 'unknown-key-id', true),
+        expectedError
+      ),
+      expectRejects(ssoConnectorApi.deleteSigningKey(id, 'unknown-key-id'), expectedError),
+    ]);
+  });
+
+  it('should keep the active key when the toggle is turned off and reuse it on re-enable', async () => {
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+    await ssoConnectorApi.update(connectorId, {
+      config: { metadata: metadataXml, signAuthnRequest: true },
+    });
+    const [keyBefore] = await ssoConnectorApi.getSigningKeys(connectorId);
+
+    // Toggle off: signing stops but the key stays active — the IdP-registered cert is kept.
+    await ssoConnectorApi.update(connectorId, {
+      config: { metadata: metadataXml, signAuthnRequest: false },
+    });
+    const [keyWhileOff] = await ssoConnectorApi.getSigningKeys(connectorId);
+    expect(keyWhileOff?.id).toBe(keyBefore?.id);
+    expect(keyWhileOff?.active).toBe(true);
+    expect(await getAuthorizationUri()).not.toContain('Signature=');
+
+    // Re-enable: signing resumes with the same key.
+    await ssoConnectorApi.update(connectorId, {
+      config: { metadata: metadataXml, signAuthnRequest: true },
+    });
+    const [keyAfter] = await ssoConnectorApi.getSigningKeys(connectorId);
+    expect(keyAfter?.id).toBe(keyBefore?.id);
+    expect(await getAuthorizationUri()).toContain('Signature=');
+  });
+
+  it('should reject deactivating the active key while signing is enabled', async () => {
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+    // Explicit setup so the guard is exercised regardless of the previous test's state.
+    await ssoConnectorApi.update(connectorId, {
+      config: { metadata: metadataXml, signAuthnRequest: true },
+    });
+    const [key] = await ssoConnectorApi.getSigningKeys(connectorId);
+    expect(key?.active).toBe(true);
+
+    await expectRejects(ssoConnectorApi.updateSigningKeyStatus(connectorId, key!.id, false), {
+      code: 'single_sign_on.can_not_deactivate_signing_key_in_use',
+      status: 400,
+    });
+
+    // The toggle and the key are untouched, and signing continues.
+    const { config } = await ssoConnectorApi.getSsoConnectorById(connectorId);
+    expect(config).toHaveProperty('signAuthnRequest', true);
+    const [keyAfter] = await ssoConnectorApi.getSigningKeys(connectorId);
+    expect(keyAfter?.active).toBe(true);
+    expect(await getAuthorizationUri()).toContain('Signature=');
+  });
+
+  it('should deactivate after disabling signing, and gate re-enabling on activation', async () => {
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+    // Disable signing first — then the still-active key can be deactivated.
+    await ssoConnectorApi.update(connectorId, {
+      config: { metadata: metadataXml, signAuthnRequest: false },
+    });
+    const [key] = await ssoConnectorApi.getSigningKeys(connectorId);
+    const deactivatedKey = await ssoConnectorApi.updateSigningKeyStatus(
+      connectorId,
+      key!.id,
+      false
+    );
+    expect(deactivatedKey.active).toBe(false);
+
+    // Re-enabling is rejected while no key is active — the config never creates keys.
+    await expectRejects(
+      ssoConnectorApi.update(connectorId, {
+        config: { metadata: metadataXml, signAuthnRequest: true },
+      }),
+      { code: 'single_sign_on.active_signing_key_required', status: 400 }
+    );
+
+    // Activating the retained key (same IdP-registered certificate) unblocks the toggle.
+    await ssoConnectorApi.updateSigningKeyStatus(connectorId, key!.id, true);
+    await ssoConnectorApi.update(connectorId, {
+      config: { metadata: metadataXml, signAuthnRequest: true },
+    });
+
+    const keys = await ssoConnectorApi.getSigningKeys(connectorId);
+    expect(keys).toHaveLength(1);
+    expect(keys[0]?.id).toBe(key?.id);
+    expect(keys[0]?.active).toBe(true);
+    expect(await getAuthorizationUri()).toContain('Signature=');
+  });
+
+  it('should treat a same-state signing-key patch as a no-op', async () => {
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+    const [activeKey] = await ssoConnectorApi.getSigningKeys(connectorId);
+    expect(activeKey?.active).toBe(true);
+
+    // Re-activating the active key succeeds without a state change.
+    const { active: reactivated } = await patchSigningKey(activeKey!.id, true);
+    expect(reactivated).toBe(true);
+
+    // Deactivating an already-inactive key while signing is enabled must not trip the in-use
+    // guard — the guard only protects the active key.
+    const stagedKey = await ssoConnectorApi.createSigningKey(connectorId);
+    const { active: stagedActive } = await patchSigningKey(stagedKey.id, false);
+    expect(stagedActive).toBe(false);
+
+    await ssoConnectorApi.deleteSigningKey(connectorId, stagedKey.id);
+    expect(await getAuthorizationUri()).toContain('Signature=');
+  });
+
+  it('should return 404 for an unknown or foreign key id', async () => {
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+    const [activeKey] = await ssoConnectorApi.getSigningKeys(connectorId);
+    const expectedError = { code: 'entity.not_found', status: 404 };
+
+    await Promise.all([
+      expectRejects(
+        ssoConnectorApi.updateSigningKeyStatus(connectorId, 'unknown-key-id', true),
+        expectedError
+      ),
+      expectRejects(ssoConnectorApi.deleteSigningKey(connectorId, 'unknown-key-id'), expectedError),
+    ]);
+
+    // A key must not be reachable through another connector's path.
+    const { id: otherConnectorId } = await ssoConnectorApi.createMockSamlConnector([
+      `baz${randomString()}.com`,
+    ]);
+    expect(await ssoConnectorApi.getSigningKeys(otherConnectorId)).toEqual([]);
+    await Promise.all([
+      expectRejects(
+        ssoConnectorApi.updateSigningKeyStatus(otherConnectorId, activeKey!.id, false),
+        expectedError
+      ),
+      expectRejects(
+        ssoConnectorApi.deleteSigningKey(otherConnectorId, activeKey!.id),
+        expectedError
+      ),
+    ]);
+  });
+
+  it('should sign with the configured signature algorithm', async () => {
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+
+    await ssoConnectorApi.update(connectorId, {
+      config: {
+        metadata: metadataXml,
+        signAuthnRequest: true,
+        requestSignatureAlgorithm: rsaSha512AlgorithmUri,
+      },
+    });
+    const [activeKey] = await ssoConnectorApi.getSigningKeys(connectorId);
+    const sha512AuthorizationUri = await getAuthorizationUri();
+    expect(new URL(sha512AuthorizationUri).searchParams.get('SigAlg')).toBe(rsaSha512AlgorithmUri);
+    expect(verifyRedirectSignature(sha512AuthorizationUri, activeKey!.certificate)).toBe(true);
+
+    // A config patch omitting the field removes it and falls back to the default algorithm.
+    await ssoConnectorApi.update(connectorId, {
+      config: { metadata: metadataXml, signAuthnRequest: true },
+    });
+    expect(new URL(await getAuthorizationUri()).searchParams.get('SigAlg')).toBe(
+      rsaSha256AlgorithmUri
+    );
+  });
+
+  it('should reject a signature algorithm outside the allowlist', async () => {
+    await expectRejects(
+      ssoConnectorApi.update(ssoConnectorApi.firstConnectorId!, {
+        config: {
+          metadata: metadataXml,
+          signAuthnRequest: true,
+          requestSignatureAlgorithm: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+        },
+      }),
+      { code: 'connector.invalid_config', status: 400 }
+    );
+  });
+
+  it('should produce a signature that verifies against the served certificate, also after rotation', async () => {
+    const connectorId = ssoConnectorApi.firstConnectorId!;
+    const [[activeKey], authorizationUri] = await Promise.all([
+      ssoConnectorApi.getSigningKeys(connectorId),
+      getAuthorizationUri(),
+    ]);
+    expect(activeKey?.active).toBe(true);
+    expect(verifyRedirectSignature(authorizationUri, activeKey!.certificate)).toBe(true);
+
+    // A create-active takeover switches signing to the new key immediately.
+    const takeoverKey = await ssoConnectorApi.createSigningKey(connectorId, true);
+    const rotatedAuthorizationUri = await getAuthorizationUri();
+    expect(verifyRedirectSignature(rotatedAuthorizationUri, takeoverKey.certificate)).toBe(true);
+    expect(verifyRedirectSignature(rotatedAuthorizationUri, activeKey!.certificate)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Releases the **signed SAML AuthnRequest** feature for enterprise SSO connectors (Refs LOG-13894, LOG-13893): removes every `isDevFeaturesEnabled` gate the feature introduced so the dev-features behavior becomes the production behavior, and adds the feature changeset (`@logto/core` + `@logto/console` minor) per the release convention.

### What changed
- **Core:** signing-key routes mount unconditionally (IdP-initiated SSO routes remain gated); the dev-off config write-gate `stripGatedSigningConfigFields` is deleted with both call sites (the active-key validation now always applies); both signing sites in `SamlConnector` are driven purely by the `signAuthnRequest` config flag; the sign-in flow always injects the active signing key (fail-closed).
- **Console:** the signing-key section always renders in the SAML connector form; the `signAuthnRequest` boolean normalization applies unconditionally.
- **OpenAPI:** the `Dev feature` tag is removed from the signing-key doc — required, since the swagger builder hides tagged supplements when dev features are off.
- **Tests:** flag stubs and dev-off legs removed across three unit suites and the integration suite (the dev-off behaviors no longer exist); one dev-off unit test is repurposed to cover the manual-config path with signing off, closing the last untested branch.

### Expected result
- Signing stays **off by default** — existing SAML connectors are unaffected until an admin generates a key and enables the toggle.
- Fixes a latent production bug: IdP metadata advertising `WantAuthnRequestsSigned="true"` previously made samlify throw during sign-in; the metadata flag is now aligned to Logto's setting and such connectors sign in unsigned.
- Console saves of SAML connectors now persist an explicit `signAuthnRequest: false` (cleanDeep keeps `false`); the server guard accepts it and enforcement only triggers on `true`.

### Reviewer notes
- One cosmetic delta: a SAML connector with a completely empty config no longer shows the metadata-upload notification (the normalized config is never empty). Rare (API-created connectors only) and matches the dev-features behavior validated in the bug bash.
- Remaining `isDevFeaturesEnabled` occurrences in touched files all belong to IdP-initiated SSO, which stays gated.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments