### PR TITLE
refactor(schemas): widen client identifier columns to varchar(200)

### DIFF
--- a/packages/schemas/alterations/next-1785399929-widen-client-identifier-columns.ts
+++ b/packages/schemas/alterations/next-1785399929-widen-client-identifier-columns.ts
@@ -7,10 +7,16 @@ const alteration: AlterationScript = {
     await pool.query(sql`
       alter table oidc_session_extensions alter column client_id set data type varchar(200);
     `);
+    await pool.query(sql`
+      alter table users alter column application_id set data type varchar(200);
+    `);
   },
   down: async (pool) => {
     await pool.query(sql`
       alter table oidc_session_extensions alter column client_id set data type varchar(21);
+    `);
+    await pool.query(sql`
+      alter table users alter column application_id set data type varchar(21);
     `);
   },
 };

--- a/packages/schemas/alterations/next-1785399929-widen-oidc-session-extensions-client-id.ts
+++ b/packages/schemas/alterations/next-1785399929-widen-oidc-session-extensions-client-id.ts
@@ -1,0 +1,18 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table oidc_session_extensions alter column client_id set data type varchar(200);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table oidc_session_extensions alter column client_id set data type varchar(21);
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/oidc_session_extensions.sql
+++ b/packages/schemas/tables/oidc_session_extensions.sql
@@ -7,7 +7,7 @@ create table oidc_session_extensions (
   account_id varchar(12) not null
     references users (id) on update cascade on delete cascade,
   last_submission jsonb /* @use JsonObject */ not null default '{}'::jsonb,
-  client_id varchar(21) null,
+  client_id varchar(200) null,
   created_at timestamptz not null default(now()),
   updated_at timestamptz not null default(now()),
   primary key (tenant_id, session_uid)

--- a/packages/schemas/tables/users.sql
+++ b/packages/schemas/tables/users.sql
@@ -16,7 +16,7 @@ create table users (
   avatar varchar(2048),
   /** Additional OpenID Connect standard claims that are not included in user's properties. */
   profile jsonb /* @use UserProfile */ not null default '{}'::jsonb,
-  application_id varchar(21),
+  application_id varchar(200),
   identities jsonb /* @use Identities */ not null default '{}'::jsonb,
   custom_data jsonb /* @use JsonObject */ not null default '{}'::jsonb,
   logto_config jsonb /* @use JsonObject */ not null default '{}'::jsonb,


### PR DESCRIPTION
## Summary

Widen the two columns that store raw OAuth client identifiers from varchar(21) to varchar(200) so they can hold CIMD client ID URLs (LOG-13942).

- `oidc_session_extensions.client_id` — stores the client of the last interactive submission; CIMD consents write the URL here.
- `users.application_id` — first-consent attribution; kept for CIMD so user management shows which client a user came from.
- All other `application_id` columns reference `applications(id)` and can never receive a CIMD URL.
- Schema-only, no behavior change; the down-script cannot narrow the columns once URL rows exist.

No changeset — schema groundwork only.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments