### PR TITLE
fix(core): declare the token signing algorithm matching the signing key's curve

### DIFF
--- a/.changeset/shiny-curves-declare.md
+++ b/.changeset/shiny-curves-declare.md
@@ -1,0 +1,7 @@
+---
+'@logto/core': patch
+---
+
+declare the token signing algorithm that matches the signing key's curve
+
+Previously, every Elliptic Curve signing key was declared as `ES384` regardless of its curve, so tenants seeded with a custom P-256 or P-521 private key advertised an algorithm their key cannot sign and clients failed validation at the authorization endpoint. The declared algorithm now follows the key's actual curve: P-256 declares `ES256`, P-384 declares `ES384`, and P-521 declares `ES512`. RSA keys keep the `RS256` default.

--- a/packages/core/jest.setup.js
+++ b/packages/core/jest.setup.js
@@ -34,7 +34,7 @@ mockEsm('#src/env-set/preconditions.js', () => ({
 // The env-set oidc unit test exercises the real module; other suites keep OIDC values inert
 // through this lightweight mock.
 if (!expect.getState().testPath.endsWith('/env-set/oidc.test.js')) {
-  // eslint-disable-next-line unicorn/consistent-function-scoping
+  // eslint-disable-next-line unicorn/consistent-function-scoping -- the nested arrow is the mocked module's default export, not a hoistable helper
   mockEsmDefault('#src/env-set/oidc.js', () => () => ({
     issuer: 'https://logto.test/oidc',
     cookieKeys: [],

--- a/packages/core/jest.setup.js
+++ b/packages/core/jest.setup.js
@@ -31,13 +31,17 @@ mockEsm('#src/env-set/preconditions.js', () => ({
   checkPreconditions: () => true,
 }));
 
-// eslint-disable-next-line unicorn/consistent-function-scoping
-mockEsmDefault('#src/env-set/oidc.js', () => () => ({
-  issuer: 'https://logto.test/oidc',
-  cookieKeys: [],
-  privateJwks: [],
-  publicJwks: [],
-}));
+// The env-set oidc unit test exercises the real module; other suites keep OIDC values inert
+// through this lightweight mock.
+if (!expect.getState().testPath.endsWith('/env-set/oidc.test.js')) {
+  // eslint-disable-next-line unicorn/consistent-function-scoping
+  mockEsmDefault('#src/env-set/oidc.js', () => () => ({
+    issuer: 'https://logto.test/oidc',
+    cookieKeys: [],
+    privateJwks: [],
+    publicJwks: [],
+  }));
+}
 /* End */
 
 // Logger is not considered in all test cases

--- a/packages/core/src/env-set/oidc.test.ts
+++ b/packages/core/src/env-set/oidc.test.ts
@@ -1,6 +1,8 @@
+import assert from 'node:assert';
 import { generateKeyPairSync } from 'node:crypto';
 
 import { LogtoOidcConfigKey, OidcSigningKeyStatus, type LogtoOidcConfigType } from '@logto/schemas';
+import { SignJWT, importJWK, jwtVerify } from 'jose';
 
 import loadOidcValues from './oidc.js';
 
@@ -33,12 +35,27 @@ describe('loadOidcValues', () => {
     ['secp384r1', 'ES384'],
     ['secp521r1', 'ES512'],
   ])('derives the signing algorithm from the %s current key', async (namedCurve, expected) => {
-    const { jwkSigningAlg } = await loadOidcValues(
+    const { jwkSigningAlg, privateJwks, localJWKSet } = await loadOidcValues(
       issuer,
       buildConfigs([generateEcPrivateKeyPem(namedCurve)])
     );
 
     expect(jwkSigningAlg).toBe(expected);
+
+    /**
+     * The declared algorithm must be one the current key can actually sign with — with a
+     * mismatched declaration (e.g. `ES384` hardcoded for a P-256 key), `importJWK` rejects the
+     * curve and this round trip fails.
+     */
+    const [currentPrivateJwk] = privateJwks;
+    assert(currentPrivateJwk && jwkSigningAlg);
+    const signingKey = await importJWK(currentPrivateJwk, jwkSigningAlg);
+    const jwt = await new SignJWT({})
+      .setProtectedHeader({ alg: jwkSigningAlg, kid: currentPrivateJwk.kid })
+      .sign(signingKey);
+    const { protectedHeader } = await jwtVerify(jwt, localJWKSet);
+
+    expect(protectedHeader.alg).toBe(expected);
   });
 
   it('keeps the signing algorithm undefined for an RSA current key', async () => {

--- a/packages/core/src/env-set/oidc.test.ts
+++ b/packages/core/src/env-set/oidc.test.ts
@@ -1,0 +1,63 @@
+import { generateKeyPairSync } from 'node:crypto';
+
+import { LogtoOidcConfigKey, OidcSigningKeyStatus, type LogtoOidcConfigType } from '@logto/schemas';
+
+import loadOidcValues from './oidc.js';
+
+const issuer = 'https://logto.test/oidc';
+
+const generateEcPrivateKeyPem = (namedCurve: string) =>
+  generateKeyPairSync('ec', { namedCurve })
+    .privateKey.export({ type: 'pkcs8', format: 'pem' })
+    .toString();
+
+const generateRsaPrivateKeyPem = () =>
+  generateKeyPairSync('rsa', { modulusLength: 2048 })
+    .privateKey.export({ type: 'pkcs8', format: 'pem' })
+    .toString();
+
+const buildConfigs = (privateKeyPems: string[]): LogtoOidcConfigType => ({
+  [LogtoOidcConfigKey.PrivateKeys]: privateKeyPems.map((value, index) => ({
+    id: `private-key-${index}`,
+    value,
+    createdAt: index,
+    status: index === 0 ? OidcSigningKeyStatus.Current : OidcSigningKeyStatus.Previous,
+  })),
+  [LogtoOidcConfigKey.CookieKeys]: [{ id: 'cookie-key', value: 'cookie-key-value', createdAt: 0 }],
+  [LogtoOidcConfigKey.Session]: {},
+});
+
+describe('loadOidcValues', () => {
+  it.each([
+    ['prime256v1', 'ES256'],
+    ['secp384r1', 'ES384'],
+    ['secp521r1', 'ES512'],
+  ])('derives the signing algorithm from the %s current key', async (namedCurve, expected) => {
+    const { jwkSigningAlg } = await loadOidcValues(
+      issuer,
+      buildConfigs([generateEcPrivateKeyPem(namedCurve)])
+    );
+
+    expect(jwkSigningAlg).toBe(expected);
+  });
+
+  it('keeps the signing algorithm undefined for an RSA current key', async () => {
+    const { jwkSigningAlg } = await loadOidcValues(
+      issuer,
+      buildConfigs([generateRsaPrivateKeyPem()])
+    );
+
+    expect(jwkSigningAlg).toBeUndefined();
+  });
+
+  it('follows the current key when a previous key of another type remains in rotation grace', async () => {
+    const { jwkSigningAlg, privateJwks, publicJwks } = await loadOidcValues(
+      issuer,
+      buildConfigs([generateEcPrivateKeyPem('prime256v1'), generateRsaPrivateKeyPem()])
+    );
+
+    expect(jwkSigningAlg).toBe('ES256');
+    expect(privateJwks).toHaveLength(2);
+    expect(publicJwks).toHaveLength(2);
+  });
+});

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -12,6 +12,21 @@ import { createLocalJWKSet } from 'jose';
 import { getOidcProviderPublicJwks } from '#src/libraries/oidc-private-key.js';
 import { exportJWK } from '#src/utils/jwks.js';
 
+const getEcSigningAlg = (crv: string | undefined) => {
+  switch (crv) {
+    case 'P-256': {
+      return 'ES256';
+    }
+    case 'P-384': {
+      return 'ES384';
+    }
+    case 'P-521': {
+      return 'ES512';
+    }
+    default:
+  }
+};
+
 const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
   const cookieKeys = configs[LogtoOidcConfigKey.CookieKeys].map(({ value }) => value);
   const currentPrivateKey = crypto.createPrivateKey(
@@ -26,9 +41,16 @@ const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
   const localJWKSet = createLocalJWKSet({ keys: publicJwks });
   const currentPrivateJwk = await exportJWK(currentPrivateKey);
 
-  // Use ES384 if it's an Elliptic Curve key, otherwise fall back to default
-  // It's for backwards compatibility since we were using RSA keys before v1.0.0-beta.20
-  const jwkSigningAlg = conditional(currentPrivateJwk.kty === 'EC' && 'ES384');
+  /**
+   * The declared algorithm must match the current key's actual curve — Logto generates P-384
+   * keys, but seeded keys (`OIDC_PRIVATE_KEYS`) may be on any supported curve, and a mismatched
+   * declaration falls outside the algorithms the tenant can sign with.
+   * RSA keys stay `undefined` to fall back to the oidc-provider `RS256` defaults, for backwards
+   * compatibility since we were using RSA keys before v1.0.0-beta.20.
+   */
+  const jwkSigningAlg = conditional(
+    currentPrivateJwk.kty === 'EC' && getEcSigningAlg(currentPrivateJwk.crv)
+  );
 
   return Object.freeze({
     cookieKeys,

--- a/packages/integration-tests/src/tests/api/logto-config.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config.test.ts
@@ -6,6 +6,7 @@ import {
   LogtoJwtTokenKeyType,
   OidcSigningKeyStatus,
 } from '@logto/schemas';
+import ky from 'ky';
 
 import {
   accessTokenJwtCustomizerPayload,
@@ -30,11 +31,36 @@ import {
   getSessionConfig,
   updateSessionConfig,
 } from '#src/api/index.js';
+import { discoveryUrl } from '#src/constants.js';
 import { expectRejects } from '#src/helpers/index.js';
+import { waitFor } from '#src/utils.js';
 
 const defaultAdminConsoleConfig: AdminConsoleData = {
   signInExperienceCustomized: false,
   organizationCreated: false,
+};
+
+const fetchDeclaredSigningAlgs = async () => {
+  const { id_token_signing_alg_values_supported: algs } = await ky
+    .get(discoveryUrl)
+    .json<{ id_token_signing_alg_values_supported: string[] }>();
+
+  return algs.slice().sort();
+};
+
+/**
+ * The tenant rebuild after a signing key change is fire-and-forget, so briefly poll until the
+ * discovery document reflects the new key set before asserting.
+ */
+const expectDeclaredSigningAlgs = async (expected: string[], retries = 10): Promise<void> => {
+  const algs = await fetchDeclaredSigningAlgs();
+
+  if (retries > 0 && algs.join(',') !== expected.join(',')) {
+    await waitFor(200);
+    return expectDeclaredSigningAlgs(expected, retries - 1);
+  }
+
+  expect(algs).toEqual(expected);
 };
 
 describe('logto config', () => {
@@ -180,6 +206,29 @@ describe('logto config', () => {
       id: rotatedPrivateKeys[0]!.id,
       status: OidcSigningKeyStatus.Current,
     });
+  });
+
+  it('should declare the signing algorithms of every coexisting key in the discovery document', async () => {
+    await expectDeclaredSigningAlgs(['ES384']);
+
+    const mixedKeys = await rotateOidcKeys(
+      LogtoOidcConfigKeyType.PrivateKeys,
+      SupportedSigningKeyAlgorithm.RSA
+    );
+    expect(mixedKeys).toHaveLength(2);
+
+    /**
+     * Both the RSA current key and the EC previous key remain usable during the rotation grace
+     * window, so the discovery document must declare the algorithms of both.
+     */
+    await expectDeclaredSigningAlgs(['ES384', 'PS256', 'RS256']);
+
+    const restoredKeys = await rotateOidcKeys(LogtoOidcConfigKeyType.PrivateKeys);
+    const previousKey = restoredKeys.find(({ status }) => status === OidcSigningKeyStatus.Previous);
+    await deleteOidcKey(LogtoOidcConfigKeyType.PrivateKeys, previousKey!.id);
+
+    /** Removing the last RSA key must also drop its algorithms from the declaration. */
+    await expectDeclaredSigningAlgs(['ES384']);
   });
 
   it('should support staged private-key rotation with a grace period', async () => {


### PR DESCRIPTION
## Summary

Make the declared token signing algorithm follow the tenant signing key's actual curve.

- `jwkSigningAlg` hardcoded `ES384` for every EC key; it now maps the current key's curve (P-256 → `ES256`, P-384 → `ES384`, P-521 → `ES512`), and RSA keys keep the `RS256` default.
- With a seeded P-256 or P-521 key (`OIDC_PRIVATE_KEYS`), the hardcoded declaration fell outside the algorithms the tenant can sign with: every application failed client validation at the authorization endpoint, and JWT access tokens failed at issuance.
- A new integration test pins the keystore-driven discovery declarations across a rotation grace window: coexisting keys declare the union of their algorithms, and deleting a key trims the declaration.

## Testing

Unit tests and integration tests.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
