### PR TITLE
refactor(schemas,cli): move cimd config out of the oidc config key enum

### DIFF
--- a/packages/cli/src/commands/database/seed/oidc-config.ts
+++ b/packages/cli/src/commands/database/seed/oidc-config.ts
@@ -18,12 +18,11 @@ import {
 
 const isBase64FormatPrivateKey = (key: string) => !key.includes('-');
 
-// Seed every OIDC config key except the optional ones below
-const optionalOidcConfigKeys = [LogtoOidcConfigKey.Session, LogtoOidcConfigKey.Cimd] as const;
-type OidcConfigKeyToSeed = Exclude<LogtoOidcConfigKey, (typeof optionalOidcConfigKeys)[number]>;
-const optionalOidcConfigKeySet: ReadonlySet<LogtoOidcConfigKey> = new Set(optionalOidcConfigKeys);
+// We only seed private keys and cookie keys
+// Session config is optional
+type OidcConfigKeyToSeed = Exclude<LogtoOidcConfigKey, LogtoOidcConfigKey.Session>;
 const oidcConfigKeysToSeed = Object.values(LogtoOidcConfigKey).filter(
-  (key): key is OidcConfigKeyToSeed => !optionalOidcConfigKeySet.has(key)
+  (key): key is OidcConfigKeyToSeed => key !== LogtoOidcConfigKey.Session
 );
 
 export const seedOidcConfigs = async (pool: DatabaseTransactionConnection, tenantId: string) => {

--- a/packages/schemas/src/types/logto-config/index.test.ts
+++ b/packages/schemas/src/types/logto-config/index.test.ts
@@ -79,23 +79,26 @@ describe('logto config guards', () => {
     );
   });
 
-  it('resolves a null CIMD config value to disabled', () => {
-    expect(logtoOidcConfigGuard[LogtoOidcConfigKey.Cimd].parse(null)).toEqual({ enabled: false });
+  it('includes the CIMD key in the logto config summary guards', () => {
+    expect(logtoConfigKeys).toContain(LogtoTenantConfigKey.Cimd);
+    expect(logtoConfigGuards[LogtoTenantConfigKey.Cimd]).toBe(
+      logtoTenantConfigGuard[LogtoTenantConfigKey.Cimd]
+    );
   });
 
   it('keeps a stored CIMD config value', () => {
-    expect(logtoOidcConfigGuard[LogtoOidcConfigKey.Cimd].parse({ enabled: true })).toEqual({
+    expect(logtoTenantConfigGuard[LogtoTenantConfigKey.Cimd].parse({ enabled: true })).toEqual({
       enabled: true,
     });
   });
 
   it('rejects invalid CIMD config values', () => {
-    const result = logtoOidcConfigGuard[LogtoOidcConfigKey.Cimd].safeParse({ enabled: 'yes' });
+    const result = logtoTenantConfigGuard[LogtoTenantConfigKey.Cimd].safeParse({ enabled: 'yes' });
 
     expect(result.success).toBe(false);
   });
 
-  it('parses OIDC configs without the optional session and CIMD rows', () => {
+  it('parses OIDC configs without the optional session row', () => {
     const result = z.object(logtoOidcConfigGuard).parse({
       [LogtoOidcConfigKey.PrivateKeys]: [
         { id: 'key_1', value: 'private-key-1', createdAt: 1_710_000_000_000 },
@@ -104,6 +107,5 @@ describe('logto config guards', () => {
     });
 
     expect(result[LogtoOidcConfigKey.Session]).toEqual({});
-    expect(result[LogtoOidcConfigKey.Cimd]).toEqual({ enabled: false });
   });
 });

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -184,12 +184,15 @@ export type SigningKeyRotationState = z.infer<typeof signingKeyRotationStateGuar
 /* --- CIMD Config --- */
 /**
  * Config for the OAuth Client ID Metadata Document (CIMD) feature. The row is only written once
- * the feature is toggled, so readers must treat a missing row as `{ enabled: false }`.
+ * the feature is toggled, so readers must fall back to {@link defaultCimdConfig}.
  */
 export const cimdConfigGuard = z.object({
   enabled: z.boolean(),
 });
 export type CimdConfig = z.infer<typeof cimdConfigGuard>;
+
+/** Applied when the `cimd` row is absent: the feature is opt-in per tenant. */
+export const defaultCimdConfig = Object.freeze({ enabled: false } satisfies CimdConfig);
 
 export enum LogtoTenantConfigKey {
   AdminConsole = 'adminConsole',

--- a/packages/schemas/src/types/logto-config/index.ts
+++ b/packages/schemas/src/types/logto-config/index.ts
@@ -35,7 +35,6 @@ export enum LogtoOidcConfigKey {
   PrivateKeys = 'oidc.privateKeys',
   CookieKeys = 'oidc.cookieKeys',
   Session = 'oidc.session',
-  Cimd = 'oidc.cimd',
 }
 
 /**
@@ -70,21 +69,10 @@ export const oidcSessionConfigGuard = z.object({
 
 export type OidcSessionConfig = z.infer<typeof oidcSessionConfigGuard>;
 
-/**
- * Tenant-level config for the OAuth Client ID Metadata Document (CIMD) feature.
- * The `oidc.cimd` row is optional; a missing row is treated as `{ enabled: false }`.
- */
-export const cimdConfigGuard = z.object({
-  enabled: z.boolean(),
-});
-
-export type CimdConfig = z.infer<typeof cimdConfigGuard>;
-
 export type LogtoOidcConfigType = {
   [LogtoOidcConfigKey.PrivateKeys]: OidcPrivateKey[];
   [LogtoOidcConfigKey.CookieKeys]: OidcConfigKey[];
   [LogtoOidcConfigKey.Session]: OidcSessionConfig;
-  [LogtoOidcConfigKey.Cimd]: CimdConfig;
 };
 
 export const logtoOidcConfigGuard: Readonly<{
@@ -98,10 +86,6 @@ export const logtoOidcConfigGuard: Readonly<{
   [LogtoOidcConfigKey.CookieKeys]: oidcConfigKeyGuard.array(),
   // Session config is optional, if not set, it will fallback to default value in core.
   [LogtoOidcConfigKey.Session]: oidcSessionConfigGuard.nullish().transform((data) => data ?? {}),
-  // CIMD config is optional; a missing row means the feature is disabled.
-  [LogtoOidcConfigKey.Cimd]: cimdConfigGuard
-    .nullish()
-    .transform((data) => data ?? { enabled: false }),
 });
 
 export enum LogtoJwtTokenKey {
@@ -197,6 +181,16 @@ export const signingKeyRotationStateGuard = z.object({
 });
 export type SigningKeyRotationState = z.infer<typeof signingKeyRotationStateGuard>;
 
+/* --- CIMD Config --- */
+/**
+ * Config for the OAuth Client ID Metadata Document (CIMD) feature. The row is only written once
+ * the feature is toggled, so readers must treat a missing row as `{ enabled: false }`.
+ */
+export const cimdConfigGuard = z.object({
+  enabled: z.boolean(),
+});
+export type CimdConfig = z.infer<typeof cimdConfigGuard>;
+
 export enum LogtoTenantConfigKey {
   AdminConsole = 'adminConsole',
   CloudConnection = 'cloudConnection',
@@ -208,6 +202,8 @@ export enum LogtoTenantConfigKey {
   SigningKeyRotationState = 'signingKeyRotationState',
   /** Internal, ops-only override of the system message send-rate-limit policy. Not exposed by any API. */
   MessageRateLimitOverride = 'messageRateLimitOverride',
+  /** Tenant-level switch for the OAuth Client ID Metadata Document feature. */
+  Cimd = 'cimd',
 }
 export type LogtoTenantConfigType = {
   [LogtoTenantConfigKey.AdminConsole]: AdminConsoleData;
@@ -216,6 +212,7 @@ export type LogtoTenantConfigType = {
   [LogtoTenantConfigKey.IdToken]: IdTokenConfig;
   [LogtoTenantConfigKey.SigningKeyRotationState]: SigningKeyRotationState;
   [LogtoTenantConfigKey.MessageRateLimitOverride]: MessageRateLimitOverride;
+  [LogtoTenantConfigKey.Cimd]: CimdConfig;
 };
 
 export const logtoTenantConfigGuard: Readonly<{
@@ -227,6 +224,7 @@ export const logtoTenantConfigGuard: Readonly<{
   [LogtoTenantConfigKey.IdToken]: idTokenConfigGuard,
   [LogtoTenantConfigKey.SigningKeyRotationState]: signingKeyRotationStateGuard,
   [LogtoTenantConfigKey.MessageRateLimitOverride]: messageRateLimitOverrideGuard,
+  [LogtoTenantConfigKey.Cimd]: cimdConfigGuard,
 });
 
 /* --- Summary --- */


### PR DESCRIPTION
## Summary

Moves the CIMD config key from `LogtoOidcConfigKey` to `LogtoTenantConfigKey`.

- `LogtoOidcConfigKey` is the set of OIDC configs seeded for every tenant. CIMD is an optional feature switch, so it belongs next to `idToken` and `signingKeyRotationState` in `LogtoTenantConfigKey`.
- Keeping it there also stops it from breaking consumers that exhaust `LogtoOidcConfigKey`: Logto Cloud builds its per-tenant seeder map over `Exclude<LogtoOidcConfigKey, LogtoOidcConfigKey.Session>`, which stopped compiling when `oidc.cimd` was added in #9310.
- The config key changes from `oidc.cimd` to `cimd`. Nothing writes the row yet, so no alteration is needed.
- Default-off moves from a guard-level nullish transform to an exported `defaultCimdConfig`, which readers apply on a missing row the way `buildMessageRateGuard` applies `defaultMessageRateLimitPolicy`. #9312 carries the reader and will be rebased onto this.

## Testing

unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
