### PR TITLE
fix(core): batch user token revocation deletes

### DIFF
--- a/packages/core/src/queries/oidc-model-instance.test.ts
+++ b/packages/core/src/queries/oidc-model-instance.test.ts
@@ -27,6 +27,7 @@ const {
   consumeInstanceById,
   destroyInstanceById,
   revokeInstanceByGrantId,
+  revokeInstanceByUserId,
   findUserActiveApplicationGrants,
 } = createOidcModelInstanceQueries(pool);
 
@@ -47,6 +48,13 @@ describe('oidc-model-instance query', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // `clearAllMocks` does not remove persistent implementations, so reset here to keep a
+    // failed test from leaking its `mockImplementation` into the rest of the file.
+    mockQuery.mockReset();
+    jest.restoreAllMocks();
   });
 
   it('upsertInstance', async () => {
@@ -294,83 +302,74 @@ describe('oidc-model-instance query', () => {
     await destroyInstanceById(instance.modelName, instance.id);
   });
 
-  it('revokeInstanceByGrantId', async () => {
-    const grantId = 'grant';
-    const batchSize = 1000;
+  const revokeBatchSize = 5000;
+  const revokeCases = {
+    revokeInstanceByGrantId: {
+      revoke: async (target: string) => revokeInstanceByGrantId(instance.modelName, target),
+      expectSql: sql`
+        delete from ${table}
+        where ${fields.id} in (
+          select ${fields.id}
+          from ${table}
+          where ${fields.modelName}=$1
+          and ${fields.payload} ? 'grantId'
+          and ${fields.payload}->>'grantId'=$2
+          limit $3
+        )
+      `,
+    },
+    revokeInstanceByUserId: {
+      revoke: async (target: string) => revokeInstanceByUserId(instance.modelName, target),
+      expectSql: sql`
+        delete from ${table}
+        where ${fields.id} in (
+          select ${fields.id}
+          from ${table}
+          where ${fields.modelName}=$1
+          and ${fields.payload} ? 'accountId'
+          and ${fields.payload}->>'accountId'=$2
+          limit $3
+        )
+      `,
+    },
+  } as const;
 
-    const expectSql = sql`
-      delete from ${table}
-      where ${fields.id} in (
-        select ${fields.id}
-        from ${table}
-        where ${fields.modelName}=$1
-        and ${fields.payload} ? 'grantId'
-        and ${fields.payload}->>'grantId'=$2
-        limit $3
-      )
-    `;
+  it.each([
+    ['revokeInstanceByGrantId', [5000, 0]],
+    ['revokeInstanceByGrantId', [2500, 200, 0]],
+    ['revokeInstanceByUserId', [5000, 0]],
+    ['revokeInstanceByUserId', [2500, 200, 0]],
+  ] as const)('%s deletes in batches until drained %j', async (method, rowCounts) => {
+    const target = 'target-id';
+    const { revoke, expectSql } = revokeCases[method];
 
-    mockQuery
+    const mockBatch = (rowCount: number) => {
       // @ts-expect-error - mock delete query
-      .mockImplementationOnce(async (sql, values) => {
+      mockQuery.mockImplementationOnce(async (sql, values) => {
         expectSqlAssert(sql, expectSql.sql);
-        expect(values).toEqual([instance.modelName, grantId, batchSize]);
+        expect(values).toEqual([instance.modelName, target, revokeBatchSize]);
 
-        return { rowCount: 1000 };
-      })
-      // @ts-expect-error - mock delete query
-      .mockImplementationOnce(async (sql, values) => {
-        expectSqlAssert(sql, expectSql.sql);
-        expect(values).toEqual([instance.modelName, grantId, batchSize]);
-
-        return { rowCount: 0 };
+        return { rowCount };
       });
+    };
 
-    await revokeInstanceByGrantId(instance.modelName, grantId);
-    expect(mockQuery).toHaveBeenCalledTimes(2);
+    for (const rowCount of rowCounts) {
+      mockBatch(rowCount);
+    }
+
+    await revoke(target);
+    expect(mockQuery).toHaveBeenCalledTimes(rowCounts.length);
   });
 
-  it('revokeInstanceByGrantId should continue until no rows are deleted', async () => {
-    const grantId = 'grant';
-    const batchSize = 1000;
+  it('revocation logs an error and stops at the max batch count', async () => {
+    const error = jest.spyOn(console, 'error').mockImplementation();
+    // @ts-expect-error - mock delete query
+    mockQuery.mockImplementation(async () => ({ rowCount: 1 }));
 
-    const expectSql = sql`
-      delete from ${table}
-      where ${fields.id} in (
-        select ${fields.id}
-        from ${table}
-        where ${fields.modelName}=$1
-        and ${fields.payload} ? 'grantId'
-        and ${fields.payload}->>'grantId'=$2
-        limit $3
-      )
-    `;
+    await revokeInstanceByUserId(instance.modelName, 'target-id');
 
-    mockQuery
-      // @ts-expect-error - mock delete query
-      .mockImplementationOnce(async (sql, values) => {
-        expectSqlAssert(sql, expectSql.sql);
-        expect(values).toEqual([instance.modelName, grantId, batchSize]);
-
-        return { rowCount: 500 };
-      })
-      // @ts-expect-error - mock delete query
-      .mockImplementationOnce(async (sql, values) => {
-        expectSqlAssert(sql, expectSql.sql);
-        expect(values).toEqual([instance.modelName, grantId, batchSize]);
-
-        return { rowCount: 200 };
-      })
-      // @ts-expect-error - mock delete query
-      .mockImplementationOnce(async (sql, values) => {
-        expectSqlAssert(sql, expectSql.sql);
-        expect(values).toEqual([instance.modelName, grantId, batchSize]);
-
-        return { rowCount: 0 };
-      });
-
-    await revokeInstanceByGrantId(instance.modelName, grantId);
-    expect(mockQuery).toHaveBeenCalledTimes(3);
+    expect(mockQuery).toHaveBeenCalledTimes(1000);
+    expect(error).toHaveBeenCalledTimes(1);
   });
 
   it('findUserActiveApplicationGrants with thirdparty', async () => {

--- a/packages/core/src/queries/oidc-model-instance.test.ts
+++ b/packages/core/src/queries/oidc-model-instance.test.ts
@@ -51,8 +51,7 @@ describe('oidc-model-instance query', () => {
   });
 
   afterEach(() => {
-    // `clearAllMocks` does not remove persistent implementations, so reset here to keep a
-    // failed test from leaking its `mockImplementation` into the rest of the file.
+    // `clearAllMocks` keeps persistent implementations; reset so a failed test cannot leak one.
     mockQuery.mockReset();
     jest.restoreAllMocks();
   });
@@ -302,7 +301,7 @@ describe('oidc-model-instance query', () => {
     await destroyInstanceById(instance.modelName, instance.id);
   });
 
-  const revokeBatchSize = 5000;
+  const revokeBatchSize = 2000;
   const revokeCases = {
     revokeInstanceByGrantId: {
       revoke: async (target: string) => revokeInstanceByGrantId(instance.modelName, target),
@@ -335,15 +334,17 @@ describe('oidc-model-instance query', () => {
   } as const;
 
   it.each([
-    ['revokeInstanceByGrantId', [5000, 0]],
-    ['revokeInstanceByGrantId', [2500, 200, 0]],
-    ['revokeInstanceByUserId', [5000, 0]],
-    ['revokeInstanceByUserId', [2500, 200, 0]],
+    ['revokeInstanceByGrantId', [2000, 0]],
+    // A partial batch must not end the loop — see the early-exit bug closed in #9151.
+    ['revokeInstanceByGrantId', [1200, 200, 0]],
+    ['revokeInstanceByUserId', [2000, 0]],
+    ['revokeInstanceByUserId', [1200, 200, 0]],
+    ['revokeInstanceByUserId', [2000, undefined]],
   ] as const)('%s deletes in batches until drained %j', async (method, rowCounts) => {
     const target = 'target-id';
     const { revoke, expectSql } = revokeCases[method];
 
-    const mockBatch = (rowCount: number) => {
+    const mockBatch = (rowCount?: number) => {
       // @ts-expect-error - mock delete query
       mockQuery.mockImplementationOnce(async (sql, values) => {
         expectSqlAssert(sql, expectSql.sql);

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -1,9 +1,11 @@
 import type { Application, OidcModelInstance, OidcModelInstancePayload } from '@logto/schemas';
 import { Applications, OidcModelInstances } from '@logto/schemas';
+import { ConsoleLog } from '@logto/shared';
 import type { Nullable } from '@silverhand/essentials';
 import { conditional } from '@silverhand/essentials';
-import type { CommonQueryMethods, ValueExpression } from '@silverhand/slonik';
+import type { CommonQueryMethods, SqlSqlToken, ValueExpression } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
+import chalk from 'chalk';
 import { addSeconds, isBefore } from 'date-fns';
 
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
@@ -30,7 +32,12 @@ const sessionModelName = 'Session';
  */
 // Hard-code this value since 3 seconds is a reasonable number for concurrency and no need for further configuration
 const refreshTokenReuseInterval = 3;
-const revokeInstanceBatchSize = 1000;
+const revokeInstanceBatchSize = 5000;
+/** Safety valve so a revocation request stays bounded even for pathological instance counts. */
+const maxRevokeInstanceBatches = 1000;
+const revokeInstanceBatchIterations = Array.from({ length: maxRevokeInstanceBatches });
+
+const consoleLog = new ConsoleLog(chalk.magenta('query'));
 
 const isConsumed = (modelName: string, consumedAt: Nullable<number>): boolean => {
   if (!consumedAt) {
@@ -181,36 +188,57 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
     `);
   };
 
-  const revokeInstanceByGrantId = async (modelName: string, grantId: string) => {
-    // Keep deleting bounded batches until the revoke query no longer finds matches.
-    for (;;) {
-      // Revocation batches must run serially to keep each delete bounded.
-      // eslint-disable-next-line no-await-in-loop
+  /**
+   * Delete instances of the given model matching the condition in bounded batches until no
+   * matches remain, so no single statement can exceed the database statement timeout.
+   * The condition must include the payload key-existence clause that matches the partial
+   * index predicate, so the batches stay index-backed under any query plan.
+   *
+   * @param target - Human-readable principal for the cap log, e.g. `accountId <userId>`.
+   */
+  const revokeInstancesInBatches = async (
+    modelName: string,
+    target: string,
+    condition: SqlSqlToken
+  ) => {
+    for (const _ of revokeInstanceBatchIterations) {
+      // eslint-disable-next-line no-await-in-loop -- revocation batches must run serially to keep each delete bounded
       const { rowCount } = await pool.query(sql`
         delete from ${table}
         where ${fields.id} in (
           select ${fields.id}
           from ${table}
           where ${fields.modelName}=${modelName}
-          and ${fields.payload} ? 'grantId'
-          and ${fields.payload}->>'grantId'=${grantId}
+          and ${condition}
           limit ${revokeInstanceBatchSize}
         )
       `);
 
-      if (rowCount === 0) {
+      if (!rowCount) {
         return;
       }
     }
+
+    consoleLog.error(
+      `Revoking ${modelName} instances for ${target} did not finish within ${maxRevokeInstanceBatches} batches; remaining instances are left for a retry.`
+    );
   };
 
-  const revokeInstanceByUserId = async (modelName: string, userId: string) => {
-    await pool.query(sql`
-      delete from ${table}
-      where ${fields.modelName}=${modelName}
-      and ${fields.payload}->>'accountId'=${userId}
-    `);
-  };
+  const revokeInstanceByGrantId = async (modelName: string, grantId: string) =>
+    revokeInstancesInBatches(
+      modelName,
+      `grantId ${grantId}`,
+      sql`${fields.payload} ? 'grantId'
+          and ${fields.payload}->>'grantId'=${grantId}`
+    );
+
+  const revokeInstanceByUserId = async (modelName: string, userId: string) =>
+    revokeInstancesInBatches(
+      modelName,
+      `accountId ${userId}`,
+      sql`${fields.payload} ? 'accountId'
+          and ${fields.payload}->>'accountId'=${userId}`
+    );
 
   const findUserActiveApplicationGrants = async (
     userId: string,

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -32,9 +32,10 @@ const sessionModelName = 'Session';
  */
 // Hard-code this value since 3 seconds is a reasonable number for concurrency and no need for further configuration
 const refreshTokenReuseInterval = 3;
-const revokeInstanceBatchSize = 5000;
+const revokeInstanceBatchSize = 2000;
 /** Safety valve so a revocation request stays bounded even for pathological instance counts. */
 const maxRevokeInstanceBatches = 1000;
+/** Fixed-length array to drive the bounded batch loop without a mutable counter. */
 const revokeInstanceBatchIterations = Array.from({ length: maxRevokeInstanceBatches });
 
 const consoleLog = new ConsoleLog(chalk.magenta('query'));
@@ -189,12 +190,12 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   };
 
   /**
-   * Delete instances of the given model matching the condition in bounded batches until no
-   * matches remain, so no single statement can exceed the database statement timeout.
-   * The condition must include the payload key-existence clause that matches the partial
-   * index predicate, so the batches stay index-backed under any query plan.
+   * Delete matching instances in bounded batches until none remain, so no single statement can
+   * exceed the database statement timeout.
    *
    * @param target - Human-readable principal for the cap log, e.g. `accountId <userId>`.
+   * @param condition - Must include the payload key-existence clause matching the partial index
+   * predicate, or the batches stop being index-backed.
    */
   const revokeInstancesInBatches = async (
     modelName: string,

--- a/packages/integration-tests/src/tests/api/sessions/index.test.ts
+++ b/packages/integration-tests/src/tests/api/sessions/index.test.ts
@@ -9,6 +9,7 @@ import {
   getUserSessions,
   revokeUserGrant,
   revokeUserSession,
+  suspendUser,
 } from '#src/api/index.js';
 import { signInWithPassword } from '#src/helpers/experience/index.js';
 import { expectRejects } from '#src/helpers/index.js';
@@ -337,6 +338,35 @@ describe('Sessions API', () => {
     const { sessions } = await getUserSessions(user.id);
     const appSession = findSessionByAppId(sessions, app.id);
     expect(appSession).toBeUndefined();
+
+    await deleteApplication(app.id);
+  });
+
+  it('should revoke user sessions and refresh tokens when the user is suspended', async () => {
+    await enableAllPasswordSignInMethods();
+
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({ username, password });
+
+    const { app, refreshToken } = await createAppAndSignInWithPassword({
+      username,
+      password,
+    });
+
+    assert(refreshToken, new Error('No refresh token found'));
+
+    const { sessions } = await getUserSessions(user.id);
+    expect(findSessionByAppId(sessions, app.id)).toBeTruthy();
+
+    await suspendUser(user.id, true);
+
+    const { sessions: sessionsAfterSuspension } = await getUserSessions(user.id);
+    expect(sessionsAfterSuspension).toHaveLength(0);
+
+    await assertRefreshTokenInvalidGrant({
+      clientId: app.id,
+      refreshToken,
+    });
 
     await deleteApplication(app.id);
   });


### PR DESCRIPTION
## Summary

Companion to #9313: `signOutUser` (user deletion and suspension) revoked a user's AccessToken/RefreshToken/Session instances with one unbounded `delete from oidc_model_instances where model_name = $1 and payload->>'accountId' = $2` per model. Even with the new index, a token-heavy user can exceed `statement_timeout` in a single delete. This bounds each statement by batching.

### What changed
- New shared `revokeInstancesInBatches(modelName, target, condition)` helper — `delete … where id in (select id … limit 2000)` looped until no rows match, with a safety cap of 1000 batches (error log naming the model and principal + stop when hit). Both `revokeInstanceByGrantId` and `revokeInstanceByUserId` are now thin wrappers over it, removing the previously duplicated loop and one of the two `no-await-in-loop` disables.
- The userId condition now includes `payload ? 'accountId'`, matching #9313's partial-index predicate verbatim (the `grantId` precedent) so the batches stay index-backed under any query plan. Semantics unchanged — `->> = $2` can never match a row lacking the key.
- Termination is `if (!rowCount)` — same semantics as `=== 0` for numbers, but terminates instead of spinning if the driver ever returns a nullish row count.
- Batch size 2000 (applies to both wrappers). Measured on a 1.2M-row table carrying all seven post-#9313 indexes, revoking a user with 200k access tokens: per-row cost plateaus at 2000 (11.6 µs/row, versus 22.9 at 1000 where fixed per-statement overhead dominates, and 12.2 at 5000). 2000 therefore matches the total throughput of a larger batch while keeping each statement ~2.6× shorter — smaller lock footprint, smaller blast radius per failed batch, and more headroom under `statement_timeout`.
- The four copy-pasted unit tests are collapsed into one `it.each` table (SQL shape + loop-until-drained semantics for both wrappers, including a partial-batch case that pins the #9151 early-exit invariant and a nullish `rowCount` case that pins the termination guard), plus a cap test (1000 batches → error log + stop). Mock cleanup lives in `afterEach` so a failed assertion cannot leak a persistent implementation into later tests. The previously needed file-level `max-lines` disable is gone.
- New integration test: suspending a user empties their sessions list and invalidates their refresh token — the first integration coverage that suspension actually revokes sessions/tokens. Both assertions are attributable to `revokeInstanceByUserId`: the sessions listing reads from `oidc_model_instances` (`model_name = 'Session'`), and the token endpoint has no suspension guard, so `invalid_grant` can only come from the deleted rows.

### Expected result
- Revocation cost per statement is bounded regardless of user token volume; a mid-way failure is retryable with monotonic progress (previously a timeout rolled back the whole delete and made zero progress). A pathological user beyond 2M instances stops at the cap with an error-level log naming the model and principal (alertable) instead of running unbounded.
- Revocation is no longer atomic per model — each batch commits on its own. A mid-loop failure now leaves a partially revoked user rather than an untouched one. This is strictly better than the previous behavior on both paths (deletion runs before `deleteUserById`, so a retry resumes; suspension previously left *every* token live on timeout, and now leaves progressively fewer), but it is a real change in failure shape and worth knowing when reading logs.
- Within one `signOutUser`, the three batched loops run on disjoint `model_name` row sets. Concurrent invocations (or an overlapping grant revocation) can still contend on the same rows; Postgres resolves any residual deadlock by aborting one retryable statement.
- Scope caveat: three of the four statements in `signOutUser` are now bounded; `oidcSessionExtensions.deleteByAccountId` remains a single-statement delete, indexed by #9319 (stacked) and bounded by the user's session count.

### Reviewer notes
- No `order by` in the subselect, deliberately: measured plans show ordering by `id` makes the planner abandon the accountId index (PK-order scan / top-N sort), so each batch reads every remaining matching row instead of 2000 — O(matches²) total. Unordered, the plan is a bounded `rows=2000` index scan. Lock ordering was never guaranteed by a subselect `order by` anyway.
- Termination is deliberately `!rowCount`, never `rowCount < batchSize`: the early-exit variant was attempted in #9151 and closed — under READ COMMITTED, concurrent deletes of selected ids can push `rowCount` below the limit while matching rows remain, leaving tokens un-revoked.
- At the cap the loop logs at error level and stops (request still succeeds): residual rows are inert after user deletion (`findAccount` rejects deleted users). On the suspension path a capped run would leave live tokens behind an apparent success — error-level logging makes it alertable; the token-path `isSuspended` guard is tracked separately, and 2M+ instances makes the case practically unreachable.
- This introduces the first `ConsoleLog` usage in the queries layer (module-local instance, mirroring `env-set/preconditions.ts`) — deliberate, since the query factory has no request context.
- Possible follow-up, not done here: `where id in (select id …)` re-probes the primary key for every deleted row, which measures as ~80% of each statement's buffer traffic (20,000 of 25,303 buffers at a 5000-row batch). Selecting `ctid` instead removes that probe entirely (~7× faster in the same harness), but it needs verification on PostgreSQL 14 (the declared minimum) and has a subtler interaction with concurrently updated rows, so it is left out of a fix that is already doing its job.
- Merge/deploy order matters: #9313 (partial accountId index) must land first. Without it, each batch's subselect falls back to scanning, multiplying the old cost instead of removing it. This PR is stacked on that branch and will be retargeted to master once it merges.

## Testing
Unit tests, integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
