### PR TITLE
fix(schemas): add account id index to oidc session extensions

### DIFF
--- a/packages/schemas/alterations/next-1785722831-add-oidc-session-extensions-account-id-index.ts
+++ b/packages/schemas/alterations/next-1785722831-add-oidc-session-extensions-account-id-index.ts
@@ -1,0 +1,27 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    // Add index to optimize deleting session extensions by accountId, including the
+    // cascades from the users table. See the index comment in tables/oidc_session_extensions.sql.
+    await pool.query(sql`
+      create index concurrently oidc_session_extensions__account_id
+        on oidc_session_extensions (account_id);
+    `);
+  },
+  up: async () => {
+    /** 'concurrently' cannot be used inside a transaction, so this up is intentionally left empty. */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently oidc_session_extensions__account_id;
+    `);
+  },
+  down: async () => {
+    /** 'concurrently' cannot be used inside a transaction, so this down is intentionally left empty. */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/oidc_session_extensions.sql
+++ b/packages/schemas/tables/oidc_session_extensions.sql
@@ -13,6 +13,10 @@ create table oidc_session_extensions (
   primary key (tenant_id, session_uid)
 );
 
+/* Leads with account_id instead of tenant_id so the cascades from the users table can use it (users.id is globally unique, so a tenant_id prefix adds no selectivity). */
+create index oidc_session_extensions__account_id
+  on oidc_session_extensions (account_id);
+
 create trigger set_updated_at
   before update on oidc_session_extensions
   for each row


### PR DESCRIPTION
## Summary

Third piece of the statement-timeout work (after #9313 and #9318): `oidc_session_extensions.deleteByAccountId` runs inside the same `signOutUser` `Promise.all` as the token revocations (every user suspension and deletion), but the table's only index is the PK `(tenant_id, session_uid)` — so it sequentially scans a table that grows one row per session and has no expiry reaper.

### What changed
- New index `oidc_session_extensions__account_id` on `(account_id)` — alteration (`create index concurrently` in `beforeUp`, hard-fail) + matching seed.

### Why `(account_id)` and not the conventional `(tenant_id, account_id)`
- The `on update/delete cascade` RI triggers from `users` query `where account_id = $1` with no `tenant_id` (RI bypasses RLS), so only an `account_id`-leading index can serve them before PG 18 skip scan.
- For the RLS-scoped `deleteByAccountId`, the shapes are equivalent: `account_id` references the globally-unique `users.id`, so all rows of an account belong to one tenant and the tenant qual filters zero rows either way.
- Verified no other query on the table would prefer the tenant-leading shape — everything else (`deleteBySessionUid`, `findBySessionUid`, the session-listing left join, the upsert conflict target) resolves via the PK.
- The rationale is recorded as a comment on the seed index (following the `users.sql` precedent for constraint-driven index shapes), so it doesn't get "corrected" back to convention later.

### Reviewer notes
- Hard-fail semantics (no `if not exists`), matching #9313 and the #8427 ruling; a failed concurrent build leaves an INVALID index to drop manually before rerun.
- Stacked on #9318; will be retargeted as parents merge. No deploy-order dependency of its own.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments