### PR TITLE
fix(core): reject token issuance for suspended users

### DIFF
--- a/.changeset/spicy-donuts-guard.md
+++ b/.changeset/spicy-donuts-guard.md
@@ -1,0 +1,7 @@
+---
+'@logto/core': patch
+---
+
+reject token issuance for suspended users
+
+Suspending a user revokes their sessions and tokens, but token issuance itself never checked the suspension flag — if revocation partially failed, a surviving refresh token kept working indefinitely. The OIDC `findAccount` hook now rejects suspended users with `invalid_grant`, mirroring how deleted users are handled, so all user token grants (refresh token, authorization code, device code, token exchange) and userinfo reject suspended users regardless of revocation state.

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -270,6 +270,23 @@ describe('refresh token grant', () => {
     );
   });
 
+  it('should throw before consuming the refresh token when the user is suspended', async () => {
+    const ctx = createOidcContext(validOidcContext);
+    const consume = jest.fn();
+    stubRefreshToken(ctx, { consume });
+    stubGrant(ctx);
+    // The suspension check lives in `findAccount` (see `oidc/init.ts`); the grant surfaces its
+    // rejection at the account validation step.
+    Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').rejects(
+      new errors.InvalidGrant('user is suspended')
+    );
+
+    await expect(mockHandler()(ctx)).rejects.toMatchError(
+      new errors.InvalidGrant('user is suspended')
+    );
+    expect(consume).not.toHaveBeenCalled();
+  });
+
   it('should throw when refresh token has been consumed', async () => {
     const ctx = createOidcContext(validOidcContext);
     stubRefreshToken(ctx, {

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import { GrantType, type Scope } from '@logto/schemas';
 import { errors, type KoaContextWithOIDC } from 'oidc-provider';
 
-import { mockResource } from '#src/__mocks__/index.js';
+import { mockResource, mockUser } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import { mockEnvSet } from '#src/test-utils/env-set.js';
@@ -375,5 +375,33 @@ describe('oidc provider init', () => {
     expect(findResourceByIndicator).toHaveBeenCalledTimes(2);
     expect(findApplicationById).toHaveBeenCalledTimes(2);
     expect(findUserScopesForResourceIndicator).toHaveBeenCalledTimes(2);
+  });
+});
+
+const findAccount = async (findUserById: () => Promise<typeof mockUser>) => {
+  const provider = createProvider(new MockTenant(undefined, { users: { findUserById } }));
+  const configuration = getProviderConfiguration(provider);
+  return configuration.findAccount(createOidcContext({ provider }), accountId);
+};
+
+describe('findAccount', () => {
+  it('should resolve the account for an active user', async () => {
+    await expect(findAccount(async () => ({ ...mockUser, id: accountId }))).resolves.toMatchObject({
+      accountId,
+    });
+  });
+
+  it('should reject when the user cannot be found', async () => {
+    await expect(
+      findAccount(async () => {
+        throw new Error('not found');
+      })
+    ).rejects.toMatchError(new errors.InvalidGrant('user not found'));
+  });
+
+  it('should reject when the user is suspended', async () => {
+    await expect(
+      findAccount(async () => ({ ...mockUser, id: accountId, isSuspended: true }))
+    ).rejects.toMatchError(new errors.InvalidGrant('user is suspended'));
   });
 });

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -372,6 +372,12 @@ export default function initOidc(
         throw new errors.InvalidGrant('user not found');
       });
 
+      // Suspension revokes the user's sessions and tokens; reject here as well so any token
+      // that survives a partial revocation still cannot be used.
+      if (user.isSuspended) {
+        throw new errors.InvalidGrant('user is suspended');
+      }
+
       return {
         accountId: sub,
         /**

--- a/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
@@ -436,3 +436,90 @@ describe('refresh token rotation and reuse detection', () => {
     });
   });
 });
+
+describe('suspended user refresh token rejection', () => {
+  const username = generateUsername();
+  const password = generatePassword();
+  /* eslint-disable @silverhand/fp/no-let */
+  let application: Application;
+  let pool: DatabasePool;
+  let userId = '';
+  /* eslint-enable @silverhand/fp/no-let */
+
+  beforeAll(async () => {
+    const [createdApplication, createdPool, user] = await Promise.all([
+      createApplication('OIDC suspended user semantics', ApplicationType.SPA, {
+        oidcClientMetadata: {
+          redirectUris: [demoAppRedirectUri],
+          postLogoutRedirectUris: [demoAppRedirectUri],
+        },
+      }),
+      createPool(assertEnv('DB_URL'), { interceptors: createInterceptorsPreset() }),
+      createUserByAdmin({ username, password }),
+      enableAllPasswordSignInMethods(),
+    ]);
+
+    /* eslint-disable @silverhand/fp/no-mutation */
+    application = createdApplication;
+    pool = createdPool;
+    userId = user.id;
+    /* eslint-enable @silverhand/fp/no-mutation */
+  });
+
+  afterAll(async () => {
+    await Promise.all([deleteApplication(application.id), deleteUser(userId), pool.end()]);
+  });
+
+  it('rejects a refresh token that survived suspension-time revocation', async () => {
+    const client = await initExperienceClient({
+      config: { appId: application.id },
+      redirectUri: demoAppRedirectUri,
+    });
+    await identifyUserWithUsernamePassword(client, username, password);
+    const { redirectTo } = await client.submitInteraction();
+    await expect(processSession(client, redirectTo)).resolves.toBe(userId);
+
+    const initialRefreshToken = await client.getRefreshToken();
+    assert(initialRefreshToken, new Error('Missing refresh token after code exchange'));
+
+    const exchangeRefreshToken = async (refreshToken: string) =>
+      oidcApi
+        .post('token', {
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: refreshToken,
+            client_id: application.id,
+          }),
+        })
+        .json<{ refresh_token: string }>();
+
+    // Baseline: the token works, and rotation leaves a fresh, unconsumed replacement.
+    const { refresh_token: rotatedRefreshToken } = await exchangeRefreshToken(initialRefreshToken);
+    assert(rotatedRefreshToken, new Error('Missing rotated refresh token'));
+
+    const setSuspended = async (isSuspended: boolean) =>
+      pool.query(sql`
+        update users set is_suspended = ${isSuspended}
+        where tenant_id = ${defaultTenantId} and id = ${userId}
+      `);
+
+    /**
+     * Suspending through the management API also revokes the user's tokens (`signOutUser`), so
+     * flip the flag directly instead — simulating a partial revocation failure where a refresh
+     * token survives. The surviving token must still be rejected by the suspension check in
+     * `findAccount`.
+     */
+    await setSuspended(true);
+
+    try {
+      await expectOidcError(exchangeRefreshToken(rotatedRefreshToken), { error: 'invalid_grant' });
+    } finally {
+      await setSuspended(false);
+    }
+
+    // The rejection consumed nothing: the same token works again after unsuspension, proving
+    // the failure above was caused by the suspension flag alone.
+    const { refresh_token: postUnsuspendToken } = await exchangeRefreshToken(rotatedRefreshToken);
+    expect(postUnsuspendToken).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
Suspending a user (`PATCH /users/:userId/is-suspended`) relies entirely on revoking the user's Session/AccessToken/RefreshToken rows — the token endpoint itself never checked `isSuspended`. If revocation partially fails (e.g. a statement error mid-way), a surviving refresh token keeps working indefinitely.

This adds defense in depth at the OIDC `findAccount` hook: suspended users are now rejected with `invalid_grant`, mirroring the existing deleted-user handling. Since `findAccount` is the single account-resolution seam of the provider, the check covers the refresh token, authorization code, device code, and token exchange grants, plus userinfo and session account loading.

- `packages/core/src/oidc/init.ts`: throw `InvalidGrant('user is suspended')` in `findAccount` when the resolved user is suspended.
- Unit tests: `findAccount` behavior for active / deleted / suspended users, and the custom refresh grant surfacing the rejection before the refresh token is consumed or rotated.
- Integration test: signs in, then flips `users.is_suspended` directly via SQL — simulating a partial revocation failure that leaves a live refresh token — and asserts the refresh grant fails with `invalid_grant`. Unsuspending makes the same token work again, proving the rejection is caused by the flag alone.

## Testing
Unit tests, integration tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments