### PR TITLE
refactor(schemas): add tenant-aware scope indexes

### DIFF
--- a/packages/schemas/alterations/next-1785481546-add-tenant-aware-scope-indexes.ts
+++ b/packages/schemas/alterations/next-1785481546-add-tenant-aware-scope-indexes.ts
@@ -4,19 +4,11 @@ import type { AlterationScript } from '../lib/types/alteration.js';
 
 const alteration: AlterationScript = {
   beforeUp: async (pool) => {
-    // Clean up an invalid index that may be left by a failed concurrent build.
-    await pool.query(sql`
-      drop index concurrently if exists scopes__tenant_id_id;
-    `);
     await pool.query(sql`
       create unique index concurrently scopes__tenant_id_id
         on scopes (tenant_id, id);
     `);
 
-    // Clean up an invalid index that may be left by a failed concurrent build.
-    await pool.query(sql`
-      drop index concurrently if exists organization_scopes__tenant_id_id;
-    `);
     await pool.query(sql`
       create unique index concurrently organization_scopes__tenant_id_id
         on organization_scopes (tenant_id, id);

--- a/packages/schemas/alterations/next-1785481546-add-tenant-aware-scope-indexes.ts
+++ b/packages/schemas/alterations/next-1785481546-add-tenant-aware-scope-indexes.ts
@@ -13,27 +13,11 @@ const alteration: AlterationScript = {
       create unique index concurrently organization_scopes__tenant_id_id
         on organization_scopes (tenant_id, id);
     `);
-
-    await pool.query(sql`
-      drop index concurrently if exists scopes__id;
-    `);
-    await pool.query(sql`
-      drop index concurrently if exists organization_scopes__id;
-    `);
   },
   up: async () => {
     // The indexes must be created outside of a transaction.
   },
   beforeDown: async (pool) => {
-    await pool.query(sql`
-      create index concurrently scopes__id
-        on scopes (tenant_id, id);
-    `);
-    await pool.query(sql`
-      create index concurrently organization_scopes__id
-        on organization_scopes (tenant_id, id);
-    `);
-
     await pool.query(sql`
       drop index concurrently if exists organization_scopes__tenant_id_id;
     `);

--- a/packages/schemas/alterations/next-1785481546-add-tenant-aware-scope-indexes.ts
+++ b/packages/schemas/alterations/next-1785481546-add-tenant-aware-scope-indexes.ts
@@ -13,11 +13,27 @@ const alteration: AlterationScript = {
       create unique index concurrently organization_scopes__tenant_id_id
         on organization_scopes (tenant_id, id);
     `);
+
+    await pool.query(sql`
+      drop index concurrently if exists scopes__id;
+    `);
+    await pool.query(sql`
+      drop index concurrently if exists organization_scopes__id;
+    `);
   },
   up: async () => {
     // The indexes must be created outside of a transaction.
   },
   beforeDown: async (pool) => {
+    await pool.query(sql`
+      create index concurrently scopes__id
+        on scopes (tenant_id, id);
+    `);
+    await pool.query(sql`
+      create index concurrently organization_scopes__id
+        on organization_scopes (tenant_id, id);
+    `);
+
     await pool.query(sql`
       drop index concurrently if exists organization_scopes__tenant_id_id;
     `);

--- a/packages/schemas/alterations/next-1785481546-add-tenant-aware-scope-indexes.ts
+++ b/packages/schemas/alterations/next-1785481546-add-tenant-aware-scope-indexes.ts
@@ -1,0 +1,41 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    // Clean up an invalid index that may be left by a failed concurrent build.
+    await pool.query(sql`
+      drop index concurrently if exists scopes__tenant_id_id;
+    `);
+    await pool.query(sql`
+      create unique index concurrently scopes__tenant_id_id
+        on scopes (tenant_id, id);
+    `);
+
+    // Clean up an invalid index that may be left by a failed concurrent build.
+    await pool.query(sql`
+      drop index concurrently if exists organization_scopes__tenant_id_id;
+    `);
+    await pool.query(sql`
+      create unique index concurrently organization_scopes__tenant_id_id
+        on organization_scopes (tenant_id, id);
+    `);
+  },
+  up: async () => {
+    // The indexes must be created outside of a transaction.
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently if exists organization_scopes__tenant_id_id;
+    `);
+    await pool.query(sql`
+      drop index concurrently if exists scopes__tenant_id_id;
+    `);
+  },
+  down: async () => {
+    // The indexes must be dropped outside of a transaction.
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/organization_scopes.sql
+++ b/packages/schemas/tables/organization_scopes.sql
@@ -15,9 +15,6 @@ create table organization_scopes (
     unique (tenant_id, name)
 );
 
-create index organization_scopes__id
-  on organization_scopes (tenant_id, id);
-
 /** Supports tenant-aware foreign keys from tenant-owned organization scope relations. */
 create unique index organization_scopes__tenant_id_id
   on organization_scopes (tenant_id, id);

--- a/packages/schemas/tables/organization_scopes.sql
+++ b/packages/schemas/tables/organization_scopes.sql
@@ -17,3 +17,7 @@ create table organization_scopes (
 
 create index organization_scopes__id
   on organization_scopes (tenant_id, id);
+
+/** Supports tenant-aware foreign keys from tenant-owned organization scope relations. */
+create unique index organization_scopes__tenant_id_id
+  on organization_scopes (tenant_id, id);

--- a/packages/schemas/tables/organization_scopes.sql
+++ b/packages/schemas/tables/organization_scopes.sql
@@ -15,6 +15,9 @@ create table organization_scopes (
     unique (tenant_id, name)
 );
 
+create index organization_scopes__id
+  on organization_scopes (tenant_id, id);
+
 /** Supports tenant-aware foreign keys from tenant-owned organization scope relations. */
 create unique index organization_scopes__tenant_id_id
   on organization_scopes (tenant_id, id);

--- a/packages/schemas/tables/scopes.sql
+++ b/packages/schemas/tables/scopes.sql
@@ -14,6 +14,9 @@ create table scopes (
     unique (tenant_id, resource_id, name)
 );
 
+create index scopes__id
+  on scopes (tenant_id, id);
+
 /** Supports tenant-aware foreign keys from tenant-owned scope relations. */
 create unique index scopes__tenant_id_id
   on scopes (tenant_id, id);

--- a/packages/schemas/tables/scopes.sql
+++ b/packages/schemas/tables/scopes.sql
@@ -14,9 +14,6 @@ create table scopes (
     unique (tenant_id, resource_id, name)
 );
 
-create index scopes__id
-  on scopes (tenant_id, id);
-
 /** Supports tenant-aware foreign keys from tenant-owned scope relations. */
 create unique index scopes__tenant_id_id
   on scopes (tenant_id, id);

--- a/packages/schemas/tables/scopes.sql
+++ b/packages/schemas/tables/scopes.sql
@@ -16,3 +16,7 @@ create table scopes (
 
 create index scopes__id
   on scopes (tenant_id, id);
+
+/** Supports tenant-aware foreign keys from tenant-owned scope relations. */
+create unique index scopes__tenant_id_id
+  on scopes (tenant_id, id);


### PR DESCRIPTION
## Summary

Add tenant-aware unique indexes for API resource scopes and organization scopes.

- Add unique `(tenant_id, id)` indexes to `scopes` and `organization_scopes` as composite foreign key targets.
- Build and drop the new indexes concurrently for existing databases.
- Keep the current non-unique lookup indexes unchanged in this PR; remove them separately after the new indexes have been deployed and verified.

## Context

This follows the same tenant-isolation failure pattern previously fixed in #7596. `organization_user_relations` originally referenced only `users (id)`, so a relation owned by tenant A could store a user ID belonging to tenant B. RLS then hid that user when the relation was read under tenant A, resulting in missing joined data and 500 responses. #7596 fixed the problem by adding a tenant-aware composite foreign key from `(tenant_id, user_id)` to `users (tenant_id, id)`.

The CIMD scope relations in #9309 have the same requirement. They use composite foreign keys containing both the tenant and scope identifier, so PostgreSQL requires matching unique parent keys on `scopes (tenant_id, id)` and `organization_scopes (tenant_id, id)`. This PR adds those parent indexes before #9309 creates the dependent relations.

The follow-up alteration must use a later timestamp so its composite foreign keys are created after these indexes.

No changeset — internal schema preparation only.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments