### PR TITLE
fix(console): remove dead warning class reference

### DIFF
--- a/packages/console/src/pages/Actions/ActionDetails/index.tsx
+++ b/packages/console/src/pages/Actions/ActionDetails/index.tsx
@@ -1,5 +1,4 @@
 import { LogtoActionKey } from '@logto/schemas';
-import classNames from 'classnames';
 import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
@@ -63,7 +62,7 @@ function Content({ actionType, mode }: ContentProps) {
             <InlineNotification
               hasIcon
               severity="alert"
-              className={classNames(styles.warning, !isMonacoLoaded && styles.hidden)}
+              className={isMonacoLoaded ? undefined : styles.hidden}
             >
               <div className={styles.warningTitle}>{t('actions.security_warning.title')}</div>
               <div>{t('actions.security_warning.description')}</div>


### PR DESCRIPTION
## Summary

[`ActionDetails/index.tsx:66`](https://github.com/logto-io/logto/blob/master/packages/console/src/pages/Actions/ActionDetails/index.tsx#L66) passed `styles.warning` to the security-warning `InlineNotification`, but `.warning` is not defined in `index.module.scss` — that file only has `.container`, `.hidden`, and `.warningTitle`. The reference resolved to `undefined` and the class was silently dropped.

Git history explains why: the feature commit that introduced this page (#9216) includes a step titled *"fix(console): remove extra spacing under P1 security warning"*, with the note that `DetailsPage` already adds margin between direct children so the warning's `margin-bottom` was doubling the gap above the editor. The `.warning` rule was deleted then, but the JSX reference was left behind — along with the comment now standing in for it in the stylesheet.

So this removes the dead reference rather than restoring the rule; re-adding `.warning` would reintroduce the exact double-gap that commit fixed.

## Details

- Spacing is already handled by `DetailsPage`'s `.container > *:not(:first-child) { margin-top: _.unit(4); }`. `CodeEditorLoadingContext.Provider` renders no DOM node, so the `InlineNotification` and `MainContent` are genuine direct children of that container and the selector applies.
- The remaining toggle is now written as `isMonacoLoaded ? undefined : styles.hidden`, matching the sibling `MainContent` prop two lines below that expresses the same show/hide.
- `classNames` was only used on that line, so its import is dropped.
- No change to `index.module.scss`.

## Testing

Not verified by tooling — `node_modules` isn't installed in this worktree, so `eslint` fails with `File '@silverhand/ts-config-react/tsconfig.base' not found` and `lint-staged` matched no projects. The change is an unused-import removal plus a ternary, so there is no type surface, but CI is the first real check.