### PR TITLE
feat(core,console): add configurable reCAPTCHA score threshold

### DIFF
--- a/.changeset/olive-pandas-threshold.md
+++ b/.changeset/olive-pandas-threshold.md
@@ -1,0 +1,8 @@
+---
+'@logto/console': minor
+'@logto/core': minor
+'@logto/phrases': minor
+'@logto/schemas': minor
+---
+
+add a configurable score threshold for reCAPTCHA Enterprise so admins can control how strict CAPTCHA verification is

--- a/packages/console/src/pages/Security/Captcha/CaptchaFormFields/index.tsx
+++ b/packages/console/src/pages/Security/Captcha/CaptchaFormFields/index.tsx
@@ -1,5 +1,11 @@
 import { RecaptchaEnterpriseMode } from '@logto/schemas';
-import { type UseFormRegister, type FieldErrors, Controller, type Control } from 'react-hook-form';
+import {
+  type UseFormRegister,
+  type FieldErrors,
+  Controller,
+  type Control,
+  useWatch,
+} from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import FormField from '@/ds-components/FormField';
@@ -25,10 +31,40 @@ function CaptchaFormFields({ metadata, errors, register, control }: Props) {
   const projectIdField = metadata.requiredFields.find((field) => field.field === 'projectId');
   const domainField = metadata.requiredFields.find((field) => field.field === 'domain');
   const modeField = metadata.requiredFields.find((field) => field.field === 'mode');
+  const scoreThresholdField = metadata.requiredFields.find(
+    (field) => field.field === 'scoreThreshold'
+  );
+  const mode = useWatch({ control, name: 'mode' });
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   return (
     <>
+      {modeField && (
+        <>
+          <FormField title={modeField.label}>
+            <Controller
+              name="mode"
+              control={control}
+              defaultValue={RecaptchaEnterpriseMode.Invisible}
+              render={({ field: { onChange, value } }) => (
+                <RadioGroup name="mode" value={value} onChange={onChange}>
+                  <Radio
+                    title="security.captcha_details.mode_invisible"
+                    value={RecaptchaEnterpriseMode.Invisible}
+                  />
+                  <Radio
+                    title="security.captcha_details.mode_checkbox"
+                    value={RecaptchaEnterpriseMode.Checkbox}
+                  />
+                </RadioGroup>
+              )}
+            />
+          </FormField>
+          <InlineNotification className={styles.modeNotice} severity="alert">
+            {t('security.captcha_details.mode_notice')}
+          </InlineNotification>
+        </>
+      )}
       {siteKeyField && (
         <FormField isRequired title={siteKeyField.label}>
           <TextInput
@@ -65,31 +101,29 @@ function CaptchaFormFields({ metadata, errors, register, control }: Props) {
           />
         </FormField>
       )}
-      {modeField && (
-        <>
-          <FormField title={modeField.label}>
-            <Controller
-              name="mode"
-              control={control}
-              defaultValue={RecaptchaEnterpriseMode.Invisible}
-              render={({ field: { onChange, value } }) => (
-                <RadioGroup name="mode" value={value} onChange={onChange}>
-                  <Radio
-                    title="security.captcha_details.mode_invisible"
-                    value={RecaptchaEnterpriseMode.Invisible}
-                  />
-                  <Radio
-                    title="security.captcha_details.mode_checkbox"
-                    value={RecaptchaEnterpriseMode.Checkbox}
-                  />
-                </RadioGroup>
-              )}
-            />
-          </FormField>
-          <InlineNotification className={styles.modeNotice} severity="alert">
-            {t('security.captcha_details.mode_notice')}
-          </InlineNotification>
-        </>
+      {mode !== RecaptchaEnterpriseMode.Checkbox && scoreThresholdField && (
+        <FormField
+          isRequired={!scoreThresholdField.isOptional}
+          title={scoreThresholdField.label}
+          description="security.captcha_details.score_threshold_description"
+        >
+          <TextInput
+            type="number"
+            min={0}
+            max={1}
+            step={0.01}
+            error={errors.scoreThreshold && t('security.captcha_details.score_threshold_error')}
+            placeholder="0.5"
+            {...register('scoreThreshold', {
+              shouldUnregister: true,
+              required: !scoreThresholdField.isOptional,
+              min: 0,
+              max: 1,
+              setValueAs: (value) => (value === '' || value === null ? undefined : Number(value)),
+              validate: (value) => value === undefined || Number.isFinite(value),
+            })}
+          />
+        </FormField>
       )}
     </>
   );

--- a/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/constants.ts
+++ b/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/constants.ts
@@ -108,6 +108,12 @@ export const captchaProviders: CaptchaProviderMetadata[] = [
         placeholder: 'security.captcha_details.domain_placeholder',
         isOptional: true,
       },
+      {
+        field: 'scoreThreshold',
+        label: 'security.captcha_details.score_threshold',
+        placeholder: 'security.captcha_details.score_threshold',
+        isOptional: true,
+      },
     ],
   },
   {

--- a/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/types.ts
+++ b/packages/console/src/pages/Security/Captcha/CreateCaptchaForm/types.ts
@@ -1,7 +1,7 @@
 import { type AdminConsoleKey } from '@logto/phrases';
 import { type CaptchaType } from '@logto/schemas';
 
-type FormField = 'siteKey' | 'secretKey' | 'projectId' | 'domain' | 'mode';
+type FormField = 'siteKey' | 'secretKey' | 'projectId' | 'domain' | 'mode' | 'scoreThreshold';
 
 export type CaptchaProviderMetadata = {
   name: AdminConsoleKey;

--- a/packages/console/src/pages/Security/Captcha/Guide/index.tsx
+++ b/packages/console/src/pages/Security/Captcha/Guide/index.tsx
@@ -44,6 +44,7 @@ function Guide({ type, onClose }: Props) {
       secretKey: '',
       projectId: '',
       mode: RecaptchaEnterpriseMode.Invisible,
+      scoreThreshold: 0.5,
     },
   });
 

--- a/packages/console/src/pages/Security/Captcha/types.tsx
+++ b/packages/console/src/pages/Security/Captcha/types.tsx
@@ -6,4 +6,5 @@ export type CaptchaFormType = {
   projectId: string;
   domain?: string;
   mode?: RecaptchaEnterpriseMode;
+  scoreThreshold?: number;
 };

--- a/packages/core/src/routes/experience/classes/libraries/captcha-validator.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/captcha-validator.test.ts
@@ -1,0 +1,61 @@
+import { RecaptchaEnterpriseMode } from '@logto/schemas';
+
+import { isScorePass } from './captcha-validator.js';
+
+describe('isScorePass', () => {
+  it('passes when the score meets the default threshold in invisible mode', () => {
+    expect(isScorePass({ valid: true, score: 0.5, mode: RecaptchaEnterpriseMode.Invisible })).toBe(
+      true
+    );
+    expect(isScorePass({ valid: true, score: 0.49, mode: RecaptchaEnterpriseMode.Invisible })).toBe(
+      false
+    );
+  });
+
+  it('falls back to the default threshold when no threshold is configured', () => {
+    expect(isScorePass({ valid: true, score: 0.5 })).toBe(true);
+    expect(isScorePass({ valid: true, score: 0.49 })).toBe(false);
+  });
+
+  it('uses the configured score threshold when provided', () => {
+    expect(
+      isScorePass({
+        valid: true,
+        score: 0.8,
+        mode: RecaptchaEnterpriseMode.Invisible,
+        scoreThreshold: 0.8,
+      })
+    ).toBe(true);
+    expect(
+      isScorePass({
+        valid: true,
+        score: 0.79,
+        mode: RecaptchaEnterpriseMode.Invisible,
+        scoreThreshold: 0.8,
+      })
+    ).toBe(false);
+  });
+
+  it('ignores the score threshold in checkbox mode and only checks validity', () => {
+    expect(isScorePass({ valid: true, score: 0, mode: RecaptchaEnterpriseMode.Checkbox })).toBe(
+      true
+    );
+    expect(
+      isScorePass({
+        valid: true,
+        score: 1,
+        mode: RecaptchaEnterpriseMode.Checkbox,
+        scoreThreshold: 1,
+      })
+    ).toBe(true);
+    expect(isScorePass({ valid: false, score: 1, mode: RecaptchaEnterpriseMode.Checkbox })).toBe(
+      false
+    );
+  });
+
+  it('fails when the token is invalid', () => {
+    expect(isScorePass({ valid: false, score: 1, mode: RecaptchaEnterpriseMode.Invisible })).toBe(
+      false
+    );
+  });
+});

--- a/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/captcha-validator.ts
@@ -10,6 +10,8 @@ import { z } from 'zod';
 
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
 
+const DEFAULT_SCORE_THRESHOLD = 0.5;
+
 function isRecaptchaEnterprise(
   config: CaptchaProvider['config']
 ): config is RecaptchaEnterpriseConfig {
@@ -19,6 +21,23 @@ function isRecaptchaEnterprise(
 function isTurnstile(config: CaptchaProvider['config']): config is TurnstileConfig {
   return config.type === CaptchaType.Turnstile;
 }
+
+type ScorePassParams = {
+  valid: boolean;
+  score: number;
+  mode?: RecaptchaEnterpriseMode;
+  scoreThreshold?: number;
+};
+
+/**
+ * Decide whether a reCAPTCHA Enterprise assessment passes.
+ * Checkbox challenges are interactive and provide binary pass/fail, so the score
+ * threshold is skipped in checkbox mode.
+ */
+export const isScorePass = ({ valid, score, mode, scoreThreshold }: ScorePassParams) =>
+  mode === RecaptchaEnterpriseMode.Checkbox
+    ? valid
+    : valid && score >= (scoreThreshold ?? DEFAULT_SCORE_THRESHOLD);
 
 export class CaptchaValidator {
   constructor(
@@ -109,11 +128,12 @@ export class CaptchaValidator {
         riskAnalysis: { score },
       } = responseGuard.parse(result);
 
-      // For checkbox mode, only check if the token is valid (skip score threshold)
-      // Checkbox challenges are interactive and provide binary pass/fail
-      const isCheckboxMode = config.mode === RecaptchaEnterpriseMode.Checkbox;
-      // TODO: customize the score threshold
-      const success = isCheckboxMode ? valid : valid && score >= 0.5;
+      const success = isScorePass({
+        valid,
+        score,
+        mode: config.mode,
+        scoreThreshold: config.scoreThreshold,
+      });
 
       this.log.append({
         success,

--- a/packages/integration-tests/src/tests/api/captcha-provider.test.ts
+++ b/packages/integration-tests/src/tests/api/captcha-provider.test.ts
@@ -32,6 +32,7 @@ describe('captcha provider', () => {
         siteKey: 'site_key',
         secretKey: 'secret_key',
         projectId: 'project_id',
+        scoreThreshold: 0.7,
       },
     });
 
@@ -43,8 +44,27 @@ describe('captcha provider', () => {
         siteKey: 'site_key',
         secretKey: 'secret_key',
         projectId: 'project_id',
+        scoreThreshold: 0.7,
       },
     });
+  });
+
+  it('should reject an out-of-range score threshold', async () => {
+    await expectRejects(
+      updateCaptchaProvider({
+        config: {
+          type: CaptchaType.RecaptchaEnterprise,
+          siteKey: 'site_key',
+          secretKey: 'secret_key',
+          projectId: 'project_id',
+          scoreThreshold: 1.5,
+        },
+      }),
+      {
+        code: 'guard.invalid_input',
+        status: 400,
+      }
+    );
   });
 
   it('should delete captcha provider successfully', async () => {

--- a/packages/phrases/src/locales/ar/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/security.ts
@@ -58,6 +58,10 @@ const security = {
     mode_checkbox: 'مربع اختيار',
     mode_notice:
       'يتم تحديد وضع التحقق في إعدادات مفتاح reCAPTCHA في Google Cloud Console. يتطلب تغيير الوضع هنا نوع مفتاح مطابق.',
+    score_threshold: 'حد النتيجة',
+    score_threshold_description:
+      'يتم رفض النتائج الأقل من الحد الأدنى. 0.0 يسمح بجميع النتائج، 1.0 يسمح فقط بالنتائج المثالية. القيمة الافتراضية هي 0.5.',
+    score_threshold_error: 'يجب أن يكون حد النتيجة بين 0 و 1.',
   },
   password_policy: {
     password_requirements: 'متطلبات كلمة المرور',

--- a/packages/phrases/src/locales/de/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'Kontrollkästchen',
     mode_notice:
       'Der Überprüfungsmodus wird in Ihren reCAPTCHA-Schlüsseleinstellungen in der Google Cloud Console definiert. Zum Ändern des Modus hier ist ein passender Schlüsseltyp erforderlich.',
+    score_threshold: 'Punkteschwelle',
+    score_threshold_description:
+      'Bewertungen unterhalb des Schwellenwerts werden abgelehnt. 0.0 erlaubt alle, 1.0 nur perfekte Bewertungen. Standard ist 0.5.',
+    score_threshold_error: 'Die Punkteschwelle muss zwischen 0 und 1 liegen.',
   },
   password_policy: {
     password_requirements: 'Passwortanforderungen',

--- a/packages/phrases/src/locales/en/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/security.ts
@@ -61,6 +61,10 @@ const security = {
     mode_checkbox: 'Checkbox',
     mode_notice:
       'The verification mode is defined in your reCAPTCHA key settings in Google Cloud Console. Changing the mode here requires a matching key type.',
+    score_threshold: 'Score threshold',
+    score_threshold_description:
+      'Scores below the threshold are rejected. 0.0 allows all, 1.0 only allows perfect scores. Default is 0.5.',
+    score_threshold_error: 'Score threshold must be between 0 and 1.',
   },
   password_policy: {
     password_requirements: 'Password requirements',

--- a/packages/phrases/src/locales/es/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'Casilla de verificación',
     mode_notice:
       'El modo de verificación se define en la configuración de tu clave reCAPTCHA en Google Cloud Console. Cambiar el modo aquí requiere un tipo de clave coincidente.',
+    score_threshold: 'Umbral de puntuación',
+    score_threshold_description:
+      'Las puntuaciones por debajo del umbral se rechazan. 0.0 permite todas, 1.0 solo permite puntuaciones perfectas. El valor predeterminado es 0.5.',
+    score_threshold_error: 'El umbral de puntuación debe estar entre 0 y 1.',
   },
   password_policy: {
     password_requirements: 'Requisitos de contraseña',

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/security.ts
@@ -61,6 +61,10 @@ const security = {
     mode_checkbox: 'چک‌باکس',
     mode_notice:
       'حالت تأیید در تنظیمات کلید reCAPTCHA شما در Google Cloud Console تعریف می‌شود. تغییر حالت در اینجا نیاز به نوع کلید متناظر دارد.',
+    score_threshold: 'آستانه امتیاز',
+    score_threshold_description:
+      'امتیازهای کمتر از آستانه رد می‌شوند. 0.0 همه را مجاز می‌کند، 1.0 فقط امتیازهای کامل را مجاز می‌کند. پیش‌فرض 0.5 است.',
+    score_threshold_error: 'آستانه امتیاز باید بین 0 و 1 باشد.',
   },
   password_policy: {
     password_requirements: 'الزامات رمز عبور',

--- a/packages/phrases/src/locales/fr/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'Case à cocher',
     mode_notice:
       'Le mode de vérification est défini dans les paramètres de votre clé reCAPTCHA dans Google Cloud Console. Changer le mode ici nécessite un type de clé correspondant.',
+    score_threshold: 'Seuil de score',
+    score_threshold_description:
+      "Les scores inférieurs au seuil sont rejetés. 0.0 accepte tout, 1.0 n'accepte que les scores parfaits. La valeur par défaut est 0.5.",
+    score_threshold_error: 'Le seuil de score doit être compris entre 0 et 1.',
   },
   password_policy: {
     password_requirements: 'Exigences relatives au mot de passe',

--- a/packages/phrases/src/locales/it/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'Casella di controllo',
     mode_notice:
       'La modalità di verifica è definita nelle impostazioni della chiave reCAPTCHA in Google Cloud Console. Per cambiare la modalità qui è necessario un tipo di chiave corrispondente.',
+    score_threshold: 'Soglia del punteggio',
+    score_threshold_description:
+      'I punteggi inferiori alla soglia vengono rifiutati. 0.0 consente tutti, 1.0 solo punteggi perfetti. Il valore predefinito è 0.5.',
+    score_threshold_error: 'La soglia del punteggio deve essere compresa tra 0 e 1.',
   },
   password_policy: {
     password_requirements: 'Requisiti per la password',

--- a/packages/phrases/src/locales/ja/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'チェックボックス',
     mode_notice:
       '認証モードは Google Cloud Console の reCAPTCHA キー設定で定義されています。ここでモードを変更するには、一致するキータイプが必要です。',
+    score_threshold: 'スコアしきい値',
+    score_threshold_description:
+      'しきい値を下回るスコアは拒否されます。0.0 はすべてを許可し、1.0 は完全なスコアのみを許可します。デフォルトは 0.5 です。',
+    score_threshold_error: 'スコアしきい値は 0 から 1 の間である必要があります。',
   },
   password_policy: {
     password_requirements: 'パスワードの要件',

--- a/packages/phrases/src/locales/ko/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: '체크박스',
     mode_notice:
       '인증 모드는 Google Cloud Console의 reCAPTCHA 키 설정에서 정의됩니다. 여기서 모드를 변경하려면 일치하는 키 유형이 필요합니다.',
+    score_threshold: '점수 임계값',
+    score_threshold_description:
+      '임계값보다 낮은 점수는 거부됩니다. 0.0은 모든 점수를 허용하고 1.0은 완벽한 점수만 허용합니다. 기본값은 0.5입니다.',
+    score_threshold_error: '점수 임계값은 0에서 1 사이여야 합니다.',
   },
   password_policy: {
     password_requirements: '비밀번호 요구사항',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'Pole wyboru',
     mode_notice:
       'Tryb weryfikacji jest zdefiniowany w ustawieniach klucza reCAPTCHA w Google Cloud Console. Zmiana trybu tutaj wymaga odpowiedniego typu klucza.',
+    score_threshold: 'Próg punktacji',
+    score_threshold_description:
+      'Wyniki poniżej progu są odrzucane. 0.0 pozwala na wszystkie, 1.0 tylko na idealne wyniki. Domyślnie 0.5.',
+    score_threshold_error: 'Próg punktacji musi wynosić od 0 do 1.',
   },
   password_policy: {
     password_requirements: 'Wymagania dotyczące hasła',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'Caixa de seleção',
     mode_notice:
       'O modo de verificação é definido nas configurações da chave reCAPTCHA no Google Cloud Console. Alterar o modo aqui requer um tipo de chave correspondente.',
+    score_threshold: 'Limite de pontuação',
+    score_threshold_description:
+      'Pontuações abaixo do limite são rejeitadas. 0.0 permite todas, 1.0 só permite pontuações perfeitas. O padrão é 0.5.',
+    score_threshold_error: 'O limite de pontuação deve estar entre 0 e 1.',
   },
   password_policy: {
     password_requirements: 'Requisitos de senha',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'Caixa de seleção',
     mode_notice:
       'O modo de verificação é definido nas definições da chave reCAPTCHA na Google Cloud Console. Alterar o modo aqui requer um tipo de chave correspondente.',
+    score_threshold: 'Limiar de pontuação',
+    score_threshold_description:
+      'Pontuações abaixo do limiar são rejeitadas. 0.0 permite todas, 1.0 apenas pontuações perfeitas. O valor predefinido é 0.5.',
+    score_threshold_error: 'O limiar de pontuação deve estar entre 0 e 1.',
   },
   password_policy: {
     password_requirements: 'Requisitos de password',

--- a/packages/phrases/src/locales/ru/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'Флажок',
     mode_notice:
       'Режим проверки определяется в настройках ключа reCAPTCHA в Google Cloud Console. Для изменения режима здесь требуется соответствующий тип ключа.',
+    score_threshold: 'Порог оценки',
+    score_threshold_description:
+      'Оценки ниже порога отклоняются. 0.0 разрешает все, 1.0 — только идеальные оценки. По умолчанию 0.5.',
+    score_threshold_error: 'Порог оценки должен быть от 0 до 1.',
   },
   password_policy: {
     password_requirements: 'Требования к паролю',

--- a/packages/phrases/src/locales/th/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'ช่องทำเครื่องหมาย',
     mode_notice:
       'โหมดการตรวจสอบถูกกำหนดในการตั้งค่าคีย์ reCAPTCHA ใน Google Cloud Console การเปลี่ยนโหมดที่นี่ต้องใช้ประเภทคีย์ที่ตรงกัน',
+    score_threshold: 'คะแนนขั้นต่ำ',
+    score_threshold_description:
+      'คะแนนที่ต่ำกว่าเกณฑ์จะถูกปฏิเสธ 0.0 อนุญาตทั้งหมด 1.0 อนุญาตเฉพาะคะแนนเต็ม ค่าเริ่มต้นคือ 0.5',
+    score_threshold_error: 'คะแนนขั้นต่ำต้องอยู่ระหว่าง 0 ถึง 1',
   },
   password_policy: {
     password_requirements: 'ข้อกำหนดรหัสผ่าน',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/security.ts
@@ -59,6 +59,10 @@ const security = {
     mode_checkbox: 'Onay kutusu',
     mode_notice:
       "Doğrulama modu, Google Cloud Console'daki reCAPTCHA anahtar ayarlarında tanımlanır. Buradaki modu değiştirmek için eşleşen bir anahtar türü gerekir.",
+    score_threshold: 'Puan eşiği',
+    score_threshold_description:
+      "Eşiğin altındaki puanlar reddedilir. 0.0 tümünü kabul eder, 1.0 yalnızca mükemmel puanları kabul eder. Varsayılan değer 0.5'tir.",
+    score_threshold_error: 'Puan eşiği 0 ile 1 arasında olmalıdır.',
   },
   password_policy: {
     password_requirements: 'Parola gereksinimleri',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/security.ts
@@ -57,6 +57,10 @@ const security = {
     mode_checkbox: '复选框验证',
     mode_notice:
       '验证模式在 Google Cloud Console 的 reCAPTCHA 密钥设置中定义。更改此处的模式需要匹配的密钥类型。',
+    score_threshold: '分数阈值',
+    score_threshold_description:
+      '低于阈值的分数将被拒绝。0.0 允许所有分数，1.0 只允许满分。默认值为 0.5。',
+    score_threshold_error: '分数阈值必须在 0 到 1 之间。',
   },
   password_policy: {
     password_requirements: '密码要求',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/security.ts
@@ -57,6 +57,10 @@ const security = {
     mode_checkbox: '複選框驗證',
     mode_notice:
       '驗證模式在 Google Cloud Console 的 reCAPTCHA 金鑰設定中定義。更改此處的模式需要匹配的金鑰類型。',
+    score_threshold: '分數門檻',
+    score_threshold_description:
+      '低於門檻的分數會被拒絕。0.0 允許所有分數，1.0 只允許滿分。預設值為 0.5。',
+    score_threshold_error: '分數門檻必須介乎 0 至 1 之間。',
   },
   password_policy: {
     password_requirements: '密碼要求',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/security.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/security.ts
@@ -57,6 +57,10 @@ const security = {
     mode_checkbox: '複選框驗證',
     mode_notice:
       '驗證模式在 Google Cloud Console 的 reCAPTCHA 金鑰設定中定義。更改此處的模式需要匹配的金鑰類型。',
+    score_threshold: '分數門檻',
+    score_threshold_description:
+      '低於門檻的分數會被拒絕。0.0 允許所有分數，1.0 只允許滿分。預設值為 0.5。',
+    score_threshold_error: '分數門檻必須介於 0 到 1 之間。',
   },
   password_policy: {
     password_requirements: '密碼需求',

--- a/packages/schemas/src/foundations/jsonb-types/captcha.ts
+++ b/packages/schemas/src/foundations/jsonb-types/captcha.ts
@@ -25,6 +25,7 @@ export const recaptchaEnterpriseConfigGuard = z.object({
   projectId: z.string(),
   domain: z.string().optional(),
   mode: z.nativeEnum(RecaptchaEnterpriseMode).optional(),
+  scoreThreshold: z.number().min(0).max(1).optional(),
 });
 
 export type RecaptchaEnterpriseConfig = z.infer<typeof recaptchaEnterpriseConfigGuard>;


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Make the reCAPTCHA Enterprise score threshold configurable. Admins can now set the minimum accepted score (0.0–1.0) in Security > Bot Protection > CAPTCHA instead of relying on the hardcoded 0.5 default. The threshold is stored in the CAPTCHA provider config and enforced by the experience CAPTCHA validator for invisible mode; checkbox mode remains a binary pass/fail and is unaffected.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
