### PR TITLE
fix(core,test): treat empty relation inserts as no-op

### DIFF
--- a/.changeset/olive-pandas-refuse.md
+++ b/.changeset/olive-pandas-refuse.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+Fix a 500 error when posting an empty array to relation-assigning Management API endpoints (e.g. `POST /applications/:applicationId/user-consent-scopes` with `{ "organizationScopes": [] }`, or `POST /organizations/:id/users/:userId/roles` with no role ids); empty arrays are now treated as no-ops.

--- a/.changeset/olive-pandas-refuse.md
+++ b/.changeset/olive-pandas-refuse.md
@@ -2,4 +2,6 @@
 "@logto/core": patch
 ---
 
-Fix a 500 error when posting an empty array to relation-assigning Management API endpoints (e.g. `POST /applications/:applicationId/user-consent-scopes` with `{ "organizationScopes": [] }`, or `POST /organizations/:id/users/:userId/roles` with no role ids); empty arrays are now treated as no-ops.
+fix a 500 error when assigning an empty list of scopes or roles
+
+Management API endpoints that assign relations, such as `POST /applications/:applicationId/user-consent-scopes` and `POST /organizations/:id/users/:userId/roles`, now accept an empty array and make no changes, instead of responding with a 500 error.

--- a/packages/core/src/utils/RelationQueries.test.ts
+++ b/packages/core/src/utils/RelationQueries.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@silverhand/slonik';
 import { type PrimitiveValueExpression } from '@silverhand/slonik/dist/src/types.js';
 
-import { TwoRelationsQueries } from './RelationQueries.js';
+import RelationQueries, { TwoRelationsQueries } from './RelationQueries.js';
 
 /** Records each SQL statement issued (including the ones inside `pool.transaction`). */
 type CapturedQuery = {
@@ -40,6 +40,37 @@ const createCapturingPool = (
   });
   return { pool, captured };
 };
+
+describe('RelationQueries.insert()', () => {
+  it('resolves without issuing any query when called with no entities', async () => {
+    const { pool, captured } = createCapturingPool([]);
+    const queries = new RelationQueries(pool, 'organization_user_relations', Organizations, Users);
+
+    // Regression: an empty entity list used to compose `values` with an empty
+    // `sql.join`, which slonik rejects with an `InvalidInputError`, surfacing as a
+    // 500 for any API route whose guard accepts an empty (but present) array.
+    await expect(queries.insert()).resolves.toBeUndefined();
+    expect(captured).toHaveLength(0);
+  });
+
+  it('inserts all given entities in a single statement', async () => {
+    const { pool, captured } = createCapturingPool([{}]);
+    const queries = new RelationQueries(pool, 'organization_user_relations', Organizations, Users);
+
+    await queries.insert(
+      { organizationId: 'org-1', userId: 'user-1' },
+      { organizationId: 'org-2', userId: 'user-2' }
+    );
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.sql).toMatch(
+      /insert into "organization_user_relations" \("organization_id", "user_id"\)/
+    );
+    expect(captured[0]?.sql).toMatch(/values \(\$1, \$2\), \(\$3, \$4\)/);
+    expect(captured[0]?.sql).toMatch(/on conflict do nothing/);
+    expect(captured[0]?.values).toEqual(['org-1', 'user-1', 'org-2', 'user-2']);
+  });
+});
 
 describe('TwoRelationsQueries.replaceWithDelta()', () => {
   it('acquires a row lock on the schema1 entity before issuing the delta statement', async () => {

--- a/packages/core/src/utils/RelationQueries.ts
+++ b/packages/core/src/utils/RelationQueries.ts
@@ -103,9 +103,12 @@ export default class RelationQueries<
    * Each entity must contain the same number of ids as the number of relations, and
    * the order of the ids must match the order of the relations.
    * Insert existing relations will be ignored.
+   * Calling with no entities is a no-op and issues no query, since an SQL `values`
+   * list cannot be empty.
    *
    * @param data Entities to insert.
-   * @returns A Promise that resolves to the query result.
+   * @returns A Promise that resolves to the query result, or `undefined` when no
+   * entities are given.
    *
    * @example
    * ```ts
@@ -120,6 +123,10 @@ export default class RelationQueries<
    * ```
    */
   async insert(...data: ReadonlyArray<CamelCaseIdObject<Schemas[number]['tableSingular']>>) {
+    if (data.length === 0) {
+      return;
+    }
+
     return this.pool.query(sql`
       insert into ${this.table} (${sql.join(
         this.schemas.map(({ tableSingular }) => sql.identifier([tableSingular + '_id'])),

--- a/packages/integration-tests/src/tests/api/application/application-user-consent-scope.test.ts
+++ b/packages/integration-tests/src/tests/api/application/application-user-consent-scope.test.ts
@@ -127,6 +127,24 @@ describe('assign user consent scopes to application', () => {
     );
   });
 
+  it('should succeed without assigning anything when scope arrays are empty', async () => {
+    await expect(
+      assignUserConsentScopes(applicationIds.get('thirdPartyApp')!, {
+        organizationScopes: [],
+        resourceScopes: [],
+        organizationResourceScopes: [],
+        userScopes: [],
+      })
+    ).resolves.not.toThrow();
+
+    const result = await getUserConsentScopes(applicationIds.get('thirdPartyApp')!);
+
+    expect(result.organizationScopes.length).toBe(0);
+    expect(result.resourceScopes.length).toBe(0);
+    expect(result.organizationResourceScopes.length).toBe(0);
+    expect(result.userScopes.length).toBe(0);
+  });
+
   it('should assign scopes to third-party application successfully', async () => {
     await expect(
       assignUserConsentScopes(applicationIds.get('thirdPartyApp')!, {

--- a/packages/integration-tests/src/tests/api/organization/organization-user.roles.test.ts
+++ b/packages/integration-tests/src/tests/api/organization/organization-user.roles.test.ts
@@ -47,6 +47,18 @@ describe('organization user role APIs', () => {
       expect(roles).toContainEqual(expect.objectContaining({ id: role2.id }));
     });
 
+    it('should succeed without assigning anything when the role id list is empty', async () => {
+      const organization = await organizationApi.create({ name: 'test' });
+      const user = await userApi.create({ username: generateTestName() });
+      await organizationApi.addUsers(organization.id, [user.id]);
+
+      const addRolesResult = await organizationApi.addUserRoles(organization.id, user.id, []);
+      expect(addRolesResult.organizationRoleIds).toEqual([]);
+
+      const roles = await organizationApi.getUserRoles(organization.id, user.id);
+      expect(roles).toEqual([]);
+    });
+
     it('should be able to get all organizations with roles for a user', async () => {
       const [organization1, organization2] = await Promise.all([
         organizationApi.create({ name: 'test' }),


### PR DESCRIPTION
## Summary

Fix a 500 error when an empty array reaches a relation-insert endpoint: `RelationQueries.insert()` composed the `values` clause with an empty `sql.join`, which slonik rejects with `InvalidInputError`.

- Add a zero-row early return in `RelationQueries.insert()`, covering all call sites.
- Reachable via `POST /applications/:applicationId/user-consent-scopes` (empty scope arrays pass the guard since they are `.optional()` but not `.nonempty()`) and `POST /organizations/:id/users/:userId/roles` (both role lists are optional); all other call sites already guard with `.nonempty()` or length checks.

## Testing

Unit tests and integration tests.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)