### PR TITLE
fix(console): update stale hosted-email comments and fallback quota

### DIFF
--- a/packages/console/src/components/HostedEmailCapBanner/index.tsx
+++ b/packages/console/src/components/HostedEmailCapBanner/index.tsx
@@ -20,9 +20,9 @@ const connectorsPasswordlessPage = `/connectors/${ConnectorsTabs.Passwordless}`;
  * the cap, a hard block that can interrupt sign-in emails) — each offering to connect an own email
  * provider or upgrade.
  *
- * Gated behind `isDevFeaturesEnabled` and to capped free/dev tenants (paid tenants report `null`
- * limits, so nothing renders). Dismissible per session; re-shown if the state escalates from
- * approaching to reached.
+ * Cloud-only (the usage hook gates on `isCloud`) and effectively limited to capped free/dev
+ * tenants (paid tenants report `null` limits, so nothing renders). Dismissible per session;
+ * re-shown if the state escalates from approaching to reached.
  */
 function HostedEmailCapBanner() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });

--- a/packages/console/src/consts/tenants.ts
+++ b/packages/console/src/consts/tenants.ts
@@ -101,8 +101,8 @@ export const defaultLogtoSku: LogtoSkuResponse = {
 export const defaultSubscriptionQuota: SubscriptionQuota = {
   mauLimit: 50_000,
   tokenLimit: 500_000,
-  hostedEmailLimit: 30_000,
-  hostedEmailDailyLimit: 1000,
+  hostedEmailLimit: 100_000,
+  hostedEmailDailyLimit: 10_000,
   applicationsLimit: 3,
   machineToMachineLimit: 1,
   resourcesLimit: 1,

--- a/packages/console/src/pages/ConnectorDetails/EmailUsage/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/EmailUsage/index.tsx
@@ -40,7 +40,7 @@ function UsageWindow({ windowKey, usage, limit }: UsageWindowProps) {
 }
 
 type Props = {
-  /** Lifetime count, shown until the hosted-email usage feature ships (and for self-hosted). */
+  /** Lifetime count, the fallback display when windowed usage is unavailable (self-hosted/OSS). */
   readonly usage?: number;
   readonly isCompact?: boolean;
 };


### PR DESCRIPTION
## Summary
Post-release cleanup for the hosted-email usage surfaces (read/display shipped in #9256):

- `HostedEmailCapBanner` JSDoc claimed the banner is gated behind `isDevFeaturesEnabled`; the actual gate since the read/display release is `isCloud` (in `useHostedEmailUsage`).
- `EmailUsage` prop comment said the lifetime count shows "until the hosted-email usage feature ships"; it shipped — the lifetime count is now the fallback for self-hosted/OSS (and while windowed usage is unavailable).
- `defaultSubscriptionQuota` (the Free-plan fallback seeding `SubscriptionDataProvider` before real subscription data loads) still carried the original hosted-email caps (30,000 monthly / 1,000 daily); aligned with the shipped Free values (100,000 / 10,000). Nothing user-visible reads these two keys today (the usage card/banner fetch the dedicated cloud endpoint), so this is a latent-staleness fix, not a behavior change.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments