### PR TITLE
refactor(core): introduce ScriptRunner types and ScriptExecutionError

### DIFF
--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -17,11 +17,7 @@ import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import type { SubscriptionLibrary } from '#src/libraries/subscription.js';
 import type { LogContext, LogPayload } from '#src/middleware/koa-audit-log.js';
 import { parseAzureFunctionsResponseError } from '#src/utils/custom-jwt/index.js';
-import {
-  buildLocalVmErrorBody,
-  LocalVmError,
-  runScriptFunctionInLocalVm,
-} from '#src/utils/local-vm/index.js';
+import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import {
   buildActionTelemetryError,
@@ -36,6 +32,7 @@ import {
   type ActionRuntimeLocation,
   trackActionExecutionMetrics,
 } from './action-telemetry.js';
+import { buildScriptExecutionErrorBody, ScriptExecutionError } from './script-runner/index.js';
 
 const actionFunctionName = 'runAction';
 const defaultActionExecutionErrorPolicy = 'block' satisfies ActionExecutionErrorPolicy;
@@ -206,12 +203,12 @@ export class ActionLibrary {
 
       return await runScriptFunctionInLocalVm(script, actionFunctionName, payload);
     } catch (error: unknown) {
-      if (error instanceof LocalVmError) {
+      if (error instanceof ScriptExecutionError) {
         throw error;
       }
 
       if (error instanceof ZodError) {
-        throw new LocalVmError(
+        throw new ScriptExecutionError(
           {
             message: 'Invalid input',
             errors: error.errors,
@@ -220,8 +217,8 @@ export class ActionLibrary {
         );
       }
 
-      throw new LocalVmError(
-        buildLocalVmErrorBody(error),
+      throw new ScriptExecutionError(
+        buildScriptExecutionErrorBody(error),
         error instanceof SyntaxError || error instanceof TypeError ? 422 : 500
       );
     }

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -32,7 +32,11 @@ import {
   type ActionRuntimeLocation,
   trackActionExecutionMetrics,
 } from './action-telemetry.js';
-import { buildScriptExecutionErrorBody, ScriptExecutionError } from './script-runner/index.js';
+import {
+  buildScriptExecutionErrorBody,
+  getScriptFailureStatusCode,
+  ScriptExecutionError,
+} from './script-runner/index.js';
 
 const actionFunctionName = 'runAction';
 const defaultActionExecutionErrorPolicy = 'block' satisfies ActionExecutionErrorPolicy;
@@ -219,7 +223,7 @@ export class ActionLibrary {
 
       throw new ScriptExecutionError(
         buildScriptExecutionErrorBody(error),
-        error instanceof SyntaxError || error instanceof TypeError ? 422 : 500
+        getScriptFailureStatusCode(error)
       );
     }
   }

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -44,7 +44,12 @@ import {
 import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
-import { buildScriptExecutionErrorBody, ScriptExecutionError } from './script-runner/index.js';
+import {
+  buildScriptExecutionErrorBody,
+  getScriptFailureStatusCode,
+  ScriptExecutionError,
+  scriptFailureStatusCodes,
+} from './script-runner/index.js';
 
 const apiContext: CustomJwtApiContext = Object.freeze({
   denyAccess: (message = 'Access denied') => {
@@ -58,7 +63,7 @@ const apiContext: CustomJwtApiContext = Object.freeze({
         message,
         error,
       },
-      403
+      scriptFailureStatusCodes.denied
     );
   },
 });
@@ -95,7 +100,7 @@ export class JwtCustomizerLibrary {
 
       throw new ScriptExecutionError(
         buildScriptExecutionErrorBody(error),
-        error instanceof SyntaxError || error instanceof TypeError ? 422 : 500
+        getScriptFailureStatusCode(error)
       );
     }
   }

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -41,13 +41,10 @@ import {
   type CustomJwtDeployRequestBody,
   parseAzureFunctionsResponseError,
 } from '#src/utils/custom-jwt/index.js';
-import {
-  buildLocalVmErrorBody,
-  LocalVmError,
-  runScriptFunctionInLocalVm,
-} from '#src/utils/local-vm/index.js';
+import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
+import { buildScriptExecutionErrorBody, ScriptExecutionError } from './script-runner/index.js';
 
 const apiContext: CustomJwtApiContext = Object.freeze({
   denyAccess: (message = 'Access denied') => {
@@ -56,7 +53,7 @@ const apiContext: CustomJwtApiContext = Object.freeze({
       message,
     };
 
-    throw new LocalVmError(
+    throw new ScriptExecutionError(
       {
         message,
         error,
@@ -80,14 +77,14 @@ export class JwtCustomizerLibrary {
       // If the `result` is not a record, we cannot merge it to the existing token payload.
       return z.record(z.unknown()).parse(result);
     } catch (error: unknown) {
-      if (error instanceof LocalVmError) {
+      if (error instanceof ScriptExecutionError) {
         throw error;
       }
 
       // Assuming we only use zod for request body validation
       if (error instanceof ZodError) {
         const { errors } = error;
-        throw new LocalVmError(
+        throw new ScriptExecutionError(
           {
             message: 'Invalid input',
             errors,
@@ -96,8 +93,8 @@ export class JwtCustomizerLibrary {
         );
       }
 
-      throw new LocalVmError(
-        buildLocalVmErrorBody(error),
+      throw new ScriptExecutionError(
+        buildScriptExecutionErrorBody(error),
         error instanceof SyntaxError || error instanceof TypeError ? 422 : 500
       );
     }

--- a/packages/core/src/libraries/script-runner/errors.ts
+++ b/packages/core/src/libraries/script-runner/errors.ts
@@ -1,0 +1,57 @@
+import { types } from 'node:util';
+
+import { ResponseError } from '@withtyped/client';
+
+import { type ScriptResult } from './types.js';
+
+type ScriptFailureKind = Extract<ScriptResult, { ok: false }>['kind'];
+
+/**
+ * The HTTP status code each failure kind maps to.
+ *
+ * This is the status mapping the local VM implementation has always used, kept as-is so
+ * route-level error handling stays untouched.
+ */
+export const scriptFailureStatusCodes = Object.freeze({
+  denied: 403,
+  syntax: 422,
+  type: 422,
+  timeout: 500,
+  oom: 500,
+  runtime: 500,
+} as const satisfies Record<ScriptFailureKind, number>);
+
+/**
+ * Extend the ResponseError from @withtyped/client.
+ * This class is used to parse the error from a script run to the WithTyped client response error.
+ * So we can unify the error handling and display logic for both the OSS and Cloud runtimes.
+ */
+export class ScriptExecutionError extends ResponseError {
+  constructor(errorBody: Record<string, unknown>, statusCode: number) {
+    super(
+      new Response(
+        new Blob([JSON.stringify(errorBody)], {
+          type: 'application/json',
+        }),
+        {
+          status: statusCode,
+        }
+      )
+    );
+  }
+}
+
+/**
+ * Build the error body for a script execution error.
+ *
+ * @remarks
+ *
+ * Catch the error thrown by the script runtime, and build the error body.
+ * Use `isNativeError` to check if the error is an instance of `Error`.
+ * If the error comes from the `node:vm` module, then it will not be an instance of `Error` but can be captured by `isNativeError`.
+ *
+ */
+export const buildScriptExecutionErrorBody = (error: unknown) =>
+  types.isNativeError(error)
+    ? { message: error.message, stack: error.stack }
+    : { message: String(error) };

--- a/packages/core/src/libraries/script-runner/errors.ts
+++ b/packages/core/src/libraries/script-runner/errors.ts
@@ -10,7 +10,8 @@ type ScriptFailureKind = Extract<ScriptResult, { ok: false }>['kind'];
  * The HTTP status code each failure kind maps to.
  *
  * This is the status mapping the local VM implementation has always used, kept as-is so
- * route-level error handling stays untouched.
+ * route-level error handling stays untouched. Call sites that throw {@link ScriptExecutionError}
+ * for a known kind should read the status from here rather than hardcoding the number.
  */
 export const scriptFailureStatusCodes = Object.freeze({
   denied: 403,
@@ -20,6 +21,19 @@ export const scriptFailureStatusCodes = Object.freeze({
   oom: 500,
   runtime: 500,
 } as const satisfies Record<ScriptFailureKind, number>);
+
+/** Map a thrown script error to the pinned {@link scriptFailureStatusCodes} status. */
+export const getScriptFailureStatusCode = (error: unknown): number => {
+  if (error instanceof SyntaxError) {
+    return scriptFailureStatusCodes.syntax;
+  }
+
+  if (error instanceof TypeError) {
+    return scriptFailureStatusCodes.type;
+  }
+
+  return scriptFailureStatusCodes.runtime;
+};
 
 /**
  * Extend the ResponseError from @withtyped/client.

--- a/packages/core/src/libraries/script-runner/index.ts
+++ b/packages/core/src/libraries/script-runner/index.ts
@@ -1,0 +1,2 @@
+export * from './errors.js';
+export * from './types.js';

--- a/packages/core/src/libraries/script-runner/types.ts
+++ b/packages/core/src/libraries/script-runner/types.ts
@@ -1,0 +1,81 @@
+/**
+ * The name of the function a user script must expose as its entry point.
+ *
+ * The authoring contract is unchanged: Custom JWT scripts declare `getCustomJwtClaims` and
+ * Actions scripts declare `runAction`.
+ */
+export type ScriptEntry = 'getCustomJwtClaims' | 'runAction';
+
+/** The resource budget granted to a single script run. */
+export type ScriptLimits = {
+  /**
+   * Host-side hard deadline for the whole run, including async work.
+   *
+   * This is the only bound that survives a promise that never settles, so every runner must
+   * enforce it.
+   */
+  wallClockMs: number;
+  /**
+   * Memory budget for the run.
+   *
+   * Best-effort on the worker thread runner (V8 heap only, so off-heap allocation is not
+   * capped), a hard per-isolate cap on the cloud runner.
+   */
+  memoryMb: number;
+  /** CPU time budget. Only enforceable by the cloud runner. */
+  cpuMs?: number;
+  /** Number of outbound requests the script may make. Only enforceable by the cloud runner. */
+  subRequests?: number;
+};
+
+/**
+ * Outbound network policy applied to a script run.
+ *
+ * Only `allowAll` is in use today, which matches the unrestricted network access scripts
+ * already have on every current path. The policy is passed explicitly so a runner never has to
+ * infer it, and so host allowlists can be added later without changing the call sites.
+ */
+export type EgressPolicy = { mode: 'allowAll' } | { mode: 'denyAll' };
+
+/**
+ * The outcome of a script run.
+ *
+ * Failures are values rather than exceptions so both runners report the same set of kinds. The
+ * mapping to HTTP status codes is unchanged from the local VM implementation: `denied` → 403,
+ * `syntax` and `type` → 422, and everything else → 500.
+ */
+export type ScriptResult =
+  | { ok: true; value: unknown }
+  /** The script called `api.denyAccess()`. */
+  | { ok: false; kind: 'denied'; message: string }
+  /**
+   * The run exceeded its wall clock deadline (`timeout`) or its memory budget (`oom`), and was
+   * terminated by the host. No error is available since the script never returned.
+   */
+  | { ok: false; kind: 'timeout' | 'oom' }
+  /**
+   * The script could not be compiled (`syntax`), or it does not expose a callable entry function
+   * or returned a value the caller cannot use (`type`).
+   */
+  | { ok: false; kind: 'syntax' | 'type'; message: string; stack?: string }
+  /** The script threw while running. */
+  | { ok: false; kind: 'runtime'; name: string; message: string; stack?: string };
+
+export type ScriptRunInput = {
+  script: string;
+  entry: ScriptEntry;
+  /** Must be structured-cloneable: runners may pass it across a thread or process boundary. */
+  payload: Record<string, unknown>;
+  limits: ScriptLimits;
+  egress: EgressPolicy;
+};
+
+/**
+ * The single interface for executing user-authored scripts, shared by Custom JWT and Actions.
+ *
+ * Implementations differ by deployment target, but must produce the same {@link ScriptResult}
+ * kinds so callers never branch on where the script ran.
+ */
+export type ScriptRunner = {
+  run(input: ScriptRunInput): Promise<ScriptResult>;
+};

--- a/packages/core/src/libraries/script-runner/types.ts
+++ b/packages/core/src/libraries/script-runner/types.ts
@@ -43,6 +43,10 @@ export type EgressPolicy = { mode: 'allowAll' } | { mode: 'denyAll' };
  * Failures are values rather than exceptions so both runners report the same set of kinds. The
  * mapping to HTTP status codes is unchanged from the local VM implementation: `denied` → 403,
  * `syntax` and `type` → 422, and everything else → 500.
+ *
+ * Call-site validation of a successful return value (e.g. Custom JWT's Zod `z.record` parse) is
+ * intentionally outside this union and keeps today's 400 "Invalid input" response — it is not a
+ * runner failure kind and must not be folded into `type`.
  */
 export type ScriptResult =
   | { ok: true; value: unknown }
@@ -55,7 +59,10 @@ export type ScriptResult =
   | { ok: false; kind: 'timeout' | 'oom' }
   /**
    * The script could not be compiled (`syntax`), or it does not expose a callable entry function
-   * or returned a value the caller cannot use (`type`).
+   * (`type`).
+   *
+   * Does not cover an unusable return value — that stays call-site validation at 400 (see the
+   * {@link ScriptResult} note above).
    */
   | { ok: false; kind: 'syntax' | 'type'; message: string; stack?: string }
   /** The script threw while running. */
@@ -64,7 +71,13 @@ export type ScriptResult =
 export type ScriptRunInput = {
   script: string;
   entry: ScriptEntry;
-  /** Must be structured-cloneable: runners may pass it across a thread or process boundary. */
+  /**
+   * Structured-cloneable data only. Runners may pass it across a thread or process boundary.
+   *
+   * Capability APIs such as `api` (with `denyAccess`) are not part of the payload: the runner
+   * constructs and injects them on its side — functions cannot cross the structured-clone
+   * boundary — and a denial comes back as `{ kind: 'denied' }`.
+   */
   payload: Record<string, unknown>;
   limits: ScriptLimits;
   egress: EgressPolicy;

--- a/packages/core/src/routes/logto-config/jwt-customizer.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.ts
@@ -245,8 +245,11 @@ export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRo
         }
       } catch (error: unknown) {
         /**
-         * - All cloud APIs should throw `RequestError`.
-         * - All script execution errors should throw `ScriptExecutionError` extended from `RequestError`.
+         * Both execution paths surface failures as a withtyped `ResponseError`:
+         *
+         * - Remote runs convert the Azure Functions `HTTPError` via `parseAzureFunctionsResponseError`,
+         *   and the cloud connection client throws `ResponseError` directly.
+         * - Local runs throw `ScriptExecutionError`, which extends `ResponseError`.
          *
          * In the admin console, we caught the error and recognized the error with the code `jwt_customizer.general`,
          * and then we extract and show the error message to the user.

--- a/packages/core/src/routes/logto-config/jwt-customizer.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.ts
@@ -246,7 +246,7 @@ export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRo
       } catch (error: unknown) {
         /**
          * - All cloud APIs should throw `RequestError`.
-         * - All local VM errors should throw `LocalVmError` extended from `RequestError`.
+         * - All script execution errors should throw `ScriptExecutionError` extended from `RequestError`.
          *
          * In the admin console, we caught the error and recognized the error with the code `jwt_customizer.general`,
          * and then we extract and show the error message to the user.

--- a/packages/core/src/utils/local-vm/index.ts
+++ b/packages/core/src/utils/local-vm/index.ts
@@ -1,27 +1,4 @@
-import { types } from 'node:util';
 import { runInNewContext } from 'node:vm';
-
-import { ResponseError } from '@withtyped/client';
-
-/**
- * Extend the ResponseError from @withtyped/client.
- * This class is used to parse the error from the local VM to the WithTyped client response error.
- * So we can unify the error handling and display logic for both local VM and Cloud version.
- */
-export class LocalVmError extends ResponseError {
-  constructor(errorBody: Record<string, unknown>, statusCode: number) {
-    super(
-      new Response(
-        new Blob([JSON.stringify(errorBody)], {
-          type: 'application/json',
-        }),
-        {
-          status: statusCode,
-        }
-      )
-    );
-  }
-}
 
 /**
  * This function is used to execute a named function in a customized code script in a local
@@ -62,18 +39,3 @@ export const runScriptFunctionInLocalVm = async (
 
   return result;
 };
-
-/**
- * Build the error body for the local VM error.
- *
- * @remarks
- *
- * Catch the error from vm module, and build the error body.
- * Use `isNativeError` to check if the error is an instance of `Error`.
- * If the error comes from `node:vm` module, then it will not be an instance of `Error` but can be captured by `isNativeError`.
- *
- */
-export const buildLocalVmErrorBody = (error: unknown) =>
-  types.isNativeError(error)
-    ? { message: error.message, stack: error.stack }
-    : { message: String(error) };


### PR DESCRIPTION
## Summary

Foundation for the consolidated script runtime shared by Custom JWT and Actions.

Adds `packages/core/src/libraries/script-runner`:

- **`types.ts`** defines the contract every future runner implements:
  - `ScriptEntry` — `'getCustomJwtClaims' | 'runAction'`
  - `ScriptLimits` — `wallClockMs`, `memoryMb`, plus optional `cpuMs` / `subRequests` that only the cloud runner can enforce
  - `ScriptResult` — `{ ok: true; value }`, or a typed failure: `denied` / `timeout` / `oom` / `syntax` / `type` / `runtime`
  - `EgressPolicy` and the `ScriptRunner` interface
- **`errors.ts`** renames `LocalVmError` to `ScriptExecutionError` and moves `buildLocalVmErrorBody` alongside it as `buildScriptExecutionErrorBody`. The class implementation is unchanged, and `scriptFailureStatusCodes` pins the existing mapping (`denied` → 403, `syntax`/`type` → 422, `timeout`/`oom`/`runtime` → 500) so route-level handling is untouched.

`utils/local-vm/index.ts` keeps only `runScriptFunctionInLocalVm`; call sites in `jwt-customizer.ts` and `action.ts` are updated to the new names, with their status-code branches unchanged.

Two small deviations from the design doc:

- `ScriptExecutionError` lives in `errors.ts` rather than `types.ts`, since it is a runtime class rather than a type.
- The `syntax` / `type` result kinds carry `message` and optional `stack`, matching what the 422 response body already exposes today.

No behavior change.

## Testing

Unit tests

