### PR TITLE
fix(core): parse the Accept-Language quality parameter per RFC 7231

### DIFF
--- a/.changeset/khaki-moons-repeat.md
+++ b/.changeset/khaki-moons-repeat.md
@@ -1,0 +1,7 @@
+---
+'@logto/core': patch
+---
+
+honor Accept-Language quality values written with whitespace before `q=`
+
+RFC 7231 allows optional whitespace around the quality parameter, so `Accept-Language: en; q=0.7, pl; q=0.9` is a valid way to ask for Polish ahead of English. Logto discarded the weight whenever that whitespace was present and fell back to header order, serving the sign-in experience and the emails it sends in the wrong language. A non-numeric quality value such as `q=high` now falls back to the default weight instead of producing `NaN`.

--- a/packages/core/src/i18n/detect-language.test.ts
+++ b/packages/core/src/i18n/detect-language.test.ts
@@ -18,6 +18,32 @@ describe('detectLanguage', () => {
     expect(language).toEqual(['en', 'en-US']);
   });
 
+  it('detectLanguage with optional whitespace around the quality parameter', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ctx: ParameterizedContext<any, any, any> = createMockContext({
+      headers: {
+        'accept-language': 'en; q=0.7, pl; q=0.9',
+      },
+    });
+
+    const language = detectLanguage(ctx);
+
+    expect(language).toEqual(['pl', 'en']);
+  });
+
+  it('detectLanguage with a non-numeric quality value', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ctx: ParameterizedContext<any, any, any> = createMockContext({
+      headers: {
+        'accept-language': 'pl;q=0.9,en;q=high',
+      },
+    });
+
+    const language = detectLanguage(ctx);
+
+    expect(language).toEqual(['en', 'pl']);
+  });
+
   it('return empty if non-language is detected', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const ctx: ParameterizedContext<any, any, any> = createMockContext({

--- a/packages/core/src/i18n/detect-language.test.ts
+++ b/packages/core/src/i18n/detect-language.test.ts
@@ -19,7 +19,7 @@ describe('detectLanguage', () => {
   });
 
   it('detectLanguage with optional whitespace around the quality parameter', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Mock context does not need typed state or body.
     const ctx: ParameterizedContext<any, any, any> = createMockContext({
       headers: {
         'accept-language': 'en; q=0.7, pl; q=0.9',
@@ -32,7 +32,7 @@ describe('detectLanguage', () => {
   });
 
   it('detectLanguage with a non-numeric quality value', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Mock context does not need typed state or body.
     const ctx: ParameterizedContext<any, any, any> = createMockContext({
       headers: {
         'accept-language': 'pl;q=0.9,en;q=high',

--- a/packages/core/src/i18n/detect-language.ts
+++ b/packages/core/src/i18n/detect-language.ts
@@ -12,7 +12,7 @@ import type { IRouterParamContext } from 'koa-router';
  */
 const resolveLanguage = (languageString: string): Optional<[string, number]> => {
   // Edited from https://github.com/lxzxl/koa-i18next-detector/blob/master/src/lookups/header.js
-  const [language, ...rest] = languageString.split(';');
+  const [language, ...rest] = languageString.split(';').map((part) => part.trim());
 
   if (!language) {
     return;
@@ -20,9 +20,10 @@ const resolveLanguage = (languageString: string): Optional<[string, number]> => 
 
   for (const item of rest) {
     const [key, value] = item.split('=');
+    const quality = Number(value);
 
-    if (key === 'q' && !Number.isNaN(value)) {
-      return [language, Number(value)];
+    if (key === 'q' && !Number.isNaN(quality)) {
+      return [language, quality];
     }
   }
 


### PR DESCRIPTION
## Summary

Closes #9332.

`resolveLanguage` splits the language string on `;` without trimming the parts. RFC 7231 §5.3.1 defines `weight = OWS ";" OWS "q=" qvalue`, so `en; q=0.7, pl; q=0.9` yields the key `" q"` and the language `" pl"`. The weight is discarded, every entry keeps the default `q=1`, and the sort is stable, so header order wins over quality order.

`getExperienceLanguage` with `autoDetect` enabled, run against both trees:

| `Accept-Language` | before | after |
|---|---|---|
| `en; q=0.7, pl; q=0.9` | `en` | `pl-PL` |
| `pl;q=0.9,en;q=high` | `pl-PL` | `en` |

The second row is the other half of the same branch: `!Number.isNaN(value)` never fires, because `value` is a string and `Number.isNaN` does not coerce, so `q=high` becomes `NaN` and the sort comparator returns `NaN`. Parsing the value before the check restores the guard's intent — an unparseable quality falls back to the default weight.

This decides the sign-in experience language via `koa-experience-ssr` and the language of the emails Logto sends via `koa-email-i18n`. Two cases were added to `detect-language.test.ts`; I verified both fail on `master` and pass with the fix. Unrelated: the two dotted-Gmail-alias cases in `email-blocklist-policy.test.ts` already fail on `master` at `aa7fb388d`.

## Testing

Unit tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
