### PR TITLE
feat(core): wire native cimd support into the oidc provider

### DIFF
--- a/packages/core/jest.setup.js
+++ b/packages/core/jest.setup.js
@@ -40,6 +40,7 @@ if (!expect.getState().testPath.endsWith('/env-set/oidc.test.js')) {
     cookieKeys: [],
     privateJwks: [],
     publicJwks: [],
+    cimdEnabled: false,
   }));
 }
 /* End */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,7 +83,7 @@
     "lru-cache": "^11.0.0",
     "nanoid": "^5.0.9",
     "node-forge": "^1.3.1",
-    "oidc-provider": "github:logto-io/node-oidc-provider#d2f08cf55fd683c18095f6b226818d4f761c0c41",
+    "oidc-provider": "github:logto-io/node-oidc-provider#e04834716e4bfee9f74e8d2e919cae21b2295a8a",
     "openapi-types": "^12.1.3",
     "otplib": "^12.0.1",
     "p-map": "^7.0.2",

--- a/packages/core/src/env-set/index.test.ts
+++ b/packages/core/src/env-set/index.test.ts
@@ -1,4 +1,4 @@
-import { LogtoOidcConfigKey, OidcSigningKeyStatus } from '@logto/schemas';
+import { LogtoOidcConfigKey, OidcSigningKeyStatus, defaultCimdConfig } from '@logto/schemas';
 import { createMockUtils } from '@logto/shared/esm';
 
 const { jest } = import.meta;
@@ -29,6 +29,7 @@ const mockLockPrivateSigningKeys = jest.fn();
 const mockGetPrivateSigningKeys = jest.fn();
 const mockUpsertPrivateSigningKeys = jest.fn();
 const mockGetOidcConfigs = jest.fn();
+const mockGetCimdConfig = jest.fn(async () => defaultCimdConfig);
 const mockPromoteScheduledSigningKeyRotation = jest.fn();
 const mockLoadOidcValues = jest.fn(async () => ({ issuer: 'https://tenant.example.com/oidc' }));
 
@@ -42,6 +43,7 @@ mockEsm('#src/queries/logto-config.js', () => ({
     lockPrivateSigningKeys: mockLockPrivateSigningKeys,
     getPrivateSigningKeys: mockGetPrivateSigningKeys,
     upsertPrivateSigningKeys: mockUpsertPrivateSigningKeys,
+    getCimdConfig: mockGetCimdConfig,
   })),
 }));
 
@@ -95,6 +97,11 @@ describe('EnvSet.load()', () => {
     expect(promoteCallOrder!).toBeLessThan(getConfigsCallOrder!);
     expect(mockPromoteScheduledSigningKeyRotation).toHaveBeenCalledTimes(1);
     expect(mockLoadOidcValues).toHaveBeenCalledTimes(1);
+    expect(mockLoadOidcValues).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      defaultCimdConfig
+    );
   });
 
   it('skips promotion when the staged signing key is not due yet', async () => {

--- a/packages/core/src/env-set/index.ts
+++ b/packages/core/src/env-set/index.ts
@@ -102,11 +102,18 @@ export class EnvSet {
 
     await promoteScheduledSigningKeyRotation();
 
-    const oidcConfigs = await getOidcConfigs(consoleLog);
+    const [oidcConfigs, cimdConfig] = await Promise.all([
+      getOidcConfigs(consoleLog),
+      logtoConfigQueries.getCimdConfig(),
+    ]);
     this.#endpoint = customDomain
       ? new URL(customDomain)
       : getTenantEndpoint(this.tenantId, EnvSet.values);
-    this.#oidc = await loadOidcValues(appendPath(this.#endpoint, '/oidc').href, oidcConfigs);
+    this.#oidc = await loadOidcValues(
+      appendPath(this.#endpoint, '/oidc').href,
+      oidcConfigs,
+      cimdConfig
+    );
   }
 
   async end() {

--- a/packages/core/src/env-set/oidc.test.ts
+++ b/packages/core/src/env-set/oidc.test.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert';
 import { generateKeyPairSync } from 'node:crypto';
 
-import { LogtoOidcConfigKey, OidcSigningKeyStatus, type LogtoOidcConfigType } from '@logto/schemas';
+import {
+  LogtoOidcConfigKey,
+  OidcSigningKeyStatus,
+  defaultCimdConfig,
+  type LogtoOidcConfigType,
+} from '@logto/schemas';
 import { SignJWT, importJWK, jwtVerify } from 'jose';
 
 import loadOidcValues from './oidc.js';
@@ -37,7 +42,8 @@ describe('loadOidcValues', () => {
   ])('derives the signing algorithm from the %s current key', async (namedCurve, expected) => {
     const { jwkSigningAlg, privateJwks, localJWKSet } = await loadOidcValues(
       issuer,
-      buildConfigs([generateEcPrivateKeyPem(namedCurve)])
+      buildConfigs([generateEcPrivateKeyPem(namedCurve)]),
+      defaultCimdConfig
     );
 
     expect(jwkSigningAlg).toBe(expected);
@@ -61,7 +67,8 @@ describe('loadOidcValues', () => {
   it('keeps the signing algorithm undefined for an RSA current key', async () => {
     const { jwkSigningAlg } = await loadOidcValues(
       issuer,
-      buildConfigs([generateRsaPrivateKeyPem()])
+      buildConfigs([generateRsaPrivateKeyPem()]),
+      defaultCimdConfig
     );
 
     expect(jwkSigningAlg).toBeUndefined();
@@ -70,7 +77,8 @@ describe('loadOidcValues', () => {
   it('follows the current key when a previous key of another type remains in rotation grace', async () => {
     const { jwkSigningAlg, privateJwks, publicJwks } = await loadOidcValues(
       issuer,
-      buildConfigs([generateEcPrivateKeyPem('prime256v1'), generateRsaPrivateKeyPem()])
+      buildConfigs([generateEcPrivateKeyPem('prime256v1'), generateRsaPrivateKeyPem()]),
+      defaultCimdConfig
     );
 
     expect(jwkSigningAlg).toBe('ES256');

--- a/packages/core/src/env-set/oidc.ts
+++ b/packages/core/src/env-set/oidc.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-import type { LogtoOidcConfigType } from '@logto/schemas';
+import type { CimdConfig, LogtoOidcConfigType } from '@logto/schemas';
 import {
   LogtoOidcConfigKey,
   getCurrentOidcPrivateKey,
@@ -27,7 +27,11 @@ const getEcSigningAlg = (crv: string | undefined) => {
   }
 };
 
-const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
+const loadOidcValues = async (
+  issuer: string,
+  configs: LogtoOidcConfigType,
+  cimdConfig: CimdConfig
+) => {
   const cookieKeys = configs[LogtoOidcConfigKey.CookieKeys].map(({ value }) => value);
   const currentPrivateKey = crypto.createPrivateKey(
     getCurrentOidcPrivateKey(configs[LogtoOidcConfigKey.PrivateKeys]).value
@@ -59,6 +63,7 @@ const loadOidcValues = async (issuer: string, configs: LogtoOidcConfigType) => {
     jwkSigningAlg,
     localJWKSet,
     sessionTtl: session.ttl,
+    cimdEnabled: cimdConfig.enabled,
     issuer,
   });
 };

--- a/packages/core/src/oidc/adapter.test.ts
+++ b/packages/core/src/oidc/adapter.test.ts
@@ -177,3 +177,119 @@ describe('postgres Adapter', () => {
     );
   });
 });
+
+describe('client adapter `find` fallback contract', () => {
+  const clientId = 'some_client_id';
+
+  /**
+   * Load the adapter (and its error classes) after resetting the module registry, so the
+   * `instanceof` checks inside the adapter observe the same class identities as the errors
+   * thrown and asserted below.
+   */
+  const loadClientAdapter = async ({
+    isDevFeaturesEnabled = true,
+    isOidcProviderSsrfProtectionEnabled = true,
+    cimdEnabled = true,
+    findApplicationById,
+  }: {
+    isDevFeaturesEnabled?: boolean;
+    isOidcProviderSsrfProtectionEnabled?: boolean;
+    cimdEnabled?: boolean;
+    findApplicationById: jest.Mock;
+  }) => {
+    jest.resetModules();
+    mockEsm('#src/env-set/index.js', () => ({
+      EnvSet: {
+        values: { isDevFeaturesEnabled, isOidcProviderSsrfProtectionEnabled },
+      },
+    }));
+
+    /**
+     * Sequential imports on purpose: concurrent `import()` calls after `jest.resetModules()`
+     * race the ESM linking of the shared dependency graph ("Module status must not be unlinked
+     * or linking").
+     */
+    const { default: loadedAdapter } = await import('./adapter.js');
+    const { default: RequestError } = await import('#src/errors/RequestError/index.js');
+    const { errors } = await import('oidc-provider');
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the adapter reads
+    const envSet = { oidc: { cimdEnabled } } as EnvSet;
+    const adapter = loadedAdapter(
+      envSet,
+      new MockQueries({ applications: { findApplicationById } }),
+      'Client'
+    );
+
+    return {
+      // eslint-disable-next-line unicorn/no-array-callback-reference -- `Adapter#find` is not an array method
+      findClient: async () => adapter.find(clientId),
+      buildNotFoundError: () =>
+        new RequestError({
+          code: 'entity.not_exists_with_id',
+          name: 'applications',
+          id: clientId,
+          status: 404,
+        }),
+      errors,
+    };
+  };
+
+  it('resolves to undefined on a confirmed missing record while CIMD is effectively enabled', async () => {
+    const findApplicationById = jest.fn();
+    const { findClient, buildNotFoundError } = await loadClientAdapter({ findApplicationById });
+    findApplicationById.mockRejectedValue(buildNotFoundError());
+
+    await expect(findClient()).resolves.toBeUndefined();
+  });
+
+  it('keeps the invalid_client behavior on a missing record when CIMD is not effectively enabled', async () => {
+    const findApplicationById = jest.fn();
+    const { findClient, buildNotFoundError, errors } = await loadClientAdapter({
+      cimdEnabled: false,
+      findApplicationById,
+    });
+    findApplicationById.mockRejectedValue(buildNotFoundError());
+
+    await expect(findClient()).rejects.toThrow(errors.InvalidClient);
+  });
+
+  it('keeps the invalid_client behavior on a missing record when SSRF protection is off', async () => {
+    const findApplicationById = jest.fn();
+    const { findClient, buildNotFoundError, errors } = await loadClientAdapter({
+      isOidcProviderSsrfProtectionEnabled: false,
+      findApplicationById,
+    });
+    findApplicationById.mockRejectedValue(buildNotFoundError());
+
+    await expect(findClient()).rejects.toThrow(errors.InvalidClient);
+  });
+
+  it('propagates database errors instead of resolving to undefined while CIMD is effectively enabled', async () => {
+    const databaseError = new Error('connection reset');
+    const findApplicationById = jest.fn().mockRejectedValue(databaseError);
+    const { findClient } = await loadClientAdapter({ findApplicationById });
+
+    await expect(findClient()).rejects.toBe(databaseError);
+  });
+
+  it('folds database errors into invalid_client when CIMD is not effectively enabled', async () => {
+    const findApplicationById = jest.fn().mockRejectedValue(new Error('connection reset'));
+    const { findClient, errors } = await loadClientAdapter({
+      cimdEnabled: false,
+      findApplicationById,
+    });
+
+    await expect(findClient()).rejects.toThrow(errors.InvalidClient);
+  });
+
+  it('folds every lookup error into invalid_client when the dev features flag is off', async () => {
+    const findApplicationById = jest.fn().mockRejectedValue(new Error('connection reset'));
+    const { findClient, errors } = await loadClientAdapter({
+      isDevFeaturesEnabled: false,
+      findApplicationById,
+    });
+
+    await expect(findClient()).rejects.toThrow(errors.InvalidClient);
+  });
+});

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -14,9 +14,11 @@ import snakecaseKeys from 'snakecase-keys';
 
 import { EnvSet } from '#src/env-set/index.js';
 import { getTenantUrls } from '#src/env-set/utils.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
 import { appLevelAccessControlMetadataKey } from './application-access-control.js';
+import { isCimdEffectivelyEnabled } from './cimd.js';
 import { getConstantClientMetadata } from './utils.js';
 
 /**
@@ -149,6 +151,32 @@ export default function postgresAdapter(
     const reject = async () => {
       throw new Error('Not implemented');
     };
+
+    /**
+     * Find the registered application for the client ID.
+     *
+     * While CIMD is effectively enabled, a confirmed "record not found" resolves to `undefined`
+     * and every other error keeps propagating — a database blip must never masquerade as
+     * "not found" and turn registered applications into CIMD fetch candidates. Otherwise the
+     * pre-CIMD behavior stays: every lookup failure folds into `invalid_client`.
+     */
+    const findApplicationWithCimdFallback = async (id: string) => {
+      // DEV: CIMD (client ID metadata document) support
+      if (isCimdEffectivelyEnabled(envSet)) {
+        try {
+          return await findApplicationById(id);
+        } catch (error) {
+          if (error instanceof RequestError && error.code === 'entity.not_exists_with_id') {
+            // Return `undefined` to hand resolution over to the provider's native CIMD resolver.
+            return;
+          }
+          throw error;
+        }
+      }
+
+      return tryThat(findApplicationById(id), new errors.InvalidClient(`invalid client ${id}`));
+    };
+
     const transpileClient = (
       {
         id: client_id,
@@ -186,10 +214,11 @@ export default function postgresAdapter(
           return buildDeviceDemoAppClientMetadata(envSet);
         }
 
-        const application = await tryThat(
-          findApplicationById(id),
-          new errors.InvalidClient(`invalid client ${id}`)
-        );
+        const application = await findApplicationWithCimdFallback(id);
+
+        if (!application) {
+          return;
+        }
 
         if (application.isThirdParty) {
           const clientScopes = await getThirdPartyClientScopes(applications, id);

--- a/packages/core/src/oidc/cimd.test.ts
+++ b/packages/core/src/oidc/cimd.test.ts
@@ -1,0 +1,70 @@
+import { createMockUtils } from '@logto/shared/esm';
+
+import { type EnvSet } from '#src/env-set/index.js';
+
+const { jest } = import.meta;
+const { mockEsm } = createMockUtils(jest);
+
+const loadCimdModule = async ({
+  isDevFeaturesEnabled = true,
+  isOidcProviderSsrfProtectionEnabled = true,
+} = {}) => {
+  jest.resetModules();
+  mockEsm('#src/env-set/index.js', () => ({
+    EnvSet: {
+      values: { isDevFeaturesEnabled, isOidcProviderSsrfProtectionEnabled },
+    },
+  }));
+
+  return import('./cimd.js');
+};
+
+const buildEnvSet = (cimdEnabled: boolean): EnvSet => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the module reads
+  return { oidc: { cimdEnabled } } as EnvSet;
+};
+
+describe('isCimdEffectivelyEnabled', () => {
+  it('is enabled only when all three conditions hold', async () => {
+    const { isCimdEffectivelyEnabled } = await loadCimdModule();
+    expect(isCimdEffectivelyEnabled(buildEnvSet(true))).toBe(true);
+  });
+
+  it('is disabled when the dev features flag is off', async () => {
+    const { isCimdEffectivelyEnabled } = await loadCimdModule({ isDevFeaturesEnabled: false });
+    expect(isCimdEffectivelyEnabled(buildEnvSet(true))).toBe(false);
+  });
+
+  it('is disabled when the tenant config is off', async () => {
+    const { isCimdEffectivelyEnabled } = await loadCimdModule();
+    expect(isCimdEffectivelyEnabled(buildEnvSet(false))).toBe(false);
+  });
+
+  it('is disabled when the provider SSRF protection is off, regardless of the stored config', async () => {
+    const { isCimdEffectivelyEnabled } = await loadCimdModule({
+      isOidcProviderSsrfProtectionEnabled: false,
+    });
+    expect(isCimdEffectivelyEnabled(buildEnvSet(true))).toBe(false);
+  });
+});
+
+describe('buildClientIdMetadataDocumentFeature', () => {
+  it('wires the feature with the draft-02 acknowledgement when effectively enabled', async () => {
+    const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();
+    expect(buildClientIdMetadataDocumentFeature(buildEnvSet(true))).toEqual({
+      clientIdMetadataDocument: { enabled: true, ack: 'draft-02' },
+    });
+  });
+
+  it('does not wire the feature at all when the dev features flag is off', async () => {
+    const { buildClientIdMetadataDocumentFeature } = await loadCimdModule({
+      isDevFeaturesEnabled: false,
+    });
+    expect(buildClientIdMetadataDocumentFeature(buildEnvSet(true))).toBeUndefined();
+  });
+
+  it('does not wire the feature when not effectively enabled', async () => {
+    const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();
+    expect(buildClientIdMetadataDocumentFeature(buildEnvSet(false))).toBeUndefined();
+  });
+});

--- a/packages/core/src/oidc/cimd.ts
+++ b/packages/core/src/oidc/cimd.ts
@@ -1,0 +1,58 @@
+/**
+ * @overview OAuth Client ID Metadata Document (CIMD) support.
+ *
+ * CIMD lets an OAuth client use a public HTTPS URL as its `client_id`; the URL serves the client
+ * metadata JSON document. The oidc-provider fork implements the draft-02 resolver, fetch, cache,
+ * validation, and discovery natively — this module wires the feature into the provider and
+ * exposes the shared enablement predicate.
+ *
+ * @see {@link https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-02.html | draft-02}
+ */
+
+import { conditional, type Optional } from '@silverhand/essentials';
+
+import { EnvSet } from '#src/env-set/index.js';
+
+/**
+ * Whether CIMD is effectively enabled for the tenant. All three conditions must hold:
+ *
+ * - The development features flag is on (release guard);
+ * - The tenant has enabled CIMD in its configs;
+ * - The provider SSRF protection is active — CIMD forces outbound fetches, so it hard-requires
+ *   the SSRF-protected dispatcher. Disabling the protection (self-hosted only) turns CIMD off
+ *   regardless of the stored config: the Management API's enable-time 422 only fails fast on the
+ *   honest path, since the env can be flipped after the config is stored.
+ *
+ * Provider construction is the authoritative gate — the tenant is rebuilt when the stored config
+ * changes, so every predicate consumer observes the same value for the provider's lifetime.
+ */
+export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
+  // DEV: CIMD (client ID metadata document) support
+  EnvSet.values.isDevFeaturesEnabled &&
+  envSet.oidc.cimdEnabled &&
+  EnvSet.values.isOidcProviderSsrfProtectionEnabled;
+
+/**
+ * Build the `features.clientIdMetadataDocument` entry for the provider configuration, or
+ * `undefined` when CIMD is not effectively enabled — with the entry absent the fork keeps the
+ * feature disabled, so the provider skips CIMD client resolution and discovery only publishes
+ * `client_id_metadata_document_supported` when effective.
+ *
+ * The `ack` pins the implemented draft version: the provider constructor throws when a fork
+ * upgrade changes the implemented version, forcing a deliberate review instead of a silent
+ * behavior change.
+ *
+ * The explicit return type stands in for `@types/oidc-provider`, which does not declare this
+ * draft feature of the fork.
+ */
+export const buildClientIdMetadataDocumentFeature = (
+  envSet: EnvSet
+): Optional<{ clientIdMetadataDocument: { enabled: true; ack: 'draft-02' } }> =>
+  conditional(
+    isCimdEffectivelyEnabled(envSet) && {
+      clientIdMetadataDocument: {
+        enabled: true,
+        ack: 'draft-02',
+      },
+    }
+  );

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -55,6 +55,7 @@ import {
   hasAppLevelAccessControlChecked,
   markAppLevelAccessControlCheckedForOidcContext,
 } from './application-access-control.js';
+import { buildClientIdMetadataDocumentFeature } from './cimd.js';
 import defaults from './defaults.js';
 import { deviceFlowConfig, defaultDeviceCodeTtl } from './device-flow.js';
 import {
@@ -189,6 +190,8 @@ export default function initOidc(
       dPoP: { enabled: false },
       backchannelLogout: { enabled: true },
       deviceFlow: deviceFlowConfig,
+      // DEV: CIMD (client ID metadata document) support
+      ...buildClientIdMetadataDocumentFeature(envSet),
       rpInitiatedLogout: {
         logoutSource: (ctx, form) => {
           // eslint-disable-next-line no-template-curly-in-string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4242,8 +4242,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       oidc-provider:
-        specifier: github:logto-io/node-oidc-provider#d2f08cf55fd683c18095f6b226818d4f761c0c41
-        version: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/d2f08cf55fd683c18095f6b226818d4f761c0c41
+        specifier: github:logto-io/node-oidc-provider#e04834716e4bfee9f74e8d2e919cae21b2295a8a
+        version: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -13417,8 +13417,8 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/d2f08cf55fd683c18095f6b226818d4f761c0c41:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/d2f08cf55fd683c18095f6b226818d4f761c0c41}
+  oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a:
+    resolution: {gitHosted: true, integrity: sha512-WEK/83nAa+Mm1r+7pYJLxTM8K0j7GOsVQC7N/CGp//17HZ5GbGUqFQgDxVlLO5p4qE6eR0QFx0jJPhd0t+KnAQ==, tarball: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a}
     version: 9.9.1
 
   on-finished@2.4.1:
@@ -26481,7 +26481,7 @@ snapshots:
 
   obug@2.1.1: {}
 
-  oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/d2f08cf55fd683c18095f6b226818d4f761c0c41:
+  oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a:
     dependencies:
       '@koa/cors': 5.0.0
       '@koa/router': 15.7.0(koa@3.2.1)


### PR DESCRIPTION
## Summary

Wire the oidc-provider fork's native CIMD (client ID metadata document, draft-02) support into core.

- Bump the fork pin to the v9 branch HEAD (`e048347`), picking up the CIMD metadata transform extension point (logto-io/node-oidc-provider#33) and the bounded interaction cookie client map (logto-io/node-oidc-provider#32).
- Provider construction is the authoritative gate: the `features.clientIdMetadataDocument` entry is only injected when the tenant `cimd` config is enabled and the provider SSRF protection is active, so self-hosted instances that disable the protection force CIMD off regardless of the stored config. The tenant is rebuilt on config change, so the gate re-evaluates.
- `ack: 'draft-02'` pins the implemented draft version — the provider constructor throws when a fork upgrade changes it, forcing a deliberate review.
- Client adapter fallback contract: while CIMD is effective, only a confirmed missing application record resolves to `undefined` (handing resolution over to the provider's native CIMD resolver) and database errors keep propagating instead of masquerading as "not found"; in every other case the current `invalid_client` behavior stays untouched.
- Discovery publishes `client_id_metadata_document_supported` only when the feature is effective, via the construction gate.
- Dev feature guard: with the flag off, nothing is wired and the adapter keeps the exact pre-CIMD behavior.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments