### PR TITLE
feat(core): enforce the cimd client identifier length bound

### DIFF
--- a/packages/core/src/oidc/cimd.test.ts
+++ b/packages/core/src/oidc/cimd.test.ts
@@ -1,4 +1,5 @@
 import { createMockUtils } from '@logto/shared/esm';
+import { type Client } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
 
@@ -22,6 +23,27 @@ const loadCimdModule = async ({
 const buildEnvSet = (cimdEnabled: boolean): EnvSet => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the module reads
   return { oidc: { cimdEnabled } } as EnvSet;
+};
+
+const cimdClientIdMaxLength = 2048;
+
+const buildClientId = (length: number) =>
+  `https://example.com/${'a'.repeat(length - 'https://example.com/'.length)}`;
+
+const buildClient = (clientId: string): Client => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub scoped to the field the hook reads
+  return { clientId } as Client;
+};
+
+const loadEnabledFeature = async () => {
+  const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();
+  const feature = buildClientIdMetadataDocumentFeature(buildEnvSet(true));
+
+  if (!feature) {
+    throw new Error('Expected the CIMD feature to be built');
+  }
+
+  return feature.clientIdMetadataDocument;
 };
 
 describe('isCimdEffectivelyEnabled', () => {
@@ -51,7 +73,7 @@ describe('isCimdEffectivelyEnabled', () => {
 describe('buildClientIdMetadataDocumentFeature', () => {
   it('wires the feature with the draft-02 acknowledgement when effectively enabled', async () => {
     const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();
-    expect(buildClientIdMetadataDocumentFeature(buildEnvSet(true))).toEqual({
+    expect(buildClientIdMetadataDocumentFeature(buildEnvSet(true))).toMatchObject({
       clientIdMetadataDocument: { enabled: true, ack: 'draft-02' },
     });
   });
@@ -66,5 +88,21 @@ describe('buildClientIdMetadataDocumentFeature', () => {
   it('does not wire the feature when not effectively enabled', async () => {
     const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();
     expect(buildClientIdMetadataDocumentFeature(buildEnvSet(false))).toBeUndefined();
+  });
+});
+
+describe('client identifier length bound', () => {
+  it('allowFetch accepts an identifier at the bound and rejects one past it', async () => {
+    const { allowFetch } = await loadEnabledFeature();
+    expect(allowFetch(undefined, buildClientId(cimdClientIdMaxLength))).toBe(true);
+    expect(allowFetch(undefined, buildClientId(cimdClientIdMaxLength + 1))).toBe(false);
+  });
+
+  it('allowClient accepts a client at the bound and rejects one past it', async () => {
+    const { allowClient } = await loadEnabledFeature();
+    expect(allowClient(undefined, buildClient(buildClientId(cimdClientIdMaxLength)))).toBe(true);
+    expect(allowClient(undefined, buildClient(buildClientId(cimdClientIdMaxLength + 1)))).toBe(
+      false
+    );
   });
 });

--- a/packages/core/src/oidc/cimd.ts
+++ b/packages/core/src/oidc/cimd.ts
@@ -10,8 +10,16 @@
  */
 
 import { conditional, type Optional } from '@silverhand/essentials';
+import { type Client, type KoaContextWithOIDC } from 'oidc-provider';
 
 import { EnvSet } from '#src/env-set/index.js';
+
+/**
+ * Must not exceed the `cimd_client_id varchar(2048)` column width — neither the draft nor the
+ * provider defines a maximum, so this bound is what keeps an over-long identifier an
+ * `invalid_client` rather than a database error.
+ */
+const cimdClientIdMaxLength = 2048;
 
 /**
  * Whether CIMD is effectively enabled for the tenant. All three conditions must hold:
@@ -43,16 +51,29 @@ export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
  * behavior change.
  *
  * The explicit return type stands in for `@types/oidc-provider`, which does not declare this
- * draft feature of the fork.
+ * draft feature of the fork. A falsy return from either callback makes the provider throw
+ * `InvalidClient`.
  */
 export const buildClientIdMetadataDocumentFeature = (
   envSet: EnvSet
-): Optional<{ clientIdMetadataDocument: { enabled: true; ack: 'draft-02' } }> =>
+): Optional<{
+  clientIdMetadataDocument: {
+    enabled: true;
+    ack: 'draft-02';
+    allowFetch: (ctx: KoaContextWithOIDC | undefined, clientId: string) => boolean;
+    allowClient: (ctx: KoaContextWithOIDC | undefined, client: Client) => boolean;
+  };
+}> =>
   conditional(
     isCimdEffectivelyEnabled(envSet) && {
       clientIdMetadataDocument: {
         enabled: true,
         ack: 'draft-02',
+        allowFetch: (_ctx: KoaContextWithOIDC | undefined, clientId: string) =>
+          clientId.length <= cimdClientIdMaxLength,
+        /** Cache hits skip `allowFetch`, so the bound must repeat here. */
+        allowClient: (_ctx: KoaContextWithOIDC | undefined, client: Client) =>
+          client.clientId.length <= cimdClientIdMaxLength,
       },
     }
   );


### PR DESCRIPTION
## Summary

Enforce the CIMD client identifier length bound (2048 characters, the `cimd_client_id` column width) in the provider feature callbacks:

- `allowFetch` rejects an over-long identifier before any outbound request is made.
- `allowClient` repeats the check on every client resolution, since cache hits never pass through `allowFetch`.
- A falsy return makes the provider throw `InvalidClient`, so an over-long identifier fails as a protocol-level `invalid_client` instead of a database varchar error.

Stacked on #9341.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments