### PR TITLE
feat(core): write cimd client identifiers to the session extension

### DIFF
--- a/packages/core/src/include.d/oidc-provider/index.d.ts
+++ b/packages/core/src/include.d/oidc-provider/index.d.ts
@@ -4,4 +4,12 @@ declare module 'oidc-provider' {
   export interface AllClientMetadata extends CustomClientMetadata {
     appLevelAccessControlEnabled?: boolean;
   }
+
+  export interface Client {
+    /**
+     * The fork's CIMD resolver stamps this marker onto every client it builds from a metadata
+     * document; registered clients never carry it. Not covered by `@types/oidc-provider`.
+     */
+    readonly clientIdMetadataDocument?: true;
+  }
 }

--- a/packages/core/src/include.d/oidc-provider/index.d.ts
+++ b/packages/core/src/include.d/oidc-provider/index.d.ts
@@ -4,12 +4,4 @@ declare module 'oidc-provider' {
   export interface AllClientMetadata extends CustomClientMetadata {
     appLevelAccessControlEnabled?: boolean;
   }
-
-  export interface Client {
-    /**
-     * The fork's CIMD resolver stamps this marker onto every client it builds from a metadata
-     * document; registered clients never carry it. Not covered by `@types/oidc-provider`.
-     */
-    readonly clientIdMetadataDocument?: true;
-  }
 }

--- a/packages/core/src/libraries/session/consent.test.ts
+++ b/packages/core/src/libraries/session/consent.test.ts
@@ -5,6 +5,7 @@ import type { Provider } from 'oidc-provider';
 import { mockUser } from '#src/__mocks__/user.js';
 import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
 import type Queries from '#src/tenants/Queries.js';
+import { mockEnvSet } from '#src/test-utils/env-set.js';
 import { GrantMock, createMockProvider } from '#src/test-utils/oidc-provider.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
@@ -63,6 +64,7 @@ describe('consent', () => {
     await consent({
       ctx: context,
       provider,
+      envSet: mockEnvSet,
       queries,
       interactionDetails: baseInteractionDetails,
     });
@@ -94,6 +96,7 @@ describe('consent', () => {
     await consent({
       ctx: context,
       provider,
+      envSet: mockEnvSet,
       queries,
       interactionDetails,
     });
@@ -118,6 +121,7 @@ describe('consent', () => {
     await consent({
       ctx: context,
       provider,
+      envSet: mockEnvSet,
       queries,
       interactionDetails: baseInteractionDetails,
       markAppLevelAccessControlChecked: true,
@@ -153,6 +157,7 @@ describe('consent', () => {
     await consent({
       ctx: context,
       provider,
+      envSet: mockEnvSet,
       queries,
       interactionDetails: baseInteractionDetails,
     });
@@ -167,6 +172,7 @@ describe('consent', () => {
     await consent({
       ctx: context,
       provider,
+      envSet: mockEnvSet,
       queries,
       interactionDetails: baseInteractionDetails,
       missingOIDCScopes: ['openid', 'profile'],

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -5,7 +5,9 @@ import type { PromptDetail, Provider } from 'oidc-provider';
 import { errors } from 'oidc-provider';
 import { z } from 'zod';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -35,6 +37,36 @@ export const getMissingScopes = (prompt: PromptDetail) => {
   return missingScopesGuard.parse(prompt.details);
 };
 
+/** Exactly one identifier is present, matching the kind of the consenting client. */
+type ClientIdentifiers = {
+  registeredClientId?: string;
+  cimdClientId?: string;
+};
+
+/**
+ * The `client_id` param alone cannot tell a registered application from a CIMD client, so the
+ * resolved client instance's marker decides. While CIMD is not effectively enabled the lookup
+ * is skipped: only registered applications can reach consent then.
+ */
+const identifyClient = async (
+  provider: Provider,
+  envSet: EnvSet,
+  clientId: string
+): Promise<ClientIdentifiers> => {
+  // DEV: CIMD (client ID metadata document) support
+  if (!isCimdEffectivelyEnabled(envSet)) {
+    return { registeredClientId: clientId };
+  }
+
+  const client = await provider.Client.find(clientId);
+
+  assertThat(client, new errors.InvalidClient('client must be available'));
+
+  return client.clientIdMetadataDocument
+    ? { cimdClientId: clientId }
+    : { registeredClientId: clientId };
+};
+
 /**
  * Persists the interaction's `lastSubmission` information to the session for future reference.
  *
@@ -59,13 +91,10 @@ export const getMissingScopes = (prompt: PromptDetail) => {
  */
 const saveInteractionLastSubmissionToSession = async (
   queries: Queries,
-  interactionDetails: Awaited<ReturnType<Provider['interactionDetails']>>
+  interactionDetails: Awaited<ReturnType<Provider['interactionDetails']>>,
+  { registeredClientId, cimdClientId }: ClientIdentifiers
 ) => {
-  const {
-    session,
-    lastSubmission,
-    params: { client_id: clientId },
-  } = interactionDetails;
+  const { session, lastSubmission } = interactionDetails;
 
   if (!session || !lastSubmission) {
     return;
@@ -75,12 +104,16 @@ const saveInteractionLastSubmissionToSession = async (
   const result = jsonObjectGuard.safeParse(lastSubmission);
 
   if (result.success) {
-    // Persist the last submission to the session extensions
+    /**
+     * The explicit `null` on the unused identifier column makes the upsert overwrite a stale
+     * value left by a previous submission of the other client type.
+     */
     await oidcSessionExtensions.insert({
       sessionUid: session.uid,
       accountId: session.accountId,
       lastSubmission: result.data,
-      ...conditional(typeof clientId === 'string' && { clientId }),
+      clientId: registeredClientId ?? null,
+      cimdClientId: cimdClientId ?? null,
     });
   }
 };
@@ -88,6 +121,7 @@ const saveInteractionLastSubmissionToSession = async (
 export const consent = async ({
   ctx,
   provider,
+  envSet,
   queries,
   interactionDetails,
   missingOIDCScopes = [],
@@ -97,6 +131,7 @@ export const consent = async ({
 }: {
   ctx: Context;
   provider: Provider;
+  envSet: EnvSet;
   queries: Queries;
   interactionDetails: Awaited<ReturnType<Provider['interactionDetails']>>;
   missingOIDCScopes?: string[];
@@ -118,13 +153,24 @@ export const consent = async ({
 
   const { accountId } = session;
 
+  const { registeredClientId, cimdClientId } = await identifyClient(provider, envSet, clientId);
+
   const grant =
     conditional(grantId && (await provider.Grant.find(grantId))) ??
     new provider.Grant({ accountId, clientId });
 
   await Promise.all([
-    saveUserFirstConsentedAppId(queries, accountId, clientId),
-    saveInteractionLastSubmissionToSession(queries, interactionDetails),
+    /**
+     * A CIMD URL must never reach `users.application_id` (varchar(21), registered ids only).
+     * TODO: @xiaoyijun persist the CIMD attribution to `users.cimd_client_id` instead (LOG-13928).
+     */
+    conditional(
+      registeredClientId && saveUserFirstConsentedAppId(queries, accountId, registeredClientId)
+    ),
+    saveInteractionLastSubmissionToSession(queries, interactionDetails, {
+      registeredClientId,
+      cimdClientId,
+    }),
   ]);
 
   // Fulfill missing scopes

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 import { type EnvSet } from '#src/env-set/index.js';
 import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
-import { isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
+import { isCimdClientId, isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -44,28 +44,16 @@ type ClientIdentifiers = {
 };
 
 /**
- * The `client_id` param alone cannot tell a registered application from a CIMD client, so the
- * resolved client instance's marker decides. While CIMD is not effectively enabled the lookup
- * is skipped: only registered applications can reach consent then.
+ * The identifier shape is a sufficient classifier here: registered application ids never take
+ * the URL shape, and authorization has already resolved the client — resolving it again via
+ * `provider.Client.find` would cost a lookup (or an outbound document fetch on a cold cache)
+ * on every consent submission for the same verdict.
  */
-const identifyClient = async (
-  provider: Provider,
-  envSet: EnvSet,
-  clientId: string
-): Promise<ClientIdentifiers> => {
+const identifyClient = (envSet: EnvSet, clientId: string): ClientIdentifiers =>
   // DEV: CIMD (client ID metadata document) support
-  if (!isCimdEffectivelyEnabled(envSet)) {
-    return { registeredClientId: clientId };
-  }
-
-  const client = await provider.Client.find(clientId);
-
-  assertThat(client, new errors.InvalidClient('client must be available'));
-
-  return client.clientIdMetadataDocument
+  isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)
     ? { cimdClientId: clientId }
     : { registeredClientId: clientId };
-};
 
 /**
  * Persists the interaction's `lastSubmission` information to the session for future reference.
@@ -153,7 +141,7 @@ export const consent = async ({
 
   const { accountId } = session;
 
-  const { registeredClientId, cimdClientId } = await identifyClient(provider, envSet, clientId);
+  const { registeredClientId, cimdClientId } = identifyClient(envSet, clientId);
 
   const grant =
     conditional(grantId && (await provider.Grant.find(grantId))) ??

--- a/packages/core/src/libraries/session/session-context.test.ts
+++ b/packages/core/src/libraries/session/session-context.test.ts
@@ -1,9 +1,13 @@
 import { type User } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import type { Provider } from 'oidc-provider';
+import { errors } from 'oidc-provider';
+import Sinon from 'sinon';
 
 import { mockUser } from '#src/__mocks__/user.js';
+import { EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
+import { mockEnvSet } from '#src/test-utils/env-set.js';
 import { GrantMock, createMockProvider } from '#src/test-utils/oidc-provider.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
@@ -34,6 +38,21 @@ const context = createContextWithRouteParameters();
 
 type Interaction = Awaited<ReturnType<Provider['interactionDetails']>>;
 
+const buildInteractionDetails = (clientId: string) =>
+  ({
+    session: { accountId: mockUser.id, uid: 'sessionUid' },
+    params: { client_id: clientId },
+    prompt: { details: {} },
+    lastSubmission: { foo: 'bar' },
+  }) as unknown as Interaction;
+
+const buildProvider = (interactionDetails: Interaction, client?: unknown) => {
+  const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+  Sinon.stub(provider, 'Client').value({ find: async () => client });
+
+  return provider;
+};
+
 describe('saveInteractionLastSubmissionToSession', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -54,6 +73,7 @@ describe('saveInteractionLastSubmissionToSession', () => {
     await consent({
       ctx: context,
       provider,
+      envSet: mockEnvSet,
       queries,
       interactionDetails,
     });
@@ -63,6 +83,101 @@ describe('saveInteractionLastSubmissionToSession', () => {
       accountId: mockUser.id,
       lastSubmission: { foo: 'bar' },
       clientId: 'clientId',
+      cimdClientId: null,
     });
+  });
+});
+
+describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabled', () => {
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  /**
+   * The predicate reads only `oidc.cimdEnabled` from the tenant env set; the static flags are
+   * stubbed onto `EnvSet.values` below.
+   */
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
+  const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
+
+  beforeEach(() => {
+    Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      isDevFeaturesEnabled: true,
+      isOidcProviderSsrfProtectionEnabled: true,
+    });
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+    jest.clearAllMocks();
+  });
+
+  it('should write a cimd client identifier to the dedicated column and skip the app attribution', async () => {
+    const interactionDetails = buildInteractionDetails(cimdClientId);
+    /** The fork resolver stamps this marker onto every client it builds from a metadata document. */
+    const provider = buildProvider(interactionDetails, { clientIdMetadataDocument: true });
+
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails,
+    });
+
+    expect(oidcSessionExtensionsInsert).toHaveBeenCalledWith({
+      sessionUid: 'sessionUid',
+      accountId: mockUser.id,
+      lastSubmission: { foo: 'bar' },
+      clientId: null,
+      cimdClientId,
+    });
+    expect(userQueries.findUserById).not.toHaveBeenCalled();
+    expect(userQueries.updateUserById).not.toHaveBeenCalled();
+  });
+
+  it('should write a registered client identifier to the client id column and keep the app attribution', async () => {
+    userQueries.findUserById.mockImplementationOnce(async () => ({
+      ...mockUser,
+      applicationId: null,
+    }));
+    const interactionDetails = buildInteractionDetails('registeredClientId');
+    const provider = buildProvider(interactionDetails, {});
+
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails,
+    });
+
+    expect(oidcSessionExtensionsInsert).toHaveBeenCalledWith({
+      sessionUid: 'sessionUid',
+      accountId: mockUser.id,
+      lastSubmission: { foo: 'bar' },
+      clientId: 'registeredClientId',
+      cimdClientId: null,
+    });
+    expect(userQueries.updateUserById).toHaveBeenCalledWith(mockUser.id, {
+      applicationId: 'registeredClientId',
+    });
+  });
+
+  it('should reject without persisting anything when the client cannot be resolved', async () => {
+    const interactionDetails = buildInteractionDetails('registeredClientId');
+    const provider = buildProvider(interactionDetails);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: cimdEnvSet,
+        queries,
+        interactionDetails,
+      })
+    ).rejects.toThrow(errors.InvalidClient);
+
+    expect(oidcSessionExtensionsInsert).not.toHaveBeenCalled();
+    expect(userQueries.updateUserById).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/libraries/session/session-context.test.ts
+++ b/packages/core/src/libraries/session/session-context.test.ts
@@ -1,7 +1,6 @@
 import { type User } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import type { Provider } from 'oidc-provider';
-import { errors } from 'oidc-provider';
 import Sinon from 'sinon';
 
 import { mockUser } from '#src/__mocks__/user.js';
@@ -46,13 +45,6 @@ const buildInteractionDetails = (clientId: string) =>
     lastSubmission: { foo: 'bar' },
   }) as unknown as Interaction;
 
-const buildProvider = (interactionDetails: Interaction, client?: unknown) => {
-  const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
-  Sinon.stub(provider, 'Client').value({ find: async () => client });
-
-  return provider;
-};
-
 describe('saveInteractionLastSubmissionToSession', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -92,7 +84,7 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
   const cimdClientId = 'https://client.example.com/metadata.json';
 
   /**
-   * The predicate reads only `oidc.cimdEnabled` from the tenant env set; the static flags are
+   * The gate reads only `oidc.cimdEnabled` from the tenant env set; the static flags are
    * stubbed onto `EnvSet.values` below.
    */
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
@@ -113,8 +105,7 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
 
   it('should write a cimd client identifier to the dedicated column and skip the app attribution', async () => {
     const interactionDetails = buildInteractionDetails(cimdClientId);
-    /** The fork resolver stamps this marker onto every client it builds from a metadata document. */
-    const provider = buildProvider(interactionDetails, { clientIdMetadataDocument: true });
+    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
 
     await consent({
       ctx: context,
@@ -141,7 +132,7 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
       applicationId: null,
     }));
     const interactionDetails = buildInteractionDetails('registeredClientId');
-    const provider = buildProvider(interactionDetails, {});
+    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
 
     await consent({
       ctx: context,
@@ -161,23 +152,5 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
     expect(userQueries.updateUserById).toHaveBeenCalledWith(mockUser.id, {
       applicationId: 'registeredClientId',
     });
-  });
-
-  it('should reject without persisting anything when the client cannot be resolved', async () => {
-    const interactionDetails = buildInteractionDetails('registeredClientId');
-    const provider = buildProvider(interactionDetails);
-
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: cimdEnvSet,
-        queries,
-        interactionDetails,
-      })
-    ).rejects.toThrow(errors.InvalidClient);
-
-    expect(oidcSessionExtensionsInsert).not.toHaveBeenCalled();
-    expect(userQueries.updateUserById).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/middleware/koa-auto-consent.test.ts
+++ b/packages/core/src/middleware/koa-auto-consent.test.ts
@@ -1,5 +1,7 @@
 import type { Provider } from 'oidc-provider';
+import Sinon from 'sinon';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -34,17 +36,17 @@ const createContext = (interactionDetails: Partial<InteractionDetails>, redirect
 
 const createTenant = ({
   isThirdParty = false,
+  findApplicationById = jest.fn(async () => ({
+    isThirdParty,
+  })) as unknown as ApplicationQueries['findApplicationById'],
   assertUserHasApplicationAccess = jest.fn(async () => {
     await Promise.resolve();
   }),
 }: {
   readonly isThirdParty?: boolean;
+  readonly findApplicationById?: ApplicationQueries['findApplicationById'];
   readonly assertUserHasApplicationAccess?: jest.Mock;
 } = {}) => {
-  const findApplicationById = jest.fn(async () => ({
-    isThirdParty,
-  })) as unknown as ApplicationQueries['findApplicationById'];
-
   return {
     findApplicationById,
     tenant: new MockTenant(
@@ -60,8 +62,33 @@ const createTenant = ({
   };
 };
 
+const cimdClientId = 'https://client.example.com/metadata.json';
+
+/**
+ * The predicate reads only `oidc.cimdEnabled` from the tenant env set; the static flags are
+ * stubbed onto `EnvSet.values` per test.
+ */
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
+const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
+
+const stubCimdStaticFlags = () =>
+  Sinon.stub(EnvSet, 'values').value({
+    ...EnvSet.values,
+    isDevFeaturesEnabled: true,
+    isOidcProviderSsrfProtectionEnabled: true,
+  });
+
+const buildNotFoundError = (id: string) =>
+  new RequestError({
+    code: 'entity.not_exists_with_id',
+    name: 'applications',
+    id,
+    status: 404,
+  });
+
 describe('koaAutoConsent middleware', () => {
   afterEach(() => {
+    Sinon.restore();
     jest.clearAllMocks();
   });
 
@@ -82,7 +109,7 @@ describe('koaAutoConsent middleware', () => {
       },
       redirect
     );
-    const guard = koaAutoConsent({} as Provider, tenant.queries, tenant.libraries);
+    const guard = koaAutoConsent({} as Provider, tenant.envSet, tenant.queries, tenant.libraries);
 
     await guard(ctx, next);
 
@@ -102,12 +129,76 @@ describe('koaAutoConsent middleware', () => {
       // @ts-expect-error
       session: { accountId: 'user-id' },
     });
-    const guard = koaAutoConsent({} as Provider, tenant.queries, tenant.libraries);
+    const guard = koaAutoConsent({} as Provider, tenant.envSet, tenant.queries, tenant.libraries);
 
     await guard(ctx, next);
 
     expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
+  });
+
+  it('should fall through to the explicit consent path for a cimd client without a lookup', async () => {
+    stubCimdStaticFlags();
+    const { findApplicationById, tenant } = createTenant();
+    const redirect = jest.fn();
+    const next = jest.fn();
+    const ctx = createContext(
+      {
+        params: { client_id: cimdClientId },
+        prompt,
+        // @ts-expect-error
+        session: { accountId: 'user-id' },
+      },
+      redirect
+    );
+    const guard = koaAutoConsent({} as Provider, cimdEnvSet, tenant.queries, tenant.libraries);
+
+    await guard(ctx, next);
+
+    expect(findApplicationById).not.toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('should keep the not-found behavior for a url client id when CIMD is not effectively enabled', async () => {
+    const findApplicationById = jest
+      .fn()
+      .mockRejectedValue(
+        buildNotFoundError(cimdClientId)
+      ) as unknown as ApplicationQueries['findApplicationById'];
+    const { tenant } = createTenant({ findApplicationById });
+    const next = jest.fn();
+    const ctx = createContext({
+      params: { client_id: cimdClientId },
+      prompt,
+      // @ts-expect-error
+      session: { accountId: 'user-id' },
+    });
+    const guard = koaAutoConsent({} as Provider, tenant.envSet, tenant.queries, tenant.libraries);
+
+    await expect(guard(ctx, next)).rejects.toThrow(RequestError);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('should keep the not-found behavior for a registered client while CIMD is effectively enabled', async () => {
+    stubCimdStaticFlags();
+    const findApplicationById = jest
+      .fn()
+      .mockRejectedValue(
+        buildNotFoundError('app-id')
+      ) as unknown as ApplicationQueries['findApplicationById'];
+    const { tenant } = createTenant({ findApplicationById });
+    const next = jest.fn();
+    const ctx = createContext({
+      params: { client_id: 'app-id' },
+      prompt,
+      // @ts-expect-error
+      session: { accountId: 'user-id' },
+    });
+    const guard = koaAutoConsent({} as Provider, cimdEnvSet, tenant.queries, tenant.libraries);
+
+    await expect(guard(ctx, next)).rejects.toThrow(RequestError);
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('should throw non-access-denied application access errors', async () => {
@@ -123,7 +214,7 @@ describe('koaAutoConsent middleware', () => {
       // @ts-expect-error
       session: { accountId: 'user-id' },
     });
-    const guard = koaAutoConsent({} as Provider, tenant.queries, tenant.libraries);
+    const guard = koaAutoConsent({} as Provider, tenant.envSet, tenant.queries, tenant.libraries);
 
     await expect(guard(ctx, next)).rejects.toBe(error);
     expect(next).not.toHaveBeenCalled();

--- a/packages/core/src/middleware/koa-auto-consent.ts
+++ b/packages/core/src/middleware/koa-auto-consent.ts
@@ -7,7 +7,7 @@ import { type EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { consent, getMissingScopes } from '#src/libraries/session/index.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
-import { isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
+import { isCimdClientId, isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -22,7 +22,7 @@ const shouldAutoConsentApplication = async (clientId: string, query: Queries, en
   } = query;
 
   // DEV: CIMD (client ID metadata document) support
-  if (isCimdEffectivelyEnabled(envSet) && clientId.startsWith('https://')) {
+  if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)) {
     /**
      * Registered application ids never take the URL shape, and authorization has already
      * resolved this client — a URL here is a CIMD client, which is never first-party.

--- a/packages/core/src/middleware/koa-auto-consent.ts
+++ b/packages/core/src/middleware/koa-auto-consent.ts
@@ -3,9 +3,11 @@ import { type MiddlewareType } from 'koa';
 import type { Provider } from 'oidc-provider';
 import { errors } from 'oidc-provider';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { consent, getMissingScopes } from '#src/libraries/session/index.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -14,10 +16,21 @@ import assertThat from '#src/utils/assert-that.js';
  * Automatically consent for the first party apps.
  */
 
-const shouldAutoConsentApplication = async (clientId: string, query: Queries) => {
+const shouldAutoConsentApplication = async (clientId: string, query: Queries, envSet: EnvSet) => {
   const {
     applications: { findApplicationById },
   } = query;
+
+  // DEV: CIMD (client ID metadata document) support
+  if (isCimdEffectivelyEnabled(envSet) && clientId.startsWith('https://')) {
+    /**
+     * Registered application ids never take the URL shape, and authorization has already
+     * resolved this client — a URL here is a CIMD client, which is never first-party.
+     * TODO: @xiaoyijun support CIMD clients on the rest of the experience consent flow
+     * (consent info and guards).
+     */
+    return false;
+  }
 
   const application = isBuiltInApplicationId(clientId)
     ? buildBuiltInApplicationDataForTenant('', clientId)
@@ -35,6 +48,7 @@ export default function koaAutoConsent<
   ResponseBodyT,
 >(
   provider: Provider,
+  envSet: EnvSet,
   query: Queries,
   libraries: Libraries
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> {
@@ -52,7 +66,7 @@ export default function koaAutoConsent<
       new errors.InvalidClient('client must be available')
     );
 
-    const shouldAutoConsent = await shouldAutoConsentApplication(clientId, query);
+    const shouldAutoConsent = await shouldAutoConsentApplication(clientId, query, envSet);
 
     if (shouldAutoConsent) {
       try {
@@ -74,6 +88,7 @@ export default function koaAutoConsent<
       const redirectTo = await consent({
         ctx,
         provider,
+        envSet,
         queries: query,
         interactionDetails,
         missingOIDCScopes,

--- a/packages/core/src/oidc/cimd.test.ts
+++ b/packages/core/src/oidc/cimd.test.ts
@@ -91,6 +91,16 @@ describe('buildClientIdMetadataDocumentFeature', () => {
   });
 });
 
+describe('isCimdClientId', () => {
+  it('matches the fork scheme test case-insensitively and never matches registered ids', async () => {
+    const { isCimdClientId } = await loadCimdModule();
+
+    expect(isCimdClientId('https://client.example.com/metadata.json')).toBe(true);
+    expect(isCimdClientId('HTTPS://client.example.com/metadata.json')).toBe(true);
+    expect(isCimdClientId('registered_client_id')).toBe(false);
+  });
+});
+
 describe('client identifier length bound', () => {
   it('allowFetch accepts an identifier at the bound and rejects one past it', async () => {
     const { allowFetch } = await loadEnabledFeature();

--- a/packages/core/src/oidc/cimd.ts
+++ b/packages/core/src/oidc/cimd.ts
@@ -41,6 +41,13 @@ export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
   EnvSet.values.isOidcProviderSsrfProtectionEnabled;
 
 /**
+ * Whether the identifier is in the CIMD namespace. Mirrors the scheme test of the fork's
+ * `isValidClientIdUrl` (case-insensitive); registered application ids never take the URL shape,
+ * so the shape safely routes — the resolved client stays the authority on what a client is.
+ */
+export const isCimdClientId = (clientId: string): boolean => /^https:\/\//iu.test(clientId);
+
+/**
  * Build the `features.clientIdMetadataDocument` entry for the provider configuration, or
  * `undefined` when CIMD is not effectively enabled — with the entry absent the fork keeps the
  * feature disabled, so the provider skips CIMD client resolution and discovery only publishes

--- a/packages/core/src/queries/oidc-session-extensions.ts
+++ b/packages/core/src/queries/oidc-session-extensions.ts
@@ -22,7 +22,7 @@ type NullablePick<T, K extends keyof T> = {
   [P in K]: Nullable<T[P]>;
 };
 export type SessionInstanceWithExtension = SessionInstance &
-  NullablePick<OidcSessionExtension, 'lastSubmission' | 'clientId' | 'accountId'>;
+  NullablePick<OidcSessionExtension, 'lastSubmission' | 'clientId' | 'cimdClientId' | 'accountId'>;
 
 export class OidcSessionExtensionsQueries {
   public readonly insert = buildInsertIntoWithPool(this.pool)(OidcSessionExtensions, {
@@ -33,6 +33,7 @@ export class OidcSessionExtensionsQueries {
         fields.updatedAt,
         fields.accountId,
         fields.clientId,
+        fields.cimdClientId,
       ],
     },
     returning: true,
@@ -74,6 +75,7 @@ export class OidcSessionExtensionsQueries {
           ...Object.values(modelInstanceFieldsWithoutTenantId),
           fields.lastSubmission,
           fields.clientId,
+          fields.cimdClientId,
           fields.accountId,
         ],
         sql`, `
@@ -100,6 +102,7 @@ export class OidcSessionExtensionsQueries {
           ...Object.values(modelInstanceFieldsWithoutTenantId),
           fields.lastSubmission,
           fields.clientId,
+          fields.cimdClientId,
           fields.accountId,
         ],
         sql`, `

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -31,7 +31,7 @@ const { InvalidClient, InvalidRedirectUri } = errors;
 
 export default function consentRoutes<T extends IRouterParamContext>(
   router: Router<unknown, WithInteractionDetailsContext<T>>,
-  { provider, queries, libraries }: TenantContext
+  { provider, envSet, queries, libraries }: TenantContext
 ) {
   const {
     applications: { validateUserConsentOrganizationMembership },
@@ -182,6 +182,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       const redirectTo = await consent({
         ctx,
         provider,
+        envSet,
         queries,
         interactionDetails,
         missingOIDCScopes: missingOIDCScope,

--- a/packages/core/src/tenants/Tenant.ts
+++ b/packages/core/src/tenants/Tenant.ts
@@ -265,7 +265,7 @@ export default class Tenant implements TenantContext {
           compose([
             koaInteractionDetails(provider),
             koaConsentGuard(libraries, queries),
-            koaAutoConsent(provider, queries, libraries),
+            koaAutoConsent(provider, envSet, queries, libraries),
           ])
         ),
         koaSpaProxy({ mountedApps, queries }),


### PR DESCRIPTION
## Summary

Write the client identifier of a CIMD client to the dedicated `oidc_session_extensions.cimd_client_id` column instead of the varchar(21) `client_id` column.

- `consent()` identifies the consenting client once (`identifyClient`) and hands the result to both persists: registered applications keep writing `client_id`, CIMD clients write `cimd_client_id` — exactly one column carries the identifier, and the explicit `null` on the other column lets the upsert overwrite a stale value from a previous submission of the other client type.
- The client kind is classified by the identifier shape via the shared `isCimdClientId` (mirroring the fork's case-insensitive scheme test): registered ids never take the URL shape, and authorization has already resolved the client, so no lookup or outbound fetch is needed on the consent submission path.
- While CIMD is not effectively enabled, the identifier is registered by definition and the pre-CIMD path stays as is.
- The first-consented-app attribution becomes registered-only: a CIMD URL never reaches `users.application_id` (varchar(21)); persisting the CIMD attribution to `users.cimd_client_id` is left as a TODO for the consent milestone.
- `koaAutoConsent` routes a URL-shaped `client_id` straight to the explicit consent path while CIMD is effectively enabled — no lookup is needed, and a registered application deleted mid-interaction keeps failing with not-found instead of being mistaken for a CIMD client.
- The session extension queries gain `cimd_client_id` in the upsert column list, the join select lists, and the row type.
- `consent()` and `koaAutoConsent()` take the tenant `envSet` to evaluate the enablement gate.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)