### PR TITLE
refactor(core): use a valid script in JWT customizer mock configs

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -231,7 +231,7 @@ export const mockJwtCustomizerConfigForAccessToken = {
   tenantId: 'fake_tenant',
   key: LogtoJwtTokenKey.AccessToken,
   value: {
-    script: 'console.log("hello world");',
+    script: 'const getCustomJwtClaims = () => ({});',
     environmentVariables: {
       API_KEY: '<api-key>',
     },
@@ -247,7 +247,7 @@ export const mockJwtCustomizerConfigForClientCredentials = {
   tenantId: 'fake_tenant',
   key: LogtoJwtTokenKey.ClientCredentials,
   value: {
-    script: 'console.log("hello world");',
+    script: 'const getCustomJwtClaims = () => ({});',
     environmentVariables: {
       API_KEY: '<api-key>',
     },


### PR DESCRIPTION
## Summary

The two JWT customizer mock configs use `console.log("hello world");` as their `script` fixture. That is not a valid customizer script — it has no `getCustomJwtClaims` — and its top-level code is a side effect waiting to happen:

- Today, `routes/logto-config/jwt-customizer.test.ts` pushes this script through the real non-cloud dry-run path, where the frozen `node:vm` context has no `console`, so it throws a silent `ReferenceError` and the test only passes because it never asserts the response.
- On the worker-thread runner (the LOG-13950 stack), a script's top-level code actually executes at worker startup with real Node globals, and worker stdout is deliberately passed through to the host process for dry-run visibility. The fixture then prints a raw `hello world` into jest/CI output, bypassing jest's console capture and `--silent`.

Replace the fixture with an inert, valid customizer script (`const getCustomJwtClaims = () => ({});`). All existing assertions compare the fixture to itself, so nothing else changes; the non-cloud dry-run route test now exercises a genuine success path instead of relying on a swallowed error.

Test-fixture-only change; no changeset.

## Testing

`routes/logto-config/*` and `libraries/logto-config` suites pass, with no stray output.
