### PR TITLE
test(core): add unit tests for the OSS script runner

### DIFF
--- a/packages/core/src/libraries/action.worker-pool.test.ts
+++ b/packages/core/src/libraries/action.worker-pool.test.ts
@@ -22,8 +22,10 @@ const script = 'const runAction = () => ({});';
 const event = Object.freeze({ user: { name: 'Foo' } });
 const environmentVariables = Object.freeze({ API_KEY: 'api-key' });
 
+const tenantId = 'test-tenant';
+
 const runAdapter = async () =>
-  ActionLibrary.runScriptInLocalVm({ script, event, environmentVariables });
+  ActionLibrary.runScriptInLocalVm({ script, event, environmentVariables }, tenantId);
 
 const catchScriptExecutionError = async (promise: Promise<unknown>) => {
   try {
@@ -63,6 +65,7 @@ describe('ActionLibrary worker-pool adapter', () => {
       script,
       entry: 'runAction',
       payload: { event, environmentVariables },
+      keyPrefix: tenantId,
       limits: ossScriptLimits,
       egress: { mode: 'allowAll' },
     });
@@ -130,22 +133,28 @@ describe('ActionLibrary worker-pool adapter', () => {
 
     it('runs the script without touching the worker pool', async () => {
       await expect(
-        ActionLibrary.runScriptInLocalVm({
-          script: 'const runAction = ({ event }) => ({ echoed: event.user.name });',
-          event,
-          environmentVariables,
-        })
+        ActionLibrary.runScriptInLocalVm(
+          {
+            script: 'const runAction = ({ event }) => ({ echoed: event.user.name });',
+            event,
+            environmentVariables,
+          },
+          tenantId
+        )
       ).resolves.toEqual({ echoed: 'Foo' });
       expect(runScript).not.toHaveBeenCalled();
     });
 
     it('maps a thrown script error to the runtime status', async () => {
       const { status, body } = await catchScriptExecutionError(
-        ActionLibrary.runScriptInLocalVm({
-          script: "const runAction = () => { throw new Error('legacy boom'); };",
-          event,
-          environmentVariables,
-        })
+        ActionLibrary.runScriptInLocalVm(
+          {
+            script: "const runAction = () => { throw new Error('legacy boom'); };",
+            event,
+            environmentVariables,
+          },
+          tenantId
+        )
       );
 
       expect(status).toBe(500);
@@ -157,11 +166,14 @@ describe('ActionLibrary worker-pool adapter', () => {
     // worker runner evaluates in its own realm and is what makes syntax failures report 422.
     it('maps a script that cannot be compiled to the runtime status', async () => {
       const { status, body } = await catchScriptExecutionError(
-        ActionLibrary.runScriptInLocalVm({
-          script: 'const runAction = () => {',
-          event,
-          environmentVariables,
-        })
+        ActionLibrary.runScriptInLocalVm(
+          {
+            script: 'const runAction = () => {',
+            event,
+            environmentVariables,
+          },
+          tenantId
+        )
       );
 
       expect(status).toBe(500);
@@ -175,11 +187,14 @@ describe('ActionLibrary worker-pool adapter', () => {
     // host-thrown TypeError and its 422.
     it('maps a non-function entry to the type status', async () => {
       const { status, body } = await catchScriptExecutionError(
-        ActionLibrary.runScriptInLocalVm({
-          script: 'const runAction = 1;',
-          event,
-          environmentVariables,
-        })
+        ActionLibrary.runScriptInLocalVm(
+          {
+            script: 'const runAction = 1;',
+            event,
+            environmentVariables,
+          },
+          tenantId
+        )
       );
 
       expect(status).toBe(422);

--- a/packages/core/src/libraries/action.worker-pool.test.ts
+++ b/packages/core/src/libraries/action.worker-pool.test.ts
@@ -1,0 +1,191 @@
+import { type ScriptRunner } from './script-runner/types.js';
+import { type ScriptFailure } from './script-runner/worker-protocol.js';
+
+const { jest } = import.meta;
+
+const runScript = jest.fn() as jest.MockedFunction<ScriptRunner['run']>;
+
+// The shared runner in `run.js` instantiates this class at module load, so mocking it here routes
+// every `runScriptOnWorkerPool` call through `runScript` while the rest of the adapter — limits,
+// egress, `buildScriptFailureError` — stays real.
+jest.unstable_mockModule('#src/libraries/script-runner/worker-thread-script-runner.js', () => ({
+  WorkerThreadScriptRunner: class {
+    run = runScript;
+  },
+}));
+
+const { EnvSet } = await import('#src/env-set/index.js');
+const { ActionLibrary } = await import('./action.js');
+const { ossScriptLimits, ScriptExecutionError } = await import('./script-runner/index.js');
+
+const script = 'const runAction = () => ({});';
+const event = Object.freeze({ user: { name: 'Foo' } });
+const environmentVariables = Object.freeze({ API_KEY: 'api-key' });
+
+const runAdapter = async () =>
+  ActionLibrary.runScriptInLocalVm({ script, event, environmentVariables });
+
+const catchScriptExecutionError = async (promise: Promise<unknown>) => {
+  try {
+    await promise;
+  } catch (error: unknown) {
+    if (error instanceof ScriptExecutionError) {
+      const body: unknown = await error.response.json();
+
+      return { status: error.status, body };
+    }
+
+    throw error;
+  }
+
+  throw new Error('Expected the adapter to throw a ScriptExecutionError.');
+};
+
+describe('ActionLibrary worker-pool adapter', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  beforeEach(() => {
+    runScript.mockReset();
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+  });
+
+  afterAll(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  it('hands the runner the standard OSS limits and the allow-all egress policy', async () => {
+    runScript.mockResolvedValueOnce({ ok: true, value: {} });
+
+    await runAdapter();
+
+    expect(runScript).toHaveBeenCalledTimes(1);
+    expect(runScript).toHaveBeenCalledWith({
+      script,
+      entry: 'runAction',
+      payload: { event, environmentVariables },
+      limits: ossScriptLimits,
+      egress: { mode: 'allowAll' },
+    });
+  });
+
+  // `toHaveBeenCalledWith` ignores keys whose value is `undefined`, so the exact key list is
+  // asserted separately: leaking `script` (or an `api`) into the payload would cross the thread
+  // boundary unnoticed otherwise.
+  it('builds a payload of exactly the event and the environment variables', async () => {
+    runScript.mockResolvedValueOnce({ ok: true, value: {} });
+
+    await runAdapter();
+
+    const input = runScript.mock.calls[0]?.[0];
+    expect(Object.keys(input?.payload ?? {})).toEqual(['event', 'environmentVariables']);
+  });
+
+  it('returns the successful value verbatim without record validation', async () => {
+    // Actions leave result validation to their call sites, so even a non-record value must come
+    // back untouched — unlike the Custom JWT adapter.
+    runScript.mockResolvedValueOnce({ ok: true, value: 42 });
+
+    await expect(runAdapter()).resolves.toBe(42);
+  });
+
+  describe('failure mapping keeps the pinned status codes', () => {
+    it.each<[ScriptFailure, number, Record<string, unknown>]>([
+      [{ ok: false, kind: 'denied', message: 'nope' }, 403, { message: 'nope' }],
+      [
+        { ok: false, kind: 'syntax', message: 'Unexpected token', stack: 'syntax-stack' },
+        422,
+        { message: 'Unexpected token', stack: 'syntax-stack' },
+      ],
+      [
+        { ok: false, kind: 'type', message: 'The script payload cannot be transferred' },
+        422,
+        { message: 'The script payload cannot be transferred' },
+      ],
+      [
+        { ok: false, kind: 'runtime', name: 'ScriptError', message: 'boom', stack: 'run-stack' },
+        500,
+        { message: 'boom', stack: 'run-stack' },
+      ],
+      [
+        { ok: false, kind: 'timeout' },
+        500,
+        { message: `Script execution timed out after ${ossScriptLimits.wallClockMs}ms.` },
+      ],
+      [{ ok: false, kind: 'oom' }, 500, { message: 'Script execution exceeded the memory limit.' }],
+    ])('maps a %o failure', async (failure, expectedStatus, expectedBody) => {
+      runScript.mockResolvedValueOnce(failure);
+
+      const { status, body } = await catchScriptExecutionError(runAdapter());
+
+      expect(status).toBe(expectedStatus);
+      expect(body).toEqual(expectedBody);
+    });
+  });
+
+  // TODO (LOG-13956): drop these together with the legacy `node:vm` execution path.
+  describe('the legacy `node:vm` path while dev features are disabled', () => {
+    beforeEach(() => {
+      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    });
+
+    it('runs the script without touching the worker pool', async () => {
+      await expect(
+        ActionLibrary.runScriptInLocalVm({
+          script: 'const runAction = ({ event }) => ({ echoed: event.user.name });',
+          event,
+          environmentVariables,
+        })
+      ).resolves.toEqual({ echoed: 'Foo' });
+      expect(runScript).not.toHaveBeenCalled();
+    });
+
+    it('maps a thrown script error to the runtime status', async () => {
+      const { status, body } = await catchScriptExecutionError(
+        ActionLibrary.runScriptInLocalVm({
+          script: "const runAction = () => { throw new Error('legacy boom'); };",
+          event,
+          environmentVariables,
+        })
+      );
+
+      expect(status).toBe(500);
+      expect(body).toMatchObject({ message: 'legacy boom' });
+    });
+
+    // The vm constructs the SyntaxError in the script's realm, so the host-side `instanceof`
+    // classification never fires and a compile error falls through to the runtime status. The
+    // worker runner evaluates in its own realm and is what makes syntax failures report 422.
+    it('maps a script that cannot be compiled to the runtime status', async () => {
+      const { status, body } = await catchScriptExecutionError(
+        ActionLibrary.runScriptInLocalVm({
+          script: 'const runAction = () => {',
+          event,
+          environmentVariables,
+        })
+      );
+
+      expect(status).toBe(500);
+      expect(body).toMatchObject({
+        message: expect.stringContaining('Unexpected end of input') as string,
+      });
+    });
+
+    // An undeclared entry throws a ReferenceError inside the vm realm (also invisible to the
+    // host-side `instanceof`) — only an entry that exists but is not a function reaches the
+    // host-thrown TypeError and its 422.
+    it('maps a non-function entry to the type status', async () => {
+      const { status, body } = await catchScriptExecutionError(
+        ActionLibrary.runScriptInLocalVm({
+          script: 'const runAction = 1;',
+          event,
+          environmentVariables,
+        })
+      );
+
+      expect(status).toBe(422);
+      expect(body).toMatchObject({
+        message: 'The script does not have a function named `runAction`',
+      });
+    });
+  });
+});

--- a/packages/core/src/libraries/jwt-customizer.worker-pool.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.worker-pool.test.ts
@@ -1,0 +1,210 @@
+import { CustomJwtErrorCode, LogtoJwtTokenKeyType, type CustomJwtFetcher } from '@logto/schemas';
+
+import { type ScriptRunner } from './script-runner/types.js';
+import { type ScriptFailure } from './script-runner/worker-protocol.js';
+
+const { jest } = import.meta;
+
+const runScript = jest.fn() as jest.MockedFunction<ScriptRunner['run']>;
+
+// The shared runner in `run.js` instantiates this class at module load, so mocking it here routes
+// every `runScriptOnWorkerPool` call through `runScript` while the rest of the adapter — limits,
+// egress, `buildScriptFailureError`, the record parse — stays real.
+jest.unstable_mockModule('#src/libraries/script-runner/worker-thread-script-runner.js', () => ({
+  WorkerThreadScriptRunner: class {
+    run = runScript;
+  },
+}));
+
+const { EnvSet } = await import('#src/env-set/index.js');
+const { JwtCustomizerLibrary } = await import('./jwt-customizer.js');
+const { ossScriptLimits, ScriptExecutionError } = await import('./script-runner/index.js');
+
+const script = 'const getCustomJwtClaims = () => ({});';
+const token = Object.freeze({ sub: 'user-id' });
+const context = Object.freeze({ user: { id: 'user-id' } });
+const environmentVariables = Object.freeze({ API_KEY: 'api-key' });
+
+const buildData = (): CustomJwtFetcher => ({
+  script,
+  tokenType: LogtoJwtTokenKeyType.AccessToken,
+  token: { ...token },
+  context: { ...context },
+  environmentVariables: { ...environmentVariables },
+});
+
+const runAdapter = async () => JwtCustomizerLibrary.runScriptInLocalVm(buildData());
+
+const catchScriptExecutionError = async (promise: Promise<unknown>) => {
+  try {
+    await promise;
+  } catch (error: unknown) {
+    if (error instanceof ScriptExecutionError) {
+      const body: unknown = await error.response.json();
+
+      return { status: error.status, body };
+    }
+
+    throw error;
+  }
+
+  throw new Error('Expected the adapter to throw a ScriptExecutionError.');
+};
+
+describe('JwtCustomizerLibrary worker-pool adapter', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  beforeEach(() => {
+    runScript.mockReset();
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+  });
+
+  afterAll(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  it('hands the runner the standard OSS limits and the allow-all egress policy', async () => {
+    runScript.mockResolvedValueOnce({ ok: true, value: {} });
+
+    await runAdapter();
+
+    expect(runScript).toHaveBeenCalledTimes(1);
+    expect(runScript).toHaveBeenCalledWith({
+      script,
+      entry: 'getCustomJwtClaims',
+      payload: { token, context, environmentVariables },
+      limits: ossScriptLimits,
+      egress: { mode: 'allowAll' },
+    });
+  });
+
+  // `toHaveBeenCalledWith` ignores keys whose value is `undefined`, so the exact key list is
+  // asserted separately: the worker injects `api` on its side, and `script` or `tokenType` in the
+  // payload would leak across the thread boundary unnoticed otherwise.
+  it('builds a payload of exactly the token, context and environment variables', async () => {
+    runScript.mockResolvedValueOnce({ ok: true, value: {} });
+
+    await runAdapter();
+
+    const input = runScript.mock.calls[0]?.[0];
+    expect(Object.keys(input?.payload ?? {})).toEqual(['token', 'context', 'environmentVariables']);
+  });
+
+  it('returns the record the script produced', async () => {
+    runScript.mockResolvedValueOnce({ ok: true, value: { role: 'admin' } });
+
+    await expect(runAdapter()).resolves.toEqual({ role: 'admin' });
+  });
+
+  // Call-site validation of a successful run, not a runner failure — it must keep today's 400
+  // rather than joining the `type` → 422 mapping.
+  it('rejects a non-record value with the 400 the local VM used', async () => {
+    runScript.mockResolvedValueOnce({ ok: true, value: 42 });
+
+    const { status, body } = await catchScriptExecutionError(runAdapter());
+
+    expect(status).toBe(400);
+    expect(body).toMatchObject({ message: 'Invalid input' });
+  });
+
+  it('attaches the access-denied error body to a denied failure', async () => {
+    runScript.mockResolvedValueOnce({ ok: false, kind: 'denied', message: 'blocked' });
+
+    const { status, body } = await catchScriptExecutionError(runAdapter());
+
+    expect(status).toBe(403);
+    expect(body).toEqual({
+      message: 'blocked',
+      error: { code: CustomJwtErrorCode.AccessDenied, message: 'blocked' },
+    });
+  });
+
+  describe('failure mapping keeps the pinned status codes', () => {
+    it.each<[ScriptFailure, number, Record<string, unknown>]>([
+      [
+        { ok: false, kind: 'syntax', message: 'Unexpected token', stack: 'syntax-stack' },
+        422,
+        { message: 'Unexpected token', stack: 'syntax-stack' },
+      ],
+      [
+        { ok: false, kind: 'type', message: 'The script return value must be JSON-serializable.' },
+        422,
+        { message: 'The script return value must be JSON-serializable.' },
+      ],
+      [
+        { ok: false, kind: 'runtime', name: 'ScriptError', message: 'boom', stack: 'run-stack' },
+        500,
+        { message: 'boom', stack: 'run-stack' },
+      ],
+      [
+        { ok: false, kind: 'timeout' },
+        500,
+        { message: `Script execution timed out after ${ossScriptLimits.wallClockMs}ms.` },
+      ],
+      [{ ok: false, kind: 'oom' }, 500, { message: 'Script execution exceeded the memory limit.' }],
+    ])('maps a %o failure', async (failure, expectedStatus, expectedBody) => {
+      runScript.mockResolvedValueOnce(failure);
+
+      const { status, body } = await catchScriptExecutionError(runAdapter());
+
+      expect(status).toBe(expectedStatus);
+      expect(body).toEqual(expectedBody);
+    });
+  });
+
+  // TODO (LOG-13956): drop these together with the legacy `node:vm` execution path.
+  describe('the legacy `node:vm` path while dev features are disabled', () => {
+    beforeEach(() => {
+      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    });
+
+    it('runs the script without touching the worker pool', async () => {
+      await expect(
+        JwtCustomizerLibrary.runScriptInLocalVm({
+          ...buildData(),
+          script: 'const getCustomJwtClaims = ({ token }) => ({ echoed: token.sub });',
+        })
+      ).resolves.toEqual({ echoed: 'user-id' });
+      expect(runScript).not.toHaveBeenCalled();
+    });
+
+    it('maps an access denial to the denied status with the error body', async () => {
+      const { status, body } = await catchScriptExecutionError(
+        JwtCustomizerLibrary.runScriptInLocalVm({
+          ...buildData(),
+          script: "const getCustomJwtClaims = ({ api }) => api.denyAccess('legacy blocked');",
+        })
+      );
+
+      expect(status).toBe(403);
+      expect(body).toEqual({
+        message: 'legacy blocked',
+        error: { code: CustomJwtErrorCode.AccessDenied, message: 'legacy blocked' },
+      });
+    });
+
+    it('rejects a non-record value with the 400 invalid-input error', async () => {
+      const { status, body } = await catchScriptExecutionError(
+        JwtCustomizerLibrary.runScriptInLocalVm({
+          ...buildData(),
+          script: 'const getCustomJwtClaims = () => 42;',
+        })
+      );
+
+      expect(status).toBe(400);
+      expect(body).toMatchObject({ message: 'Invalid input' });
+    });
+
+    it('maps a thrown script error to the runtime status', async () => {
+      const { status, body } = await catchScriptExecutionError(
+        JwtCustomizerLibrary.runScriptInLocalVm({
+          ...buildData(),
+          script: "const getCustomJwtClaims = () => { throw new Error('legacy boom'); };",
+        })
+      );
+
+      expect(status).toBe(500);
+      expect(body).toMatchObject({ message: 'legacy boom' });
+    });
+  });
+});

--- a/packages/core/src/libraries/jwt-customizer.worker-pool.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.worker-pool.test.ts
@@ -33,7 +33,9 @@ const buildData = (): CustomJwtFetcher => ({
   environmentVariables: { ...environmentVariables },
 });
 
-const runAdapter = async () => JwtCustomizerLibrary.runScriptInLocalVm(buildData());
+const tenantId = 'test-tenant';
+
+const runAdapter = async () => JwtCustomizerLibrary.runScriptInLocalVm(buildData(), tenantId);
 
 const catchScriptExecutionError = async (promise: Promise<unknown>) => {
   try {
@@ -73,6 +75,7 @@ describe('JwtCustomizerLibrary worker-pool adapter', () => {
       script,
       entry: 'getCustomJwtClaims',
       payload: { token, context, environmentVariables },
+      keyPrefix: tenantId,
       limits: ossScriptLimits,
       egress: { mode: 'allowAll' },
     });
@@ -160,20 +163,26 @@ describe('JwtCustomizerLibrary worker-pool adapter', () => {
 
     it('runs the script without touching the worker pool', async () => {
       await expect(
-        JwtCustomizerLibrary.runScriptInLocalVm({
-          ...buildData(),
-          script: 'const getCustomJwtClaims = ({ token }) => ({ echoed: token.sub });',
-        })
+        JwtCustomizerLibrary.runScriptInLocalVm(
+          {
+            ...buildData(),
+            script: 'const getCustomJwtClaims = ({ token }) => ({ echoed: token.sub });',
+          },
+          tenantId
+        )
       ).resolves.toEqual({ echoed: 'user-id' });
       expect(runScript).not.toHaveBeenCalled();
     });
 
     it('maps an access denial to the denied status with the error body', async () => {
       const { status, body } = await catchScriptExecutionError(
-        JwtCustomizerLibrary.runScriptInLocalVm({
-          ...buildData(),
-          script: "const getCustomJwtClaims = ({ api }) => api.denyAccess('legacy blocked');",
-        })
+        JwtCustomizerLibrary.runScriptInLocalVm(
+          {
+            ...buildData(),
+            script: "const getCustomJwtClaims = ({ api }) => api.denyAccess('legacy blocked');",
+          },
+          tenantId
+        )
       );
 
       expect(status).toBe(403);
@@ -185,10 +194,13 @@ describe('JwtCustomizerLibrary worker-pool adapter', () => {
 
     it('rejects a non-record value with the 400 invalid-input error', async () => {
       const { status, body } = await catchScriptExecutionError(
-        JwtCustomizerLibrary.runScriptInLocalVm({
-          ...buildData(),
-          script: 'const getCustomJwtClaims = () => 42;',
-        })
+        JwtCustomizerLibrary.runScriptInLocalVm(
+          {
+            ...buildData(),
+            script: 'const getCustomJwtClaims = () => 42;',
+          },
+          tenantId
+        )
       );
 
       expect(status).toBe(400);
@@ -197,10 +209,13 @@ describe('JwtCustomizerLibrary worker-pool adapter', () => {
 
     it('maps a thrown script error to the runtime status', async () => {
       const { status, body } = await catchScriptExecutionError(
-        JwtCustomizerLibrary.runScriptInLocalVm({
-          ...buildData(),
-          script: "const getCustomJwtClaims = () => { throw new Error('legacy boom'); };",
-        })
+        JwtCustomizerLibrary.runScriptInLocalVm(
+          {
+            ...buildData(),
+            script: "const getCustomJwtClaims = () => { throw new Error('legacy boom'); };",
+          },
+          tenantId
+        )
       );
 
       expect(status).toBe(500);

--- a/packages/core/src/libraries/script-runner/errors.test.ts
+++ b/packages/core/src/libraries/script-runner/errors.test.ts
@@ -1,0 +1,62 @@
+import {
+  buildScriptExecutionErrorBody,
+  getScriptFailureStatusCode,
+  ScriptExecutionError,
+  scriptFailureStatusCodes,
+} from './errors.js';
+
+describe('scriptFailureStatusCodes', () => {
+  // The status mapping the local VM implementation has always used. Route-level error handling
+  // depends on it, so any change here is a breaking change rather than a refactor.
+  it('pins every failure kind to its historical status code', () => {
+    expect(scriptFailureStatusCodes).toEqual({
+      denied: 403,
+      syntax: 422,
+      type: 422,
+      timeout: 500,
+      oom: 500,
+      runtime: 500,
+    });
+  });
+});
+
+describe('getScriptFailureStatusCode', () => {
+  it('maps a SyntaxError to the syntax status', () => {
+    expect(getScriptFailureStatusCode(new SyntaxError('bad token'))).toBe(422);
+  });
+
+  it('maps a TypeError to the type status', () => {
+    expect(getScriptFailureStatusCode(new TypeError('not a function'))).toBe(422);
+  });
+
+  it('maps every other error to the runtime status', () => {
+    expect(getScriptFailureStatusCode(new RangeError('out of range'))).toBe(500);
+    expect(getScriptFailureStatusCode(new Error('boom'))).toBe(500);
+    expect(getScriptFailureStatusCode('not an error')).toBe(500);
+  });
+});
+
+describe('buildScriptExecutionErrorBody', () => {
+  it('carries the message and stack of a native error', () => {
+    const error = new Error('boom');
+
+    expect(buildScriptExecutionErrorBody(error)).toEqual({
+      message: 'boom',
+      stack: error.stack,
+    });
+  });
+
+  it('stringifies a thrown non-error value', () => {
+    expect(buildScriptExecutionErrorBody('boom')).toEqual({ message: 'boom' });
+    expect(buildScriptExecutionErrorBody(42)).toEqual({ message: '42' });
+  });
+});
+
+describe('ScriptExecutionError', () => {
+  it('exposes the body and status through the response', async () => {
+    const error = new ScriptExecutionError({ message: 'boom', stack: 'stack' }, 422);
+
+    expect(error.status).toBe(422);
+    await expect(error.response.json()).resolves.toEqual({ message: 'boom', stack: 'stack' });
+  });
+});

--- a/packages/core/src/libraries/script-runner/pooled-worker.ts
+++ b/packages/core/src/libraries/script-runner/pooled-worker.ts
@@ -21,8 +21,8 @@ type PooledWorkerOptions = {
   /**
    * V8 old space cap for the thread.
    *
-   * `resourceLimits` are fixed at spawn, so a pooled worker keeps the budget of the run that
-   * created it.
+   * `resourceLimits` are fixed at spawn; the pool keys workers on this value, so every run this
+   * worker serves asked for exactly this budget.
    *
    * It is a per-isolate constraint, and V8 lets the process-global `--max-old-space-size` override
    * it: a host started with that flag (directly or through `NODE_OPTIONS`) lets a script grow to

--- a/packages/core/src/libraries/script-runner/pooled-worker.ts
+++ b/packages/core/src/libraries/script-runner/pooled-worker.ts
@@ -86,16 +86,6 @@ export class PooledWorker {
       // worker's output through to the host process — the passthrough dry runs rely on.
     });
 
-    /**
-     * The per-run deadline is the only handle this class refs. The event loop therefore stays alive
-     * exactly as long as a run is outstanding, and an idle or leaked worker can never hold the
-     * process — or a test runner — open.
-     *
-     * Startup has no separate timer: `reserve(wallClockMs)` arms before the caller awaits ready, so
-     * a worker that never signals still settles through the run deadline.
-     */
-    this.worker.unref();
-
     // All three are attached synchronously and for the worker's whole life. An unhandled `error`
     // event on a worker crashes the host process.
     this.worker.on('message', (response: ScriptWorkerResponse) => {
@@ -124,6 +114,19 @@ export class PooledWorker {
         message: `The script worker exited unexpectedly with code ${code}.`,
       });
     });
+
+    /**
+     * The per-run deadline is the only handle this class refs. The event loop therefore stays alive
+     * exactly as long as a run is outstanding, and an idle or leaked worker can never hold the
+     * process — or a test runner — open.
+     *
+     * Must come after the listeners: attaching a `message` listener refs the worker's message port
+     * again, so unref-then-listen leaves the worker holding the event loop for its whole idle TTL.
+     *
+     * Startup has no separate timer: `reserve(wallClockMs)` arms before the caller awaits ready, so
+     * a worker that never signals still settles through the run deadline.
+     */
+    this.worker.unref();
   }
 
   /** Whether the pool may hand this worker a new run. */

--- a/packages/core/src/libraries/script-runner/run.test.ts
+++ b/packages/core/src/libraries/script-runner/run.test.ts
@@ -1,0 +1,65 @@
+import { buildScriptFailureError, ossScriptLimits } from './run.js';
+import { type ScriptFailure } from './worker-protocol.js';
+
+const readError = async (failure: ScriptFailure) => {
+  const error = buildScriptFailureError(failure);
+  const body: unknown = await error.response.json();
+
+  return { status: error.status, body };
+};
+
+describe('ossScriptLimits', () => {
+  it('bounds every run by wall clock and memory', () => {
+    expect(ossScriptLimits).toEqual({ wallClockMs: 5000, memoryMb: 128 });
+  });
+});
+
+describe('buildScriptFailureError', () => {
+  it('synthesizes a message for a timeout, which carries none of its own', async () => {
+    await expect(readError({ ok: false, kind: 'timeout' })).resolves.toEqual({
+      status: 500,
+      body: { message: 'Script execution timed out after 5000ms.' },
+    });
+  });
+
+  it('synthesizes a message for an out-of-memory failure', async () => {
+    await expect(readError({ ok: false, kind: 'oom' })).resolves.toEqual({
+      status: 500,
+      body: { message: 'Script execution exceeded the memory limit.' },
+    });
+  });
+
+  it('carries the denial message at the denied status', async () => {
+    await expect(readError({ ok: false, kind: 'denied', message: 'nope' })).resolves.toEqual({
+      status: 403,
+      body: { message: 'nope' },
+    });
+  });
+
+  it('carries the message and stack of a syntax failure', async () => {
+    await expect(
+      readError({ ok: false, kind: 'syntax', message: 'Unexpected token', stack: 'stack' })
+    ).resolves.toEqual({
+      status: 422,
+      body: { message: 'Unexpected token', stack: 'stack' },
+    });
+  });
+
+  it('carries the message of a type failure', async () => {
+    await expect(
+      readError({ ok: false, kind: 'type', message: 'Not transferable' })
+    ).resolves.toEqual({
+      status: 422,
+      body: { message: 'Not transferable' },
+    });
+  });
+
+  it('carries the message and stack of a runtime failure without its name', async () => {
+    await expect(
+      readError({ ok: false, kind: 'runtime', name: 'CustomError', message: 'boom', stack: 's' })
+    ).resolves.toEqual({
+      status: 500,
+      body: { message: 'boom', stack: 's' },
+    });
+  });
+});

--- a/packages/core/src/libraries/script-runner/run.ts
+++ b/packages/core/src/libraries/script-runner/run.ts
@@ -24,9 +24,9 @@ export const ossScriptLimits: ScriptLimits = Object.freeze({
 /**
  * The process-wide runner shared by Custom JWT and Actions.
  *
- * A single pool is deliberate: workers are keyed by `{tenantId}:{entry}:{sha256(script)}`, so
- * neither the two libraries nor two tenants can ever collide on a worker, and one pool keeps the
- * worker cap a process-level bound. Never dispose it from a call site — it outlives every tenant.
+ * A single pool is deliberate: workers are keyed by
+ * `{tenantId}:{entry}:{memoryMb}:{sha256(script)}`, so neither the two libraries nor two tenants
+ * can ever collide on a worker, and one pool keeps the worker cap a process-level bound. Never dispose it from a call site — it outlives every tenant.
  */
 const sharedRunner = new WorkerThreadScriptRunner();
 

--- a/packages/core/src/libraries/script-runner/worker-thread-script-runner.pool.test.ts
+++ b/packages/core/src/libraries/script-runner/worker-thread-script-runner.pool.test.ts
@@ -24,6 +24,8 @@ const buildInput = (
 
 /** Keep in sync with `maxWorkers` in `worker-thread-script-runner.ts`. */
 const maxWorkers = 4;
+/** Keep in sync with `maxInvocationsPerWorker` in `pooled-worker.ts`. */
+const maxInvocationsPerWorker = 1000;
 
 describe('WorkerThreadScriptRunner pooling', () => {
   const runners: WorkerThreadScriptRunner[] = [];
@@ -110,6 +112,37 @@ describe('WorkerThreadScriptRunner pooling', () => {
     expect(new Set(counts).size).toBe(30);
     expect(runner.size).toBe(1);
   }, 15_000);
+
+  // Recycling after a fixed number of runs bounds how much state — and how much leaked memory — a
+  // long-lived script can accumulate on one thread.
+  it('retires a worker after its invocation budget and starts the next run fresh', async () => {
+    const runner = createRunner();
+    const input = {
+      ...buildInput(counterScript()),
+      // One worker serves every run sequentially, so the deadline must cover the whole queue.
+      limits: { wallClockMs: 30_000, memoryMb: 64 },
+    };
+    const results = await Promise.all(
+      Array.from({ length: maxInvocationsPerWorker }, async () => runner.run(input))
+    );
+    const counts = results.map((result) =>
+      result.ok &&
+      typeof result.value === 'object' &&
+      result.value !== null &&
+      'count' in result.value
+        ? result.value.count
+        : undefined
+    );
+
+    // Every admission was served by the same worker: one counter, no duplicates.
+    expect(new Set(counts).size).toBe(maxInvocationsPerWorker);
+    // The budget was exhausted, so the worker retired and left the pool once it drained.
+    expect(runner.size).toBe(0);
+    // The next run starts a fresh counter on a fresh worker.
+    await expect(runner.run(buildInput(counterScript()))).resolves.toMatchObject({
+      value: { count: 1 },
+    });
+  }, 60_000);
 
   it('evicts the least recently used worker at the cap', async () => {
     const runner = createRunner();

--- a/packages/core/src/libraries/script-runner/worker-thread-script-runner.runaway.test.ts
+++ b/packages/core/src/libraries/script-runner/worker-thread-script-runner.runaway.test.ts
@@ -85,6 +85,51 @@ describe('WorkerThreadScriptRunner runaway containment', () => {
     expect(result).toMatchObject({ ok: false, kind: 'runtime' });
   }, 10_000);
 
+  // Recycling after an out-of-memory kill lives in `worker-thread-script-runner.spawn.test.ts`:
+  // reproducing a real OOM here would race a multi-gigabyte allocation against the wall clock,
+  // because the jest process's `--max_old_space_size` overrides the per-worker limit.
+
+  it('serves the next run on a fresh worker after the script exits the thread', async () => {
+    const runner = createRunner();
+    const script = `var runs = 0;
+       const runAction = ({ die }) => {
+         runs += 1;
+         if (die) { process.exit(0); }
+         return { runs };
+       };`;
+
+    await expect(
+      runner.run({ ...buildInput(script, { wallClockMs: 5000 }), payload: { die: true } })
+    ).resolves.toMatchObject({ ok: false, kind: 'runtime' });
+    expect(runner.size).toBe(0);
+
+    await expect(
+      runner.run({ ...buildInput(script, { wallClockMs: 5000 }), payload: { die: false } })
+    ).resolves.toEqual({ ok: true, value: { runs: 1 } });
+  }, 10_000);
+
+  it('recycles the worker when the script crashes it outside a run', async () => {
+    // A throw from a timer escapes the worker's request handling entirely, so it surfaces as the
+    // worker `error` event rather than a settled result — the third recycling trigger next to
+    // timeout and out-of-memory.
+    const runner = createRunner();
+    const script = `const runAction = () => {
+         setTimeout(() => { throw new Error('crash'); }, 0);
+         return new Promise((resolve) => setTimeout(() => resolve({ survived: true }), 5000));
+       };`;
+
+    await expect(runner.run(buildInput(script, { wallClockMs: 8000 }))).resolves.toMatchObject({
+      ok: false,
+      kind: 'runtime',
+      message: 'crash',
+    });
+    expect(runner.size).toBe(0);
+
+    await expect(
+      runner.run(buildInput('const runAction = () => ({ healthy: true });'))
+    ).resolves.toEqual({ ok: true, value: { healthy: true } });
+  }, 15_000);
+
   it('serves the next run after a timeout on a fresh worker', async () => {
     const runner = createRunner();
     const script = 'const runAction = () => { while (true) {} };';

--- a/packages/core/src/libraries/script-runner/worker-thread-script-runner.spawn.test.ts
+++ b/packages/core/src/libraries/script-runner/worker-thread-script-runner.spawn.test.ts
@@ -1,0 +1,177 @@
+import EventEmitter from 'node:events';
+
+import { type ScriptRunInput } from './types.js';
+import {
+  type ScriptWorkerData,
+  type ScriptWorkerRequest,
+  type ScriptWorkerResponse,
+} from './worker-protocol.js';
+
+const { jest } = import.meta;
+
+/**
+ * A stand-in worker thread that records how it was spawned and lets each test script its fate.
+ *
+ * The real thing cannot pin two contracts: `resourceLimits` is invisible from inside a worker once
+ * the jest process's `--max_old_space_size` overrides it, and a real out-of-memory kill would race
+ * a multi-gigabyte allocation against the wall clock for the same reason. Faking the thread makes
+ * both deterministic — at the cost of not exercising the worker entry, which every sibling suite
+ * does with real threads.
+ */
+// eslint-disable-next-line unicorn/prefer-event-target -- the real `Worker` is an EventEmitter, and the code under test uses its `on` API
+class FakeWorker extends EventEmitter {
+  readonly requests: ScriptWorkerRequest[] = [];
+
+  constructor(
+    readonly workerPath: string,
+    readonly options: { workerData: ScriptWorkerData; resourceLimits: Record<string, number> }
+  ) {
+    super();
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- test bookkeeping
+    spawnedWorkers.push(this);
+    queueMicrotask(() => {
+      this.emit('message', { type: 'ready' } satisfies ScriptWorkerResponse);
+    });
+  }
+
+  postMessage(request: ScriptWorkerRequest): void {
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- test bookkeeping
+    this.requests.push(request);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function -- only the real worker holds the event loop
+  unref(): void {}
+
+  async terminate(): Promise<number> {
+    return 0;
+  }
+
+  /** Settle the most recent run this worker was handed. */
+  succeedLast(value: unknown): void {
+    const request = this.requests.at(-1);
+
+    if (!request) {
+      throw new Error('No request has reached this worker yet.');
+    }
+
+    this.emit('message', {
+      type: 'result',
+      runId: request.runId,
+      result: { ok: true, value },
+    } satisfies ScriptWorkerResponse);
+  }
+}
+
+const spawnedWorkers: FakeWorker[] = [];
+
+jest.unstable_mockModule('node:worker_threads', () => ({
+  Worker: FakeWorker,
+}));
+
+const { WorkerThreadScriptRunner } = await import('./worker-thread-script-runner.js');
+
+const buildInput = (script: string, memoryMb: number): ScriptRunInput => ({
+  script,
+  entry: 'runAction',
+  payload: {},
+  limits: { wallClockMs: 2000, memoryMb },
+  egress: { mode: 'allowAll' },
+});
+
+/** Poll until the runner's asynchronous spawn work has produced the expected state. */
+const waitFor = async (predicate: () => boolean, remainingMs = 1000): Promise<void> => {
+  if (predicate()) {
+    return;
+  }
+
+  if (remainingMs <= 0) {
+    throw new Error('Timed out waiting for the runner to reach the expected state.');
+  }
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 5);
+  });
+
+  return waitFor(predicate, remainingMs - 5);
+};
+
+describe('WorkerThreadScriptRunner spawn contract', () => {
+  const runners: Array<InstanceType<typeof WorkerThreadScriptRunner>> = [];
+
+  const createRunner = () => {
+    const runner = new WorkerThreadScriptRunner();
+
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- test bookkeeping for teardown
+    runners.push(runner);
+
+    return runner;
+  };
+
+  afterEach(async () => {
+    await Promise.all(runners.map(async (runner) => runner.dispose()));
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- test bookkeeping for teardown
+    runners.splice(0, runners.length);
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- test bookkeeping for teardown
+    spawnedWorkers.splice(0, spawnedWorkers.length);
+  });
+
+  // The jest process's own `--max_old_space_size` makes the limit unobservable from inside a real
+  // worker, so this is the assertion that keeps `limits.memoryMb` plumbed into the spawn at all.
+  it('spawns the worker with the script, entry and memory budget of the run', async () => {
+    const runner = createRunner();
+    const promise = runner.run(buildInput('worker-source', 64));
+
+    await waitFor(() => spawnedWorkers[0]?.requests.length === 1);
+    spawnedWorkers[0]?.succeedLast({ done: true });
+
+    await expect(promise).resolves.toEqual({ ok: true, value: { done: true } });
+    expect(spawnedWorkers).toHaveLength(1);
+    expect(spawnedWorkers[0]?.options).toEqual({
+      workerData: { script: 'worker-source', entry: 'runAction' },
+      resourceLimits: { maxOldGenerationSizeMb: 64 },
+    });
+  });
+
+  it('maps an out-of-memory kill to oom and serves the next run on a fresh worker', async () => {
+    const runner = createRunner();
+    const first = runner.run(buildInput('worker-source', 64));
+
+    await waitFor(() => spawnedWorkers[0]?.requests.length === 1);
+    // What Node emits when the worker breaches `maxOldGenerationSizeMb`.
+    const oomError = new Error('Worker terminated due to reaching memory limit');
+    Reflect.set(oomError, 'code', 'ERR_WORKER_OUT_OF_MEMORY');
+    spawnedWorkers[0]?.emit('error', oomError);
+
+    await expect(first).resolves.toEqual({ ok: false, kind: 'oom' });
+    // The faulted worker left the pool rather than lingering as a corpse the next run would await.
+    expect(runner.size).toBe(0);
+
+    const second = runner.run(buildInput('worker-source', 64));
+
+    await waitFor(() => spawnedWorkers[1]?.requests.length === 1);
+    spawnedWorkers[1]?.succeedLast({ fresh: true });
+
+    await expect(second).resolves.toEqual({ ok: true, value: { fresh: true } });
+    expect(spawnedWorkers).toHaveLength(2);
+  });
+
+  // `resourceLimits` are fixed at spawn, so a pooled worker keeps the budget of the run that
+  // created it — documented on `PooledWorkerOptions.memoryMb`.
+  it('keeps the memory budget of the run that spawned the worker', async () => {
+    const runner = createRunner();
+    const first = runner.run(buildInput('worker-source', 64));
+
+    await waitFor(() => spawnedWorkers[0]?.requests.length === 1);
+    spawnedWorkers[0]?.succeedLast({});
+    await first;
+
+    const second = runner.run(buildInput('worker-source', 256));
+
+    await waitFor(() => spawnedWorkers[0]?.requests.length === 2);
+    spawnedWorkers[0]?.succeedLast({});
+    await second;
+
+    expect(spawnedWorkers).toHaveLength(1);
+    expect(spawnedWorkers[0]?.options.resourceLimits).toEqual({ maxOldGenerationSizeMb: 64 });
+  });
+});

--- a/packages/core/src/libraries/script-runner/worker-thread-script-runner.spawn.test.ts
+++ b/packages/core/src/libraries/script-runner/worker-thread-script-runner.spawn.test.ts
@@ -155,9 +155,9 @@ describe('WorkerThreadScriptRunner spawn contract', () => {
     expect(spawnedWorkers).toHaveLength(2);
   });
 
-  // `resourceLimits` are fixed at spawn, so a pooled worker keeps the budget of the run that
-  // created it — documented on `PooledWorkerOptions.memoryMb`.
-  it('keeps the memory budget of the run that spawned the worker', async () => {
+  // `resourceLimits` are fixed at spawn, so the memory budget is part of the pool key: a run
+  // asking for a different budget gets a fresh worker instead of one with the wrong limit.
+  it('spawns a fresh worker when a run requests a different memory budget', async () => {
     const runner = createRunner();
     const first = runner.run(buildInput('worker-source', 64));
 
@@ -167,11 +167,21 @@ describe('WorkerThreadScriptRunner spawn contract', () => {
 
     const second = runner.run(buildInput('worker-source', 256));
 
-    await waitFor(() => spawnedWorkers[0]?.requests.length === 2);
-    spawnedWorkers[0]?.succeedLast({});
+    await waitFor(() => spawnedWorkers[1]?.requests.length === 1);
+    spawnedWorkers[1]?.succeedLast({});
     await second;
 
-    expect(spawnedWorkers).toHaveLength(1);
+    expect(spawnedWorkers).toHaveLength(2);
     expect(spawnedWorkers[0]?.options.resourceLimits).toEqual({ maxOldGenerationSizeMb: 64 });
+    expect(spawnedWorkers[1]?.options.resourceLimits).toEqual({ maxOldGenerationSizeMb: 256 });
+
+    const third = runner.run(buildInput('worker-source', 256));
+
+    await waitFor(() => spawnedWorkers[1]?.requests.length === 2);
+    spawnedWorkers[1]?.succeedLast({});
+    await third;
+
+    // Same script and same budget reuse the pooled worker rather than spawning a third.
+    expect(spawnedWorkers).toHaveLength(2);
   });
 });

--- a/packages/core/src/libraries/script-runner/worker-thread-script-runner.test.ts
+++ b/packages/core/src/libraries/script-runner/worker-thread-script-runner.test.ts
@@ -111,13 +111,85 @@ describe('WorkerThreadScriptRunner', () => {
         runner.run(buildInput('const runAction = ({ api }) => ({ apiType: typeof api });'))
       ).resolves.toEqual({ ok: true, value: { apiType: 'undefined' } });
     });
+
+    // The sentinel class is private to the worker module, so a script can imitate its name but
+    // never its identity — the `instanceof` check must not be fooled into a 403.
+    it('does not mistake a script-thrown error named like the deny sentinel for a denial', async () => {
+      await expect(
+        runner.run(
+          buildInput(
+            `const getCustomJwtClaims = () => {
+               const error = new Error('forged');
+               error.name = 'DenyAccessSignal';
+               throw error;
+             };`,
+            'getCustomJwtClaims'
+          )
+        )
+      ).resolves.toMatchObject({
+        ok: false,
+        kind: 'runtime',
+        name: 'DenyAccessSignal',
+        message: 'forged',
+      });
+    });
+
+    it('keeps serving on the same worker after a denial', async () => {
+      const isolated = new WorkerThreadScriptRunner();
+      const script = `var count = 0;
+         const getCustomJwtClaims = ({ api, deny }) => {
+           count += 1;
+           if (deny) { api.denyAccess('no'); }
+           return { count };
+         };`;
+
+      try {
+        await expect(
+          isolated.run(buildInput(script, 'getCustomJwtClaims', { deny: true }))
+        ).resolves.toEqual({ ok: false, kind: 'denied', message: 'no' });
+        // A denial is a settled outcome rather than a fault, so the worker stays pooled and its
+        // state proves the second run reused it.
+        await expect(
+          isolated.run(buildInput(script, 'getCustomJwtClaims', { deny: false }))
+        ).resolves.toEqual({ ok: true, value: { count: 2 } });
+        expect(isolated.size).toBe(1);
+      } finally {
+        await isolated.dispose();
+      }
+    });
   });
 
   describe('failure kinds', () => {
     it('reports syntax for a script that cannot be compiled', async () => {
       const result = await runner.run(buildInput('const runAction = () => {'));
 
-      expect(result).toMatchObject({ ok: false, kind: 'syntax' });
+      // The compiler's message survives the flattening that carries it across the thread.
+      expect(result).toMatchObject({
+        ok: false,
+        kind: 'syntax',
+        message: expect.stringContaining('Unexpected end of input') as string,
+      });
+    });
+
+    // The protocol promises that a script which cannot start never occupies a pool slot, so a
+    // tenant retrying a broken script cannot pin the pool full of corpses.
+    it('keeps a startup-failed worker out of the pool', async () => {
+      const isolated = new WorkerThreadScriptRunner();
+
+      try {
+        await expect(isolated.run(buildInput('const runAction = () => {'))).resolves.toMatchObject({
+          ok: false,
+          kind: 'syntax',
+        });
+        expect(isolated.size).toBe(0);
+
+        await expect(
+          isolated.run(buildInput('const somethingElse = () => ({});'))
+        ).resolves.toMatchObject({ ok: false, kind: 'type' });
+        expect(isolated.size).toBe(0);
+      } finally {
+        await isolated.dispose();
+      }
     });
 
     it('reports type when the entry function is missing', async () => {
@@ -240,7 +312,12 @@ describe('WorkerThreadScriptRunner', () => {
       const script = 'const runAction = () => () => 1;';
       const result = await runner.run(buildInput(script));
 
-      expect(result).toMatchObject({ ok: false, kind: 'type' });
+      // The `DataCloneError` is deliberately flattened to this constant, author-facing message.
+      expect(result).toEqual({
+        ok: false,
+        kind: 'type',
+        message: 'The script return value must be JSON-serializable.',
+      });
 
       // Nothing was terminated, so the worker keeps serving.
       await expect(
@@ -254,7 +331,11 @@ describe('WorkerThreadScriptRunner', () => {
         buildInput(script, 'runAction', { callback: () => 'not cloneable' })
       );
 
-      expect(result).toMatchObject({ ok: false, kind: 'type' });
+      expect(result).toMatchObject({
+        ok: false,
+        kind: 'type',
+        message: expect.stringContaining('cannot be transferred to the worker thread') as string,
+      });
       await expect(runner.run(buildInput(script))).resolves.toEqual({
         ok: true,
         value: { count: 1 },

--- a/packages/core/src/libraries/script-runner/worker-thread-script-runner.ts
+++ b/packages/core/src/libraries/script-runner/worker-thread-script-runner.ts
@@ -44,10 +44,12 @@ const resolveWorkerPath = async () => {
  * runaway allocation from taking the host's heap with it. It is not an isolation boundary — a
  * script still runs with the host's privileges.
  *
- * Workers are keyed by `{keyPrefix}:{entry}:{sha256(script)}`, so a script is compiled once and
- * its worker is reused across runs, while runs with different key prefixes (e.g. different
- * tenants) never share a worker even for a byte-identical script. Recycling happens on fault, on
- * idle expiry, and after a fixed number of runs.
+ * Workers are keyed by `{keyPrefix}:{entry}:{memoryMb}:{sha256(script)}`, so a script is compiled
+ * once and its worker is reused across runs, while runs with different key prefixes (e.g.
+ * different tenants) never share a worker even for a byte-identical script. The memory budget is
+ * part of the key because `resourceLimits` are fixed at spawn: keying on it is what guarantees a
+ * run is never served by a worker with a stricter or looser limit than it asked for. Recycling
+ * happens on fault, on idle expiry, and after a fixed number of runs.
  */
 export class WorkerThreadScriptRunner implements ScriptRunner {
   /** Insertion-ordered, which makes the first entry the least recently used. */
@@ -98,7 +100,7 @@ export class WorkerThreadScriptRunner implements ScriptRunner {
     // every run against a broken build fails the same way instead of retrying the resolution.
     this.workerPath ||= resolveWorkerPath();
     const workerPath = await this.workerPath;
-    const key = this.buildKey(keyPrefix, entry, script);
+    const key = this.buildKey(keyPrefix, entry, limits.memoryMb, script);
 
     /**
      * Synchronous through `reserve()`: Node runs it without suspension, so two concurrent misses on
@@ -124,10 +126,15 @@ export class WorkerThreadScriptRunner implements ScriptRunner {
    * The key prefix leads and the fixed-length hash trails, so a prefix containing `:` can never
    * collide with another prefix/entry combination.
    */
-  private buildKey(keyPrefix: string | undefined, entry: ScriptEntry, script: string): string {
+  private buildKey(
+    keyPrefix: string | undefined,
+    entry: ScriptEntry,
+    memoryMb: number,
+    script: string
+  ): string {
     const hash = createHash('sha256').update(script).digest('hex');
 
-    return `${keyPrefix ?? ''}:${entry}:${hash}`;
+    return `${keyPrefix ?? ''}:${entry}:${memoryMb}:${hash}`;
   }
 
   /** Must never contain an `await` — see the synchronous region in {@link run}. */

--- a/packages/core/src/routes/experience/classes/libraries/action-result-validation.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/action-result-validation.test.ts
@@ -2,6 +2,7 @@ import { SignInIdentifier, type ActionUser, type JwtCustomizerUserContext } from
 
 import { mockUser } from '#src/__mocks__/user.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { WorkerThreadScriptRunner } from '#src/libraries/script-runner/worker-thread-script-runner.js';
 import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import {
@@ -248,6 +249,7 @@ describe('validatePostSignInActionResult', () => {
     }
   );
 
+  // TODO (LOG-13956): drop this case together with the legacy `node:vm` execution path.
   it('accepts an empty plain object returned from a separate VM realm as a no-op', async () => {
     const result = await runScriptFunctionInLocalVm(
       'const runAction = () => ({})',
@@ -260,6 +262,32 @@ describe('validatePostSignInActionResult', () => {
       continueResult
     );
   });
+
+  // The worker-pool analog of the separate-realm case above: the value reaches validation after a
+  // structured-clone round trip across the thread boundary.
+  it('accepts an empty plain object returned across the worker thread boundary as a no-op', async () => {
+    const runner = new WorkerThreadScriptRunner();
+
+    try {
+      const result = await runner.run({
+        script: 'const runAction = () => ({})',
+        entry: 'runAction',
+        payload: {},
+        limits: { wallClockMs: 5000, memoryMb: 64 },
+        egress: { mode: 'allowAll' },
+      });
+
+      expect(result).toEqual({ ok: true, value: {} });
+      expect(
+        validatePostSignInActionResult({
+          userId: actionUser.id,
+          result: result.ok ? result.value : undefined,
+        })
+      ).toEqual(continueResult);
+    } finally {
+      await runner.dispose();
+    }
+  }, 10_000);
 
   it('accepts updateUser with a sanitized provisioning profile', () => {
     expect(


### PR DESCRIPTION
## Summary

Stacked on #9343 (and, through it, #9339); the branch also carries #9346's commit, since the unref fix is load-bearing for any suite that touches real workers — the merge diff deflates to test-only changes once #9346 lands in #9339. Closes LOG-13955.

Unit coverage for the OSS runner and its adapters. Originally test-only; review turned up one production fix that now rides along (8b35f4c26): `resourceLimits` are fixed at worker spawn while `limits.memoryMb` is per-run input, so a pooled worker could serve a later run under the wrong memory cap — `memoryMb` is now part of the pool key (`{keyPrefix}:{entry}:{memoryMb}:{sha256(script)}`), and a run is only ever served by a worker spawned with exactly the budget it asked for.

### Runner (`libraries/script-runner/*.test.ts`)

- **Recycling on every fault leg** — new cases for unexpected `process.exit`, an out-of-run crash (a timer throw surfacing as the worker `error` event), and out-of-memory: the faulted worker leaves the pool and the next run gets a fresh one. Timeout recycling was already covered.
- **Spawn contract against a faked `node:worker_threads`** (new `worker-thread-script-runner.spawn.test.ts`) — `resourceLimits.maxOldGenerationSizeMb` plumbing, the `ERR_WORKER_OUT_OF_MEMORY` → `oom` mapping + recycling, and that a run requesting a different memory budget gets a fresh worker with that budget while an identical request reuses the pooled one. Faked deliberately: the jest process runs with `--max_old_space_size=4096`, which (per `pooled-worker.ts`'s own note) overrides the per-worker limit — so a real OOM can neither observe the 16 MB contract nor beat the wall clock reliably. ⚠️ The pre-existing `reports oom for a runaway allocation` case from #9339 still races a real multi-GB allocation against its 20 s deadline; left untouched here since it's #9339's code, but worth revisiting there.
- **Pool hygiene** — startup failures (syntax / missing entry) never occupy a pool slot; a worker retires after its 1000-admission budget and the next run starts fresh; a denial is a settled outcome, not a fault (worker stays pooled, state intact).
- **Sentinel integrity** — a script throwing an error *named* `DenyAccessSignal` reports `runtime`, not `denied`; the private-class `instanceof` check can't be forged.
- **Message pinning** — the flattened `DataCloneError` messages (`The script return value must be JSON-serializable.`, payload-transfer failure) and the syntax message round-trip are now asserted, not just the kinds.

### Adapters (`action.worker-pool.test.ts`, `jwt-customizer.worker-pool.test.ts`, new)

Mocked at the `WorkerThreadScriptRunner` seam so `run.ts` (limits, egress, `buildScriptFailureError`) stays real:

- Payload shape is pinned by exact key list — no `api`, no `script`/`tokenType` leaking across the thread boundary — plus `ossScriptLimits` and the `allowAll` egress policy.
- The full failure→status matrix on both adapters (denied 403 / syntax + type 422 / timeout + oom + runtime 500), the Custom JWT `AccessDenied` error body, the non-record 400 `Invalid input`, and Actions returning non-record values verbatim.
- **The legacy `node:vm` branch** (still the production path until LOG-13956): routing under the gate, denial 403, non-record 400, runtime 500 — and two truths worth documenting: a compile error maps to **500**, not 422, because the vm constructs the `SyntaxError` in the script's realm where the host `instanceof` can't see it (the worker runner is what makes syntax report 422), and an undeclared entry throws a realm-side `ReferenceError` (500) — only a declared non-function entry reaches the host `TypeError` and its 422.
- `scriptFailureStatusCodes` / `getScriptFailureStatusCode` / `buildScriptFailureError` pinned directly in `errors.test.ts` / `run.test.ts`.

### Existing suites from the issue's adapt list

- `action-result-validation.test.ts` — the separate-realm no-op case now has a worker-thread-boundary twin (structured clone instead of cross-realm prototypes); the legacy case keeps a `TODO (LOG-13956)`.
- `action.test.ts`, `action.cloud.test.ts`, `extra-token-claims.test.ts` — audited, no changes needed: they mock/spy the preserved `runScriptInLocalVm` seam, and under `NODE_ENV=test` (dev features on) already exercise the worker-pool path end to end.

### Verification

`@logto/core` jest: 271 suites — all green except the four `sign-in-experience` suites that fail on this machine for the known local-env reason (unbuilt `connectors/*/lib`), unrelated to this change. The 14 suites touching the runner/adapters: 205 tests, all passing. ESLint clean.
