### PR TITLE
fix(core): align default ID token signing algorithm with the tenant signing key

### DIFF
--- a/packages/core/src/oidc/cimd.test.ts
+++ b/packages/core/src/oidc/cimd.test.ts
@@ -20,9 +20,9 @@ const loadCimdModule = async ({
   return import('./cimd.js');
 };
 
-const buildEnvSet = (cimdEnabled: boolean): EnvSet => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the module reads
-  return { oidc: { cimdEnabled } } as EnvSet;
+const buildEnvSet = (cimdEnabled: boolean, jwkSigningAlg?: 'ES256' | 'ES384' | 'ES512'): EnvSet => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the fields the module reads
+  return { oidc: { cimdEnabled, jwkSigningAlg } } as EnvSet;
 };
 
 const cimdClientIdMaxLength = 2048;
@@ -30,14 +30,14 @@ const cimdClientIdMaxLength = 2048;
 const buildClientId = (length: number) =>
   `https://example.com/${'a'.repeat(length - 'https://example.com/'.length)}`;
 
-const buildClient = (clientId: string): Client => {
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub scoped to the field the hook reads
-  return { clientId } as Client;
+const buildClient = (clientId: string, idTokenSignedResponseAlg?: string): Client => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub scoped to the fields the hook reads
+  return { clientId, idTokenSignedResponseAlg } as Client;
 };
 
-const loadEnabledFeature = async () => {
+const loadEnabledFeature = async (jwkSigningAlg?: 'ES256' | 'ES384' | 'ES512') => {
   const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();
-  const feature = buildClientIdMetadataDocumentFeature(buildEnvSet(true));
+  const feature = buildClientIdMetadataDocumentFeature(buildEnvSet(true, jwkSigningAlg));
 
   if (!feature) {
     throw new Error('Expected the CIMD feature to be built');
@@ -114,5 +114,44 @@ describe('client identifier length bound', () => {
     expect(allowClient(undefined, buildClient(buildClientId(cimdClientIdMaxLength + 1)))).toBe(
       false
     );
+  });
+});
+
+describe('ID token signing algorithm guard', () => {
+  const clientId = buildClientId(64);
+
+  it('allowClient accepts the tenant signing algorithm and an omitted declaration on an EC tenant', async () => {
+    const { allowClient } = await loadEnabledFeature('ES384');
+    expect(allowClient(undefined, buildClient(clientId, 'ES384'))).toBe(true);
+    expect(allowClient(undefined, buildClient(clientId))).toBe(true);
+  });
+
+  it('allowClient rejects a declaration the EC tenant signing key cannot sign', async () => {
+    const { allowClient } = await loadEnabledFeature('ES384');
+
+    /**
+     * `jest.resetModules` gives cimd.js its own `oidc-provider` module instance, so class
+     * identity assertions would fail; the thrown error also keeps the OIDC error code in
+     * `message` and the human-readable text in `error_description`.
+     */
+    const thrown = ((): unknown => {
+      try {
+        return allowClient(undefined, buildClient(clientId, 'RS256'));
+      } catch (error) {
+        return error;
+      }
+    })();
+
+    expect(thrown).toMatchObject({
+      message: 'invalid_client_metadata',
+      error_description:
+        'id_token_signed_response_alg RS256 cannot be signed with the tenant signing key',
+    });
+  });
+
+  it('allowClient does not guard the algorithm when the tenant key derives none', async () => {
+    const { allowClient } = await loadEnabledFeature();
+    expect(allowClient(undefined, buildClient(clientId, 'RS256'))).toBe(true);
+    expect(allowClient(undefined, buildClient(clientId, 'ES384'))).toBe(true);
   });
 });

--- a/packages/core/src/oidc/cimd.ts
+++ b/packages/core/src/oidc/cimd.ts
@@ -10,7 +10,7 @@
  */
 
 import { conditional, type Optional } from '@silverhand/essentials';
-import { type Client, type KoaContextWithOIDC } from 'oidc-provider';
+import { type Client, errors, type KoaContextWithOIDC } from 'oidc-provider';
 
 import { EnvSet } from '#src/env-set/index.js';
 
@@ -59,7 +59,7 @@ export const isCimdClientId = (clientId: string): boolean => /^https:\/\//iu.tes
  *
  * The explicit return type stands in for `@types/oidc-provider`, which does not declare this
  * draft feature of the fork. A falsy return from either callback makes the provider throw
- * `InvalidClient`.
+ * `InvalidClient`; an OIDC error thrown inside a callback propagates to the client as-is.
  */
 export const buildClientIdMetadataDocumentFeature = (
   envSet: EnvSet
@@ -79,8 +79,32 @@ export const buildClientIdMetadataDocumentFeature = (
         allowFetch: (_ctx: KoaContextWithOIDC | undefined, clientId: string) =>
           clientId.length <= cimdClientIdMaxLength,
         /** Cache hits skip `allowFetch`, so the bound must repeat here. */
-        allowClient: (_ctx: KoaContextWithOIDC | undefined, client: Client) =>
-          client.clientId.length <= cimdClientIdMaxLength,
+        allowClient: (_ctx: KoaContextWithOIDC | undefined, client: Client) => {
+          if (client.clientId.length > cimdClientIdMaxLength) {
+            return false;
+          }
+
+          /**
+           * The client schema only checks the algorithm against the product-level allowlist —
+           * a declaration the tenant's current signing key cannot sign would fail late at
+           * token issuance with a server error. RSA tenants derive no algorithm and can sign
+           * the built-in `RS256` default, so there is nothing to enforce for them.
+           */
+          const { idTokenSignedResponseAlg } = client;
+          const { jwkSigningAlg } = envSet.oidc;
+
+          if (
+            jwkSigningAlg &&
+            idTokenSignedResponseAlg &&
+            idTokenSignedResponseAlg !== jwkSigningAlg
+          ) {
+            throw new errors.InvalidClientMetadata(
+              `id_token_signed_response_alg ${idTokenSignedResponseAlg} cannot be signed with the tenant signing key`
+            );
+          }
+
+          return true;
+        },
       },
     }
   );

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert';
 
-import { GrantType, type Scope } from '@logto/schemas';
+import { defaultTenantId, GrantType, type Scope } from '@logto/schemas';
 import { errors, type KoaContextWithOIDC } from 'oidc-provider';
 
 import { mockResource, mockUser } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import { mockEnvSet } from '#src/test-utils/env-set.js';
@@ -52,6 +53,19 @@ const createProvider = (tenant: MockTenant) =>
     tenant.logtoConfigs,
     tenant.subscription
   );
+
+/**
+ * The jest-level `loadOidcValues` mock leaves `jwkSigningAlg` undefined, which matches how RSA
+ * tenants load. Asserting the EC-tenant provider defaults needs an env set that carries the
+ * algorithm derived from the tenant key.
+ */
+class MockEcEnvSet extends EnvSet {
+  override get oidc(): EnvSet['oidc'] {
+    return { ...mockEnvSet.oidc, jwkSigningAlg: 'ES384' };
+  }
+}
+
+const ecEnvSet = new MockEcEnvSet(defaultTenantId, EnvSet.values.dbUrl);
 
 const createTestClient = (): KoaContextWithOIDC['oidc']['client'] => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub for OIDC context testing
@@ -103,6 +117,25 @@ describe('oidc provider init', () => {
     expect(() =>
       initOidc(id, mockEnvSet, queries, libraries, logtoConfigs, subscription)
     ).not.toThrow();
+  });
+
+  it('should align the default id_token_signed_response_alg with the tenant signing key', () => {
+    const { id, queries, libraries, logtoConfigs, subscription } = new MockTenant();
+    const provider = initOidc(id, ecEnvSet, queries, libraries, logtoConfigs, subscription);
+    const { clientDefaults } = getProviderConfiguration(provider);
+
+    expect(clientDefaults.id_token_signed_response_alg).toBe('ES384');
+    // The configured override merges per property; the other built-in defaults must survive.
+    expect(clientDefaults.grant_types).toEqual(['authorization_code']);
+    expect(clientDefaults.response_types).toEqual(['code']);
+    expect(clientDefaults.token_endpoint_auth_method).toBe('client_secret_basic');
+  });
+
+  it('should keep the built-in RS256 default when the tenant key derives no signing algorithm', () => {
+    const provider = createProvider(new MockTenant());
+    const { clientDefaults } = getProviderConfiguration(provider);
+
+    expect(clientDefaults.id_token_signed_response_alg).toBe('RS256');
   });
 
   it('should allow missing application access control client metadata', async () => {

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -170,13 +170,9 @@ export default function initOidc(
       keys: envSet.oidc.privateJwks,
     },
     /**
-     * Registered applications never rely on this default — the adapter force-writes their
-     * `id_token_signed_response_alg` via `getConstantClientMetadata()`. Dynamically resolved
-     * clients (e.g. Client ID Metadata Documents) skip that path and fall back to
-     * oidc-provider's built-in default `RS256`, which passes client validation (it checks the
-     * product-level allowlist above) while an EC-keystore tenant cannot sign it, so token
-     * issuance would fail late with a server error. Align the default with the tenant signing
-     * key; RSA tenants keep the built-in `RS256`.
+     * Clients that skip the adapter's metadata force-write (e.g. CIMD) fall back to the
+     * built-in `RS256` default, which EC-keystore tenants cannot sign. Align the default
+     * with the tenant signing key; RSA tenants keep the built-in `RS256`.
      */
     ...conditional(
       envSet.oidc.jwkSigningAlg && {

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -16,7 +16,7 @@ import {
   ExtraParamsKey,
   type Json,
 } from '@logto/schemas';
-import { trySafe, tryThat } from '@silverhand/essentials';
+import { conditional, trySafe, tryThat } from '@silverhand/essentials';
 import { type i18n } from 'i18next';
 import { type KoaContextWithOIDC, Provider, type ResourceServer, errors } from 'oidc-provider';
 import getRawBody from 'raw-body';
@@ -169,6 +169,22 @@ export default function initOidc(
     jwks: {
       keys: envSet.oidc.privateJwks,
     },
+    /**
+     * Registered applications never rely on this default — the adapter force-writes their
+     * `id_token_signed_response_alg` via `getConstantClientMetadata()`. Dynamically resolved
+     * clients (e.g. Client ID Metadata Documents) skip that path and fall back to
+     * oidc-provider's built-in default `RS256`, which passes client validation (it checks the
+     * product-level allowlist above) while an EC-keystore tenant cannot sign it, so token
+     * issuance would fail late with a server error. Align the default with the tenant signing
+     * key; RSA tenants keep the built-in `RS256`.
+     */
+    ...conditional(
+      envSet.oidc.jwkSigningAlg && {
+        clientDefaults: {
+          id_token_signed_response_alg: envSet.oidc.jwkSigningAlg,
+        },
+      }
+    ),
     enabledJWA: {
       authorizationSigningAlgValues: [...supportedSigningAlgs],
       userinfoSigningAlgValues: [...supportedSigningAlgs],


### PR DESCRIPTION
## Summary

Align ID token signing with the tenant signing key for dynamically resolved (CIMD) clients, in both directions:

- `clientDefaults.id_token_signed_response_alg` now follows the tenant signing key at provider construction: a client whose metadata omits the field previously fell back to oidc-provider's built-in default `RS256`, which passes client-metadata validation (it checks the product-level algorithm allowlist) while an EC-keystore tenant cannot sign it — authorization succeeded and token issuance then failed with a server error.
- The CIMD `allowClient` callback now rejects a document whose effective `id_token_signed_response_alg` differs from the algorithm the tenant derives from its current signing key, turning the same late server error into a diagnosable `invalid_client_metadata` at client resolution. Current-key-only on purpose: retired keys stay in the keystore to verify old tokens but do not sign new ones.
- Registered applications are unaffected: the adapter force-writes the field for them, so neither change reaches their behavior.
- RSA tenants derive no signing algorithm and are untouched by both changes: they keep the built-in `RS256` default (which their key can sign), and the guard has no tenant declaration to enforce.
- The configured `clientDefaults` override merges per property; the remaining built-in client defaults are untouched (pinned in the unit tests).

## Testing

Unit tests.

## Checklist

- [ ] `.changeset` (skipped: no behavior change for any existing client path; CIMD is dev-gated)
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)