### PR TITLE
feat(core): enforce cimd structural policies in allowClient

### DIFF
--- a/packages/core/src/oidc/cimd.test.ts
+++ b/packages/core/src/oidc/cimd.test.ts
@@ -1,5 +1,5 @@
 import { createMockUtils } from '@logto/shared/esm';
-import { type Client } from 'oidc-provider';
+import { type AllClientMetadata, type Client } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
 
@@ -30,9 +30,27 @@ const cimdClientIdMaxLength = 2048;
 const buildClientId = (length: number) =>
   `https://example.com/${'a'.repeat(length - 'https://example.com/'.length)}`;
 
-const buildClient = (clientId: string, idTokenSignedResponseAlg?: string): Client => {
+const buildClient = (
+  clientId: string,
+  idTokenSignedResponseAlg?: string,
+  metadata: AllClientMetadata = {}
+): Client => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub scoped to the fields the hook reads
-  return { clientId, idTokenSignedResponseAlg } as Client;
+  return { clientId, idTokenSignedResponseAlg, metadata: () => metadata } as Client;
+};
+
+/**
+ * `jest.resetModules` gives cimd.js its own `oidc-provider` module instance, so class identity
+ * assertions on thrown errors would fail; assert on the thrown shape instead — the OIDC error
+ * code lives in `message` and the human-readable text in `error_description`.
+ */
+const captureThrown = (run: () => unknown): unknown => {
+  try {
+    run();
+    return undefined;
+  } catch (error: unknown) {
+    return error;
+  }
 };
 
 const loadEnabledFeature = async (jwkSigningAlg?: 'ES256' | 'ES384' | 'ES512') => {
@@ -102,18 +120,27 @@ describe('isCimdClientId', () => {
 });
 
 describe('client identifier length bound', () => {
+  const overLengthRejection = {
+    message: 'invalid_client',
+    error_description: `client_id must not exceed ${cimdClientIdMaxLength} characters`,
+  };
+
   it('allowFetch accepts an identifier at the bound and rejects one past it', async () => {
     const { allowFetch } = await loadEnabledFeature();
     expect(allowFetch(undefined, buildClientId(cimdClientIdMaxLength))).toBe(true);
-    expect(allowFetch(undefined, buildClientId(cimdClientIdMaxLength + 1))).toBe(false);
+    expect(
+      captureThrown(() => allowFetch(undefined, buildClientId(cimdClientIdMaxLength + 1)))
+    ).toMatchObject(overLengthRejection);
   });
 
   it('allowClient accepts a client at the bound and rejects one past it', async () => {
     const { allowClient } = await loadEnabledFeature();
     expect(allowClient(undefined, buildClient(buildClientId(cimdClientIdMaxLength)))).toBe(true);
-    expect(allowClient(undefined, buildClient(buildClientId(cimdClientIdMaxLength + 1)))).toBe(
-      false
-    );
+    expect(
+      captureThrown(() =>
+        allowClient(undefined, buildClient(buildClientId(cimdClientIdMaxLength + 1)))
+      )
+    ).toMatchObject(overLengthRejection);
   });
 });
 
@@ -129,20 +156,9 @@ describe('ID token signing algorithm guard', () => {
   it('allowClient rejects a declaration the EC tenant signing key cannot sign', async () => {
     const { allowClient } = await loadEnabledFeature('ES384');
 
-    /**
-     * `jest.resetModules` gives cimd.js its own `oidc-provider` module instance, so class
-     * identity assertions would fail; the thrown error also keeps the OIDC error code in
-     * `message` and the human-readable text in `error_description`.
-     */
-    const thrown = ((): unknown => {
-      try {
-        return allowClient(undefined, buildClient(clientId, 'RS256'));
-      } catch (error) {
-        return error;
-      }
-    })();
-
-    expect(thrown).toMatchObject({
+    expect(
+      captureThrown(() => allowClient(undefined, buildClient(clientId, 'RS256')))
+    ).toMatchObject({
       message: 'invalid_client_metadata',
       error_description:
         'id_token_signed_response_alg RS256 cannot be signed with the tenant signing key',
@@ -153,5 +169,97 @@ describe('ID token signing algorithm guard', () => {
     const { allowClient } = await loadEnabledFeature();
     expect(allowClient(undefined, buildClient(clientId, 'RS256'))).toBe(true);
     expect(allowClient(undefined, buildClient(clientId, 'ES384'))).toBe(true);
+  });
+});
+
+describe('private metadata deny', () => {
+  const clientId = buildClientId(64);
+
+  it('allowClient rejects a document carrying a custom client metadata key', async () => {
+    const { allowClient } = await loadEnabledFeature();
+
+    expect(
+      captureThrown(() =>
+        allowClient(
+          undefined,
+          buildClient(clientId, undefined, { corsAllowedOrigins: ['https://app.example.com'] })
+        )
+      )
+    ).toMatchObject({
+      message: 'invalid_client_metadata',
+      error_description:
+        'client_id metadata document must not contain Logto private metadata (corsAllowedOrigins)',
+    });
+  });
+
+  it('allowClient rejects a document carrying the app-level access control key', async () => {
+    const { allowClient } = await loadEnabledFeature();
+
+    expect(
+      captureThrown(() =>
+        allowClient(
+          undefined,
+          buildClient(clientId, undefined, { appLevelAccessControlEnabled: true })
+        )
+      )
+    ).toMatchObject({
+      message: 'invalid_client_metadata',
+      error_description:
+        'client_id metadata document must not contain Logto private metadata (appLevelAccessControlEnabled)',
+    });
+  });
+});
+
+describe('wildcard redirect URI pattern validation', () => {
+  const clientId = buildClientId(64);
+
+  it('allowClient accepts exact URIs and supported wildcard patterns', async () => {
+    const { allowClient } = await loadEnabledFeature();
+
+    expect(
+      allowClient(
+        undefined,
+        buildClient(clientId, undefined, {
+          redirect_uris: ['https://app.example.com/callback', 'https://*.example.com/callback'],
+          post_logout_redirect_uris: ['https://*.example.com/signed-out'],
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('allowClient rejects a pattern the runtime matcher would never match', async () => {
+    const { allowClient } = await loadEnabledFeature();
+
+    expect(
+      captureThrown(() =>
+        allowClient(
+          undefined,
+          buildClient(clientId, undefined, { redirect_uris: ['https://*.com/callback'] })
+        )
+      )
+    ).toMatchObject({
+      message: 'invalid_client_metadata',
+      error_description:
+        'client_id metadata document contains an unsupported wildcard redirect URI pattern (https://*.com/callback)',
+    });
+  });
+
+  it('allowClient validates post_logout_redirect_uris with the same rules', async () => {
+    const { allowClient } = await loadEnabledFeature();
+
+    expect(
+      captureThrown(() =>
+        allowClient(
+          undefined,
+          buildClient(clientId, undefined, {
+            post_logout_redirect_uris: ['https://example.*/signed-out'],
+          })
+        )
+      )
+    ).toMatchObject({
+      message: 'invalid_client_metadata',
+      error_description:
+        'client_id metadata document contains an unsupported wildcard redirect URI pattern (https://example.*/signed-out)',
+    });
   });
 });

--- a/packages/core/src/oidc/cimd.ts
+++ b/packages/core/src/oidc/cimd.ts
@@ -9,10 +9,14 @@
  * @see {@link https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-02.html | draft-02}
  */
 
+import { CustomClientMetadataKey } from '@logto/schemas';
 import { conditional, type Optional } from '@silverhand/essentials';
 import { type Client, errors, type KoaContextWithOIDC } from 'oidc-provider';
 
 import { EnvSet } from '#src/env-set/index.js';
+
+import { appLevelAccessControlMetadataKey } from './application-access-control.js';
+import { isValidWildcardRedirectUriPattern } from './wildcard-redirect-uri.js';
 
 /**
  * Must not exceed the `cimd_client_id varchar(2048)` column width — neither the draft nor the
@@ -20,6 +24,23 @@ import { EnvSet } from '#src/env-set/index.js';
  * `invalid_client` rather than a database error.
  */
 const cimdClientIdMaxLength = 2048;
+
+const assertClientIdWithinLengthBound = (clientId: string) => {
+  if (clientId.length > cimdClientIdMaxLength) {
+    throw new errors.InvalidClient(`client_id must not exceed ${cimdClientIdMaxLength} characters`);
+  }
+};
+
+/**
+ * Logto private client metadata that a remote CIMD document must never carry. The provider
+ * recognizes these keys through `extraClientMetadata`, so without this deny a remote document
+ * could set them and have them honored. Derived from the code-defined key collections so future
+ * private keys are covered automatically.
+ */
+const forbiddenCimdMetadataKeys = Object.freeze([
+  ...Object.values(CustomClientMetadataKey),
+  appLevelAccessControlMetadataKey,
+]);
 
 /**
  * Whether CIMD is effectively enabled for the tenant. All three conditions must hold:
@@ -58,8 +79,9 @@ export const isCimdClientId = (clientId: string): boolean => /^https:\/\//iu.tes
  * behavior change.
  *
  * The explicit return type stands in for `@types/oidc-provider`, which does not declare this
- * draft feature of the fork. A falsy return from either callback makes the provider throw
- * `InvalidClient`; an OIDC error thrown inside a callback propagates to the client as-is.
+ * draft feature of the fork. Both callbacks reject by throwing specific OIDC errors — the fork
+ * propagates them to the client as-is, while a falsy return would only yield the generic
+ * `InvalidClient` with no failure reason.
  */
 export const buildClientIdMetadataDocumentFeature = (
   envSet: EnvSet
@@ -76,13 +98,17 @@ export const buildClientIdMetadataDocumentFeature = (
       clientIdMetadataDocument: {
         enabled: true,
         ack: 'draft-02',
-        allowFetch: (_ctx: KoaContextWithOIDC | undefined, clientId: string) =>
-          clientId.length <= cimdClientIdMaxLength,
-        /** Cache hits skip `allowFetch`, so the bound must repeat here. */
+        allowFetch: (_ctx: KoaContextWithOIDC | undefined, clientId: string) => {
+          assertClientIdWithinLengthBound(clientId);
+          return true;
+        },
+        /**
+         * Runs on every use of a CIMD client including metadata-cache hits (a cached document
+         * can be up to 24 hours old), so tenant policy always applies before the client is
+         * used. The length bound must repeat here because cache hits skip `allowFetch`.
+         */
         allowClient: (_ctx: KoaContextWithOIDC | undefined, client: Client) => {
-          if (client.clientId.length > cimdClientIdMaxLength) {
-            return false;
-          }
+          assertClientIdWithinLengthBound(client.clientId);
 
           /**
            * The client schema only checks the algorithm against the product-level allowlist —
@@ -100,6 +126,31 @@ export const buildClientIdMetadataDocumentFeature = (
           ) {
             throw new errors.InvalidClientMetadata(
               `id_token_signed_response_alg ${idTokenSignedResponseAlg} cannot be signed with the tenant signing key`
+            );
+          }
+
+          const metadata = client.metadata();
+          const forbiddenKey = forbiddenCimdMetadataKeys.find((key) => metadata[key] !== undefined);
+
+          if (forbiddenKey) {
+            throw new errors.InvalidClientMetadata(
+              `client_id metadata document must not contain Logto private metadata (${forbiddenKey})`
+            );
+          }
+
+          /**
+           * An unsupported wildcard pattern never matches at runtime, so pre-validating with
+           * the matcher's own parser turns a dead registration into an upfront error naming
+           * the pattern instead of an unexplained redirect_uri mismatch at authorization.
+           */
+          const invalidPattern = [
+            ...(metadata.redirect_uris ?? []),
+            ...(metadata.post_logout_redirect_uris ?? []),
+          ].find((uri) => uri.includes('*') && !isValidWildcardRedirectUriPattern(uri));
+
+          if (invalidPattern !== undefined) {
+            throw new errors.InvalidClientMetadata(
+              `client_id metadata document contains an unsupported wildcard redirect URI pattern (${invalidPattern})`
             );
           }
 

--- a/packages/core/src/oidc/wildcard-redirect-uri.test.ts
+++ b/packages/core/src/oidc/wildcard-redirect-uri.test.ts
@@ -2,7 +2,11 @@ import type { Provider } from 'oidc-provider';
 
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
 
-import { installWildcardRedirectUriMatching, wildcardUrlMatch } from './wildcard-redirect-uri.js';
+import {
+  installWildcardRedirectUriMatching,
+  isValidWildcardRedirectUriPattern,
+  wildcardUrlMatch,
+} from './wildcard-redirect-uri.js';
 
 type ClientInstance = InstanceType<Provider['Client']>;
 
@@ -73,6 +77,20 @@ describe('wildcardUrlMatch', () => {
     expect(
       wildcardUrlMatch('https://*.example.com/cb', new URL('https://a.example.com:8443/cb'))
     ).toBe(false);
+  });
+});
+
+describe('isValidWildcardRedirectUriPattern', () => {
+  it('accepts patterns the runtime matcher supports', () => {
+    expect(isValidWildcardRedirectUriPattern('https://*.example.com/callback')).toBe(true);
+    expect(isValidWildcardRedirectUriPattern('https://app.example.com/cb/*')).toBe(true);
+  });
+
+  it('rejects patterns the runtime matcher would never match', () => {
+    expect(isValidWildcardRedirectUriPattern('https://*.com/callback')).toBe(false);
+    expect(isValidWildcardRedirectUriPattern('https://example.*/callback')).toBe(false);
+    expect(isValidWildcardRedirectUriPattern('https://app.example.com:*/cb')).toBe(false);
+    expect(isValidWildcardRedirectUriPattern('not-a-url')).toBe(false);
   });
 });
 

--- a/packages/core/src/oidc/wildcard-redirect-uri.ts
+++ b/packages/core/src/oidc/wildcard-redirect-uri.ts
@@ -203,6 +203,14 @@ export const wildcardUrlMatch = (pattern: string, actual: URL): boolean => {
   return actual.search === parsedPattern.search && actual.hash === parsedPattern.hash;
 };
 
+/**
+ * Whether a redirect URI value containing `*` is a valid Logto wildcard pattern. Used by the
+ * CIMD `allowClient` policy so remote metadata documents cannot register patterns the runtime
+ * matcher would never match (or overly broad ones such as `*.com`).
+ */
+export const isValidWildcardRedirectUriPattern = (pattern: string): boolean =>
+  parseWildcardUrlPattern(pattern) !== undefined;
+
 const matchAgainstRegistered = (registeredUris: readonly string[], parsed: URL) =>
   registeredUris.some((allowed) =>
     allowed.includes('*')


### PR DESCRIPTION
## Summary

Add the Logto-specific admission policies to the CIMD `allowClient` callback, which runs on every use of a CIMD client including metadata-cache hits.

- Reject documents that carry Logto private client metadata, naming the offending key; the deny set derives from the code-defined key collections (`CustomClientMetadataKey` + the app-level access control key), which the provider recognizes through `extraClientMetadata` and would otherwise honor.
- Pre-validate wildcard patterns in `redirect_uris` / `post_logout_redirect_uris` with the runtime matcher's own parser, so a pattern that would never match (e.g. `https://*.com/callback`) fails at client resolution with the pattern named, instead of an unexplained `redirect_uri` mismatch at authorization.
- Reject via thrown specific OIDC errors rather than `false` — the fork propagates thrown errors as-is, while a falsy return yields only the generic `InvalidClient`; the existing length bound switches to the same style and now reports the limit under `invalid_client`.

Stacked on #9350.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)