### PR TITLE
fix(console): skip initializing PostHog without a public key

### DIFF
--- a/.changeset/posthog-skip-without-key.md
+++ b/.changeset/posthog-skip-without-key.md
@@ -1,0 +1,7 @@
+---
+"@logto/console": patch
+---
+
+skip initializing PostHog in the Console when no public key is configured
+
+Self-hosted deployments that opt out of telemetry by omitting `POSTHOG_PUBLIC_KEY` now render the PostHog provider with a no-op client instead of an empty API key, avoiding spurious browser console warnings.

--- a/packages/console/src/App.tsx
+++ b/packages/console/src/App.tsx
@@ -25,6 +25,7 @@ import 'react-day-picker/dist/style.css';
 import CloudAppRoutes from '@/cloud/AppRoutes';
 import AppLoading from '@/components/AppLoading';
 import { isCloud, postHogHost, postHogUiHost, postHogKey } from '@/consts/env';
+import { noopPostHogClient } from '@/consts/posthog';
 import { cloudApi, getManagementApi, meApi } from '@/consts/resources';
 import { ConsoleRoutes } from '@/containers/ConsoleRoutes';
 
@@ -107,12 +108,16 @@ function Providers() {
 
   return (
     <PostHogProvider
-      apiKey={postHogKey ?? ''} // Empty key will disable PostHog
-      options={{
-        ui_host: postHogUiHost,
-        api_host: postHogHost,
-        defaults: '2025-05-24',
-      }}
+      {...(postHogKey // If there is no key, use the no-op client to avoid errors in the consumers and console warnings.
+        ? {
+            apiKey: postHogKey,
+            options: {
+              ui_host: postHogUiHost,
+              api_host: postHogHost,
+              defaults: '2025-05-24',
+            },
+          }
+        : { client: noopPostHogClient })}
     >
       <LogtoProvider
         unstable_enableCache

--- a/packages/console/src/consts/posthog.test.ts
+++ b/packages/console/src/consts/posthog.test.ts
@@ -1,0 +1,23 @@
+import { noopPostHogClient } from './posthog';
+
+const client = noopPostHogClient as unknown as Record<string, () => void>;
+
+describe('noopPostHogClient', () => {
+  const consumerMethods = ['identify', 'group', 'resetGroups', 'reset', 'capture'];
+
+  it.each(consumerMethods)('provides a no-op %s()', (method) => {
+    const call = client[method]!;
+    expect(typeof call).toBe('function');
+    expect(() => {
+      call();
+    }).not.toThrow();
+  });
+
+  it('returns a no-op for any other PostHog method', () => {
+    const call = client.getFeatureFlags!;
+    expect(typeof call).toBe('function');
+    expect(() => {
+      call();
+    }).not.toThrow();
+  });
+});

--- a/packages/console/src/consts/posthog.ts
+++ b/packages/console/src/consts/posthog.ts
@@ -1,0 +1,15 @@
+import { noop } from '@silverhand/essentials';
+import { type PostHog } from 'posthog-js/react';
+
+// When no public PostHog key is configured, `PostHogProvider` is rendered with this no-op client so
+// that every `usePostHog()` consumer (identify, group, reset, resetGroups, capture, ...) becomes a
+// harmless no-op instead of erroring on the uninitialized global instance. The Proxy returns a no-op
+// for any property, so the client never goes stale as new PostHog methods get used.
+// eslint-disable-next-line no-restricted-syntax -- the proxy intentionally implements the full `PostHog` surface with no-ops
+export const noopPostHogClient = new Proxy(
+  {
+    isIdentified: () => false,
+    hasOptedIn: () => false,
+  },
+  { get: () => noop }
+) as unknown as PostHog;


### PR DESCRIPTION

<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->
closes #9351 
<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Self-hosted deployments that omit `POSTHOG_PUBLIC_KEY` currently pass an
empty API key to `PostHogProvider`, producing spurious browser console
warnings. When no key is configured, render the provider with a `Proxy`-based
no-op client instead, so all `usePostHog()` consumers become harmless no-ops
without erroring on the uninitialized global instance.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
