### PR TITLE
feat(core): take over cimd client scope and grant types server side

### DIFF
--- a/packages/core/src/oidc/cimd/index.test.ts
+++ b/packages/core/src/oidc/cimd/index.test.ts
@@ -1,7 +1,9 @@
+import { UserScope } from '@logto/core-kit';
 import { createMockUtils } from '@logto/shared/esm';
 import { type AllClientMetadata, type Client } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
+import type Queries from '#src/tenants/Queries.js';
 
 const { jest } = import.meta;
 const { mockEsm } = createMockUtils(jest);
@@ -23,6 +25,13 @@ const loadCimdModule = async ({
 const buildEnvSet = (cimdEnabled: boolean, jwkSigningAlg?: 'ES256' | 'ES384' | 'ES512'): EnvSet => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the fields the module reads
   return { oidc: { cimdEnabled, jwkSigningAlg } } as EnvSet;
+};
+
+const buildCimdQueries = (findAllUserScopes: () => Promise<UserScope[]> = async () => []) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal queries stub scoped to the methods the transform reads
+  return {
+    userScopes: { findAll: findAllUserScopes },
+  } as Queries['cimd'];
 };
 
 const cimdClientIdMaxLength = 2048;
@@ -55,17 +64,23 @@ const captureThrown = (run: () => unknown): unknown => {
 
 const loadEnabledFeature = async ({
   jwkSigningAlg,
+  ceilingUserScopes = [],
 }: {
   jwkSigningAlg?: 'ES256' | 'ES384' | 'ES512';
+  ceilingUserScopes?: UserScope[];
 } = {}) => {
   const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();
-  const feature = buildClientIdMetadataDocumentFeature(buildEnvSet(true, jwkSigningAlg));
+  const findAllUserScopes = jest.fn(async () => ceilingUserScopes);
+  const feature = buildClientIdMetadataDocumentFeature(
+    buildEnvSet(true, jwkSigningAlg),
+    buildCimdQueries(findAllUserScopes)
+  );
 
   if (!feature) {
     throw new Error('Expected the CIMD feature to be built');
   }
 
-  return feature.clientIdMetadataDocument;
+  return { ...feature.clientIdMetadataDocument, findAllUserScopes };
 };
 
 describe('isCimdEffectivelyEnabled', () => {
@@ -95,7 +110,9 @@ describe('isCimdEffectivelyEnabled', () => {
 describe('buildClientIdMetadataDocumentFeature', () => {
   it('wires the feature with the draft-02 acknowledgement when effectively enabled', async () => {
     const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();
-    expect(buildClientIdMetadataDocumentFeature(buildEnvSet(true))).toMatchObject({
+    expect(
+      buildClientIdMetadataDocumentFeature(buildEnvSet(true), buildCimdQueries())
+    ).toMatchObject({
       clientIdMetadataDocument: { enabled: true, ack: 'draft-02' },
     });
   });
@@ -104,12 +121,16 @@ describe('buildClientIdMetadataDocumentFeature', () => {
     const { buildClientIdMetadataDocumentFeature } = await loadCimdModule({
       isDevFeaturesEnabled: false,
     });
-    expect(buildClientIdMetadataDocumentFeature(buildEnvSet(true))).toBeUndefined();
+    expect(
+      buildClientIdMetadataDocumentFeature(buildEnvSet(true), buildCimdQueries())
+    ).toBeUndefined();
   });
 
   it('does not wire the feature when not effectively enabled', async () => {
     const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();
-    expect(buildClientIdMetadataDocumentFeature(buildEnvSet(false))).toBeUndefined();
+    expect(
+      buildClientIdMetadataDocumentFeature(buildEnvSet(false), buildCimdQueries())
+    ).toBeUndefined();
   });
 });
 
@@ -135,6 +156,76 @@ describe('client identifier length bound', () => {
         allowClient(undefined, buildClient(buildClientId(cimdClientIdMaxLength + 1)))
       )
     ).toMatchObject(overLengthRejection);
+  });
+});
+
+describe('server-side metadata takeover', () => {
+  it('overrides the document scope with the tenant user-scope ceiling and pins grant and response types', async () => {
+    const { transformClientMetadata } = await loadEnabledFeature({
+      ceilingUserScopes: [UserScope.Profile, UserScope.Email],
+    });
+
+    await expect(
+      transformClientMetadata(undefined, {
+        scope: 'openid phone custom:unknown',
+        grant_types: ['client_credentials', 'implicit'],
+        response_types: ['id_token'],
+      })
+    ).resolves.toEqual({
+      scope: 'openid offline_access profile email',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+    });
+  });
+
+  it('pins the server-side values when the document omits the fields, with an empty ceiling denying all user scopes', async () => {
+    const { transformClientMetadata } = await loadEnabledFeature();
+
+    await expect(transformClientMetadata(undefined, {})).resolves.toEqual({
+      scope: 'openid offline_access',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+    });
+  });
+
+  it('re-reads the user-scope ceiling on every client resolution so changes apply immediately', async () => {
+    const { transformClientMetadata, findAllUserScopes } = await loadEnabledFeature({
+      ceilingUserScopes: [UserScope.Profile],
+    });
+
+    await expect(transformClientMetadata(undefined, {})).resolves.toMatchObject({
+      scope: 'openid offline_access profile',
+    });
+
+    // A memoized implementation would keep serving the first result; the ceiling must be
+    // re-queried per resolution for tenant changes to apply without a provider rebuild.
+    findAllUserScopes.mockResolvedValueOnce([UserScope.Profile, UserScope.Email]);
+
+    await expect(transformClientMetadata(undefined, {})).resolves.toMatchObject({
+      scope: 'openid offline_access profile email',
+    });
+    expect(findAllUserScopes).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes the other document fields through untouched', async () => {
+    const { transformClientMetadata } = await loadEnabledFeature();
+
+    await expect(
+      transformClientMetadata(undefined, {
+        client_id: 'https://client.example.com/oauth/metadata',
+        client_name: 'Example MCP client',
+        redirect_uris: ['https://app.example.com/callback'],
+        token_endpoint_auth_method: 'none',
+      })
+    ).resolves.toEqual({
+      client_id: 'https://client.example.com/oauth/metadata',
+      client_name: 'Example MCP client',
+      redirect_uris: ['https://app.example.com/callback'],
+      token_endpoint_auth_method: 'none',
+      scope: 'openid offline_access',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+    });
   });
 });
 

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -9,10 +9,18 @@
  * @see {@link https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-02.html | draft-02}
  */
 
+import { ReservedScope } from '@logto/core-kit';
+import { GrantType } from '@logto/schemas';
 import { conditional, type Optional } from '@silverhand/essentials';
-import { type Client, errors, type KoaContextWithOIDC } from 'oidc-provider';
+import {
+  type AllClientMetadata,
+  type Client,
+  errors,
+  type KoaContextWithOIDC,
+} from 'oidc-provider';
 
 import { EnvSet } from '#src/env-set/index.js';
+import type Queries from '#src/tenants/Queries.js';
 
 import { extraClientMetadataKeys } from '../application-access-control.js';
 import { isValidWildcardRedirectUriPattern } from '../redirect-uri/utils.js';
@@ -65,12 +73,17 @@ export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
  * `InvalidClient` with no failure reason.
  */
 export const buildClientIdMetadataDocumentFeature = (
-  envSet: EnvSet
+  envSet: EnvSet,
+  cimdQueries: Queries['cimd']
 ): Optional<{
   clientIdMetadataDocument: {
     enabled: true;
     ack: 'draft-02';
     allowFetch: (ctx: KoaContextWithOIDC | undefined, clientId: string) => boolean;
+    transformClientMetadata: (
+      ctx: KoaContextWithOIDC | undefined,
+      metadata: AllClientMetadata
+    ) => Promise<AllClientMetadata>;
     allowClient: (ctx: KoaContextWithOIDC | undefined, client: Client) => boolean;
   };
 }> =>
@@ -83,6 +96,36 @@ export const buildClientIdMetadataDocumentFeature = (
           assertClientIdWithinLengthBound(clientId);
           return true;
         },
+        /**
+         * `scope` and `grant_types` are server-owned — registered applications never
+         * take them from client input — so the document's declarations are replaced,
+         * not honored. The override must happen before the client schema runs: declared
+         * values the provider does not recognize would reject the whole client.
+         *
+         * - `scope` carries the tenant's user-scope ceiling so enforcement runs through
+         *   the provider's native `check_scope` like third-party applications, which
+         *   also covers PAR.
+         *   TODO: @xiaoyijun enforce the resource and organization scope ceilings on the
+         *   resource-server filter path (LOG-13927, LOG-13930).
+         * - `grant_types`: a remote document must not self-grant client_credentials,
+         *   device code, or token exchange, which registered applications only get by
+         *   type or explicit opt-in.
+         * - `response_types` must be pinned too, or the schema re-derives the implicit
+         *   grant from a declared response type.
+         */
+        transformClientMetadata: async (
+          _ctx: KoaContextWithOIDC | undefined,
+          metadata: AllClientMetadata
+        ): Promise<AllClientMetadata> => ({
+          ...metadata,
+          scope: [
+            ReservedScope.OpenId,
+            ReservedScope.OfflineAccess,
+            ...(await cimdQueries.userScopes.findAll()),
+          ].join(' '),
+          grant_types: [GrantType.AuthorizationCode, GrantType.RefreshToken],
+          response_types: ['code'],
+        }),
         /**
          * Runs on every use of a CIMD client including metadata-cache hits (a cached document
          * can be up to 24 hours old), so tenant policy always applies before the client is

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -203,7 +203,7 @@ export default function initOidc(
       backchannelLogout: { enabled: true },
       deviceFlow: deviceFlowConfig,
       // DEV: CIMD (client ID metadata document) support
-      ...buildClientIdMetadataDocumentFeature(envSet),
+      ...buildClientIdMetadataDocumentFeature(envSet, queries.cimd),
       rpInitiatedLogout: {
         logoutSource: (ctx, form) => {
           // eslint-disable-next-line no-template-curly-in-string


### PR DESCRIPTION
## Summary

Take over `scope` and `grant_types` for CIMD clients server side via the fork's `transformClientMetadata` hook, which runs on every document resolution (including cache hits, so ceiling changes apply immediately to new authorization requests regardless of the document cache TTL) before the client schema validates the metadata — both fields are server-owned for registered applications and stay server-owned for CIMD clients.

- Override `scope` with the tenant's user-scope ceiling (`openid` + `offline_access` + `cimd_user_scopes`, no intersection with the document's self-declared value) — user scope enforcement then runs through the provider's native `check_scope` exactly like third-party applications, which also covers PAR pushes and redemptions. Resource and organization scope ceilings are enforced on the resource-server filter path and land with LOG-13927 / LOG-13930.
- Pin `grant_types` to the interactive public-client set (`authorization_code` + `refresh_token`) — the provider-level grant set also carries `client_credentials`, device code, and token exchange, which registered applications only get by type or explicit opt-in; a remote document must not self-grant them.
- Pin `response_types` to `code` alongside: the client schema derives the `implicit` grant back from declared response types, which would undo the grant pin.

Stacked on #9355.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
