### PR TITLE
fix(core): unblock user deletion on revocation statement timeout

### DIFF
--- a/packages/core/src/routes/admin-user/basics.test.ts
+++ b/packages/core/src/routes/admin-user/basics.test.ts
@@ -3,6 +3,7 @@ import type { CreateUser, Role, SignInExperience, User } from '@logto/schemas';
 import { RoleType, UsersPasswordEncryptionMethod } from '@logto/schemas';
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
 import { removeUndefinedKeys } from '@silverhand/essentials';
+import { StatementTimeoutError } from '@silverhand/slonik';
 
 import { mockSignInExperience, mockUser, mockUserResponse } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -470,6 +471,22 @@ describe('adminUserRoutes', () => {
     const response = await userRequest.delete(`/users/${userId}`);
     expect(response.status).toEqual(204);
     expect(signOutUser).toHaveBeenCalledWith(userId);
+  });
+
+  it('DELETE /users/:userId should proceed with deletion when revocation times out', async () => {
+    const userId = 'fooUser';
+    signOutUser.mockRejectedValueOnce(new StatementTimeoutError(new Error('statement timeout')));
+    const response = await userRequest.delete(`/users/${userId}`);
+    expect(response.status).toEqual(204);
+    expect(deleteUserById).toHaveBeenCalledWith(userId);
+  });
+
+  it('DELETE /users/:userId should fail when revocation fails with a non-timeout error', async () => {
+    const userId = 'fooUser';
+    signOutUser.mockRejectedValueOnce(new Error('connection refused'));
+    const response = await userRequest.delete(`/users/${userId}`);
+    expect(response.status).toEqual(500);
+    expect(deleteUserById).not.toHaveBeenCalled();
   });
 
   it('DELETE /users/:userId should throw if user is deleting self', async () => {

--- a/packages/core/src/routes/admin-user/basics.ts
+++ b/packages/core/src/routes/admin-user/basics.ts
@@ -10,6 +10,7 @@ import {
   userProfileGuard,
 } from '@logto/schemas';
 import { conditional, yes } from '@silverhand/essentials';
+import { StatementTimeoutError } from '@silverhand/slonik';
 import { boolean, literal, nativeEnum, object, string } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -26,6 +27,7 @@ import {
 } from '#src/libraries/user.utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
+import { getConsoleLogFromContext } from '#src/utils/console.js';
 
 import { parseLegacyPassword } from '../../utils/password.js';
 import { captureDeveloperEvent } from '../../utils/posthog.js';
@@ -484,7 +486,22 @@ export default function adminUserBasicsRoutes<T extends ManagementApiRouter>(
 
       const user = await findUserById(userId);
 
-      await signOutUser(userId);
+      // Revocation is best-effort on deletion: once the user row is gone, the remaining
+      // OIDC instances can no longer be exchanged or introspected since the account fails
+      // to resolve, and they are pruned after expiry. A revocation statement timeout on a
+      // pathological instance count must not leave the user permanently undeletable.
+      try {
+        await signOutUser(userId);
+      } catch (error: unknown) {
+        if (!(error instanceof StatementTimeoutError)) {
+          throw error;
+        }
+        getConsoleLogFromContext(ctx).error(
+          `Failed to revoke sessions and tokens for user ${userId} before deletion. Proceeding with the deletion; remaining instances are left to expire.`,
+          error
+        );
+      }
+
       await deleteUserById(userId);
 
       if (tenantId === adminTenantId) {


### PR DESCRIPTION
## Summary

Deleting a user first revokes their sessions and tokens via `signOutUser`. For a user with a pathological number of `oidc_model_instances` rows, a revocation batch can still exceed the database statement timeout, which fails the whole `DELETE /api/users/:userId` request and leaves the user permanently undeletable (observed in production even with the accountId partial index and batched deletes in place).

Revocation is now best-effort on the deletion path: a `StatementTimeoutError` from `signOutUser` is logged and the deletion proceeds. This is safe because once the user row is deleted, the remaining instances are unusable — refresh-token exchange, session interactions, and introspection all fail when the account no longer resolves — and the leftover rows are removed after they expire.

Scope notes:

- Only `StatementTimeoutError` is tolerated; any other revocation error still fails the request.
- The suspension path (`PATCH /users/:userId/is-suspended`) is unchanged: revocation remains mandatory there since it is the enforcement mechanism for suspension.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
