### PR TITLE
feat(core): filter resource scopes by the cimd tenant ceiling

### DIFF
--- a/packages/core/src/oidc/cimd/resource-scopes.test.ts
+++ b/packages/core/src/oidc/cimd/resource-scopes.test.ts
@@ -1,0 +1,101 @@
+import { ReservedResource } from '@logto/core-kit';
+import { type OrganizationScope, type Scope } from '@logto/schemas';
+
+import { MockQueries } from '#src/test-utils/tenant.js';
+
+import { filterResourceScopesForTheCimdClient } from './resource-scopes.js';
+
+const { jest } = import.meta;
+
+const indicator = 'https://foo.logto.io/api';
+const resourceId = 'resource_id';
+
+const buildScope = (id: string, name: string): Scope => ({
+  tenantId: 'tenant_id',
+  id,
+  resourceId,
+  name,
+  description: null,
+  createdAt: 0,
+});
+
+const buildOrganizationScope = (id: string, name: string): OrganizationScope => ({
+  tenantId: 'tenant_id',
+  id,
+  name,
+  description: null,
+});
+
+const buildCeilingQueries = ({
+  resourceScopes = [],
+  organizationResourceScopes = [],
+  organizationScopes = [],
+}: {
+  resourceScopes?: readonly Scope[];
+  organizationResourceScopes?: readonly Scope[];
+  organizationScopes?: readonly OrganizationScope[];
+}) =>
+  new MockQueries({
+    cimd: {
+      resourceScopes: {
+        insert: jest.fn(),
+        findAll: jest.fn().mockResolvedValue(resourceScopes),
+        delete: jest.fn(),
+      },
+      organizationResourceScopes: {
+        insert: jest.fn(),
+        findAll: jest.fn().mockResolvedValue(organizationResourceScopes),
+        delete: jest.fn(),
+      },
+      organizationScopes: {
+        insert: jest.fn(),
+        findAll: jest.fn().mockResolvedValue(organizationScopes),
+        delete: jest.fn(),
+      },
+    },
+  });
+
+describe('filterResourceScopesForTheCimdClient', () => {
+  it('should keep only the scopes within the resource and organization resource ceilings', async () => {
+    const queries = buildCeilingQueries({
+      resourceScopes: [buildScope('scope_1', 'read:api')],
+      organizationResourceScopes: [buildScope('scope_3', 'read:organization-api')],
+    });
+
+    const filtered = await filterResourceScopesForTheCimdClient(queries, indicator, [
+      buildScope('scope_1', 'read:api'),
+      buildScope('scope_2', 'write:api'),
+      buildScope('scope_3', 'read:organization-api'),
+    ]);
+
+    expect(filtered.map(({ name }) => name)).toEqual(['read:api', 'read:organization-api']);
+  });
+
+  it('should drop every scope when the ceiling is empty', async () => {
+    const queries = buildCeilingQueries({});
+
+    const filtered = await filterResourceScopesForTheCimdClient(queries, indicator, [
+      buildScope('scope_1', 'read:api'),
+      buildScope('scope_2', 'write:api'),
+    ]);
+
+    expect(filtered).toEqual([]);
+  });
+
+  it('should filter the reserved organization resource through the organization scope ceiling', async () => {
+    const queries = buildCeilingQueries({
+      organizationScopes: [buildOrganizationScope('org_scope_1', 'read:members')],
+    });
+
+    const filtered = await filterResourceScopesForTheCimdClient(
+      queries,
+      ReservedResource.Organization,
+      [
+        { id: 'org_scope_1', name: 'read:members' },
+        { id: 'org_scope_2', name: 'manage:members' },
+      ]
+    );
+
+    expect(filtered.map(({ name }) => name)).toEqual(['read:members']);
+  });
+});

--- a/packages/core/src/oidc/cimd/resource-scopes.ts
+++ b/packages/core/src/oidc/cimd/resource-scopes.ts
@@ -1,0 +1,58 @@
+// DEV: CIMD (client ID metadata document) support
+/**
+ * @overview The tenant-wide CIMD permission ceiling filter for resource scopes.
+ */
+
+import { ReservedResource } from '@logto/core-kit';
+
+import type Queries from '#src/tenants/Queries.js';
+
+import { isReservedResource } from '../resource.js';
+
+/**
+ * Filter out the scopes that fall outside the tenant-wide CIMD permission ceiling.
+ *
+ * CIMD clients are unregistered, so there is no application-level user consent configuration
+ * to consult — the tenant-wide ceiling tables take that role, with the same filtering shape
+ * as `filterResourceScopesForTheThirdPartyApplication`. Out-of-ceiling scopes are
+ * silently dropped before they can enter a grant: consent computes missing scopes against
+ * the filtered set, and the refresh-token resource path re-intersects with it on every
+ * issuance. On the authorization-code path the persisted grant stays authoritative until
+ * revoked — the same enforcement geometry as third-party applications.
+ */
+export const filterResourceScopesForTheCimdClient = async (
+  { cimd }: Queries,
+  indicator: string,
+  scopes: ReadonlyArray<{ name: string; id: string }>
+) => {
+  if (isReservedResource(indicator)) {
+    switch (indicator) {
+      case ReservedResource.Organization: {
+        const ceilingOrganizationScopes = await cimd.organizationScopes.findAll();
+        const ceilingOrganizationScopeIds = new Set(ceilingOrganizationScopes.map(({ id }) => id));
+
+        return scopes.filter(({ id }) => ceilingOrganizationScopeIds.has(id));
+      }
+      // Mirror the third-party filter: other reserved resources are not ceiling-governed
+      // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
+      default: {
+        return scopes;
+      }
+    }
+  }
+
+  /**
+   * A resource can sit behind the ceiling as a plain API resource or as an organization
+   * resource; scope ids are globally unique, so the flat union mirrors the third-party
+   * filter's per-indicator merge of the two application consent tables.
+   */
+  const [ceilingResourceScopes, ceilingOrganizationResourceScopes] = await Promise.all([
+    cimd.resourceScopes.findAll(),
+    cimd.organizationResourceScopes.findAll(),
+  ]);
+  const ceilingScopeIds = new Set(
+    [...ceilingResourceScopes, ...ceilingOrganizationResourceScopes].map(({ id }) => id)
+  );
+
+  return scopes.filter(({ id }) => ceilingScopeIds.has(id));
+};

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- provider init tests share one harness; splitting fragments the shared mock setup. */
 import assert from 'node:assert';
 
 import { defaultTenantId, GrantType, type Scope } from '@logto/schemas';
@@ -66,6 +67,20 @@ class MockEcEnvSet extends EnvSet {
 }
 
 const ecEnvSet = new MockEcEnvSet(defaultTenantId, EnvSet.values.dbUrl);
+
+// DEV: CIMD (client ID metadata document) support
+/**
+ * The tenant-level `cimdEnabled` flag is the only effective-enablement input the jest
+ * environment leaves off (dev features and SSRF protection are both on), so flipping it is
+ * enough to exercise the CIMD paths.
+ */
+class MockCimdEnvSet extends EnvSet {
+  override get oidc(): EnvSet['oidc'] {
+    return { ...mockEnvSet.oidc, cimdEnabled: true };
+  }
+}
+
+const cimdEnvSet = new MockCimdEnvSet(defaultTenantId, EnvSet.values.dbUrl);
 
 const createTestClient = (): KoaContextWithOIDC['oidc']['client'] => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub for OIDC context testing
@@ -420,6 +435,87 @@ describe('oidc provider init', () => {
   });
 });
 
+// DEV: CIMD (client ID metadata document) support
+describe('getResourceServerInfo for CIMD clients', () => {
+  const cimdClientId = 'https://client.example.com/client-metadata.json';
+
+  const createCimdContext = (provider: KoaContextWithOIDC['oidc']['provider']) =>
+    createContext(provider, { grantType: GrantType.AuthorizationCode, clientId: cimdClientId });
+
+  it('should filter resource scopes through the tenant ceiling without touching the applications table', async () => {
+    const findResourceByIndicator = jest.fn().mockResolvedValue({
+      ...mockResource,
+      indicator,
+      accessTokenTtl: 3600,
+    });
+    const findApplicationById = jest.fn();
+    const findUserScopesForResourceIndicator = jest
+      .fn()
+      .mockResolvedValue([
+        buildScope('scope_1', 'read:api'),
+        buildScope('scope_2', 'write:api'),
+        buildScope('scope_3', 'read:organization-api'),
+      ]);
+    const tenant = new MockTenant(undefined, {
+      resources: { findResourceByIndicator },
+      applications: { findApplicationById },
+      cimd: {
+        resourceScopes: {
+          insert: jest.fn(),
+          findAll: jest.fn().mockResolvedValue([buildScope('scope_1', 'read:api')]),
+          delete: jest.fn(),
+        },
+        organizationResourceScopes: {
+          insert: jest.fn(),
+          findAll: jest.fn().mockResolvedValue([buildScope('scope_3', 'read:organization-api')]),
+          delete: jest.fn(),
+        },
+      },
+    });
+
+    tenant.setPartial('libraries', {
+      users: { findUserScopesForResourceIndicator },
+    });
+
+    const { id, queries, libraries, logtoConfigs, subscription } = tenant;
+    const provider = initOidc(id, cimdEnvSet, queries, libraries, logtoConfigs, subscription);
+    const ctx = createCimdContext(provider);
+
+    const result = await getResourceServerInfo(ctx, indicator);
+
+    expect(result.scope).toBe('read:api read:organization-api');
+    expect(findApplicationById).not.toHaveBeenCalled();
+  });
+
+  it('should keep the legacy application lookup when CIMD is not effectively enabled', async () => {
+    const findResourceByIndicator = jest.fn().mockResolvedValue({
+      ...mockResource,
+      indicator,
+      accessTokenTtl: 3600,
+    });
+    const findApplicationById = jest.fn().mockRejectedValue(new Error('not found'));
+    const findUserScopesForResourceIndicator = jest
+      .fn()
+      .mockResolvedValue([buildScope('scope_1', 'read:api'), buildScope('scope_2', 'write:api')]);
+    const tenant = new MockTenant(undefined, {
+      resources: { findResourceByIndicator },
+      applications: { findApplicationById },
+    });
+
+    tenant.setPartial('libraries', {
+      users: { findUserScopesForResourceIndicator },
+    });
+
+    const provider = createProvider(tenant);
+    const ctx = createCimdContext(provider);
+
+    const result = await getResourceServerInfo(ctx, indicator);
+
+    expect(result.scope).toBe('read:api write:api');
+    expect(findApplicationById).toHaveBeenCalledWith(cimdClientId);
+  });
+});
+
 const findAccount = async (findUserById: () => Promise<typeof mockUser>) => {
   const provider = createProvider(new MockTenant(undefined, { users: { findUserById } }));
   const configuration = getProviderConfiguration(provider);
@@ -447,3 +543,4 @@ describe('findAccount', () => {
     ).rejects.toMatchError(new errors.InvalidGrant('user is suspended'));
   });
 });
+/* eslint-enable max-lines */

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -55,7 +55,9 @@ import {
   hasAppLevelAccessControlChecked,
   markAppLevelAccessControlCheckedForOidcContext,
 } from './application-access-control.js';
-import { buildClientIdMetadataDocumentFeature } from './cimd/index.js';
+import { isCimdClientId } from './cimd/client-id.js';
+import { buildClientIdMetadataDocumentFeature, isCimdEffectivelyEnabled } from './cimd/index.js';
+import { filterResourceScopesForTheCimdClient } from './cimd/resource-scopes.js';
 import defaults from './defaults.js';
 import { deviceFlowConfig, defaultDeviceCodeTtl } from './device-flow.js';
 import {
@@ -124,6 +126,22 @@ export default function initOidc(
       applicationId: clientId,
       userId,
     });
+
+    // DEV: CIMD (client ID metadata document) support
+    if (clientId && isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)) {
+      /**
+       * CIMD clients are unregistered: the tenant-wide ceiling replaces the per-application
+       * consent configuration, and the client identifier URL must never be used to query the
+       * applications table (which the third-party check below would do).
+       */
+      const filteredScopes = await filterResourceScopesForTheCimdClient(queries, indicator, scopes);
+
+      return {
+        ...getSharedResourceServerData(envSet),
+        accessTokenTTL,
+        scope: filteredScopes.map(({ name }) => name).join(' '),
+      };
+    }
 
     if (clientId && (await isThirdPartyApplication(queries, clientId))) {
       const filteredScopes = await filterResourceScopesForTheThirdPartyApplication(

--- a/packages/core/src/oidc/resource.ts
+++ b/packages/core/src/oidc/resource.ts
@@ -7,7 +7,7 @@ import { type EnvSet } from '#src/env-set/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
-const isReservedResource = (indicator: string): indicator is ReservedResource =>
+export const isReservedResource = (indicator: string): indicator is ReservedResource =>
   // eslint-disable-next-line no-restricted-syntax -- it's the best way to do it
   Object.values(ReservedResource).includes(indicator as ReservedResource);
 


### PR DESCRIPTION
## Summary

Apply the tenant-wide CIMD permission ceiling to resource scope resolution in `getResourceServerInfo`, mirroring the third-party application filter with the tenant-level ceiling tables in place of the application consent tables — the resource-side counterpart of the user-scope takeover in #9357 (LOG-13927).

- The CIMD branch runs ahead of the third-party check, so the client identifier URL is never used to query the `applications` table on this path.
- API resource scopes are intersected with the `cimd_resource_scopes` + `cimd_organization_resource_scopes` ceiling; the reserved organization resource goes through `cimd_organization_scopes`. Out-of-ceiling scopes never enter new grants.
- Enforcement geometry (third-party parity): the ceiling gates what enters a grant at consent, and the refresh-token resource path re-intersects with the current ceiling on every issuance; on the authorization-code path the persisted grant stays authoritative until revoked. Organization token issuance (the `organization_id` + no `resource` refresh branch) is tracked by LOG-13930.

Stacked on #9357.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
