### PR TITLE
perf(core): lower the revocation batch size to 500

### DIFF
--- a/packages/core/src/queries/oidc-model-instance.test.ts
+++ b/packages/core/src/queries/oidc-model-instance.test.ts
@@ -301,7 +301,7 @@ describe('oidc-model-instance query', () => {
     await destroyInstanceById(instance.modelName, instance.id);
   });
 
-  const revokeBatchSize = 2000;
+  const revokeBatchSize = 500;
   const revokeCases = {
     revokeInstanceByGrantId: {
       revoke: async (target: string) => revokeInstanceByGrantId(instance.modelName, target),
@@ -334,12 +334,12 @@ describe('oidc-model-instance query', () => {
   } as const;
 
   it.each([
-    ['revokeInstanceByGrantId', [2000, 0]],
+    ['revokeInstanceByGrantId', [500, 0]],
     // A partial batch must not end the loop — see the early-exit bug closed in #9151.
-    ['revokeInstanceByGrantId', [1200, 200, 0]],
-    ['revokeInstanceByUserId', [2000, 0]],
-    ['revokeInstanceByUserId', [1200, 200, 0]],
-    ['revokeInstanceByUserId', [2000, undefined]],
+    ['revokeInstanceByGrantId', [300, 200, 0]],
+    ['revokeInstanceByUserId', [500, 0]],
+    ['revokeInstanceByUserId', [300, 200, 0]],
+    ['revokeInstanceByUserId', [500, undefined]],
   ] as const)('%s deletes in batches until drained %j', async (method, rowCounts) => {
     const target = 'target-id';
     const { revoke, expectSql } = revokeCases[method];

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -32,7 +32,12 @@ const sessionModelName = 'Session';
  */
 // Hard-code this value since 3 seconds is a reasonable number for concurrency and no need for further configuration
 const refreshTokenReuseInterval = 3;
-const revokeInstanceBatchSize = 2000;
+/**
+ * Kept small because each deleted row also updates every index on the table, so the
+ * per-statement random I/O must fit within a storage-throttled moment without hitting
+ * the statement timeout.
+ */
+const revokeInstanceBatchSize = 500;
 /** Safety valve so a revocation request stays bounded even for pathological instance counts. */
 const maxRevokeInstanceBatches = 1000;
 /** Fixed-length array to drive the bounded batch loop without a mutable counter. */


### PR DESCRIPTION
## Summary

Production statement-timeout kills on the batched revocation deletes (both the `accountId` and `grantId` paths — they share `revokeInstancesInBatches`) are episodic and hit correctly-planned statements: the plans are verified index-backed, but a 2000-row batch also performs leaf maintenance in every index on `oidc_model_instances` (nine indexes, ~17 GB), so a single statement can issue tens of thousands of random I/Os against mostly cold pages. During storage-stall episodes that is enough to exceed the 60s statement timeout.

Lowering the batch size to 500 quarters the per-statement I/O so each statement stays comfortably inside a degraded moment. Total work is unchanged — the loop simply runs more, shorter statements. The 1000-batch safety cap is intentionally unchanged: the per-request ceiling drops from 2M to 500k rows per model, which observed data (the affected users have tens of rows) shows is not a practical constraint, and cap overruns are error-logged and left for a retry.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
