### PR TITLE
feat(core): isolate cimd from application acl and auto-consent

### DIFF
--- a/packages/core/src/event-listeners/authorization-success.test.ts
+++ b/packages/core/src/event-listeners/authorization-success.test.ts
@@ -1,6 +1,7 @@
 import { appInsights } from '@logto/app-insights/node';
 import { LogResult, type ExceptionHookEvent } from '@logto/schemas';
 
+import { mockEnvSet } from '#src/test-utils/env-set.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
@@ -78,6 +79,7 @@ describe('createAuthorizationSuccessListener', () => {
     const findUserActiveGrantsByClientId = jest.fn(async () => []);
 
     const listener = createAuthorizationSuccessListener(
+      mockEnvSet,
       // @ts-expect-error Provider mock is enough for unit test
       provider,
       new MockQueries({
@@ -139,6 +141,7 @@ describe('createAuthorizationSuccessListener', () => {
     ]);
 
     const listener = createAuthorizationSuccessListener(
+      mockEnvSet,
       // @ts-expect-error Provider mock is enough for unit test
       provider,
       new MockQueries({
@@ -220,6 +223,7 @@ describe('createAuthorizationSuccessListener', () => {
     });
 
     const listener = createAuthorizationSuccessListener(
+      mockEnvSet,
       // @ts-expect-error Provider mock is enough for unit test
       provider,
       new MockQueries({
@@ -261,6 +265,7 @@ describe('createAuthorizationSuccessListener', () => {
     });
 
     const listener = createAuthorizationSuccessListener(
+      mockEnvSet,
       // @ts-expect-error Provider mock is enough for unit test
       provider,
       new MockQueries({
@@ -297,6 +302,7 @@ describe('createAuthorizationSuccessListener', () => {
       },
     ]);
     const listener = createAuthorizationSuccessListener(
+      mockEnvSet,
       // @ts-expect-error Provider mock is enough for unit test
       provider,
       new MockQueries({
@@ -353,6 +359,7 @@ describe('createAuthorizationSuccessListener', () => {
     });
 
     const listener = createAuthorizationSuccessListener(
+      mockEnvSet,
       // @ts-expect-error Provider mock is enough for unit test
       provider,
       new MockQueries({

--- a/packages/core/src/event-listeners/authorization-success.ts
+++ b/packages/core/src/event-listeners/authorization-success.ts
@@ -8,6 +8,7 @@ import { type ConsoleLog } from '@logto/shared';
 import { trySafe } from '@silverhand/essentials';
 import type { KoaContextWithOIDC, Provider } from 'oidc-provider';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { createSessionLibrary } from '#src/libraries/session/index.js';
 import { assertLogContext, type LogContext } from '#src/middleware/koa-audit-log.js';
@@ -66,6 +67,7 @@ const getGrantIdsToRevokeForMaxAllowedGrants = ({
 
 const enforceMaxAllowedGrantsRevocation = async (
   ctx: KoaContextWithOIDC & LogContext,
+  envSet: EnvSet,
   provider: Provider,
   queries: Queries,
   triggerEvent?: TriggerEvent
@@ -94,7 +96,7 @@ const enforceMaxAllowedGrantsRevocation = async (
 
   const revokeGrantsLog = ctx.createLog('RevokeGrants');
   revokeGrantsLog.append({
-    ...extractInteractionContext(ctx),
+    ...extractInteractionContext(envSet, ctx),
     revokeGrantIds: grantIdsToRevoke,
     reason: 'maxAllowedGrants limit reached',
   });
@@ -181,12 +183,13 @@ const enforceMaxAllowedGrantsRevocation = async (
 };
 
 export const createAuthorizationSuccessListener = (
+  envSet: EnvSet,
   provider: Provider,
   queries: Queries,
   triggerEvent?: TriggerEvent
 ) => {
   return async (ctx: KoaContextWithOIDC) => {
     assertLogContext(ctx);
-    await enforceMaxAllowedGrantsRevocation(ctx, provider, queries, triggerEvent);
+    await enforceMaxAllowedGrantsRevocation(ctx, envSet, provider, queries, triggerEvent);
   };
 };

--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -1,11 +1,14 @@
 import type { LogKey } from '@logto/schemas';
 import { LogResult, token } from '@logto/schemas';
+import Sinon from 'sinon';
 
+import { EnvSet } from '#src/env-set/index.js';
+import { mockEnvSet } from '#src/test-utils/env-set.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { stringifyError } from '#src/utils/format.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
-import { grantListener, grantRevocationListener } from './grant.js';
+import { createGrantListener, createGrantRevocationListener } from './grant.js';
 
 const { jest } = import.meta;
 
@@ -23,6 +26,17 @@ const entities = {
 
 const baseCallArgs = { applicationId, sessionId, userId };
 
+const buildCimdContext = (clientId: string) => ({
+  ...createContextWithRouteParameters(),
+  createLog: log.createLog,
+  prependAllLogEntries: log.prependAllLogEntries,
+  oidc: {
+    entities: { ...entities, Client: { clientId } },
+    params: { grant_type: 'refresh_token' },
+  },
+  body: { access_token: 'newAccessTokenValue' },
+});
+
 const testGrantListener = (
   parameters: { grant_type: string } & Record<string, unknown>,
   body: Record<string, string>,
@@ -39,7 +53,7 @@ const testGrantListener = (
   };
 
   // @ts-expect-error pass complex type check to mock ctx directly
-  grantListener(ctx, expectError);
+  createGrantListener(mockEnvSet)(ctx, expectError);
   expect(log.createLog).toHaveBeenCalledWith(expectLogKey);
   expect(log.mockAppend).toHaveBeenCalledWith({
     ...baseCallArgs,
@@ -118,6 +132,59 @@ describe('grantSuccessListener', () => {
   });
 });
 
+// DEV: CIMD (client ID metadata document) support
+describe('grantSuccessListener while CIMD is effectively enabled', () => {
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  /**
+   * The gate reads only `oidc.cimdEnabled` from the tenant env set; the static flags are
+   * stubbed onto `EnvSet.values` below.
+   */
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
+  const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
+
+  beforeEach(() => {
+    Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      isDevFeaturesEnabled: true,
+      isOidcProviderSsrfProtectionEnabled: true,
+    });
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+    jest.clearAllMocks();
+  });
+
+  it('should log a cimd client identifier under the dedicated key', () => {
+    const ctx = buildCimdContext(cimdClientId);
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    createGrantListener(cimdEnvSet)(ctx);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      cimdClientId,
+      sessionId,
+      userId,
+      tokenTypes: [token.TokenType.AccessToken],
+      params: { grant_type: 'refresh_token' },
+    });
+  });
+
+  it('should keep a url-shaped identifier under applicationId when CIMD is not effectively enabled', () => {
+    const ctx = buildCimdContext(cimdClientId);
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    createGrantListener(mockEnvSet)(ctx);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      applicationId: cimdClientId,
+      sessionId,
+      userId,
+      tokenTypes: [token.TokenType.AccessToken],
+      params: { grant_type: 'refresh_token' },
+    });
+  });
+});
+
 describe('grantErrorListener', () => {
   const errorMessage = 'error ocurred';
 
@@ -176,7 +243,7 @@ describe('grantRevocationListener', () => {
     };
 
     // @ts-expect-error pass complex type check to mock ctx directly
-    grantRevocationListener(ctx, grantId);
+    createGrantRevocationListener(mockEnvSet)(ctx, grantId);
     expect(log.createLog).toHaveBeenCalledWith('RevokeToken');
     expect(log.mockAppend).toHaveBeenCalledWith({
       applicationId,
@@ -205,7 +272,7 @@ describe('grantRevocationListener', () => {
     };
 
     // @ts-expect-error pass complex type check to mock ctx directly
-    grantRevocationListener(ctx, grantId);
+    createGrantRevocationListener(mockEnvSet)(ctx, grantId);
     expect(log.createLog).toHaveBeenCalledWith('RevokeToken');
     expect(log.mockAppend).toHaveBeenCalledWith({
       applicationId,

--- a/packages/core/src/event-listeners/grant.ts
+++ b/packages/core/src/event-listeners/grant.ts
@@ -2,6 +2,7 @@ import { GrantType, LogResult, token } from '@logto/schemas';
 import type { errors, KoaContextWithOIDC } from 'oidc-provider';
 import { z } from 'zod';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import { assertLogContext } from '#src/middleware/koa-audit-log.js';
 
 import { stringifyError } from '../utils/format.js';
@@ -13,49 +14,51 @@ import { extractInteractionContext } from './utils.js';
  * @see {@link https://github.com/panva/node-oidc-provider/blob/v7.x/lib/actions/token.js#L71 Success event emission}
  * @see {@link https://github.com/panva/node-oidc-provider/blob/v7.x/lib/shared/error_handler.js OIDC Provider error handler}
  */
-export const grantListener = (ctx: KoaContextWithOIDC, error?: errors.OIDCProviderError) => {
-  assertLogContext(ctx);
+export const createGrantListener =
+  (envSet: EnvSet) => (ctx: KoaContextWithOIDC, error?: errors.OIDCProviderError) => {
+    assertLogContext(ctx);
 
-  const { params } = ctx.oidc;
+    const { params } = ctx.oidc;
 
-  const log = ctx.createLog(
-    `${token.Type.ExchangeTokenBy}.${getExchangeByType(params?.grant_type)}`
-  );
+    const log = ctx.createLog(
+      `${token.Type.ExchangeTokenBy}.${getExchangeByType(params?.grant_type)}`
+    );
 
-  const parsedBody = grantBodyGuard.safeParse(ctx.body);
-  const { access_token, refresh_token, id_token, scope } = parsedBody.success
-    ? parsedBody.data
-    : emptyGrantBody;
-  const tokenTypes = [
-    access_token && token.TokenType.AccessToken,
-    refresh_token && token.TokenType.RefreshToken,
-    id_token && token.TokenType.IdToken,
-  ].filter(Boolean);
+    const parsedBody = grantBodyGuard.safeParse(ctx.body);
+    const { access_token, refresh_token, id_token, scope } = parsedBody.success
+      ? parsedBody.data
+      : emptyGrantBody;
+    const tokenTypes = [
+      access_token && token.TokenType.AccessToken,
+      refresh_token && token.TokenType.RefreshToken,
+      id_token && token.TokenType.IdToken,
+    ].filter(Boolean);
 
-  log.append({
-    ...extractInteractionContext(ctx),
-    result: error && LogResult.Error,
-    tokenTypes,
-    scope,
-    error: error && stringifyError(error),
-  });
-};
+    log.append({
+      ...extractInteractionContext(envSet, ctx),
+      result: error && LogResult.Error,
+      tokenTypes,
+      scope,
+      error: error && stringifyError(error),
+    });
+  };
 
 // The grant.revoked event is emitted at https://github.com/panva/node-oidc-provider/blob/v7.x/lib/helpers/revoke.js#L25
-export const grantRevocationListener = (ctx: KoaContextWithOIDC, grantId: string) => {
-  assertLogContext(ctx);
+export const createGrantRevocationListener =
+  (envSet: EnvSet) => (ctx: KoaContextWithOIDC, grantId: string) => {
+    assertLogContext(ctx);
 
-  const {
-    entities: { AccessToken, RefreshToken },
-  } = ctx.oidc;
+    const {
+      entities: { AccessToken, RefreshToken },
+    } = ctx.oidc;
 
-  // TODO: Check if this is needed or just use `Account?.accountId`
-  const userId = AccessToken?.accountId ?? RefreshToken?.accountId;
-  const tokenTypes = getRevocationTokenTypes(ctx.oidc);
+    // TODO: Check if this is needed or just use `Account?.accountId`
+    const userId = AccessToken?.accountId ?? RefreshToken?.accountId;
+    const tokenTypes = getRevocationTokenTypes(ctx.oidc);
 
-  const log = ctx.createLog('RevokeToken');
-  log.append({ ...extractInteractionContext(ctx), userId, grantId, tokenTypes });
-};
+    const log = ctx.createLog('RevokeToken');
+    log.append({ ...extractInteractionContext(envSet, ctx), userId, grantId, tokenTypes });
+  };
 
 /**
  * The grant response body. Only the log-relevant fields are guarded; on the `grant.error` event

--- a/packages/core/src/event-listeners/index.test.ts
+++ b/packages/core/src/event-listeners/index.test.ts
@@ -1,11 +1,10 @@
 import { defaultTenantId } from '@logto/schemas';
 
+import { mockEnvSet } from '#src/test-utils/env-set.js';
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
 
-import { grantListener, grantRevocationListener } from './grant.js';
 import { addOidcEventListeners } from './index.js';
-import { interactionEndedListener, interactionStartedListener } from './interaction.js';
 
 const { jest } = import.meta;
 
@@ -17,11 +16,22 @@ describe('addOidcEventListeners', () => {
   it('should add proper listeners', () => {
     const provider = createMockProvider();
     const addListener = jest.spyOn(provider, 'addListener');
-    addOidcEventListeners(defaultTenantId, provider, new MockQueries());
-    expect(addListener).toHaveBeenCalledWith('grant.success', grantListener);
-    expect(addListener).toHaveBeenCalledWith('grant.error', grantListener);
-    expect(addListener).toHaveBeenCalledWith('grant.revoked', grantRevocationListener);
-    expect(addListener).toHaveBeenCalledWith('interaction.started', interactionStartedListener);
-    expect(addListener).toHaveBeenCalledWith('interaction.ended', interactionEndedListener);
+    addOidcEventListeners(defaultTenantId, mockEnvSet, provider, new MockQueries());
+    expect(addListener).toHaveBeenCalledWith('grant.success', expect.any(Function));
+    expect(addListener).toHaveBeenCalledWith('grant.error', expect.any(Function));
+    expect(addListener).toHaveBeenCalledWith('grant.revoked', expect.any(Function));
+    expect(addListener).toHaveBeenCalledWith('interaction.started', expect.any(Function));
+    expect(addListener).toHaveBeenCalledWith('interaction.ended', expect.any(Function));
+  });
+
+  it('should register the same listener for grant success and error', () => {
+    const provider = createMockProvider();
+    const addListener = jest.spyOn(provider, 'addListener');
+    addOidcEventListeners(defaultTenantId, mockEnvSet, provider, new MockQueries());
+
+    const findListener = (event: string) =>
+      addListener.mock.calls.find(([name]) => name === event)?.[1];
+
+    expect(findListener('grant.success')).toBe(findListener('grant.error'));
   });
 });

--- a/packages/core/src/event-listeners/index.ts
+++ b/packages/core/src/event-listeners/index.ts
@@ -1,14 +1,15 @@
 import { appInsights } from '@logto/app-insights/node';
 import { type Provider } from 'oidc-provider';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import { TokenUsageType } from '#src/queries/daily-token-usage.js';
 import type Queries from '#src/tenants/Queries.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import { createAuthorizationSuccessListener, type TriggerEvent } from './authorization-success.js';
-import { grantListener, grantRevocationListener } from './grant.js';
-import { interactionEndedListener, interactionStartedListener } from './interaction.js';
+import { createGrantListener, createGrantRevocationListener } from './grant.js';
+import { createInteractionEndedListener, createInteractionStartedListener } from './interaction.js';
 import { recordActiveUsers } from './record-active-users.js';
 import { deleteSessionExtensions } from './session.js';
 
@@ -18,6 +19,7 @@ import { deleteSessionExtensions } from './session.js';
  */
 export const addOidcEventListeners = (
   tenantId: string,
+  envSet: EnvSet,
   provider: Provider,
   queries: Queries,
   triggerEvent?: TriggerEvent
@@ -32,13 +34,14 @@ export const addOidcEventListeners = (
   const m2mTokenUsageListener = async () =>
     recordTokenUsage(new Date(), { type: TokenUsageType.M2m });
 
+  const grantListener = createGrantListener(envSet);
   provider.addListener('grant.success', grantListener);
   provider.addListener('grant.error', grantListener);
-  provider.addListener('grant.revoked', grantRevocationListener);
+  provider.addListener('grant.revoked', createGrantRevocationListener(envSet));
 
   provider.addListener(
     'authorization.success',
-    createAuthorizationSuccessListener(provider, queries, triggerEvent)
+    createAuthorizationSuccessListener(envSet, provider, queries, triggerEvent)
   );
 
   provider.addListener('access_token.issued', async (token) => {
@@ -47,8 +50,8 @@ export const addOidcEventListeners = (
   provider.addListener('access_token.saved', async (token) => {
     return recordActiveUsers(token, queries);
   });
-  provider.addListener('interaction.started', interactionStartedListener);
-  provider.addListener('interaction.ended', interactionEndedListener);
+  provider.addListener('interaction.started', createInteractionStartedListener(envSet));
+  provider.addListener('interaction.ended', createInteractionEndedListener(envSet));
   provider.addListener('server_error', (ctx, error) => {
     getConsoleLogFromContext(ctx).error('server_error:', error);
 

--- a/packages/core/src/event-listeners/interaction.test.ts
+++ b/packages/core/src/event-listeners/interaction.test.ts
@@ -1,10 +1,11 @@
 import type { LogKey } from '@logto/schemas';
 import type { PromptDetail } from 'oidc-provider';
 
+import { mockEnvSet } from '#src/test-utils/env-set.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
-import { interactionEndedListener, interactionStartedListener } from './interaction.js';
+import { createInteractionEndedListener, createInteractionStartedListener } from './interaction.js';
 
 const { jest } = import.meta;
 
@@ -31,7 +32,9 @@ const prompt: PromptDetail = {
 const baseCallArgs = { applicationId, sessionId, userId };
 
 const testInteractionListener = (
-  listener: typeof interactionStartedListener | typeof interactionEndedListener,
+  listener:
+    | ReturnType<typeof createInteractionStartedListener>
+    | ReturnType<typeof createInteractionEndedListener>,
   parameters: { grant_type: string } & Record<string, unknown>,
   expectLogKey: LogKey,
   expectPrompt?: PromptDetail
@@ -60,7 +63,7 @@ describe('interactionStartedListener', () => {
 
   it('should log proper interaction started info', async () => {
     testInteractionListener(
-      interactionStartedListener,
+      createInteractionStartedListener(mockEnvSet),
       { grant_type: 'authorization_code', code: 'codeValue' },
       'Interaction.Create',
       prompt
@@ -69,7 +72,7 @@ describe('interactionStartedListener', () => {
 
   it('should log proper interaction ended info', async () => {
     testInteractionListener(
-      interactionEndedListener,
+      createInteractionEndedListener(mockEnvSet),
       { grant_type: 'authorization_code', code: 'codeValue' },
       'Interaction.End'
     );

--- a/packages/core/src/event-listeners/interaction.ts
+++ b/packages/core/src/event-listeners/interaction.ts
@@ -1,10 +1,12 @@
 import type { KoaContextWithOIDC, PromptDetail } from 'oidc-provider';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import { assertLogContext } from '#src/middleware/koa-audit-log.js';
 
 import { extractInteractionContext } from './utils.js';
 
 const interactionListener = (
+  envSet: EnvSet,
   event: 'started' | 'ended',
   ctx: KoaContextWithOIDC,
   prompt?: PromptDetail
@@ -12,13 +14,14 @@ const interactionListener = (
   assertLogContext(ctx);
 
   const log = ctx.createLog(`Interaction.${event === 'started' ? 'Create' : 'End'}`);
-  log.append({ ...extractInteractionContext(ctx), prompt });
+  log.append({ ...extractInteractionContext(envSet, ctx), prompt });
 };
 
-export const interactionStartedListener = (ctx: KoaContextWithOIDC, prompt: PromptDetail) => {
-  interactionListener('started', ctx, prompt);
-};
+export const createInteractionStartedListener =
+  (envSet: EnvSet) => (ctx: KoaContextWithOIDC, prompt: PromptDetail) => {
+    interactionListener(envSet, 'started', ctx, prompt);
+  };
 
-export const interactionEndedListener = (ctx: KoaContextWithOIDC) => {
-  interactionListener('ended', ctx);
+export const createInteractionEndedListener = (envSet: EnvSet) => (ctx: KoaContextWithOIDC) => {
+  interactionListener(envSet, 'ended', ctx);
 };

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -1,9 +1,12 @@
 import type { KoaContextWithOIDC } from 'oidc-provider';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
 import type { LogPayload } from '#src/middleware/koa-audit-log.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd.js';
 
 export const extractInteractionContext = (
+  envSet: EnvSet,
   ctx: WithAppSecretContext<KoaContextWithOIDC>
 ): LogPayload => {
   const {
@@ -12,7 +15,8 @@ export const extractInteractionContext = (
   } = ctx.oidc;
 
   return {
-    applicationId: Client?.clientId,
+    // DEV: CIMD (client ID metadata document) support
+    ...getClientIdentifierPayload(envSet, Client?.clientId),
     applicationSecret: ctx.appSecret,
     sessionId: Session?.jti,
     interactionId: Interaction?.jti,

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -82,7 +82,8 @@ type ActionEventSource<Event> =
 type RunActionData<Event> = ActionEventSource<Event> & {
   key: LogtoActionKey;
   auditContext: Pick<LogContext, 'createLog'> &
-    Pick<LogPayload, 'applicationId' | 'sessionId' | 'userId'>;
+    // DEV: CIMD (client ID metadata document) support
+    Pick<LogPayload, 'applicationId' | 'cimdClientId' | 'sessionId' | 'userId'>;
 };
 
 type ActionExecutionErrorHandlingData = {

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -127,7 +127,8 @@ export const createHookLibrary = (queries: Queries) => {
       return;
     }
 
-    const { interactionEvent, sessionId, applicationId, userIp, userAgent } = metadata;
+    const { interactionEvent, sessionId, applicationId, cimdClientId, userIp, userAgent } =
+      metadata;
 
     const found = await findAllHooks();
 
@@ -173,6 +174,8 @@ export const createHookLibrary = (queries: Queries) => {
         userIp,
         user: user && pick(user, ...userInfoSelectFields),
         application: application && pick(application, 'id', 'type', 'name', 'description'),
+        // DEV: CIMD (client ID metadata document) support
+        cimdClientId,
       } satisfies BetterOmit<InteractionHookEventPayload, 'hookId'>;
 
       // eslint-disable-next-line @silverhand/fp/no-mutating-methods

--- a/packages/core/src/middleware/koa-app-access-control.test.ts
+++ b/packages/core/src/middleware/koa-app-access-control.test.ts
@@ -1,5 +1,7 @@
 import type { Provider } from 'oidc-provider';
+import Sinon from 'sinon';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -44,7 +46,7 @@ describe('koaAppAccessControl middleware', () => {
       // @ts-expect-error
       session: { accountId: 'user-id' },
     });
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await guard(ctx, next);
 
@@ -60,7 +62,7 @@ describe('koaAppAccessControl middleware', () => {
       session: { accountId: 'user-id' },
       result: markAppLevelAccessControlChecked(undefined, 'app-id', 'user-id'),
     });
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await guard(ctx, next);
 
@@ -76,7 +78,7 @@ describe('koaAppAccessControl middleware', () => {
       session: { accountId: 'user-id' },
       lastSubmission: markAppLevelAccessControlChecked(undefined, 'app-id', 'user-id'),
     });
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await guard(ctx, next);
 
@@ -92,7 +94,7 @@ describe('koaAppAccessControl middleware', () => {
       session: { accountId: 'user-id' },
     });
     assertUserHasApplicationAccess.mockRejectedValueOnce(new RequestError('oidc.access_denied'));
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await expect(guard(ctx, next)).rejects.toMatchObject({ code: 'oidc.access_denied' });
     expect(ctx.interactionDetails.persist).not.toHaveBeenCalled();
@@ -104,8 +106,74 @@ describe('koaAppAccessControl middleware', () => {
       params: { client_id: 'app-id' },
       session: undefined,
     });
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await expect(guard(ctx, next)).rejects.toThrow(new RequestError({ code: 'session.not_found' }));
+  });
+
+  // DEV: CIMD (client ID metadata document) support
+  describe('while CIMD is effectively enabled', () => {
+    const cimdClientId = 'https://client.example.com/metadata.json';
+
+    /**
+     * The gate reads only `oidc.cimdEnabled` from the tenant env set; the static flags are
+     * stubbed onto `EnvSet.values` below.
+     */
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
+    const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
+
+    beforeEach(() => {
+      Sinon.stub(EnvSet, 'values').value({
+        ...EnvSet.values,
+        isDevFeaturesEnabled: true,
+        isOidcProviderSsrfProtectionEnabled: true,
+      });
+    });
+
+    afterEach(() => {
+      Sinon.restore();
+    });
+
+    it('should skip the application access check for a cimd client', async () => {
+      const ctx = createContext({
+        params: { client_id: cimdClientId },
+        // @ts-expect-error
+        session: { accountId: 'user-id' },
+      });
+      const guard = koaAppAccessControl(cimdEnvSet, mockTenant.libraries);
+
+      await guard(ctx, next);
+
+      expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should keep the access check for a url client id when CIMD is not effectively enabled', async () => {
+      const ctx = createContext({
+        params: { client_id: cimdClientId },
+        // @ts-expect-error
+        session: { accountId: 'user-id' },
+      });
+      const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
+
+      await guard(ctx, next);
+
+      expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(cimdClientId, 'user-id');
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should keep the access check for a registered client while CIMD is effectively enabled', async () => {
+      const ctx = createContext({
+        params: { client_id: 'app-id' },
+        // @ts-expect-error
+        session: { accountId: 'user-id' },
+      });
+      const guard = koaAppAccessControl(cimdEnvSet, mockTenant.libraries);
+
+      await guard(ctx, next);
+
+      expect(assertUserHasApplicationAccess).toHaveBeenCalledWith('app-id', 'user-id');
+      expect(next).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/middleware/koa-app-access-control.ts
+++ b/packages/core/src/middleware/koa-app-access-control.ts
@@ -1,9 +1,12 @@
 import { type MiddlewareType } from 'koa';
 import { errors } from 'oidc-provider';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import { hasAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
+import { isCimdClientId } from '#src/oidc/cimd-client-id.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -11,7 +14,7 @@ export default function koaAppAccessControl<
   StateT,
   ContextT extends WithInteractionDetailsContext,
   ResponseBodyT,
->(libraries: Libraries): MiddlewareType<StateT, ContextT, ResponseBodyT> {
+>(envSet: EnvSet, libraries: Libraries): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   return async (ctx, next) => {
     const {
       params: { client_id: clientId },
@@ -23,6 +26,16 @@ export default function koaAppAccessControl<
       clientId && typeof clientId === 'string',
       new errors.InvalidClient('client must be available')
     );
+
+    // DEV: CIMD (client ID metadata document) support
+    if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)) {
+      /**
+       * Application-level access control only applies to registered applications; the library's
+       * fallback lookup would query the applications table with the identifier URL and deny on
+       * not-found.
+       */
+      return next();
+    }
 
     if (
       hasAppLevelAccessControlChecked(ctx.interactionDetails.result, clientId, session.accountId)

--- a/packages/core/src/middleware/koa-auto-consent.ts
+++ b/packages/core/src/middleware/koa-auto-consent.ts
@@ -27,8 +27,6 @@ const shouldAutoConsentApplication = async (clientId: string, query: Queries, en
     /**
      * Registered application ids never take the URL shape, and authorization has already
      * resolved this client — a URL here is a CIMD client, which is never first-party.
-     * TODO: @xiaoyijun support CIMD clients on the rest of the experience consent flow
-     * (consent info and guards).
      */
     return false;
   }

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -30,6 +30,7 @@ import { isAccessDeniedError, parseCustomJwtResponseError } from '#src/utils/cus
 import { i18next } from '#src/utils/i18n.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
+import { getClientIdentifierPayload } from './cimd.js';
 import { tokenExchangeActGuard } from './grants/token-exchange/types.js';
 
 const hasI18n = (ctx: KoaContextWithOIDC): ctx is KoaContextWithOIDC & { i18n: i18n } =>
@@ -273,7 +274,8 @@ export const getExtraTokenClaimsForJwtCustomization = async (
 
     logEntry.append({
       sessionId: ctx.oidc.session?.uid,
-      applicationId: ctx.oidc.client?.clientId,
+      // DEV: CIMD (client ID metadata document) support
+      ...getClientIdentifierPayload(envSet, ctx.oidc.client?.clientId),
       ...conditional(logtoUserInfo && { userId: logtoUserInfo.id }),
       tenantId: envSet.tenantId,
     });

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -30,7 +30,8 @@ import { isAccessDeniedError, parseCustomJwtResponseError } from '#src/utils/cus
 import { i18next } from '#src/utils/i18n.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
-import { getClientIdentifierPayload } from './cimd.js';
+import { isCimdClientId } from './cimd-client-id.js';
+import { getClientIdentifierPayload, isCimdEffectivelyEnabled } from './cimd.js';
 import { tokenExchangeActGuard } from './grants/token-exchange/types.js';
 
 const hasI18n = (ctx: KoaContextWithOIDC): ctx is KoaContextWithOIDC & { i18n: i18n } =>
@@ -245,8 +246,17 @@ export const getExtraTokenClaimsForJwtCustomization = async (
     );
 
     const clientId = token.clientId ?? ctx.oidc.client?.clientId;
+    // DEV: CIMD (client ID metadata document) support
+    /**
+     * CIMD clients are unregistered, so there is no application context to expose and the
+     * identifier URL must never be used to query the applications table.
+     */
+    const isCimdClient =
+      clientId !== undefined && isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId);
     const applicationContext = conditional(
-      clientId && (await libraries.jwtCustomizers.getApplicationContext(envSet.tenantId, clientId))
+      clientId &&
+        !isCimdClient &&
+        (await libraries.jwtCustomizers.getApplicationContext(envSet.tenantId, clientId))
     );
 
     // For organization (API resource) tokens, expose the target organization so the customizer

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -1,8 +1,10 @@
+/* eslint-disable max-lines */
 import { UserScope } from '@logto/core-kit';
 import { type KoaContextWithOIDC, errors, type Adapter } from 'oidc-provider';
 import Sinon from 'sinon';
 
 import { mockApplication } from '#src/__mocks__/index.js';
+import { type EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import { createOidcContext } from '#src/test-utils/oidc-provider.js';
@@ -443,3 +445,87 @@ describe('refresh token grant', () => {
     });
   });
 });
+
+// DEV: CIMD (client ID metadata document) support
+describe('refresh token grant for CIMD clients', () => {
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  /**
+   * The gate reads only `oidc.cimdEnabled` from the tenant env set; the jest environment keeps
+   * the dev-features and SSRF-protection static flags on already.
+   */
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
+  const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
+
+  const cimdClient: Client = {
+    clientId: cimdClientId,
+    grantTypeAllowed: jest.fn().mockResolvedValue(true),
+    clientAuthMethod: 'none',
+    metadata: jest.fn(() => ({ client_id: cimdClientId })),
+  } as unknown as Client;
+
+  const buildCimdHandler = (tenant: MockTenant, envSet: EnvSet = cimdEnvSet) =>
+    buildHandler(envSet, tenant.queries, { assertUserHasApplicationAccess });
+
+  const createCimdPreparedContext = () => {
+    const ctx = createOidcContext({
+      ...validOidcContext,
+      entities: { ...validOidcContext.entities, Client: cimdClient },
+      client: cimdClient,
+    });
+    stubRefreshToken(ctx, { clientId: cimdClientId });
+    stubGrant(ctx, { clientId: cimdClientId });
+    stubAccount(ctx);
+    return ctx;
+  };
+
+  afterEach(() => {
+    assertUserHasApplicationAccess.mockClear();
+  });
+
+  it('should skip the application access check and the organization grant lookup', async () => {
+    const ctx = createCimdPreparedContext();
+    const tenant = new MockTenant();
+
+    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
+    const findApplicationById = Sinon.stub(tenant.queries.applications, 'findApplicationById');
+    const userConsentOrganizationExists = Sinon.stub(
+      tenant.queries.applications.userConsentOrganizations,
+      'exists'
+    );
+    Sinon.stub(tenant.queries.organizations.relations.usersRoles, 'getUserScopes').resolves([
+      { tenantId: 'default', id: 'foo', name: 'foo', description: 'foo' },
+      { tenantId: 'default', id: 'bar', name: 'bar', description: 'bar' },
+    ]);
+    Sinon.stub(tenant.queries.organizations, 'getMfaStatus').resolves({
+      isMfaRequired: false,
+      hasMfaConfigured: false,
+    });
+
+    await expect(buildCimdHandler(tenant)(ctx)).resolves.toBeUndefined();
+
+    expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
+    expect(findApplicationById.called).toBe(false);
+    expect(userConsentOrganizationExists.called).toBe(false);
+  });
+
+  it('should keep the organization membership gate', async () => {
+    const ctx = createCimdPreparedContext();
+    const tenant = new MockTenant();
+    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(false);
+
+    await expect(buildCimdHandler(tenant)(ctx)).rejects.toThrow(
+      createAccessDeniedError('user is not a member of the organization', 403)
+    );
+  });
+
+  it('should keep the application access check for a url client id when CIMD is not effectively enabled', async () => {
+    const ctx = createCimdPreparedContext();
+    const tenant = new MockTenant();
+    assertUserHasApplicationAccess.mockRejectedValueOnce(new RequestError('oidc.access_denied'));
+
+    await expect(buildCimdHandler(tenant, tenant.envSet)(ctx)).rejects.toThrow(errors.AccessDenied);
+    expect(assertUserHasApplicationAccess).toHaveBeenCalled();
+  });
+});
+/* eslint-enable max-lines */

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -36,6 +36,8 @@ import { errors, type Provider } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
 import { assertUserHasApplicationAccessForOidc } from '#src/oidc/application-access-control.js';
+import { isCimdClientId } from '#src/oidc/cimd-client-id.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
 import {
   applyMtlsBinding,
   buildTokenResponse,
@@ -229,15 +231,23 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     throw new InvalidRequest('authorization_details is unsupported for this refresh token');
   }
 
-  await assertUserHasApplicationAccessForOidc(
-    appAccess,
-    client.clientId,
-    account.accountId,
-    client.metadata().appLevelAccessControlEnabled
-  );
+  // DEV: CIMD (client ID metadata document) support
+  /**
+   * Application-level access control only applies to registered applications; the
+   * access-control library's fallback lookup would query the applications table with the CIMD
+   * identifier URL and deny on not-found.
+   */
+  if (!(isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId))) {
+    await assertUserHasApplicationAccessForOidc(
+      appAccess,
+      client.clientId,
+      account.accountId,
+      client.metadata().appLevelAccessControlEnabled
+    );
+  }
 
   /* === RFC 0001 === */
-  const { organizationId } = await checkOrganizationAccess(ctx, queries, account);
+  const { organizationId } = await checkOrganizationAccess(ctx, envSet, queries, account);
 
   if (
     organizationId && // Validate if the refresh token has the required scope from RFC 0001.

--- a/packages/core/src/oidc/grants/token-exchange/index.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.ts
@@ -133,7 +133,13 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     clientId: client.clientId,
   } as ConstructorParameters<typeof Grant>[0]);
 
-  const { organizationId } = await checkOrganizationAccess(ctx, queries, account, isThirdParty);
+  const { organizationId } = await checkOrganizationAccess(
+    ctx,
+    envSet,
+    queries,
+    account,
+    isThirdParty
+  );
 
   const accessToken = createAccessToken(
     ctx,

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -7,6 +7,8 @@ import { type EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { isCimdClientId } from '../cimd-client-id.js';
+import { isCimdEffectivelyEnabled } from '../cimd.js';
 import {
   getSharedResourceServerData,
   isOrganizationConsentedToApplication,
@@ -21,6 +23,7 @@ const { InvalidGrant, InvalidClient, AccessDenied } = errors;
  */
 export const checkOrganizationAccess = async (
   ctx: KoaContextWithOIDC,
+  envSet: EnvSet,
   queries: Queries,
   account: Account,
   isThirdParty?: boolean
@@ -46,8 +49,20 @@ export const checkOrganizationAccess = async (
       throw error;
     }
 
+    // DEV: CIMD (client ID metadata document) support
+    /**
+     * A CIMD identifier would silently fall through `isThirdPartyApplication` — the not-found
+     * fallback reads as first-party — while also querying the applications table with the URL.
+     * Keep the skip explicit instead: organization grants are keyed to registered applications
+     * (`application_user_consent_organizations`), and the grant-scoped check for CIMD clients
+     * lands with LOG-13930. Until then organization tokens for CIMD clients stay gated by the
+     * membership check above and the MFA check below.
+     */
+    const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId);
+
     // Check if the organization is granted (third-party application only) by the user
     if (
+      !isCimdClient &&
       (isThirdParty ?? (await isThirdPartyApplication(queries, client.clientId))) &&
       !(await isOrganizationConsentedToApplication(
         queries,

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -523,6 +523,66 @@ describe('getResourceServerInfo for CIMD clients', () => {
   });
 });
 
+// DEV: CIMD (client ID metadata document) support
+describe('loadExistingGrant for CIMD clients', () => {
+  const cimdClientId = 'https://client.example.com/client-metadata.json';
+
+  const createCimdTestClient = (): KoaContextWithOIDC['oidc']['client'] => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub for OIDC context testing
+    return {
+      clientId: cimdClientId,
+      metadata: () => ({}),
+    } as KoaContextWithOIDC['oidc']['client'];
+  };
+
+  it('should load the grant without the application access check', async () => {
+    const assertUserHasApplicationAccess = jest.fn();
+    const tenant = new MockTenant();
+
+    tenant.setPartial('libraries', {
+      applicationAccessControl: { assertUserHasApplicationAccess },
+    });
+
+    const { id, queries, libraries, logtoConfigs, subscription } = tenant;
+    const provider = initOidc(id, cimdEnvSet, queries, libraries, logtoConfigs, subscription);
+    const findGrant = mockGrantFound(provider);
+    const configuration = getProviderConfiguration(provider);
+    const ctx = createOidcContext({
+      provider,
+      account: { accountId, claims: async () => ({ sub: accountId }) },
+      client: createCimdTestClient(),
+      result: { consent: { grantId: 'grant_id' } },
+    } as Partial<KoaContextWithOIDC['oidc']>);
+
+    await expect(configuration.loadExistingGrant(ctx)).resolves.toBeDefined();
+    expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
+    expect(findGrant).toHaveBeenCalledWith('grant_id');
+  });
+
+  it('should keep the application access check for a url client id when CIMD is not effectively enabled', async () => {
+    const assertUserHasApplicationAccess = jest
+      .fn()
+      .mockRejectedValueOnce(new RequestError('oidc.access_denied'));
+    const tenant = new MockTenant();
+
+    tenant.setPartial('libraries', {
+      applicationAccessControl: { assertUserHasApplicationAccess },
+    });
+
+    const provider = createProvider(tenant);
+    const configuration = getProviderConfiguration(provider);
+    const ctx = createOidcContext({
+      provider,
+      account: { accountId },
+      client: createCimdTestClient(),
+      result: { consent: { grantId: 'grant_id' } },
+    } as Partial<KoaContextWithOIDC['oidc']>);
+
+    await expect(configuration.loadExistingGrant(ctx)).rejects.toThrow(errors.AccessDenied);
+    expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(cimdClientId, accountId, undefined);
+  });
+});
+
 const findAccount = async (findUserById: () => Promise<typeof mockUser>) => {
   const provider = createProvider(new MockTenant(undefined, { users: { findUserById } }));
   const configuration = getProviderConfiguration(provider);

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -320,6 +320,13 @@ export default function initOidc(
       const shouldCheckApplicationAccess =
         account &&
         client &&
+        /**
+         * Application-level access control only applies to registered applications; the
+         * access-control library's fallback lookup would query the applications table with the
+         * CIMD identifier URL and deny on not-found.
+         */
+        // DEV: CIMD (client ID metadata document) support
+        !(isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId)) &&
         !hasAppLevelAccessControlChecked(result, client.clientId, account.accountId);
 
       if (grantId && shouldCheckApplicationAccess) {

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -514,7 +514,7 @@ export default function initOidc(
   });
 
   installWildcardRedirectUriMatching(oidc);
-  addOidcEventListeners(tenantId, oidc, queries, libraries.hooks.triggerEvent);
+  addOidcEventListeners(tenantId, envSet, oidc, queries, libraries.hooks.triggerEvent);
   registerGrants(oidc, envSet, queries, libraries);
 
   // Register first so all downstream cookie operations go through the rebound instance

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -16,6 +16,7 @@ import { conditional, trySafe } from '@silverhand/essentials';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayload } from '#src/libraries/user.utils.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
@@ -711,6 +712,7 @@ export default class ExperienceInteraction {
     }
 
     const {
+      envSet,
       libraries: { actions, jwtCustomizers },
     } = this.tenant;
     const actionResult = validatePostSignInActionResult({
@@ -720,9 +722,13 @@ export default class ExperienceInteraction {
         auditContext: {
           createLog: this.ctx.createLog,
           sessionId: this.ctx.interactionDetails.jti,
-          applicationId: conditional(
-            typeof this.ctx.interactionDetails.params.client_id === 'string' &&
-              this.ctx.interactionDetails.params.client_id
+          // DEV: CIMD (client ID metadata document) support
+          ...getClientIdentifierPayload(
+            envSet,
+            conditional(
+              typeof this.ctx.interactionDetails.params.client_id === 'string' &&
+                this.ctx.interactionDetails.params.client_id
+            )
           ),
           userId,
         },

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -47,16 +47,16 @@ type RouterContext<T> = T extends Router<unknown, infer Context> ? Context : nev
 export default function experienceApiRoutes<T extends AnonymousRouter>(
   ...[anonymousRouter, tenant]: RouterInitArgs<T>
 ) {
-  const { provider, libraries } = tenant;
+  const { provider, envSet, libraries } = tenant;
 
   const experienceRouter =
     // @ts-expect-error for good koa types
     // eslint-disable-next-line no-restricted-syntax
     (anonymousRouter as Router<unknown, ExperienceInteractionRouterContext<RouterContext<T>>>).use(
       koaInteractionDetails(provider),
-      koaExperienceInteractionHooks(libraries),
+      koaExperienceInteractionHooks(envSet, libraries),
       koaExperienceInteraction(tenant),
-      koaExperienceAuditLog()
+      koaExperienceAuditLog(envSet)
     );
 
   experienceRouter.put(

--- a/packages/core/src/routes/experience/middleware/koa-experience-audit-log.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-audit-log.ts
@@ -1,22 +1,25 @@
 import { conditionalString } from '@silverhand/essentials';
 import { type MiddlewareType } from 'koa';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import { type LogContext } from '#src/middleware/koa-audit-log.js';
 import { type WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd.js';
 
 export default function koaExperienceAuditLog<
   StateT,
   ContextT extends WithInteractionDetailsContext & LogContext,
   ResponseT,
->(): MiddlewareType<StateT, ContextT, ResponseT> {
+>(envSet: EnvSet): MiddlewareType<StateT, ContextT, ResponseT> {
   return async (ctx, next) => {
     const { prependAllLogEntries, interactionDetails } = ctx;
-    const applicationId = conditionalString(interactionDetails.params.client_id);
+    const clientId = conditionalString(interactionDetails.params.client_id);
 
     try {
       await next();
     } finally {
-      prependAllLogEntries({ applicationId });
+      // DEV: CIMD (client ID metadata document) support
+      prependAllLogEntries(getClientIdentifierPayload(envSet, clientId));
     }
   };
 }

--- a/packages/core/src/routes/experience/middleware/koa-experience-interaction-hooks.test.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-interaction-hooks.test.ts
@@ -6,6 +6,7 @@ import { type Provider } from 'oidc-provider';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import type Libraries from '#src/tenants/Libraries.js';
+import { mockEnvSet } from '#src/test-utils/env-set.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
 import {
@@ -67,9 +68,9 @@ describe('exception hooks', () => {
       throw error;
     });
 
-    await expect(koaExperienceInteractionHooks(mockHooksLibrary)(ctx, next)).rejects.toThrowError(
-      error
-    );
+    await expect(
+      koaExperienceInteractionHooks(mockEnvSet, mockHooksLibrary)(ctx, next)
+    ).rejects.toThrowError(error);
 
     expect(triggerInteractionHooks).not.toBeCalled();
     expect(triggerDataHooks).not.toBeCalled();
@@ -128,9 +129,9 @@ describe('exception hooks', () => {
       throw error;
     });
 
-    await expect(koaExperienceInteractionHooks(mockHooksLibrary)(ctx, next)).rejects.toThrowError(
-      error
-    );
+    await expect(
+      koaExperienceInteractionHooks(mockEnvSet, mockHooksLibrary)(ctx, next)
+    ).rejects.toThrowError(error);
 
     expect(triggerInteractionHooks).toBeCalledTimes(1);
 
@@ -200,9 +201,9 @@ describe('exception hooks', () => {
       throw error;
     });
 
-    await expect(koaExperienceInteractionHooks(mockHooksLibrary)(ctx, next)).rejects.toThrowError(
-      error
-    );
+    await expect(
+      koaExperienceInteractionHooks(mockEnvSet, mockHooksLibrary)(ctx, next)
+    ).rejects.toThrowError(error);
 
     expect(triggerInteractionHooks).toBeCalledTimes(1);
 
@@ -255,7 +256,7 @@ describe('exception hooks', () => {
     });
 
     await expect(
-      koaExperienceInteractionHooks(mockHooksLibrary)(ctx, next)
+      koaExperienceInteractionHooks(mockEnvSet, mockHooksLibrary)(ctx, next)
     ).resolves.toBeUndefined();
 
     expect(triggerInteractionHooks).toBeCalledTimes(2);

--- a/packages/core/src/routes/experience/middleware/koa-experience-interaction-hooks.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-interaction-hooks.ts
@@ -4,11 +4,13 @@ import { type MiddlewareType } from 'koa';
 import { type IRouterParamContext } from 'koa-router';
 import { z } from 'zod';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import {
   HookContextManager,
   InteractionHookContextManager,
 } from '#src/libraries/hook/context-manager.js';
 import { type WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 
@@ -29,9 +31,10 @@ export function koaExperienceInteractionHooks<
   StateT,
   ContextT extends WithInteractionDetailsContext,
   ResponseT,
->({
-  hooks: { triggerInteractionHooks, triggerDataHooks, triggerExceptionHooks },
-}: Libraries): MiddlewareType<StateT, WithExperienceInteractionHooksContext<ContextT>, ResponseT> {
+>(
+  envSet: EnvSet,
+  { hooks: { triggerInteractionHooks, triggerDataHooks, triggerExceptionHooks } }: Libraries
+): MiddlewareType<StateT, WithExperienceInteractionHooksContext<ContextT>, ResponseT> {
   return async (ctx, next) => {
     const {
       interactionDetails,
@@ -54,7 +57,8 @@ export function koaExperienceInteractionHooks<
     const interactionApiMetadata = {
       interactionEvent,
       userAgent,
-      applicationId: conditionalString(interactionDetails.params.client_id),
+      // DEV: CIMD (client ID metadata document) support
+      ...getClientIdentifierPayload(envSet, conditionalString(interactionDetails.params.client_id)),
       sessionId: interactionDetails.jti,
     };
     const interactionHookContext = new InteractionHookContextManager({

--- a/packages/core/src/routes/experience/verification-routes/password-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/password-verification.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
 import { appendPasswordPayloadToActionProvisioningProfile } from '../classes/libraries/action-provisioning-profile.js';
@@ -53,7 +54,7 @@ const toActionUser = ({
 
 export default function passwordVerificationRoutes<T extends ExperienceInteractionRouterContext>(
   router: Router<unknown, T>,
-  { libraries, queries, sentinel }: TenantContext
+  { envSet, libraries, queries, sentinel }: TenantContext
 ) {
   router.post(
     `${experienceRoutes.verification}/password`,
@@ -129,9 +130,13 @@ export default function passwordVerificationRoutes<T extends ExperienceInteracti
                 auditContext: {
                   createLog: ctx.createLog,
                   sessionId: ctx.interactionDetails.jti,
-                  applicationId: conditional(
-                    typeof ctx.interactionDetails.params.client_id === 'string' &&
-                      ctx.interactionDetails.params.client_id
+                  // DEV: CIMD (client ID metadata document) support
+                  ...getClientIdentifierPayload(
+                    envSet,
+                    conditional(
+                      typeof ctx.interactionDetails.params.client_id === 'string' &&
+                        ctx.interactionDetails.params.client_id
+                    )
                   ),
                   userId: existingUser?.id,
                 },

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -46,7 +46,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       }),
       status: [200, 400],
     }),
-    koaAppAccessControl(libraries),
+    koaAppAccessControl(envSet, libraries),
     async (ctx, next) => {
       const {
         interactionDetails,
@@ -206,7 +206,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       status: [200, 400],
       response: consentInfoResponseGuard,
     }),
-    koaAppAccessControl(libraries),
+    koaAppAccessControl(envSet, libraries),
     async (ctx, next) => {
       const { interactionDetails } = ctx;
 

--- a/packages/core/src/routes/interaction/index.ts
+++ b/packages/core/src/routes/interaction/index.ts
@@ -51,7 +51,7 @@ export type RouterContext<T> = T extends Router<unknown, infer Context> ? Contex
 export default function interactionRoutes<T extends AnonymousRouter>(
   ...[anonymousRouter, tenant]: RouterInitArgs<T>
 ) {
-  const { provider, queries, libraries } = tenant;
+  const { provider, envSet, queries, libraries } = tenant;
   const router =
     // @ts-expect-error for good koa types
     // eslint-disable-next-line no-restricted-syntax
@@ -329,7 +329,7 @@ export default function interactionRoutes<T extends AnonymousRouter>(
         .optional(),
     }),
     koaInteractionSie(queries),
-    koaInteractionHooks(libraries),
+    koaInteractionHooks(envSet, libraries),
     async (ctx, next) => {
       const { interactionDetails, createLog } = ctx;
       const interactionStorage = getInteractionStorage(interactionDetails.result);

--- a/packages/core/src/routes/interaction/middleware/koa-interaction-hooks.ts
+++ b/packages/core/src/routes/interaction/middleware/koa-interaction-hooks.ts
@@ -2,11 +2,13 @@ import { conditionalString, trySafe } from '@silverhand/essentials';
 import type { MiddlewareType } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import {
   HookContextManager,
   InteractionHookContextManager,
 } from '#src/libraries/hook/context-manager.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 
@@ -28,9 +30,10 @@ export default function koaInteractionHooks<
   StateT,
   ContextT extends WithInteractionDetailsContext,
   ResponseT,
->({
-  hooks: { triggerInteractionHooks, triggerDataHooks },
-}: Libraries): MiddlewareType<StateT, WithInteractionHooksContext<ContextT>, ResponseT> {
+>(
+  envSet: EnvSet,
+  { hooks: { triggerInteractionHooks, triggerDataHooks } }: Libraries
+): MiddlewareType<StateT, WithInteractionHooksContext<ContextT>, ResponseT> {
   return async (ctx, next) => {
     const { event: interactionEvent } = getInteractionStorage(ctx.interactionDetails.result);
 
@@ -43,7 +46,8 @@ export default function koaInteractionHooks<
     const interactionApiMetadata = {
       interactionEvent,
       userAgent,
-      applicationId: conditionalString(interactionDetails.params.client_id),
+      // DEV: CIMD (client ID metadata document) support
+      ...getClientIdentifierPayload(envSet, conditionalString(interactionDetails.params.client_id)),
       sessionId: interactionDetails.jti,
     };
 

--- a/packages/core/src/routes/interaction/single-sign-on.ts
+++ b/packages/core/src/routes/interaction/single-sign-on.ts
@@ -28,7 +28,7 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
   router: Router<unknown, WithInteractionDetailsContext<WithLogContext<T>>>,
   tenant: TenantContext
 ) {
-  const { provider, libraries, queries } = tenant;
+  const { provider, envSet, libraries, queries } = tenant;
 
   const { ssoConnectors: ssoConnectorsLibrary } = libraries;
 
@@ -84,7 +84,7 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
         redirectTo: z.string(),
       }),
     }),
-    koaInteractionHooks(libraries),
+    koaInteractionHooks(envSet, libraries),
     async (ctx, next) => {
       const { guard, interactionDetails, assignReleaseOnSuccessInteractionHookResult } = ctx;
 
@@ -131,7 +131,7 @@ export default function singleSignOnRoutes<T extends IRouterParamContext>(
       }),
     }),
     koaInteractionSie(queries),
-    koaInteractionHooks(libraries),
+    koaInteractionHooks(envSet, libraries),
     async (ctx, next) => {
       const {
         assignReleaseOnSuccessInteractionHookResult,


### PR DESCRIPTION
## Summary

Isolate CIMD clients from application-level access control: they are unregistered external clients, so the applications table is never queried with the identifier URL (LOG-13928).

- Skip application ACL for CIMD clients in the app access control middleware (consent GET/POST), the provider `loadExistingGrant`, and the custom refresh token grant; registered applications and URL-shaped identifiers without effective CIMD enablement keep the checks.
- Make the organization-grant skip in `checkOrganizationAccess` an explicit CIMD verdict instead of the accidental first-party fallback of `isThirdPartyApplication`; the grant-scoped organization check lands with LOG-13930, and membership plus MFA gates stay active.
- Skip the JWT-customizer application context for CIMD clients.
- Drop the stale auto-consent TODO now that the remaining consent-flow work is tracked in follow-up slices.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
