### PR TITLE
feat(core): attribute cimd clients in oidc event logs

### DIFF
--- a/packages/core/src/event-listeners/authorization-success.test.ts
+++ b/packages/core/src/event-listeners/authorization-success.test.ts
@@ -1,11 +1,13 @@
 import { appInsights } from '@logto/app-insights/node';
 import { LogResult, type ExceptionHookEvent } from '@logto/schemas';
+import Sinon from 'sinon';
 
+import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
-import { createAuthorizationSuccessListener } from './authorization-success.js';
+import { createAuthorizationSuccessListener, type TriggerEvent } from './authorization-success.js';
 
 const { jest } = import.meta;
 
@@ -251,6 +253,80 @@ describe('createAuthorizationSuccessListener', () => {
         userAgent: 'test-agent',
       }
     );
+  });
+
+  // DEV: CIMD (client ID metadata document) support
+  describe('grant limit webhook payload for a cimd client', () => {
+    const cimdClientId = 'https://client.example.com/metadata.json';
+
+    afterEach(() => {
+      Sinon.restore();
+    });
+
+    /**
+     * No grant-ceiling source exists for CIMD clients today, so this locks the payload contract
+     * for any future one: the identifier routes by namespace, keeping `applicationId`
+     * registered-only by construction.
+     */
+    it('should attribute the identifier under the dedicated key', async () => {
+      Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isDevFeaturesEnabled: true });
+
+      const { provider } = createMockProvider();
+      const findUserActiveGrantsByClientId = jest.fn(async () => [
+        {
+          id: 'grant-2',
+          payload: {
+            exp: 999_999_999,
+            iat: 20,
+            jti: 'grant-jti-2',
+            kind: 'Grant',
+            clientId: cimdClientId,
+            accountId: 'user-id',
+          },
+          expiresAt: Date.now() + 1000,
+        },
+        {
+          id: 'grant-1',
+          payload: {
+            exp: 999_999_999,
+            iat: 10,
+            jti: 'grant-jti-1',
+            kind: 'Grant',
+            clientId: cimdClientId,
+            accountId: 'user-id',
+          },
+          expiresAt: Date.now() + 1000,
+        },
+      ]);
+
+      const triggerEvent = jest.fn<Promise<void>, Parameters<TriggerEvent>>(async () => {
+        await Promise.resolve();
+      });
+
+      const listener = createAuthorizationSuccessListener(
+        // @ts-expect-error Provider mock is enough for unit test
+        provider,
+        new MockQueries({
+          oidcModelInstances: {
+            findUserActiveGrantsByClientId,
+            findUserActiveSessionUidByGrantId: jest.fn(async () => null),
+          },
+        }),
+        triggerEvent
+      );
+
+      const context = createMockAuthorizationSuccessContext({
+        clientId: cimdClientId,
+        maxAllowedGrants: 1,
+      });
+      // @ts-expect-error Context mock is enough for unit test
+      await listener(context);
+
+      expect(triggerEvent).toHaveBeenCalledTimes(1);
+      const payload = triggerEvent.mock.calls[0]?.[2];
+      expect(payload).toMatchObject({ cimdClientId, revokedGrantIds: ['grant-1'] });
+      expect(payload).not.toHaveProperty('applicationId');
+    });
   });
 
   it('should throw when grant query fails', async () => {

--- a/packages/core/src/event-listeners/authorization-success.ts
+++ b/packages/core/src/event-listeners/authorization-success.ts
@@ -11,6 +11,7 @@ import type { KoaContextWithOIDC, Provider } from 'oidc-provider';
 import RequestError from '#src/errors/RequestError/index.js';
 import { createSessionLibrary } from '#src/libraries/session/index.js';
 import { assertLogContext, type LogContext } from '#src/middleware/koa-audit-log.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 import { stringifyError } from '#src/utils/format.js';
@@ -112,7 +113,8 @@ const enforceMaxAllowedGrantsRevocation = async (
             'Grant.LimitExceeded',
             {
               userId,
-              applicationId: clientId,
+              // DEV: CIMD (client ID metadata document) support
+              ...getClientIdentifierPayload(clientId),
               revokedGrantIds: revokeResult.succeededNames,
               maxAllowedGrants,
               preRevocationActiveGrantCount: activeGrants.length,

--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -1,6 +1,8 @@
 import type { LogKey } from '@logto/schemas';
 import { LogResult, token } from '@logto/schemas';
+import Sinon from 'sinon';
 
+import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { stringifyError } from '#src/utils/format.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
@@ -22,6 +24,10 @@ const entities = {
 };
 
 const baseCallArgs = { applicationId, sessionId, userId };
+
+const stubDevFeaturesFlag = (isDevFeaturesEnabled: boolean) => {
+  Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isDevFeaturesEnabled });
+};
 
 const testGrantListener = (
   parameters: { grant_type: string } & Record<string, unknown>,
@@ -115,6 +121,57 @@ describe('grantSuccessListener', () => {
       'ExchangeTokenBy.Unknown',
       [token.TokenType.AccessToken]
     );
+  });
+});
+
+// DEV: CIMD (client ID metadata document) support
+describe('grantSuccessListener with a cimd client identifier', () => {
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  const buildCimdContext = () => ({
+    ...createContextWithRouteParameters(),
+    createLog: log.createLog,
+    prependAllLogEntries: log.prependAllLogEntries,
+    oidc: {
+      entities: { ...entities, Client: { clientId: cimdClientId } },
+      params: { grant_type: 'refresh_token' },
+    },
+    body: { access_token: 'newAccessTokenValue' },
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+    jest.clearAllMocks();
+  });
+
+  it('should log a cimd client identifier under the dedicated key', () => {
+    stubDevFeaturesFlag(true);
+    const ctx = buildCimdContext();
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      cimdClientId,
+      sessionId,
+      userId,
+      tokenTypes: [token.TokenType.AccessToken],
+      params: { grant_type: 'refresh_token' },
+    });
+  });
+
+  it('should keep a url-shaped identifier under applicationId when the dev features flag is off', () => {
+    stubDevFeaturesFlag(false);
+    const ctx = buildCimdContext();
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      applicationId: cimdClientId,
+      sessionId,
+      userId,
+      tokenTypes: [token.TokenType.AccessToken],
+      params: { grant_type: 'refresh_token' },
+    });
   });
 });
 

--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -42,13 +42,13 @@ const buildCimdContext = () => ({
   body: { access_token: 'newAccessTokenValue' },
 });
 
-const buildUnresolvedClientContext = (clientId: string) => ({
+const buildUnresolvedClientContext = (params: Record<string, unknown>) => ({
   ...createContextWithRouteParameters(),
   createLog: log.createLog,
   prependAllLogEntries: log.prependAllLogEntries,
   oidc: {
     entities: {},
-    params: { grant_type: 'authorization_code', client_id: clientId },
+    params,
   },
   body: { error: 'invalid_client' },
 });
@@ -197,7 +197,8 @@ describe('grantErrorListener with an unresolved client', () => {
 
   it('should attribute a cimd-namespace client_id from params when the client is not resolved', () => {
     stubDevFeaturesFlag(true);
-    const ctx = buildUnresolvedClientContext(cimdClientId);
+    const params = { grant_type: 'authorization_code', client_id: cimdClientId };
+    const ctx = buildUnresolvedClientContext(params);
 
     // @ts-expect-error pass complex type check to mock ctx directly
     grantListener(ctx, error);
@@ -206,13 +207,14 @@ describe('grantErrorListener with an unresolved client', () => {
       result: LogResult.Error,
       tokenTypes: [],
       error: stringifyError(error),
-      params: { grant_type: 'authorization_code', client_id: cimdClientId },
+      params,
     });
   });
 
   it('should keep an unresolved non-cimd client_id unattributed', () => {
     stubDevFeaturesFlag(true);
-    const ctx = buildUnresolvedClientContext('app-typo');
+    const params = { grant_type: 'authorization_code', client_id: 'app-typo' };
+    const ctx = buildUnresolvedClientContext(params);
 
     // @ts-expect-error pass complex type check to mock ctx directly
     grantListener(ctx, error);
@@ -220,7 +222,46 @@ describe('grantErrorListener with an unresolved client', () => {
       result: LogResult.Error,
       tokenTypes: [],
       error: stringifyError(error),
-      params: { grant_type: 'authorization_code', client_id: 'app-typo' },
+      params,
+    });
+  });
+
+  it('should keep an unresolved url-shaped client_id unattributed when the dev features flag is off', () => {
+    stubDevFeaturesFlag(false);
+    const params = { grant_type: 'authorization_code', client_id: cimdClientId };
+    const ctx = buildUnresolvedClientContext(params);
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx, error);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      result: LogResult.Error,
+      tokenTypes: [],
+      error: stringifyError(error),
+      params,
+    });
+  });
+
+  /**
+   * Attribution reads the resolved Client and the explicit `client_id` parameter only; an
+   * identifier embedded in authentication material (e.g. `client_assertion.sub`) stays raw in
+   * `params` for forensics.
+   */
+  it('should keep an assertion-only failure unattributed while params carry the assertion', () => {
+    stubDevFeaturesFlag(true);
+    const params = {
+      grant_type: 'authorization_code',
+      client_assertion: 'header.payload.signature',
+      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+    };
+    const ctx = buildUnresolvedClientContext(params);
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx, error);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      result: LogResult.Error,
+      tokenTypes: [],
+      error: stringifyError(error),
+      params,
     });
   });
 });

--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -29,6 +29,30 @@ const stubDevFeaturesFlag = (isDevFeaturesEnabled: boolean) => {
   Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isDevFeaturesEnabled });
 };
 
+const cimdClientId = 'https://client.example.com/metadata.json';
+
+const buildCimdContext = () => ({
+  ...createContextWithRouteParameters(),
+  createLog: log.createLog,
+  prependAllLogEntries: log.prependAllLogEntries,
+  oidc: {
+    entities: { ...entities, Client: { clientId: cimdClientId } },
+    params: { grant_type: 'refresh_token' },
+  },
+  body: { access_token: 'newAccessTokenValue' },
+});
+
+const buildUnresolvedClientContext = (clientId: string) => ({
+  ...createContextWithRouteParameters(),
+  createLog: log.createLog,
+  prependAllLogEntries: log.prependAllLogEntries,
+  oidc: {
+    entities: {},
+    params: { grant_type: 'authorization_code', client_id: clientId },
+  },
+  body: { error: 'invalid_client' },
+});
+
 const testGrantListener = (
   parameters: { grant_type: string } & Record<string, unknown>,
   body: Record<string, string>,
@@ -126,19 +150,6 @@ describe('grantSuccessListener', () => {
 
 // DEV: CIMD (client ID metadata document) support
 describe('grantSuccessListener with a cimd client identifier', () => {
-  const cimdClientId = 'https://client.example.com/metadata.json';
-
-  const buildCimdContext = () => ({
-    ...createContextWithRouteParameters(),
-    createLog: log.createLog,
-    prependAllLogEntries: log.prependAllLogEntries,
-    oidc: {
-      entities: { ...entities, Client: { clientId: cimdClientId } },
-      params: { grant_type: 'refresh_token' },
-    },
-    body: { access_token: 'newAccessTokenValue' },
-  });
-
   afterEach(() => {
     Sinon.restore();
     jest.clearAllMocks();
@@ -171,6 +182,45 @@ describe('grantSuccessListener with a cimd client identifier', () => {
       userId,
       tokenTypes: [token.TokenType.AccessToken],
       params: { grant_type: 'refresh_token' },
+    });
+  });
+});
+
+// DEV: CIMD (client ID metadata document) support
+describe('grantErrorListener with an unresolved client', () => {
+  const error = new Error('client metadata fetch failed');
+
+  afterEach(() => {
+    Sinon.restore();
+    jest.clearAllMocks();
+  });
+
+  it('should attribute a cimd-namespace client_id from params when the client is not resolved', () => {
+    stubDevFeaturesFlag(true);
+    const ctx = buildUnresolvedClientContext(cimdClientId);
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx, error);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      cimdClientId,
+      result: LogResult.Error,
+      tokenTypes: [],
+      error: stringifyError(error),
+      params: { grant_type: 'authorization_code', client_id: cimdClientId },
+    });
+  });
+
+  it('should keep an unresolved non-cimd client_id unattributed', () => {
+    stubDevFeaturesFlag(true);
+    const ctx = buildUnresolvedClientContext('app-typo');
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx, error);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      result: LogResult.Error,
+      tokenTypes: [],
+      error: stringifyError(error),
+      params: { grant_type: 'authorization_code', client_id: 'app-typo' },
     });
   });
 });

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -2,6 +2,7 @@ import type { KoaContextWithOIDC } from 'oidc-provider';
 
 import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
 import type { LogPayload } from '#src/middleware/koa-audit-log.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 
 export const extractInteractionContext = (
   ctx: WithAppSecretContext<KoaContextWithOIDC>
@@ -12,7 +13,8 @@ export const extractInteractionContext = (
   } = ctx.oidc;
 
   return {
-    applicationId: Client?.clientId,
+    // DEV: CIMD (client ID metadata document) support
+    ...getClientIdentifierPayload(Client?.clientId),
     applicationSecret: ctx.appSecret,
     sessionId: Session?.jti,
     interactionId: Interaction?.jti,

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -1,7 +1,10 @@
+import { conditional } from '@silverhand/essentials';
 import type { KoaContextWithOIDC } from 'oidc-provider';
 
+import { EnvSet } from '#src/env-set/index.js';
 import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
 import type { LogPayload } from '#src/middleware/koa-audit-log.js';
+import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
 import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 
 export const extractInteractionContext = (
@@ -12,9 +15,25 @@ export const extractInteractionContext = (
     params,
   } = ctx.oidc;
 
+  const submittedClientId = params?.client_id;
+
+  // DEV: CIMD (client ID metadata document) support
+  /**
+   * `grant.error` fires for failures thrown before the provider resolves the Client entity — a
+   * CIMD document fetch or metadata-validation failure lands exactly there — so fall back to the
+   * submitted `client_id`, but only within the CIMD namespace: `applicationId` attribution stays
+   * resolution-backed, keeping a mistyped registered id unattributed as before.
+   */
+  const cimdFallbackClientId = conditional(
+    EnvSet.values.isDevFeaturesEnabled &&
+      typeof submittedClientId === 'string' &&
+      isCimdClientId(submittedClientId) &&
+      submittedClientId
+  );
+
   return {
     // DEV: CIMD (client ID metadata document) support
-    ...getClientIdentifierPayload(Client?.clientId),
+    ...getClientIdentifierPayload(Client?.clientId ?? cimdFallbackClientId),
     applicationSecret: ctx.appSecret,
     sessionId: Session?.jti,
     interactionId: Interaction?.jti,

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -1,6 +1,7 @@
 import {
   LogResult,
   userInfoSelectFields,
+  type BetterOmit,
   type ExceptionHookEventPayload,
   type GrantLimitExceededEventData,
   type Hook,
@@ -26,10 +27,6 @@ import {
   type HookContext,
 } from './context-manager.js';
 import { generateHookTestPayload, parseResponse, sendWebhookRequest } from './utils.js';
-
-type BetterOmit<T, Ignore> = {
-  [key in keyof T as key extends Ignore ? never : key]: T[key];
-};
 
 type HookEventPayloadWithoutHookId = BetterOmit<HookEventPayload, 'hookId'>;
 
@@ -320,7 +317,12 @@ export const createHookLibrary = (queries: Queries) => {
       return;
     }
 
-    const application = await trySafe(async () => findApplicationById(payload.applicationId));
+    const { applicationId } = payload;
+    // DEV: CIMD (client ID metadata document) support
+    /** A CIMD-attributed payload carries no registered application id to enrich with. */
+    const application = conditional(
+      applicationId && (await trySafe(async () => findApplicationById(applicationId)))
+    );
 
     const webhookPayloads = matchingHooks.map((hook) => ({
       hook,

--- a/packages/core/src/oidc/cimd/index.test.ts
+++ b/packages/core/src/oidc/cimd/index.test.ts
@@ -110,30 +110,30 @@ describe('isCimdEffectivelyEnabled', () => {
 describe('getClientIdentifierPayload', () => {
   const cimdClientId = 'https://client.example.com/metadata.json';
 
-  it('routes a cimd identifier to the dedicated key when effectively enabled', async () => {
+  it('routes a cimd-namespace identifier to the dedicated key', async () => {
     const { getClientIdentifierPayload } = await loadCimdModule();
-    expect(getClientIdentifierPayload(buildEnvSet(true), cimdClientId)).toEqual({
+    expect(getClientIdentifierPayload(cimdClientId)).toStrictEqual({
       cimdClientId,
     });
   });
 
   it('routes a registered application id to applicationId', async () => {
     const { getClientIdentifierPayload } = await loadCimdModule();
-    expect(getClientIdentifierPayload(buildEnvSet(true), 'app-id')).toEqual({
+    expect(getClientIdentifierPayload('app-id')).toStrictEqual({
       applicationId: 'app-id',
     });
   });
 
-  it('keeps a url-shaped identifier under applicationId when not effectively enabled', async () => {
-    const { getClientIdentifierPayload } = await loadCimdModule();
-    expect(getClientIdentifierPayload(buildEnvSet(false), cimdClientId)).toEqual({
+  it('keeps a url-shaped identifier under applicationId when the dev features flag is off', async () => {
+    const { getClientIdentifierPayload } = await loadCimdModule({ isDevFeaturesEnabled: false });
+    expect(getClientIdentifierPayload(cimdClientId)).toStrictEqual({
       applicationId: cimdClientId,
     });
   });
 
   it('yields an undefined applicationId for a missing identifier', async () => {
     const { getClientIdentifierPayload } = await loadCimdModule();
-    expect(getClientIdentifierPayload(buildEnvSet(true))).toEqual({
+    expect(getClientIdentifierPayload()).toStrictEqual({
       applicationId: undefined,
     });
   });

--- a/packages/core/src/oidc/cimd/index.test.ts
+++ b/packages/core/src/oidc/cimd/index.test.ts
@@ -107,6 +107,38 @@ describe('isCimdEffectivelyEnabled', () => {
   });
 });
 
+describe('getClientIdentifierPayload', () => {
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  it('routes a cimd identifier to the dedicated key when effectively enabled', async () => {
+    const { getClientIdentifierPayload } = await loadCimdModule();
+    expect(getClientIdentifierPayload(buildEnvSet(true), cimdClientId)).toEqual({
+      cimdClientId,
+    });
+  });
+
+  it('routes a registered application id to applicationId', async () => {
+    const { getClientIdentifierPayload } = await loadCimdModule();
+    expect(getClientIdentifierPayload(buildEnvSet(true), 'app-id')).toEqual({
+      applicationId: 'app-id',
+    });
+  });
+
+  it('keeps a url-shaped identifier under applicationId when not effectively enabled', async () => {
+    const { getClientIdentifierPayload } = await loadCimdModule();
+    expect(getClientIdentifierPayload(buildEnvSet(false), cimdClientId)).toEqual({
+      applicationId: cimdClientId,
+    });
+  });
+
+  it('yields an undefined applicationId for a missing identifier', async () => {
+    const { getClientIdentifierPayload } = await loadCimdModule();
+    expect(getClientIdentifierPayload(buildEnvSet(true))).toEqual({
+      applicationId: undefined,
+    });
+  });
+});
+
 describe('buildClientIdMetadataDocumentFeature', () => {
   it('wires the feature with the draft-02 acknowledgement when effectively enabled', async () => {
     const { buildClientIdMetadataDocumentFeature } = await loadCimdModule();

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -25,6 +25,8 @@ import type Queries from '#src/tenants/Queries.js';
 import { extraClientMetadataKeys } from '../application-access-control.js';
 import { isValidWildcardRedirectUriPattern } from '../redirect-uri/utils.js';
 
+import { isCimdClientId } from './client-id.js';
+
 /**
  * Must not exceed the `cimd_client_id varchar(2048)` column width — neither the draft nor the
  * provider defines a maximum, so this bound is what keeps an over-long identifier an
@@ -56,6 +58,28 @@ export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
   EnvSet.values.isDevFeaturesEnabled &&
   envSet.oidc.cimdEnabled &&
   EnvSet.values.isOidcProviderSsrfProtectionEnabled;
+
+/** Exactly one identifier is set, matching the kind of the client. */
+export type ClientIdentifierPayload = {
+  applicationId?: string;
+  cimdClientId?: string;
+};
+
+/**
+ * Route a client identifier into the payload key its kind owns: `applicationId` carries
+ * registered application ids only, while a CIMD identifier goes under the dedicated
+ * `cimdClientId` key — audit log and webhook consumers branch on key presence instead of
+ * parsing URL shapes. Identifiers merely shaped like URLs while CIMD is not effectively
+ * enabled keep flowing through `applicationId` unchanged.
+ */
+export const getClientIdentifierPayload = (
+  envSet: EnvSet,
+  clientId?: string
+): ClientIdentifierPayload =>
+  // DEV: CIMD (client ID metadata document) support
+  clientId !== undefined && isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)
+    ? { cimdClientId: clientId }
+    : { applicationId: clientId };
 
 /**
  * Build the `features.clientIdMetadataDocument` entry for the provider configuration, or

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -59,7 +59,7 @@ export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
   envSet.oidc.cimdEnabled &&
   EnvSet.values.isOidcProviderSsrfProtectionEnabled;
 
-/** Exactly one identifier is set, matching the namespace of the client identifier. */
+/** At most one identifier is set, matching the namespace of the client identifier. */
 export type ClientIdentifierPayload = {
   applicationId?: string;
   cimdClientId?: string;

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -59,25 +59,28 @@ export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
   envSet.oidc.cimdEnabled &&
   EnvSet.values.isOidcProviderSsrfProtectionEnabled;
 
-/** Exactly one identifier is set, matching the kind of the client. */
+/** Exactly one identifier is set, matching the namespace of the client identifier. */
 export type ClientIdentifierPayload = {
   applicationId?: string;
   cimdClientId?: string;
 };
 
 /**
- * Route a client identifier into the payload key its kind owns: `applicationId` carries
- * registered application ids only, while a CIMD identifier goes under the dedicated
- * `cimdClientId` key — audit log and webhook consumers branch on key presence instead of
- * parsing URL shapes. Identifiers merely shaped like URLs while CIMD is not effectively
- * enabled keep flowing through `applicationId` unchanged.
+ * Route a client identifier into the payload key its namespace owns: `applicationId` carries
+ * registered application ids only, while an identifier in the CIMD namespace goes under the
+ * dedicated `cimdClientId` key — audit log and webhook consumers branch on key presence instead
+ * of parsing URL shapes.
+ *
+ * The namespace alone decides, deliberately ignoring the tenant CIMD config: the config can flip
+ * between an interaction's creation and its payload emission (the tenant is rebuilt on config
+ * change), and routing by it would put the in-flight interaction's URL identifier under
+ * `applicationId`, breaking the registered-only contract. The key attributes the identifier the
+ * requester presented, not a resolved client — an identifier that later fails resolution still
+ * lands under `cimdClientId`.
  */
-export const getClientIdentifierPayload = (
-  envSet: EnvSet,
-  clientId?: string
-): ClientIdentifierPayload =>
+export const getClientIdentifierPayload = (clientId?: string): ClientIdentifierPayload =>
   // DEV: CIMD (client ID metadata document) support
-  clientId !== undefined && isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)
+  clientId !== undefined && EnvSet.values.isDevFeaturesEnabled && isCimdClientId(clientId)
     ? { cimdClientId: clientId }
     : { applicationId: clientId };
 

--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -27,10 +27,13 @@ jest.unstable_mockModule('#src/libraries/jwt-customizer.js', () => ({
 const { EnvSet } = await import('#src/env-set/index.js');
 const { getExtraTokenClaimsForJwtCustomization } = await import('./extra-token-claims.js');
 
-const buildContextAndToken = ({ organizationId }: { organizationId?: string } = {}) => {
+const buildContextAndToken = ({
+  organizationId,
+  clientId = 'app-1',
+}: { organizationId?: string; clientId?: string } = {}) => {
   const ctx = createOidcContext({
     session: { uid: sessionUid } as unknown as KoaContextWithOIDC['oidc']['session'],
-    client: { clientId: 'app-1' } as unknown as KoaContextWithOIDC['oidc']['client'],
+    client: { clientId } as unknown as KoaContextWithOIDC['oidc']['client'],
     params: { organization_id: organizationId },
   });
 
@@ -54,7 +57,7 @@ const buildContextAndToken = ({ organizationId }: { organizationId?: string } = 
     gty: { value: 'password', enumerable: true },
   }) as AccessToken;
 
-  return { ctxWithLog, token };
+  return { ctxWithLog, token, logEntry };
 };
 
 const mockOrganization = {
@@ -122,6 +125,21 @@ const callGetExtraTokenClaimsForJwtCustomization = async ({
     libraries: tenant.libraries,
     logtoConfigs: tenant.logtoConfigs,
   });
+};
+
+// DEV: CIMD (client ID metadata document) support
+const runJwtCustomizationWithClientId = async (clientId: string) => {
+  const tenant = createTenant({});
+  const { ctxWithLog, token, logEntry } = buildContextAndToken({ clientId });
+
+  await getExtraTokenClaimsForJwtCustomization(ctxWithLog, token, {
+    envSet: tenant.envSet,
+    queries: tenant.queries,
+    libraries: tenant.libraries,
+    logtoConfigs: tenant.logtoConfigs,
+  });
+
+  return logEntry;
 };
 
 const createResponseError = (status: number, body: Record<string, unknown>) =>
@@ -254,5 +272,28 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
     await expect(
       callGetExtraTokenClaimsForJwtCustomization({ blockIssuanceOnError: true })
     ).rejects.toBeInstanceOf(errors.InvalidRequest);
+  });
+
+  // DEV: CIMD (client ID metadata document) support
+  describe('log attribution for a cimd client identifier', () => {
+    const cimdClientId = 'https://client.example.com/metadata.json';
+
+    it('routes the identifier to the dedicated key when dev features are enabled', async () => {
+      const logEntry = await runJwtCustomizationWithClientId(cimdClientId);
+
+      const payload: unknown = logEntry.append.mock.calls[0]?.[0];
+      expect(payload).toHaveProperty('cimdClientId', cimdClientId);
+      expect(payload).not.toHaveProperty('applicationId');
+    });
+
+    it('keeps the url-shaped identifier under applicationId when dev features are disabled', async () => {
+      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+
+      const logEntry = await runJwtCustomizationWithClientId(cimdClientId);
+
+      expect(logEntry.append).toHaveBeenCalledWith(
+        expect.objectContaining({ applicationId: cimdClientId })
+      );
+    });
   });
 });

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -30,6 +30,7 @@ import { isAccessDeniedError, parseCustomJwtResponseError } from '#src/utils/cus
 import { i18next } from '#src/utils/i18n.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
+import { getClientIdentifierPayload } from './cimd/index.js';
 import { tokenExchangeActGuard } from './grants/token-exchange/types.js';
 
 const hasI18n = (ctx: KoaContextWithOIDC): ctx is KoaContextWithOIDC & { i18n: i18n } =>
@@ -273,7 +274,8 @@ export const getExtraTokenClaimsForJwtCustomization = async (
 
     logEntry.append({
       sessionId: ctx.oidc.session?.uid,
-      applicationId: ctx.oidc.client?.clientId,
+      // DEV: CIMD (client ID metadata document) support
+      ...getClientIdentifierPayload(ctx.oidc.client?.clientId),
       ...conditional(logtoUserInfo && { userId: logtoUserInfo.id }),
       tenantId: envSet.tenantId,
     });

--- a/packages/schemas/src/foundations/jsonb-types/logs.ts
+++ b/packages/schemas/src/foundations/jsonb-types/logs.ts
@@ -72,7 +72,14 @@ export const logContextPayloadGuard = z
     userAgent: z.string().optional(),
     userAgentParsed: userAgentParsedGuard.optional(),
     userId: z.string().optional(),
+    /** Registered application ids only; a CIMD client identifier goes under {@link cimdClientId}. */
     applicationId: z.string().optional(),
+    // DEV: CIMD (client ID metadata document) support
+    /**
+     * The CIMD client identifier URL, kept apart from `applicationId` so payload consumers
+     * branch on key presence instead of URL shape.
+     */
+    cimdClientId: z.string().optional(),
     sessionId: z.string().optional(),
     params: z.record(z.string(), z.unknown()).optional(),
   })

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -103,7 +103,16 @@ export type DataHookEventPayload = {
   Partial<ManagementApiContext> &
   Record<string, unknown>;
 
-export type ExceptionHookEventPayload = Omit<DataHookEventPayload, 'event'> & {
+/**
+ * A key-remapping omit instead of the built-in `Omit`: `DataHookEventPayload` carries a string
+ * index signature, under which `Omit` collapses every named property into `unknown`; the
+ * homomorphic form keeps the named properties typed.
+ */
+type BetterOmit<T, Ignore> = {
+  [key in keyof T as key extends Ignore ? never : key]: T[key];
+};
+
+export type ExceptionHookEventPayload = BetterOmit<DataHookEventPayload, 'event'> & {
   event: ExceptionHookEvent;
 };
 export type GrantLimitExceededEventData = {

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -36,8 +36,14 @@ export type HookTestErrorResponseData = z.infer<typeof hookTestErrorResponseData
  * we will store the context before processing the interaction and consume it after the interaction is processed if needed.
  */
 export type InteractionApiMetadata = {
-  /** The application ID if the hook is triggered by interaction API. */
+  /** The registered application ID if the hook is triggered by interaction API. */
   applicationId?: string;
+  // DEV: CIMD (client ID metadata document) support
+  /**
+   * The CIMD client identifier URL, kept apart from `applicationId` so payload consumers
+   * branch on key presence instead of URL shape.
+   */
+  cimdClientId?: string;
   /** The session ID if the hook is triggered by interaction API. */
   sessionId?: string;
   /** The InteractionEvent if the hook is triggered by interaction API. */
@@ -47,6 +53,9 @@ export type InteractionApiMetadata = {
 type InteractionApiContextPayload = {
   /** Fetch application detail by application ID before sending the hook event */
   application?: Pick<Application, 'id' | 'type' | 'name' | 'description'>;
+  // DEV: CIMD (client ID metadata document) support
+  /** CIMD clients are unregistered, so the identifier URL stands in for `application`. */
+  cimdClientId?: string;
   sessionId?: string;
   interactionEvent?: InteractionEvent;
 };

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -104,11 +104,11 @@ export type DataHookEventPayload = {
   Record<string, unknown>;
 
 /**
- * A key-remapping omit instead of the built-in `Omit`: `DataHookEventPayload` carries a string
- * index signature, under which `Omit` collapses every named property into `unknown`; the
- * homomorphic form keeps the named properties typed.
+ * A key-remapping omit instead of the built-in `Omit`: on a type carrying a string index
+ * signature (e.g. the hook event payloads), `Omit` collapses every named property into
+ * `unknown`; the homomorphic form keeps the named properties typed.
  */
-type BetterOmit<T, Ignore> = {
+export type BetterOmit<T, Ignore> = {
   [key in keyof T as key extends Ignore ? never : key]: T[key];
 };
 
@@ -117,7 +117,16 @@ export type ExceptionHookEventPayload = BetterOmit<DataHookEventPayload, 'event'
 };
 export type GrantLimitExceededEventData = {
   userId: string;
-  applicationId: string;
+  /** The registered application ID; absent for a CIMD client. */
+  applicationId?: string;
+  // DEV: CIMD (client ID metadata document) support
+  /**
+   * The CIMD client identifier URL, set instead of `applicationId`. No grant-ceiling source
+   * exists for CIMD clients today (the CIMD policy denies Logto private client metadata
+   * regardless of source), so this key is defensive: it keeps `applicationId` registered-only
+   * by construction should a ceiling for CIMD clients ever be introduced.
+   */
+  cimdClientId?: string;
   revokedGrantIds: string[];
   maxAllowedGrants: number;
   preRevocationActiveGrantCount: number;


### PR DESCRIPTION
## Summary

Attribute CIMD clients under a dedicated `cimdClientId` key in the OIDC provider event logs, so audit log and webhook consumers branch on key presence instead of parsing URL shapes (LOG-13928).

- Add `getClientIdentifierPayload`, which routes a client identifier by its namespace: registered application ids go under `applicationId`, CIMD-namespace (`https://`) identifiers under the dedicated `cimdClientId` key. Classification ignores the tenant CIMD config, so attribution holds for interactions in flight when the config flips.
- Extend the log-payload and webhook-metadata types with the optional `cimdClientId` field; `applicationId` keeps carrying registered application ids only.
- Route the identifier through the helper in `extractInteractionContext` (shared by the grant, interaction, revocation, and authorization-success listeners) and in the JWT-customization log entry.
- `grant.error` can fire before the provider resolves the Client entity (a CIMD document fetch or metadata-validation failure), so the extractor falls back to the submitted `client_id` when it is in the CIMD namespace; `applicationId` attribution stays resolution-backed.

The interaction hook and audit payload consumers land in the follow-up PR.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
