### PR TITLE
feat(core): handle cimd clients on the consent routes

### DIFF
--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -20,6 +20,8 @@ import { consent, getMissingScopes } from '#src/libraries/session/index.js';
 import koaAppAccessControl from '#src/middleware/koa-app-access-control.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { isCimdClientId } from '#src/oidc/cimd-client-id.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -27,7 +29,7 @@ import { interactionPrefix } from '../const.js';
 
 import { filterAndParseMissingResourceScopes } from './utils.js';
 
-const { InvalidClient, InvalidRedirectUri } = errors;
+const { InvalidClient, InvalidRedirectUri, InvalidRequest } = errors;
 
 export default function consentRoutes<T extends IRouterParamContext>(
   router: Router<unknown, WithInteractionDetailsContext<T>>,
@@ -70,8 +72,22 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const { accountId: userId } = session;
 
+      // DEV: CIMD (client ID metadata document) support
+      const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(applicationId);
+
       // Grant the organizations to the application if the user has selected the organizations
       if (organizationIds?.length) {
+        /**
+         * Organization grants are keyed to registered applications
+         * (`application_user_consent_organizations`); the grant-scoped counterpart for CIMD
+         * clients lands with LOG-13930, so a CIMD consent submission must not carry any
+         * organization selection.
+         */
+        assertThat(
+          !isCimdClient,
+          new InvalidRequest('organization consent is not available for CIMD clients')
+        );
+
         // Assert that user is a member of all organizations
         await validateUserConsentOrganizationMembership(userId, organizationIds);
 
@@ -93,14 +109,16 @@ export default function consentRoutes<T extends IRouterParamContext>(
       // to ensure the scopes are correct.
 
       // Find the organizations granted by the user
-      // The user may send consent request multiple times, so we need to find the organizations again
-      const [, organizations] = await queries.applications.userConsentOrganizations.getEntities(
-        Organizations,
-        {
-          applicationId,
-          userId,
-        }
-      );
+      // The user may send consent request multiple times, so we need to find the organizations again.
+      // A CIMD client can hold none until LOG-13930 lands the grant-scoped storage.
+      const organizations = isCimdClient
+        ? []
+        : await queries.applications.userConsentOrganizations
+            .getEntities(Organizations, {
+              applicationId,
+              userId,
+            })
+            .then(([, entities]) => entities);
 
       // The missingResourceScopes from the prompt details are from `getResourceServerInfo`,
       // which contains resource scopes and organization resource scopes.
@@ -108,6 +126,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       // The "scopes" in `missingResourceScopes` do not have "id", so we have to rebuild the scopes list.
       const missingResourceScopes = await filterAndParseMissingResourceScopes({
         resourceScopes: allMissingResourceScopes,
+        envSet,
         queries,
         libraries,
         userId,
@@ -118,6 +137,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
         organizations.map(async ({ name, id }) => {
           const missingResourceScopes = await filterAndParseMissingResourceScopes({
             resourceScopes: allMissingResourceScopes,
+            envSet,
             queries,
             libraries,
             userId,
@@ -225,18 +245,54 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const { accountId } = session;
 
-      const application = isBuiltInApplicationId(clientId)
-        ? buildBuiltInApplicationDataForTenant('', clientId)
-        : await queries.applications.findApplicationById(clientId);
+      // DEV: CIMD (client ID metadata document) support
+      const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId);
 
-      const isDeviceFlowApplication =
-        application.type === ApplicationType.Native &&
-        Boolean(application.customClientMetadata.isDeviceFlow);
+      /**
+       * CIMD clients are unregistered: display data comes from the provider-resolved metadata
+       * document (cache-backed) instead of the applications table, and no application-level
+       * sign-in experience or device-flow variant exists for them.
+       */
+      const getApplicationDisplayData = async (): Promise<{
+        application: ConsentInfoResponse['application'];
+        isDeviceFlowApplication: boolean;
+      }> => {
+        // DEV: CIMD (client ID metadata document) support
+        if (isCimdClient) {
+          const client = await provider.Client.find(clientId);
+          assertThat(client, new InvalidClient('client must be available'));
 
-      const applicationSignInExperience =
-        await queries.applicationSignInExperiences.safeFindSignInExperienceByApplicationId(
-          clientId
-        );
+          return {
+            application: { id: clientId, name: client.clientName ?? clientId },
+            isDeviceFlowApplication: false,
+          };
+        }
+
+        const application = isBuiltInApplicationId(clientId)
+          ? buildBuiltInApplicationDataForTenant('', clientId)
+          : await queries.applications.findApplicationById(clientId);
+
+        const applicationSignInExperience =
+          await queries.applicationSignInExperiences.safeFindSignInExperienceByApplicationId(
+            clientId
+          );
+
+        return {
+          // Merge the public application data and application sign-in-experience data
+          application: {
+            ...publicApplicationGuard.parse(application),
+            ...conditional(
+              applicationSignInExperience &&
+                applicationSignInExperienceGuard.parse(applicationSignInExperience)
+            ),
+          },
+          isDeviceFlowApplication:
+            application.type === ApplicationType.Native &&
+            Boolean(application.customClientMetadata.isDeviceFlow),
+        };
+      };
+
+      const { application, isDeviceFlowApplication } = await getApplicationDisplayData();
 
       if (!isDeviceFlowApplication) {
         assertThat(
@@ -256,21 +312,29 @@ export default function consentRoutes<T extends IRouterParamContext>(
       // The "scopes" in `missingResourceScopes` do not have "id", so we have to rebuild the scopes list.
       const missingResourceScopes = await filterAndParseMissingResourceScopes({
         resourceScopes: allMissingResourceScopes,
+        envSet,
         queries,
         libraries,
         userId: accountId,
         applicationId: clientId,
       });
 
-      // Find the organizations if the application is requesting the organizations scope
-      const organizations = missingOIDCScope?.includes(UserScope.Organizations)
-        ? await queries.organizations.relations.users.getOrganizationsByUserId(accountId)
-        : [];
+      // Find the organizations if the application is requesting the organizations scope.
+      /**
+       * Organization grants are keyed to registered applications
+       * (`application_user_consent_organizations`); the grant-scoped counterpart for CIMD
+       * clients lands with LOG-13930, so a CIMD consent offers no organization selection yet.
+       */
+      const organizations =
+        !isCimdClient && missingOIDCScope?.includes(UserScope.Organizations)
+          ? await queries.organizations.relations.users.getOrganizationsByUserId(accountId)
+          : [];
 
       const organizationsWithMissingResourceScopes = await Promise.all(
         organizations.map(async ({ name, id }) => {
           const missingResourceScopes = await filterAndParseMissingResourceScopes({
             resourceScopes: allMissingResourceScopes,
+            envSet,
             queries,
             libraries,
             userId: accountId,
@@ -283,14 +347,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       );
 
       ctx.body = {
-        // Merge the public application data and application sign-in-experience data
-        application: {
-          ...publicApplicationGuard.parse(application),
-          ...conditional(
-            applicationSignInExperience &&
-              applicationSignInExperienceGuard.parse(applicationSignInExperience)
-          ),
-        },
+        application,
         user: publicUserInfoGuard.parse(userInfo),
         organizations: organizationsWithMissingResourceScopes,
         // Filter out the OIDC scopes that are not needed for the consent page.

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -2,7 +2,11 @@ import { ReservedResource } from '@logto/core-kit';
 import { type MissingResourceScopes, type Scope, missingResourceScopesGuard } from '@logto/schemas';
 import { errors } from 'oidc-provider';
 
+import { type EnvSet } from '#src/env-set/index.js';
+import { isCimdClientId } from '#src/oidc/cimd-client-id.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
 import {
+  filterResourceScopesForTheCimdClient,
   filterResourceScopesForTheThirdPartyApplication,
   findResourceScopes,
   isThirdPartyApplication,
@@ -91,6 +95,7 @@ const parseMissingResourceScopesInfo = async (
  */
 export const filterAndParseMissingResourceScopes = async ({
   resourceScopes,
+  envSet,
   queries,
   libraries,
   userId,
@@ -98,6 +103,7 @@ export const filterAndParseMissingResourceScopes = async ({
   organizationId,
 }: {
   resourceScopes: Record<string, string[]>;
+  envSet: EnvSet;
   queries: Queries;
   libraries: Libraries;
   userId: string;
@@ -118,6 +124,26 @@ export const filterAndParseMissingResourceScopes = async ({
             findFromOrganizations: Boolean(organizationId),
             organizationId,
           });
+
+          // DEV: CIMD (client ID metadata document) support
+          if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(applicationId)) {
+            /**
+             * CIMD clients are unregistered: the tenant-wide ceiling replaces the
+             * per-application consent configuration, and the identifier URL must never reach
+             * `isThirdPartyApplication` (its not-found fallback would read as first-party and
+             * skip the filter entirely).
+             */
+            const filteredScopes = await filterResourceScopesForTheCimdClient(
+              queries,
+              resourceIndicator,
+              scopes
+            );
+
+            return [
+              resourceIndicator,
+              missingScopes.filter((scope) => filteredScopes.some(({ name }) => name === scope)),
+            ];
+          }
 
           const isThirdPartyApp = await isThirdPartyApplication(queries, applicationId);
 

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -24,11 +24,21 @@ export type PublicUserInfo = z.infer<typeof publicUserInfoGuard>;
 
 /**
  * Define the public application info that can be exposed to the public. e.g. on the user consent page.
+ *
+ * The overrides lift the applications-table column length bounds: a CIMD client puts its
+ * identifier URL (up to 2048 characters) in `id` and the remote document's `client_name`,
+ * which no column bound governs, in `name`.
  */
-export const publicApplicationGuard = Applications.guard.pick({
-  id: true,
-  name: true,
-});
+export const publicApplicationGuard = Applications.guard
+  .pick({
+    id: true,
+    name: true,
+  })
+  // DEV: CIMD (client ID metadata document) support
+  .extend({
+    id: z.string(),
+    name: z.string(),
+  });
 export type PublicApplication = z.infer<typeof publicApplicationGuard>;
 export const applicationSignInExperienceGuard = ApplicationSignInExperiences.guard.pick({
   branding: true,


### PR DESCRIPTION
## Summary

Handle CIMD clients on the experience consent routes (LOG-13928).

- Serve the consent info for CIMD clients from the provider-resolved metadata document instead of the applications table; no application sign-in experience or device-flow variant applies.
- Reject organization selections on CIMD consent submissions and skip the organization lookups on both GET and POST; the grant-scoped organization support lands with LOG-13930.
- Rebuild the missing resource scopes through the tenant-wide CIMD ceiling (`filterResourceScopesForTheCimdClient`).
- Widen `publicApplicationGuard` so the identifier URL and the remote `client_name` fit the consent response.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
