### PR TITLE
feat: unify the consent client summary and expose the redirect uri match type

### DIFF
--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -22,6 +22,7 @@ import koaGuard from '#src/middleware/koa-guard.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import { isCimdClientId } from '#src/oidc/cimd-client-id.js';
 import { isCimdEffectivelyEnabled } from '#src/oidc/cimd.js';
+import { getRedirectUriMatchType } from '#src/oidc/wildcard-redirect-uri.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -249,21 +250,40 @@ export default function consentRoutes<T extends IRouterParamContext>(
       const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId);
 
       /**
-       * CIMD clients are unregistered: display data comes from the provider-resolved metadata
-       * document (cache-backed) instead of the applications table, and no application-level
-       * sign-in experience or device-flow variant exists for them.
+       * Every consenting client already resolved through the provider at the authorization
+       * endpoint, so the provider client is the single authority for both the registered
+       * redirect URIs the match type classifies against and the CIMD metadata document the
+       * display data comes from.
        */
-      const getApplicationDisplayData = async (): Promise<{
-        application: ConsentInfoResponse['application'];
+      const oidcClient = await provider.Client.find(clientId);
+      assertThat(oidcClient, new InvalidClient('client must be available'));
+
+      /**
+       * CIMD clients are unregistered: display data comes from the provider-resolved metadata
+       * document (cache-backed) instead of the applications table, no application entity
+       * exists for them, and no application-level sign-in experience or device-flow variant
+       * applies. Registered applications keep their response field-for-field and mirror the
+       * `{ id, name }` pair onto the kind-agnostic client summary.
+       */
+      const getClientDisplayData = async (): Promise<{
+        application?: ConsentInfoResponse['application'];
+        client: ConsentInfoResponse['client'];
         isDeviceFlowApplication: boolean;
       }> => {
         // DEV: CIMD (client ID metadata document) support
         if (isCimdClient) {
-          const client = await provider.Client.find(clientId);
-          assertThat(client, new InvalidClient('client must be available'));
+          const { hostname } = new URL(clientId);
 
           return {
-            application: { id: clientId, name: client.clientName ?? clientId },
+            client: {
+              id: clientId,
+              name: oidcClient.clientName ?? hostname,
+              hostname,
+              logoUri: oidcClient.logoUri,
+              clientUri: oidcClient.clientUri,
+              policyUri: oidcClient.policyUri,
+              tosUri: oidcClient.tosUri,
+            },
             isDeviceFlowApplication: false,
           };
         }
@@ -277,27 +297,47 @@ export default function consentRoutes<T extends IRouterParamContext>(
             clientId
           );
 
+        const publicApplication = publicApplicationGuard.parse(application);
+
         return {
           // Merge the public application data and application sign-in-experience data
           application: {
-            ...publicApplicationGuard.parse(application),
+            ...publicApplication,
             ...conditional(
               applicationSignInExperience &&
                 applicationSignInExperienceGuard.parse(applicationSignInExperience)
             ),
           },
+          client: { id: publicApplication.id, name: publicApplication.name },
           isDeviceFlowApplication:
             application.type === ApplicationType.Native &&
             Boolean(application.customClientMetadata.isDeviceFlow),
         };
       };
 
-      const { application, isDeviceFlowApplication } = await getApplicationDisplayData();
+      const { application, client, isDeviceFlowApplication } = await getClientDisplayData();
 
       if (!isDeviceFlowApplication) {
         assertThat(
           redirectUri && typeof redirectUri === 'string',
           new InvalidRedirectUri('redirect_uri must be available')
+        );
+      }
+
+      /**
+       * Authorization already validated the value against the same client, so a missing match
+       * here means the registered set changed mid-flow (for CIMD clients the metadata document
+       * may refetch between authorization and consent); the consent screen must not vouch for
+       * a redirect target the client no longer registers.
+       */
+      const redirectUriMatchType = conditional(
+        typeof redirectUri === 'string' && getRedirectUriMatchType(oidcClient, redirectUri)
+      );
+
+      if (typeof redirectUri === 'string') {
+        assertThat(
+          redirectUriMatchType,
+          new InvalidRedirectUri('redirect_uri must match a registered redirect uri')
         );
       }
 
@@ -348,6 +388,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       ctx.body = {
         application,
+        client,
         user: publicUserInfoGuard.parse(userInfo),
         organizations: organizationsWithMissingResourceScopes,
         // Filter out the OIDC scopes that are not needed for the consent page.
@@ -357,6 +398,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
         missingResourceScopes,
         // Device flow consent does not require a redirect_uri.
         redirectUri: typeof redirectUri === 'string' ? redirectUri : undefined,
+        redirectUriMatchType,
       } satisfies ConsentInfoResponse;
 
       return next();

--- a/packages/experience/src/Layout/LandingPageLayout/index.tsx
+++ b/packages/experience/src/Layout/LandingPageLayout/index.tsx
@@ -13,7 +13,7 @@ import FirstScreenLayout from '../FirstScreenLayout';
 
 import styles from './index.module.scss';
 
-type ThirdPartyBranding = ConsentInfoResponse['application']['branding'];
+type ThirdPartyBranding = NonNullable<ConsentInfoResponse['application']>['branding'];
 
 type Props = {
   readonly children: ReactNode;

--- a/packages/experience/src/pages/Consent/index.test.tsx
+++ b/packages/experience/src/pages/Consent/index.test.tsx
@@ -28,6 +28,10 @@ const consentInfo: ConsentInfoResponse = {
     privacyPolicyUrl: null,
     termsOfUseUrl: null,
   },
+  client: {
+    id: 'application_id',
+    name: 'Application',
+  },
   user: {
     id: 'user_id',
     name: null,

--- a/packages/experience/src/pages/Consent/index.tsx
+++ b/packages/experience/src/pages/Consent/index.tsx
@@ -53,7 +53,7 @@ const Consent = () => {
   const signOut = useCallback(() => {
     const applicationId =
       new URLSearchParams(window.location.search).get(searchKeys.appId) ??
-      consentData?.application.id;
+      consentData?.application?.id;
     const signOutUrl = new URL('/oidc/session/end', window.location.origin);
 
     if (applicationId) {
@@ -61,7 +61,7 @@ const Consent = () => {
     }
 
     window.location.assign(signOutUrl.href);
-  }, [consentData?.application.id]);
+  }, [consentData?.application?.id]);
 
   const consentHandler = useCallback(async () => {
     setIsConsentLoading(true);
@@ -120,9 +120,18 @@ const Consent = () => {
     return null;
   }
 
-  const {
-    application: { displayName, name, termsOfUseUrl, privacyPolicyUrl },
-  } = consentData;
+  const { application } = consentData;
+
+  // DEV: CIMD (client ID metadata document) support
+  /**
+   * A response without `application` is a CIMD client; this page renders registered
+   * applications only until LOG-13931 lands the kind-agnostic client rendering.
+   */
+  if (!application) {
+    return null;
+  }
+
+  const { displayName, name, termsOfUseUrl, privacyPolicyUrl } = application;
 
   const applicationName = displayName ?? name;
   const showTerms = Boolean(termsOfUseUrl ?? privacyPolicyUrl);
@@ -137,7 +146,7 @@ const Consent = () => {
       titleInterpolation={{
         name: applicationName,
       }}
-      thirdPartyBranding={consentData.application.branding}
+      thirdPartyBranding={application.branding}
     >
       <UserProfile user={consentData.user} />
       <ScopesListCard

--- a/packages/experience/src/pages/SwitchAccount/index.test.tsx
+++ b/packages/experience/src/pages/SwitchAccount/index.test.tsx
@@ -29,6 +29,10 @@ const consentInfo: ConsentInfoResponse = {
     privacyPolicyUrl: null,
     termsOfUseUrl: null,
   },
+  client: {
+    id: 'application_id',
+    name: 'Application',
+  },
   user: {
     id: 'user_id',
     name: null,

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -73,14 +73,44 @@ export const publicOrganizationGuard = Organizations.guard
 
 export type PublicOrganization = z.infer<typeof publicOrganizationGuard>;
 
+// DEV: CIMD (client ID metadata document) support
+/**
+ * The kind-agnostic client summary for the consent page: one flat object instead of a
+ * discriminated union, so the experience renders by field presence without judging the client
+ * kind. `id` is the OAuth client_id for both kinds (a registered application id or a CIMD
+ * client identifier URL). The optional fields are present only for CIMD clients, resolved
+ * server-side from the provider-validated metadata document; `name` falls back to the client
+ * identifier hostname when the document carries no `client_name` (a compliant document without
+ * a name must not break authorization).
+ */
+export const publicClientSummaryGuard = z.object({
+  id: z.string(),
+  name: z.string(),
+  hostname: z.string().optional(),
+  logoUri: z.string().optional(),
+  clientUri: z.string().optional(),
+  policyUri: z.string().optional(),
+  tosUri: z.string().optional(),
+});
+export type PublicClientSummary = z.infer<typeof publicClientSummaryGuard>;
+
 export const consentInfoResponseGuard = z.object({
-  application: publicApplicationGuard.merge(applicationSignInExperienceGuard.partial()),
+  // DEV: CIMD (client ID metadata document) support
+  /** Present only for registered applications; a CIMD client carries no application entity. */
+  application: publicApplicationGuard.merge(applicationSignInExperienceGuard.partial()).optional(),
+  client: publicClientSummaryGuard,
   user: publicUserInfoGuard,
   organizations: publicOrganizationGuard.array().optional(),
   missingOIDCScope: z.string().array().optional(),
   missingResourceScopes: missingResourceScopesGuard.array().optional(),
   // Device flow consent does not require a redirect_uri.
   redirectUri: z.string().optional(),
+  /**
+   * How the authorization `redirect_uri` matches the client's registered redirect URIs,
+   * computed server-side from the registered values and the matcher — never trusted from the
+   * client or the experience. Absent for device-flow consent, which carries no redirect URI.
+   */
+  redirectUriMatchType: z.enum(['exact', 'wildcard']).optional(),
 });
 
 export type ConsentInfoResponse = z.infer<typeof consentInfoResponseGuard>;


### PR DESCRIPTION
## Summary

Unify the consent info response behind a kind-agnostic client summary and expose how the redirect URI matched (LOG-13929).

- `application` becomes optional and stays field-for-field identical for registered applications; a CIMD client carries no application entity.
- New flat `client` summary for both kinds — `{ id, name, hostname?, logoUri?, clientUri?, policyUri?, tosUri? }`. Optional fields are present only for CIMD clients, resolved server-side from the provider-validated metadata document; `name` falls back to the identifier hostname when `client_name` is absent.
- New `redirectUriMatchType: 'exact' | 'wildcard'` on the consent info, computed server-side via `getRedirectUriMatchType` — never trusted from the client; consent now rejects a redirect target the client no longer registers (mid-flow metadata rotation).
- The experience consent page keeps rendering registered applications only; the kind-agnostic field-presence rendering lands with LOG-13931.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
