### PR TITLE
feat(core): route cimd client identifiers to the dedicated key in oidc event logs

### DIFF
--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -1,6 +1,8 @@
 import type { LogKey } from '@logto/schemas';
 import { LogResult, token } from '@logto/schemas';
+import Sinon from 'sinon';
 
+import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { stringifyError } from '#src/utils/format.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
@@ -22,6 +24,10 @@ const entities = {
 };
 
 const baseCallArgs = { applicationId, sessionId, userId };
+
+const stubDevFeaturesFlag = (isDevFeaturesEnabled: boolean) => {
+  Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isDevFeaturesEnabled });
+};
 
 const testGrantListener = (
   parameters: { grant_type: string } & Record<string, unknown>,
@@ -115,6 +121,57 @@ describe('grantSuccessListener', () => {
       'ExchangeTokenBy.Unknown',
       [token.TokenType.AccessToken]
     );
+  });
+});
+
+// DEV: CIMD (client ID metadata document) support
+describe('grantSuccessListener with a cimd client identifier', () => {
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  const buildCimdContext = () => ({
+    ...createContextWithRouteParameters(),
+    createLog: log.createLog,
+    prependAllLogEntries: log.prependAllLogEntries,
+    oidc: {
+      entities: { ...entities, Client: { clientId: cimdClientId } },
+      params: { grant_type: 'refresh_token' },
+    },
+    body: { access_token: 'newAccessTokenValue' },
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+    jest.clearAllMocks();
+  });
+
+  it('should log a cimd client identifier under the dedicated key', () => {
+    stubDevFeaturesFlag(true);
+    const ctx = buildCimdContext();
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      cimdClientId,
+      sessionId,
+      userId,
+      tokenTypes: [token.TokenType.AccessToken],
+      params: { grant_type: 'refresh_token' },
+    });
+  });
+
+  it('should keep a url-shaped identifier under applicationId when the dev features flag is off', () => {
+    stubDevFeaturesFlag(false);
+    const ctx = buildCimdContext();
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      applicationId: cimdClientId,
+      sessionId,
+      userId,
+      tokenTypes: [token.TokenType.AccessToken],
+      params: { grant_type: 'refresh_token' },
+    });
   });
 });
 

--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -42,13 +42,13 @@ const buildCimdContext = () => ({
   body: { access_token: 'newAccessTokenValue' },
 });
 
-const buildUnresolvedClientContext = (clientId: string) => ({
+const buildUnresolvedClientContext = (params: Record<string, unknown>) => ({
   ...createContextWithRouteParameters(),
   createLog: log.createLog,
   prependAllLogEntries: log.prependAllLogEntries,
   oidc: {
     entities: {},
-    params: { grant_type: 'authorization_code', client_id: clientId },
+    params,
   },
   body: { error: 'invalid_client' },
 });
@@ -197,7 +197,8 @@ describe('grantErrorListener with an unresolved client', () => {
 
   it('should attribute a cimd-namespace client_id from params when the client is not resolved', () => {
     stubDevFeaturesFlag(true);
-    const ctx = buildUnresolvedClientContext(cimdClientId);
+    const params = { grant_type: 'authorization_code', client_id: cimdClientId };
+    const ctx = buildUnresolvedClientContext(params);
 
     // @ts-expect-error pass complex type check to mock ctx directly
     grantListener(ctx, error);
@@ -206,13 +207,14 @@ describe('grantErrorListener with an unresolved client', () => {
       result: LogResult.Error,
       tokenTypes: [],
       error: stringifyError(error),
-      params: { grant_type: 'authorization_code', client_id: cimdClientId },
+      params,
     });
   });
 
   it('should keep an unresolved non-cimd client_id unattributed', () => {
     stubDevFeaturesFlag(true);
-    const ctx = buildUnresolvedClientContext('app-typo');
+    const params = { grant_type: 'authorization_code', client_id: 'app-typo' };
+    const ctx = buildUnresolvedClientContext(params);
 
     // @ts-expect-error pass complex type check to mock ctx directly
     grantListener(ctx, error);
@@ -220,7 +222,46 @@ describe('grantErrorListener with an unresolved client', () => {
       result: LogResult.Error,
       tokenTypes: [],
       error: stringifyError(error),
-      params: { grant_type: 'authorization_code', client_id: 'app-typo' },
+      params,
+    });
+  });
+
+  it('should keep an unresolved url-shaped client_id unattributed when the dev features flag is off', () => {
+    stubDevFeaturesFlag(false);
+    const params = { grant_type: 'authorization_code', client_id: cimdClientId };
+    const ctx = buildUnresolvedClientContext(params);
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx, error);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      result: LogResult.Error,
+      tokenTypes: [],
+      error: stringifyError(error),
+      params,
+    });
+  });
+
+  /**
+   * Attribution reads the resolved Client and the explicit `client_id` parameter only; an
+   * identifier embedded in authentication material (e.g. `client_assertion.sub`) stays raw in
+   * `params` for forensics.
+   */
+  it('should keep an assertion-only failure unattributed while params carry the assertion', () => {
+    stubDevFeaturesFlag(true);
+    const params = {
+      grant_type: 'authorization_code',
+      client_assertion: 'header.payload.signature',
+      client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+    };
+    const ctx = buildUnresolvedClientContext(params);
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx, error);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      result: LogResult.Error,
+      tokenTypes: [],
+      error: stringifyError(error),
+      params,
     });
   });
 });

--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -29,6 +29,30 @@ const stubDevFeaturesFlag = (isDevFeaturesEnabled: boolean) => {
   Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isDevFeaturesEnabled });
 };
 
+const cimdClientId = 'https://client.example.com/metadata.json';
+
+const buildCimdContext = () => ({
+  ...createContextWithRouteParameters(),
+  createLog: log.createLog,
+  prependAllLogEntries: log.prependAllLogEntries,
+  oidc: {
+    entities: { ...entities, Client: { clientId: cimdClientId } },
+    params: { grant_type: 'refresh_token' },
+  },
+  body: { access_token: 'newAccessTokenValue' },
+});
+
+const buildUnresolvedClientContext = (clientId: string) => ({
+  ...createContextWithRouteParameters(),
+  createLog: log.createLog,
+  prependAllLogEntries: log.prependAllLogEntries,
+  oidc: {
+    entities: {},
+    params: { grant_type: 'authorization_code', client_id: clientId },
+  },
+  body: { error: 'invalid_client' },
+});
+
 const testGrantListener = (
   parameters: { grant_type: string } & Record<string, unknown>,
   body: Record<string, string>,
@@ -126,19 +150,6 @@ describe('grantSuccessListener', () => {
 
 // DEV: CIMD (client ID metadata document) support
 describe('grantSuccessListener with a cimd client identifier', () => {
-  const cimdClientId = 'https://client.example.com/metadata.json';
-
-  const buildCimdContext = () => ({
-    ...createContextWithRouteParameters(),
-    createLog: log.createLog,
-    prependAllLogEntries: log.prependAllLogEntries,
-    oidc: {
-      entities: { ...entities, Client: { clientId: cimdClientId } },
-      params: { grant_type: 'refresh_token' },
-    },
-    body: { access_token: 'newAccessTokenValue' },
-  });
-
   afterEach(() => {
     Sinon.restore();
     jest.clearAllMocks();
@@ -171,6 +182,45 @@ describe('grantSuccessListener with a cimd client identifier', () => {
       userId,
       tokenTypes: [token.TokenType.AccessToken],
       params: { grant_type: 'refresh_token' },
+    });
+  });
+});
+
+// DEV: CIMD (client ID metadata document) support
+describe('grantErrorListener with an unresolved client', () => {
+  const error = new Error('client metadata fetch failed');
+
+  afterEach(() => {
+    Sinon.restore();
+    jest.clearAllMocks();
+  });
+
+  it('should attribute a cimd-namespace client_id from params when the client is not resolved', () => {
+    stubDevFeaturesFlag(true);
+    const ctx = buildUnresolvedClientContext(cimdClientId);
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx, error);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      cimdClientId,
+      result: LogResult.Error,
+      tokenTypes: [],
+      error: stringifyError(error),
+      params: { grant_type: 'authorization_code', client_id: cimdClientId },
+    });
+  });
+
+  it('should keep an unresolved non-cimd client_id unattributed', () => {
+    stubDevFeaturesFlag(true);
+    const ctx = buildUnresolvedClientContext('app-typo');
+
+    // @ts-expect-error pass complex type check to mock ctx directly
+    grantListener(ctx, error);
+    expect(log.mockAppend).toHaveBeenCalledWith({
+      result: LogResult.Error,
+      tokenTypes: [],
+      error: stringifyError(error),
+      params: { grant_type: 'authorization_code', client_id: 'app-typo' },
     });
   });
 });

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -2,6 +2,7 @@ import type { KoaContextWithOIDC } from 'oidc-provider';
 
 import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
 import type { LogPayload } from '#src/middleware/koa-audit-log.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 
 export const extractInteractionContext = (
   ctx: WithAppSecretContext<KoaContextWithOIDC>
@@ -12,7 +13,8 @@ export const extractInteractionContext = (
   } = ctx.oidc;
 
   return {
-    applicationId: Client?.clientId,
+    // DEV: CIMD (client ID metadata document) support
+    ...getClientIdentifierPayload(Client?.clientId),
     applicationSecret: ctx.appSecret,
     sessionId: Session?.jti,
     interactionId: Interaction?.jti,

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -1,7 +1,10 @@
+import { conditional } from '@silverhand/essentials';
 import type { KoaContextWithOIDC } from 'oidc-provider';
 
+import { EnvSet } from '#src/env-set/index.js';
 import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
 import type { LogPayload } from '#src/middleware/koa-audit-log.js';
+import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
 import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 
 export const extractInteractionContext = (
@@ -12,9 +15,25 @@ export const extractInteractionContext = (
     params,
   } = ctx.oidc;
 
+  const submittedClientId = params?.client_id;
+
+  // DEV: CIMD (client ID metadata document) support
+  /**
+   * `grant.error` fires for failures thrown before the provider resolves the Client entity — a
+   * CIMD document fetch or metadata-validation failure lands exactly there — so fall back to the
+   * submitted `client_id`, but only within the CIMD namespace: `applicationId` attribution stays
+   * resolution-backed, keeping a mistyped registered id unattributed as before.
+   */
+  const cimdFallbackClientId = conditional(
+    EnvSet.values.isDevFeaturesEnabled &&
+      typeof submittedClientId === 'string' &&
+      isCimdClientId(submittedClientId) &&
+      submittedClientId
+  );
+
   return {
     // DEV: CIMD (client ID metadata document) support
-    ...getClientIdentifierPayload(Client?.clientId),
+    ...getClientIdentifierPayload(Client?.clientId ?? cimdFallbackClientId),
     applicationSecret: ctx.appSecret,
     sessionId: Session?.jti,
     interactionId: Interaction?.jti,

--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -27,10 +27,13 @@ jest.unstable_mockModule('#src/libraries/jwt-customizer.js', () => ({
 const { EnvSet } = await import('#src/env-set/index.js');
 const { getExtraTokenClaimsForJwtCustomization } = await import('./extra-token-claims.js');
 
-const buildContextAndToken = ({ organizationId }: { organizationId?: string } = {}) => {
+const buildContextAndToken = ({
+  organizationId,
+  clientId = 'app-1',
+}: { organizationId?: string; clientId?: string } = {}) => {
   const ctx = createOidcContext({
     session: { uid: sessionUid } as unknown as KoaContextWithOIDC['oidc']['session'],
-    client: { clientId: 'app-1' } as unknown as KoaContextWithOIDC['oidc']['client'],
+    client: { clientId } as unknown as KoaContextWithOIDC['oidc']['client'],
     params: { organization_id: organizationId },
   });
 
@@ -54,7 +57,7 @@ const buildContextAndToken = ({ organizationId }: { organizationId?: string } = 
     gty: { value: 'password', enumerable: true },
   }) as AccessToken;
 
-  return { ctxWithLog, token };
+  return { ctxWithLog, token, logEntry };
 };
 
 const mockOrganization = {
@@ -122,6 +125,21 @@ const callGetExtraTokenClaimsForJwtCustomization = async ({
     libraries: tenant.libraries,
     logtoConfigs: tenant.logtoConfigs,
   });
+};
+
+// DEV: CIMD (client ID metadata document) support
+const runJwtCustomizationWithClientId = async (clientId: string) => {
+  const tenant = createTenant({});
+  const { ctxWithLog, token, logEntry } = buildContextAndToken({ clientId });
+
+  await getExtraTokenClaimsForJwtCustomization(ctxWithLog, token, {
+    envSet: tenant.envSet,
+    queries: tenant.queries,
+    libraries: tenant.libraries,
+    logtoConfigs: tenant.logtoConfigs,
+  });
+
+  return logEntry;
 };
 
 const createResponseError = (status: number, body: Record<string, unknown>) =>
@@ -254,5 +272,28 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
     await expect(
       callGetExtraTokenClaimsForJwtCustomization({ blockIssuanceOnError: true })
     ).rejects.toBeInstanceOf(errors.InvalidRequest);
+  });
+
+  // DEV: CIMD (client ID metadata document) support
+  describe('log attribution for a cimd client identifier', () => {
+    const cimdClientId = 'https://client.example.com/metadata.json';
+
+    it('routes the identifier to the dedicated key when dev features are enabled', async () => {
+      const logEntry = await runJwtCustomizationWithClientId(cimdClientId);
+
+      const payload: unknown = logEntry.append.mock.calls[0]?.[0];
+      expect(payload).toHaveProperty('cimdClientId', cimdClientId);
+      expect(payload).not.toHaveProperty('applicationId');
+    });
+
+    it('keeps the url-shaped identifier under applicationId when dev features are disabled', async () => {
+      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+
+      const logEntry = await runJwtCustomizationWithClientId(cimdClientId);
+
+      expect(logEntry.append).toHaveBeenCalledWith(
+        expect.objectContaining({ applicationId: cimdClientId })
+      );
+    });
   });
 });

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -30,6 +30,7 @@ import { isAccessDeniedError, parseCustomJwtResponseError } from '#src/utils/cus
 import { i18next } from '#src/utils/i18n.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
+import { getClientIdentifierPayload } from './cimd/index.js';
 import { tokenExchangeActGuard } from './grants/token-exchange/types.js';
 
 const hasI18n = (ctx: KoaContextWithOIDC): ctx is KoaContextWithOIDC & { i18n: i18n } =>
@@ -273,7 +274,8 @@ export const getExtraTokenClaimsForJwtCustomization = async (
 
     logEntry.append({
       sessionId: ctx.oidc.session?.uid,
-      applicationId: ctx.oidc.client?.clientId,
+      // DEV: CIMD (client ID metadata document) support
+      ...getClientIdentifierPayload(ctx.oidc.client?.clientId),
       ...conditional(logtoUserInfo && { userId: logtoUserInfo.id }),
       tenantId: envSet.tenantId,
     });


### PR DESCRIPTION
## Summary

Route CIMD client identifiers to the dedicated `cimdClientId` key in the OIDC provider event logs (LOG-13928).

- `extractInteractionContext` (shared by the grant, interaction, revocation, and authorization-success listeners) and the JWT-customization log entry route the client identifier through `getClientIdentifierPayload`.
- `grant.error` can fire before the provider resolves the Client entity (a CIMD document fetch or metadata-validation failure), so the extractor falls back to the submitted `client_id` when it is in the CIMD namespace; `applicationId` attribution stays resolution-backed.
- Attribution is namespace-based (no env-set plumbing), so the listener signatures stay untouched.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
