### PR TITLE
feat(core): carry cimd client identifiers on interaction hook and audit payloads

### DIFF
--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -84,7 +84,8 @@ type ActionEventSource<Event> =
 type RunActionData<Event> = ActionEventSource<Event> & {
   key: LogtoActionKey;
   auditContext: Pick<LogContext, 'createLog'> &
-    Pick<LogPayload, 'applicationId' | 'sessionId' | 'userId'>;
+    // DEV: CIMD (client ID metadata document) support
+    Pick<LogPayload, 'applicationId' | 'cimdClientId' | 'sessionId' | 'userId'>;
 };
 
 type ActionExecutionErrorHandlingData = {

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -124,7 +124,8 @@ export const createHookLibrary = (queries: Queries) => {
       return;
     }
 
-    const { interactionEvent, sessionId, applicationId, userIp, userAgent } = metadata;
+    const { interactionEvent, sessionId, applicationId, cimdClientId, userIp, userAgent } =
+      metadata;
 
     const found = await findAllHooks();
 
@@ -170,6 +171,8 @@ export const createHookLibrary = (queries: Queries) => {
         userIp,
         user: user && pick(user, ...userInfoSelectFields),
         application: application && pick(application, 'id', 'type', 'name', 'description'),
+        // DEV: CIMD (client ID metadata document) support
+        cimdClientId,
       } satisfies BetterOmit<InteractionHookEventPayload, 'hookId'>;
 
       // eslint-disable-next-line @silverhand/fp/no-mutating-methods

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -16,6 +16,7 @@ import { conditional, trySafe } from '@silverhand/essentials';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayload } from '#src/libraries/user.utils.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
@@ -720,9 +721,12 @@ export default class ExperienceInteraction {
         auditContext: {
           createLog: this.ctx.createLog,
           sessionId: this.ctx.interactionDetails.jti,
-          applicationId: conditional(
-            typeof this.ctx.interactionDetails.params.client_id === 'string' &&
-              this.ctx.interactionDetails.params.client_id
+          // DEV: CIMD (client ID metadata document) support
+          ...getClientIdentifierPayload(
+            conditional(
+              typeof this.ctx.interactionDetails.params.client_id === 'string' &&
+                this.ctx.interactionDetails.params.client_id
+            )
           ),
           userId,
         },

--- a/packages/core/src/routes/experience/middleware/koa-experience-audit-log.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-audit-log.ts
@@ -3,6 +3,7 @@ import { type MiddlewareType } from 'koa';
 
 import { type LogContext } from '#src/middleware/koa-audit-log.js';
 import { type WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 
 export default function koaExperienceAuditLog<
   StateT,
@@ -11,12 +12,13 @@ export default function koaExperienceAuditLog<
 >(): MiddlewareType<StateT, ContextT, ResponseT> {
   return async (ctx, next) => {
     const { prependAllLogEntries, interactionDetails } = ctx;
-    const applicationId = conditionalString(interactionDetails.params.client_id);
+    const clientId = conditionalString(interactionDetails.params.client_id);
 
     try {
       await next();
     } finally {
-      prependAllLogEntries({ applicationId });
+      // DEV: CIMD (client ID metadata document) support
+      prependAllLogEntries(getClientIdentifierPayload(clientId));
     }
   };
 }

--- a/packages/core/src/routes/experience/middleware/koa-experience-interaction-hooks.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-interaction-hooks.ts
@@ -9,6 +9,7 @@ import {
   InteractionHookContextManager,
 } from '#src/libraries/hook/context-manager.js';
 import { type WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 
@@ -54,7 +55,8 @@ export function koaExperienceInteractionHooks<
     const interactionApiMetadata = {
       interactionEvent,
       userAgent,
-      applicationId: conditionalString(interactionDetails.params.client_id),
+      // DEV: CIMD (client ID metadata document) support
+      ...getClientIdentifierPayload(conditionalString(interactionDetails.params.client_id)),
       sessionId: interactionDetails.jti,
     };
     const interactionHookContext = new InteractionHookContextManager({

--- a/packages/core/src/routes/experience/verification-routes/password-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/password-verification.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 
 import { appendPasswordPayloadToActionProvisioningProfile } from '../classes/libraries/action-provisioning-profile.js';
@@ -129,9 +130,12 @@ export default function passwordVerificationRoutes<T extends ExperienceInteracti
                 auditContext: {
                   createLog: ctx.createLog,
                   sessionId: ctx.interactionDetails.jti,
-                  applicationId: conditional(
-                    typeof ctx.interactionDetails.params.client_id === 'string' &&
-                      ctx.interactionDetails.params.client_id
+                  // DEV: CIMD (client ID metadata document) support
+                  ...getClientIdentifierPayload(
+                    conditional(
+                      typeof ctx.interactionDetails.params.client_id === 'string' &&
+                        ctx.interactionDetails.params.client_id
+                    )
                   ),
                   userId: existingUser?.id,
                 },

--- a/packages/core/src/routes/interaction/middleware/koa-interaction-hooks.ts
+++ b/packages/core/src/routes/interaction/middleware/koa-interaction-hooks.ts
@@ -7,6 +7,7 @@ import {
   InteractionHookContextManager,
 } from '#src/libraries/hook/context-manager.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 
@@ -43,7 +44,8 @@ export default function koaInteractionHooks<
     const interactionApiMetadata = {
       interactionEvent,
       userAgent,
-      applicationId: conditionalString(interactionDetails.params.client_id),
+      // DEV: CIMD (client ID metadata document) support
+      ...getClientIdentifierPayload(conditionalString(interactionDetails.params.client_id)),
       sessionId: interactionDetails.jti,
     };
 


### PR DESCRIPTION
## Summary

Carry CIMD client identifiers under the dedicated `cimdClientId` key on interaction API hook payloads and experience audit logs (LOG-13928).

- Interaction API hook metadata and experience audit-log entries route the presented client identifier through `getClientIdentifierPayload`; webhook payloads and post-sign-in action audit contexts include `cimdClientId`, while `applicationId` keeps registered application ids only.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
