### PR TITLE
feat(core): write cimd first-consent attribution to the dedicated user column

### DIFF
--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -28,6 +28,26 @@ const saveUserFirstConsentedAppId = async (
   }
 };
 
+// DEV: CIMD (client ID metadata document) support
+/**
+ * The CIMD mirror of {@link saveUserFirstConsentedAppId} on the dedicated
+ * `users.cimd_client_id` column: `users.application_id` (varchar(21)) keeps meaning "first
+ * consented registered application", so a CIMD URL must never reach it — user management still
+ * shows which client a user came from through the dedicated column.
+ */
+const saveUserFirstConsentedCimdClientId = async (
+  queries: Queries,
+  userId: string,
+  cimdClientId: string
+) => {
+  const { findUserById, updateUserById } = queries.users;
+  const { cimdClientId: firstConsentedCimdClientId } = await findUserById(userId);
+
+  if (!firstConsentedCimdClientId) {
+    await updateUserById(userId, { cimdClientId });
+  }
+};
+
 // Get the missing scopes from prompt details
 const missingScopesGuard = z.object({
   missingOIDCScope: z.string().array().optional(),
@@ -149,12 +169,12 @@ export const consent = async ({
     new provider.Grant({ accountId, clientId });
 
   await Promise.all([
-    /**
-     * A CIMD URL must never reach `users.application_id` (varchar(21), registered ids only).
-     * TODO: @xiaoyijun persist the CIMD attribution to `users.cimd_client_id` instead (LOG-13928).
-     */
     conditional(
       registeredClientId && saveUserFirstConsentedAppId(queries, accountId, registeredClientId)
+    ),
+    // DEV: CIMD (client ID metadata document) support
+    conditional(
+      cimdClientId && saveUserFirstConsentedCimdClientId(queries, accountId, cimdClientId)
     ),
     saveInteractionLastSubmissionToSession(queries, interactionDetails, {
       registeredClientId,

--- a/packages/core/src/libraries/session/session-context.test.ts
+++ b/packages/core/src/libraries/session/session-context.test.ts
@@ -103,7 +103,11 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
     jest.clearAllMocks();
   });
 
-  it('should write a cimd client identifier to the dedicated column and skip the app attribution', async () => {
+  it('should write a cimd client identifier to the dedicated columns and keep the app attribution null', async () => {
+    userQueries.findUserById.mockImplementationOnce(async () => ({
+      ...mockUser,
+      cimdClientId: null,
+    }));
     const interactionDetails = buildInteractionDetails(cimdClientId);
     const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
 
@@ -122,7 +126,25 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
       clientId: null,
       cimdClientId,
     });
-    expect(userQueries.findUserById).not.toHaveBeenCalled();
+    expect(userQueries.updateUserById).toHaveBeenCalledWith(mockUser.id, { cimdClientId });
+  });
+
+  it('should not overwrite an existing first-consent cimd attribution', async () => {
+    userQueries.findUserById.mockImplementationOnce(async () => ({
+      ...mockUser,
+      cimdClientId: 'https://first.example.com/metadata.json',
+    }));
+    const interactionDetails = buildInteractionDetails(cimdClientId);
+    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails,
+    });
+
     expect(userQueries.updateUserById).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Write the first-consent attribution for CIMD clients to the dedicated `users.cimd_client_id` column (LOG-13928).

- `users.application_id` stays null and keeps meaning "first consented registered application"; the mirror helper writes the dedicated column once and never overwrites an existing attribution.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
