### PR TITLE
feat(core): omit the cimd identifier from the experience cookie

### DIFF
--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- provider init tests share one harness; splitting fragments the shared mock setup. */
 import assert from 'node:assert';
 
-import { defaultTenantId, GrantType, type Scope } from '@logto/schemas';
+import { defaultTenantId, GrantType, logtoCookieKey, type Scope } from '@logto/schemas';
 import { errors, type KoaContextWithOIDC } from 'oidc-provider';
 
 import { mockResource, mockUser } from '#src/__mocks__/index.js';
@@ -580,6 +580,59 @@ describe('loadExistingGrant for CIMD clients', () => {
 
     await expect(configuration.loadExistingGrant(ctx)).rejects.toThrow(errors.AccessDenied);
     expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(cimdClientId, accountId, undefined);
+  });
+});
+
+const runInteractionUrl = (provider: ReturnType<typeof createProvider>, promptClientId: string) => {
+  const configuration = getProviderConfiguration(provider);
+  const ctx = createOidcContext({ provider });
+  const interaction = {
+    params: { client_id: promptClientId },
+    prompt: { name: 'consent', reasons: [], details: {} },
+  } as unknown as Parameters<typeof configuration.interactions.url>[1];
+
+  return { ctx, url: configuration.interactions.url(ctx, interaction) };
+};
+
+// DEV: CIMD (client ID metadata document) support
+describe('experience cookie for CIMD prompts', () => {
+  const cimdClientId = 'https://client.example.com/client-metadata.json';
+
+  it('should omit appId from the experience cookie for a cimd prompt', async () => {
+    const { id, queries, libraries, logtoConfigs, subscription } = new MockTenant();
+    const provider = initOidc(id, cimdEnvSet, queries, libraries, logtoConfigs, subscription);
+
+    const { ctx } = runInteractionUrl(provider, cimdClientId);
+
+    expect(ctx.cookies.set).toHaveBeenCalledWith(
+      logtoCookieKey,
+      JSON.stringify({}),
+      expect.anything()
+    );
+  });
+
+  it('should keep appId in the experience cookie for a registered client prompt', async () => {
+    const provider = createProvider(new MockTenant());
+
+    const { ctx } = runInteractionUrl(provider, clientId);
+
+    expect(ctx.cookies.set).toHaveBeenCalledWith(
+      logtoCookieKey,
+      JSON.stringify({ appId: clientId }),
+      expect.anything()
+    );
+  });
+
+  it('should keep appId in the experience cookie for a url client id when CIMD is not effectively enabled', async () => {
+    const provider = createProvider(new MockTenant());
+
+    const { ctx } = runInteractionUrl(provider, cimdClientId);
+
+    expect(ctx.cookies.set).toHaveBeenCalledWith(
+      logtoCookieKey,
+      JSON.stringify({ appId: cimdClientId }),
+      expect.anything()
+    );
   });
 });
 

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -272,14 +272,27 @@ export default function initOidc(
     interactions: {
       url: (ctx, { params: { client_id: appId }, prompt }) => {
         const params = trySafe(() => extraParamsObjectGuard.parse(ctx.oidc.params ?? {})) ?? {};
+        const resolvedAppId = readOptionalQueryString(appId);
         const sharedParams = {
-          appId: readOptionalQueryString(appId),
+          appId: resolvedAppId,
           organizationId: params.organization_id,
           uiLocales: params.ui_locales,
         };
 
+        /**
+         * A CIMD identifier can span 2048 characters — omitting `appId` keeps the URL out of a
+         * second browser cookie, and with no per-application overrides to resolve, the cookie
+         * consumers (experience SSR, verification-code template context) fall back to the
+         * tenant default sign-in experience without any application lookup.
+         */
+        // DEV: CIMD (client ID metadata document) support
+        const cookieParams =
+          resolvedAppId && isCimdEffectivelyEnabled(envSet) && isCimdClientId(resolvedAppId)
+            ? { ...sharedParams, appId: undefined }
+            : sharedParams;
+
         // Cookies are required to apply the correct server-side rendering
-        ctx.cookies.set(logtoCookieKey, JSON.stringify(buildSharedExperienceCookie(sharedParams)), {
+        ctx.cookies.set(logtoCookieKey, JSON.stringify(buildSharedExperienceCookie(cookieParams)), {
           sameSite: 'lax',
           overwrite: true,
           httpOnly: false,


### PR DESCRIPTION
## Summary

Omit `appId` from the experience `_logto` cookie for CIMD prompts (LOG-13928).

- A CIMD identifier can span 2048 characters, and with no per-application overrides to resolve, the cookie consumers fall back to the tenant default sign-in experience without any application lookup.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
