### PR TITLE
refactor(core): extract redirect uri match classification from the wildcard matcher

### DIFF
--- a/packages/core/src/oidc/wildcard-redirect-uri.test.ts
+++ b/packages/core/src/oidc/wildcard-redirect-uri.test.ts
@@ -3,6 +3,7 @@ import type { Provider } from 'oidc-provider';
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
 
 import {
+  getRedirectUriMatchType,
   installWildcardRedirectUriMatching,
   isValidWildcardRedirectUriPattern,
   wildcardUrlMatch,
@@ -284,5 +285,72 @@ describe('postLogoutRedirectUriAllowed override', () => {
     // …and RP-Initiated Logout has no loopback exception: variable ports never match.
     expect(postLogoutRedirectUriAllowed.call(cimdClient, 'http://localhost/bye')).toBe(true);
     expect(postLogoutRedirectUriAllowed.call(cimdClient, 'http://localhost:49152/bye')).toBe(false);
+  });
+});
+
+describe('getRedirectUriMatchType', () => {
+  const client = asClient({
+    applicationType: 'web',
+    redirectUris: ['https://*.example.com/callback', 'https://exact.example.org/cb'],
+  });
+
+  it('classifies literal registrations as exact and pattern registrations as wildcard', () => {
+    expect(getRedirectUriMatchType(client, 'https://exact.example.org/cb')).toBe('exact');
+    expect(getRedirectUriMatchType(client, 'https://tenant.example.com/callback')).toBe('wildcard');
+    expect(getRedirectUriMatchType(client, 'https://tenant.example.net/callback')).toBeUndefined();
+  });
+
+  it('prefers exact when a value matches both a literal and a pattern registration', () => {
+    const overlapping = asClient({
+      applicationType: 'web',
+      redirectUris: ['https://*.example.com/callback', 'https://tenant.example.com/callback'],
+    });
+
+    expect(getRedirectUriMatchType(overlapping, 'https://tenant.example.com/callback')).toBe(
+      'exact'
+    );
+  });
+
+  it('rejects candidate values containing a wildcard or failing to parse', () => {
+    expect(getRedirectUriMatchType(client, 'https://*.example.com/callback')).toBeUndefined();
+    expect(getRedirectUriMatchType(client, 'not-a-url')).toBeUndefined();
+  });
+
+  it('classifies the loopback port retry as exact for native registered applications only', () => {
+    const nativeClient = asClient({
+      applicationType: 'native',
+      redirectUris: ['http://127.0.0.1:3000/cb'],
+    });
+    const webClient = asClient({
+      applicationType: 'web',
+      redirectUris: ['http://127.0.0.1:3000/cb'],
+    });
+
+    expect(getRedirectUriMatchType(nativeClient, 'http://127.0.0.1:49152/cb')).toBe('exact');
+    expect(getRedirectUriMatchType(webClient, 'http://127.0.0.1:49152/cb')).toBeUndefined();
+  });
+
+  // DEV: CIMD (client ID metadata document) support
+  it('classifies cimd raw-string and loopback matches as exact, patterns as wildcard', () => {
+    const cimdClient = asClient({
+      clientId: 'https://client.example.com/oauth/metadata.json',
+      applicationType: 'web',
+      redirectUris: [
+        'https://app.example.com/callback',
+        'https://*.tenant.example.com/callback',
+        'http://localhost/cb',
+      ],
+    });
+
+    expect(getRedirectUriMatchType(cimdClient, 'https://app.example.com/callback')).toBe('exact');
+    // Raw-string comparison: normalized-equal values stay unmatched.
+    expect(
+      getRedirectUriMatchType(cimdClient, 'https://app.example.com:443/callback')
+    ).toBeUndefined();
+    expect(getRedirectUriMatchType(cimdClient, 'https://a.tenant.example.com/callback')).toBe(
+      'wildcard'
+    );
+    // The shape-based loopback retry stays exact: the registered value is a literal URI.
+    expect(getRedirectUriMatchType(cimdClient, 'http://localhost:49152/cb')).toBe('exact');
   });
 });

--- a/packages/core/src/oidc/wildcard-redirect-uri.ts
+++ b/packages/core/src/oidc/wildcard-redirect-uri.ts
@@ -306,6 +306,76 @@ const matchLoopbackPortInsensitiveCimd = (
   return registeredUris.some((allowed) => stripLoopbackPort(allowed) === candidate);
 };
 
+type RedirectUriMatchType = 'exact' | 'wildcard';
+
+/**
+ * Classify how an authorization `redirect_uri` value matches a client's registered redirect
+ * URIs. This is the decision tree behind `redirectUriAllowed` (which delegates here so the
+ * boolean and the classification can never drift), split by the registration kind that
+ * matched: `'exact'` covers literal registrations — including the RFC 8252/9700 loopback port
+ * retry, whose registered value is still a literal URI — and `'wildcard'` covers Logto
+ * wildcard patterns. `undefined` means no registration matches. A value matching both a
+ * literal and a wildcard registration classifies as `'exact'`.
+ *
+ * Registered applications reach the loopback retry only when declared native — the shipped
+ * behavior, where the tenant picks the type in the Console. CIMD clients reach it on URI
+ * shape alone: their application type is self-declared and commonly omitted
+ * (schema-defaulted to `web`), and it cannot be inferred from registered URIs either —
+ * native apps span custom schemes, loopback, and https App Links, the last
+ * indistinguishable from web callbacks. An `http:` loopback registration has no non-local
+ * use whatever the label says, so only such registrations match through the retry. This
+ * deliberately extends RFC 9700's literal native-app scoping for CIMD interoperability;
+ * the exposure is low and mitigated by the PKCE requirement on public clients.
+ */
+export const getRedirectUriMatchType = (
+  {
+    clientId,
+    applicationType,
+    redirectUris,
+  }: {
+    clientId: string;
+    applicationType?: string;
+    redirectUris?: readonly string[];
+  },
+  value: string
+): RedirectUriMatchType | undefined => {
+  if (value.includes('*')) {
+    return;
+  }
+
+  const parsed = parseUrl(value);
+  if (!parsed) {
+    return;
+  }
+
+  const cimd = isCimdClientId(clientId);
+  const registeredUris = redirectUris ?? [];
+  const literalUris = registeredUris.filter((allowed) => !allowed.includes('*'));
+  const wildcardUris = registeredUris.filter((allowed) => allowed.includes('*'));
+
+  const literalMatched = cimd
+    ? matchAgainstRegisteredCimd(literalUris, value, parsed)
+    : matchAgainstRegistered(literalUris, parsed);
+
+  if (literalMatched) {
+    return 'exact';
+  }
+
+  if (wildcardUris.some((allowed) => wildcardUrlMatch(allowed, parsed))) {
+    return 'wildcard';
+  }
+
+  if (!cimd && applicationType !== 'native') {
+    return;
+  }
+
+  const loopbackMatched = cimd
+    ? matchLoopbackPortInsensitiveCimd(registeredUris, value, parsed)
+    : matchLoopbackPortInsensitive(registeredUris, parsed);
+
+  return loopbackMatched ? 'exact' : undefined;
+};
+
 /**
  * Override `redirectUriAllowed` and `postLogoutRedirectUriAllowed` on the provider's per-tenant
  * `Client` class with wildcard-aware implementations. Call right after `new Provider(...)`.
@@ -320,40 +390,7 @@ export const installWildcardRedirectUriMatching = (provider: Provider) => {
 
   /* eslint-disable @silverhand/fp/no-mutation -- overriding prototype methods requires mutation */
   Client.prototype.redirectUriAllowed = function (value: string) {
-    if (value.includes('*')) {
-      return false;
-    }
-
-    const parsed = parseUrl(value);
-    if (!parsed) {
-      return false;
-    }
-
-    const cimd = isCimdClientId(this.clientId);
-    const registeredUris = this.redirectUris ?? [];
-
-    const matched = cimd
-      ? matchAgainstRegisteredCimd(registeredUris, value, parsed)
-      : matchAgainstRegistered(registeredUris, parsed);
-
-    /**
-     * Registered applications reach the loopback retry only when declared native — the shipped
-     * behavior, where the tenant picks the type in the Console. CIMD clients reach it on URI
-     * shape alone: their application type is self-declared and commonly omitted
-     * (schema-defaulted to `web`), and it cannot be inferred from registered URIs either —
-     * native apps span custom schemes, loopback, and https App Links, the last
-     * indistinguishable from web callbacks. An `http:` loopback registration has no non-local
-     * use whatever the label says, so only such registrations match through the retry. This
-     * deliberately extends RFC 9700's literal native-app scoping for CIMD interoperability;
-     * the exposure is low and mitigated by the PKCE requirement on public clients.
-     */
-    if (matched || (!cimd && this.applicationType !== 'native')) {
-      return matched;
-    }
-
-    return cimd
-      ? matchLoopbackPortInsensitiveCimd(registeredUris, value, parsed)
-      : matchLoopbackPortInsensitive(registeredUris, parsed);
+    return getRedirectUriMatchType(this, value) !== undefined;
   };
 
   /**


### PR DESCRIPTION
## Summary

Extract the `redirectUriAllowed` decision tree into `getRedirectUriMatchType`, which classifies how a value matches the registered redirect URIs — `'exact'` for literal registrations (including the loopback port retry), `'wildcard'` for Logto patterns; the prototype override delegates to it so the boolean and the classification cannot drift (LOG-13929).

No behavior change. The consent API consumer lands in the follow-up PR.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
