### PR TITLE
fix: fix pr size diff for fork pull requests

### DIFF
--- a/.github/workflows/update-pr-metadata.yml
+++ b/.github/workflows/update-pr-metadata.yml
@@ -35,15 +35,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # https://github.com/actions/checkout/issues/518#issuecomment-890401887
-          ref: refs/pull/${{ github.event.number }}/merge
+          ref: master
           fetch-depth: 0
           persist-credentials: false
 
       - name: Prepare
         run: |
-          git checkout master
-          git checkout -
+          git fetch origin +refs/pull/${{ github.event.number }}/merge:refs/remotes/pull/${{ github.event.number }}/merge
           curl -fsSLO https://gist.githubusercontent.com/gao-sun/88dac6c38e86f4ae12c8a7c3e777040a/raw/07276574142455b3dfeace5d7f4a370447a112b3/git-file-size-diff.sh
           chmod +x git-file-size-diff.sh
 
@@ -54,7 +52,7 @@ jobs:
           script: |
             const child_process = require('child_process');
             const result = child_process
-              .execSync('./git-file-size-diff.sh --cached master', { encoding: 'utf-8' })
+              .execSync('./git-file-size-diff.sh master refs/remotes/pull/${{ github.event.number }}/merge', { encoding: 'utf-8' })
               .split('\n');
             const diff = Number(result.pop());
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Problem: The Update Metadata workflow (update-pr-metadata.yml) fails on every PR submitted from a fork. The failure is in the pr-size-diff job, at the actions/checkout step.

Root cause: The job checks out refs/pull/${{ github.event.number }}/merge inside a pull_request_target workflow. This is exactly the "pwn request" pattern that actions/checkout now refuses by default: the enforcement shipped with checkout v7 on June 18, 2026 and was backported to actions/checkout@v4 (used here) on July 20, 2026. For fork PRs the checkout now throws Refusing to check out fork pull request code from a 'pull_request_target' workflow... before fetching anything. Same-repo PRs are unaffected because the guard only applies to fork PRs — which is why the workflow keeps passing for org PRs while failing for fork PRs.

Fix: Stop checking out the fork merge ref. Check out the trusted master branch instead, fetch the merge ref as objects only (git fetch origin +refs/pull/N/merge), and compute the size diff with the size-diff script's diff-tree mode against the two trees. The output (per-file diff + total) is unchanged, but fork code is never checked out or executed, so the pwn-request protection stays intact.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
