### PR TITLE
test(core): recycle jest workers above an idle heap limit

### DIFF
--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -8,6 +8,13 @@ const config = {
   testPathIgnorePatterns: ['/node_modules/', '/build/routes/session/'], // `routes/session` is freezed
   setupFilesAfterEnv: ['jest-matcher-specific-error', './jest.setup.js'],
   roots: ['./build'],
+  /**
+   * Workers accumulate module registry and v8 coverage state across test files, and the whole run
+   * peaks within a few percent of the 4 GB heap cap. Recycle a worker once it goes idle above this
+   * limit. The limit is checked between test files only, so it has to leave room for the largest
+   * single-file growth (~1 GB observed) on top of it.
+   */
+  workerIdleMemoryLimit: '2.5GB',
   moduleNameMapper: {
     '^#src/(.*)\\.js(x)?$': '<rootDir>/build/$1',
     '^(chalk|inquirer)$': '<rootDir>/../shared/lib/esm/module-proxy.js',


### PR DESCRIPTION
## Summary

Fix the intermittent out-of-memory failure of `packages/core` unit tests in the `main-test` job.

- Jest workers accumulate module registry and v8 coverage state across the ~266 test suites, and the run peaks at ~97% of the 4 GB heap cap — which suite tips over is random, and zero tests actually fail when it happens.
- `workerIdleMemoryLimit: '2.5GB'` makes Jest recycle a worker once it goes idle above the limit, so the tail of the run keeps headroom instead of relying on luck.
- Preferred over raising `--max_old_space_size`, which only moves the ceiling.

### Why 2.5 GB

The limit is only checked between test files, so the worst case is the limit plus the largest single-file growth (~1 GB, from `--logHeapUsage` across two runs of 266 suites):

| limit | actual threshold | worker recycles | worst-case peak | headroom under 4 GB |
|---|---|---|---|---|
| `'2GB'` | 1907 MiB | 127–135 / 266 | ~2857 MiB | 1239 MiB (30%) |
| **`'2.5GB'`** | **2384 MiB** | **86–90 / 266** | **~3334 MiB** | **762 MiB (19%)** |
| `'3GB'` | 2861 MiB | 51–62 / 266 | ~3811 MiB | 285 MiB (7%) |

2 GB recycles about half the suites for headroom we do not need; 3 GB brings the margin back down to roughly where the flake lives today.

Note the threshold column: Jest parses `GB` as decimal (1e9) while `--logHeapUsage` prints MiB.

## Testing

N/A

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
