### PR TITLE
feat(core): isolate cimd from application acl and auto-consent

### DIFF
--- a/packages/core/src/middleware/koa-app-access-control.test.ts
+++ b/packages/core/src/middleware/koa-app-access-control.test.ts
@@ -137,7 +137,7 @@ describe('koaAppAccessControl middleware', () => {
     it('should skip the application access check for a cimd client', async () => {
       const ctx = createContext({
         params: { client_id: cimdClientId },
-        // @ts-expect-error
+        // @ts-expect-error -- minimal session stub for middleware testing
         session: { accountId: 'user-id' },
       });
       const guard = koaAppAccessControl(cimdEnvSet, mockTenant.libraries);
@@ -151,7 +151,7 @@ describe('koaAppAccessControl middleware', () => {
     it('should keep the access check for a url client id when CIMD is not effectively enabled', async () => {
       const ctx = createContext({
         params: { client_id: cimdClientId },
-        // @ts-expect-error
+        // @ts-expect-error -- minimal session stub for middleware testing
         session: { accountId: 'user-id' },
       });
       const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
@@ -165,7 +165,7 @@ describe('koaAppAccessControl middleware', () => {
     it('should keep the access check for a registered client while CIMD is effectively enabled', async () => {
       const ctx = createContext({
         params: { client_id: 'app-id' },
-        // @ts-expect-error
+        // @ts-expect-error -- minimal session stub for middleware testing
         session: { accountId: 'user-id' },
       });
       const guard = koaAppAccessControl(cimdEnvSet, mockTenant.libraries);

--- a/packages/core/src/middleware/koa-app-access-control.test.ts
+++ b/packages/core/src/middleware/koa-app-access-control.test.ts
@@ -111,7 +111,6 @@ describe('koaAppAccessControl middleware', () => {
     await expect(guard(ctx, next)).rejects.toThrow(new RequestError({ code: 'session.not_found' }));
   });
 
-  // DEV: CIMD (client ID metadata document) support
   describe('while CIMD is effectively enabled', () => {
     const cimdClientId = 'https://client.example.com/metadata.json';
 

--- a/packages/core/src/middleware/koa-app-access-control.test.ts
+++ b/packages/core/src/middleware/koa-app-access-control.test.ts
@@ -1,5 +1,7 @@
 import type { Provider } from 'oidc-provider';
+import Sinon from 'sinon';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -44,7 +46,7 @@ describe('koaAppAccessControl middleware', () => {
       // @ts-expect-error
       session: { accountId: 'user-id' },
     });
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await guard(ctx, next);
 
@@ -60,7 +62,7 @@ describe('koaAppAccessControl middleware', () => {
       session: { accountId: 'user-id' },
       result: markAppLevelAccessControlChecked(undefined, 'app-id', 'user-id'),
     });
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await guard(ctx, next);
 
@@ -76,7 +78,7 @@ describe('koaAppAccessControl middleware', () => {
       session: { accountId: 'user-id' },
       lastSubmission: markAppLevelAccessControlChecked(undefined, 'app-id', 'user-id'),
     });
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await guard(ctx, next);
 
@@ -92,7 +94,7 @@ describe('koaAppAccessControl middleware', () => {
       session: { accountId: 'user-id' },
     });
     assertUserHasApplicationAccess.mockRejectedValueOnce(new RequestError('oidc.access_denied'));
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await expect(guard(ctx, next)).rejects.toMatchObject({ code: 'oidc.access_denied' });
     expect(ctx.interactionDetails.persist).not.toHaveBeenCalled();
@@ -104,8 +106,74 @@ describe('koaAppAccessControl middleware', () => {
       params: { client_id: 'app-id' },
       session: undefined,
     });
-    const guard = koaAppAccessControl(mockTenant.libraries);
+    const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
 
     await expect(guard(ctx, next)).rejects.toThrow(new RequestError({ code: 'session.not_found' }));
+  });
+
+  // DEV: CIMD (client ID metadata document) support
+  describe('while CIMD is effectively enabled', () => {
+    const cimdClientId = 'https://client.example.com/metadata.json';
+
+    /**
+     * The gate reads only `oidc.cimdEnabled` from the tenant env set; the static flags are
+     * stubbed onto `EnvSet.values` below.
+     */
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
+    const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
+
+    beforeEach(() => {
+      Sinon.stub(EnvSet, 'values').value({
+        ...EnvSet.values,
+        isDevFeaturesEnabled: true,
+        isOidcProviderSsrfProtectionEnabled: true,
+      });
+    });
+
+    afterEach(() => {
+      Sinon.restore();
+    });
+
+    it('should skip the application access check for a cimd client', async () => {
+      const ctx = createContext({
+        params: { client_id: cimdClientId },
+        // @ts-expect-error
+        session: { accountId: 'user-id' },
+      });
+      const guard = koaAppAccessControl(cimdEnvSet, mockTenant.libraries);
+
+      await guard(ctx, next);
+
+      expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should keep the access check for a url client id when CIMD is not effectively enabled', async () => {
+      const ctx = createContext({
+        params: { client_id: cimdClientId },
+        // @ts-expect-error
+        session: { accountId: 'user-id' },
+      });
+      const guard = koaAppAccessControl(mockTenant.envSet, mockTenant.libraries);
+
+      await guard(ctx, next);
+
+      expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(cimdClientId, 'user-id');
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should keep the access check for a registered client while CIMD is effectively enabled', async () => {
+      const ctx = createContext({
+        params: { client_id: 'app-id' },
+        // @ts-expect-error
+        session: { accountId: 'user-id' },
+      });
+      const guard = koaAppAccessControl(cimdEnvSet, mockTenant.libraries);
+
+      await guard(ctx, next);
+
+      expect(assertUserHasApplicationAccess).toHaveBeenCalledWith('app-id', 'user-id');
+      expect(next).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/src/middleware/koa-app-access-control.ts
+++ b/packages/core/src/middleware/koa-app-access-control.ts
@@ -5,8 +5,7 @@ import { type EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import { hasAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
-import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
-import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
+import { isCimdClient } from '#src/oidc/cimd/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -27,8 +26,7 @@ export default function koaAppAccessControl<
       new errors.InvalidClient('client must be available')
     );
 
-    // DEV: CIMD (client ID metadata document) support
-    if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)) {
+    if (isCimdClient(envSet, clientId)) {
       /**
        * Application-level access control only applies to registered applications; the library's
        * fallback lookup would query the applications table with the identifier URL and deny on

--- a/packages/core/src/middleware/koa-app-access-control.ts
+++ b/packages/core/src/middleware/koa-app-access-control.ts
@@ -1,9 +1,12 @@
 import { type MiddlewareType } from 'koa';
 import { errors } from 'oidc-provider';
 
+import { type EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
 import { hasAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
+import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -11,7 +14,7 @@ export default function koaAppAccessControl<
   StateT,
   ContextT extends WithInteractionDetailsContext,
   ResponseBodyT,
->(libraries: Libraries): MiddlewareType<StateT, ContextT, ResponseBodyT> {
+>(envSet: EnvSet, libraries: Libraries): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   return async (ctx, next) => {
     const {
       params: { client_id: clientId },
@@ -23,6 +26,16 @@ export default function koaAppAccessControl<
       clientId && typeof clientId === 'string',
       new errors.InvalidClient('client must be available')
     );
+
+    // DEV: CIMD (client ID metadata document) support
+    if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)) {
+      /**
+       * Application-level access control only applies to registered applications; the library's
+       * fallback lookup would query the applications table with the identifier URL and deny on
+       * not-found.
+       */
+      return next();
+    }
 
     if (
       hasAppLevelAccessControlChecked(ctx.interactionDetails.result, clientId, session.accountId)

--- a/packages/core/src/middleware/koa-auto-consent.ts
+++ b/packages/core/src/middleware/koa-auto-consent.ts
@@ -25,8 +25,6 @@ const shouldAutoConsentApplication = async (clientId: string, query: Queries, en
     /**
      * Registered application ids never take the URL shape, and authorization has already
      * resolved this client — a URL here is a CIMD client, which is never first-party.
-     * TODO: @xiaoyijun support CIMD clients on the rest of the experience consent flow
-     * (consent info and guards).
      */
     return false;
   }

--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -209,6 +209,53 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
     expect(runScriptInLocalVm.mock.calls[0]?.[0]?.context).not.toHaveProperty('organization');
   });
 
+  // DEV: CIMD (client ID metadata document) support
+  describe('for CIMD clients', () => {
+    const cimdClientId = 'https://client.example.com/metadata.json';
+
+    it('skips the application context lookup while CIMD is effectively enabled', async () => {
+      const tenant = createTenant({});
+      const { ctxWithLog, token } = buildContextAndToken({ clientId: cimdClientId });
+
+      /**
+       * The gate additionally reads the static dev-features and SSRF-protection flags from
+       * `EnvSet.values`; the jest environment keeps both on.
+       */
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- spread copy of the mock env set with the tenant CIMD toggle on; `oidc` is a getter and must be rebuilt explicitly
+      const cimdEnvSet = {
+        ...tenant.envSet,
+        oidc: { ...tenant.envSet.oidc, cimdEnabled: true },
+      } as InstanceType<typeof EnvSet>;
+
+      await getExtraTokenClaimsForJwtCustomization(ctxWithLog, token, {
+        envSet: cimdEnvSet,
+        queries: tenant.queries,
+        libraries: tenant.libraries,
+        logtoConfigs: tenant.logtoConfigs,
+      });
+
+      expect(tenant.libraries.jwtCustomizers.getApplicationContext).not.toHaveBeenCalled();
+      expect(runScriptInLocalVm.mock.calls[0]?.[0]?.context).not.toHaveProperty('application');
+    });
+
+    it('keeps the application context lookup for a url client id when CIMD is not effectively enabled', async () => {
+      const tenant = createTenant({});
+      const { ctxWithLog, token } = buildContextAndToken({ clientId: cimdClientId });
+
+      await getExtraTokenClaimsForJwtCustomization(ctxWithLog, token, {
+        envSet: tenant.envSet,
+        queries: tenant.queries,
+        libraries: tenant.libraries,
+        logtoConfigs: tenant.logtoConfigs,
+      });
+
+      expect(tenant.libraries.jwtCustomizers.getApplicationContext).toHaveBeenCalledWith(
+        tenant.envSet.tenantId,
+        cimdClientId
+      );
+    });
+  });
+
   it('throws invalid request with original error message on script failure when blocking is enabled', async () => {
     runScriptInLocalVm.mockRejectedValue(new Error('boom'));
 

--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -209,7 +209,6 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
     expect(runScriptInLocalVm.mock.calls[0]?.[0]?.context).not.toHaveProperty('organization');
   });
 
-  // DEV: CIMD (client ID metadata document) support
   describe('for CIMD clients', () => {
     const cimdClientId = 'https://client.example.com/metadata.json';
 

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -30,7 +30,7 @@ import { isAccessDeniedError, parseCustomJwtResponseError } from '#src/utils/cus
 import { i18next } from '#src/utils/i18n.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
-import { getClientIdentifierPayload } from './cimd/index.js';
+import { getClientIdentifierPayload, isCimdClient } from './cimd/index.js';
 import { tokenExchangeActGuard } from './grants/token-exchange/types.js';
 
 const hasI18n = (ctx: KoaContextWithOIDC): ctx is KoaContextWithOIDC & { i18n: i18n } =>
@@ -245,8 +245,14 @@ export const getExtraTokenClaimsForJwtCustomization = async (
     );
 
     const clientId = token.clientId ?? ctx.oidc.client?.clientId;
+    /**
+     * CIMD clients are unregistered, so there is no application context to expose and the
+     * identifier URL must never be used to query the applications table.
+     */
     const applicationContext = conditional(
-      clientId && (await libraries.jwtCustomizers.getApplicationContext(envSet.tenantId, clientId))
+      clientId &&
+        !isCimdClient(envSet, clientId) &&
+        (await libraries.jwtCustomizers.getApplicationContext(envSet.tenantId, clientId))
     );
 
     // For organization (API resource) tokens, expose the target organization so the customizer

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines */
+/* eslint-disable max-lines -- the CIMD grant scenarios push the suite over the limit */
 import { UserScope } from '@logto/core-kit';
 import { type KoaContextWithOIDC, errors, type Adapter } from 'oidc-provider';
 import Sinon from 'sinon';
@@ -467,9 +467,10 @@ describe('refresh token grant for CIMD clients', () => {
   const buildCimdHandler = (tenant: MockTenant, envSet: EnvSet = cimdEnvSet) =>
     buildHandler(envSet, tenant.queries, { assertUserHasApplicationAccess });
 
-  const createCimdPreparedContext = () => {
+  const createCimdPreparedContext = (params = validOidcContext.params) => {
     const ctx = createOidcContext({
       ...validOidcContext,
+      params,
       entities: { ...validOidcContext.entities, Client: cimdClient },
       client: cimdClient,
     });
@@ -483,40 +484,40 @@ describe('refresh token grant for CIMD clients', () => {
     assertUserHasApplicationAccess.mockClear();
   });
 
-  it('should skip the application access check and the organization grant lookup', async () => {
-    const ctx = createCimdPreparedContext();
+  it('should skip the application access check without an organization_id', async () => {
+    const ctx = createCimdPreparedContext({
+      ...validOidcContext.params,
+      organization_id: undefined,
+    });
     const tenant = new MockTenant();
 
-    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
     const findApplicationById = Sinon.stub(tenant.queries.applications, 'findApplicationById');
-    const userConsentOrganizationExists = Sinon.stub(
-      tenant.queries.applications.userConsentOrganizations,
-      'exists'
-    );
-    Sinon.stub(tenant.queries.organizations.relations.usersRoles, 'getUserScopes').resolves([
-      { tenantId: 'default', id: 'foo', name: 'foo', description: 'foo' },
-      { tenantId: 'default', id: 'bar', name: 'bar', description: 'bar' },
-    ]);
-    Sinon.stub(tenant.queries.organizations, 'getMfaStatus').resolves({
-      isMfaRequired: false,
-      hasMfaConfigured: false,
-    });
 
     await expect(buildCimdHandler(tenant)(ctx)).resolves.toBeUndefined();
 
     expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
     expect(findApplicationById.called).toBe(false);
-    expect(userConsentOrganizationExists.called).toBe(false);
   });
 
-  it('should keep the organization membership gate', async () => {
+  it('should reject organization token requests until the grant-scoped check lands', async () => {
     const ctx = createCimdPreparedContext();
     const tenant = new MockTenant();
-    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(false);
+
+    const membershipExists = Sinon.stub(tenant.queries.organizations.relations.users, 'exists');
+    const findApplicationById = Sinon.stub(tenant.queries.applications, 'findApplicationById');
+    const userConsentOrganizationExists = Sinon.stub(
+      tenant.queries.applications.userConsentOrganizations,
+      'exists'
+    );
 
     await expect(buildCimdHandler(tenant)(ctx)).rejects.toThrow(
-      createAccessDeniedError('user is not a member of the organization', 403)
+      createAccessDeniedError('organization tokens are not supported for CIMD clients', 403)
     );
+
+    expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
+    expect(membershipExists.called).toBe(false);
+    expect(findApplicationById.called).toBe(false);
+    expect(userConsentOrganizationExists.called).toBe(false);
   });
 
   it('should keep the application access check for a url client id when CIMD is not effectively enabled', async () => {

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -1,8 +1,10 @@
+/* eslint-disable max-lines */
 import { UserScope } from '@logto/core-kit';
 import { type KoaContextWithOIDC, errors, type Adapter } from 'oidc-provider';
 import Sinon from 'sinon';
 
 import { mockApplication } from '#src/__mocks__/index.js';
+import { type EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import { createOidcContext } from '#src/test-utils/oidc-provider.js';
@@ -443,3 +445,87 @@ describe('refresh token grant', () => {
     });
   });
 });
+
+// DEV: CIMD (client ID metadata document) support
+describe('refresh token grant for CIMD clients', () => {
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  /**
+   * The gate reads only `oidc.cimdEnabled` from the tenant env set; the jest environment keeps
+   * the dev-features and SSRF-protection static flags on already.
+   */
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
+  const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
+
+  const cimdClient: Client = {
+    clientId: cimdClientId,
+    grantTypeAllowed: jest.fn().mockResolvedValue(true),
+    clientAuthMethod: 'none',
+    metadata: jest.fn(() => ({ client_id: cimdClientId })),
+  } as unknown as Client;
+
+  const buildCimdHandler = (tenant: MockTenant, envSet: EnvSet = cimdEnvSet) =>
+    buildHandler(envSet, tenant.queries, { assertUserHasApplicationAccess });
+
+  const createCimdPreparedContext = () => {
+    const ctx = createOidcContext({
+      ...validOidcContext,
+      entities: { ...validOidcContext.entities, Client: cimdClient },
+      client: cimdClient,
+    });
+    stubRefreshToken(ctx, { clientId: cimdClientId });
+    stubGrant(ctx, { clientId: cimdClientId });
+    stubAccount(ctx);
+    return ctx;
+  };
+
+  afterEach(() => {
+    assertUserHasApplicationAccess.mockClear();
+  });
+
+  it('should skip the application access check and the organization grant lookup', async () => {
+    const ctx = createCimdPreparedContext();
+    const tenant = new MockTenant();
+
+    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
+    const findApplicationById = Sinon.stub(tenant.queries.applications, 'findApplicationById');
+    const userConsentOrganizationExists = Sinon.stub(
+      tenant.queries.applications.userConsentOrganizations,
+      'exists'
+    );
+    Sinon.stub(tenant.queries.organizations.relations.usersRoles, 'getUserScopes').resolves([
+      { tenantId: 'default', id: 'foo', name: 'foo', description: 'foo' },
+      { tenantId: 'default', id: 'bar', name: 'bar', description: 'bar' },
+    ]);
+    Sinon.stub(tenant.queries.organizations, 'getMfaStatus').resolves({
+      isMfaRequired: false,
+      hasMfaConfigured: false,
+    });
+
+    await expect(buildCimdHandler(tenant)(ctx)).resolves.toBeUndefined();
+
+    expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
+    expect(findApplicationById.called).toBe(false);
+    expect(userConsentOrganizationExists.called).toBe(false);
+  });
+
+  it('should keep the organization membership gate', async () => {
+    const ctx = createCimdPreparedContext();
+    const tenant = new MockTenant();
+    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(false);
+
+    await expect(buildCimdHandler(tenant)(ctx)).rejects.toThrow(
+      createAccessDeniedError('user is not a member of the organization', 403)
+    );
+  });
+
+  it('should keep the application access check for a url client id when CIMD is not effectively enabled', async () => {
+    const ctx = createCimdPreparedContext();
+    const tenant = new MockTenant();
+    assertUserHasApplicationAccess.mockRejectedValueOnce(new RequestError('oidc.access_denied'));
+
+    await expect(buildCimdHandler(tenant, tenant.envSet)(ctx)).rejects.toThrow(errors.AccessDenied);
+    expect(assertUserHasApplicationAccess).toHaveBeenCalled();
+  });
+});
+/* eslint-enable max-lines */

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -446,7 +446,6 @@ describe('refresh token grant', () => {
   });
 });
 
-// DEV: CIMD (client ID metadata document) support
 describe('refresh token grant for CIMD clients', () => {
   const cimdClientId = 'https://client.example.com/metadata.json';
 

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -247,7 +247,7 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
   }
 
   /* === RFC 0001 === */
-  const { organizationId } = await checkOrganizationAccess(ctx, envSet, queries, account);
+  const { organizationId } = await checkOrganizationAccess(ctx, { envSet, queries, account });
 
   if (
     organizationId && // Validate if the refresh token has the required scope from RFC 0001.

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -36,6 +36,8 @@ import { errors, type Provider } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
 import { assertUserHasApplicationAccessForOidc } from '#src/oidc/application-access-control.js';
+import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
 import {
   applyMtlsBinding,
   buildTokenResponse,
@@ -229,15 +231,23 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     throw new InvalidRequest('authorization_details is unsupported for this refresh token');
   }
 
-  await assertUserHasApplicationAccessForOidc(
-    appAccess,
-    client.clientId,
-    account.accountId,
-    client.metadata().appLevelAccessControlEnabled
-  );
+  // DEV: CIMD (client ID metadata document) support
+  /**
+   * Application-level access control only applies to registered applications; the
+   * access-control library's fallback lookup would query the applications table with the CIMD
+   * identifier URL and deny on not-found.
+   */
+  if (!(isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId))) {
+    await assertUserHasApplicationAccessForOidc(
+      appAccess,
+      client.clientId,
+      account.accountId,
+      client.metadata().appLevelAccessControlEnabled
+    );
+  }
 
   /* === RFC 0001 === */
-  const { organizationId } = await checkOrganizationAccess(ctx, queries, account);
+  const { organizationId } = await checkOrganizationAccess(ctx, envSet, queries, account);
 
   if (
     organizationId && // Validate if the refresh token has the required scope from RFC 0001.

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -36,8 +36,7 @@ import { errors, type Provider } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
 import { assertUserHasApplicationAccessForOidc } from '#src/oidc/application-access-control.js';
-import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
-import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
+import { isCimdClient } from '#src/oidc/cimd/index.js';
 import {
   applyMtlsBinding,
   buildTokenResponse,
@@ -231,13 +230,12 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     throw new InvalidRequest('authorization_details is unsupported for this refresh token');
   }
 
-  // DEV: CIMD (client ID metadata document) support
   /**
    * Application-level access control only applies to registered applications; the
    * access-control library's fallback lookup would query the applications table with the CIMD
    * identifier URL and deny on not-found.
    */
-  if (!(isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId))) {
+  if (!isCimdClient(envSet, client.clientId)) {
     await assertUserHasApplicationAccessForOidc(
       appAccess,
       client.clientId,

--- a/packages/core/src/oidc/grants/token-exchange/index.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.ts
@@ -133,13 +133,12 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     clientId: client.clientId,
   } as ConstructorParameters<typeof Grant>[0]);
 
-  const { organizationId } = await checkOrganizationAccess(
-    ctx,
+  const { organizationId } = await checkOrganizationAccess(ctx, {
     envSet,
     queries,
     account,
-    isThirdParty
-  );
+    isThirdParty,
+  });
 
   const accessToken = createAccessToken(
     ctx,

--- a/packages/core/src/oidc/grants/token-exchange/index.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.ts
@@ -133,7 +133,13 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     clientId: client.clientId,
   } as ConstructorParameters<typeof Grant>[0]);
 
-  const { organizationId } = await checkOrganizationAccess(ctx, queries, account, isThirdParty);
+  const { organizationId } = await checkOrganizationAccess(
+    ctx,
+    envSet,
+    queries,
+    account,
+    isThirdParty
+  );
 
   const accessToken = createAccessToken(
     ctx,

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -23,10 +23,17 @@ const { InvalidGrant, InvalidClient, AccessDenied } = errors;
  */
 export const checkOrganizationAccess = async (
   ctx: KoaContextWithOIDC,
-  envSet: EnvSet,
-  queries: Queries,
-  account: Account,
-  isThirdParty?: boolean
+  {
+    envSet,
+    queries,
+    account,
+    isThirdParty,
+  }: {
+    envSet: EnvSet;
+    queries: Queries;
+    account: Account;
+    isThirdParty?: boolean;
+  }
 ): Promise<{ organizationId?: string }> => {
   const { client, params } = ctx.oidc;
 
@@ -36,6 +43,23 @@ export const checkOrganizationAccess = async (
   const organizationId = cond(Boolean(params.organization_id) && String(params.organization_id));
 
   if (organizationId) {
+    // DEV: CIMD (client ID metadata document) support
+    /**
+     * Organization grants are keyed to registered applications
+     * (`application_user_consent_organizations`), so no user has ever granted an organization to
+     * a CIMD client — and the accidental alternative would silently pass `isThirdPartyApplication`,
+     * whose not-found fallback reads the identifier URL as first-party. Membership alone is a
+     * user-to-organization relation, not a substitute for the user-to-client grant, so fail
+     * closed instead of skipping the consent check.
+     */
+    if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId)) {
+      // TODO: @xiaoyijun replace the rejection with the grant-scoped organization check (LOG-13930)
+      const error = new AccessDenied('organization tokens are not supported for CIMD clients');
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      error.statusCode = 403;
+      throw error;
+    }
+
     // Check membership
     if (
       !(await queries.organizations.relations.users.exists({
@@ -49,20 +73,8 @@ export const checkOrganizationAccess = async (
       throw error;
     }
 
-    // DEV: CIMD (client ID metadata document) support
-    /**
-     * A CIMD identifier would silently fall through `isThirdPartyApplication` — the not-found
-     * fallback reads as first-party — while also querying the applications table with the URL.
-     * Keep the skip explicit instead: organization grants are keyed to registered applications
-     * (`application_user_consent_organizations`), and the grant-scoped check for CIMD clients
-     * lands with LOG-13930. Until then organization tokens for CIMD clients stay gated by the
-     * membership check above and the MFA check below.
-     */
-    const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId);
-
     // Check if the organization is granted (third-party application only) by the user
     if (
-      !isCimdClient &&
       (isThirdParty ?? (await isThirdPartyApplication(queries, client.clientId))) &&
       !(await isOrganizationConsentedToApplication(
         queries,

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -7,6 +7,8 @@ import { type EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { isCimdClientId } from '../cimd/client-id.js';
+import { isCimdEffectivelyEnabled } from '../cimd/index.js';
 import {
   getSharedResourceServerData,
   isOrganizationConsentedToApplication,
@@ -21,6 +23,7 @@ const { InvalidGrant, InvalidClient, AccessDenied } = errors;
  */
 export const checkOrganizationAccess = async (
   ctx: KoaContextWithOIDC,
+  envSet: EnvSet,
   queries: Queries,
   account: Account,
   isThirdParty?: boolean
@@ -46,8 +49,20 @@ export const checkOrganizationAccess = async (
       throw error;
     }
 
+    // DEV: CIMD (client ID metadata document) support
+    /**
+     * A CIMD identifier would silently fall through `isThirdPartyApplication` — the not-found
+     * fallback reads as first-party — while also querying the applications table with the URL.
+     * Keep the skip explicit instead: organization grants are keyed to registered applications
+     * (`application_user_consent_organizations`), and the grant-scoped check for CIMD clients
+     * lands with LOG-13930. Until then organization tokens for CIMD clients stay gated by the
+     * membership check above and the MFA check below.
+     */
+    const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId);
+
     // Check if the organization is granted (third-party application only) by the user
     if (
+      !isCimdClient &&
       (isThirdParty ?? (await isThirdPartyApplication(queries, client.clientId))) &&
       !(await isOrganizationConsentedToApplication(
         queries,

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -55,7 +55,7 @@ export const checkOrganizationAccess = async (
     if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId)) {
       // TODO: @xiaoyijun replace the rejection with the grant-scoped organization check (LOG-13930)
       const error = new AccessDenied('organization tokens are not supported for CIMD clients');
-      // eslint-disable-next-line @silverhand/fp/no-mutation
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- oidc-provider errors take the HTTP status by assignment after construction
       error.statusCode = 403;
       throw error;
     }

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -7,8 +7,7 @@ import { type EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { isCimdClientId } from '../cimd/client-id.js';
-import { isCimdEffectivelyEnabled } from '../cimd/index.js';
+import { isCimdClient } from '../cimd/index.js';
 import {
   getSharedResourceServerData,
   isOrganizationConsentedToApplication,
@@ -43,7 +42,6 @@ export const checkOrganizationAccess = async (
   const organizationId = cond(Boolean(params.organization_id) && String(params.organization_id));
 
   if (organizationId) {
-    // DEV: CIMD (client ID metadata document) support
     /**
      * Organization grants are keyed to registered applications
      * (`application_user_consent_organizations`), so no user has ever granted an organization to
@@ -52,7 +50,7 @@ export const checkOrganizationAccess = async (
      * user-to-organization relation, not a substitute for the user-to-client grant, so fail
      * closed instead of skipping the consent check.
      */
-    if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId)) {
+    if (isCimdClient(envSet, client.clientId)) {
       // TODO: @xiaoyijun replace the rejection with the grant-scoped organization check (LOG-13930)
       const error = new AccessDenied('organization tokens are not supported for CIMD clients');
       // eslint-disable-next-line @silverhand/fp/no-mutation -- oidc-provider errors take the HTTP status by assignment after construction

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -514,7 +514,6 @@ describe('getResourceServerInfo for CIMD clients', () => {
   });
 });
 
-// DEV: CIMD (client ID metadata document) support
 describe('loadExistingGrant for CIMD clients', () => {
   const cimdClientId = 'https://client.example.com/client-metadata.json';
 

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -514,6 +514,66 @@ describe('getResourceServerInfo for CIMD clients', () => {
   });
 });
 
+// DEV: CIMD (client ID metadata document) support
+describe('loadExistingGrant for CIMD clients', () => {
+  const cimdClientId = 'https://client.example.com/client-metadata.json';
+
+  const createCimdTestClient = (): KoaContextWithOIDC['oidc']['client'] => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub for OIDC context testing
+    return {
+      clientId: cimdClientId,
+      metadata: () => ({}),
+    } as KoaContextWithOIDC['oidc']['client'];
+  };
+
+  it('should load the grant without the application access check', async () => {
+    const assertUserHasApplicationAccess = jest.fn();
+    const tenant = new MockTenant();
+
+    tenant.setPartial('libraries', {
+      applicationAccessControl: { assertUserHasApplicationAccess },
+    });
+
+    const { id, queries, libraries, logtoConfigs, subscription } = tenant;
+    const provider = initOidc(id, cimdEnvSet, queries, libraries, logtoConfigs, subscription);
+    const findGrant = mockGrantFound(provider);
+    const configuration = getProviderConfiguration(provider);
+    const ctx = createOidcContext({
+      provider,
+      account: { accountId, claims: async () => ({ sub: accountId }) },
+      client: createCimdTestClient(),
+      result: { consent: { grantId: 'grant_id' } },
+    } as Partial<KoaContextWithOIDC['oidc']>);
+
+    await expect(configuration.loadExistingGrant(ctx)).resolves.toBeDefined();
+    expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
+    expect(findGrant).toHaveBeenCalledWith('grant_id');
+  });
+
+  it('should keep the application access check for a url client id when CIMD is not effectively enabled', async () => {
+    const assertUserHasApplicationAccess = jest
+      .fn()
+      .mockRejectedValueOnce(new RequestError('oidc.access_denied'));
+    const tenant = new MockTenant();
+
+    tenant.setPartial('libraries', {
+      applicationAccessControl: { assertUserHasApplicationAccess },
+    });
+
+    const provider = createProvider(tenant);
+    const configuration = getProviderConfiguration(provider);
+    const ctx = createOidcContext({
+      provider,
+      account: { accountId },
+      client: createCimdTestClient(),
+      result: { consent: { grantId: 'grant_id' } },
+    } as Partial<KoaContextWithOIDC['oidc']>);
+
+    await expect(configuration.loadExistingGrant(ctx)).rejects.toThrow(errors.AccessDenied);
+    expect(assertUserHasApplicationAccess).toHaveBeenCalledWith(cimdClientId, accountId, undefined);
+  });
+});
+
 const findAccount = async (findUserById: () => Promise<typeof mockUser>) => {
   const provider = createProvider(new MockTenant(undefined, { users: { findUserById } }));
   const configuration = getProviderConfiguration(provider);

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -317,6 +317,13 @@ export default function initOidc(
       const shouldCheckApplicationAccess =
         account &&
         client &&
+        /**
+         * Application-level access control only applies to registered applications; the
+         * access-control library's fallback lookup would query the applications table with the
+         * CIMD identifier URL and deny on not-found.
+         */
+        // DEV: CIMD (client ID metadata document) support
+        !(isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId)) &&
         !hasAppLevelAccessControlChecked(result, client.clientId, account.accountId);
 
       if (grantId && shouldCheckApplicationAccess) {

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -322,8 +322,7 @@ export default function initOidc(
          * access-control library's fallback lookup would query the applications table with the
          * CIMD identifier URL and deny on not-found.
          */
-        // DEV: CIMD (client ID metadata document) support
-        !(isCimdEffectivelyEnabled(envSet) && isCimdClientId(client.clientId)) &&
+        !isCimdClient(envSet, client.clientId) &&
         !hasAppLevelAccessControlChecked(result, client.clientId, account.accountId);
 
       if (grantId && shouldCheckApplicationAccess) {

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -46,7 +46,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       }),
       status: [200, 400],
     }),
-    koaAppAccessControl(libraries),
+    koaAppAccessControl(envSet, libraries),
     async (ctx, next) => {
       const {
         interactionDetails,
@@ -206,7 +206,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       status: [200, 400],
       response: consentInfoResponseGuard,
     }),
-    koaAppAccessControl(libraries),
+    koaAppAccessControl(envSet, libraries),
     async (ctx, next) => {
       const { interactionDetails } = ctx;
 


### PR DESCRIPTION
## Summary

Isolate CIMD clients from application-level access control: they are unregistered external clients, so the applications table is never queried with the identifier URL (LOG-13928).

- Skip application ACL for CIMD clients in the app access control middleware (consent GET/POST), the provider `loadExistingGrant`, and the custom refresh token grant; registered applications and URL-shaped identifiers without effective CIMD enablement keep the checks.
- Reject CIMD `organization_id` requests in `checkOrganizationAccess` (fail closed) instead of the accidental first-party fallback of `isThirdPartyApplication`, whose not-found lookup read the identifier URL as first-party and skipped the organization consent check; the grant-scoped organization check lands with LOG-13930.
- Skip the JWT-customizer application context for CIMD clients.
- Drop the stale auto-consent TODO now that the remaining consent-flow work is tracked in follow-up slices.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)


