### PR TITLE
feat(core): handle cimd clients on the consent routes

### DIFF
--- a/packages/core/src/oidc/cimd/resource-scopes.test.ts
+++ b/packages/core/src/oidc/cimd/resource-scopes.test.ts
@@ -71,6 +71,38 @@ describe('filterResourceScopesForTheCimdClient', () => {
     expect(filtered.map(({ name }) => name)).toEqual(['read:api', 'read:organization-api']);
   });
 
+  it('should keep the organization resource ceiling out of an organization-less filter', async () => {
+    const queries = buildCeilingQueries({
+      resourceScopes: [buildScope('scope_1', 'read:api')],
+      organizationResourceScopes: [buildScope('scope_2', 'write:api')],
+    });
+
+    const filtered = await filterResourceScopesForTheCimdClient(
+      queries,
+      indicator,
+      [buildScope('scope_1', 'read:api'), buildScope('scope_2', 'write:api')],
+      { includeOrganizationResourceScopes: false, includeResourceScopes: true }
+    );
+
+    expect(filtered.map(({ name }) => name)).toEqual(['read:api']);
+  });
+
+  it('should keep the resource ceiling out of an organization-scoped filter', async () => {
+    const queries = buildCeilingQueries({
+      resourceScopes: [buildScope('scope_1', 'read:api')],
+      organizationResourceScopes: [buildScope('scope_2', 'write:api')],
+    });
+
+    const filtered = await filterResourceScopesForTheCimdClient(
+      queries,
+      indicator,
+      [buildScope('scope_1', 'read:api'), buildScope('scope_2', 'write:api')],
+      { includeOrganizationResourceScopes: true, includeResourceScopes: false }
+    );
+
+    expect(filtered.map(({ name }) => name)).toEqual(['write:api']);
+  });
+
   it('should drop every scope when the ceiling is empty', async () => {
     const queries = buildCeilingQueries({});
 

--- a/packages/core/src/oidc/cimd/resource-scopes.ts
+++ b/packages/core/src/oidc/cimd/resource-scopes.ts
@@ -22,7 +22,11 @@ import { isReservedResource } from '../resource.js';
 export const filterResourceScopesForTheCimdClient = async (
   { cimd }: Queries,
   indicator: string,
-  scopes: ReadonlyArray<{ name: string; id: string }>
+  scopes: ReadonlyArray<{ name: string; id: string }>,
+  {
+    includeOrganizationResourceScopes = true,
+    includeResourceScopes = true,
+  }: { includeOrganizationResourceScopes?: boolean; includeResourceScopes?: boolean } = {}
 ) => {
   if (isReservedResource(indicator)) {
     switch (indicator) {
@@ -41,13 +45,14 @@ export const filterResourceScopesForTheCimdClient = async (
   }
 
   /**
-   * A resource can sit behind the ceiling as a plain API resource or as an organization
-   * resource; scope ids are globally unique, so the flat union mirrors the third-party
-   * filter's per-indicator merge of the two application consent tables.
+   * The two ceiling tables carry different authorization contexts, mirroring the
+   * third-party filter's include flags: a scope configured only as an organization
+   * resource scope must stay out of an ordinary (organization-less) grant, where no
+   * organization membership is ever checked.
    */
   const [ceilingResourceScopes, ceilingOrganizationResourceScopes] = await Promise.all([
-    cimd.resourceScopes.findAll(),
-    cimd.organizationResourceScopes.findAll(),
+    includeResourceScopes ? cimd.resourceScopes.findAll() : [],
+    includeOrganizationResourceScopes ? cimd.organizationResourceScopes.findAll() : [],
   ]);
   const ceilingScopeIds = new Set(
     [...ceilingResourceScopes, ...ceilingOrganizationResourceScopes].map(({ id }) => id)

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -20,6 +20,8 @@ import { consent, getMissingScopes } from '#src/libraries/session/index.js';
 import koaAppAccessControl from '#src/middleware/koa-app-access-control.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
+import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -27,7 +29,7 @@ import { interactionPrefix } from '../const.js';
 
 import { filterAndParseMissingResourceScopes } from './utils.js';
 
-const { InvalidClient, InvalidRedirectUri } = errors;
+const { InvalidClient, InvalidRedirectUri, InvalidRequest } = errors;
 
 export default function consentRoutes<T extends IRouterParamContext>(
   router: Router<unknown, WithInteractionDetailsContext<T>>,
@@ -70,8 +72,22 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const { accountId: userId } = session;
 
+      // DEV: CIMD (client ID metadata document) support
+      const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(applicationId);
+
       // Grant the organizations to the application if the user has selected the organizations
       if (organizationIds?.length) {
+        /**
+         * Organization grants are keyed to registered applications
+         * (`application_user_consent_organizations`); the grant-scoped counterpart for CIMD
+         * clients lands with LOG-13930, so a CIMD consent submission must not carry any
+         * organization selection.
+         */
+        assertThat(
+          !isCimdClient,
+          new InvalidRequest('organization consent is not available for CIMD clients')
+        );
+
         // Assert that user is a member of all organizations
         await validateUserConsentOrganizationMembership(userId, organizationIds);
 
@@ -93,14 +109,16 @@ export default function consentRoutes<T extends IRouterParamContext>(
       // to ensure the scopes are correct.
 
       // Find the organizations granted by the user
-      // The user may send consent request multiple times, so we need to find the organizations again
-      const [, organizations] = await queries.applications.userConsentOrganizations.getEntities(
-        Organizations,
-        {
-          applicationId,
-          userId,
-        }
-      );
+      // The user may send consent request multiple times, so we need to find the organizations again.
+      // A CIMD client can hold none until LOG-13930 lands the grant-scoped storage.
+      const organizations = isCimdClient
+        ? []
+        : await queries.applications.userConsentOrganizations
+            .getEntities(Organizations, {
+              applicationId,
+              userId,
+            })
+            .then(([, entities]) => entities);
 
       // The missingResourceScopes from the prompt details are from `getResourceServerInfo`,
       // which contains resource scopes and organization resource scopes.
@@ -108,6 +126,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       // The "scopes" in `missingResourceScopes` do not have "id", so we have to rebuild the scopes list.
       const missingResourceScopes = await filterAndParseMissingResourceScopes({
         resourceScopes: allMissingResourceScopes,
+        envSet,
         queries,
         libraries,
         userId,
@@ -118,6 +137,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
         organizations.map(async ({ name, id }) => {
           const missingResourceScopes = await filterAndParseMissingResourceScopes({
             resourceScopes: allMissingResourceScopes,
+            envSet,
             queries,
             libraries,
             userId,
@@ -225,18 +245,54 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const { accountId } = session;
 
-      const application = isBuiltInApplicationId(clientId)
-        ? buildBuiltInApplicationDataForTenant('', clientId)
-        : await queries.applications.findApplicationById(clientId);
+      // DEV: CIMD (client ID metadata document) support
+      const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId);
 
-      const isDeviceFlowApplication =
-        application.type === ApplicationType.Native &&
-        Boolean(application.customClientMetadata.isDeviceFlow);
+      /**
+       * CIMD clients are unregistered: display data comes from the provider-resolved metadata
+       * document (cache-backed) instead of the applications table, and no application-level
+       * sign-in experience or device-flow variant exists for them.
+       */
+      const getApplicationDisplayData = async (): Promise<{
+        application: ConsentInfoResponse['application'];
+        isDeviceFlowApplication: boolean;
+      }> => {
+        // DEV: CIMD (client ID metadata document) support
+        if (isCimdClient) {
+          const client = await provider.Client.find(clientId);
+          assertThat(client, new InvalidClient('client must be available'));
 
-      const applicationSignInExperience =
-        await queries.applicationSignInExperiences.safeFindSignInExperienceByApplicationId(
-          clientId
-        );
+          return {
+            application: { id: clientId, name: client.clientName ?? clientId },
+            isDeviceFlowApplication: false,
+          };
+        }
+
+        const application = isBuiltInApplicationId(clientId)
+          ? buildBuiltInApplicationDataForTenant('', clientId)
+          : await queries.applications.findApplicationById(clientId);
+
+        const applicationSignInExperience =
+          await queries.applicationSignInExperiences.safeFindSignInExperienceByApplicationId(
+            clientId
+          );
+
+        return {
+          // Merge the public application data and application sign-in-experience data
+          application: {
+            ...publicApplicationGuard.parse(application),
+            ...conditional(
+              applicationSignInExperience &&
+                applicationSignInExperienceGuard.parse(applicationSignInExperience)
+            ),
+          },
+          isDeviceFlowApplication:
+            application.type === ApplicationType.Native &&
+            Boolean(application.customClientMetadata.isDeviceFlow),
+        };
+      };
+
+      const { application, isDeviceFlowApplication } = await getApplicationDisplayData();
 
       if (!isDeviceFlowApplication) {
         assertThat(
@@ -256,21 +312,29 @@ export default function consentRoutes<T extends IRouterParamContext>(
       // The "scopes" in `missingResourceScopes` do not have "id", so we have to rebuild the scopes list.
       const missingResourceScopes = await filterAndParseMissingResourceScopes({
         resourceScopes: allMissingResourceScopes,
+        envSet,
         queries,
         libraries,
         userId: accountId,
         applicationId: clientId,
       });
 
-      // Find the organizations if the application is requesting the organizations scope
-      const organizations = missingOIDCScope?.includes(UserScope.Organizations)
-        ? await queries.organizations.relations.users.getOrganizationsByUserId(accountId)
-        : [];
+      // Find the organizations if the application is requesting the organizations scope.
+      /**
+       * Organization grants are keyed to registered applications
+       * (`application_user_consent_organizations`); the grant-scoped counterpart for CIMD
+       * clients lands with LOG-13930, so a CIMD consent offers no organization selection yet.
+       */
+      const organizations =
+        !isCimdClient && missingOIDCScope?.includes(UserScope.Organizations)
+          ? await queries.organizations.relations.users.getOrganizationsByUserId(accountId)
+          : [];
 
       const organizationsWithMissingResourceScopes = await Promise.all(
         organizations.map(async ({ name, id }) => {
           const missingResourceScopes = await filterAndParseMissingResourceScopes({
             resourceScopes: allMissingResourceScopes,
+            envSet,
             queries,
             libraries,
             userId: accountId,
@@ -283,14 +347,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       );
 
       ctx.body = {
-        // Merge the public application data and application sign-in-experience data
-        application: {
-          ...publicApplicationGuard.parse(application),
-          ...conditional(
-            applicationSignInExperience &&
-              applicationSignInExperienceGuard.parse(applicationSignInExperience)
-          ),
-        },
+        application,
         user: publicUserInfoGuard.parse(userInfo),
         organizations: organizationsWithMissingResourceScopes,
         // Filter out the OIDC scopes that are not needed for the consent page.

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -20,8 +20,7 @@ import { consent, getMissingScopes } from '#src/libraries/session/index.js';
 import koaAppAccessControl from '#src/middleware/koa-app-access-control.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
-import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
-import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
+import { isCimdClient } from '#src/oidc/cimd/index.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -72,10 +71,9 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const { accountId: userId } = session;
 
-      // DEV: CIMD (client ID metadata document) support
-      const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(applicationId);
+      const cimd = isCimdClient(envSet, applicationId);
 
-      if (isCimdClient) {
+      if (cimd) {
         /**
          * The oidc-provider resume path re-runs `checkClient` (re-fetching the metadata
          * document when its cache has expired) but not `check_redirect_uri`, so a URI removed
@@ -101,7 +99,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
          * organization selection.
          */
         assertThat(
-          !isCimdClient,
+          !cimd,
           new InvalidRequest('organization consent is not available for CIMD clients')
         );
 
@@ -128,7 +126,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
       // Find the organizations granted by the user
       // The user may send consent request multiple times, so we need to find the organizations again.
       // A CIMD client can hold none until LOG-13930 lands the grant-scoped storage.
-      const organizations = isCimdClient
+      const organizations = cimd
         ? []
         : await queries.applications.userConsentOrganizations
             .getEntities(Organizations, {
@@ -222,7 +220,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
              * organization support reopens the rebuild and retires this branch.
              * TODO: @xiaoyijun reopen the organization rebuild for CIMD (LOG-13930).
              */
-            return [resourceIndicator, isCimdClient ? scopes : []];
+            return [resourceIndicator, cimd ? scopes : []];
           }
 
           return [resourceIndicator, scopes.filter((scope) => !resource.includes(scope))];
@@ -275,8 +273,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const { accountId } = session;
 
-      // DEV: CIMD (client ID metadata document) support
-      const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId);
+      const cimd = isCimdClient(envSet, clientId);
 
       /**
        * CIMD clients are unregistered: display data comes from the provider-resolved metadata
@@ -287,8 +284,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
         application: ConsentInfoResponse['application'];
         isDeviceFlowApplication: boolean;
       }> => {
-        // DEV: CIMD (client ID metadata document) support
-        if (isCimdClient) {
+        if (cimd) {
           assertThat(
             await provider.Client.find(clientId),
             new InvalidClient('client must be available')
@@ -365,7 +361,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
        * clients lands with LOG-13930, so a CIMD consent offers no organization selection yet.
        */
       const organizations =
-        !isCimdClient && missingOIDCScope?.includes(UserScope.Organizations)
+        !cimd && missingOIDCScope?.includes(UserScope.Organizations)
           ? await queries.organizations.relations.users.getOrganizationsByUserId(accountId)
           : [];
 

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -78,7 +78,10 @@ export default function consentRoutes<T extends IRouterParamContext>(
          * The oidc-provider resume path re-runs `checkClient` (re-fetching the metadata
          * document when its cache has expired) but not `check_redirect_uri`, so a URI removed
          * from the current document would still receive the authorization code. Re-assert it
-         * here: the document resolved now is the one resume reads moments later.
+         * here against whatever document the cache serves at submission time — best effort,
+         * not airtight: a cache expiry between this check and resume can still swap in a
+         * changed document unchecked. It narrows the exposure from the whole login-to-consent
+         * span to that cache-boundary race.
          */
         const client = await provider.Client.find(applicationId);
         assertThat(client, new InvalidClient('client must be available'));

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -59,7 +59,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const {
         session,
-        params: { client_id: applicationId },
+        params: { client_id: applicationId, redirect_uri: redirectUri },
         prompt,
       } = interactionDetails;
 
@@ -74,6 +74,23 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       // DEV: CIMD (client ID metadata document) support
       const isCimdClient = isCimdEffectivelyEnabled(envSet) && isCimdClientId(applicationId);
+
+      if (isCimdClient) {
+        /**
+         * The oidc-provider resume path re-runs `checkClient` (re-fetching the metadata
+         * document when its cache has expired) but not `check_redirect_uri`, so a URI removed
+         * from the current document would still receive the authorization code. Re-assert it
+         * here: the document resolved now is the one resume reads moments later.
+         */
+        const client = await provider.Client.find(applicationId);
+        assertThat(client, new InvalidClient('client must be available'));
+        assertThat(
+          typeof redirectUri === 'string' && client.redirectUriAllowed(redirectUri),
+          new InvalidRedirectUri(
+            'redirect_uri must still be allowed by the client metadata document'
+          )
+        );
+      }
 
       // Grant the organizations to the application if the user has selected the organizations
       if (organizationIds?.length) {
@@ -192,7 +209,14 @@ export default function consentRoutes<T extends IRouterParamContext>(
           const resource = resourceScopesToGrant[resourceIndicator];
 
           if (!resource) {
-            return [resourceIndicator, []];
+            /**
+             * With the organization rebuild closed for CIMD (until LOG-13930), a scope held
+             * only through organization roles can end up neither granted nor rejected; the
+             * provider would then see it still missing on resume and restart the consent
+             * prompt indefinitely. Reject the whole group instead — consistent with the
+             * consent page, which never displayed these scopes.
+             */
+            return [resourceIndicator, isCimdClient ? scopes : []];
           }
 
           return [resourceIndicator, scopes.filter((scope) => !resource.includes(scope))];
@@ -259,11 +283,20 @@ export default function consentRoutes<T extends IRouterParamContext>(
       }> => {
         // DEV: CIMD (client ID metadata document) support
         if (isCimdClient) {
-          const client = await provider.Client.find(clientId);
-          assertThat(client, new InvalidClient('client must be available'));
+          assertThat(
+            await provider.Client.find(clientId),
+            new InvalidClient('client must be available')
+          );
 
+          /**
+           * The document's `client_name` is fully controlled by the remote, unregistered
+           * client, and the consent page renders the name as the only identity signal — so
+           * showing it verbatim invites phishing (CIMD draft-02 §8.5). Until the identifier
+           * hostname is rendered alongside it, the unforgeable identifier URL is the name.
+           * TODO: @xiaoyijun display the fetched name with the identifier hostname (LOG-13990).
+           */
           return {
-            application: { id: clientId, name: client.clientName ?? clientId },
+            application: { id: clientId, name: clientId },
             isDeviceFlowApplication: false,
           };
         }

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -215,6 +215,12 @@ export default function consentRoutes<T extends IRouterParamContext>(
              * provider would then see it still missing on resume and restart the consent
              * prompt indefinitely. Reject the whole group instead — consistent with the
              * consent page, which never displayed these scopes.
+             *
+             * The rejection persists on the grant (rejected counts as encountered), so the
+             * scope stays withheld even if the user becomes eligible later — accepted as an
+             * interim state: CIMD ships together with LOG-13930, whose grant-scoped
+             * organization support reopens the rebuild and retires this branch.
+             * TODO: @xiaoyijun reopen the organization rebuild for CIMD (LOG-13930).
              */
             return [resourceIndicator, isCimdClient ? scopes : []];
           }

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -3,8 +3,7 @@ import { type MissingResourceScopes, type Scope, missingResourceScopesGuard } fr
 import { errors } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
-import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
-import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
+import { isCimdClient } from '#src/oidc/cimd/index.js';
 import { filterResourceScopesForTheCimdClient } from '#src/oidc/cimd/resource-scopes.js';
 import {
   filterResourceScopesForTheThirdPartyApplication,
@@ -125,8 +124,7 @@ export const filterAndParseMissingResourceScopes = async ({
             organizationId,
           });
 
-          // DEV: CIMD (client ID metadata document) support
-          if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(applicationId)) {
+          if (isCimdClient(envSet, applicationId)) {
             /**
              * CIMD clients are unregistered: the tenant-wide ceiling replaces the
              * per-application consent configuration, and the identifier URL must never reach

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -136,7 +136,11 @@ export const filterAndParseMissingResourceScopes = async ({
             const filteredScopes = await filterResourceScopesForTheCimdClient(
               queries,
               resourceIndicator,
-              scopes
+              scopes,
+              {
+                includeOrganizationResourceScopes: Boolean(organizationId),
+                includeResourceScopes: !organizationId,
+              }
             );
 
             return [

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -2,6 +2,10 @@ import { ReservedResource } from '@logto/core-kit';
 import { type MissingResourceScopes, type Scope, missingResourceScopesGuard } from '@logto/schemas';
 import { errors } from 'oidc-provider';
 
+import { type EnvSet } from '#src/env-set/index.js';
+import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
+import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
+import { filterResourceScopesForTheCimdClient } from '#src/oidc/cimd/resource-scopes.js';
 import {
   filterResourceScopesForTheThirdPartyApplication,
   findResourceScopes,
@@ -91,6 +95,7 @@ const parseMissingResourceScopesInfo = async (
  */
 export const filterAndParseMissingResourceScopes = async ({
   resourceScopes,
+  envSet,
   queries,
   libraries,
   userId,
@@ -98,6 +103,7 @@ export const filterAndParseMissingResourceScopes = async ({
   organizationId,
 }: {
   resourceScopes: Record<string, string[]>;
+  envSet: EnvSet;
   queries: Queries;
   libraries: Libraries;
   userId: string;
@@ -118,6 +124,26 @@ export const filterAndParseMissingResourceScopes = async ({
             findFromOrganizations: Boolean(organizationId),
             organizationId,
           });
+
+          // DEV: CIMD (client ID metadata document) support
+          if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(applicationId)) {
+            /**
+             * CIMD clients are unregistered: the tenant-wide ceiling replaces the
+             * per-application consent configuration, and the identifier URL must never reach
+             * `isThirdPartyApplication` (its not-found fallback would read as first-party and
+             * skip the filter entirely).
+             */
+            const filteredScopes = await filterResourceScopesForTheCimdClient(
+              queries,
+              resourceIndicator,
+              scopes
+            );
+
+            return [
+              resourceIndicator,
+              missingScopes.filter((scope) => filteredScopes.some(({ name }) => name === scope)),
+            ];
+          }
 
           const isThirdPartyApp = await isThirdPartyApplication(queries, applicationId);
 

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -33,7 +33,6 @@ export const publicApplicationGuard = Applications.guard
     id: true,
     name: true,
   })
-  // DEV: CIMD (client ID metadata document) support
   .extend({
     id: z.string(),
     name: z.string(),

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -24,11 +24,21 @@ export type PublicUserInfo = z.infer<typeof publicUserInfoGuard>;
 
 /**
  * Define the public application info that can be exposed to the public. e.g. on the user consent page.
+ *
+ * The overrides lift the applications-table column length bounds: a CIMD client puts its
+ * identifier URL (up to 2048 characters) in `id` and the remote document's `client_name`,
+ * which no column bound governs, in `name`.
  */
-export const publicApplicationGuard = Applications.guard.pick({
-  id: true,
-  name: true,
-});
+export const publicApplicationGuard = Applications.guard
+  .pick({
+    id: true,
+    name: true,
+  })
+  // DEV: CIMD (client ID metadata document) support
+  .extend({
+    id: z.string(),
+    name: z.string(),
+  });
 export type PublicApplication = z.infer<typeof publicApplicationGuard>;
 export const applicationSignInExperienceGuard = ApplicationSignInExperiences.guard.pick({
   branding: true,

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -26,8 +26,7 @@ export type PublicUserInfo = z.infer<typeof publicUserInfoGuard>;
  * Define the public application info that can be exposed to the public. e.g. on the user consent page.
  *
  * The overrides lift the applications-table column length bounds: a CIMD client puts its
- * identifier URL (up to 2048 characters) in `id` and the remote document's `client_name`,
- * which no column bound governs, in `name`.
+ * identifier URL (up to 2048 characters) in both `id` and `name`.
  */
 export const publicApplicationGuard = Applications.guard
   .pick({


### PR DESCRIPTION
## Summary

Handle CIMD clients on the experience consent routes (LOG-13928).

- Serve the consent info for CIMD clients from the provider-resolved metadata document instead of the applications table; no application sign-in experience or device-flow variant applies.
- Reject organization selections on CIMD consent submissions and skip the organization lookups on both GET and POST; the grant-scoped organization support lands with LOG-13930.
- Rebuild the missing resource scopes through the tenant-wide CIMD ceiling (`filterResourceScopesForTheCimdClient`).
- Widen `publicApplicationGuard` so the identifier URL and the remote `client_name` fit the consent response.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

