### PR TITLE
feat(core): write cimd first-consent attribution to the dedicated user column

### DIFF
--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -13,39 +13,6 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { updateInteractionResult } from './interaction.js';
 
-const saveUserFirstConsentedAppId = async (
-  queries: Queries,
-  userId: string,
-  applicationId: string
-) => {
-  const { findUserById, updateUserById } = queries.users;
-  const { applicationId: firstConsentedAppId } = await findUserById(userId);
-
-  if (!firstConsentedAppId) {
-    // Save application id that the user first consented
-    await updateUserById(userId, { applicationId });
-  }
-};
-
-/**
- * The CIMD mirror of {@link saveUserFirstConsentedAppId} on the dedicated
- * `users.cimd_client_id` column: `users.application_id` (varchar(21)) keeps meaning "first
- * consented registered application", so a CIMD URL must never reach it — user management still
- * shows which client a user came from through the dedicated column.
- */
-const saveUserFirstConsentedCimdClientId = async (
-  queries: Queries,
-  userId: string,
-  cimdClientId: string
-) => {
-  const { findUserById, updateUserById } = queries.users;
-  const { cimdClientId: firstConsentedCimdClientId } = await findUserById(userId);
-
-  if (!firstConsentedCimdClientId) {
-    await updateUserById(userId, { cimdClientId });
-  }
-};
-
 // Get the missing scopes from prompt details
 const missingScopesGuard = z.object({
   missingOIDCScope: z.string().array().optional(),
@@ -70,6 +37,34 @@ type ClientIdentifiers = {
  */
 const identifyClient = (envSet: EnvSet, clientId: string): ClientIdentifiers =>
   isCimdClient(envSet, clientId) ? { cimdClientId: clientId } : { registeredClientId: clientId };
+
+/**
+ * `users.application_id` and `users.cimd_client_id` form a single first-consent attribution,
+ * so a user already attributed through either column is never written again. The columns stay
+ * separate because `application_id` (varchar(21)) only ever holds registered application ids —
+ * a CIMD client identifier URL must never reach it.
+ */
+const saveUserFirstConsentedClient = async (
+  queries: Queries,
+  userId: string,
+  { registeredClientId, cimdClientId }: ClientIdentifiers
+) => {
+  const { findUserById, updateUserById } = queries.users;
+  const user = await findUserById(userId);
+
+  if (user.applicationId ?? user.cimdClientId) {
+    return;
+  }
+
+  if (registeredClientId) {
+    await updateUserById(userId, { applicationId: registeredClientId });
+    return;
+  }
+
+  if (cimdClientId) {
+    await updateUserById(userId, { cimdClientId });
+  }
+};
 
 /**
  * Persists the interaction's `lastSubmission` information to the session for future reference.
@@ -164,12 +159,7 @@ export const consent = async ({
     new provider.Grant({ accountId, clientId });
 
   await Promise.all([
-    conditional(
-      registeredClientId && saveUserFirstConsentedAppId(queries, accountId, registeredClientId)
-    ),
-    conditional(
-      cimdClientId && saveUserFirstConsentedCimdClientId(queries, accountId, cimdClientId)
-    ),
+    saveUserFirstConsentedClient(queries, accountId, { registeredClientId, cimdClientId }),
     saveInteractionLastSubmissionToSession(queries, interactionDetails, {
       registeredClientId,
       cimdClientId,

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -27,6 +27,25 @@ const saveUserFirstConsentedAppId = async (
   }
 };
 
+/**
+ * The CIMD mirror of {@link saveUserFirstConsentedAppId} on the dedicated
+ * `users.cimd_client_id` column: `users.application_id` (varchar(21)) keeps meaning "first
+ * consented registered application", so a CIMD URL must never reach it — user management still
+ * shows which client a user came from through the dedicated column.
+ */
+const saveUserFirstConsentedCimdClientId = async (
+  queries: Queries,
+  userId: string,
+  cimdClientId: string
+) => {
+  const { findUserById, updateUserById } = queries.users;
+  const { cimdClientId: firstConsentedCimdClientId } = await findUserById(userId);
+
+  if (!firstConsentedCimdClientId) {
+    await updateUserById(userId, { cimdClientId });
+  }
+};
+
 // Get the missing scopes from prompt details
 const missingScopesGuard = z.object({
   missingOIDCScope: z.string().array().optional(),
@@ -145,12 +164,11 @@ export const consent = async ({
     new provider.Grant({ accountId, clientId });
 
   await Promise.all([
-    /**
-     * A CIMD URL must never reach `users.application_id` (varchar(21), registered ids only).
-     * TODO: @xiaoyijun persist the CIMD attribution to `users.cimd_client_id` instead (LOG-13928).
-     */
     conditional(
       registeredClientId && saveUserFirstConsentedAppId(queries, accountId, registeredClientId)
+    ),
+    conditional(
+      cimdClientId && saveUserFirstConsentedCimdClientId(queries, accountId, cimdClientId)
     ),
     saveInteractionLastSubmissionToSession(queries, interactionDetails, {
       registeredClientId,

--- a/packages/core/src/libraries/session/session-context.test.ts
+++ b/packages/core/src/libraries/session/session-context.test.ts
@@ -103,7 +103,11 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
     jest.clearAllMocks();
   });
 
-  it('should write a cimd client identifier to the dedicated column and skip the app attribution', async () => {
+  it('should write a cimd client identifier to the dedicated columns and keep the app attribution null', async () => {
+    userQueries.findUserById.mockImplementationOnce(async () => ({
+      ...mockUser,
+      cimdClientId: null,
+    }));
     const interactionDetails = buildInteractionDetails(cimdClientId);
     const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
 
@@ -122,7 +126,25 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
       clientId: null,
       cimdClientId,
     });
-    expect(userQueries.findUserById).not.toHaveBeenCalled();
+    expect(userQueries.updateUserById).toHaveBeenCalledWith(mockUser.id, { cimdClientId });
+  });
+
+  it('should not overwrite an existing first-consent cimd attribution', async () => {
+    userQueries.findUserById.mockImplementationOnce(async () => ({
+      ...mockUser,
+      cimdClientId: 'https://first.example.com/metadata.json',
+    }));
+    const interactionDetails = buildInteractionDetails(cimdClientId);
+    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails,
+    });
+
     expect(userQueries.updateUserById).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/libraries/session/session-context.test.ts
+++ b/packages/core/src/libraries/session/session-context.test.ts
@@ -103,9 +103,10 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
     jest.clearAllMocks();
   });
 
-  it('should write a cimd client identifier to the dedicated columns and keep the app attribution null', async () => {
+  it('should write a cimd client identifier to the dedicated column for a cimd-first user', async () => {
     userQueries.findUserById.mockImplementationOnce(async () => ({
       ...mockUser,
+      applicationId: null,
       cimdClientId: null,
     }));
     const interactionDetails = buildInteractionDetails(cimdClientId);
@@ -126,12 +127,14 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
       clientId: null,
       cimdClientId,
     });
+    expect(userQueries.updateUserById).toHaveBeenCalledTimes(1);
     expect(userQueries.updateUserById).toHaveBeenCalledWith(mockUser.id, { cimdClientId });
   });
 
   it('should not overwrite an existing first-consent cimd attribution', async () => {
     userQueries.findUserById.mockImplementationOnce(async () => ({
       ...mockUser,
+      applicationId: null,
       cimdClientId: 'https://first.example.com/metadata.json',
     }));
     const interactionDetails = buildInteractionDetails(cimdClientId);
@@ -148,10 +151,51 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
     expect(userQueries.updateUserById).not.toHaveBeenCalled();
   });
 
-  it('should write a registered client identifier to the client id column and keep the app attribution', async () => {
+  it('should not write the cimd column for a user attributed to a registered application', async () => {
+    userQueries.findUserById.mockImplementationOnce(async () => ({
+      ...mockUser,
+      applicationId: 'bar',
+      cimdClientId: null,
+    }));
+    const interactionDetails = buildInteractionDetails(cimdClientId);
+    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails,
+    });
+
+    expect(userQueries.updateUserById).not.toHaveBeenCalled();
+  });
+
+  it('should not write the app attribution for a cimd-first user consenting to a registered application', async () => {
     userQueries.findUserById.mockImplementationOnce(async () => ({
       ...mockUser,
       applicationId: null,
+      cimdClientId: 'https://first.example.com/metadata.json',
+    }));
+    const interactionDetails = buildInteractionDetails('registeredClientId');
+    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails,
+    });
+
+    expect(userQueries.updateUserById).not.toHaveBeenCalled();
+  });
+
+  it('should write a registered client identifier to the client id column and save the app attribution', async () => {
+    userQueries.findUserById.mockImplementationOnce(async () => ({
+      ...mockUser,
+      applicationId: null,
+      cimdClientId: null,
     }));
     const interactionDetails = buildInteractionDetails('registeredClientId');
     const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
@@ -171,6 +215,7 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
       clientId: 'registeredClientId',
       cimdClientId: null,
     });
+    expect(userQueries.updateUserById).toHaveBeenCalledTimes(1);
     expect(userQueries.updateUserById).toHaveBeenCalledWith(mockUser.id, {
       applicationId: 'registeredClientId',
     });


### PR DESCRIPTION
## Summary

Write the first-consent attribution for CIMD clients to the dedicated `users.cimd_client_id` column (LOG-13928).

- `users.application_id` keeps meaning "first consented registered application"; both columns form a single first-consent attribution, and a user already attributed through either column is never written again.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
