### PR TITLE
feat(core): add trusted device credential library

### DIFF
--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -1,0 +1,281 @@
+import { createHash } from 'node:crypto';
+
+import type { TrustedDevice } from '@logto/schemas';
+
+import type { TrustedDeviceQueries } from '#src/queries/trusted-device.js';
+
+import {
+  createTrustedDeviceLibrary,
+  generateTrustedDeviceSecret,
+  getTrustedDeviceCookieName,
+  hashTrustedDeviceSecret,
+  parseTrustedDeviceCredential,
+  serializeTrustedDeviceCredential,
+  type TrustedDeviceCookieContext,
+  verifyTrustedDeviceSecret,
+} from './trusted-device.js';
+
+const { jest } = import.meta;
+
+const tenantId = 'tenant-id';
+const userId = 'user-id';
+const trustedDeviceId = 'trusteddeviceid';
+
+const createCookieContext = (value?: string) => {
+  const get = jest.fn(
+    (..._args: Parameters<TrustedDeviceCookieContext['cookies']['get']>) => value
+  ) as jest.MockedFunction<TrustedDeviceCookieContext['cookies']['get']>;
+  const set = jest.fn() as jest.MockedFunction<TrustedDeviceCookieContext['cookies']['set']>;
+  const ctx = { cookies: { get, set } } as unknown as TrustedDeviceCookieContext;
+
+  return { ctx, get, set };
+};
+
+const createQueries = () =>
+  ({
+    insert: jest.fn(),
+    findActiveByIdAndUserId: jest.fn(),
+    deleteExpiredByIdAndUserId: jest.fn(),
+    deleteExpiredByTenant: jest.fn(),
+  }) as unknown as jest.Mocked<TrustedDeviceQueries>;
+
+const buildTrustedDevice = (secretHash: Uint8Array): TrustedDevice => ({
+  tenantId,
+  id: trustedDeviceId,
+  userId,
+  secretHash: Buffer.from(secretHash),
+  userAgent: null,
+  ip: null,
+  country: null,
+  city: null,
+  createdAt: 1,
+  lastUsedAt: 1,
+  expiresAt: Date.now() + 60_000,
+});
+
+describe('trusted device credential helpers', () => {
+  it('builds deterministic non-identifying per-user cookie names', () => {
+    const developmentName = getTrustedDeviceCookieName(tenantId, userId, false);
+    const productionName = getTrustedDeviceCookieName(tenantId, userId, true);
+
+    expect(developmentName).toMatch(/^logto-trusted-device-[\w-]{43}$/);
+    expect(developmentName).not.toContain(tenantId);
+    expect(developmentName).not.toContain(userId);
+    expect(productionName).toBe(`__Host-${developmentName}`);
+    expect(getTrustedDeviceCookieName(tenantId, 'another-user', false)).not.toBe(developmentName);
+  });
+
+  it('generates 32-byte secrets and hashes their decoded bytes with SHA-256', () => {
+    const secret = generateTrustedDeviceSecret();
+    const decoded = Buffer.from(secret, 'base64url');
+    const hash = hashTrustedDeviceSecret(secret);
+
+    expect(decoded).toHaveLength(32);
+    expect(hash).toEqual(createHash('sha256').update(decoded).digest());
+    expect(verifyTrustedDeviceSecret(secret, hash)).toBe(true);
+    expect(verifyTrustedDeviceSecret(secret, Buffer.alloc(31))).toBe(false);
+  });
+
+  it('round-trips a credential and rejects malformed values', () => {
+    const credential = { id: trustedDeviceId, secret: generateTrustedDeviceSecret() };
+
+    expect(parseTrustedDeviceCredential(serializeTrustedDeviceCredential(credential))).toEqual(
+      credential
+    );
+
+    expect(parseTrustedDeviceCredential('missing-secret')).toBeUndefined();
+    expect(parseTrustedDeviceCredential(`id.${credential.secret}.extra`)).toBeUndefined();
+    expect(parseTrustedDeviceCredential(`${'a'.repeat(22)}.${credential.secret}`)).toBeUndefined();
+    expect(parseTrustedDeviceCredential(`${'A'.repeat(21)}.${credential.secret}`)).toBeUndefined();
+    expect(parseTrustedDeviceCredential(`id.not-base64!`)).toBeUndefined();
+    expect(parseTrustedDeviceCredential(`id.${credential.secret.slice(1)}`)).toBeUndefined();
+  });
+});
+
+describe('trusted device library', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a record with only the secret hash and writes an unsigned host-only cookie', async () => {
+    const now = Date.now();
+    const expiresAt = now + 60_000;
+    const queries = createQueries();
+    const { ctx, set } = createCookieContext();
+
+    queries.insert.mockImplementationOnce(async (data) => ({
+      tenantId,
+      userAgent: null,
+      ip: null,
+      country: null,
+      city: null,
+      createdAt: now,
+      lastUsedAt: now,
+      ...data,
+    }));
+    queries.deleteExpiredByTenant.mockResolvedValueOnce(0);
+
+    const library = createTrustedDeviceLibrary(tenantId, queries, { isProduction: false });
+    const record = await library.createCredential({ ctx, userId, expiresAt });
+    const inserted = queries.insert.mock.calls[0]?.[0];
+    const cookieValue = set.mock.calls[0]?.[1];
+    const parsed =
+      typeof cookieValue === 'string' ? parseTrustedDeviceCredential(cookieValue) : null;
+
+    expect(inserted?.id).toBe(record.id);
+    expect(inserted?.userId).toBe(userId);
+    expect(inserted?.expiresAt).toBe(expiresAt);
+    expect(parsed?.id).toBe(record.id);
+    expect(inserted?.secretHash).toEqual(
+      parsed ? hashTrustedDeviceSecret(parsed.secret) : undefined
+    );
+    expect(JSON.stringify(inserted)).not.toContain(parsed?.secret);
+    expect(set).toHaveBeenCalledWith(
+      getTrustedDeviceCookieName(tenantId, userId, false),
+      expect.any(String),
+      expect.objectContaining({
+        expires: new Date(expiresAt),
+        httpOnly: true,
+        overwrite: true,
+        path: '/',
+        sameSite: 'lax',
+        secure: false,
+        signed: false,
+      })
+    );
+    expect(set.mock.calls[0]?.[2]?.maxAge).toBeLessThanOrEqual(expiresAt - now);
+    expect(set.mock.calls[0]?.[2]).not.toHaveProperty('domain');
+    expect(queries.deleteExpiredByTenant).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses Secure and the __Host- prefix in production', () => {
+    const queries = createQueries();
+    const { ctx, set } = createCookieContext();
+    const library = createTrustedDeviceLibrary(tenantId, queries, { isProduction: true });
+    const credential = { id: trustedDeviceId, secret: generateTrustedDeviceSecret() };
+
+    library.writeCredential(ctx, userId, credential, Date.now() + 60_000);
+
+    expect(set).toHaveBeenCalledWith(
+      getTrustedDeviceCookieName(tenantId, userId, true),
+      serializeTrustedDeviceCredential(credential),
+      expect.objectContaining({ secure: true, signed: false, path: '/' })
+    );
+  });
+
+  it('reads the unsigned user-specific cookie and validates the active record hash', async () => {
+    const secret = generateTrustedDeviceSecret();
+    const secretHash = hashTrustedDeviceSecret(secret);
+    const record = buildTrustedDevice(secretHash);
+    const queries = createQueries();
+    const { ctx, get, set } = createCookieContext(
+      serializeTrustedDeviceCredential({ id: record.id, secret })
+    );
+    queries.findActiveByIdAndUserId.mockResolvedValueOnce(record);
+
+    const library = createTrustedDeviceLibrary(tenantId, queries, { isProduction: false });
+
+    await expect(library.validateCredential(ctx, userId)).resolves.toEqual(record);
+    expect(get).toHaveBeenCalledWith(getTrustedDeviceCookieName(tenantId, userId, false), {
+      signed: false,
+    });
+    expect(queries.findActiveByIdAndUserId).toHaveBeenCalledWith(record.id, userId);
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  it('clears a malformed credential without querying a record', async () => {
+    const queries = createQueries();
+    const { ctx, set } = createCookieContext('malformed');
+    const library = createTrustedDeviceLibrary(tenantId, queries, { isProduction: false });
+
+    await expect(library.validateCredential(ctx, userId)).resolves.toBeUndefined();
+    expect(queries.findActiveByIdAndUserId).not.toHaveBeenCalled();
+    expect(set).toHaveBeenCalledWith(
+      getTrustedDeviceCookieName(tenantId, userId, false),
+      '',
+      expect.objectContaining({
+        expires: new Date(0),
+        maxAge: 0,
+        signed: false,
+      })
+    );
+  });
+
+  it('clears a credential with an invalid record ID without querying the database', async () => {
+    const queries = createQueries();
+    const { ctx, set } = createCookieContext(
+      serializeTrustedDeviceCredential({
+        id: 'a'.repeat(22),
+        secret: generateTrustedDeviceSecret(),
+      })
+    );
+    const library = createTrustedDeviceLibrary(tenantId, queries, { isProduction: false });
+
+    await expect(library.validateCredential(ctx, userId)).resolves.toBeUndefined();
+    expect(queries.findActiveByIdAndUserId).not.toHaveBeenCalled();
+    expect(set).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a tampered credential after an equal-length hash comparison fails', async () => {
+    const secret = generateTrustedDeviceSecret();
+    const otherSecret = generateTrustedDeviceSecret();
+    const record = buildTrustedDevice(hashTrustedDeviceSecret(otherSecret));
+    const queries = createQueries();
+    const { ctx, set } = createCookieContext(
+      serializeTrustedDeviceCredential({ id: record.id, secret })
+    );
+    queries.findActiveByIdAndUserId.mockResolvedValueOnce(record);
+
+    const library = createTrustedDeviceLibrary(tenantId, queries, { isProduction: false });
+
+    await expect(library.validateCredential(ctx, userId)).resolves.toBeUndefined();
+    expect(set).toHaveBeenCalledTimes(1);
+    expect(queries.deleteExpiredByIdAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('silently attempts exact cleanup for a missing or expired presented record', async () => {
+    const secret = generateTrustedDeviceSecret();
+    const queries = createQueries();
+    const { ctx, set } = createCookieContext(
+      serializeTrustedDeviceCredential({ id: trustedDeviceId, secret })
+    );
+    queries.findActiveByIdAndUserId.mockResolvedValueOnce(null);
+    queries.deleteExpiredByIdAndUserId.mockResolvedValueOnce(1);
+
+    const library = createTrustedDeviceLibrary(tenantId, queries, { isProduction: false });
+
+    await expect(library.validateCredential(ctx, userId)).resolves.toBeUndefined();
+    await Promise.resolve();
+
+    expect(queries.deleteExpiredByIdAndUserId).toHaveBeenCalledWith(trustedDeviceId, userId);
+    expect(set).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates concurrent opportunistic cleanup within the cooldown', async () => {
+    const queries = createQueries();
+    queries.deleteExpiredByTenant.mockResolvedValue(2);
+    const library = createTrustedDeviceLibrary(tenantId, queries, {
+      isProduction: false,
+      cleanupCooldown: 60_000,
+    });
+
+    await expect(
+      Promise.all([library.cleanupExpired(), library.cleanupExpired(), library.cleanupExpired()])
+    ).resolves.toEqual([2, undefined, undefined]);
+    expect(queries.deleteExpiredByTenant).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries opportunistic cleanup after a failed attempt', async () => {
+    const queries = createQueries();
+    queries.deleteExpiredByTenant.mockRejectedValueOnce(new Error('cleanup failed'));
+    queries.deleteExpiredByTenant.mockResolvedValueOnce(2);
+    const library = createTrustedDeviceLibrary(tenantId, queries, {
+      isProduction: false,
+      cleanupCooldown: 60_000,
+    });
+
+    await expect(library.cleanupExpired()).resolves.toBeUndefined();
+    await expect(library.cleanupExpired()).resolves.toBe(2);
+    expect(queries.deleteExpiredByTenant).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -1,0 +1,241 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+
+import { TrustedDevices } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import { trySafe } from '@silverhand/essentials';
+import { type Context } from 'koa';
+
+import { EnvSet } from '#src/env-set/index.js';
+import type { TrustedDeviceMetadata, TrustedDeviceQueries } from '#src/queries/trusted-device.js';
+
+const trustedDeviceSecretByteLength = 32;
+const trustedDeviceSecretHashAlgorithm = 'sha256';
+const trustedDeviceCookiePrefix = 'logto-trusted-device-';
+const trustedDeviceCleanupCooldown = 5 * 60 * 1000;
+const trustedDeviceIdPattern = /^[\da-z]+$/;
+
+export type TrustedDeviceCookieContext = Readonly<{
+  cookies: Pick<Context['cookies'], 'get' | 'set'>;
+}>;
+
+type TrustedDeviceCredential = Readonly<{
+  id: string;
+  secret: string;
+}>;
+
+type TrustedDeviceLibraryOptions = Readonly<{
+  isProduction?: boolean;
+  cleanupCooldown?: number;
+}>;
+
+type CreateTrustedDeviceCredential = TrustedDeviceMetadata &
+  Readonly<{
+    ctx: TrustedDeviceCookieContext;
+    userId: string;
+    expiresAt: number;
+  }>;
+
+export const getTrustedDeviceCookieName = (
+  tenantId: string,
+  userId: string,
+  isProduction: boolean
+) => {
+  const subjectHash = createHash(trustedDeviceSecretHashAlgorithm)
+    .update(`${tenantId}:${userId}`)
+    .digest('base64url');
+  const name = `${trustedDeviceCookiePrefix}${subjectHash}`;
+
+  return isProduction ? `__Host-${name}` : name;
+};
+
+export const generateTrustedDeviceSecret = () =>
+  randomBytes(trustedDeviceSecretByteLength).toString('base64url');
+
+const decodeTrustedDeviceSecret = (secret: string) => {
+  if (!/^[\w-]+$/.test(secret)) {
+    return;
+  }
+
+  const decoded = Buffer.from(secret, 'base64url');
+
+  if (
+    decoded.byteLength !== trustedDeviceSecretByteLength ||
+    decoded.toString('base64url') !== secret
+  ) {
+    return;
+  }
+
+  return decoded;
+};
+
+const isTrustedDeviceId = (id: string) =>
+  TrustedDevices.guard.shape.id.safeParse(id).success && trustedDeviceIdPattern.test(id);
+
+const hashTrustedDeviceSecretBytes = (secret: Uint8Array) =>
+  createHash(trustedDeviceSecretHashAlgorithm).update(secret).digest();
+
+export const hashTrustedDeviceSecret = (secret: string) =>
+  hashTrustedDeviceSecretBytes(Buffer.from(secret, 'base64url'));
+
+export const verifyTrustedDeviceSecret = (secret: string, expectedHash: Uint8Array) => {
+  const decoded = decodeTrustedDeviceSecret(secret);
+
+  if (!decoded) {
+    return false;
+  }
+
+  const actualHash = hashTrustedDeviceSecretBytes(decoded);
+
+  return (
+    actualHash.byteLength === expectedHash.byteLength && timingSafeEqual(actualHash, expectedHash)
+  );
+};
+
+export const serializeTrustedDeviceCredential = ({ id, secret }: TrustedDeviceCredential) =>
+  `${id}.${secret}`;
+
+export const parseTrustedDeviceCredential = (
+  value: string
+): TrustedDeviceCredential | undefined => {
+  const [id, secret, extra] = value.split('.');
+
+  if (
+    !id ||
+    !isTrustedDeviceId(id) ||
+    !secret ||
+    extra !== undefined ||
+    !decodeTrustedDeviceSecret(secret)
+  ) {
+    return;
+  }
+
+  return { id, secret };
+};
+
+export const createTrustedDeviceLibrary = (
+  tenantId: string,
+  queries: TrustedDeviceQueries,
+  {
+    isProduction = EnvSet.values.isProduction,
+    cleanupCooldown = trustedDeviceCleanupCooldown,
+  }: TrustedDeviceLibraryOptions = {}
+) => {
+  // eslint-disable-next-line @silverhand/fp/no-let -- Track cooldown state within this tenant library instance.
+  let lastCleanupAt = 0;
+
+  const getCookieName = (userId: string) =>
+    getTrustedDeviceCookieName(tenantId, userId, isProduction);
+
+  const clearCredential = (ctx: TrustedDeviceCookieContext, userId: string) => {
+    ctx.cookies.set(getCookieName(userId), '', {
+      expires: new Date(0),
+      httpOnly: true,
+      maxAge: 0,
+      overwrite: true,
+      path: '/',
+      sameSite: 'lax',
+      secure: isProduction,
+      signed: false,
+    });
+  };
+
+  const writeCredential = (
+    ctx: TrustedDeviceCookieContext,
+    userId: string,
+    credential: TrustedDeviceCredential,
+    expiresAt: number
+  ) => {
+    ctx.cookies.set(getCookieName(userId), serializeTrustedDeviceCredential(credential), {
+      expires: new Date(expiresAt),
+      httpOnly: true,
+      maxAge: Math.max(0, expiresAt - Date.now()),
+      overwrite: true,
+      path: '/',
+      sameSite: 'lax',
+      secure: isProduction,
+      signed: false,
+    });
+  };
+
+  const cleanupExpired = async () => {
+    const now = Date.now();
+
+    if (now - lastCleanupAt < cleanupCooldown) {
+      return;
+    }
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Reserve this cleanup window before the asynchronous delete.
+    lastCleanupAt = now;
+    const deletedCount = await trySafe(async () => queries.deleteExpiredByTenant());
+
+    if (deletedCount === undefined) {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Allow the next opportunity to retry a failed cleanup.
+      lastCleanupAt = 0;
+    }
+
+    return deletedCount;
+  };
+
+  const createCredential = async ({
+    ctx,
+    userId,
+    expiresAt,
+    ...metadata
+  }: CreateTrustedDeviceCredential) => {
+    const id = generateStandardId();
+    const secret = generateTrustedDeviceSecret();
+    const secretHash = hashTrustedDeviceSecret(secret);
+
+    const trustedDevice = await queries.insert({
+      id,
+      userId,
+      secretHash,
+      expiresAt,
+      ...metadata,
+    });
+
+    writeCredential(ctx, userId, { id, secret }, trustedDevice.expiresAt);
+    void cleanupExpired();
+
+    return trustedDevice;
+  };
+
+  const validateCredential = async (ctx: TrustedDeviceCookieContext, userId: string) => {
+    const cookieValue = ctx.cookies.get(getCookieName(userId), { signed: false });
+
+    if (!cookieValue) {
+      return;
+    }
+
+    const credential = parseTrustedDeviceCredential(cookieValue);
+
+    if (!credential) {
+      clearCredential(ctx, userId);
+      return;
+    }
+
+    const trustedDevice = await queries.findActiveByIdAndUserId(credential.id, userId);
+
+    if (!trustedDevice) {
+      void trySafe(async () => queries.deleteExpiredByIdAndUserId(credential.id, userId));
+      clearCredential(ctx, userId);
+      return;
+    }
+
+    if (!verifyTrustedDeviceSecret(credential.secret, trustedDevice.secretHash)) {
+      clearCredential(ctx, userId);
+      return;
+    }
+
+    return trustedDevice;
+  };
+
+  return {
+    cleanupExpired,
+    clearCredential,
+    createCredential,
+    getCookieName,
+    validateCredential,
+    writeCredential,
+  };
+};

--- a/packages/core/src/queries/trusted-device.test.ts
+++ b/packages/core/src/queries/trusted-device.test.ts
@@ -1,0 +1,234 @@
+import { TrustedDevices, type TrustedDevice } from '@logto/schemas';
+import { createMockPool, createMockQueryResult, sql } from '@silverhand/slonik';
+
+import { expandFields } from '#src/database/utils.js';
+import { convertToIdentifiers } from '#src/utils/sql.js';
+import type { QueryType } from '#src/utils/test-utils.js';
+import { expectSqlAssert } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
+const pool = createMockPool({
+  query: async (sql, values) => mockQuery(sql, values),
+});
+
+const { TrustedDeviceQueries } = await import('./trusted-device.js');
+const queries = new TrustedDeviceQueries(pool);
+
+const { table, fields } = convertToIdentifiers(TrustedDevices);
+
+const trustedDevice: TrustedDevice = {
+  tenantId: 'tenant-id',
+  id: 'trusted-device-id',
+  userId: 'user-id',
+  secretHash: Buffer.alloc(32, 1),
+  userAgent: 'user-agent',
+  ip: '127.0.0.1',
+  country: 'US',
+  city: 'San Francisco',
+  createdAt: 1,
+  lastUsedAt: 1,
+  expiresAt: 2,
+};
+
+describe('trusted device queries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQuery.mockReset();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('inserts a trusted device record', async () => {
+    mockQuery.mockImplementationOnce(async (query, values) => {
+      expect(query).toMatch(/insert into "trusted_devices"/i);
+      expect(values).toEqual([
+        trustedDevice.id,
+        trustedDevice.userId,
+        trustedDevice.secretHash,
+        trustedDevice.userAgent,
+        trustedDevice.ip,
+        trustedDevice.country,
+        trustedDevice.city,
+        trustedDevice.expiresAt,
+      ]);
+
+      return createMockQueryResult([trustedDevice]);
+    });
+
+    await expect(
+      queries.insert({
+        id: trustedDevice.id,
+        userId: trustedDevice.userId,
+        secretHash: trustedDevice.secretHash,
+        userAgent: trustedDevice.userAgent,
+        ip: trustedDevice.ip,
+        country: trustedDevice.country,
+        city: trustedDevice.city,
+        expiresAt: trustedDevice.expiresAt,
+      })
+    ).resolves.toEqual(trustedDevice);
+  });
+
+  it('uses the same strict active predicate for paginated list and count', async () => {
+    const listSql = sql`
+      select ${expandFields(TrustedDevices)}
+      from ${table}
+      where ${fields.userId} = $1
+        and ${fields.expiresAt} > now()
+      order by ${fields.createdAt} desc
+      limit $2 offset $3
+    `;
+    const countSql = sql`
+      select count(*)
+      from ${table}
+      where ${fields.userId} = $1
+        and ${fields.expiresAt} > now()
+    `;
+
+    mockQuery
+      .mockImplementationOnce(async (query, values) => {
+        expectSqlAssert(query, countSql.sql);
+        expect(values).toEqual([trustedDevice.userId]);
+        return createMockQueryResult([{ count: '1' }]);
+      })
+      .mockImplementationOnce(async (query, values) => {
+        expectSqlAssert(query, listSql.sql);
+        expect(values).toEqual([trustedDevice.userId, 20, 40]);
+        return createMockQueryResult([trustedDevice]);
+      });
+
+    await expect(
+      queries.findActiveByUserId(trustedDevice.userId, { limit: 20, offset: 40 })
+    ).resolves.toEqual([1, [trustedDevice]]);
+  });
+
+  it('constrains active point lookup by record and user ownership', async () => {
+    const expectSql = sql`
+      select ${expandFields(TrustedDevices)}
+      from ${table}
+      where ${fields.id} = $1
+        and ${fields.userId} = $2
+        and ${fields.expiresAt} > now()
+    `;
+
+    mockQuery.mockImplementationOnce(async (query, values) => {
+      expectSqlAssert(query, expectSql.sql);
+      expect(values).toEqual([trustedDevice.id, trustedDevice.userId]);
+      return createMockQueryResult([trustedDevice]);
+    });
+
+    await expect(
+      queries.findActiveByIdAndUserId(trustedDevice.id, trustedDevice.userId)
+    ).resolves.toEqual(trustedDevice);
+  });
+
+  it('updates metadata without overwriting missing values and replaces a supplied location pair', async () => {
+    jest.spyOn(Date, 'now').mockReturnValue(123_000);
+
+    const expectSql = sql`
+      update ${table}
+      set ${fields.lastUsedAt}=to_timestamp($1::double precision / 1000), ${fields.userAgent}=$2, ${fields.country}=$3, ${fields.city}=$4
+      where ${fields.id}=$5 and ${fields.userId}=$6
+      returning *
+    `;
+
+    mockQuery.mockImplementationOnce(async (query, values) => {
+      expectSqlAssert(query, expectSql.sql);
+      expect(values).toEqual([
+        123_000,
+        'new-user-agent',
+        'CA',
+        null,
+        trustedDevice.id,
+        trustedDevice.userId,
+      ]);
+      return createMockQueryResult([trustedDevice]);
+    });
+
+    await expect(
+      queries.updateMetadataByIdAndUserId(trustedDevice.id, trustedDevice.userId, {
+        userAgent: 'new-user-agent',
+        country: 'CA',
+      })
+    ).resolves.toEqual(trustedDevice);
+  });
+
+  it('deletes only the presented owned record at the expiry boundary', async () => {
+    const expectSql = sql`
+      delete from ${table}
+      where ${fields.id} = $1
+        and ${fields.userId} = $2
+        and ${fields.expiresAt} <= now()
+    `;
+
+    mockQuery.mockImplementationOnce(async (query, values) => {
+      expectSqlAssert(query, expectSql.sql);
+      expect(values).toEqual([trustedDevice.id, trustedDevice.userId]);
+      return createMockQueryResult([trustedDevice]);
+    });
+
+    await expect(
+      queries.deleteExpiredByIdAndUserId(trustedDevice.id, trustedDevice.userId)
+    ).resolves.toBe(1);
+  });
+
+  it('deletes a record only when both its ID and owner match', async () => {
+    const expectSql = sql`
+      delete from ${table}
+      where ${fields.id} = $1
+        and ${fields.userId} = $2
+      returning ${expandFields(TrustedDevices)}
+    `;
+
+    mockQuery.mockImplementationOnce(async (query, values) => {
+      expectSqlAssert(query, expectSql.sql);
+      expect(values).toEqual([trustedDevice.id, trustedDevice.userId]);
+      return createMockQueryResult([trustedDevice]);
+    });
+
+    await expect(
+      queries.deleteByIdAndUserId(trustedDevice.id, trustedDevice.userId)
+    ).resolves.toEqual(trustedDevice);
+  });
+
+  it('deletes every RLS-visible row for the current tenant', async () => {
+    const expectSql = sql`
+      delete from ${table}
+    `;
+
+    mockQuery.mockImplementationOnce(async (query, values) => {
+      expectSqlAssert(query, expectSql.sql);
+      expect(values).toEqual([]);
+      return createMockQueryResult([trustedDevice]);
+    });
+
+    await expect(queries.deleteAllByTenant()).resolves.toBe(1);
+  });
+
+  it('allows concurrent tenant cleanup calls to remain idempotent', async () => {
+    const expectSql = sql`
+      delete from ${table}
+      where ${fields.expiresAt} <= now()
+    `;
+
+    mockQuery
+      .mockImplementationOnce(async (query, values) => {
+        expectSqlAssert(query, expectSql.sql);
+        expect(values).toEqual([]);
+        return createMockQueryResult([trustedDevice]);
+      })
+      .mockImplementationOnce(async (query, values) => {
+        expectSqlAssert(query, expectSql.sql);
+        expect(values).toEqual([]);
+        return createMockQueryResult([]);
+      });
+
+    await expect(
+      Promise.all([queries.deleteExpiredByTenant(), queries.deleteExpiredByTenant()])
+    ).resolves.toEqual([1, 0]);
+  });
+});

--- a/packages/core/src/queries/trusted-device.ts
+++ b/packages/core/src/queries/trusted-device.ts
@@ -1,0 +1,131 @@
+import { type TrustedDevice, TrustedDevices } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import { type CommonQueryMethods, sql } from '@silverhand/slonik';
+
+import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
+import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
+import { expandFields } from '#src/database/utils.js';
+import { convertToIdentifiers, manyRows } from '#src/utils/sql.js';
+
+const { table, fields } = convertToIdentifiers(TrustedDevices);
+const activePredicate = sql`${fields.expiresAt} > now()`;
+
+export type TrustedDeviceMetadata = Readonly<{
+  userAgent?: string;
+  ip?: string;
+  country?: string;
+  city?: string;
+}>;
+
+type Pagination = Readonly<{
+  limit: number;
+  offset: number;
+}>;
+
+export class TrustedDeviceQueries {
+  public readonly insert = buildInsertIntoWithPool(this.pool)(TrustedDevices, {
+    returning: true,
+  });
+
+  private readonly updateMetadata = buildUpdateWhereWithPool(this.pool)(TrustedDevices, true);
+
+  constructor(public readonly pool: CommonQueryMethods) {}
+
+  public async findActiveByUserId(
+    userId: string,
+    { limit, offset }: Pagination
+  ): Promise<[totalNumber: number, rows: readonly TrustedDevice[]]> {
+    return Promise.all([
+      this.countActiveByUserId(userId),
+      manyRows(
+        this.pool.query<TrustedDevice>(sql`
+          select ${expandFields(TrustedDevices)}
+          from ${table}
+          where ${fields.userId} = ${userId}
+            and ${activePredicate}
+          order by ${fields.createdAt} desc
+          limit ${limit} offset ${offset}
+        `)
+      ),
+    ]);
+  }
+
+  public async findActiveByIdAndUserId(id: string, userId: string) {
+    return this.pool.maybeOne<TrustedDevice>(sql`
+      select ${expandFields(TrustedDevices)}
+      from ${table}
+      where ${fields.id} = ${id}
+        and ${fields.userId} = ${userId}
+        and ${activePredicate}
+    `);
+  }
+
+  public async updateMetadataByIdAndUserId(
+    id: string,
+    userId: string,
+    { userAgent, ip, country, city }: TrustedDeviceMetadata
+  ) {
+    const shouldReplaceLocation = country !== undefined || city !== undefined;
+
+    return this.updateMetadata({
+      set: {
+        lastUsedAt: Date.now(),
+        userAgent,
+        ip,
+        ...conditional(shouldReplaceLocation && { country: country ?? null, city: city ?? null }),
+      },
+      where: { id, userId },
+      jsonbMode: 'replace',
+    });
+  }
+
+  public async deleteExpiredByIdAndUserId(id: string, userId: string) {
+    const { rowCount } = await this.pool.query<TrustedDevice>(sql`
+      delete from ${table}
+      where ${fields.id} = ${id}
+        and ${fields.userId} = ${userId}
+        and ${fields.expiresAt} <= now()
+    `);
+
+    return rowCount;
+  }
+
+  public async deleteByIdAndUserId(id: string, userId: string) {
+    return this.pool.maybeOne<TrustedDevice>(sql`
+      delete from ${table}
+      where ${fields.id} = ${id}
+        and ${fields.userId} = ${userId}
+      returning ${expandFields(TrustedDevices)}
+    `);
+  }
+
+  public async deleteAllByTenant() {
+    // Tenant isolation is enforced by RLS through the tenant-scoped pool.
+    const { rowCount } = await this.pool.query<TrustedDevice>(sql`
+      delete from ${table}
+    `);
+
+    return rowCount;
+  }
+
+  public async deleteExpiredByTenant() {
+    // Tenant isolation is enforced by RLS through the tenant-scoped pool.
+    const { rowCount } = await this.pool.query<TrustedDevice>(sql`
+      delete from ${table}
+      where ${fields.expiresAt} <= now()
+    `);
+
+    return rowCount;
+  }
+
+  private async countActiveByUserId(userId: string) {
+    return Number(
+      await this.pool.oneFirst<string>(sql`
+        select count(*)
+        from ${table}
+        where ${fields.userId} = ${userId}
+          and ${activePredicate}
+      `)
+    );
+  }
+}

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -24,6 +24,7 @@ import { createSignInExperienceLibrary } from '#src/libraries/sign-in-experience
 import { createSocialLibrary } from '#src/libraries/social.js';
 import { createSsoConnectorLibrary } from '#src/libraries/sso-connector.js';
 import { type SubscriptionLibrary } from '#src/libraries/subscription.js';
+import { createTrustedDeviceLibrary } from '#src/libraries/trusted-device.js';
 import { createUserLibrary } from '#src/libraries/user.js';
 import { createVerificationStatusLibrary } from '#src/libraries/verification-status.js';
 
@@ -81,6 +82,8 @@ export default class Libraries {
   oidcPrivateKeys = new OidcPrivateKeyLibrary(this.queries);
 
   customProfileFields = createCustomProfileFieldsLibrary(this.queries);
+
+  trustedDevices = createTrustedDeviceLibrary(this.tenantId, this.queries.trustedDevices);
 
   session = createSessionLibrary(this.queries);
 

--- a/packages/core/src/tenants/Queries.ts
+++ b/packages/core/src/tenants/Queries.ts
@@ -34,6 +34,7 @@ import { createSignInExperienceQueries } from '#src/queries/sign-in-experience.j
 import SsoConnectorQueries from '#src/queries/sso-connectors.js';
 import { createSubjectTokenQueries } from '#src/queries/subject-token.js';
 import createTenantQueries from '#src/queries/tenant.js';
+import { TrustedDeviceQueries } from '#src/queries/trusted-device.js';
 import { createUserGeoLocationQueries } from '#src/queries/user-geo-location.js';
 import { createUserSignInCountriesQueries } from '#src/queries/user-sign-in-countries.js';
 import UserSsoIdentityQueries from '#src/queries/user-sso-identities.js';
@@ -91,6 +92,7 @@ export default class Queries {
   verificationRecords = new VerificationRecordQueries(this.pool);
   accountCenters = new AccountCenterQueries(this.pool, this.wellKnownCache);
   tenants = createTenantQueries(this.pool);
+  trustedDevices = new TrustedDeviceQueries(this.pool);
   tenantUsage = new TenantUsageQuery(this.pool);
   emailTemplates = new EmailTemplatesQueries(this.pool, this.wellKnownCache);
   captchaProviders = new CaptchaProviderQueries(this.pool);


### PR DESCRIPTION
## Summary
Add tenant-scoped active trusted-device record queries for pagination, metadata updates, ownership-constrained deletion, and idempotent expiry cleanup.

Add the shared server-side credential library for 32-byte secret generation, SHA-256 hash storage, unsigned per-user host-only cookies, active-record validation, and cooldown-based opportunistic cleanup. Register both layers in the tenant context for later API and Experience integrations.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments