### PR TITLE
feat(core,schemas): purge edge region-lookup cache on custom domain changes

### DIFF
--- a/.changeset/purge-region-lookup-cache.md
+++ b/.changeset/purge-region-lookup-cache.md
@@ -1,0 +1,10 @@
+---
+'@logto/schemas': patch
+'@logto/core': patch
+---
+
+purge the edge region-lookup cache on custom domain changes
+
+In multi-region Cloud deployments, the edge worker caches hostname → region bindings, but adding or deleting a custom domain only cleared the region-local Redis cache. When a custom domain was deleted from one tenant and re-added to a tenant in a different region, the edge kept proxying to the old region until the cache entry expired (up to 8 hours), and requests failed with 404.
+
+A new optional `cloudflareRegionLookupKvProvider` system configuration (account ID, KV namespace ID, key prefix, and an API token with KV Storage Edit permission) lets core delete the corresponding Cloudflare KV entry whenever a custom domain is added, deleted, or cleaned up, so hostname re-bindings take effect at the edge immediately. The purge is best-effort and skipped when the configuration is absent, so OSS and single-region deployments are unaffected.

--- a/packages/core/src/libraries/domain.test.ts
+++ b/packages/core/src/libraries/domain.test.ts
@@ -15,15 +15,18 @@ import { mockFallbackOrigin } from '#src/utils/cloudflare/mock.js';
 const { jest } = import.meta;
 const { mockEsmWithActual } = createMockUtils(jest);
 
-const { getCustomHostname, createCustomHostname, deleteCustomHostname } = await mockEsmWithActual(
-  '#src/utils/cloudflare/index.js',
-  () => ({
-    createCustomHostname: jest.fn(async () => mockCloudflareData),
-    getCustomHostname: jest.fn(async () => mockCloudflareData),
-    deleteCustomHostname: jest.fn(),
-    getFallbackOrigin: jest.fn(async () => mockFallbackOrigin),
-  })
-);
+const {
+  getCustomHostname,
+  createCustomHostname,
+  deleteCustomHostname,
+  deleteRegionLookupKvRecord,
+} = await mockEsmWithActual('#src/utils/cloudflare/index.js', () => ({
+  createCustomHostname: jest.fn(async () => mockCloudflareData),
+  getCustomHostname: jest.fn(async () => mockCloudflareData),
+  deleteCustomHostname: jest.fn(),
+  deleteRegionLookupKvRecord: jest.fn(),
+  getFallbackOrigin: jest.fn(async () => mockFallbackOrigin),
+}));
 
 const { clearCustomDomainCache } = await mockEsmWithActual('#src/utils/tenant.js', () => ({
   clearCustomDomainCache: jest.fn(),
@@ -43,19 +46,28 @@ const { syncDomainStatus, addDomain, deleteDomain, cleanupDomains } = createDoma
   })
 );
 
+const mockRegionLookupKvProviderConfig = {
+  accountIdentifier: 'fake_account_id',
+  namespaceIdentifier: 'fake_namespace_id',
+  keyName: 'region',
+  apiToken: '',
+};
+
+/* eslint-disable @silverhand/fp/no-mutation */
 beforeAll(() => {
-  // eslint-disable-next-line @silverhand/fp/no-mutation
   SystemContext.shared.hostnameProviderConfig = {
     zoneId: 'fake_zone_id',
     apiToken: '',
     blockedDomains: ['blocked.com'],
   };
+  SystemContext.shared.regionLookupKvProviderConfig = mockRegionLookupKvProviderConfig;
 });
 
 afterAll(() => {
-  // eslint-disable-next-line @silverhand/fp/no-mutation
   SystemContext.shared.hostnameProviderConfig = undefined;
+  SystemContext.shared.regionLookupKvProviderConfig = undefined;
 });
+/* eslint-enable @silverhand/fp/no-mutation */
 
 afterEach(() => {
   clearCustomDomainCache.mockClear();
@@ -65,6 +77,7 @@ afterEach(() => {
   findAllDomains.mockClear();
   deleteDomainById.mockClear();
   deleteCustomHostname.mockClear();
+  deleteRegionLookupKvRecord.mockClear();
   getCustomHostname.mockClear();
 });
 
@@ -74,6 +87,10 @@ describe('addDomain()', () => {
     expect(createCustomHostname).toBeCalledTimes(1);
     expect(insertDomain).toBeCalledTimes(1);
     expect(clearCustomDomainCache).toBeCalledTimes(1);
+    expect(deleteRegionLookupKvRecord).toHaveBeenCalledWith(
+      mockRegionLookupKvProviderConfig,
+      mockDomain.domain
+    );
     expect(response.cloudflareData).toMatchObject(mockCloudflareData);
     expect(response.dnsRecords).toContainEqual({
       type: 'CNAME',
@@ -86,6 +103,21 @@ describe('addDomain()', () => {
     await expect(addDomain('hi.blocked.com')).rejects.toMatchError(
       new RequestError({ code: 'domain.domain_is_not_allowed' })
     );
+  });
+
+  it('should skip the edge region cache purge when the provider is not configured', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    SystemContext.shared.regionLookupKvProviderConfig = undefined;
+
+    try {
+      await addDomain(mockDomain.domain);
+    } finally {
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      SystemContext.shared.regionLookupKvProviderConfig = mockRegionLookupKvProviderConfig;
+    }
+
+    expect(clearCustomDomainCache).toBeCalledTimes(1);
+    expect(deleteRegionLookupKvRecord).not.toHaveBeenCalled();
   });
 });
 
@@ -103,6 +135,7 @@ describe('syncDomainStatus()', () => {
     });
     expect(getCustomHostname).toBeCalledTimes(1);
     expect(clearCustomDomainCache).toBeCalledTimes(1);
+    expect(deleteRegionLookupKvRecord).not.toHaveBeenCalled();
     expect(response.cloudflareData).toMatchObject(mockCloudflareData);
   });
 
@@ -160,6 +193,10 @@ describe('cleanupDomains()', () => {
     });
     expect(deleteDomainById).toHaveBeenCalledWith(orphanDomain.id);
     expect(clearCustomDomainCache).toHaveBeenCalledWith(orphanDomain.domain);
+    expect(deleteRegionLookupKvRecord).toHaveBeenCalledWith(
+      mockRegionLookupKvProviderConfig,
+      orphanDomain.domain
+    );
     expect(getCustomHostname).not.toHaveBeenCalled();
   });
 
@@ -286,6 +323,10 @@ describe('deleteDomain()', () => {
     await deleteDomain(mockDomain.id);
     expect(deleteCustomHostname).toBeCalledTimes(1);
     expect(clearCustomDomainCache).toBeCalledTimes(1);
+    expect(deleteRegionLookupKvRecord).toHaveBeenCalledWith(
+      mockRegionLookupKvProviderConfig,
+      mockDomainWithCloudflareData.domain
+    );
     expect(deleteDomainById).toBeCalledTimes(1);
   });
 
@@ -304,6 +345,14 @@ describe('deleteDomain()', () => {
     );
     await expect(deleteDomain(mockDomain.id)).resolves.not.toThrow();
     expect(clearCustomDomainCache).toBeCalledTimes(1);
+    expect(deleteDomainById).toBeCalledTimes(1);
+  });
+
+  it('should tolerate edge region cache purge failures', async () => {
+    findDomainById.mockResolvedValueOnce(mockDomainWithCloudflareData);
+    deleteRegionLookupKvRecord.mockRejectedValueOnce(new Error('Cloudflare KV is down'));
+    await expect(deleteDomain(mockDomain.id)).resolves.not.toThrow();
+    expect(deleteRegionLookupKvRecord).toBeCalledTimes(1);
     expect(deleteDomainById).toBeCalledTimes(1);
   });
 });

--- a/packages/core/src/libraries/domain.ts
+++ b/packages/core/src/libraries/domain.ts
@@ -10,11 +10,27 @@ import {
   getCustomHostname,
   createCustomHostname,
   deleteCustomHostname,
+  deleteRegionLookupKvRecord,
   getFallbackOrigin,
   getDomainStatusFromCloudflareData,
 } from '#src/utils/cloudflare/index.js';
 import { isSubdomainOf } from '#src/utils/domain.js';
 import { clearCustomDomainCache } from '#src/utils/tenant.js';
+
+/**
+ * Clears the region-local custom domain cache and best-effort purges the edge region-lookup
+ * cache, so a hostname that is re-bound to a tenant in another region stops being proxied to
+ * this region right away instead of when the edge cache entry expires.
+ */
+const clearDomainCache = async (hostname: string) => {
+  await clearCustomDomainCache(hostname);
+
+  const { regionLookupKvProviderConfig } = SystemContext.shared;
+
+  if (regionLookupKvProviderConfig) {
+    await trySafe(async () => deleteRegionLookupKvRecord(regionLookupKvProviderConfig, hostname));
+  }
+};
 
 export type DomainCleanupSummary = {
   scannedCount: number;
@@ -97,7 +113,7 @@ export const createDomainLibrary = (queries: Queries) => {
         },
       ],
     });
-    await clearCustomDomainCache(hostname);
+    await clearDomainCache(hostname);
     return insertedDomain;
   };
 
@@ -119,7 +135,7 @@ export const createDomainLibrary = (queries: Queries) => {
     }
 
     await deleteDomainById(id);
-    await clearCustomDomainCache(domain.domain);
+    await clearDomainCache(domain.domain);
   };
 
   const cleanupDomains = async (staleDays: number): Promise<DomainCleanupSummary> => {
@@ -142,7 +158,7 @@ export const createDomainLibrary = (queries: Queries) => {
       if (!domain.cloudflareData) {
         try {
           await deleteDomainById(domain.id);
-          await clearCustomDomainCache(domain.domain);
+          await clearDomainCache(domain.domain);
           summary.deletedCount += 1;
         } catch {
           summary.failedCount += 1;
@@ -159,7 +175,7 @@ export const createDomainLibrary = (queries: Queries) => {
         if (error instanceof RequestError && error.code === 'domain.cloudflare_not_found') {
           try {
             await deleteDomainById(domain.id);
-            await clearCustomDomainCache(domain.domain);
+            await clearDomainCache(domain.domain);
             summary.deletedCount += 1;
           } catch {
             summary.failedCount += 1;

--- a/packages/core/src/tenants/SystemContext.ts
+++ b/packages/core/src/tenants/SystemContext.ts
@@ -8,6 +8,8 @@ import {
   type SystemKey,
   type ProtectedAppConfigProviderData,
   protectedAppConfigProviderDataGuard,
+  type RegionLookupKvProviderData,
+  regionLookupKvProviderDataGuard,
 } from '@logto/schemas';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { type ZodType } from 'zod';
@@ -23,6 +25,7 @@ export default class SystemContext {
   public hostnameProviderConfig?: HostnameProviderData;
   public protectedAppConfigProviderConfig?: ProtectedAppConfigProviderData;
   public protectedAppHostnameProviderConfig?: HostnameProviderData;
+  public regionLookupKvProviderConfig?: RegionLookupKvProviderData;
 
   async loadProviderConfigs(pool: CommonQueryMethods) {
     await Promise.all([
@@ -66,6 +69,13 @@ export default class SystemContext {
           pool,
           CloudflareKey.ProtectedAppHostnameProvider,
           hostnameProviderDataGuard
+        );
+      })(),
+      (async () => {
+        this.regionLookupKvProviderConfig = await this.loadConfig(
+          pool,
+          CloudflareKey.RegionLookupKvProvider,
+          regionLookupKvProviderDataGuard
         );
       })(),
     ]);

--- a/packages/core/src/utils/cloudflare/kv.ts
+++ b/packages/core/src/utils/cloudflare/kv.ts
@@ -1,6 +1,9 @@
 import path from 'node:path';
 
-import { type ProtectedAppConfigProviderData } from '@logto/schemas';
+import {
+  type ProtectedAppConfigProviderData,
+  type RegionLookupKvProviderData,
+} from '@logto/schemas';
 import { got } from 'got';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -73,6 +76,42 @@ export const deleteProtectedAppSiteConfigs = async (
       throwHttpErrors: false,
     }
   );
+
+  handleResponse(response);
+};
+
+/**
+ * Deletes the edge region-lookup cache entry (`<keyName>:<host>`, e.g. `region:auth.example.com`)
+ * so the edge worker resolves the hostname's region afresh on the next request. Needed when a
+ * custom domain is re-bound to a tenant in another region, since the edge cache is otherwise only
+ * evicted by TTL.
+ */
+export const deleteRegionLookupKvRecord = async (
+  auth: RegionLookupKvProviderData,
+  host: string
+) => {
+  const response = await got.delete(
+    new URL(
+      path.join(
+        baseUrl.pathname,
+        `/accounts/${auth.accountIdentifier}/storage/kv/namespaces/${
+          auth.namespaceIdentifier
+        }/values/${encodeURIComponent(`${auth.keyName}:${host}`)}`
+      ),
+      baseUrl
+    ),
+    {
+      headers: {
+        Authorization: `Bearer ${auth.apiToken}`,
+      },
+      throwHttpErrors: false,
+    }
+  );
+
+  // The cache entry may have expired or never been written; a missing key is not an error.
+  if (response.statusCode === 404) {
+    return;
+  }
 
   handleResponse(response);
 };

--- a/packages/schemas/src/types/system.ts
+++ b/packages/schemas/src/types/system.ts
@@ -184,6 +184,19 @@ export const protectedAppConfigProviderDataGuard = z.object({
 
 export type ProtectedAppConfigProviderData = z.infer<typeof protectedAppConfigProviderDataGuard>;
 
+// Cloudflare KV for the edge region-lookup cache (hostname → region/tenant bindings)
+export const regionLookupKvProviderDataGuard = z.object({
+  /* Cloudflare Workers & Pages account ID */
+  accountIdentifier: z.string(),
+  /* KV namespace ID */
+  namespaceIdentifier: z.string(),
+  /* Key prefix for region lookup cache entries (e.g. `region`) */
+  keyName: z.string(),
+  apiToken: z.string(), // Requires account permission for "KV Storage Edit"
+});
+
+export type RegionLookupKvProviderData = z.infer<typeof regionLookupKvProviderDataGuard>;
+
 /**
  * Cloudflare workers config for custom JWT.
  * Ref: https://developers.cloudflare.com/api/
@@ -206,6 +219,7 @@ export enum CloudflareKey {
   ProtectedAppConfigProvider = 'cloudflareProtectedAppConfigProvider',
   ProtectedAppHostnameProvider = 'cloudflareProtectedAppHostnameProvider',
   CustomJwtWorkerConfig = 'cloudflareCustomJwtWorkerConfig',
+  RegionLookupKvProvider = 'cloudflareRegionLookupKvProvider',
 }
 
 export type CloudflareType = {
@@ -213,6 +227,7 @@ export type CloudflareType = {
   [CloudflareKey.ProtectedAppConfigProvider]: ProtectedAppConfigProviderData;
   [CloudflareKey.ProtectedAppHostnameProvider]: HostnameProviderData;
   [CloudflareKey.CustomJwtWorkerConfig]: CustomJwtWorkerConfig;
+  [CloudflareKey.RegionLookupKvProvider]: RegionLookupKvProviderData;
 };
 
 export const cloudflareGuard: Readonly<{
@@ -222,6 +237,7 @@ export const cloudflareGuard: Readonly<{
   [CloudflareKey.ProtectedAppConfigProvider]: protectedAppConfigProviderDataGuard,
   [CloudflareKey.ProtectedAppHostnameProvider]: hostnameProviderDataGuard,
   [CloudflareKey.CustomJwtWorkerConfig]: customJwtWorkerConfigGuard,
+  [CloudflareKey.RegionLookupKvProvider]: regionLookupKvProviderDataGuard,
 });
 
 // Summary


### PR DESCRIPTION
## Summary

In multi-region Cloud deployments, the edge region-lookup worker caches hostname → region/tenant bindings in Workers KV with an 8-hour TTL, but nothing invalidates those entries when a domain binding changes. When a custom domain is deleted from one tenant and re-added to a tenant in a different region, the edge keeps proxying to the old region until the entry expires, and the old region's core returns 404 for up to 8 hours.

This PR adds the core-side invalidation:

- New optional `cloudflareRegionLookupKvProvider` system configuration (`accountIdentifier`, `namespaceIdentifier`, `keyName`, `apiToken`), following the existing `cloudflareProtectedAppConfigProvider` pattern, loaded by `SystemContext`.
- New `deleteRegionLookupKvRecord()` Cloudflare KV util that deletes the `<keyName>:<hostname>` entry via the Cloudflare REST API, treating a missing key (404) as success.
- `addDomain`, `deleteDomain`, and `cleanupDomains` now purge the edge KV entry (best-effort, via `trySafe`) alongside the existing region-local Redis cache clear. `syncDomainStatus` intentionally keeps Redis-only clearing: it is polled frequently during domain verification, and the edge never caches a hostname that is not actively served.

When the configuration is absent (OSS / single-region deployments), the purge is skipped entirely, so behavior is unchanged.

A complementary edge-side safety net (revalidating the cached binding when a cached proxy returns 404) is implemented separately in the cloud repo's region-lookup worker.

## Testing

- `packages/core` domain library unit tests extended: purge called with the provider config on add/delete/cleanup paths, not called on status sync, skipped when unconfigured, and domain operations tolerate purge failures (21/21 passing).
- `tsc` build and ESLint clean on the changed packages.

## Checklist

- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments