### PR TITLE
refactor(core): short-circuit cimd client ids in the client adapter

### DIFF
--- a/packages/core/src/oidc/adapter.test.ts
+++ b/packages/core/src/oidc/adapter.test.ts
@@ -178,118 +178,79 @@ describe('postgres Adapter', () => {
   });
 });
 
-describe('client adapter `find` fallback contract', () => {
-  const clientId = 'some_client_id';
+/**
+ * Load the adapter (and its error classes) after resetting the module registry, so the error
+ * classes asserted below share the identities of the ones the adapter throws.
+ */
+const loadClientAdapter = async ({
+  isDevFeaturesEnabled = true,
+  isOidcProviderSsrfProtectionEnabled = true,
+  cimdEnabled = true,
+  findApplicationById,
+}: {
+  isDevFeaturesEnabled?: boolean;
+  isOidcProviderSsrfProtectionEnabled?: boolean;
+  cimdEnabled?: boolean;
+  findApplicationById: jest.Mock;
+}) => {
+  jest.resetModules();
+  mockEsm('#src/env-set/index.js', () => ({
+    EnvSet: {
+      values: { isDevFeaturesEnabled, isOidcProviderSsrfProtectionEnabled },
+    },
+  }));
 
   /**
-   * Load the adapter (and its error classes) after resetting the module registry, so the
-   * `instanceof` checks inside the adapter observe the same class identities as the errors
-   * thrown and asserted below.
+   * Sequential imports on purpose: concurrent `import()` calls after `jest.resetModules()`
+   * race the ESM linking of the shared dependency graph ("Module status must not be unlinked
+   * or linking").
    */
-  const loadClientAdapter = async ({
-    isDevFeaturesEnabled = true,
-    isOidcProviderSsrfProtectionEnabled = true,
-    cimdEnabled = true,
-    findApplicationById,
-  }: {
-    isDevFeaturesEnabled?: boolean;
-    isOidcProviderSsrfProtectionEnabled?: boolean;
-    cimdEnabled?: boolean;
-    findApplicationById: jest.Mock;
-  }) => {
-    jest.resetModules();
-    mockEsm('#src/env-set/index.js', () => ({
-      EnvSet: {
-        values: { isDevFeaturesEnabled, isOidcProviderSsrfProtectionEnabled },
-      },
-    }));
+  const { default: loadedAdapter } = await import('./adapter.js');
+  const { errors } = await import('oidc-provider');
 
-    /**
-     * Sequential imports on purpose: concurrent `import()` calls after `jest.resetModules()`
-     * race the ESM linking of the shared dependency graph ("Module status must not be unlinked
-     * or linking").
-     */
-    const { default: loadedAdapter } = await import('./adapter.js');
-    const { default: RequestError } = await import('#src/errors/RequestError/index.js');
-    const { errors } = await import('oidc-provider');
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the adapter reads
+  const envSet = { oidc: { cimdEnabled } } as EnvSet;
+  const adapter = loadedAdapter(
+    envSet,
+    new MockQueries({ applications: { findApplicationById } }),
+    'Client'
+  );
 
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the adapter reads
-    const envSet = { oidc: { cimdEnabled } } as EnvSet;
-    const adapter = loadedAdapter(
-      envSet,
-      new MockQueries({ applications: { findApplicationById } }),
-      'Client'
-    );
-
-    return {
-      // eslint-disable-next-line unicorn/no-array-callback-reference -- `Adapter#find` is not an array method
-      findClient: async () => adapter.find(clientId),
-      buildNotFoundError: () =>
-        new RequestError({
-          code: 'entity.not_exists_with_id',
-          name: 'applications',
-          id: clientId,
-          status: 404,
-        }),
-      errors,
-    };
+  return {
+    // eslint-disable-next-line unicorn/no-array-callback-reference -- `Adapter#find` is not an array method
+    findClient: async (clientId: string) => adapter.find(clientId),
+    errors,
   };
+};
 
-  it('resolves to undefined on a confirmed missing record while CIMD is effectively enabled', async () => {
+describe('client adapter `find` fallback contract', () => {
+  const registeredClientId = 'some_client_id';
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  it('resolves a CIMD client ID to undefined without a database lookup while CIMD is effectively enabled', async () => {
     const findApplicationById = jest.fn();
-    const { findClient, buildNotFoundError } = await loadClientAdapter({ findApplicationById });
-    findApplicationById.mockRejectedValue(buildNotFoundError());
-
-    await expect(findClient()).resolves.toBeUndefined();
-  });
-
-  it('keeps the invalid_client behavior on a missing record when CIMD is not effectively enabled', async () => {
-    const findApplicationById = jest.fn();
-    const { findClient, buildNotFoundError, errors } = await loadClientAdapter({
-      cimdEnabled: false,
-      findApplicationById,
-    });
-    findApplicationById.mockRejectedValue(buildNotFoundError());
-
-    await expect(findClient()).rejects.toThrow(errors.InvalidClient);
-  });
-
-  it('keeps the invalid_client behavior on a missing record when SSRF protection is off', async () => {
-    const findApplicationById = jest.fn();
-    const { findClient, buildNotFoundError, errors } = await loadClientAdapter({
-      isOidcProviderSsrfProtectionEnabled: false,
-      findApplicationById,
-    });
-    findApplicationById.mockRejectedValue(buildNotFoundError());
-
-    await expect(findClient()).rejects.toThrow(errors.InvalidClient);
-  });
-
-  it('propagates database errors instead of resolving to undefined while CIMD is effectively enabled', async () => {
-    const databaseError = new Error('connection reset');
-    const findApplicationById = jest.fn().mockRejectedValue(databaseError);
     const { findClient } = await loadClientAdapter({ findApplicationById });
 
-    await expect(findClient()).rejects.toBe(databaseError);
+    await expect(findClient(cimdClientId)).resolves.toBeUndefined();
+    expect(findApplicationById).not.toHaveBeenCalled();
   });
 
-  it('folds database errors into invalid_client when CIMD is not effectively enabled', async () => {
-    const findApplicationById = jest.fn().mockRejectedValue(new Error('connection reset'));
-    const { findClient, errors } = await loadClientAdapter({
-      cimdEnabled: false,
-      findApplicationById,
-    });
+  it.each([
+    ['CIMD is disabled for the tenant', { cimdEnabled: false }],
+    ['SSRF protection is off', { isOidcProviderSsrfProtectionEnabled: false }],
+    ['the dev features flag is off', { isDevFeaturesEnabled: false }],
+  ])('looks a CIMD client ID up as a registered application when %s', async (_, flags) => {
+    const findApplicationById = jest.fn().mockRejectedValue(new Error('not found'));
+    const { findClient, errors } = await loadClientAdapter({ ...flags, findApplicationById });
 
-    await expect(findClient()).rejects.toThrow(errors.InvalidClient);
+    await expect(findClient(cimdClientId)).rejects.toThrow(errors.InvalidClient);
+    expect(findApplicationById).toHaveBeenCalledWith(cimdClientId);
   });
 
-  it('folds every lookup error into invalid_client when the dev features flag is off', async () => {
+  it('folds lookup errors of a registered client ID into invalid_client while CIMD is effectively enabled', async () => {
     const findApplicationById = jest.fn().mockRejectedValue(new Error('connection reset'));
-    const { findClient, errors } = await loadClientAdapter({
-      isDevFeaturesEnabled: false,
-      findApplicationById,
-    });
+    const { findClient, errors } = await loadClientAdapter({ findApplicationById });
 
-    await expect(findClient()).rejects.toThrow(errors.InvalidClient);
+    await expect(findClient(registeredClientId)).rejects.toThrow(errors.InvalidClient);
   });
 });

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -14,10 +14,10 @@ import snakecaseKeys from 'snakecase-keys';
 
 import { EnvSet } from '#src/env-set/index.js';
 import { getTenantUrls } from '#src/env-set/utils.js';
-import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
 import { appLevelAccessControlMetadataKey } from './application-access-control.js';
+import { isCimdClientId } from './cimd/client-id.js';
 import { isCimdEffectivelyEnabled } from './cimd/index.js';
 import { getConstantClientMetadata } from './utils.js';
 
@@ -152,31 +152,6 @@ export default function postgresAdapter(
       throw new Error('Not implemented');
     };
 
-    /**
-     * Find the registered application for the client ID.
-     *
-     * While CIMD is effectively enabled, a confirmed "record not found" resolves to `undefined`
-     * and every other error keeps propagating — a database blip must never masquerade as
-     * "not found" and turn registered applications into CIMD fetch candidates. Otherwise the
-     * pre-CIMD behavior stays: every lookup failure folds into `invalid_client`.
-     */
-    const findApplicationWithCimdFallback = async (id: string) => {
-      // DEV: CIMD (client ID metadata document) support
-      if (isCimdEffectivelyEnabled(envSet)) {
-        try {
-          return await findApplicationById(id);
-        } catch (error) {
-          if (error instanceof RequestError && error.code === 'entity.not_exists_with_id') {
-            // Return `undefined` to hand resolution over to the provider's native CIMD resolver.
-            return;
-          }
-          throw error;
-        }
-      }
-
-      return tryThat(findApplicationById(id), new errors.InvalidClient(`invalid client ${id}`));
-    };
-
     const transpileClient = (
       {
         id: client_id,
@@ -214,11 +189,20 @@ export default function postgresAdapter(
           return buildDeviceDemoAppClientMetadata(envSet);
         }
 
-        const application = await findApplicationWithCimdFallback(id);
-
-        if (!application) {
+        /**
+         * A CIMD client ID is a URL and can never name a registered application, so resolution is
+         * handed over to the provider's native CIMD resolver without a database lookup — every
+         * other identifier keeps folding its lookup failures into `invalid_client`.
+         */
+        // DEV: CIMD (client ID metadata document) support
+        if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(id)) {
           return;
         }
+
+        const application = await tryThat(
+          findApplicationById(id),
+          new errors.InvalidClient(`invalid client ${id}`)
+        );
 
         if (application.isThirdParty) {
           const clientScopes = await getThirdPartyClientScopes(applications, id);


### PR DESCRIPTION
## Summary

Resolve CIMD client IDs in the OIDC client adapter before touching the database, instead of running the registered-application lookup first and unwrapping its not-found error.

- A CIMD client ID is a URL and can never name a registered application, so it now hands over to the provider's native CIMD resolver without a database round trip.
- Every other identifier keeps the pre-CIMD behavior: any lookup failure folds into `invalid_client`.

## Testing

unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments