### PR TITLE
refactor(core,schemas): extract the cimd predicates and prune stray dev markers

### DIFF
--- a/packages/core/src/event-listeners/authorization-success.test.ts
+++ b/packages/core/src/event-listeners/authorization-success.test.ts
@@ -255,7 +255,6 @@ describe('createAuthorizationSuccessListener', () => {
     );
   });
 
-  // DEV: CIMD (client ID metadata document) support
   describe('grant limit webhook payload for a cimd client', () => {
     const cimdClientId = 'https://client.example.com/metadata.json';
 

--- a/packages/core/src/event-listeners/authorization-success.ts
+++ b/packages/core/src/event-listeners/authorization-success.ts
@@ -113,7 +113,6 @@ const enforceMaxAllowedGrantsRevocation = async (
             'Grant.LimitExceeded',
             {
               userId,
-              // DEV: CIMD (client ID metadata document) support
               ...getClientIdentifierPayload(clientId),
               revokedGrantIds: revokeResult.succeededNames,
               maxAllowedGrants,

--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -148,7 +148,6 @@ describe('grantSuccessListener', () => {
   });
 });
 
-// DEV: CIMD (client ID metadata document) support
 describe('grantSuccessListener with a cimd client identifier', () => {
   afterEach(() => {
     Sinon.restore();
@@ -186,7 +185,6 @@ describe('grantSuccessListener with a cimd client identifier', () => {
   });
 });
 
-// DEV: CIMD (client ID metadata document) support
 describe('grantErrorListener with an unresolved client', () => {
   const error = new Error('client metadata fetch failed');
 

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -1,11 +1,9 @@
 import { conditional } from '@silverhand/essentials';
 import type { KoaContextWithOIDC } from 'oidc-provider';
 
-import { EnvSet } from '#src/env-set/index.js';
 import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
 import type { LogPayload } from '#src/middleware/koa-audit-log.js';
-import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
-import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
+import { getClientIdentifierPayload, isInCimdNamespace } from '#src/oidc/cimd/index.js';
 
 export const extractInteractionContext = (
   ctx: WithAppSecretContext<KoaContextWithOIDC>
@@ -25,9 +23,8 @@ export const extractInteractionContext = (
    * resolution-backed, keeping a mistyped registered id unattributed as before.
    */
   const cimdFallbackClientId = conditional(
-    EnvSet.values.isDevFeaturesEnabled &&
-      typeof submittedClientId === 'string' &&
-      isCimdClientId(submittedClientId) &&
+    typeof submittedClientId === 'string' &&
+      isInCimdNamespace(submittedClientId) &&
       submittedClientId
   );
 

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -3,7 +3,7 @@ import type { KoaContextWithOIDC } from 'oidc-provider';
 
 import { type WithAppSecretContext } from '#src/middleware/koa-app-secret-transpilation.js';
 import type { LogPayload } from '#src/middleware/koa-audit-log.js';
-import { getClientIdentifierPayload, isInCimdNamespace } from '#src/oidc/cimd/index.js';
+import { getClientIdentifierPayload, shouldAttributeToCimd } from '#src/oidc/cimd/index.js';
 
 export const extractInteractionContext = (
   ctx: WithAppSecretContext<KoaContextWithOIDC>
@@ -18,12 +18,12 @@ export const extractInteractionContext = (
   /**
    * `grant.error` fires for failures thrown before the provider resolves the Client entity — a
    * CIMD document fetch or metadata-validation failure lands exactly there — so fall back to the
-   * submitted `client_id`, but only within the CIMD namespace: `applicationId` attribution stays
-   * resolution-backed, keeping a mistyped registered id unattributed as before.
+   * submitted `client_id`, but only when it should be attributed to CIMD: `applicationId`
+   * attribution stays resolution-backed, keeping a mistyped registered id unattributed as before.
    */
   const cimdFallbackClientId = conditional(
     typeof submittedClientId === 'string' &&
-      isInCimdNamespace(submittedClientId) &&
+      shouldAttributeToCimd(submittedClientId) &&
       submittedClientId
   );
 

--- a/packages/core/src/event-listeners/utils.ts
+++ b/packages/core/src/event-listeners/utils.ts
@@ -15,7 +15,6 @@ export const extractInteractionContext = (
 
   const submittedClientId = params?.client_id;
 
-  // DEV: CIMD (client ID metadata document) support
   /**
    * `grant.error` fires for failures thrown before the provider resolves the Client entity — a
    * CIMD document fetch or metadata-validation failure lands exactly there — so fall back to the
@@ -29,7 +28,6 @@ export const extractInteractionContext = (
   );
 
   return {
-    // DEV: CIMD (client ID metadata document) support
     ...getClientIdentifierPayload(Client?.clientId ?? cimdFallbackClientId),
     applicationSecret: ctx.appSecret,
     sessionId: Session?.jti,

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -84,7 +84,6 @@ type ActionEventSource<Event> =
 type RunActionData<Event> = ActionEventSource<Event> & {
   key: LogtoActionKey;
   auditContext: Pick<LogContext, 'createLog'> &
-    // DEV: CIMD (client ID metadata document) support
     Pick<LogPayload, 'applicationId' | 'cimdClientId' | 'sessionId' | 'userId'>;
 };
 

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -171,7 +171,6 @@ export const createHookLibrary = (queries: Queries) => {
         userIp,
         user: user && pick(user, ...userInfoSelectFields),
         application: application && pick(application, 'id', 'type', 'name', 'description'),
-        // DEV: CIMD (client ID metadata document) support
         cimdClientId,
       } satisfies BetterOmit<InteractionHookEventPayload, 'hookId'>;
 
@@ -321,7 +320,6 @@ export const createHookLibrary = (queries: Queries) => {
     }
 
     const { applicationId } = payload;
-    // DEV: CIMD (client ID metadata document) support
     /** A CIMD-attributed payload carries no registered application id to enrich with. */
     const application = conditional(
       applicationId && (await trySafe(async () => findApplicationById(applicationId)))

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -50,7 +50,6 @@ type ClientIdentifiers = {
  * on every consent submission for the same verdict.
  */
 const identifyClient = (envSet: EnvSet, clientId: string): ClientIdentifiers =>
-  // DEV: CIMD (client ID metadata document) support
   isCimdClient(envSet, clientId) ? { cimdClientId: clientId } : { registeredClientId: clientId };
 
 /**

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -7,8 +7,7 @@ import { z } from 'zod';
 
 import { type EnvSet } from '#src/env-set/index.js';
 import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
-import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
-import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
+import { isCimdClient } from '#src/oidc/cimd/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -52,9 +51,7 @@ type ClientIdentifiers = {
  */
 const identifyClient = (envSet: EnvSet, clientId: string): ClientIdentifiers =>
   // DEV: CIMD (client ID metadata document) support
-  isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)
-    ? { cimdClientId: clientId }
-    : { registeredClientId: clientId };
+  isCimdClient(envSet, clientId) ? { cimdClientId: clientId } : { registeredClientId: clientId };
 
 /**
  * Persists the interaction's `lastSubmission` information to the session for future reference.

--- a/packages/core/src/middleware/koa-auto-consent.ts
+++ b/packages/core/src/middleware/koa-auto-consent.ts
@@ -7,8 +7,7 @@ import { type EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { consent, getMissingScopes } from '#src/libraries/session/index.js';
 import type { WithInteractionDetailsContext } from '#src/middleware/koa-interaction-details.js';
-import { isCimdClientId } from '#src/oidc/cimd/client-id.js';
-import { isCimdEffectivelyEnabled } from '#src/oidc/cimd/index.js';
+import { isCimdClient } from '#src/oidc/cimd/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -23,7 +22,7 @@ const shouldAutoConsentApplication = async (clientId: string, query: Queries, en
   } = query;
 
   // DEV: CIMD (client ID metadata document) support
-  if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)) {
+  if (isCimdClient(envSet, clientId)) {
     /**
      * Registered application ids never take the URL shape, and authorization has already
      * resolved this client — a URL here is a CIMD client, which is never first-party.

--- a/packages/core/src/middleware/koa-auto-consent.ts
+++ b/packages/core/src/middleware/koa-auto-consent.ts
@@ -21,7 +21,6 @@ const shouldAutoConsentApplication = async (clientId: string, query: Queries, en
     applications: { findApplicationById },
   } = query;
 
-  // DEV: CIMD (client ID metadata document) support
   if (isCimdClient(envSet, clientId)) {
     /**
      * Registered application ids never take the URL shape, and authorization has already

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -17,8 +17,7 @@ import { getTenantUrls } from '#src/env-set/utils.js';
 import type Queries from '#src/tenants/Queries.js';
 
 import { appLevelAccessControlMetadataKey } from './application-access-control.js';
-import { isCimdClientId } from './cimd/client-id.js';
-import { isCimdEffectivelyEnabled } from './cimd/index.js';
+import { isCimdClient } from './cimd/index.js';
 import { getConstantClientMetadata } from './utils.js';
 
 /**
@@ -195,7 +194,7 @@ export default function postgresAdapter(
          * other identifier keeps folding its lookup failures into `invalid_client`.
          */
         // DEV: CIMD (client ID metadata document) support
-        if (isCimdEffectivelyEnabled(envSet) && isCimdClientId(id)) {
+        if (isCimdClient(envSet, id)) {
           return;
         }
 

--- a/packages/core/src/oidc/adapter.ts
+++ b/packages/core/src/oidc/adapter.ts
@@ -193,7 +193,6 @@ export default function postgresAdapter(
          * handed over to the provider's native CIMD resolver without a database lookup — every
          * other identifier keeps folding its lookup failures into `invalid_client`.
          */
-        // DEV: CIMD (client ID metadata document) support
         if (isCimdClient(envSet, id)) {
           return;
         }

--- a/packages/core/src/oidc/cimd/index.test.ts
+++ b/packages/core/src/oidc/cimd/index.test.ts
@@ -107,37 +107,37 @@ describe('isCimdEffectivelyEnabled', () => {
   });
 });
 
-describe('isInCimdNamespace', () => {
+describe('shouldAttributeToCimd', () => {
   const cimdClientId = 'https://client.example.com/metadata.json';
 
-  it('is in the namespace for a url-shaped identifier', async () => {
-    const { isInCimdNamespace } = await loadCimdModule();
-    expect(isInCimdNamespace(cimdClientId)).toBe(true);
+  it('attributes a url-shaped identifier to cimd', async () => {
+    const { shouldAttributeToCimd } = await loadCimdModule();
+    expect(shouldAttributeToCimd(cimdClientId)).toBe(true);
   });
 
-  it('is not in the namespace for a registered application id or a missing identifier', async () => {
-    const { isInCimdNamespace } = await loadCimdModule();
-    expect(isInCimdNamespace('app-id')).toBe(false);
-    expect(isInCimdNamespace()).toBe(false);
+  it('does not attribute a registered application id or a missing identifier', async () => {
+    const { shouldAttributeToCimd } = await loadCimdModule();
+    expect(shouldAttributeToCimd('app-id')).toBe(false);
+    expect(shouldAttributeToCimd()).toBe(false);
   });
 
-  it('is not in the namespace when the dev features flag is off', async () => {
-    const { isInCimdNamespace } = await loadCimdModule({ isDevFeaturesEnabled: false });
-    expect(isInCimdNamespace(cimdClientId)).toBe(false);
+  it('does not attribute when the dev features flag is off', async () => {
+    const { shouldAttributeToCimd } = await loadCimdModule({ isDevFeaturesEnabled: false });
+    expect(shouldAttributeToCimd(cimdClientId)).toBe(false);
   });
 
-  it('is in the namespace regardless of the tenant cimd config', async () => {
-    const { isInCimdNamespace } = await loadCimdModule({
+  it('attributes even when cimd is not effectively enabled for the tenant', async () => {
+    const { shouldAttributeToCimd } = await loadCimdModule({
       isOidcProviderSsrfProtectionEnabled: false,
     });
-    expect(isInCimdNamespace(cimdClientId)).toBe(true);
+    expect(shouldAttributeToCimd(cimdClientId)).toBe(true);
   });
 });
 
 describe('getClientIdentifierPayload', () => {
   const cimdClientId = 'https://client.example.com/metadata.json';
 
-  it('routes a cimd-namespace identifier to the dedicated key', async () => {
+  it('routes a cimd client identifier to the dedicated key', async () => {
     const { getClientIdentifierPayload } = await loadCimdModule();
     expect(getClientIdentifierPayload(cimdClientId)).toStrictEqual({
       cimdClientId,

--- a/packages/core/src/oidc/cimd/index.test.ts
+++ b/packages/core/src/oidc/cimd/index.test.ts
@@ -107,6 +107,33 @@ describe('isCimdEffectivelyEnabled', () => {
   });
 });
 
+describe('isInCimdNamespace', () => {
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  it('is in the namespace for a url-shaped identifier', async () => {
+    const { isInCimdNamespace } = await loadCimdModule();
+    expect(isInCimdNamespace(cimdClientId)).toBe(true);
+  });
+
+  it('is not in the namespace for a registered application id or a missing identifier', async () => {
+    const { isInCimdNamespace } = await loadCimdModule();
+    expect(isInCimdNamespace('app-id')).toBe(false);
+    expect(isInCimdNamespace()).toBe(false);
+  });
+
+  it('is not in the namespace when the dev features flag is off', async () => {
+    const { isInCimdNamespace } = await loadCimdModule({ isDevFeaturesEnabled: false });
+    expect(isInCimdNamespace(cimdClientId)).toBe(false);
+  });
+
+  it('is in the namespace regardless of the tenant cimd config', async () => {
+    const { isInCimdNamespace } = await loadCimdModule({
+      isOidcProviderSsrfProtectionEnabled: false,
+    });
+    expect(isInCimdNamespace(cimdClientId)).toBe(true);
+  });
+});
+
 describe('getClientIdentifierPayload', () => {
   const cimdClientId = 'https://client.example.com/metadata.json';
 
@@ -136,6 +163,30 @@ describe('getClientIdentifierPayload', () => {
     expect(getClientIdentifierPayload()).toStrictEqual({
       applicationId: undefined,
     });
+  });
+});
+
+describe('isCimdClient', () => {
+  const cimdClientId = 'https://client.example.com/client-metadata.json';
+
+  it('is a cimd client when the feature is effective and the identifier is url-shaped', async () => {
+    const { isCimdClient } = await loadCimdModule();
+    expect(isCimdClient(buildEnvSet(true), cimdClientId)).toBe(true);
+  });
+
+  it('is not a cimd client for a registered application id', async () => {
+    const { isCimdClient } = await loadCimdModule();
+    expect(isCimdClient(buildEnvSet(true), 'registered_client_id')).toBe(false);
+  });
+
+  it('is not a cimd client without an identifier', async () => {
+    const { isCimdClient } = await loadCimdModule();
+    expect(isCimdClient(buildEnvSet(true))).toBe(false);
+  });
+
+  it('is not a cimd client when the feature is not effectively enabled', async () => {
+    const { isCimdClient } = await loadCimdModule();
+    expect(isCimdClient(buildEnvSet(false), cimdClientId)).toBe(false);
   });
 });
 

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -89,7 +89,6 @@ export type ClientIdentifierPayload = {
  * that later fails resolution still lands under `cimdClientId`.
  */
 export const getClientIdentifierPayload = (clientId?: string): ClientIdentifierPayload =>
-  // DEV: CIMD (client ID metadata document) support
   isInCimdNamespace(clientId) ? { cimdClientId: clientId } : { applicationId: clientId };
 
 /**
@@ -101,7 +100,6 @@ export const getClientIdentifierPayload = (clientId?: string): ClientIdentifierP
  * a CIMD client.
  */
 export const isCimdClient = (envSet: EnvSet, clientId?: string): boolean =>
-  // DEV: CIMD (client ID metadata document) support
   clientId !== undefined && isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId);
 
 /**

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -60,39 +60,40 @@ export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
   EnvSet.values.isOidcProviderSsrfProtectionEnabled;
 
 /**
- * Whether the identifier falls in the CIMD namespace, gated only by the release flag.
+ * Whether an identifier presented as a `client_id` should be attributed to a CIMD client —
+ * payload builders route it under `cimdClientId` instead of `applicationId`.
  *
- * Deliberately ignores the tenant CIMD config, unlike {@link isCimdClient}: attribution paths
- * classify the identifier a requester presented, and the config can flip between the moment an
- * identifier enters the system and the moment it is attributed (the tenant is rebuilt on config
- * change), which would retroactively move an in-flight URL identifier into the registered-only
- * namespace. Use this to answer "whose namespace is this identifier in"; use {@link isCimdClient}
- * to answer "does this tenant resolve this client through CIMD".
+ * Deliberately ignores the tenant CIMD config, unlike {@link isCimdClient}: attribution
+ * classifies the identifier the requester presented, and the config can flip between the moment
+ * an identifier enters the system and the moment it is attributed (the tenant is rebuilt on
+ * config change), which would retroactively re-route an in-flight URL identifier into
+ * `applicationId` and break its registered-ids-only contract. Gate behavior with
+ * {@link isCimdClient}; use this only to decide where an identifier is recorded.
  */
-export const isInCimdNamespace = (clientId?: string): boolean =>
+export const shouldAttributeToCimd = (clientId?: string): boolean =>
   // DEV: CIMD (client ID metadata document) support
   clientId !== undefined && EnvSet.values.isDevFeaturesEnabled && isCimdClientId(clientId);
 
-/** At most one identifier is set, matching the namespace of the client identifier. */
+/** At most one identifier is set — a registered application id or a CIMD client identifier. */
 export type ClientIdentifierPayload = {
   applicationId?: string;
   cimdClientId?: string;
 };
 
 /**
- * Route a client identifier into the payload key its namespace owns: `applicationId` carries
- * registered application ids only, while an identifier in the CIMD namespace goes under the
- * dedicated `cimdClientId` key — audit log and webhook consumers branch on key presence instead
+ * Route a client identifier to the payload key that owns it: `applicationId` carries registered
+ * application ids only, while a CIMD client identifier goes under the dedicated
+ * `cimdClientId` key — audit log and webhook consumers branch on key presence instead
  * of parsing URL shapes.
  *
  * The key attributes the identifier the requester presented, not a resolved client — an identifier
  * that later fails resolution still lands under `cimdClientId`.
  */
 export const getClientIdentifierPayload = (clientId?: string): ClientIdentifierPayload =>
-  isInCimdNamespace(clientId) ? { cimdClientId: clientId } : { applicationId: clientId };
+  shouldAttributeToCimd(clientId) ? { cimdClientId: clientId } : { applicationId: clientId };
 
 /**
- * Whether the identifier names a CIMD client on this tenant's provider: the namespace shape only
+ * Whether the identifier names a CIMD client on this tenant's provider: the URL shape only
  * routes while the feature is effectively enabled, so a URL-shaped identifier stays an ordinary
  * (and unresolvable) client id otherwise.
  *

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -59,6 +59,20 @@ export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
   envSet.oidc.cimdEnabled &&
   EnvSet.values.isOidcProviderSsrfProtectionEnabled;
 
+/**
+ * Whether the identifier falls in the CIMD namespace, gated only by the release flag.
+ *
+ * Deliberately ignores the tenant CIMD config, unlike {@link isCimdClient}: attribution paths
+ * classify the identifier a requester presented, and the config can flip between the moment an
+ * identifier enters the system and the moment it is attributed (the tenant is rebuilt on config
+ * change), which would retroactively move an in-flight URL identifier into the registered-only
+ * namespace. Use this to answer "whose namespace is this identifier in"; use {@link isCimdClient}
+ * to answer "does this tenant resolve this client through CIMD".
+ */
+export const isInCimdNamespace = (clientId?: string): boolean =>
+  // DEV: CIMD (client ID metadata document) support
+  clientId !== undefined && EnvSet.values.isDevFeaturesEnabled && isCimdClientId(clientId);
+
 /** At most one identifier is set, matching the namespace of the client identifier. */
 export type ClientIdentifierPayload = {
   applicationId?: string;
@@ -71,18 +85,24 @@ export type ClientIdentifierPayload = {
  * dedicated `cimdClientId` key — audit log and webhook consumers branch on key presence instead
  * of parsing URL shapes.
  *
- * The namespace alone decides, deliberately ignoring the tenant CIMD config: the config can flip
- * between an interaction's creation and its payload emission (the tenant is rebuilt on config
- * change), and routing by it would put the in-flight interaction's URL identifier under
- * `applicationId`, breaking the registered-only contract. The key attributes the identifier the
- * requester presented, not a resolved client — an identifier that later fails resolution still
- * lands under `cimdClientId`.
+ * The key attributes the identifier the requester presented, not a resolved client — an identifier
+ * that later fails resolution still lands under `cimdClientId`.
  */
 export const getClientIdentifierPayload = (clientId?: string): ClientIdentifierPayload =>
   // DEV: CIMD (client ID metadata document) support
-  clientId !== undefined && EnvSet.values.isDevFeaturesEnabled && isCimdClientId(clientId)
-    ? { cimdClientId: clientId }
-    : { applicationId: clientId };
+  isInCimdNamespace(clientId) ? { cimdClientId: clientId } : { applicationId: clientId };
+
+/**
+ * Whether the identifier names a CIMD client on this tenant's provider: the namespace shape only
+ * routes while the feature is effectively enabled, so a URL-shaped identifier stays an ordinary
+ * (and unresolvable) client id otherwise.
+ *
+ * Callers that hold an optional identifier can pass it directly — an absent identifier is never
+ * a CIMD client.
+ */
+export const isCimdClient = (envSet: EnvSet, clientId?: string): boolean =>
+  // DEV: CIMD (client ID metadata document) support
+  clientId !== undefined && isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId);
 
 /**
  * Build the `features.clientIdMetadataDocument` entry for the provider configuration, or

--- a/packages/core/src/oidc/cimd/resource-scopes.ts
+++ b/packages/core/src/oidc/cimd/resource-scopes.ts
@@ -1,4 +1,3 @@
-// DEV: CIMD (client ID metadata document) support
 /**
  * @overview The tenant-wide CIMD permission ceiling filter for resource scopes.
  */

--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -127,7 +127,6 @@ const callGetExtraTokenClaimsForJwtCustomization = async ({
   });
 };
 
-// DEV: CIMD (client ID metadata document) support
 const runJwtCustomizationWithClientId = async (clientId: string) => {
   const tenant = createTenant({});
   const { ctxWithLog, token, logEntry } = buildContextAndToken({ clientId });
@@ -274,7 +273,6 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
     ).rejects.toBeInstanceOf(errors.InvalidRequest);
   });
 
-  // DEV: CIMD (client ID metadata document) support
   describe('log attribution for a cimd client identifier', () => {
     const cimdClientId = 'https://client.example.com/metadata.json';
 

--- a/packages/core/src/oidc/extra-token-claims.ts
+++ b/packages/core/src/oidc/extra-token-claims.ts
@@ -274,7 +274,6 @@ export const getExtraTokenClaimsForJwtCustomization = async (
 
     logEntry.append({
       sessionId: ctx.oidc.session?.uid,
-      // DEV: CIMD (client ID metadata document) support
       ...getClientIdentifierPayload(ctx.oidc.client?.clientId),
       ...conditional(logtoUserInfo && { userId: logtoUserInfo.id }),
       tenantId: envSet.tenantId,

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -68,7 +68,6 @@ class MockEcEnvSet extends EnvSet {
 
 const ecEnvSet = new MockEcEnvSet(defaultTenantId, EnvSet.values.dbUrl);
 
-// DEV: CIMD (client ID metadata document) support
 /**
  * The tenant-level `cimdEnabled` flag is the only effective-enablement input the jest
  * environment leaves off (dev features and SSRF protection are both on), so flipping it is
@@ -435,7 +434,6 @@ describe('oidc provider init', () => {
   });
 });
 
-// DEV: CIMD (client ID metadata document) support
 describe('getResourceServerInfo for CIMD clients', () => {
   const cimdClientId = 'https://client.example.com/client-metadata.json';
 

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -126,7 +126,6 @@ export default function initOidc(
       userId,
     });
 
-    // DEV: CIMD (client ID metadata document) support
     if (isCimdClient(envSet, clientId)) {
       /**
        * CIMD clients are unregistered: the tenant-wide ceiling replaces the per-application
@@ -219,7 +218,6 @@ export default function initOidc(
       dPoP: { enabled: false },
       backchannelLogout: { enabled: true },
       deviceFlow: deviceFlowConfig,
-      // DEV: CIMD (client ID metadata document) support
       ...buildClientIdMetadataDocumentFeature(envSet, queries.cimd),
       rpInitiatedLogout: {
         logoutSource: (ctx, form) => {

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -55,8 +55,7 @@ import {
   hasAppLevelAccessControlChecked,
   markAppLevelAccessControlCheckedForOidcContext,
 } from './application-access-control.js';
-import { isCimdClientId } from './cimd/client-id.js';
-import { buildClientIdMetadataDocumentFeature, isCimdEffectivelyEnabled } from './cimd/index.js';
+import { buildClientIdMetadataDocumentFeature, isCimdClient } from './cimd/index.js';
 import { filterResourceScopesForTheCimdClient } from './cimd/resource-scopes.js';
 import defaults from './defaults.js';
 import { deviceFlowConfig, defaultDeviceCodeTtl } from './device-flow.js';
@@ -128,7 +127,7 @@ export default function initOidc(
     });
 
     // DEV: CIMD (client ID metadata document) support
-    if (clientId && isCimdEffectivelyEnabled(envSet) && isCimdClientId(clientId)) {
+    if (isCimdClient(envSet, clientId)) {
       /**
        * CIMD clients are unregistered: the tenant-wide ceiling replaces the per-application
        * consent configuration, and the client identifier URL must never be used to query the

--- a/packages/core/src/queries/logto-config.ts
+++ b/packages/core/src/queries/logto-config.ts
@@ -261,7 +261,6 @@ export const createLogtoConfigQueries = (
     ['id-token-config']
   );
 
-  // DEV: CIMD (client ID metadata document) support
   const getCimdConfig = async (): Promise<CimdConfig> => {
     const { rows } = await getRowsByKeys([LogtoTenantConfigKey.Cimd]);
 
@@ -272,7 +271,6 @@ export const createLogtoConfigQueries = (
     return cimdConfigGuard.parse(rows[0]?.value);
   };
 
-  // DEV: CIMD (client ID metadata document) support
   const upsertCimdConfig = async (value: CimdConfig) =>
     pool.query(sql`
       insert into ${table} (${fields.key}, ${fields.value})

--- a/packages/core/src/routes/cimd.ts
+++ b/packages/core/src/routes/cimd.ts
@@ -42,7 +42,6 @@ export default function cimdRoutes<T extends ManagementApiRouter>(
     );
   };
 
-  // DEV: CIMD (client ID metadata document) support
   router.get(
     '/cimd/user-consent-scopes',
     koaGuard({
@@ -70,7 +69,6 @@ export default function cimdRoutes<T extends ManagementApiRouter>(
     }
   );
 
-  // DEV: CIMD (client ID metadata document) support
   router.post(
     '/cimd/user-consent-scopes',
     koaGuard({
@@ -111,7 +109,6 @@ export default function cimdRoutes<T extends ManagementApiRouter>(
     }
   );
 
-  // DEV: CIMD (client ID metadata document) support
   router.delete(
     '/cimd/user-consent-scopes/:scopeType/:scopeId',
     koaGuard({

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -721,7 +721,6 @@ export default class ExperienceInteraction {
         auditContext: {
           createLog: this.ctx.createLog,
           sessionId: this.ctx.interactionDetails.jti,
-          // DEV: CIMD (client ID metadata document) support
           ...getClientIdentifierPayload(
             conditional(
               typeof this.ctx.interactionDetails.params.client_id === 'string' &&

--- a/packages/core/src/routes/experience/middleware/koa-experience-audit-log.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-audit-log.ts
@@ -17,7 +17,6 @@ export default function koaExperienceAuditLog<
     try {
       await next();
     } finally {
-      // DEV: CIMD (client ID metadata document) support
       prependAllLogEntries(getClientIdentifierPayload(clientId));
     }
   };

--- a/packages/core/src/routes/experience/middleware/koa-experience-interaction-hooks.ts
+++ b/packages/core/src/routes/experience/middleware/koa-experience-interaction-hooks.ts
@@ -55,7 +55,6 @@ export function koaExperienceInteractionHooks<
     const interactionApiMetadata = {
       interactionEvent,
       userAgent,
-      // DEV: CIMD (client ID metadata document) support
       ...getClientIdentifierPayload(conditionalString(interactionDetails.params.client_id)),
       sessionId: interactionDetails.jti,
     };

--- a/packages/core/src/routes/experience/verification-routes/password-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/password-verification.ts
@@ -130,7 +130,6 @@ export default function passwordVerificationRoutes<T extends ExperienceInteracti
                 auditContext: {
                   createLog: ctx.createLog,
                   sessionId: ctx.interactionDetails.jti,
-                  // DEV: CIMD (client ID metadata document) support
                   ...getClientIdentifierPayload(
                     conditional(
                       typeof ctx.interactionDetails.params.client_id === 'string' &&

--- a/packages/core/src/routes/init.ts
+++ b/packages/core/src/routes/init.ts
@@ -100,7 +100,6 @@ const createRouters = (tenant: TenantContext) => {
   sentinelActivitiesRoutes(managementRouter, tenant);
   customProfileFieldsRoutes(managementRouter, tenant);
   secretsRoutes(managementRouter, tenant);
-  // DEV: CIMD (client ID metadata document) support
   cimdRoutes(managementRouter, tenant);
 
   // General anonymous router for publicly accessible APIs

--- a/packages/core/src/routes/interaction/middleware/koa-interaction-hooks.ts
+++ b/packages/core/src/routes/interaction/middleware/koa-interaction-hooks.ts
@@ -44,7 +44,6 @@ export default function koaInteractionHooks<
     const interactionApiMetadata = {
       interactionEvent,
       userAgent,
-      // DEV: CIMD (client ID metadata document) support
       ...getClientIdentifierPayload(conditionalString(interactionDetails.params.client_id)),
       sessionId: interactionDetails.jti,
     };

--- a/packages/core/src/routes/logto-config/cimd.ts
+++ b/packages/core/src/routes/logto-config/cimd.ts
@@ -20,7 +20,6 @@ export default function logtoConfigCimdRoutes<T extends ManagementApiRouter>(
 
   const { getCimdConfig, upsertCimdConfig } = tenant.queries.logtoConfigs;
 
-  // DEV: CIMD (client ID metadata document) support
   router.get(
     '/configs/cimd',
     koaGuard({
@@ -34,7 +33,6 @@ export default function logtoConfigCimdRoutes<T extends ManagementApiRouter>(
     }
   );
 
-  // DEV: CIMD (client ID metadata document) support
   router.patch(
     '/configs/cimd',
     koaGuard({

--- a/packages/core/src/routes/logto-config/index.ts
+++ b/packages/core/src/routes/logto-config/index.ts
@@ -232,6 +232,5 @@ export default function logtoConfigRoutes<T extends ManagementApiRouter>(
   logtoConfigJwtCustomizerRoutes(router, tenant);
   idTokenRoutes(router, tenant);
   logtoConfigActionRoutes(router, tenant);
-  // DEV: CIMD (client ID metadata document) support
   logtoConfigCimdRoutes(router, tenant);
 }

--- a/packages/schemas/src/foundations/jsonb-types/logs.ts
+++ b/packages/schemas/src/foundations/jsonb-types/logs.ts
@@ -74,7 +74,6 @@ export const logContextPayloadGuard = z
     userId: z.string().optional(),
     /** Registered application ids only; a CIMD client identifier goes under {@link cimdClientId}. */
     applicationId: z.string().optional(),
-    // DEV: CIMD (client ID metadata document) support
     /**
      * The CIMD client identifier URL, kept apart from `applicationId` so payload consumers
      * branch on key presence instead of URL shape.

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -38,7 +38,6 @@ export type HookTestErrorResponseData = z.infer<typeof hookTestErrorResponseData
 export type InteractionApiMetadata = {
   /** The registered application ID if the hook is triggered by interaction API. */
   applicationId?: string;
-  // DEV: CIMD (client ID metadata document) support
   /**
    * The CIMD client identifier URL, kept apart from `applicationId` so payload consumers
    * branch on key presence instead of URL shape.
@@ -53,7 +52,6 @@ export type InteractionApiMetadata = {
 type InteractionApiContextPayload = {
   /** Fetch application detail by application ID before sending the hook event */
   application?: Pick<Application, 'id' | 'type' | 'name' | 'description'>;
-  // DEV: CIMD (client ID metadata document) support
   /** CIMD clients are unregistered, so the identifier URL stands in for `application`. */
   cimdClientId?: string;
   sessionId?: string;
@@ -119,7 +117,6 @@ export type GrantLimitExceededEventData = {
   userId: string;
   /** The registered application ID; absent for a CIMD client. */
   applicationId?: string;
-  // DEV: CIMD (client ID metadata document) support
   /**
    * The CIMD client identifier URL, set instead of `applicationId`. No grant-ceiling source
    * exists for CIMD clients today (the CIMD policy denies Logto private client metadata


### PR DESCRIPTION
## Summary

Two independent cleanups on the CIMD code, both about making one idea have one spelling.

### 1. Extract the two CIMD predicates

Two CIMD classifications were re-spelled at every call site, three of them binding the first to a local named `isCimdClient`:

- **`isCimdClient(envSet, clientId)`** — the tenant resolves this client through CIMD. Behavior branches use this.
- **`shouldAttributeToCimd(clientId)`** — the identifier should be recorded under the `cimdClientId` payload key. Attribution paths (audit logs, hook payloads) use this, gated by the release flag only: the tenant config can flip between the moment an identifier enters the system and the moment it is attributed, and attribution flipping with it would put a URL identifier under `applicationId`, breaking its registered-ids-only contract.

Naming the second predicate by its purpose is deliberate — the purpose is exactly what licenses the weaker gate. The signatures also keep them apart: gating behavior requires the `envSet`, deciding attribution forbids it.

### 2. Prune `// DEV:` markers that guard nothing

The marker exists so a dev feature graduation can grep for every place it has to act on. It had spread to every line that merely mentions CIMD — 45 markers, of which 40 sat on code with no `isDevFeaturesEnabled` read and therefore no graduation action.

The five kept are the ones a graduation must visit:

| Location | Graduation action |
|---|---|
| `oidc/cimd/index.ts` — `isCimdEffectivelyEnabled` | drop the flag from the condition |
| `oidc/cimd/index.ts` — `shouldAttributeToCimd` | drop the flag from the condition |
| `routes/swagger/utils/general.ts` | unwrap the `if (isDevFeaturesEnabled)` block |
| `routes/swagger/utils/operation-id.ts` | move entries to `customRoutes` |
| `console/.../routes/applications.tsx` | drop the `isDevFeaturesEnabled &&` guard |

No behavior change in either part.

## Testing

Both predicates are covered in `packages/core/src/oidc/cimd/index.test.ts`, including that `shouldAttributeToCimd` stays true when CIMD is not effectively enabled for the tenant while `isCimdClient` does not.