### PR TITLE
feat(schemas): add cimd grant organizations table

### DIFF
--- a/packages/schemas/alterations/next-1786325989-add-cimd-grant-organizations-table.ts
+++ b/packages/schemas/alterations/next-1786325989-add-cimd-grant-organizations-table.ts
@@ -32,6 +32,15 @@ const alteration: AlterationScript = {
           on update cascade on delete cascade
       );
     `);
+    /**
+     * Backs the membership FK's cascade lookup; the PK leaves `organization_id` outside its
+     * usable prefix. The table is created empty in this transaction, so a plain (non-concurrent)
+     * index build is free.
+     */
+    await pool.query(sql`
+      create index cimd_grant_organizations__organization_id_user_id
+        on cimd_grant_organizations (tenant_id, organization_id, user_id);
+    `);
     await applyTableRls(pool, 'cimd_grant_organizations');
   },
   down: async (pool) => {

--- a/packages/schemas/alterations/next-1786325989-add-cimd-grant-organizations-table.ts
+++ b/packages/schemas/alterations/next-1786325989-add-cimd-grant-organizations-table.ts
@@ -1,0 +1,45 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+/**
+ * Add the grant-scoped organization authorization table for client ID metadata document (CIMD)
+ * clients. CIMD clients are unregistered URL identities with no deletion lifecycle and
+ * transferable ownership, so organization access follows the single authorization instead of a
+ * long-lived cross-grant relation: rows cascade away with the Grant row (revocation hard-deletes
+ * it) and with the user's organization membership.
+ */
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table cimd_grant_organizations (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        grant_id varchar(128) not null,
+        grant_model_name varchar(64) not null default 'Grant',
+        organization_id varchar(21) not null,
+        user_id varchar(21) not null,
+        primary key (tenant_id, grant_id, organization_id),
+        constraint cimd_grant_organizations__grant_model_name
+          check (grant_model_name = 'Grant'),
+        foreign key (tenant_id, grant_model_name, grant_id)
+          references oidc_model_instances (tenant_id, model_name, id)
+          on update cascade on delete cascade,
+        foreign key (tenant_id, organization_id, user_id)
+          references organization_user_relations (tenant_id, organization_id, user_id)
+          on update cascade on delete cascade
+      );
+    `);
+    await applyTableRls(pool, 'cimd_grant_organizations');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'cimd_grant_organizations');
+    await pool.query(sql`
+      drop table cimd_grant_organizations;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/cimd_grant_organizations.sql
+++ b/packages/schemas/tables/cimd_grant_organizations.sql
@@ -14,6 +14,7 @@ create table cimd_grant_organizations (
   /** Fixed discriminator so the composite foreign key can target Grant rows in the polymorphic `oidc_model_instances` table. */
   grant_model_name varchar(64) not null default 'Grant',
   organization_id varchar(21) not null,
+  /** The user the grant was issued to and the membership FK's target. Must match the Grant payload's `accountId` (unreachable by FK) — the consent write enforces the pairing. */
   user_id varchar(21) not null,
   primary key (tenant_id, grant_id, organization_id),
   constraint cimd_grant_organizations__grant_model_name
@@ -27,3 +28,11 @@ create table cimd_grant_organizations (
     references organization_user_relations (tenant_id, organization_id, user_id)
     on update cascade on delete cascade
 );
+
+/**
+  Backs the membership FK's cascade lookup: rows live as long as the Grant row (not the grant's
+  validity), so membership deletions would otherwise scan the tenant's whole row set per deleted
+  membership, amplified by member count on organization deletion.
+*/
+create index cimd_grant_organizations__organization_id_user_id
+  on cimd_grant_organizations (tenant_id, organization_id, user_id);

--- a/packages/schemas/tables/cimd_grant_organizations.sql
+++ b/packages/schemas/tables/cimd_grant_organizations.sql
@@ -1,0 +1,29 @@
+/* init_order = 3 */
+
+/**
+  The organization authorized on a single OIDC Grant for a client ID metadata document (CIMD) client.
+  CIMD clients are unregistered URL identities with no deletion lifecycle and transferable ownership,
+  so organization access follows the single authorization instead of a long-lived cross-grant
+  relation: rows cascade away with the Grant row and with the user's organization membership.
+*/
+create table cimd_grant_organizations (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  /** The ID of the Grant row in `oidc_model_instances`. */
+  grant_id varchar(128) not null,
+  /** Fixed discriminator so the composite foreign key can target Grant rows in the polymorphic `oidc_model_instances` table. */
+  grant_model_name varchar(64) not null default 'Grant',
+  organization_id varchar(21) not null,
+  user_id varchar(21) not null,
+  primary key (tenant_id, grant_id, organization_id),
+  constraint cimd_grant_organizations__grant_model_name
+    check (grant_model_name = 'Grant'),
+  /** Revoking the grant hard-deletes the Grant row, which erases the organization authorization with it. */
+  foreign key (tenant_id, grant_model_name, grant_id)
+    references oidc_model_instances (tenant_id, model_name, id)
+    on update cascade on delete cascade,
+  /** Leaving the organization revokes the authorization. */
+  foreign key (tenant_id, organization_id, user_id)
+    references organization_user_relations (tenant_id, organization_id, user_id)
+    on update cascade on delete cascade
+);


### PR DESCRIPTION
## Summary

Add the `cimd_grant_organizations` table for grant-scoped organization authorization on CIMD clients (LOG-13992).

- Organization access for CIMD clients follows the single authorization instead of a long-lived cross-grant relation: an unregistered URL identity has no deletion lifecycle and its ownership can change hands, so long-term accumulation is the risk.
- Rows cascade away with the Grant row in `oidc_model_instances` (revocation hard-deletes it) and with the user's organization membership.
- `grant_model_name` is fixed to `'Grant'` by a check constraint so the composite foreign key can target Grant rows in the polymorphic instances table.
- The table structurally allows multiple organizations per grant; the one-grant-one-organization product rule is enforced at the consent layer (LOG-13930).

Schema only — queries and enforcement land with LOG-13993 (issuance) and LOG-13930 (consent write).

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
