### PR TITLE
feat(core): enforce grant-scoped organization access for cimd clients

### DIFF
--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -148,9 +148,10 @@ export const buildClientIdMetadataDocumentFeature = (
          *
          * - `scope` carries the tenant's user-scope ceiling so enforcement runs through
          *   the provider's native `check_scope` like third-party applications, which
-         *   also covers PAR.
-         *   TODO: @xiaoyijun enforce the resource and organization scope ceilings on the
-         *   resource-server filter path (LOG-13927, LOG-13930).
+         *   also covers PAR. The resource and organization-resource ceilings apply on the
+         *   resource-server filter path (`getResourceServerInfo` in `init.ts`), and the
+         *   organization-scope ceiling caps organization role scopes on the refresh
+         *   grant's organization token path.
          * - `grant_types`: a remote document must not self-grant client_credentials,
          *   device code, or token exchange, which registered applications only get by
          *   type or explicit opt-in.

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -466,7 +466,10 @@ describe('refresh token grant for CIMD clients', () => {
   const buildCimdHandler = (tenant: MockTenant, envSet: EnvSet = cimdEnvSet) =>
     buildHandler(envSet, tenant.queries, { assertUserHasApplicationAccess });
 
-  const createCimdPreparedContext = (params = validOidcContext.params) => {
+  const createCimdPreparedContext = (
+    params = validOidcContext.params,
+    grantOverrides?: Partial<Grant> & Record<string, unknown>
+  ) => {
     const ctx = createOidcContext({
       ...validOidcContext,
       params,
@@ -474,7 +477,7 @@ describe('refresh token grant for CIMD clients', () => {
       client: cimdClient,
     });
     stubRefreshToken(ctx, { clientId: cimdClientId });
-    stubGrant(ctx, { clientId: cimdClientId });
+    stubGrant(ctx, { clientId: cimdClientId, ...grantOverrides });
     stubAccount(ctx);
     return ctx;
   };
@@ -513,7 +516,7 @@ describe('refresh token grant for CIMD clients', () => {
       'exists'
     );
 
-    await expect(buildCimdHandler(tenant)(ctx)).rejects.toThrow(
+    await expect(buildCimdHandler(tenant)(ctx)).rejects.toMatchError(
       createAccessDeniedError('organization access is not granted to the application', 403)
     );
 
@@ -523,8 +526,11 @@ describe('refresh token grant for CIMD clients', () => {
     expect(userConsentOrganizationExists.called).toBe(false);
   });
 
-  it('should cap the organization token scopes at the tenant ceiling', async () => {
-    const ctx = createCimdPreparedContext();
+  it('should bound the organization token scopes by the grant record and the tenant ceiling', async () => {
+    // The Grant recorded only `foo` under the organization resource.
+    const ctx = createCimdPreparedContext(validOidcContext.params, {
+      getResourceScope: jest.fn().mockReturnValue('foo'),
+    });
     const tenant = new MockTenant();
 
     Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
@@ -534,9 +540,10 @@ describe('refresh token grant for CIMD clients', () => {
       { tenantId: 'default', id: 'bar', name: 'bar', description: 'bar' },
       { tenantId: 'default', id: 'baz', name: 'baz', description: 'baz' },
     ]);
-    // Only `foo` sits inside the tenant-wide organization-scope ceiling.
+    // `foo` and `bar` sit inside the tenant-wide organization-scope ceiling.
     Sinon.stub(tenant.queries.cimd.organizationScopes, 'findAll').resolves([
       { tenantId: 'default', id: 'foo', name: 'foo', description: 'foo' },
+      { tenantId: 'default', id: 'bar', name: 'bar', description: 'bar' },
     ]);
     Sinon.stub(tenant.queries.organizations, 'getMfaStatus').resolves({
       isMfaRequired: false,
@@ -546,14 +553,15 @@ describe('refresh token grant for CIMD clients', () => {
     const entityStub = Sinon.stub(ctx.oidc, 'entity');
     await expect(buildCimdHandler(tenant)(ctx)).resolves.toBeUndefined();
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- `entity()` args are typed `unknown`; the assertions below narrow them
     const [key, value] = entityStub.lastCall.args;
     expect(key).toBe('AccessToken');
     expect(value).toMatchObject({
       accountId,
       clientId: cimdClientId,
       grantId,
-      // The requested `foo bar` intersects the role scopes and then the ceiling.
+      // Requested `foo bar` ∩ role scopes ∩ ceiling (`foo bar`) ∩ grant record (`foo`):
+      // `bar` survives the ceiling but was never granted under the organization resource.
       scope: 'foo',
       aud: 'urn:logto:organization:some_org_id',
     });

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -498,11 +498,15 @@ describe('refresh token grant for CIMD clients', () => {
     expect(findApplicationById.called).toBe(false);
   });
 
-  it('should reject organization token requests until the grant-scoped check lands', async () => {
+  it('should throw if the organization is not authorized on the grant', async () => {
     const ctx = createCimdPreparedContext();
     const tenant = new MockTenant();
 
-    const membershipExists = Sinon.stub(tenant.queries.organizations.relations.users, 'exists');
+    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
+    const grantOrganizationExists = Sinon.stub(
+      tenant.queries.cimd.grantOrganizations,
+      'exists'
+    ).resolves(false);
     const findApplicationById = Sinon.stub(tenant.queries.applications, 'findApplicationById');
     const userConsentOrganizationExists = Sinon.stub(
       tenant.queries.applications.userConsentOrganizations,
@@ -510,13 +514,49 @@ describe('refresh token grant for CIMD clients', () => {
     );
 
     await expect(buildCimdHandler(tenant)(ctx)).rejects.toThrow(
-      createAccessDeniedError('organization tokens are not supported for CIMD clients', 403)
+      createAccessDeniedError('organization access is not granted to the application', 403)
     );
 
-    expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
-    expect(membershipExists.called).toBe(false);
+    // The check keys on the grant behind the refresh token, off the application relations.
+    expect(grantOrganizationExists.calledOnceWith(grantId, 'some_org_id')).toBe(true);
     expect(findApplicationById.called).toBe(false);
     expect(userConsentOrganizationExists.called).toBe(false);
+  });
+
+  it('should cap the organization token scopes at the tenant ceiling', async () => {
+    const ctx = createCimdPreparedContext();
+    const tenant = new MockTenant();
+
+    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
+    Sinon.stub(tenant.queries.cimd.grantOrganizations, 'exists').resolves(true);
+    Sinon.stub(tenant.queries.organizations.relations.usersRoles, 'getUserScopes').resolves([
+      { tenantId: 'default', id: 'foo', name: 'foo', description: 'foo' },
+      { tenantId: 'default', id: 'bar', name: 'bar', description: 'bar' },
+      { tenantId: 'default', id: 'baz', name: 'baz', description: 'baz' },
+    ]);
+    // Only `foo` sits inside the tenant-wide organization-scope ceiling.
+    Sinon.stub(tenant.queries.cimd.organizationScopes, 'findAll').resolves([
+      { tenantId: 'default', id: 'foo', name: 'foo', description: 'foo' },
+    ]);
+    Sinon.stub(tenant.queries.organizations, 'getMfaStatus').resolves({
+      isMfaRequired: false,
+      hasMfaConfigured: false,
+    });
+
+    const entityStub = Sinon.stub(ctx.oidc, 'entity');
+    await expect(buildCimdHandler(tenant)(ctx)).resolves.toBeUndefined();
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const [key, value] = entityStub.lastCall.args;
+    expect(key).toBe('AccessToken');
+    expect(value).toMatchObject({
+      accountId,
+      clientId: cimdClientId,
+      grantId,
+      // The requested `foo bar` intersects the role scopes and then the ceiling.
+      scope: 'foo',
+      aud: 'urn:logto:organization:some_org_id',
+    });
   });
 
   it('should keep the application access check for a url client id when CIMD is not effectively enabled', async () => {

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -342,9 +342,9 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     const availableScopes = isCimdClient(envSet, client.clientId)
       ? await queries.cimd.organizationScopes.findAll().then((ceiling) => {
           const ceilingNames = new Set(ceiling.map(({ name }) => name));
+          // `getResourceScope` returns `''` when the Grant carries no record for the resource.
           const grantedOrganizationScopes = new Set(
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the typings promise a string, but the fork returns `undefined` when the Grant carries no record for the resource
-            grant.getResourceScope(ReservedResource.Organization)?.split(' ') ?? []
+            grant.getResourceScope(ReservedResource.Organization).split(' ').filter(Boolean)
           );
           return roleScopeNames.filter(
             (name) => ceilingNames.has(name) && grantedOrganizationScopes.has(name)

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -325,10 +325,21 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
   // the logic is handled in `getResourceServerInfo` and `extraTokenClaims`, see the init file of oidc-provider.
   if (organizationId && !params.resource) {
     /* === RFC 0001 === */
-    /** All available scopes for the user in the organization. */
-    const availableScopes = await queries.organizations.relations.usersRoles
+    /** All the scopes granted to the user through organization roles. */
+    const roleScopeNames = await queries.organizations.relations.usersRoles
       .getUserScopes(organizationId, account.accountId)
       .then((scopes) => scopes.map(({ name }) => name));
+    /**
+     * CIMD clients cap organization role scopes at the tenant-wide `cimd_organization_scopes`
+     * ceiling — the organization-scope counterpart of the resource-server ceiling filter in
+     * `init.ts`. Registered applications are governed by their own consent configuration.
+     */
+    const availableScopes = isCimdClient(envSet, client.clientId)
+      ? await queries.cimd.organizationScopes.findAll().then((ceiling) => {
+          const ceilingNames = new Set(ceiling.map(({ name }) => name));
+          return roleScopeNames.filter((name) => ceilingNames.has(name));
+        })
+      : roleScopeNames;
     await handleOrganizationToken({
       envSet,
       availableScopes,

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -30,7 +30,7 @@
  *   from the v8 fork; upstream relies on the grant lookup failing instead.
  */
 
-import { UserScope } from '@logto/core-kit';
+import { ReservedResource, UserScope } from '@logto/core-kit';
 import { noop } from '@silverhand/essentials';
 import { errors, type Provider } from 'oidc-provider';
 
@@ -330,14 +330,25 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
       .getUserScopes(organizationId, account.accountId)
       .then((scopes) => scopes.map(({ name }) => name));
     /**
-     * CIMD clients cap organization role scopes at the tenant-wide `cimd_organization_scopes`
-     * ceiling — the organization-scope counterpart of the resource-server ceiling filter in
-     * `init.ts`. Registered applications are governed by their own consent configuration.
+     * CIMD clients bound organization role scopes twice: by the Grant's organization-resource
+     * record and by the tenant-wide `cimd_organization_scopes` ceiling (the organization-scope
+     * counterpart of the resource-server ceiling filter in `init.ts`). The Grant intersection is
+     * load-bearing — scope names are not unique across resources, and the flat refresh-token
+     * scope set passed to `handleOrganizationToken` cannot carry the organization resource's
+     * boundary, so without it a name granted for an unrelated API resource would issue the
+     * same-named organization scope. Registered applications are governed by their own consent
+     * configuration.
      */
     const availableScopes = isCimdClient(envSet, client.clientId)
       ? await queries.cimd.organizationScopes.findAll().then((ceiling) => {
           const ceilingNames = new Set(ceiling.map(({ name }) => name));
-          return roleScopeNames.filter((name) => ceilingNames.has(name));
+          const grantedOrganizationScopes = new Set(
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the typings promise a string, but the fork returns `undefined` when the Grant carries no record for the resource
+            grant.getResourceScope(ReservedResource.Organization)?.split(' ') ?? []
+          );
+          return roleScopeNames.filter(
+            (name) => ceilingNames.has(name) && grantedOrganizationScopes.has(name)
+          );
         })
       : roleScopeNames;
     await handleOrganizationToken({

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -17,28 +17,61 @@ import {
 
 const { InvalidGrant, InvalidClient, AccessDenied } = errors;
 
-/**
- * Assert the organization was authorized on the grant behind the current refresh token, reading
- * `cimd_grant_organizations`. Caller contract: organization tokens are only obtainable through
- * the refresh grant — CIMD `grant_types` are pinned to authorization_code + refresh_token and
- * the fork's token endpoint gates every grant type through `grantTypeAllowed`, so the
- * client-credentials and token-exchange callers never reach here with a CIMD client — and the
- * refresh grant asserts `grantId` before validating the grant, so the refresh token entity is
- * always present on this path. Fail closed if it ever is not.
- */
-const assertCimdOrganizationGrantAccess = async (
-  ctx: KoaContextWithOIDC,
-  queries: Queries,
-  organizationId: string
-) => {
-  const grantId = ctx.oidc.entities.RefreshToken?.grantId;
+/** Build the 403 denial the RFC 0001 organization access checks answer with. */
+const accessDenied = (message: string) => {
+  const error = new AccessDenied(message);
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- oidc-provider errors take the HTTP status by assignment after construction
+  error.statusCode = 403;
+  return error;
+};
 
-  if (!grantId || !(await queries.cimd.grantOrganizations.exists(grantId, organizationId))) {
-    const error = new AccessDenied('organization access is not granted to the application');
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- oidc-provider errors take the HTTP status by assignment after construction
-    error.statusCode = 403;
-    throw error;
+type OrganizationAccessOptions = {
+  envSet: EnvSet;
+  queries: Queries;
+  account: Account;
+  isThirdParty?: boolean;
+};
+
+/**
+ * Whether the user has granted this organization to this client.
+ *
+ * The CIMD test must come first: `isThirdPartyApplication`'s not-found fallback reads the
+ * identifier URL as first-party, which would skip the user-to-client grant check entirely.
+ */
+const isOrganizationGrantedToClient = async (
+  ctx: KoaContextWithOIDC,
+  clientId: string,
+  organizationId: string,
+  { envSet, queries, account, isThirdParty }: OrganizationAccessOptions
+): Promise<boolean> => {
+  /**
+   * CIMD organization access is grant-scoped, keyed on the grant behind the current refresh
+   * token. Caller contract: organization tokens are only obtainable through the refresh grant —
+   * CIMD `grant_types` are pinned to authorization_code + refresh_token and the fork's token
+   * endpoint gates every grant type through `grantTypeAllowed`, so the client-credentials and
+   * token-exchange callers never reach here with a CIMD client — and the refresh grant asserts
+   * `grantId` before validating the grant, so the entity is always present. Fail closed if it
+   * ever is not: at an authorization boundary a broken contract must not be distinguishable
+   * from a plain denial.
+   */
+  if (isCimdClient(envSet, clientId)) {
+    const grantId = ctx.oidc.entities.RefreshToken?.grantId;
+
+    return grantId !== undefined && queries.cimd.grantOrganizations.exists(grantId, organizationId);
   }
+
+  // Registered third-party applications carry the cross-grant consent relation.
+  if (isThirdParty ?? (await isThirdPartyApplication(queries, clientId))) {
+    return isOrganizationConsentedToApplication(
+      queries,
+      clientId,
+      account.accountId,
+      organizationId
+    );
+  }
+
+  // First-party applications are implicitly granted every organization the user belongs to.
+  return true;
 };
 
 /**
@@ -46,18 +79,9 @@ const assertCimdOrganizationGrantAccess = async (
  */
 export const checkOrganizationAccess = async (
   ctx: KoaContextWithOIDC,
-  {
-    envSet,
-    queries,
-    account,
-    isThirdParty,
-  }: {
-    envSet: EnvSet;
-    queries: Queries;
-    account: Account;
-    isThirdParty?: boolean;
-  }
+  options: OrganizationAccessOptions
 ): Promise<{ organizationId?: string }> => {
+  const { queries, account } = options;
   const { client, params } = ctx.oidc;
 
   assertThat(params, new InvalidGrant('parameters must be available'));
@@ -73,34 +97,12 @@ export const checkOrganizationAccess = async (
         userId: account.accountId,
       }))
     ) {
-      const error = new AccessDenied('user is not a member of the organization');
-      // eslint-disable-next-line @silverhand/fp/no-mutation
-      error.statusCode = 403;
-      throw error;
+      throw accessDenied('user is not a member of the organization');
     }
 
-    /**
-     * CIMD organization access is grant-scoped (`cimd_grant_organizations`), not the cross-grant
-     * relation registered third-party applications use. The branch must come before
-     * `isThirdPartyApplication`, whose not-found fallback reads the identifier URL as
-     * first-party and would silently skip the user-to-client grant check.
-     */
-    if (isCimdClient(envSet, client.clientId)) {
-      await assertCimdOrganizationGrantAccess(ctx, queries, organizationId);
-    } else if (
-      // Check if the organization is granted (third-party application only) by the user
-      (isThirdParty ?? (await isThirdPartyApplication(queries, client.clientId))) &&
-      !(await isOrganizationConsentedToApplication(
-        queries,
-        client.clientId,
-        account.accountId,
-        organizationId
-      ))
-    ) {
-      const error = new AccessDenied('organization access is not granted to the application');
-      // eslint-disable-next-line @silverhand/fp/no-mutation
-      error.statusCode = 403;
-      throw error;
+    // Check if the organization is granted to the client by the user
+    if (!(await isOrganizationGrantedToClient(ctx, client.clientId, organizationId, options))) {
+      throw accessDenied('organization access is not granted to the application');
     }
 
     // Check if the organization requires MFA and the user has MFA enabled
@@ -109,10 +111,7 @@ export const checkOrganizationAccess = async (
       account.accountId
     );
     if (isMfaRequired && !hasMfaConfigured) {
-      const error = new AccessDenied('organization requires MFA but user has no MFA configured');
-      // eslint-disable-next-line @silverhand/fp/no-mutation
-      error.statusCode = 403;
-      throw error;
+      throw accessDenied('organization requires MFA but user has no MFA configured');
     }
   }
 

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -18,6 +18,30 @@ import {
 const { InvalidGrant, InvalidClient, AccessDenied } = errors;
 
 /**
+ * Assert the organization was authorized on the grant behind the current refresh token, reading
+ * `cimd_grant_organizations`. Caller contract: organization tokens are only obtainable through
+ * the refresh grant — CIMD `grant_types` are pinned to authorization_code + refresh_token and
+ * the fork's token endpoint gates every grant type through `grantTypeAllowed`, so the
+ * client-credentials and token-exchange callers never reach here with a CIMD client — and the
+ * refresh grant asserts `grantId` before validating the grant, so the refresh token entity is
+ * always present on this path. Fail closed if it ever is not.
+ */
+const assertCimdOrganizationGrantAccess = async (
+  ctx: KoaContextWithOIDC,
+  queries: Queries,
+  organizationId: string
+) => {
+  const grantId = ctx.oidc.entities.RefreshToken?.grantId;
+
+  if (!grantId || !(await queries.cimd.grantOrganizations.exists(grantId, organizationId))) {
+    const error = new AccessDenied('organization access is not granted to the application');
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    error.statusCode = 403;
+    throw error;
+  }
+};
+
+/**
  * Implement access check for RFC 0001
  */
 export const checkOrganizationAccess = async (
@@ -42,22 +66,6 @@ export const checkOrganizationAccess = async (
   const organizationId = cond(Boolean(params.organization_id) && String(params.organization_id));
 
   if (organizationId) {
-    /**
-     * Organization grants are keyed to registered applications
-     * (`application_user_consent_organizations`), so no user has ever granted an organization to
-     * a CIMD client — and the accidental alternative would silently pass `isThirdPartyApplication`,
-     * whose not-found fallback reads the identifier URL as first-party. Membership alone is a
-     * user-to-organization relation, not a substitute for the user-to-client grant, so fail
-     * closed instead of skipping the consent check.
-     */
-    if (isCimdClient(envSet, client.clientId)) {
-      // TODO: @xiaoyijun replace the rejection with the grant-scoped organization check (LOG-13930)
-      const error = new AccessDenied('organization tokens are not supported for CIMD clients');
-      // eslint-disable-next-line @silverhand/fp/no-mutation -- oidc-provider errors take the HTTP status by assignment after construction
-      error.statusCode = 403;
-      throw error;
-    }
-
     // Check membership
     if (
       !(await queries.organizations.relations.users.exists({
@@ -71,8 +79,16 @@ export const checkOrganizationAccess = async (
       throw error;
     }
 
-    // Check if the organization is granted (third-party application only) by the user
-    if (
+    /**
+     * CIMD organization access is grant-scoped (`cimd_grant_organizations`), not the cross-grant
+     * relation registered third-party applications use. The branch must come before
+     * `isThirdPartyApplication`, whose not-found fallback reads the identifier URL as
+     * first-party and would silently skip the user-to-client grant check.
+     */
+    if (isCimdClient(envSet, client.clientId)) {
+      await assertCimdOrganizationGrantAccess(ctx, queries, organizationId);
+    } else if (
+      // Check if the organization is granted (third-party application only) by the user
       (isThirdParty ?? (await isThirdPartyApplication(queries, client.clientId))) &&
       !(await isOrganizationConsentedToApplication(
         queries,

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -35,7 +35,7 @@ const assertCimdOrganizationGrantAccess = async (
 
   if (!grantId || !(await queries.cimd.grantOrganizations.exists(grantId, organizationId))) {
     const error = new AccessDenied('organization access is not granted to the application');
-    // eslint-disable-next-line @silverhand/fp/no-mutation
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- oidc-provider errors take the HTTP status by assignment after construction
     error.statusCode = 403;
     throw error;
   }

--- a/packages/core/src/queries/cimd.ts
+++ b/packages/core/src/queries/cimd.ts
@@ -1,5 +1,6 @@
 import { type UserScope } from '@logto/core-kit';
 import {
+  CimdGrantOrganizations,
   CimdOrganizationResourceScopes,
   CimdOrganizationScopes,
   CimdResourceScopes,
@@ -140,9 +141,30 @@ const createOrganizationResourceScopeQueries = (pool: CommonQueryMethods) => {
   return { insert, findAll, delete: deleteByScopeId };
 };
 
+const cimdGrantOrganizations = convertToIdentifiers(CimdGrantOrganizations, true);
+
+const createGrantOrganizationQueries = (pool: CommonQueryMethods) => {
+  /**
+   * Whether the organization was authorized on the given grant. Row presence is only an
+   * additional condition on top of a provider-validated live grant, never a validity source:
+   * rows live as long as the Grant *row*, which can outlast the grant's validity by up to the
+   * pruning retention. The consent-side insert lands with LOG-13930.
+   */
+  const exists = async (grantId: string, organizationId: string) =>
+    pool.exists(sql`
+      select 1
+      from ${cimdGrantOrganizations.table}
+      where ${cimdGrantOrganizations.fields.grantId} = ${grantId}
+      and ${cimdGrantOrganizations.fields.organizationId} = ${organizationId}
+    `);
+
+  return { exists };
+};
+
 export const createCimdQueries = (pool: CommonQueryMethods) => ({
   userScopes: createUserScopeQueries(pool),
   resourceScopes: createResourceScopeQueries(pool),
   organizationScopes: createOrganizationScopeQueries(pool),
   organizationResourceScopes: createOrganizationResourceScopeQueries(pool),
+  grantOrganizations: createGrantOrganizationQueries(pool),
 });


### PR DESCRIPTION
## Summary

Enforce grant-scoped organization access and organization scope bounds for CIMD organization token issuance (LOG-13993), replacing the interim fail-closed rejection from #9377.

- `checkOrganizationAccess` gains a CIMD branch: the authorization check reads `cimd_grant_organizations` keyed by the grant behind the current refresh token, instead of the cross-grant `application_user_consent_organizations` relation.
- Organization role scopes are bounded twice on the organization token path: by the Grant's organization-resource record and by the tenant-wide `cimd_organization_scopes` ceiling (scope names are not unique across resources, so the flat refresh-token scope set cannot carry the organization resource's boundary).
- Deny-by-default: the consent-side write lands with LOG-13930, so with no rows written CIMD organization token requests keep failing 403.
- Client credentials and token exchange need no code: the fork's token endpoint gates every grant type through `grantTypeAllowed` and CIMD `grant_types` are pinned to `authorization_code` + `refresh_token`.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
