### PR TITLE
feat(schemas): add the send-email-failed service log type

### DIFF
--- a/packages/schemas/src/types/service-log.ts
+++ b/packages/schemas/src/types/service-log.ts
@@ -1,5 +1,16 @@
+/**
+ * Types of `service_logs` rows. The rows are written by the Logto Cloud service; some members
+ * are cloud-only concepts kept here so every type shares this single definition.
+ */
 export enum ServiceLogType {
   SendEmail = 'sendEmail',
   SendSms = 'sendSms',
+  /** Cloud-only: custom JWT worker invocations. */
   FetchCustomJwt = 'fetchCustomJwt',
+  /**
+   * Cloud-only: a hosted-email send that failed at the provider; the payload carries the
+   * normalized provider error. Deliberately distinct from {@link ServiceLogType.SendEmail}:
+   * usage counting matches on that exact type, so failed sends never count toward email usage.
+   */
+  SendEmailFailed = 'sendEmailFailed',
 }


### PR DESCRIPTION
## Summary

Refs LOG-13965 (Phase 4.2 of hosted-email logs & observability; the cloud-side implementation is logto-io/cloud#2058). Adds a `SendEmailFailed = 'sendEmailFailed'` member to `ServiceLogType`, with comments marking the cloud-only members — keeping every `service_logs` type in this single shared definition rather than a parallel cloud-side registry.

The member is deliberately distinct from `SendEmail`: usage counting matches on that exact type, so failed sends never count toward email usage. Type-only change — no runtime behavior, no schema change (the `type` column is `varchar(64)`), and OSS core neither reads nor writes `service_logs`. No changeset per the cloud-only-feature convention.

After this merges, the cloud repo bumps its `.logto` submodule and logto-io/cloud#2058 switches from its interim registry to this enum member.

## Testing

N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
