### PR TITLE
feat(schemas): add a service log type for Actions script runs

### DIFF
--- a/packages/schemas/src/types/service-log.ts
+++ b/packages/schemas/src/types/service-log.ts
@@ -13,4 +13,6 @@ export enum ServiceLogType {
    * usage counting matches on that exact type, so failed sends never count toward email usage.
    */
   SendEmailFailed = 'sendEmailFailed',
+  /** Cloud-only: an Actions script run on the script runner. Mirrors the `runAction` entry. */
+  RunAction = 'runAction',
 }


### PR DESCRIPTION
## Summary

Adds `ServiceLogType.RunAction` so Logto Cloud can service-log Actions script runs.

Cloud writes a `service_logs` row for every script run it executes through `POST /api/services/script-run`, keyed by the script entry. The enum only had `fetchCustomJwt`, so the `runAction` entry passed through unlogged — Actions runs were invisible to Cloud's audit and usage reads.

Type-only addition; nothing in core reads or writes `ServiceLogType`, and `service_logs.type` is a plain `varchar` (no DB enum), so no alteration is needed.

## Related

- Linear: [LOG-13994](https://linear.app/silverhand/issue/LOG-13994/add-service-logging-and-usage-counting-for-actions-script-runs)
- Consumed by the Cloud-side PR that logs the entry.

## Testing

No behavior change in core; `pnpm -F @logto/schemas build` is the only affected surface.