### PR TITLE
feat(core): support organization selection on cimd consent

### DIFF
--- a/packages/core/src/libraries/session/consent.test.ts
+++ b/packages/core/src/libraries/session/consent.test.ts
@@ -45,9 +45,9 @@ const userQueries = {
 const insertGrantOrganization = jest.fn();
 
 const queries: Queries = {
-  // @ts-expect-error
+  // @ts-expect-error -- partial mock of the user queries
   users: userQueries,
-  // @ts-expect-error
+  // @ts-expect-error -- partial mock of the cimd queries
   cimd: { grantOrganizations: { insert: insertGrantOrganization } },
 };
 const context = createContextWithRouteParameters();

--- a/packages/core/src/libraries/session/consent.test.ts
+++ b/packages/core/src/libraries/session/consent.test.ts
@@ -42,8 +42,14 @@ const userQueries = {
   updateUserById: jest.fn(async (..._args: unknown[]) => ({ id: 'id' })),
 };
 
-// @ts-expect-error
-const queries: Queries = { users: userQueries };
+const insertGrantOrganization = jest.fn();
+
+const queries: Queries = {
+  // @ts-expect-error
+  users: userQueries,
+  // @ts-expect-error
+  cimd: { grantOrganizations: { insert: insertGrantOrganization } },
+};
 const context = createContextWithRouteParameters();
 
 type Interaction = Awaited<ReturnType<Provider['interactionDetails']>>;
@@ -165,6 +171,57 @@ describe('consent', () => {
     expect(userQueries.updateUserById).toHaveBeenCalledWith(mockUser.id, {
       applicationId: baseInteractionDetails.params.client_id,
     });
+  });
+
+  it('should write the grant-scoped organization row after the grant is saved', async () => {
+    const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
+    await consent({
+      ctx: context,
+      provider,
+      envSet: mockEnvSet,
+      queries,
+      interactionDetails: baseInteractionDetails,
+      cimdOrganizationId: 'org_id',
+    });
+
+    expect(insertGrantOrganization).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      organizationId: 'org_id',
+      userId: mockUser.id,
+    });
+    expect(grantSave.mock.invocationCallOrder[0]).toBeLessThan(
+      insertGrantOrganization.mock.invocationCallOrder[0] ?? 0
+    );
+  });
+
+  it('should fail the consent before the interaction result update when the organization row write fails', async () => {
+    insertGrantOrganization.mockRejectedValueOnce(new Error('write failed'));
+    const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: mockEnvSet,
+        queries,
+        interactionDetails: baseInteractionDetails,
+        cimdOrganizationId: 'org_id',
+      })
+    ).rejects.toThrow('write failed');
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
+  it('should not write any organization row without an organization selection', async () => {
+    const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
+    await consent({
+      ctx: context,
+      provider,
+      envSet: mockEnvSet,
+      queries,
+      interactionDetails: baseInteractionDetails,
+    });
+
+    expect(insertGrantOrganization).not.toHaveBeenCalled();
   });
 
   it('should grant missing scopes', async () => {

--- a/packages/core/src/libraries/session/consent.test.ts
+++ b/packages/core/src/libraries/session/consent.test.ts
@@ -215,8 +215,62 @@ describe('consent', () => {
         cimdOrganizationId: 'org_id',
       })
     ).rejects.toMatchError(
-      new errors.InvalidRequest('a different organization is already authorized on the grant')
+      new errors.InvalidRequest(
+        'the grant organization binding does not match the submitted organization'
+      )
     );
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
+  it('should occupy the organization binding before changing a reused grant', async () => {
+    const interactionDetails = {
+      ...baseInteractionDetails,
+      grantId: 'exists',
+    } as unknown as Interaction;
+    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+
+    await consent({
+      ctx: context,
+      provider,
+      envSet: mockEnvSet,
+      queries,
+      interactionDetails,
+      cimdOrganizationId: 'org_id',
+    });
+
+    expect(insertGrantOrganization).toHaveBeenCalledWith({
+      grantId: 'exists',
+      organizationId: 'org_id',
+      userId: mockUser.id,
+    });
+    expect(insertGrantOrganization.mock.invocationCallOrder[0]).toBeLessThan(
+      grantSave.mock.invocationCallOrder[0] ?? 0
+    );
+  });
+
+  it('should fail before any grant change when a reused grant carries a different organization', async () => {
+    findGrantOrganizationIds.mockResolvedValueOnce(['other_org_id']);
+    const interactionDetails = {
+      ...baseInteractionDetails,
+      grantId: 'exists',
+    } as unknown as Interaction;
+    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: mockEnvSet,
+        queries,
+        interactionDetails,
+        cimdOrganizationId: 'org_id',
+      })
+    ).rejects.toMatchError(
+      new errors.InvalidRequest(
+        'the grant organization binding does not match the submitted organization'
+      )
+    );
+    expect(grantSave).not.toHaveBeenCalled();
     expect(provider.interactionResult).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/libraries/session/consent.test.ts
+++ b/packages/core/src/libraries/session/consent.test.ts
@@ -222,6 +222,27 @@ describe('consent', () => {
     expect(provider.interactionResult).not.toHaveBeenCalled();
   });
 
+  it('should fail the consent when the organization binding is missing after the write', async () => {
+    findGrantOrganizationIds.mockResolvedValueOnce([]);
+    const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: mockEnvSet,
+        queries,
+        interactionDetails: baseInteractionDetails,
+        cimdOrganizationId: 'org_id',
+      })
+    ).rejects.toMatchError(
+      new errors.InvalidRequest(
+        'the grant organization binding does not match the submitted organization'
+      )
+    );
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
   it('should occupy the organization binding before changing a reused grant', async () => {
     const interactionDetails = {
       ...baseInteractionDetails,

--- a/packages/core/src/libraries/session/consent.test.ts
+++ b/packages/core/src/libraries/session/consent.test.ts
@@ -1,6 +1,6 @@
 import { type User } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
-import type { Provider } from 'oidc-provider';
+import { errors, type Provider } from 'oidc-provider';
 
 import { mockUser } from '#src/__mocks__/user.js';
 import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
@@ -43,12 +43,19 @@ const userQueries = {
 };
 
 const insertGrantOrganization = jest.fn();
+const findGrantOrganizationIds = jest.fn(async () => ['org_id']);
 
 const queries: Queries = {
   // @ts-expect-error -- partial mock of the user queries
   users: userQueries,
   // @ts-expect-error -- partial mock of the cimd queries
-  cimd: { grantOrganizations: { insert: insertGrantOrganization } },
+  cimd: {
+    grantOrganizations: {
+      insert: insertGrantOrganization,
+      findOrganizationIds: findGrantOrganizationIds,
+      exists: jest.fn(),
+    },
+  },
 };
 const context = createContextWithRouteParameters();
 
@@ -192,6 +199,25 @@ describe('consent', () => {
     expect(grantSave.mock.invocationCallOrder[0]).toBeLessThan(
       insertGrantOrganization.mock.invocationCallOrder[0] ?? 0
     );
+  });
+
+  it('should fail the consent when a different organization is already authorized on the grant', async () => {
+    findGrantOrganizationIds.mockResolvedValueOnce(['other_org_id']);
+    const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: mockEnvSet,
+        queries,
+        interactionDetails: baseInteractionDetails,
+        cimdOrganizationId: 'org_id',
+      })
+    ).rejects.toMatchError(
+      new errors.InvalidRequest('a different organization is already authorized on the grant')
+    );
+    expect(provider.interactionResult).not.toHaveBeenCalled();
   });
 
   it('should fail the consent before the interaction result update when the organization row write fails', async () => {

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -191,6 +191,16 @@ export const consent = async ({
       organizationId: cimdOrganizationId,
       userId: accountId,
     });
+
+    /**
+     * The conflict-ignored insert cannot tell a same-organization retry from a different
+     * organization landing on this grant — re-read and fail closed on a mismatch.
+     */
+    const organizationIds = await queries.cimd.grantOrganizations.findOrganizationIds(finalGrantId);
+    assertThat(
+      organizationIds.every((organizationId) => organizationId === cimdOrganizationId),
+      new errors.InvalidRequest('a different organization is already authorized on the grant')
+    );
   }
 
   const result = {

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -117,6 +117,31 @@ const saveInteractionLastSubmissionToSession = async (
   }
 };
 
+/**
+ * Insert the grant-scoped organization row and assert the binding holds: exactly one row,
+ * carrying the submitted organization. The conflict-ignored insert cannot tell a
+ * same-organization retry from a different organization landing on the grant, and the
+ * exactly-one read also fails closed when the row was cascade-deleted in between. No-ops
+ * without an organization — the binding is CIMD-only.
+ */
+const bindCimdGrantOrganization = async (
+  queries: Queries,
+  { organizationId, ...data }: { grantId: string; organizationId?: string; userId: string }
+) => {
+  if (!organizationId) {
+    return;
+  }
+
+  await queries.cimd.grantOrganizations.insert({ ...data, organizationId });
+  const organizationIds = await queries.cimd.grantOrganizations.findOrganizationIds(data.grantId);
+  assertThat(
+    organizationIds.length === 1 && organizationIds[0] === organizationId,
+    new errors.InvalidRequest(
+      'the grant organization binding does not match the submitted organization'
+    )
+  );
+};
+
 export const consent = async ({
   ctx,
   provider,
@@ -157,9 +182,21 @@ export const consent = async ({
 
   const { registeredClientId, cimdClientId } = identifyClient(envSet, clientId);
 
-  const grant =
-    conditional(grantId && (await provider.Grant.find(grantId))) ??
-    new provider.Grant({ accountId, clientId });
+  const existingGrant = conditional(grantId && (await provider.Grant.find(grantId)));
+  const grant = existingGrant ?? new provider.Grant({ accountId, clientId });
+
+  /**
+   * Occupying the organization binding precedes every change to a reused grant, so a
+   * conflicting organization fails before this round mutates the grant. A fresh grant cannot
+   * conflict, and its row must follow `grant.save()` — the row's FK needs the grant row.
+   */
+  if (grantId && existingGrant) {
+    await bindCimdGrantOrganization(queries, {
+      grantId,
+      organizationId: cimdOrganizationId,
+      userId: accountId,
+    });
+  }
 
   await Promise.all([
     saveUserFirstConsentedClient(queries, accountId, { registeredClientId, cimdClientId }),
@@ -184,23 +221,13 @@ export const consent = async ({
 
   const finalGrantId = await grant.save();
 
-  if (cimdOrganizationId) {
+  if (!existingGrant) {
     /** Precedes the interaction result update so a failed write fails the whole consent. */
-    await queries.cimd.grantOrganizations.insert({
+    await bindCimdGrantOrganization(queries, {
       grantId: finalGrantId,
       organizationId: cimdOrganizationId,
       userId: accountId,
     });
-
-    /**
-     * The conflict-ignored insert cannot tell a same-organization retry from a different
-     * organization landing on this grant — re-read and fail closed on a mismatch.
-     */
-    const organizationIds = await queries.cimd.grantOrganizations.findOrganizationIds(finalGrantId);
-    assertThat(
-      organizationIds.every((organizationId) => organizationId === cimdOrganizationId),
-      new errors.InvalidRequest('a different organization is already authorized on the grant')
-    );
   }
 
   const result = {

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -127,6 +127,7 @@ export const consent = async ({
   resourceScopesToGrant = {},
   resourceScopesToReject = {},
   markAppLevelAccessControlChecked: shouldMarkAppLevelAccessControlChecked = false,
+  cimdOrganizationId,
 }: {
   ctx: Context;
   provider: Provider;
@@ -137,6 +138,8 @@ export const consent = async ({
   resourceScopesToGrant?: Record<string, string[]>;
   resourceScopesToReject?: Record<string, string[]>;
   markAppLevelAccessControlChecked?: boolean;
+  /** CIMD clients only — organization access is grant-scoped, at most one per grant. */
+  cimdOrganizationId?: string;
 }) => {
   const {
     session,
@@ -180,6 +183,16 @@ export const consent = async ({
   }
 
   const finalGrantId = await grant.save();
+
+  if (cimdOrganizationId) {
+    /** Precedes the interaction result update so a failed write fails the whole consent. */
+    await queries.cimd.grantOrganizations.insert({
+      grantId: finalGrantId,
+      organizationId: cimdOrganizationId,
+      userId: accountId,
+    });
+  }
+
   const result = {
     consent: { grantId: finalGrantId },
   };

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -369,6 +369,30 @@ describe('oidc provider init', () => {
     expect(findGrant).toHaveBeenCalledWith('grant_id');
   });
 
+  it('should reuse the session grant for registered clients', async () => {
+    const assertUserHasApplicationAccess = jest.fn();
+    const tenant = new MockTenant();
+
+    tenant.setPartial('libraries', {
+      applicationAccessControl: { assertUserHasApplicationAccess },
+    });
+
+    const provider = createProvider(tenant);
+    const findGrant = mockGrantFound(provider);
+    const configuration = getProviderConfiguration(provider);
+    const grantIdFor = jest.fn().mockReturnValue('session_grant_id');
+    const ctx = createOidcContext({
+      provider,
+      account: { accountId, claims: async () => ({ sub: accountId }) },
+      client: createTestClient(),
+      session: { grantIdFor },
+    } as unknown as Partial<KoaContextWithOIDC['oidc']>);
+
+    await expect(configuration.loadExistingGrant(ctx)).resolves.toBeDefined();
+    expect(grantIdFor).toHaveBeenCalledWith(clientId);
+    expect(findGrant).toHaveBeenCalledWith('session_grant_id');
+  });
+
   it('should defer application access check to consent prompt when no existing grant is loaded', async () => {
     const assertUserHasApplicationAccess = jest
       .fn()
@@ -599,6 +623,25 @@ describe('loadExistingGrant for CIMD clients', () => {
     await expect(configuration.loadExistingGrant(ctx)).resolves.toBeDefined();
     expect(assertUserHasApplicationAccess).not.toHaveBeenCalled();
     expect(findGrant).toHaveBeenCalledWith('grant_id');
+  });
+
+  it('should skip the session grant reuse so each authorization gets a fresh grant', async () => {
+    const tenant = new MockTenant();
+    const { id, queries, libraries, logtoConfigs, subscription } = tenant;
+    const provider = initOidc(id, cimdEnvSet, queries, libraries, logtoConfigs, subscription);
+    const findGrant = jest.spyOn(provider.Grant, 'find');
+    const configuration = getProviderConfiguration(provider);
+    const grantIdFor = jest.fn().mockReturnValue('session_grant_id');
+    const ctx = createOidcContext({
+      provider,
+      account: { accountId, claims: async () => ({ sub: accountId }) },
+      client: createCimdTestClient(),
+      session: { grantIdFor },
+    } as unknown as Partial<KoaContextWithOIDC['oidc']>);
+
+    await expect(configuration.loadExistingGrant(ctx)).resolves.toBeUndefined();
+    expect(grantIdFor).not.toHaveBeenCalled();
+    expect(findGrant).not.toHaveBeenCalled();
   });
 
   it('should keep the application access check for a url client id when CIMD is not effectively enabled', async () => {

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -323,8 +323,15 @@ export default function initOidc(
     },
     loadExistingGrant: async (ctx) => {
       const { account, client, provider, result, session } = ctx.oidc;
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Keep oidc-provider's default loadExistingGrant fallback semantics.
-      const grantId = result?.consent?.grantId || (client && session?.grantIdFor(client.clientId));
+      const cimd = isCimdClient(envSet, client?.clientId);
+      /**
+       * CIMD organization access is grant-scoped, so a Grant must never serve more than one
+       * authorization — skip the session grant reuse. The `result.consent.grantId` branch
+       * stays: it is this same authorization's grant on the post-consent resume.
+       */
+      const grantId =
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Keep oidc-provider's default loadExistingGrant fallback semantics.
+        result?.consent?.grantId || (client && !cimd && session?.grantIdFor(client.clientId));
       const shouldCheckApplicationAccess =
         account &&
         client &&
@@ -333,7 +340,7 @@ export default function initOidc(
          * access-control library's fallback lookup would query the applications table with the
          * CIMD identifier URL and deny on not-found.
          */
-        !isCimdClient(envSet, client.clientId) &&
+        !cimd &&
         !hasAppLevelAccessControlChecked(result, client.clientId, account.accountId);
 
       if (grantId && shouldCheckApplicationAccess) {

--- a/packages/core/src/queries/cimd.ts
+++ b/packages/core/src/queries/cimd.ts
@@ -166,7 +166,16 @@ const createGrantOrganizationQueries = (pool: CommonQueryMethods) => {
       and ${cimdGrantOrganizations.fields.organizationId} = ${organizationId}
     `);
 
-  return { insert, exists };
+  const findOrganizationIds = async (grantId: string) => {
+    const rows = await pool.any<{ organizationId: string }>(sql`
+      select ${cimdGrantOrganizations.fields.organizationId}
+      from ${cimdGrantOrganizations.table}
+      where ${cimdGrantOrganizations.fields.grantId} = ${grantId}
+    `);
+    return rows.map(({ organizationId }) => organizationId);
+  };
+
+  return { insert, exists, findOrganizationIds };
 };
 
 export const createCimdQueries = (pool: CommonQueryMethods) => ({

--- a/packages/core/src/queries/cimd.ts
+++ b/packages/core/src/queries/cimd.ts
@@ -12,7 +12,10 @@ import {
 } from '@logto/schemas';
 import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 
-import { buildBatchInsertIntoWithPool } from '#src/database/insert-into.js';
+import {
+  buildBatchInsertIntoWithPool,
+  buildInsertIntoWithPool,
+} from '#src/database/insert-into.js';
 import { DeletionError } from '#src/errors/SlonikError/index.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 
@@ -144,11 +147,16 @@ const createOrganizationResourceScopeQueries = (pool: CommonQueryMethods) => {
 const cimdGrantOrganizations = convertToIdentifiers(CimdGrantOrganizations, true);
 
 const createGrantOrganizationQueries = (pool: CommonQueryMethods) => {
+  /** Idempotent so a retried consent submission re-writes the same row instead of failing. */
+  const insert = buildInsertIntoWithPool(pool)(CimdGrantOrganizations, {
+    onConflict: { ignore: true },
+  });
+
   /**
    * Whether the organization was authorized on the given grant. Row presence is only an
    * additional condition on top of a provider-validated live grant, never a validity source:
    * rows live as long as the Grant *row*, which can outlast the grant's validity by up to the
-   * pruning retention. The consent-side insert lands with LOG-13930.
+   * pruning retention.
    */
   const exists = async (grantId: string, organizationId: string) =>
     pool.exists(sql`
@@ -158,7 +166,7 @@ const createGrantOrganizationQueries = (pool: CommonQueryMethods) => {
       and ${cimdGrantOrganizations.fields.organizationId} = ${organizationId}
     `);
 
-  return { exists };
+  return { insert, exists };
 };
 
 export const createCimdQueries = (pool: CommonQueryMethods) => ({

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -216,7 +216,13 @@ export default function consentRoutes<T extends IRouterParamContext>(
           const resource = resourceScopesToGrant[resourceIndicator];
 
           if (!resource) {
-            return [resourceIndicator, []];
+            /**
+             * An empty rejection is cleaned off the grant, so an all-ineligible group would
+             * stay "missing" and reopen consent forever — reject it whole for CIMD, where the
+             * rejection dies with the per-authorization grant; a registered client's long-lived
+             * grant must stay re-askable for later eligibility changes.
+             */
+            return [resourceIndicator, cimd ? scopes : []];
           }
 
           return [resourceIndicator, scopes.filter((scope) => !resource.includes(scope))];

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -27,7 +27,7 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { interactionPrefix } from '../const.js';
 
-import { filterAndParseMissingResourceScopes } from './utils.js';
+import { buildResourceScopesToReject, filterAndParseMissingResourceScopes } from './utils.js';
 
 const { InvalidClient, InvalidRedirectUri, InvalidRequest } = errors;
 
@@ -211,22 +211,10 @@ export default function consentRoutes<T extends IRouterParamContext>(
         )
       );
 
-      const resourceScopesToReject = Object.fromEntries(
-        Object.entries(allMissingResourceScopes).map(([resourceIndicator, scopes]) => {
-          const resource = resourceScopesToGrant[resourceIndicator];
-
-          if (!resource) {
-            /**
-             * An empty rejection is cleaned off the grant, so an all-ineligible group would
-             * stay "missing" and reopen consent forever — reject it whole for CIMD, where the
-             * rejection dies with the per-authorization grant; a registered client's long-lived
-             * grant must stay re-askable for later eligibility changes.
-             */
-            return [resourceIndicator, cimd ? scopes : []];
-          }
-
-          return [resourceIndicator, scopes.filter((scope) => !resource.includes(scope))];
-        })
+      const resourceScopesToReject = buildResourceScopesToReject(
+        allMissingResourceScopes,
+        resourceScopesToGrant,
+        cimd
       );
 
       const redirectTo = await consent({

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -96,27 +96,27 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       // Grant the organizations to the application if the user has selected the organizations
       if (organizationIds?.length) {
-        /**
-         * Organization grants are keyed to registered applications
-         * (`application_user_consent_organizations`); the grant-scoped counterpart for CIMD
-         * clients lands with LOG-13930, so a CIMD consent submission must not carry any
-         * organization selection.
-         */
-        assertThat(
-          !cimd,
-          new InvalidRequest('organization consent is not available for CIMD clients')
-        );
+        /** One grant carries one organization for a CIMD client. */
+        if (cimd) {
+          assertThat(
+            organizationIds.length === 1,
+            new InvalidRequest('at most one organization can be consented to a CIMD client')
+          );
+        }
 
         // Assert that user is a member of all organizations
         await validateUserConsentOrganizationMembership(userId, organizationIds);
 
-        await queries.applications.userConsentOrganizations.insert(
-          ...organizationIds.map((organizationId) => ({
-            applicationId,
-            userId,
-            organizationId,
-          }))
-        );
+        /** The CIMD counterpart is grant-keyed — `consent()` writes it after `grant.save()`. */
+        if (!cimd) {
+          await queries.applications.userConsentOrganizations.insert(
+            ...organizationIds.map((organizationId) => ({
+              applicationId,
+              userId,
+              organizationId,
+            }))
+          );
+        }
       }
 
       const { missingOIDCScope = [], missingResourceScopes: allMissingResourceScopes = {} } =
@@ -127,11 +127,16 @@ export default function consentRoutes<T extends IRouterParamContext>(
       // Instead of trust the front-end's submission, we choose to find the organizations and build the resource scopes again,
       // to ensure the scopes are correct.
 
-      // Find the organizations granted by the user
-      // The user may send consent request multiple times, so we need to find the organizations again.
-      // A CIMD client can hold none until LOG-13930 lands the grant-scoped storage.
+      /**
+       * A CIMD authorization is served by its own grant alone, so the just-validated selection
+       * is its whole organization set; registered applications re-query the cross-grant relation.
+       */
       const organizations = cimd
-        ? []
+        ? await Promise.all(
+            (organizationIds ?? []).map(async (organizationId) =>
+              queries.organizations.findById(organizationId)
+            )
+          )
         : await queries.applications.userConsentOrganizations
             .getEntities(Organizations, {
               applicationId,
@@ -211,20 +216,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
           const resource = resourceScopesToGrant[resourceIndicator];
 
           if (!resource) {
-            /**
-             * With the organization rebuild closed for CIMD (until LOG-13930), a scope held
-             * only through organization roles can end up neither granted nor rejected; the
-             * provider would then see it still missing on resume and restart the consent
-             * prompt indefinitely. Reject the whole group instead — consistent with the
-             * consent page, which never displayed these scopes.
-             *
-             * The rejection persists on the grant (rejected counts as encountered), so the
-             * scope stays withheld even if the user becomes eligible later — accepted as an
-             * interim state: CIMD ships together with LOG-13930, whose grant-scoped
-             * organization support reopens the rebuild and retires this branch.
-             * TODO: @xiaoyijun reopen the organization rebuild for CIMD (LOG-13930).
-             */
-            return [resourceIndicator, cimd ? scopes : []];
+            return [resourceIndicator, []];
           }
 
           return [resourceIndicator, scopes.filter((scope) => !resource.includes(scope))];
@@ -241,6 +233,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
         resourceScopesToGrant,
         resourceScopesToReject,
         markAppLevelAccessControlChecked: true,
+        cimdOrganizationId: conditional(cimd && organizationIds?.[0]),
       });
 
       ctx.body = { redirectTo };
@@ -382,15 +375,9 @@ export default function consentRoutes<T extends IRouterParamContext>(
       });
 
       // Find the organizations if the application is requesting the organizations scope.
-      /**
-       * Organization grants are keyed to registered applications
-       * (`application_user_consent_organizations`); the grant-scoped counterpart for CIMD
-       * clients lands with LOG-13930, so a CIMD consent offers no organization selection yet.
-       */
-      const organizations =
-        !cimd && missingOIDCScope?.includes(UserScope.Organizations)
-          ? await queries.organizations.relations.users.getOrganizationsByUserId(accountId)
-          : [];
+      const organizations = missingOIDCScope?.includes(UserScope.Organizations)
+        ? await queries.organizations.relations.users.getOrganizationsByUserId(accountId)
+        : [];
 
       const organizationsWithMissingResourceScopes = await Promise.all(
         organizations.map(async ({ name, id }) => {

--- a/packages/core/src/routes/interaction/consent/utils.test.ts
+++ b/packages/core/src/routes/interaction/consent/utils.test.ts
@@ -1,0 +1,38 @@
+import { buildResourceScopesToReject } from './utils.js';
+
+describe('buildResourceScopesToReject', () => {
+  it('should reject the remainder of a partially granted group', () => {
+    expect(
+      buildResourceScopesToReject(
+        { 'https://api.example.com': ['read', 'write'] },
+        { 'https://api.example.com': ['read'] },
+        false
+      )
+    ).toEqual({ 'https://api.example.com': ['write'] });
+  });
+
+  it('should reject the whole group for a CIMD consent submitted without an organization', () => {
+    // The group's scopes are reachable through organization roles only, so the rebuild grants nothing for it.
+    expect(
+      buildResourceScopesToReject({ 'https://api.example.com': ['read', 'write'] }, {}, true)
+    ).toEqual({ 'https://api.example.com': ['read', 'write'] });
+  });
+
+  it('should reject the whole group for a CIMD consent when the selected organization contributes none of the requested scopes', () => {
+    expect(
+      buildResourceScopesToReject(
+        { 'https://api.example.com': ['read'] },
+        { 'urn:logto:resource:organizations': ['org:read'] },
+        true
+      )
+    ).toEqual({ 'https://api.example.com': ['read'] });
+  });
+
+  it('should leave an ungrantable group unencountered for a registered client', () => {
+    expect(buildResourceScopesToReject({ 'https://api.example.com': ['read'] }, {}, false)).toEqual(
+      {
+        'https://api.example.com': [],
+      }
+    );
+  });
+});

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -87,6 +87,32 @@ const parseMissingResourceScopesInfo = async (
 };
 
 /**
+ * Build the resource scopes to reject on the grant — the requested-but-not-granted remainder of
+ * each group.
+ *
+ * An empty rejection is cleaned off the grant, so an all-ineligible group would stay "missing"
+ * and reopen consent forever — reject it whole for a CIMD client, where the rejection dies with
+ * the per-authorization grant; a registered client's long-lived grant must stay re-askable for
+ * later eligibility changes.
+ */
+export const buildResourceScopesToReject = (
+  allMissingResourceScopes: Record<string, string[]>,
+  resourceScopesToGrant: Record<string, string[]>,
+  cimd: boolean
+): Record<string, string[]> =>
+  Object.fromEntries(
+    Object.entries(allMissingResourceScopes).map(([resourceIndicator, scopes]) => {
+      const resource = resourceScopesToGrant[resourceIndicator];
+
+      if (!resource) {
+        return [resourceIndicator, cimd ? scopes : []];
+      }
+
+      return [resourceIndicator, scopes.filter((scope) => !resource.includes(scope))];
+    })
+  );
+
+/**
  * The missingResourceScopes in the prompt details are from `getResourceServerInfo`,
  * which contains resource scopes and organization resource scopes.
  * We need to separate the organization resource scopes from the resource scopes.


### PR DESCRIPTION
## Summary

Reopen organization selection on the CIMD consent flow and store the authorization grant-scoped (LOG-13930). Stacked on #9409 (grant-level uniqueness) → #9400 (issuance).

- Consent GET lists the user's organizations for CIMD clients again (the selector is data-driven, no frontend change).
- Consent POST accepts at most one organization for a CIMD client, validates membership, and binds the organization to the grant with a strict verify: exactly one row, carrying the submitted organization (an empty read after a cascade delete also fails closed). A reused grant occupies the binding before any grant change, so a conflicting organization fails without mutating the grant's scopes; a fresh grant cannot conflict, and its row follows `grant.save()` — the row's FK needs the grant row. A failed binding fails the whole consent; grant-level uniqueness under concurrency comes from #9409's `(tenant_id, grant_id)` primary key.
- `loadExistingGrant` skips the session grant reuse for CIMD clients, so every authorization gets a fresh Grant: organization rows must not accumulate across authorizations, and the issuance-side lookup (#9400) relies on one-authorization-one-grant. The `result.consent.grantId` branch (same-authorization resume) stays.
- The organization resource scope rebuild runs for CIMD from the submitted selection, through the existing tenant ceiling filter. An all-ineligible scope group is rejected whole (kept from #9378): an empty rejection is cleaned off the grant, so the group would otherwise stay "missing" and reopen consent indefinitely; under per-authorization grants the rejection cannot outlive the authorization, while registered clients keep the re-askable `[]` branch.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
