### PR TITLE
feat(core): route both script libraries to the cloud script-run endpoint

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
     "zod": "3.24.3"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-a4e30ff",
+    "@logto/cloud": "0.2.5-db73b11",
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/ts-config": "6.0.0",
     "@types/adm-zip": "^0.5.5",

--- a/packages/core/src/libraries/action-telemetry.ts
+++ b/packages/core/src/libraries/action-telemetry.ts
@@ -15,7 +15,15 @@ export const actionMetricNames = Object.freeze({
   executionDuration: 'core/action/execution_duration_ms',
 } as const);
 
-export type ActionRuntimeLocation = 'local' | 'azure';
+/**
+ * Where a script run actually executed.
+ *
+ * `azure` and `cloud` are both Cloud runs, kept apart on purpose while the two remote runtimes
+ * coexist behind `isDevFeaturesEnabled`: it makes the migration off Azure Functions readable in
+ * the metric itself. `azure` also keeps the pre-existing series intact rather than renaming it.
+ * Once LOG-13958 removes the Azure Functions runtime, `azure` goes with it.
+ */
+export type ActionRuntimeLocation = 'local' | 'azure' | 'cloud';
 
 type ActionExecutionOutcome = 'success' | 'executionError' | 'invalidResult' | 'noop' | 'fallback';
 type ActionExecutionAction = 'createUser' | 'updateUser' | 'noop';

--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -1,6 +1,8 @@
+/* eslint-disable max-lines -- The dev-features-gated script-run path and the legacy Azure Functions path share one setup. */
 import { appInsights } from '@logto/app-insights/node';
 import { LogtoActionKey } from '@logto/schemas';
 import { ResponseError } from '@withtyped/client';
+import nock from 'nock';
 
 import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
@@ -34,6 +36,7 @@ const createLibrary = (tenantId = 'tenant_id') =>
   );
 
 const originalIsCloud = EnvSet.values.isCloud;
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 
 const setIsCloud = (isCloud: boolean) => {
   // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for Cloud/local selection tests.
@@ -64,6 +67,7 @@ describe('ActionLibrary Cloud execution routing', () => {
     library.runAction({ ...input, auditContext: { createLog } });
 
   beforeEach(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Provide an AppInsights client for metric assertions.
     appInsights.client = {
       trackMetric,
@@ -82,6 +86,7 @@ describe('ActionLibrary Cloud execution routing', () => {
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the shared AppInsights singleton.
     appInsights.client = originalAppInsightsClient;
     setIsCloud(originalIsCloud);
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('runs the script through the Cloud script-run endpoint', async () => {
@@ -320,3 +325,143 @@ describe('ActionLibrary Cloud execution routing', () => {
     expect(runScriptInLocalVm).not.toHaveBeenCalled();
   });
 });
+
+describe('ActionLibrary Cloud execution routing without dev features', () => {
+  const library = createLibrary();
+  const { createLog } = createMockLogContext();
+  const runAction = async <Event>(input: RunActionInput<Event>) =>
+    library.runAction({ ...input, auditContext: { createLog } });
+
+  beforeEach(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Provide an AppInsights client for metric assertions.
+    appInsights.client = {
+      trackMetric,
+      trackException: jest.fn(),
+    } as unknown as NonNullable<typeof appInsights.client>;
+    getSubscriptionData.mockResolvedValue({
+      quota: {
+        actionsEnabled: true,
+      },
+    } as Awaited<ReturnType<SubscriptionLibrary['getSubscriptionData']>>);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the shared AppInsights singleton.
+    appInsights.client = originalAppInsightsClient;
+    setIsCloud(originalIsCloud);
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  it('throws an action error when the remote runner is not configured', async () => {
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
+
+    await expect(
+      library.runScriptRemotely({
+        actionType: LogtoActionKey.PostSignIn,
+        script: 'const runAction = () => ({ action: "continue" });',
+        event: {
+          key: LogtoActionKey.PostSignIn,
+        },
+      })
+    ).rejects.toMatchObject({
+      code: 'action.general',
+      status: 422,
+      data: {
+        message: 'Remote action runner is not configured.',
+      },
+    });
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('routes Cloud runAction through the Azure Function endpoint with the execution payload', async () => {
+    setIsCloud(true);
+    const endpoint = 'https://untrusted.example.com';
+    const functionKey = 'function-key';
+    const script = 'const runAction = () => ({ action: "updateUser", user: { name: "Bar" } });';
+    const event = {
+      key: LogtoActionKey.PostSignIn,
+      interactionEvent: 'SignIn',
+      user: {
+        id: 'foo',
+        name: 'Foo',
+      },
+    };
+    const environmentVariables = { NAME_SUFFIX: ' updated' };
+    const executionResult = {
+      action: 'updateUser',
+      user: {
+        name: 'Bar',
+      },
+    };
+    const matchRunnerPayload = jest.fn((_body: unknown) => true);
+    const remoteRunner = nock(endpoint, {
+      reqheaders: {
+        'x-functions-key': functionKey,
+      },
+    })
+      .post('/api/actions', matchRunnerPayload)
+      .reply(200, executionResult);
+
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+    getAction.mockResolvedValueOnce({
+      enabled: true,
+      script,
+      environmentVariables,
+    });
+
+    await expect(
+      runAction({
+        key: LogtoActionKey.PostSignIn,
+        event,
+      })
+    ).resolves.toEqual(executionResult);
+    expect(remoteRunner.isDone()).toBe(true);
+    expect(post).not.toHaveBeenCalled();
+    expect(matchRunnerPayload.mock.calls[0]?.[0]).toMatchObject({
+      script,
+      actionType: LogtoActionKey.PostSignIn,
+      event,
+      environmentVariables,
+    });
+  });
+
+  it('applies allow-mode policy when the Azure Function run fails', async () => {
+    setIsCloud(true);
+    const endpoint = 'https://untrusted.example.com';
+    const functionKey = 'function-key';
+    const remoteRunner = nock(endpoint, {
+      reqheaders: {
+        'x-functions-key': functionKey,
+      },
+    })
+      .post('/api/actions')
+      .reply(500, {
+        message: 'Remote runner failed',
+      });
+
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+    getAction.mockResolvedValueOnce({
+      enabled: true,
+      onExecutionError: 'allow',
+      script: 'const runAction = () => ({ action: "continue" });',
+    });
+    const runScriptInLocalVm = jest.spyOn(ActionLibrary, 'runScriptInLocalVm');
+
+    await expect(
+      runAction({
+        key: LogtoActionKey.PostSignIn,
+        event: {},
+      })
+    ).resolves.toBeUndefined();
+    expect(remoteRunner.isDone()).toBe(true);
+    expect(runScriptInLocalVm).not.toHaveBeenCalled();
+  });
+});
+/* eslint-enable max-lines */

--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -122,9 +122,7 @@ describe('ActionLibrary Cloud execution routing', () => {
     ['oom', 500],
     ['runtime', 500],
   ])('maps a %s script failure to status %i', async (kind, status) => {
-    post.mockRejectedValueOnce(
-      buildScriptFailureResponseError(status, 'Script failed', { kind, name: 'Error' })
-    );
+    post.mockRejectedValueOnce(buildScriptFailureResponseError(status, 'Script failed', { kind }));
 
     await expect(
       library.runScriptRemotely({
@@ -133,6 +131,47 @@ describe('ActionLibrary Cloud execution routing', () => {
         event: {},
       })
     ).rejects.toMatchObject({ status });
+  });
+
+  it('marks a dry run as a test', async () => {
+    const payload = {
+      actionType: LogtoActionKey.PostSignIn,
+      script: 'const runAction = () => ({ action: "continue" });',
+      event: { key: LogtoActionKey.PostSignIn },
+    };
+    post.mockResolvedValueOnce({ value: { action: 'continue' } });
+
+    await library.runScriptRemotely(payload, true);
+    expect(post).toHaveBeenCalledWith('/api/services/script-run', {
+      body: {
+        entry: 'runAction',
+        script: payload.script,
+        payload: {
+          event: payload.event,
+          environmentVariables: undefined,
+        },
+        isTest: true,
+      },
+    });
+  });
+
+  it('forwards the dry-run flag from executeScript', async () => {
+    setIsCloud(true);
+    const payload = {
+      actionType: LogtoActionKey.PostSignIn,
+      script: 'const runAction = () => ({ action: "continue" });',
+      event: { key: LogtoActionKey.PostSignIn },
+    };
+    post.mockResolvedValueOnce({ value: { action: 'continue' } });
+
+    await library.executeScript({ ...payload, isTest: true });
+    expect(post).toHaveBeenCalledWith(
+      '/api/services/script-run',
+      expect.objectContaining({
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Jest asymmetric matcher is typed as `any`.
+        body: expect.objectContaining({ isTest: true }),
+      })
+    );
   });
 
   it('rethrows a non-script-failure error untouched', async () => {
@@ -163,7 +202,7 @@ describe('ActionLibrary Cloud execution routing', () => {
     const runScriptInLocalVm = jest.spyOn(ActionLibrary, 'runScriptInLocalVm');
 
     await expect(library.executeScript(payload)).resolves.toEqual({ action: 'continue' });
-    expect(runScriptRemotely).toHaveBeenCalledWith(payload);
+    expect(runScriptRemotely).toHaveBeenCalledWith(payload, undefined);
     expect(runScriptInLocalVm).not.toHaveBeenCalled();
   });
 
@@ -254,10 +293,7 @@ describe('ActionLibrary Cloud execution routing', () => {
   it('applies allow-mode policy when Cloud remote execution fails without local fallback', async () => {
     setIsCloud(true);
     post.mockRejectedValueOnce(
-      buildScriptFailureResponseError(500, 'Remote runner failed', {
-        kind: 'runtime',
-        name: 'Error',
-      })
+      buildScriptFailureResponseError(500, 'Remote runner failed', { kind: 'runtime' })
     );
     getAction.mockResolvedValueOnce({
       enabled: true,

--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -1,13 +1,13 @@
 import { appInsights } from '@logto/app-insights/node';
 import { LogtoActionKey } from '@logto/schemas';
 import { ResponseError } from '@withtyped/client';
-import nock from 'nock';
 
 import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 
 import { actionMetricNames } from './action-telemetry.js';
 import { ActionLibrary } from './action.js';
+import type { CloudConnectionLibrary } from './cloud-connection.js';
 import type { LogtoConfigLibrary } from './logto-config.js';
 import type { SubscriptionLibrary } from './subscription.js';
 
@@ -17,14 +17,20 @@ const getAction = jest.fn() as jest.MockedFunction<LogtoConfigLibrary['getAction
 const getSubscriptionData = jest.fn() as jest.MockedFunction<
   SubscriptionLibrary['getSubscriptionData']
 >;
+const post = jest.fn();
 const trackMetric = jest.fn();
 const originalAppInsightsClient = appInsights.client;
+
+const cloudConnection = {
+  getClient: async () => ({ post }),
+} as unknown as CloudConnectionLibrary;
 
 const createLibrary = (tenantId = 'tenant_id') =>
   new ActionLibrary(
     tenantId,
     { getAction } as unknown as LogtoConfigLibrary,
-    { getSubscriptionData } as unknown as SubscriptionLibrary
+    { getSubscriptionData } as unknown as SubscriptionLibrary,
+    cloudConnection
   );
 
 const originalIsCloud = EnvSet.values.isCloud;
@@ -33,6 +39,19 @@ const setIsCloud = (isCloud: boolean) => {
   // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for Cloud/local selection tests.
   (EnvSet.values as { isCloud: boolean }).isCloud = isCloud;
 };
+
+/** The body `POST /api/services/script-run` returns for a failed run, as withtyped shapes it. */
+const buildScriptFailureResponseError = (
+  status: number,
+  message: string,
+  error: Record<string, unknown>
+) =>
+  new ResponseError(
+    new Response(JSON.stringify({ message, error }), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  );
 
 type RunActionInput<Event> = {
   key: LogtoActionKey;
@@ -58,7 +77,6 @@ describe('ActionLibrary Cloud execution routing', () => {
   });
 
   afterEach(() => {
-    nock.cleanAll();
     jest.restoreAllMocks();
     jest.clearAllMocks();
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the shared AppInsights singleton.
@@ -66,66 +84,63 @@ describe('ActionLibrary Cloud execution routing', () => {
     setIsCloud(originalIsCloud);
   });
 
-  it('throws an action error when the remote runner is not configured', async () => {
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
-
-    await expect(
-      library.runScriptRemotely({
-        actionType: LogtoActionKey.PostSignIn,
-        script: 'const runAction = () => ({ action: "continue" });',
-        event: {
-          key: LogtoActionKey.PostSignIn,
-        },
-      })
-    ).rejects.toMatchObject({
-      code: 'action.general',
-      status: 422,
-      data: {
-        message: 'Remote action runner is not configured.',
-      },
-    });
-  });
-
-  it('runs the script through the regional untrusted runner endpoint', async () => {
-    const endpoint = 'https://untrusted.example.com';
-    const functionKey = 'function-key';
+  it('runs the script through the Cloud script-run endpoint', async () => {
     const payload = {
       actionType: LogtoActionKey.PostSignIn,
       script: 'const runAction = () => ({ action: "continue" });',
       event: {
         key: LogtoActionKey.PostSignIn,
       },
+      environmentVariables: { NAME_SUFFIX: ' updated' },
     };
-    const executionResult = { action: 'continue' };
-    const matchRunnerPayload = jest.fn((_body: unknown) => true);
-    const remoteRunner = nock(endpoint, {
-      reqheaders: {
-        'x-functions-key': functionKey,
+    post.mockResolvedValueOnce({ value: { action: 'continue' } });
+
+    await expect(library.runScriptRemotely(payload)).resolves.toEqual({ action: 'continue' });
+    expect(post).toHaveBeenCalledWith('/api/services/script-run', {
+      body: {
+        entry: 'runAction',
+        script: payload.script,
+        // `actionType` selects the script on this side and must not reach the user script.
+        payload: {
+          event: payload.event,
+          environmentVariables: payload.environmentVariables,
+        },
       },
-    })
-      .post('/api/actions', matchRunnerPayload)
-      .reply(200, executionResult);
-
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
-
-    await expect(library.runScriptRemotely(payload)).resolves.toEqual(executionResult);
-    expect(remoteRunner.isDone()).toBe(true);
-    const requestBody = matchRunnerPayload.mock.calls[0]?.[0];
-    expect(requestBody).toMatchObject({
-      actionType: payload.actionType,
-      event: payload.event,
     });
-    if (
-      typeof requestBody !== 'object' ||
-      requestBody === null ||
-      !('script' in requestBody) ||
-      typeof requestBody.script !== 'string'
-    ) {
-      throw new TypeError('Expected the runner request body to contain a script');
-    }
-    expect(requestBody.script).toBe(payload.script);
+  });
+
+  it.each([
+    ['denied', 403],
+    ['syntax', 422],
+    ['type', 422],
+    ['timeout', 500],
+    ['oom', 500],
+    ['runtime', 500],
+  ])('maps a %s script failure to status %i', async (kind, status) => {
+    post.mockRejectedValueOnce(
+      buildScriptFailureResponseError(status, 'Script failed', { kind, name: 'Error' })
+    );
+
+    await expect(
+      library.runScriptRemotely({
+        actionType: LogtoActionKey.PostSignIn,
+        script: 'const runAction = () => ({ action: "continue" });',
+        event: {},
+      })
+    ).rejects.toMatchObject({ status });
+  });
+
+  it('rethrows a non-script-failure error untouched', async () => {
+    const error = buildScriptFailureResponseError(403, 'Actions feature is not available.', {});
+    post.mockRejectedValueOnce(error);
+
+    await expect(
+      library.runScriptRemotely({
+        actionType: LogtoActionKey.PostSignIn,
+        script: 'const runAction = () => ({ action: "continue" });',
+        event: {},
+      })
+    ).rejects.toBe(error);
   });
 
   it('uses the remote runner for Cloud executeScript without falling back to local VM', async () => {
@@ -166,10 +181,8 @@ describe('ActionLibrary Cloud execution routing', () => {
     expect(runScriptRemotely).not.toHaveBeenCalled();
   });
 
-  it('routes Cloud runAction through the Azure Function endpoint with the execution payload', async () => {
+  it('routes Cloud runAction through the script-run endpoint with the execution payload', async () => {
     setIsCloud(true);
-    const endpoint = 'https://untrusted.example.com';
-    const functionKey = 'function-key';
     const script = 'const runAction = () => ({ action: "updateUser", user: { name: "Bar" } });';
     const event = {
       key: LogtoActionKey.PostSignIn,
@@ -186,17 +199,7 @@ describe('ActionLibrary Cloud execution routing', () => {
         name: 'Bar',
       },
     };
-    const matchRunnerPayload = jest.fn((_body: unknown) => true);
-    const remoteRunner = nock(endpoint, {
-      reqheaders: {
-        'x-functions-key': functionKey,
-      },
-    })
-      .post('/api/actions', matchRunnerPayload)
-      .reply(200, executionResult);
-
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+    post.mockResolvedValueOnce({ value: executionResult });
     getAction.mockResolvedValueOnce({
       enabled: true,
       script,
@@ -210,22 +213,13 @@ describe('ActionLibrary Cloud execution routing', () => {
         event,
       })
     ).resolves.toEqual(executionResult);
-    expect(remoteRunner.isDone()).toBe(true);
-    const requestBody = matchRunnerPayload.mock.calls[0]?.[0];
-    expect(requestBody).toMatchObject({
-      actionType: LogtoActionKey.PostSignIn,
-      event,
-      environmentVariables,
+    expect(post).toHaveBeenCalledWith('/api/services/script-run', {
+      body: {
+        entry: 'runAction',
+        script,
+        payload: { event, environmentVariables },
+      },
     });
-    if (
-      typeof requestBody !== 'object' ||
-      requestBody === null ||
-      !('script' in requestBody) ||
-      typeof requestBody.script !== 'string'
-    ) {
-      throw new TypeError('Expected the runner request body to contain a script');
-    }
-    expect(requestBody.script).toBe(script);
     expect(runScriptInLocalVm).not.toHaveBeenCalled();
     expect(mockAppend).toHaveBeenNthCalledWith(
       1,
@@ -253,20 +247,12 @@ describe('ActionLibrary Cloud execution routing', () => {
 
   it('applies allow-mode policy when Cloud remote execution fails without local fallback', async () => {
     setIsCloud(true);
-    const endpoint = 'https://untrusted.example.com';
-    const functionKey = 'function-key';
-    const remoteRunner = nock(endpoint, {
-      reqheaders: {
-        'x-functions-key': functionKey,
-      },
-    })
-      .post('/api/actions')
-      .reply(500, {
-        message: 'Remote runner failed',
-      });
-
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+    post.mockRejectedValueOnce(
+      buildScriptFailureResponseError(500, 'Remote runner failed', {
+        kind: 'runtime',
+        name: 'Error',
+      })
+    );
     getAction.mockResolvedValueOnce({
       enabled: true,
       onExecutionError: 'allow',
@@ -280,20 +266,17 @@ describe('ActionLibrary Cloud execution routing', () => {
         event: {},
       })
     ).resolves.toBeUndefined();
-    expect(remoteRunner.isDone()).toBe(true);
+    expect(post).toHaveBeenCalledTimes(1);
     expect(runScriptInLocalVm).not.toHaveBeenCalled();
   });
 
   it('blocks PostSignIn when Cloud remote execution fails by default', async () => {
     setIsCloud(true);
-    jest.spyOn(library, 'runScriptRemotely').mockRejectedValueOnce(
-      new ResponseError(
-        new Response(JSON.stringify({ message: 'Remote runner failed' }), {
-          status: 500,
-          headers: { 'content-type': 'application/json' },
-        })
-      )
-    );
+    jest
+      .spyOn(library, 'runScriptRemotely')
+      .mockRejectedValueOnce(
+        buildScriptFailureResponseError(500, 'Remote runner failed', { kind: 'runtime' })
+      );
     getAction.mockResolvedValueOnce({
       enabled: true,
       script: 'const runAction = () => ({ action: "continue" });',

--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -232,7 +232,8 @@ describe('ActionLibrary Cloud execution routing', () => {
     );
     const metricProperties = {
       actionType: 'PostSignIn',
-      runtimeLocation: 'azure',
+      // `cloud`, not `azure`: the metric distinguishes the two remote runtimes while both exist.
+      runtimeLocation: 'cloud',
       outcome: 'success',
       action: 'updateUser',
     };
@@ -428,6 +429,16 @@ describe('ActionLibrary Cloud execution routing without dev features', () => {
       actionType: LogtoActionKey.PostSignIn,
       event,
       environmentVariables,
+    });
+    expect(trackMetric).toHaveBeenNthCalledWith(1, {
+      name: actionMetricNames.executionCount,
+      value: 1,
+      properties: {
+        actionType: 'PostSignIn',
+        runtimeLocation: 'azure',
+        outcome: 'success',
+        action: 'updateUser',
+      },
     });
   });
 

--- a/packages/core/src/libraries/action.test.ts
+++ b/packages/core/src/libraries/action.test.ts
@@ -16,6 +16,7 @@ import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { actionMetricNames, type ActionTelemetryProperties } from './action-telemetry.js';
 import { getActionExecutionErrorPolicyDecision, ActionLibrary } from './action.js';
 import type { ActionExecutionErrorFallback, ActionExecutionErrorPolicyDecision } from './action.js';
+import type { CloudConnectionLibrary } from './cloud-connection.js';
 import type { LogtoConfigLibrary } from './logto-config.js';
 import type { SubscriptionLibrary } from './subscription.js';
 
@@ -47,7 +48,8 @@ const createLibrary = (tenantId = 'tenant_id') =>
   new ActionLibrary(
     tenantId,
     { getAction } as unknown as LogtoConfigLibrary,
-    { getSubscriptionData } as unknown as SubscriptionLibrary
+    { getSubscriptionData } as unknown as SubscriptionLibrary,
+    {} as CloudConnectionLibrary
   );
 
 const originalIsCloud = EnvSet.values.isCloud;

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -8,7 +8,6 @@ import {
   type ActionExecutionErrorPolicy,
   type ActionExecutionRequestBody,
 } from '@logto/schemas';
-import { got, HTTPError } from 'got';
 import { ZodError } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
@@ -16,7 +15,6 @@ import RequestError from '#src/errors/RequestError/index.js';
 import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import type { SubscriptionLibrary } from '#src/libraries/subscription.js';
 import type { LogContext, LogPayload } from '#src/middleware/koa-audit-log.js';
-import { parseAzureFunctionsResponseError } from '#src/utils/custom-jwt/index.js';
 import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import {
@@ -32,21 +30,20 @@ import {
   type ActionRuntimeLocation,
   trackActionExecutionMetrics,
 } from './action-telemetry.js';
+import { type CloudConnectionLibrary } from './cloud-connection.js';
 import {
+  buildCloudScriptFailureError,
   buildScriptExecutionErrorBody,
   buildScriptFailureError,
   getScriptFailureStatusCode,
+  parseCloudScriptFailure,
+  runScriptOnCloud,
   runScriptOnWorkerPool,
   ScriptExecutionError,
 } from './script-runner/index.js';
 
 const actionFunctionName = 'runAction';
 const defaultActionExecutionErrorPolicy = 'block' satisfies ActionExecutionErrorPolicy;
-/**
- * Azure Function vm2 timeout is 3000ms. Use a slightly higher HTTP deadline so the
- * client can surface Function-side failures instead of racing the sandbox limit.
- */
-const remoteActionRequestTimeout = 5000;
 
 export type ActionExecutionErrorFallback = {
   action: 'rejectInvalidCredentials';
@@ -266,14 +263,9 @@ export class ActionLibrary {
   constructor(
     private readonly tenantId: string,
     private readonly logtoConfigs: LogtoConfigLibrary,
-    private readonly subscription: SubscriptionLibrary
+    private readonly subscription: SubscriptionLibrary,
+    private readonly cloudConnection: CloudConnectionLibrary
   ) {}
-
-  get isRegionalAzureFunctionAppConfigured(): boolean {
-    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
-
-    return Boolean(azureFunctionUntrustedAppKey && azureFunctionUntrustedAppEndpoint);
-  }
 
   /**
    * Shared entry point for production `runAction()` and Management API dry runs.
@@ -308,7 +300,6 @@ export class ActionLibrary {
    */
   async runScriptRemotely({
     script,
-    actionType,
     event,
     environmentVariables,
   }: {
@@ -317,38 +308,24 @@ export class ActionLibrary {
     event: unknown;
     environmentVariables?: Record<string, string>;
   }): Promise<unknown> {
-    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
-
-    if (!this.isRegionalAzureFunctionAppConfigured) {
-      throw new RequestError(
-        { code: 'action.general', status: 422 },
-        { message: 'Remote action runner is not configured.' }
-      );
-    }
+    /**
+     * `actionType` selects the script on this side and is deliberately not forwarded — anything
+     * in `payload` becomes a visible field of the script's `runAction` argument, and the
+     * authoring contract promises `{ event, environmentVariables }` only.
+     */
+    const payload: ActionScriptPayload<unknown> = { event, environmentVariables };
 
     try {
-      return await got
-        // The remote runner must invoke `runAction` from the supplied script.
-        .post(new URL('/api/actions', azureFunctionUntrustedAppEndpoint), {
-          json: {
-            script,
-            actionType,
-            event,
-            environmentVariables,
-          },
-          headers: {
-            'x-functions-key': azureFunctionUntrustedAppKey,
-          },
-          // Got@14 expects a Delays object; bound the whole request slightly above the AF VM timeout.
-          timeout: { request: remoteActionRequestTimeout },
-        })
-        .json<unknown>();
+      return await runScriptOnCloud({
+        cloudConnection: this.cloudConnection,
+        script,
+        entry: actionFunctionName,
+        payload,
+      });
     } catch (error: unknown) {
-      if (error instanceof HTTPError) {
-        throw parseAzureFunctionsResponseError(error);
-      }
+      const failure = await parseCloudScriptFailure(error);
 
-      throw error;
+      throw failure ? buildCloudScriptFailureError(failure) : error;
     }
   }
 

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -309,17 +309,24 @@ export class ActionLibrary {
     actionType,
     event,
     environmentVariables,
+    isTest,
   }: {
     script: string;
     actionType: LogtoActionKey;
     // Production events are typed domain objects; dry-run uses JSON via the guard.
     event: unknown;
     environmentVariables?: Record<string, string>;
+    /**
+     * Whether this is a dry run. Set by the Management API test route, never by `runAction()`, so
+     * the Cloud runner can tell a Console "test" apart from production traffic. The local runners
+     * ignore it.
+     */
+    isTest?: boolean;
   }): Promise<unknown> {
     const payload = { script, actionType, event, environmentVariables };
 
     if (EnvSet.values.isCloud) {
-      return this.runScriptRemotely(payload);
+      return this.runScriptRemotely(payload, isTest);
     }
 
     return ActionLibrary.runScriptInLocalVm(payload, this.tenantId);
@@ -329,12 +336,16 @@ export class ActionLibrary {
    * For Logto Cloud use only. Run the action script remotely in an isolated environment.
    * For OSS version, use @see ActionLibrary.runScriptInLocalVm instead.
    */
-  async runScriptRemotely(data: {
-    script: string;
-    actionType: LogtoActionKey;
-    event: unknown;
-    environmentVariables?: Record<string, string>;
-  }): Promise<unknown> {
+  async runScriptRemotely(
+    data: {
+      script: string;
+      actionType: LogtoActionKey;
+      event: unknown;
+      environmentVariables?: Record<string, string>;
+    },
+    /** Whether this is a dry run. The legacy Azure Functions path has no notion of it. */
+    isTest?: boolean
+  ): Promise<unknown> {
     // TODO (LOG-13958): drop the legacy Azure Functions path and the gate once the Cloud script
     // runner has been manually verified and released.
     if (!EnvSet.values.isDevFeaturesEnabled) {
@@ -356,6 +367,7 @@ export class ActionLibrary {
         script,
         entry: actionFunctionName,
         payload,
+        isTest,
       });
     } catch (error: unknown) {
       const failure = await parseCloudScriptFailure(error);

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -8,6 +8,7 @@ import {
   type ActionExecutionErrorPolicy,
   type ActionExecutionRequestBody,
 } from '@logto/schemas';
+import { got, HTTPError } from 'got';
 import { ZodError } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
@@ -15,6 +16,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import type { SubscriptionLibrary } from '#src/libraries/subscription.js';
 import type { LogContext, LogPayload } from '#src/middleware/koa-audit-log.js';
+import { parseAzureFunctionsResponseError } from '#src/utils/custom-jwt/index.js';
 import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import {
@@ -44,6 +46,13 @@ import {
 
 const actionFunctionName = 'runAction';
 const defaultActionExecutionErrorPolicy = 'block' satisfies ActionExecutionErrorPolicy;
+/**
+ * Azure Function vm2 timeout is 3000ms. Use a slightly higher HTTP deadline so the
+ * client can surface Function-side failures instead of racing the sandbox limit.
+ *
+ * Only used by the legacy Azure Functions path; the Cloud script runner owns its own budget.
+ */
+const remoteActionRequestTimeout = 5000;
 
 export type ActionExecutionErrorFallback = {
   action: 'rejectInvalidCredentials';
@@ -267,6 +276,12 @@ export class ActionLibrary {
     private readonly cloudConnection: CloudConnectionLibrary
   ) {}
 
+  get isRegionalAzureFunctionAppConfigured(): boolean {
+    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
+
+    return Boolean(azureFunctionUntrustedAppKey && azureFunctionUntrustedAppEndpoint);
+  }
+
   /**
    * Shared entry point for production `runAction()` and Management API dry runs.
    * Cloud always executes remotely; OSS / self-hosted runs locally — on the worker pool behind
@@ -298,16 +313,20 @@ export class ActionLibrary {
    * For Logto Cloud use only. Run the action script remotely in an isolated environment.
    * For OSS version, use @see ActionLibrary.runScriptInLocalVm instead.
    */
-  async runScriptRemotely({
-    script,
-    event,
-    environmentVariables,
-  }: {
+  async runScriptRemotely(data: {
     script: string;
     actionType: LogtoActionKey;
     event: unknown;
     environmentVariables?: Record<string, string>;
   }): Promise<unknown> {
+    // TODO (LOG-13958): drop the legacy Azure Functions path and the gate once the Cloud script
+    // runner has been manually verified and released.
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return this.runScriptOnAzureFunction(data);
+    }
+
+    const { script, event, environmentVariables } = data;
+
     /**
      * `actionType` selects the script on this side and is deliberately not forwarded — anything
      * in `payload` becomes a visible field of the script's `runAction` argument, and the
@@ -422,6 +441,53 @@ export class ActionLibrary {
       return result;
     } finally {
       trackActionExecutionMetrics({ durationMs, properties: telemetryProperties });
+    }
+  }
+
+  /** The pre-script-runner remote path, still serving production until the gate above lifts. */
+  private async runScriptOnAzureFunction({
+    script,
+    actionType,
+    event,
+    environmentVariables,
+  }: {
+    script: string;
+    actionType: LogtoActionKey;
+    event: unknown;
+    environmentVariables?: Record<string, string>;
+  }): Promise<unknown> {
+    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
+
+    if (!this.isRegionalAzureFunctionAppConfigured) {
+      throw new RequestError(
+        { code: 'action.general', status: 422 },
+        { message: 'Remote action runner is not configured.' }
+      );
+    }
+
+    try {
+      return await got
+        // The remote runner must invoke `runAction` from the supplied script.
+        .post(new URL('/api/actions', azureFunctionUntrustedAppEndpoint), {
+          json: {
+            script,
+            actionType,
+            event,
+            environmentVariables,
+          },
+          headers: {
+            'x-functions-key': azureFunctionUntrustedAppKey,
+          },
+          // Got@14 expects a Delays object; bound the whole request slightly above the AF VM timeout.
+          timeout: { request: remoteActionRequestTimeout },
+        })
+        .json<unknown>();
+    } catch (error: unknown) {
+      if (error instanceof HTTPError) {
+        throw parseAzureFunctionsResponseError(error);
+      }
+
+      throw error;
     }
   }
 

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -193,6 +193,22 @@ export const getActionExecutionErrorPolicyDecision = ({
   return getActionErrorFallback(key);
 };
 
+/**
+ * The telemetry label for where a run executes.
+ *
+ * Deliberately kept in sync with the branch {@link ActionLibrary.runScriptRemotely} takes: while
+ * both remote runtimes coexist behind `isDevFeaturesEnabled`, splitting `azure` from `cloud` is
+ * what makes the share of traffic already served by the Cloud script runner readable in the
+ * metric. Collapses back to `azure`-free once LOG-13958 removes the Azure Functions path.
+ */
+const getTelemetryRuntimeLocation = (): ActionRuntimeLocation => {
+  if (!EnvSet.values.isCloud) {
+    return 'local';
+  }
+
+  return EnvSet.values.isDevFeaturesEnabled ? 'cloud' : 'azure';
+};
+
 const applyActionExecutionErrorPolicyDecision = (decision: ActionExecutionErrorPolicyDecision) => {
   if (decision.action === 'throw') {
     throw decision.error;
@@ -374,9 +390,7 @@ export class ActionLibrary {
     };
     const onExecutionError = action.onExecutionError ?? defaultActionExecutionErrorPolicy;
     const runtimeLocation = EnvSet.values.isCloud ? 'remote' : 'local';
-    const telemetryRuntimeLocation: ActionRuntimeLocation = EnvSet.values.isCloud
-      ? 'azure'
-      : 'local';
+    const telemetryRuntimeLocation = getTelemetryRuntimeLocation();
     const log = createLog(getActionLogKey(key), { independent: true });
 
     log.append({

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -1,0 +1,132 @@
+import { CustomJwtErrorCode, LogtoJwtTokenKeyType } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+import { ResponseError } from '@withtyped/client';
+
+import type Queries from '#src/tenants/Queries.js';
+import { isAccessDeniedError, parseCustomJwtResponseError } from '#src/utils/custom-jwt/index.js';
+
+import type { CloudConnectionLibrary } from './cloud-connection.js';
+import { JwtCustomizerLibrary } from './jwt-customizer.js';
+import type { LogtoConfigLibrary } from './logto-config.js';
+import type { ScopeLibrary } from './scope.js';
+import type { UserLibrary } from './user.js';
+
+const { jest } = import.meta;
+
+const post = jest.fn();
+
+const library = new JwtCustomizerLibrary(
+  {} as Queries,
+  {} as LogtoConfigLibrary,
+  { getClient: async () => ({ post }) } as unknown as CloudConnectionLibrary,
+  {} as UserLibrary,
+  {} as ScopeLibrary
+);
+
+const payload = Object.freeze({
+  script: 'const getCustomJwtClaims = () => ({ foo: "bar" });',
+  tokenType: LogtoJwtTokenKeyType.AccessToken,
+  token: { sub: 'foo' },
+  context: { user: { id: 'foo' } },
+  environmentVariables: { SECRET: 'secret' },
+});
+
+/** The body `POST /api/services/script-run` returns for a failed run, as withtyped shapes it. */
+const buildScriptFailureResponseError = (
+  status: number,
+  message: string,
+  error: Record<string, unknown>
+) =>
+  new ResponseError(
+    new Response(JSON.stringify({ message, error }), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+  );
+
+describe('JwtCustomizerLibrary.runScriptRemotely', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('runs the script through the Cloud script-run endpoint', async () => {
+    post.mockResolvedValueOnce({ value: { foo: 'bar' } });
+
+    await expect(library.runScriptRemotely(payload)).resolves.toEqual({ foo: 'bar' });
+    expect(post).toHaveBeenCalledWith('/api/services/script-run', {
+      body: {
+        entry: 'getCustomJwtClaims',
+        script: payload.script,
+        // `tokenType` selects the customizer on this side and must not reach the user script.
+        payload: {
+          token: payload.token,
+          context: payload.context,
+          environmentVariables: payload.environmentVariables,
+        },
+      },
+    });
+  });
+
+  it('marks a dry run as a test', async () => {
+    post.mockResolvedValueOnce({ value: {} });
+
+    await library.runScriptRemotely(payload, true);
+    expect(post).toHaveBeenCalledWith('/api/services/script-run', {
+      body: {
+        entry: 'getCustomJwtClaims',
+        script: payload.script,
+        payload: {
+          token: payload.token,
+          context: payload.context,
+          environmentVariables: payload.environmentVariables,
+        },
+        isTest: true,
+      },
+    });
+  });
+
+  it('rejects a returned value that is not a record', async () => {
+    post.mockResolvedValueOnce({ value: 'not a record' });
+
+    await expect(library.runScriptRemotely(payload)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('converts a denial into a recognizable access denied error', async () => {
+    post.mockRejectedValueOnce(
+      buildScriptFailureResponseError(403, 'Nope', { kind: 'denied', name: 'Error' })
+    );
+
+    const error: unknown = await library
+      .runScriptRemotely(payload)
+      .catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(ResponseError);
+    assert(error instanceof ResponseError, new Error('Expected a `ResponseError`'));
+
+    const body = await parseCustomJwtResponseError(error);
+    expect(body.message).toBe('Nope');
+    expect(isAccessDeniedError(body.error)).toBe(true);
+    expect(body.error).toMatchObject({ code: CustomJwtErrorCode.AccessDenied, message: 'Nope' });
+  });
+
+  it.each([
+    ['syntax', 422],
+    ['type', 422],
+    ['timeout', 500],
+    ['oom', 500],
+    ['runtime', 500],
+  ])('maps a %s script failure to status %i', async (kind, status) => {
+    post.mockRejectedValueOnce(
+      buildScriptFailureResponseError(status, 'Script failed', { kind, name: 'Error' })
+    );
+
+    await expect(library.runScriptRemotely(payload)).rejects.toMatchObject({ status });
+  });
+
+  it('rethrows a non-script-failure error untouched', async () => {
+    const error = buildScriptFailureResponseError(403, 'Custom JWT is not available.', {});
+    post.mockRejectedValueOnce(error);
+
+    await expect(library.runScriptRemotely(payload)).rejects.toBe(error);
+  });
+});

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -1,7 +1,9 @@
 import { CustomJwtErrorCode, LogtoJwtTokenKeyType } from '@logto/schemas';
 import { assert } from '@silverhand/essentials';
 import { ResponseError } from '@withtyped/client';
+import nock from 'nock';
 
+import { EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import { isAccessDeniedError, parseCustomJwtResponseError } from '#src/utils/custom-jwt/index.js';
 
@@ -44,9 +46,16 @@ const buildScriptFailureResponseError = (
     })
   );
 
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
 describe('JwtCustomizerLibrary.runScriptRemotely', () => {
+  beforeEach(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('runs the script through the Cloud script-run endpoint', async () => {
@@ -128,5 +137,47 @@ describe('JwtCustomizerLibrary.runScriptRemotely', () => {
     post.mockRejectedValueOnce(error);
 
     await expect(library.runScriptRemotely(payload)).rejects.toBe(error);
+  });
+});
+
+describe('JwtCustomizerLibrary.runScriptRemotely without dev features', () => {
+  beforeEach(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  it('runs the script through the regional untrusted Azure Function app when configured', async () => {
+    const endpoint = 'https://untrusted.example.com';
+    const functionKey = 'function-key';
+    const remoteRunner = nock(endpoint, {
+      reqheaders: { 'x-functions-key': functionKey },
+    })
+      .post('/api/custom-jwt')
+      .reply(200, { foo: 'bar' });
+
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+
+    await expect(library.runScriptRemotely(payload)).resolves.toEqual({ foo: 'bar' });
+    expect(remoteRunner.isDone()).toBe(true);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the deprecated custom-jwt cloud endpoint', async () => {
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
+    post.mockResolvedValueOnce({ foo: 'bar' });
+
+    await expect(library.runScriptRemotely(payload, true)).resolves.toEqual({ foo: 'bar' });
+    expect(post).toHaveBeenCalledWith('/api/services/custom-jwt', {
+      body: payload,
+      search: { isTest: 'true' },
+    });
   });
 });

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -101,9 +101,7 @@ describe('JwtCustomizerLibrary.runScriptRemotely', () => {
   });
 
   it('converts a denial into a recognizable access denied error', async () => {
-    post.mockRejectedValueOnce(
-      buildScriptFailureResponseError(403, 'Nope', { kind: 'denied', name: 'Error' })
-    );
+    post.mockRejectedValueOnce(buildScriptFailureResponseError(403, 'Nope', { kind: 'denied' }));
 
     const error: unknown = await library
       .runScriptRemotely(payload)
@@ -125,9 +123,7 @@ describe('JwtCustomizerLibrary.runScriptRemotely', () => {
     ['oom', 500],
     ['runtime', 500],
   ])('maps a %s script failure to status %i', async (kind, status) => {
-    post.mockRejectedValueOnce(
-      buildScriptFailureResponseError(status, 'Script failed', { kind, name: 'Error' })
-    );
+    post.mockRejectedValueOnce(buildScriptFailureResponseError(status, 'Script failed', { kind }));
 
     await expect(library.runScriptRemotely(payload)).rejects.toMatchObject({ status });
   });

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -280,6 +280,14 @@ export class JwtCustomizerLibrary {
    * @params payload.key - The tokenType of the JWT customizer.
    * @params payload.value - JWT customizer value
    * @params payload.useCase - The use case of JWT customizer script, can be either `test` or `production`.
+   *
+   * @remarks
+   * Deliberately left outside the `isDevFeaturesEnabled` gate that {@link runScriptRemotely} is
+   * behind, so this and {@link undeployJwtCustomizerScript} keep the worker service in sync while
+   * the legacy `POST /api/services/custom-jwt` path is still one rollback away from serving
+   * production. The cost is real and accepted: with dev features on and no Azure app configured,
+   * every save, delete and Console "test" still pays a deploy whose result the script run no
+   * longer reads. Both come out with the legacy paths in LOG-13958.
    */
   async deployJwtCustomizerScript<T extends LogtoJwtTokenKey>(
     consoleLog: ConsoleLog,

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- The legacy `node:vm` and Azure Functions paths coexist with the script-runner adapters until LOG-13956 and LOG-13958 remove them. */
 import {
   type CustomJwtErrorBody,
   CustomJwtErrorCode,
@@ -12,6 +13,7 @@ import {
   type LogtoJwtTokenKey,
   type CustomJwtApiContext,
   type CustomJwtScriptPayload,
+  jsonObjectGuard,
   isBuiltInApplicationId,
   buildBuiltInApplicationDataForTenant,
 } from '@logto/schemas';
@@ -25,6 +27,7 @@ import {
   trySafe,
 } from '@silverhand/essentials';
 import deepmerge from 'deepmerge';
+import { got, HTTPError } from 'got';
 import { type UnknownObject } from 'oidc-provider';
 import { ZodError, z } from 'zod';
 
@@ -37,6 +40,7 @@ import type Queries from '#src/tenants/Queries.js';
 import {
   getJwtCustomizerScripts,
   type CustomJwtDeployRequestBody,
+  parseAzureFunctionsResponseError,
 } from '#src/utils/custom-jwt/index.js';
 import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
@@ -383,6 +387,12 @@ export class JwtCustomizerLibrary {
     payload: CustomJwtFetcher,
     isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
+    // TODO (LOG-13958): drop the legacy remote paths and the gate once the Cloud script runner
+    // has been manually verified and released.
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return this.runScriptOnLegacyRuntime(payload, isTest);
+    }
+
     /**
      * `api` is not part of the payload — it carries a function and cannot travel over the wire.
      * The runner merges it in inside the isolate and reports a denial as a `denied` failure,
@@ -391,6 +401,48 @@ export class JwtCustomizerLibrary {
     const value = await this.postScriptRun(payload, isTest);
 
     return JwtCustomizerLibrary.parseScriptResultValue(value);
+  }
+
+  /**
+   * The pre-script-runner remote paths, still serving production until the gate above lifts:
+   * the regional untrusted Azure Function app where configured, otherwise the deprecated
+   * `POST /api/services/custom-jwt` cloud endpoint.
+   */
+  private async runScriptOnLegacyRuntime(
+    payload: CustomJwtFetcher,
+    isTest?: boolean
+  ): Promise<Optional<UnknownObject>> {
+    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
+
+    if (this.isRegionalAzureFunctionAppConfigured) {
+      try {
+        const result = await got
+          .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
+            json: payload,
+            headers: {
+              'x-functions-key': azureFunctionUntrustedAppKey,
+            },
+          })
+          .json<unknown>();
+
+        const parsedResult = jsonObjectGuard.parse(result);
+        return parsedResult;
+      } catch (error: unknown) {
+        // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
+        if (error instanceof HTTPError) {
+          throw parseAzureFunctionsResponseError(error);
+        }
+
+        throw error;
+      }
+    }
+
+    // Fallback to use cloud connection to call the custom JWT API.
+    const client = await this.cloudConnection.getClient();
+    return client.post(`/api/services/custom-jwt`, {
+      body: payload,
+      search: isTest ? { isTest: 'true' } : {},
+    });
   }
 
   /**
@@ -419,3 +471,4 @@ export class JwtCustomizerLibrary {
     }
   }
 }
+/* eslint-enable max-lines */

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- The legacy `node:vm` path coexists with the worker-pool adapter until LOG-13956 removes it. */
 import {
   type CustomJwtErrorBody,
   CustomJwtErrorCode,
@@ -13,7 +12,6 @@ import {
   type LogtoJwtTokenKey,
   type CustomJwtApiContext,
   type CustomJwtScriptPayload,
-  jsonObjectGuard,
   isBuiltInApplicationId,
   buildBuiltInApplicationDataForTenant,
 } from '@logto/schemas';
@@ -27,7 +25,6 @@ import {
   trySafe,
 } from '@silverhand/essentials';
 import deepmerge from 'deepmerge';
-import { got, HTTPError } from 'got';
 import { type UnknownObject } from 'oidc-provider';
 import { ZodError, z } from 'zod';
 
@@ -40,34 +37,41 @@ import type Queries from '#src/tenants/Queries.js';
 import {
   getJwtCustomizerScripts,
   type CustomJwtDeployRequestBody,
-  parseAzureFunctionsResponseError,
 } from '#src/utils/custom-jwt/index.js';
 import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
 import {
+  buildCloudScriptFailureError,
   buildScriptExecutionErrorBody,
   buildScriptFailureError,
   getScriptFailureStatusCode,
+  parseCloudScriptFailure,
+  runScriptOnCloud,
   runScriptOnWorkerPool,
   ScriptExecutionError,
   scriptFailureStatusCodes,
 } from './script-runner/index.js';
 
+/**
+ * The error a denial (`api.denyAccess()`) leaves the library as, on every runtime.
+ *
+ * The `CustomJwtErrorBody` under `error` is what makes the denial recognizable downstream
+ * (`isAccessDeniedError`), which is why a `denied` failure never goes through the generic
+ * failure-to-error mapping.
+ */
+const buildAccessDeniedError = (message: string) => {
+  const error: CustomJwtErrorBody = {
+    code: CustomJwtErrorCode.AccessDenied,
+    message,
+  };
+
+  return new ScriptExecutionError({ message, error }, scriptFailureStatusCodes.denied);
+};
+
 const apiContext: CustomJwtApiContext = Object.freeze({
   denyAccess: (message = 'Access denied') => {
-    const error: CustomJwtErrorBody = {
-      code: CustomJwtErrorCode.AccessDenied,
-      message,
-    };
-
-    throw new ScriptExecutionError(
-      {
-        message,
-        error,
-      },
-      scriptFailureStatusCodes.denied
-    );
+    throw buildAccessDeniedError(message);
   },
 });
 
@@ -100,23 +104,23 @@ export class JwtCustomizerLibrary {
 
     if (!result.ok) {
       if (result.kind === 'denied') {
-        const error: CustomJwtErrorBody = {
-          code: CustomJwtErrorCode.AccessDenied,
-          message: result.message,
-        };
-
-        throw new ScriptExecutionError(
-          { message: result.message, error },
-          scriptFailureStatusCodes.denied
-        );
+        throw buildAccessDeniedError(result.message);
       }
 
       throw buildScriptFailureError(result);
     }
 
-    // If the returned value is not a record, we cannot merge it to the existing token payload.
-    // This is call-site validation of a successful run, not a runner failure — it keeps the 400.
-    const parsed = z.record(z.unknown()).safeParse(result.value);
+    return JwtCustomizerLibrary.parseScriptResultValue(result.value);
+  }
+
+  /**
+   * Validate the value a successful run returned.
+   *
+   * If it is not a record, we cannot merge it to the existing token payload. This is call-site
+   * validation of a successful run, not a runner failure — it keeps the 400.
+   */
+  private static parseScriptResultValue(value: unknown) {
+    const parsed = z.record(z.unknown()).safeParse(value);
 
     if (!parsed.success) {
       throw new ScriptExecutionError(
@@ -379,37 +383,39 @@ export class JwtCustomizerLibrary {
     payload: CustomJwtFetcher,
     isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
-    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
+    /**
+     * `api` is not part of the payload — it carries a function and cannot travel over the wire.
+     * The runner merges it in inside the isolate and reports a denial as a `denied` failure,
+     * exactly like the worker-thread runner does.
+     */
+    const value = await this.postScriptRun(payload, isTest);
 
-    if (this.isRegionalAzureFunctionAppConfigured) {
-      try {
-        const result = await got
-          .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
-            json: payload,
-            headers: {
-              'x-functions-key': azureFunctionUntrustedAppKey,
-            },
-          })
-          .json<unknown>();
+    return JwtCustomizerLibrary.parseScriptResultValue(value);
+  }
 
-        const parsedResult = jsonObjectGuard.parse(result);
-        return parsedResult;
-      } catch (error: unknown) {
-        // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
-        if (error instanceof HTTPError) {
-          throw parseAzureFunctionsResponseError(error);
-        }
+  /**
+   * Post the run to the Cloud script runner, mapping a script failure onto the same
+   * `ScriptExecutionError` the local runners produce.
+   */
+  private async postScriptRun(payload: CustomJwtFetcher, isTest?: boolean): Promise<unknown> {
+    try {
+      return await runScriptOnCloud({
+        cloudConnection: this.cloudConnection,
+        script: payload.script,
+        entry: 'getCustomJwtClaims',
+        payload: pick(payload, 'token', 'context', 'environmentVariables'),
+        isTest,
+      });
+    } catch (error: unknown) {
+      const failure = await parseCloudScriptFailure(error);
 
+      if (!failure) {
         throw error;
       }
-    }
 
-    // Fallback to use cloud connection to call the custom JWT API.
-    const client = await this.cloudConnection.getClient();
-    return client.post(`/api/services/custom-jwt`, {
-      body: payload,
-      search: isTest ? { isTest: 'true' } : {},
-    });
+      throw failure.kind === 'denied'
+        ? buildAccessDeniedError(failure.message)
+        : buildCloudScriptFailureError(failure);
+    }
   }
 }
-/* eslint-enable max-lines */

--- a/packages/core/src/libraries/script-runner/cloud.test.ts
+++ b/packages/core/src/libraries/script-runner/cloud.test.ts
@@ -1,0 +1,77 @@
+import { type CloudConnectionLibrary } from '../cloud-connection.js';
+
+import { runScriptOnCloud } from './cloud.js';
+
+const { jest } = import.meta;
+
+const post = jest.fn();
+
+const cloudConnection = {
+  getClient: async () => ({ post }),
+} as unknown as CloudConnectionLibrary;
+
+/**
+ * Let the `await cloudConnection.getClient()` hop settle so the deadline timer is armed. Enough
+ * microtask hops to cover the awaits `runScriptOnCloud` takes before `setTimeout` runs.
+ */
+const flushMicrotasks = async (hops = 5): Promise<void> => {
+  if (hops === 0) {
+    return;
+  }
+
+  await Promise.resolve();
+
+  return flushMicrotasks(hops - 1);
+};
+
+const run = async () =>
+  runScriptOnCloud({
+    cloudConnection,
+    script: 'const runAction = () => ({ action: "continue" });',
+    entry: 'runAction',
+    payload: {},
+  });
+
+describe('runScriptOnCloud', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('unwraps the value envelope', async () => {
+    post.mockResolvedValueOnce({ value: { action: 'continue' } });
+
+    await expect(run()).resolves.toEqual({ action: 'continue' });
+  });
+
+  it('tolerates a body-less response instead of throwing on the destructure', async () => {
+    // The withtyped client returns `undefined` for a 204 whatever the route declares.
+    // eslint-disable-next-line unicorn/no-useless-undefined -- That `undefined` is the case under test.
+    post.mockResolvedValueOnce(undefined);
+
+    await expect(run()).resolves.toBeUndefined();
+  });
+
+  it('rejects with a timeout error when the request never settles', async () => {
+    jest.useFakeTimers();
+    // eslint-disable-next-line @typescript-eslint/no-empty-function -- A request that never settles is the case under test.
+    post.mockReturnValueOnce(new Promise(() => {}));
+
+    const result = run();
+    // Attach the assertion before advancing so the rejection is never unhandled.
+    const expectation = expect(result).rejects.toMatchObject({ status: 500 });
+
+    await flushMicrotasks();
+    expect(jest.getTimerCount()).toBe(1);
+    jest.advanceTimersByTime(10_000);
+    await expectation;
+  });
+
+  it('does not leave a pending timer behind on a settled request', async () => {
+    jest.useFakeTimers();
+    post.mockResolvedValueOnce({ value: 'done' });
+
+    await expect(run()).resolves.toBe('done');
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/core/src/libraries/script-runner/cloud.test.ts
+++ b/packages/core/src/libraries/script-runner/cloud.test.ts
@@ -63,7 +63,7 @@ describe('runScriptOnCloud', () => {
 
     await flushMicrotasks();
     expect(jest.getTimerCount()).toBe(1);
-    jest.advanceTimersByTime(10_000);
+    jest.advanceTimersByTime(5000);
     await expectation;
   });
 

--- a/packages/core/src/libraries/script-runner/cloud.ts
+++ b/packages/core/src/libraries/script-runner/cloud.ts
@@ -10,6 +10,51 @@ import { type ScriptEntry, type ScriptResult } from './types.js';
 type ScriptFailureKind = Extract<ScriptResult, { ok: false }>['kind'];
 
 /**
+ * Host-side deadline for the whole `POST /api/services/script-run` round trip.
+ *
+ * The runner owns the per-isolate budget, but that bound stops at the isolate: the withtyped
+ * client calls bare `fetch` with no `signal`, so without a deadline here a hung request is left
+ * to undici's 300s defaults — on `PostSignIn` / `PostFirstFactorVerification` that hangs sign-in
+ * inline, and `onExecutionError: 'allow'` cannot rescue a call that never returns.
+ *
+ * Set above the runner's own wall clock (the 5s `ossScriptLimits` grants locally) so a slow script
+ * hits that bound and reports a real `timeout`, leaving this to fire only when the hop itself is
+ * stuck. Racing does not cancel the underlying request — the runner still finishes and drops the
+ * response — which is fine: the run is bounded on its side, and it is the caller that must stop
+ * waiting.
+ */
+const cloudScriptRunTimeout = 10_000;
+
+/**
+ * Bound `run` at {@link cloudScriptRunTimeout}, rejecting with the 500 `ScriptExecutionError` a
+ * runner-side `timeout` produces so route-level handling stays identical.
+ */
+const withCloudScriptRunTimeout = async <T>(run: Promise<T>): Promise<T> => {
+  // Node keeps the process alive for a pending timer, so the timeout must be cleared either way.
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let timer: Optional<NodeJS.Timeout>;
+
+  try {
+    return await Promise.race([
+      run,
+      new Promise<never>((_resolve, reject) => {
+        // eslint-disable-next-line @silverhand/fp/no-mutation
+        timer = setTimeout(() => {
+          reject(
+            new ScriptExecutionError(
+              { message: `Script execution timed out after ${cloudScriptRunTimeout}ms.` },
+              scriptFailureStatusCodes.timeout
+            )
+          );
+        }, cloudScriptRunTimeout);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/**
  * The failure body `POST /api/services/script-run` returns, i.e. `ScriptFailureBody` in
  * `@logto/cloud-models`.
  *
@@ -25,8 +70,6 @@ const cloudScriptFailureBodyGuard = z.object({
   message: z.string(),
   error: z.object({
     kind: z.enum(['denied', 'timeout', 'oom', 'syntax', 'type', 'runtime']),
-    /** The original error constructor name. Always present for `runtime`. */
-    name: z.string().optional(),
     /** Absent for `denied`; redacted for every other kind. */
     stack: z.string().optional(),
   }),
@@ -36,7 +79,6 @@ const cloudScriptFailureBodyGuard = z.object({
 export type CloudScriptFailure = {
   kind: ScriptFailureKind;
   message: string;
-  name?: string;
   stack?: string;
 };
 
@@ -51,7 +93,10 @@ export type CloudScriptFailure = {
  * any override to its ceiling, so duplicating a budget here would only let the two drift apart.
  *
  * Failures come back as a non-2xx and therefore as a withtyped `ResponseError`; pair this with
- * {@link parseCloudScriptFailure} to recover the failure kind.
+ * {@link parseCloudScriptFailure} to recover the failure kind. A breach of
+ * {@link cloudScriptRunTimeout} is not one of them — it is a transport failure, so it throws the
+ * same 500 `ScriptExecutionError` a runner-side `timeout` maps to and never parses as a script
+ * failure.
  */
 export const runScriptOnCloud = async ({
   cloudConnection,
@@ -70,10 +115,18 @@ export const runScriptOnCloud = async ({
   /**
    * The script's return value travels enveloped: the transport layer drops a falsy top-level
    * JSON body entirely, and `null` is the outcome of any script without a return statement.
+   *
+   * `?? {}` covers a 204, for which the withtyped client returns `undefined` whatever the route
+   * declares — unreachable today given the response guard, but a bare destructure would throw a
+   * `TypeError` before any caller could map it.
    */
-  const { value } = await client.post('/api/services/script-run', {
-    body: { ...input, ...conditional(isTest && { isTest }) },
-  });
+  const { value } =
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- The route type says non-nullable; the client returns `undefined` for a 204 regardless.
+    (await withCloudScriptRunTimeout(
+      client.post('/api/services/script-run', {
+        body: { ...input, ...conditional(isTest && { isTest }) },
+      })
+    )) ?? {};
 
   return value;
 };
@@ -101,13 +154,12 @@ export const parseCloudScriptFailure = async (
 
   const {
     message,
-    error: { kind, name, stack },
+    error: { kind, stack },
   } = result.data;
 
   return {
     kind,
     message,
-    ...conditional(name !== undefined && { name }),
     ...conditional(stack !== undefined && { stack }),
   };
 };

--- a/packages/core/src/libraries/script-runner/cloud.ts
+++ b/packages/core/src/libraries/script-runner/cloud.ts
@@ -17,13 +17,21 @@ type ScriptFailureKind = Extract<ScriptResult, { ok: false }>['kind'];
  * to undici's 300s defaults — on `PostSignIn` / `PostFirstFactorVerification` that hangs sign-in
  * inline, and `onExecutionError: 'allow'` cannot rescue a call that never returns.
  *
- * Set above the runner's own wall clock (the 5s `ossScriptLimits` grants locally) so a slow script
- * hits that bound and reports a real `timeout`, leaving this to fire only when the hop itself is
- * stuck. Racing does not cancel the underlying request — the runner still finishes and drops the
- * response — which is fine: the run is bounded on its side, and it is the caller that must stop
- * waiting.
+ * The value is a ceiling on how long core is willing to block, not an inference about the runner:
+ * core can neither read nor set the per-isolate budget (the route body takes `cpuMs` and
+ * `subRequests` only). 5s is the ceiling every other script path already carries — what the Azure
+ * hop bounded (`remoteActionRequestTimeout`) and what a local run gets (`ossScriptLimits`) — so a
+ * script blocks sign-in for the same time wherever it runs.
+ *
+ * Should the runner's own budget reach this, the two race and a runner-side breach can surface as
+ * this timeout instead of the runner's `timeout`, losing its message. That is the accepted trade:
+ * the failure is a timeout either way, and no script may hold sign-in longer than the ceiling.
+ * Keeping the isolate budget below it keeps the runner's own report the one that wins.
+ *
+ * Racing does not cancel the underlying request — the runner still finishes and drops the response
+ * — which is fine: the run is bounded on its side, and it is the caller that must stop waiting.
  */
-const cloudScriptRunTimeout = 10_000;
+const cloudScriptRunTimeout = 5000;
 
 /**
  * Bound `run` at {@link cloudScriptRunTimeout}, rejecting with the 500 `ScriptExecutionError` a

--- a/packages/core/src/libraries/script-runner/cloud.ts
+++ b/packages/core/src/libraries/script-runner/cloud.ts
@@ -1,0 +1,135 @@
+import { conditional, type Optional, trySafe } from '@silverhand/essentials';
+import { ResponseError } from '@withtyped/client';
+import { z } from 'zod';
+
+import { type CloudConnectionLibrary } from '../cloud-connection.js';
+
+import { ScriptExecutionError, scriptFailureStatusCodes } from './errors.js';
+import { type ScriptEntry, type ScriptResult } from './types.js';
+
+type ScriptFailureKind = Extract<ScriptResult, { ok: false }>['kind'];
+
+/**
+ * The failure body `POST /api/services/script-run` returns, i.e. `ScriptFailureBody` in
+ * `@logto/cloud-models`.
+ *
+ * Redeclared here rather than imported: `@logto/cloud` only ships its route types, so the shared
+ * guard itself never reaches core. Indexing {@link scriptFailureStatusCodes} with the parsed
+ * `kind` below keeps the two lists from drifting apart in the direction that matters — a kind
+ * Cloud can send but core does not know about would not compile.
+ *
+ * The status alone cannot reconstruct the failure (`timeout`, `oom` and `runtime` all map to
+ * 500), so `kind` is read from the body rather than inferred.
+ */
+const cloudScriptFailureBodyGuard = z.object({
+  message: z.string(),
+  error: z.object({
+    kind: z.enum(['denied', 'timeout', 'oom', 'syntax', 'type', 'runtime']),
+    /** The original error constructor name. Always present for `runtime`. */
+    name: z.string().optional(),
+    /** Absent for `denied`; redacted for every other kind. */
+    stack: z.string().optional(),
+  }),
+});
+
+/** A script failure reported by the Cloud runner, flattened out of its wire envelope. */
+export type CloudScriptFailure = {
+  kind: ScriptFailureKind;
+  message: string;
+  name?: string;
+  stack?: string;
+};
+
+/**
+ * Run a user script on the Cloud script runner.
+ *
+ * The Cloud counterpart of {@link runScriptOnWorkerPool}, shared by Custom JWT and Actions:
+ * `entry` selects which authoring contract the runner invokes, and `payload` must carry exactly
+ * what that entry promises — anything extra becomes a visible field of the script's argument.
+ *
+ * `limits` is deliberately not sent. The runner applies its own per-isolate defaults and clamps
+ * any override to its ceiling, so duplicating a budget here would only let the two drift apart.
+ *
+ * Failures come back as a non-2xx and therefore as a withtyped `ResponseError`; pair this with
+ * {@link parseCloudScriptFailure} to recover the failure kind.
+ */
+export const runScriptOnCloud = async ({
+  cloudConnection,
+  isTest,
+  ...input
+}: {
+  cloudConnection: CloudConnectionLibrary;
+  script: string;
+  entry: ScriptEntry;
+  payload: Record<string, unknown>;
+  /** Whether this is a dry run (Console "test" / the Management API test routes). */
+  isTest?: boolean;
+}): Promise<unknown> => {
+  const client = await cloudConnection.getClient();
+
+  /**
+   * The script's return value travels enveloped: the transport layer drops a falsy top-level
+   * JSON body entirely, and `null` is the outcome of any script without a return statement.
+   */
+  const { value } = await client.post('/api/services/script-run', {
+    body: { ...input, ...conditional(isTest && { isTest }) },
+  });
+
+  return value;
+};
+
+/**
+ * Recover the {@link CloudScriptFailure} a Cloud script-run error carries.
+ *
+ * Returns `undefined` for anything that is not a script failure — transport errors, a quota 403,
+ * a runner-side 500 — which the caller must rethrow untouched.
+ */
+export const parseCloudScriptFailure = async (
+  error: unknown
+): Promise<Optional<CloudScriptFailure>> => {
+  if (!(error instanceof ResponseError)) {
+    return;
+  }
+
+  // Clone: the caller rethrows the original error on a parse miss, and its body must stay unread.
+  const body = await trySafe<unknown>(async () => error.response.clone().json());
+  const result = cloudScriptFailureBodyGuard.safeParse(body);
+
+  if (!result.success) {
+    return;
+  }
+
+  const {
+    message,
+    error: { kind, name, stack },
+  } = result.data;
+
+  return {
+    kind,
+    message,
+    ...conditional(name !== undefined && { name }),
+    ...conditional(stack !== undefined && { stack }),
+  };
+};
+
+/**
+ * Convert a Cloud script failure into the {@link ScriptExecutionError} the routes already handle,
+ * with the status pinned by {@link scriptFailureStatusCodes} — the same mapping the local runners
+ * produce, so route-level handling never branches on where the script ran.
+ *
+ * Unlike {@link buildScriptFailureError}, no message is synthesized for `timeout` and `oom`: the
+ * Cloud runner always names the failure itself.
+ *
+ * A `denied` failure needs the call site's own error body (Custom JWT attaches a
+ * `CustomJwtErrorBody` so the denial is recognizable downstream), so callers that support
+ * `api.denyAccess()` must intercept that kind before reaching here.
+ */
+export const buildCloudScriptFailureError = ({
+  kind,
+  message,
+  stack,
+}: CloudScriptFailure): ScriptExecutionError =>
+  new ScriptExecutionError(
+    { message, ...conditional(stack !== undefined && { stack }) },
+    scriptFailureStatusCodes[kind]
+  );

--- a/packages/core/src/libraries/script-runner/index.ts
+++ b/packages/core/src/libraries/script-runner/index.ts
@@ -1,3 +1,4 @@
+export * from './cloud.js';
 export * from './errors.js';
 export * from './run.js';
 export * from './types.js';

--- a/packages/core/src/routes/logto-config/action.ts
+++ b/packages/core/src/routes/logto-config/action.ts
@@ -84,8 +84,9 @@ export default function logtoConfigActionRoutes<T extends ManagementApiRouter>(
       const { body } = ctx.guard;
 
       try {
-        // Share the same Cloud/local execution selection as production `runAction()`.
-        const result = await libraries.actions.executeScript(body);
+        // Share the same Cloud/local execution selection as production `runAction()`, flagged as
+        // a dry run so the Cloud runner does not account for it as production traffic.
+        const result = await libraries.actions.executeScript({ ...body, isTest: true });
 
         if (result === undefined) {
           ctx.status = 204;

--- a/packages/core/src/routes/logto-config/jwt-customizer.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.ts
@@ -249,8 +249,8 @@ export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRo
         /**
          * Both execution paths surface failures as a withtyped `ResponseError`:
          *
-         * - Remote runs convert the Azure Functions `HTTPError` via `parseAzureFunctionsResponseError`,
-         *   and the cloud connection client throws `ResponseError` directly.
+         * - Remote runs map the Cloud script-run failure onto a `ScriptExecutionError`, and any
+         *   other cloud connection failure throws `ResponseError` directly.
          * - Local runs throw `ScriptExecutionError`, which extends `ResponseError`.
          *
          * In the admin console, we caught the error and recognized the error with the code `jwt_customizer.general`,

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -34,7 +34,13 @@ export default class Libraries {
   users = createUserLibrary(this.tenantId, this.queries);
   phrases = createPhraseLibrary(this.queries);
   hooks = createHookLibrary(this.queries);
-  actions = new ActionLibrary(this.tenantId, this.logtoConfigs, this.subscription);
+  actions = new ActionLibrary(
+    this.tenantId,
+    this.logtoConfigs,
+    this.subscription,
+    this.cloudConnection
+  );
+
   scopes = createScopeLibrary(this.queries);
   socials = createSocialLibrary(this.queries, this.connectors);
   jwtCustomizers = new JwtCustomizerLibrary(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4303,8 +4303,8 @@ importers:
         version: 3.24.3
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-a4e30ff
-        version: 0.2.5-a4e30ff(zod@3.24.3)
+        specifier: 0.2.5-db73b11
+        version: 0.2.5-db73b11(zod@3.24.3)
       '@silverhand/eslint-config':
         specifier: 6.0.1
         version: 6.0.1(eslint@8.57.0)(prettier@3.5.3)(typescript@5.5.3)
@@ -6579,6 +6579,10 @@ packages:
 
   '@logto/cloud@0.2.5-a4e30ff':
     resolution: {integrity: sha512-jsYbimDtlLdNNHTQNmrMMC1iGL2YT+aqTHHda76OHJnHZnBxnkC+jNNdnjPnktMehMtW2Co8wAA0JM0F4UogFQ==}
+    engines: {node: ^22.14.0}
+
+  '@logto/cloud@0.2.5-db73b11':
+    resolution: {integrity: sha512-mVVJRdZKE9+9T9pN6tNI+BAV/DIafwOGTAK+GV/6HM2aXnwQ3IYcjLuvQsuTTnLuCuU2dXUhHwhYdCRljxyeLg==}
     engines: {node: ^22.14.0}
 
   '@logto/js@5.1.0':
@@ -17911,6 +17915,13 @@ snapshots:
       jose: 5.9.6
 
   '@logto/cloud@0.2.5-a4e30ff(zod@3.24.3)':
+    dependencies:
+      '@silverhand/essentials': 2.9.3
+      '@withtyped/server': 0.14.0(zod@3.24.3)
+    transitivePeerDependencies:
+      - zod
+
+  '@logto/cloud@0.2.5-db73b11(zod@3.24.3)':
     dependencies:
       '@silverhand/essentials': 2.9.3
       '@withtyped/server': 0.14.0(zod@3.24.3)


### PR DESCRIPTION
Closes LOG-13954.

Routes the Cloud execution paths of Custom JWT and Actions through `POST /api/services/script-run`, **behind `isDevFeaturesEnabled`** (cloud side landed in logto-io/cloud#2057 / #2059, published as `@logto/cloud@0.2.5-db73b11`).

With dev features off, both libraries keep exactly their previous behavior: the untrusted Azure Function app where configured, and for Custom JWT the `POST /api/services/custom-jwt` fallback otherwise. This mirrors how the worker-thread runner is gated for OSS (LOG-13956) — the gate and the legacy paths come out together in LOG-13958.

## What changed

- **New `script-runner/cloud.ts`** — the Cloud counterpart of `runScriptOnWorkerPool`. Posts `{ entry, script, payload, isTest? }`, unwraps the `{ value }` envelope, and maps a `ScriptFailure` back onto the same `ScriptExecutionError` the local runners produce (`denied` → 403, `syntax`/`type` → 422, `timeout`/`oom`/`runtime` → 500). Anything that is not a recognizable script failure — a quota 403, a transport error, a runner-side 500 — is rethrown untouched.
- **`JwtCustomizerLibrary.runScriptRemotely`** — on the new path, `isTest` travels in the body instead of as a search param. A denial keeps carrying its `CustomJwtErrorBody`, so `isAccessDeniedError` downstream still works; the value validation the worker-pool path already did (`z.record` → 400 "Invalid input") is now shared by both runtimes.
- **`ActionLibrary.runScriptRemotely`** — on the new path, stops forwarding `actionType`: it selects the script on this side, and anything in `payload` becomes a visible field of the user script's `runAction` argument. `ActionLibrary` takes a `CloudConnectionLibrary` for this.
- **Actions telemetry** — `runtimeLocation` gains a `cloud` value alongside `azure`, picked by the same gate `runScriptRemotely` branches on, so the share of traffic already on the script runner is readable in the metric during the rollout. The existing `azure` series stays intact rather than being renamed out from under the dashboards; it disappears with the Azure Functions path in LOG-13958.
- `limits` is deliberately not sent — the cloud runner owns the per-isolate budget and clamps any override.

## Notes

- The failure-body guard is redeclared in core rather than imported: `@logto/cloud` only ships its route types, so `@logto/cloud-models`' `scriptFailureBodyGuard` never reaches us. Indexing `scriptFailureStatusCodes` with the parsed `kind` keeps a kind Cloud can send but core doesn't know about from compiling.
- `isRegionalAzureFunctionAppConfigured` stays on both libraries: the legacy paths and the Custom JWT worker deploy/undeploy still use it.

## Testing

- `jwt-customizer.cloud.test.ts` (new) and a rewritten `action.cloud.test.ts` cover both sides of the gate — request shape, the `isTest` flag, per-kind status mapping, the access-denied conversion, non-record return values, pass-through of non-script-failure errors, the `cloud` vs `azure` telemetry label, and that with dev features off the Azure Function / `custom-jwt` paths are still the ones taken.
- Full `@logto/core` suite: 3 failed suites / 24 tests, all `sign-in-experience/guard*`, which fail identically on `master` in this environment (unbuilt local `connectors/*`).