### PR TITLE
refactor(schemas): enforce one organization per cimd grant

### DIFF
--- a/packages/schemas/alterations/next-1786373004-tighten-cimd-grant-organizations-pkey.ts
+++ b/packages/schemas/alterations/next-1786373004-tighten-cimd-grant-organizations-pkey.ts
@@ -1,0 +1,28 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+/**
+ * Tighten the `cimd_grant_organizations` primary key to `(tenant_id, grant_id)` so the schema
+ * itself enforces the at-most-one-organization-per-grant invariant that token issuance relies on,
+ * instead of leaving it to the consent flow's composition. The table is dev-feature-gated and
+ * empty in every environment, so swapping the constraint needs no data migration.
+ */
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      alter table cimd_grant_organizations
+        drop constraint cimd_grant_organizations_pkey,
+        add primary key (tenant_id, grant_id);
+    `);
+  },
+  down: async (pool) => {
+    await pool.query(sql`
+      alter table cimd_grant_organizations
+        drop constraint cimd_grant_organizations_pkey,
+        add primary key (tenant_id, grant_id, organization_id);
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/cimd_grant_organizations.sql
+++ b/packages/schemas/tables/cimd_grant_organizations.sql
@@ -16,7 +16,7 @@ create table cimd_grant_organizations (
   organization_id varchar(21) not null,
   /** The user the grant was issued to and the membership FK's target. Must match the Grant payload's `accountId` (unreachable by FK) — the consent write enforces the pairing. */
   user_id varchar(21) not null,
-  primary key (tenant_id, grant_id, organization_id),
+  primary key (tenant_id, grant_id),
   constraint cimd_grant_organizations__grant_model_name
     check (grant_model_name = 'Grant'),
   /** Revoking the grant hard-deletes the Grant row, which erases the organization authorization with it. */


### PR DESCRIPTION
## Summary

Tighten the `cimd_grant_organizations` primary key from `(tenant_id, grant_id, organization_id)` to `(tenant_id, grant_id)` so the database structurally enforces at most one organization per CIMD grant.

- Token issuance relies on this invariant, but it previously rested on the consent-flow composition (a fresh grant per authorization plus the single-organization assert at the write site); now it is structural (from the #9406 / LOG-13930 review round).
- The paired alteration swaps the primary key in place; the table is dev-feature-gated and empty in every environment, so no data migration is involved.
- The composite membership foreign key and its supporting index are untouched.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset` (not needed: dev-feature-gated, no end-user impact)
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments