### PR TITLE
fix(core): retry webhook POST deliveries on HTTP 5xx

### DIFF
--- a/.changeset/webhook-5xx-retry.md
+++ b/.changeset/webhook-5xx-retry.md
@@ -5,3 +5,5 @@
 retry webhook deliveries on HTTP 5xx responses
 
 Webhook POST requests now retry up to 3 times when the endpoint returns any 5xx status, matching the documented delivery contract.
+
+Since retries may deliver the same webhook more than once, webhook receivers should process events idempotently.

--- a/.changeset/webhook-5xx-retry.md
+++ b/.changeset/webhook-5xx-retry.md
@@ -4,4 +4,4 @@
 
 retry webhook deliveries on HTTP 5xx responses
 
-Webhook POST requests now retry up to 3 times when the endpoint returns any 5xx status, matching the documented delivery contract. Previously the retry limit was configured but never applied because the HTTP client skipped POST by default.
+Webhook POST requests now retry up to 3 times when the endpoint returns any 5xx status, matching the documented delivery contract.

--- a/.changeset/webhook-5xx-retry.md
+++ b/.changeset/webhook-5xx-retry.md
@@ -1,0 +1,7 @@
+---
+"@logto/core": patch
+---
+
+retry webhook deliveries on HTTP 5xx responses
+
+Webhook POST requests now retry up to 3 times when the endpoint returns any 5xx status, matching the documented delivery contract. Previously the retry limit was configured but never applied because the HTTP client skipped POST by default.

--- a/packages/core/src/libraries/hook/utils.retry.test.ts
+++ b/packages/core/src/libraries/hook/utils.retry.test.ts
@@ -1,10 +1,23 @@
 /* eslint-disable @silverhand/fp/no-mutation -- local HTTP fixture counters increment per request */
-import { createServer, type Server } from 'node:http';
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
 import { type AddressInfo } from 'node:net';
 
 import { InteractionHookEvent } from '@logto/schemas';
 
 import { generateHookTestPayload, sendWebhookRequest } from './utils.js';
+
+type MockReply =
+  | {
+      status: number;
+      headers?: Record<string, string>;
+      body?: string;
+    }
+  | { reset: true };
+
+type RetryServerFixture = {
+  endpoint: string;
+  getAttempts: () => number;
+};
 
 const listen = async (server: Server) =>
   new Promise<number>((resolve) => {
@@ -24,154 +37,132 @@ const close = async (server: Server) =>
     });
   });
 
-const sendToServer = async (port: number, retries?: number) =>
+const sendToServer = async (endpoint: string, retries?: number) =>
   sendWebhookRequest({
     hookConfig: {
-      url: `http://127.0.0.1:${port}`,
+      url: endpoint,
       retries,
     },
     payload: generateHookTestPayload('hook-id', InteractionHookEvent.PostSignIn),
     signingKey: 'signing-key',
   });
 
+const withRetryServer = async (
+  replyForAttempt: (attempt: number) => MockReply,
+  run: (fixture: RetryServerFixture) => Promise<void>
+) => {
+  const state = { attempts: 0 };
+
+  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+    state.attempts += 1;
+    const reply = replyForAttempt(state.attempts);
+
+    if ('reset' in reply) {
+      request.socket.destroy();
+      return;
+    }
+
+    response.writeHead(reply.status, reply.headers);
+    response.end(reply.body);
+  });
+
+  const port = await listen(server);
+
+  try {
+    await run({
+      endpoint: `http://127.0.0.1:${port}`,
+      getAttempts: () => state.attempts,
+    });
+  } finally {
+    await close(server);
+  }
+};
+
 describe('sendWebhookRequest HTTP retries', () => {
   it.each([500, 501, 599])(
     'retries POST %s responses three times for a total of four attempts',
-    async (statusCode) => {
-      const state = { attempts: 0 };
-      const server = createServer((_request, response) => {
-        state.attempts += 1;
-        response.writeHead(statusCode);
-        response.end();
-      });
-
-      try {
-        const port = await listen(server);
-
-        await expect(sendToServer(port)).rejects.toThrow();
-        expect(state.attempts).toBe(4);
-      } finally {
-        await close(server);
-      }
+    async (status) => {
+      await withRetryServer(
+        () => ({ status }),
+        async ({ endpoint, getAttempts }) => {
+          await expect(sendToServer(endpoint)).rejects.toThrow();
+          expect(getAttempts()).toBe(4);
+        }
+      );
     },
     20_000
   );
 
   it('stops retrying after a successful attempt', async () => {
-    const state = { attempts: 0 };
-    const server = createServer((_request, response) => {
-      state.attempts += 1;
-      if (state.attempts < 3) {
-        response.writeHead(500);
-        response.end();
-        return;
+    await withRetryServer(
+      (attempt) =>
+        attempt < 3
+          ? { status: 500 }
+          : {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+              body: '{"ok":true}',
+            },
+      async ({ endpoint, getAttempts }) => {
+        await expect(sendToServer(endpoint)).resolves.toHaveProperty('status', 200);
+        expect(getAttempts()).toBe(3);
       }
-
-      response.writeHead(200, { 'Content-Type': 'application/json' });
-      response.end('{"ok":true}');
-    });
-
-    try {
-      const port = await listen(server);
-
-      await expect(sendToServer(port)).resolves.toHaveProperty('status', 200);
-      expect(state.attempts).toBe(3);
-    } finally {
-      await close(server);
-    }
+    );
   }, 20_000);
 
   it('does not retry 4xx responses', async () => {
-    const state = { attempts: 0 };
-    const server = createServer((_request, response) => {
-      state.attempts += 1;
-      response.writeHead(400);
-      response.end();
-    });
-
-    try {
-      const port = await listen(server);
-
-      await expect(sendToServer(port)).rejects.toThrow();
-      expect(state.attempts).toBe(1);
-    } finally {
-      await close(server);
-    }
+    await withRetryServer(
+      () => ({ status: 400 }),
+      async ({ endpoint, getAttempts }) => {
+        await expect(sendToServer(endpoint)).rejects.toThrow();
+        expect(getAttempts()).toBe(1);
+      }
+    );
   });
 
   it('does not retry when the connection is reset', async () => {
-    const state = { attempts: 0 };
-    const server = createServer((request) => {
-      state.attempts += 1;
-      request.socket.destroy();
-    });
-
-    try {
-      const port = await listen(server);
-
-      await expect(sendToServer(port)).rejects.toThrow();
-      expect(state.attempts).toBe(1);
-    } finally {
-      await close(server);
-    }
+    await withRetryServer(
+      () => ({ reset: true }),
+      async ({ endpoint, getAttempts }) => {
+        await expect(sendToServer(endpoint)).rejects.toThrow();
+        expect(getAttempts()).toBe(1);
+      }
+    );
   });
 
   it('does not retry when hook config retries is 0', async () => {
-    const state = { attempts: 0 };
-    const server = createServer((_request, response) => {
-      state.attempts += 1;
-      response.writeHead(500);
-      response.end();
-    });
-
-    try {
-      const port = await listen(server);
-
-      await expect(sendToServer(port, 0)).rejects.toThrow();
-      expect(state.attempts).toBe(1);
-    } finally {
-      await close(server);
-    }
+    await withRetryServer(
+      () => ({ status: 500 }),
+      async ({ endpoint, getAttempts }) => {
+        await expect(sendToServer(endpoint, 0)).rejects.toThrow();
+        expect(getAttempts()).toBe(1);
+      }
+    );
   });
 
   it('honors hook config retries when set below the default', async () => {
-    const state = { attempts: 0 };
-    const server = createServer((_request, response) => {
-      state.attempts += 1;
-      response.writeHead(500);
-      response.end();
-    });
-
-    try {
-      const port = await listen(server);
-
-      await expect(sendToServer(port, 1)).rejects.toThrow();
-      expect(state.attempts).toBe(2);
-    } finally {
-      await close(server);
-    }
+    await withRetryServer(
+      () => ({ status: 500 }),
+      async ({ endpoint, getAttempts }) => {
+        await expect(sendToServer(endpoint, 1)).rejects.toThrow();
+        expect(getAttempts()).toBe(2);
+      }
+    );
   }, 20_000);
 
   it.each(['0', '86400'])(
     'retries 503 even when Retry-After is %s',
     async (retryAfter) => {
-      const state = { attempts: 0 };
       const startedAt = Date.now();
-      const server = createServer((_request, response) => {
-        state.attempts += 1;
-        response.writeHead(503, { 'Retry-After': retryAfter });
-        response.end();
-      });
 
-      try {
-        const port = await listen(server);
-
-        await expect(sendToServer(port)).rejects.toThrow();
-        expect(state.attempts).toBe(4);
-        expect(Date.now() - startedAt).toBeLessThan(10_000);
-      } finally {
-        await close(server);
-      }
+      await withRetryServer(
+        () => ({ status: 503, headers: { 'Retry-After': retryAfter } }),
+        async ({ endpoint, getAttempts }) => {
+          await expect(sendToServer(endpoint)).rejects.toThrow();
+          expect(getAttempts()).toBe(4);
+          expect(Date.now() - startedAt).toBeLessThan(10_000);
+        }
+      );
     },
     20_000
   );

--- a/packages/core/src/libraries/hook/utils.retry.test.ts
+++ b/packages/core/src/libraries/hook/utils.retry.test.ts
@@ -1,0 +1,121 @@
+/* eslint-disable @silverhand/fp/no-mutation -- local HTTP fixture counters increment per request */
+import { createServer, type Server } from 'node:http';
+import { type AddressInfo } from 'node:net';
+
+import { InteractionHookEvent } from '@logto/schemas';
+
+import { generateHookTestPayload, sendWebhookRequest } from './utils.js';
+
+const listen = async (server: Server) =>
+  new Promise<number>((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve((server.address() as AddressInfo).port);
+    });
+  });
+
+const close = async (server: Server) =>
+  new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+
+const sendToServer = async (port: number, retries?: number) =>
+  sendWebhookRequest({
+    hookConfig: {
+      url: `http://127.0.0.1:${port}`,
+      retries,
+    },
+    payload: generateHookTestPayload('hook-id', InteractionHookEvent.PostSignIn),
+    signingKey: 'signing-key',
+  });
+
+describe('sendWebhookRequest HTTP retries', () => {
+  it.each([500, 501, 599])(
+    'retries POST %s responses three times for a total of four attempts',
+    async (statusCode) => {
+      const state = { attempts: 0 };
+      const server = createServer((_request, response) => {
+        state.attempts += 1;
+        response.writeHead(statusCode);
+        response.end();
+      });
+
+      try {
+        const port = await listen(server);
+
+        await expect(sendToServer(port)).rejects.toThrow();
+        expect(state.attempts).toBe(4);
+      } finally {
+        await close(server);
+      }
+    },
+    20_000
+  );
+
+  it('stops retrying after a successful attempt', async () => {
+    const state = { attempts: 0 };
+    const server = createServer((_request, response) => {
+      state.attempts += 1;
+      if (state.attempts < 3) {
+        response.writeHead(500);
+        response.end();
+        return;
+      }
+
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end('{"ok":true}');
+    });
+
+    try {
+      const port = await listen(server);
+
+      await expect(sendToServer(port)).resolves.toHaveProperty('status', 200);
+      expect(state.attempts).toBe(3);
+    } finally {
+      await close(server);
+    }
+  }, 20_000);
+
+  it('does not retry 4xx responses', async () => {
+    const state = { attempts: 0 };
+    const server = createServer((_request, response) => {
+      state.attempts += 1;
+      response.writeHead(400);
+      response.end();
+    });
+
+    try {
+      const port = await listen(server);
+
+      await expect(sendToServer(port)).rejects.toThrow();
+      expect(state.attempts).toBe(1);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('ignores deprecated retries config and still retries 5xx three times', async () => {
+    const state = { attempts: 0 };
+    const server = createServer((_request, response) => {
+      state.attempts += 1;
+      response.writeHead(500);
+      response.end();
+    });
+
+    try {
+      const port = await listen(server);
+
+      await expect(sendToServer(port, 0)).rejects.toThrow();
+      expect(state.attempts).toBe(4);
+    } finally {
+      await close(server);
+    }
+  }, 20_000);
+});
+
+/* eslint-enable @silverhand/fp/no-mutation */

--- a/packages/core/src/libraries/hook/utils.retry.test.ts
+++ b/packages/core/src/libraries/hook/utils.retry.test.ts
@@ -99,6 +99,23 @@ describe('sendWebhookRequest HTTP retries', () => {
     }
   });
 
+  it('does not retry when the connection is reset', async () => {
+    const state = { attempts: 0 };
+    const server = createServer((request) => {
+      state.attempts += 1;
+      request.socket.destroy();
+    });
+
+    try {
+      const port = await listen(server);
+
+      await expect(sendToServer(port)).rejects.toThrow();
+      expect(state.attempts).toBe(1);
+    } finally {
+      await close(server);
+    }
+  });
+
   it('does not retry when hook config retries is 0', async () => {
     const state = { attempts: 0 };
     const server = createServer((_request, response) => {

--- a/packages/core/src/libraries/hook/utils.retry.test.ts
+++ b/packages/core/src/libraries/hook/utils.retry.test.ts
@@ -99,7 +99,7 @@ describe('sendWebhookRequest HTTP retries', () => {
     }
   });
 
-  it('ignores deprecated retries config and still retries 5xx three times', async () => {
+  it('does not retry when hook config retries is 0', async () => {
     const state = { attempts: 0 };
     const server = createServer((_request, response) => {
       state.attempts += 1;
@@ -111,7 +111,25 @@ describe('sendWebhookRequest HTTP retries', () => {
       const port = await listen(server);
 
       await expect(sendToServer(port, 0)).rejects.toThrow();
-      expect(state.attempts).toBe(4);
+      expect(state.attempts).toBe(1);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('honors hook config retries when set below the default', async () => {
+    const state = { attempts: 0 };
+    const server = createServer((_request, response) => {
+      state.attempts += 1;
+      response.writeHead(500);
+      response.end();
+    });
+
+    try {
+      const port = await listen(server);
+
+      await expect(sendToServer(port, 1)).rejects.toThrow();
+      expect(state.attempts).toBe(2);
     } finally {
       await close(server);
     }

--- a/packages/core/src/libraries/hook/utils.retry.test.ts
+++ b/packages/core/src/libraries/hook/utils.retry.test.ts
@@ -153,14 +153,11 @@ describe('sendWebhookRequest HTTP retries', () => {
   it.each(['0', '86400'])(
     'retries 503 even when Retry-After is %s',
     async (retryAfter) => {
-      const startedAt = Date.now();
-
       await withRetryServer(
         () => ({ status: 503, headers: { 'Retry-After': retryAfter } }),
         async ({ endpoint, getAttempts }) => {
           await expect(sendToServer(endpoint)).rejects.toThrow();
           expect(getAttempts()).toBe(4);
-          expect(Date.now() - startedAt).toBeLessThan(10_000);
         }
       );
     },

--- a/packages/core/src/libraries/hook/utils.retry.test.ts
+++ b/packages/core/src/libraries/hook/utils.retry.test.ts
@@ -134,6 +134,30 @@ describe('sendWebhookRequest HTTP retries', () => {
       await close(server);
     }
   }, 20_000);
+
+  it.each(['0', '86400'])(
+    'retries 503 even when Retry-After is %s',
+    async (retryAfter) => {
+      const state = { attempts: 0 };
+      const startedAt = Date.now();
+      const server = createServer((_request, response) => {
+        state.attempts += 1;
+        response.writeHead(503, { 'Retry-After': retryAfter });
+        response.end();
+      });
+
+      try {
+        const port = await listen(server);
+
+        await expect(sendToServer(port)).rejects.toThrow();
+        expect(state.attempts).toBe(4);
+        expect(Date.now() - startedAt).toBeLessThan(10_000);
+      } finally {
+        await close(server);
+      }
+    },
+    20_000
+  );
 });
 
 /* eslint-enable @silverhand/fp/no-mutation */

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -48,7 +48,11 @@ describe('sendWebhookRequest', () => {
         'logto-signature-sha-256': mockSignature,
       },
       json: testPayload,
-      retry: { limit: 3 },
+      retry: {
+        limit: 3,
+        methods: ['post'],
+        statusCodes: Array.from({ length: 100 }, (_, index) => 500 + index),
+      },
       timeout: 10_000,
     });
   });

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -21,6 +21,7 @@ const {
   sendWebhookRequest,
   truncateMembershipDelta,
   MEMBERSHIP_DELTA_CAP,
+  rangeInclusive,
 } = await import('./utils.js');
 
 describe('sendWebhookRequest', () => {
@@ -51,8 +52,7 @@ describe('sendWebhookRequest', () => {
       retry: {
         limit: 3,
         methods: ['post'],
-        // Ky requires an explicit list; HTTP 5xx class is 500–599.
-        statusCodes: Array.from({ length: 100 }, (_, index) => 500 + index),
+        statusCodes: rangeInclusive(500, 599),
       },
       timeout: 10_000,
     });
@@ -81,8 +81,7 @@ describe('sendWebhookRequest', () => {
       retry: {
         limit: 1,
         methods: ['post'],
-        // Ky requires an explicit list; HTTP 5xx class is 500–599.
-        statusCodes: Array.from({ length: 100 }, (_, index) => 500 + index),
+        statusCodes: rangeInclusive(500, 599),
       },
       timeout: 10_000,
     });

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -57,6 +57,7 @@ describe('sendWebhookRequest', () => {
       timeout: 10_000,
       hooks: {
         afterResponse: [expect.any(Function)],
+        beforeRetry: [expect.any(Function)],
       },
     });
   });
@@ -89,6 +90,7 @@ describe('sendWebhookRequest', () => {
       timeout: 10_000,
       hooks: {
         afterResponse: [expect.any(Function)],
+        beforeRetry: [expect.any(Function)],
       },
     });
   });

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -4,7 +4,7 @@ import ky from 'ky';
 
 const { jest } = import.meta;
 
-const { mockEsm, mockEsmWithActual } = createMockUtils(jest);
+const { mockEsm } = createMockUtils(jest);
 
 const post = jest
   .spyOn(ky, 'post')
@@ -21,11 +21,10 @@ const {
   sendWebhookRequest,
   truncateMembershipDelta,
   MEMBERSHIP_DELTA_CAP,
-  webhookRetryStatusCodes,
 } = await import('./utils.js');
 
 describe('sendWebhookRequest', () => {
-  it('should call got.post with correct values', async () => {
+  it('sends a signed webhook request with the default retry limit', async () => {
     const mockHookId = 'mockHookId';
     const mockEvent: HookEvent = InteractionHookEvent.PostSignIn;
     const testPayload = generateHookTestPayload(mockHookId, mockEvent);
@@ -42,7 +41,8 @@ describe('sendWebhookRequest', () => {
       signingKey: mockSigningKey,
     });
 
-    expect(post).toBeCalledWith(mockUrl, {
+    expect(post.mock.calls[0]?.[0]).toBe(mockUrl);
+    expect(post.mock.calls[0]?.[1]).toMatchObject({
       headers: {
         'user-agent': 'Logto (https://logto.io/)',
         foo: 'bar',
@@ -52,14 +52,17 @@ describe('sendWebhookRequest', () => {
       retry: {
         limit: 3,
         methods: ['post'],
-        statusCodes: webhookRetryStatusCodes,
       },
       timeout: 10_000,
-      hooks: {
-        afterResponse: [expect.any(Function)],
-        beforeRetry: [expect.any(Function)],
-      },
     });
+    expect(post.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        hooks: {
+          afterResponse: [expect.any(Function)],
+          beforeRetry: [expect.any(Function)],
+        },
+      })
+    );
   });
 
   it('passes hook config retries through to ky', async () => {
@@ -76,7 +79,8 @@ describe('sendWebhookRequest', () => {
       signingKey: 'mockSigningKey',
     });
 
-    expect(post).toHaveBeenLastCalledWith('https://logto.gg', {
+    expect(post.mock.lastCall?.[0]).toBe('https://logto.gg');
+    expect(post.mock.lastCall?.[1]).toMatchObject({
       headers: {
         'user-agent': 'Logto (https://logto.io/)',
         'logto-signature-sha-256': mockSignature,
@@ -85,14 +89,17 @@ describe('sendWebhookRequest', () => {
       retry: {
         limit: 1,
         methods: ['post'],
-        statusCodes: webhookRetryStatusCodes,
       },
       timeout: 10_000,
-      hooks: {
-        afterResponse: [expect.any(Function)],
-        beforeRetry: [expect.any(Function)],
-      },
     });
+    expect(post.mock.lastCall?.[1]).toEqual(
+      expect.objectContaining({
+        hooks: {
+          afterResponse: [expect.any(Function)],
+          beforeRetry: [expect.any(Function)],
+        },
+      })
+    );
   });
 });
 

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -51,6 +51,37 @@ describe('sendWebhookRequest', () => {
       retry: {
         limit: 3,
         methods: ['post'],
+        // Ky requires an explicit list; HTTP 5xx class is 500–599.
+        statusCodes: Array.from({ length: 100 }, (_, index) => 500 + index),
+      },
+      timeout: 10_000,
+    });
+  });
+
+  it('passes hook config retries through to ky', async () => {
+    const mockHookId = 'mockHookId';
+    const mockEvent: HookEvent = InteractionHookEvent.PostSignIn;
+    const testPayload = generateHookTestPayload(mockHookId, mockEvent);
+
+    await sendWebhookRequest({
+      hookConfig: {
+        url: 'https://logto.gg',
+        retries: 1,
+      },
+      payload: testPayload,
+      signingKey: 'mockSigningKey',
+    });
+
+    expect(post).toHaveBeenLastCalledWith('https://logto.gg', {
+      headers: {
+        'user-agent': 'Logto (https://logto.io/)',
+        'logto-signature-sha-256': mockSignature,
+      },
+      json: testPayload,
+      retry: {
+        limit: 1,
+        methods: ['post'],
+        // Ky requires an explicit list; HTTP 5xx class is 500–599.
         statusCodes: Array.from({ length: 100 }, (_, index) => 500 + index),
       },
       timeout: 10_000,

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -21,7 +21,7 @@ const {
   sendWebhookRequest,
   truncateMembershipDelta,
   MEMBERSHIP_DELTA_CAP,
-  rangeInclusive,
+  webhookRetryStatusCodes,
 } = await import('./utils.js');
 
 describe('sendWebhookRequest', () => {
@@ -52,9 +52,12 @@ describe('sendWebhookRequest', () => {
       retry: {
         limit: 3,
         methods: ['post'],
-        statusCodes: rangeInclusive(500, 599),
+        statusCodes: webhookRetryStatusCodes,
       },
       timeout: 10_000,
+      hooks: {
+        afterResponse: [expect.any(Function)],
+      },
     });
   });
 
@@ -81,9 +84,12 @@ describe('sendWebhookRequest', () => {
       retry: {
         limit: 1,
         methods: ['post'],
-        statusCodes: rangeInclusive(500, 599),
+        statusCodes: webhookRetryStatusCodes,
       },
       timeout: 10_000,
+      hooks: {
+        afterResponse: [expect.any(Function)],
+      },
     });
   });
 });

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -33,7 +33,6 @@ type SendWebhookRequest = {
 const rangeInclusive = (start: number, end: number) =>
   Array.from({ length: end - start + 1 }, (_, index) => start + index);
 
-/** Public contract: retry webhook POST on HTTP 5xx. Ky 1.2.3 defaults omit POST and most 5xx codes. */
 const webhookRetryLimit = 3;
 /** Ky only accepts `statusCodes` as a number list; HTTP 5xx class is 500–599. */
 const webhookRetryStatusCodes = rangeInclusive(500, 599);
@@ -57,7 +56,7 @@ const dropRetryAfterHeader = async (
   _options: unknown,
   response: Response
 ): Promise<Response> => {
-  if (!response.headers.has('retry-after')) {
+  if (response.status !== 503 || !response.headers.has('retry-after')) {
     return response;
   }
 
@@ -97,6 +96,8 @@ export const sendWebhookRequest = async ({
       ...conditional(signingKey && { 'logto-signature-sha-256': sign(signingKey, payload) }),
     },
     json: payload,
+    // Public webhook delivery contract: retry POST requests on HTTP 5xx only.
+    // 408 and 429 are intentionally excluded so receivers cannot control this short retry window.
     retry: {
       limit: retries ?? webhookRetryLimit,
       methods: ['post'],

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -11,7 +11,7 @@ import {
 import { conditional, trySafe } from '@silverhand/essentials';
 import { type Context } from 'koa';
 import { type IRouterParamContext } from 'koa-router';
-import ky, { type KyResponse } from 'ky';
+import ky, { HTTPError, type KyResponse } from 'ky';
 
 import { sign } from '#src/utils/sign.js';
 
@@ -71,6 +71,18 @@ const dropRetryAfterHeader = async (
   });
 };
 
+/**
+ * Webhook retry contract is HTTP 5xx only. Ky 1.2.3 retries any non-timeout
+ * error once POST is in `methods`; `statusCodes` only filters HTTPError.
+ * Rethrow network failures so they stay at one attempt. Do not return
+ * `ky.stop` — that resolves the request as success.
+ */
+const abortRetryOnNonHttpError = ({ error }: { error: Error }) => {
+  if (!(error instanceof HTTPError)) {
+    throw error;
+  }
+};
+
 export const sendWebhookRequest = async ({
   hookConfig,
   payload,
@@ -94,6 +106,7 @@ export const sendWebhookRequest = async ({
     timeout: 10_000,
     hooks: {
       afterResponse: [dropRetryAfterHeader],
+      beforeRetry: [abortRetryOnNonHttpError],
     },
   });
 };

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -30,16 +30,20 @@ type SendWebhookRequest = {
   signingKey: string;
 };
 
+const rangeInclusive = (start: number, end: number) =>
+  Array.from({ length: end - start + 1 }, (_, index) => start + index);
+
 /** Public contract: retry webhook POST on HTTP 5xx. Ky 1.2.3 defaults omit POST and most 5xx codes. */
 const webhookRetryLimit = 3;
-const webhookRetryStatusCodes = Array.from({ length: 100 }, (_, index) => 500 + index);
+/** Ky only accepts `statusCodes` as a number list; HTTP 5xx class is 500–599. */
+const webhookRetryStatusCodes = rangeInclusive(500, 599);
 
 export const sendWebhookRequest = async ({
   hookConfig,
   payload,
   signingKey,
 }: SendWebhookRequest) => {
-  const { url, headers } = hookConfig;
+  const { url, headers, retries } = hookConfig;
 
   return ky.post(url, {
     headers: {
@@ -49,7 +53,7 @@ export const sendWebhookRequest = async ({
     },
     json: payload,
     retry: {
-      limit: webhookRetryLimit,
+      limit: retries ?? webhookRetryLimit,
       methods: ['post'],
       statusCodes: webhookRetryStatusCodes,
     },

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -36,7 +36,7 @@ const rangeInclusive = (start: number, end: number) =>
 /** Public contract: retry webhook POST on HTTP 5xx. Ky 1.2.3 defaults omit POST and most 5xx codes. */
 const webhookRetryLimit = 3;
 /** Ky only accepts `statusCodes` as a number list; HTTP 5xx class is 500–599. */
-export const webhookRetryStatusCodes = rangeInclusive(500, 599);
+const webhookRetryStatusCodes = rangeInclusive(500, 599);
 
 /**
  * Ky 1.2.3 always honors `Retry-After` on 503: `afterStatusCodes` is hardcoded to

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -30,13 +30,46 @@ type SendWebhookRequest = {
   signingKey: string;
 };
 
-export const rangeInclusive = (start: number, end: number) =>
+const rangeInclusive = (start: number, end: number) =>
   Array.from({ length: end - start + 1 }, (_, index) => start + index);
 
 /** Public contract: retry webhook POST on HTTP 5xx. Ky 1.2.3 defaults omit POST and most 5xx codes. */
 const webhookRetryLimit = 3;
 /** Ky only accepts `statusCodes` as a number list; HTTP 5xx class is 500–599. */
-const webhookRetryStatusCodes = rangeInclusive(500, 599);
+export const webhookRetryStatusCodes = rangeInclusive(500, 599);
+
+/**
+ * Ky 1.2.3 always honors `Retry-After` on 503: `afterStatusCodes` is hardcoded to
+ * `[413, 429, 503]` and cannot be overridden.
+ * See https://github.com/sindresorhus/ky/issues/473
+ * `timeout` / `backoffLimit` do not cap that delay, and `Retry-After: 0` skips
+ * further attempts (fixed in ky 1.5.0: https://github.com/sindresorhus/ky/pull/604).
+ * Drop the header so webhook 5xx stays on the short in-process backoff.
+ *
+ * Preferred fix after upgrading to ky >= 1.5.0: set `retry.afterStatusCodes: []`
+ * instead of mutating the response.
+ * https://github.com/sindresorhus/ky/releases/tag/v1.5.0
+ * https://github.com/sindresorhus/ky/pull/598
+ * https://github.com/sindresorhus/ky#retry
+ */
+const dropRetryAfterHeader = async (
+  _request: Request,
+  _options: unknown,
+  response: Response
+): Promise<Response> => {
+  if (!response.headers.has('retry-after')) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.delete('retry-after');
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
 
 export const sendWebhookRequest = async ({
   hookConfig,
@@ -56,8 +89,12 @@ export const sendWebhookRequest = async ({
       limit: retries ?? webhookRetryLimit,
       methods: ['post'],
       statusCodes: webhookRetryStatusCodes,
+      // `afterStatusCodes: []` is ignored on ky 1.2.3; see dropRetryAfterHeader.
     },
     timeout: 10_000,
+    hooks: {
+      afterResponse: [dropRetryAfterHeader],
+    },
   });
 };
 

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -30,7 +30,7 @@ type SendWebhookRequest = {
   signingKey: string;
 };
 
-const rangeInclusive = (start: number, end: number) =>
+export const rangeInclusive = (start: number, end: number) =>
   Array.from({ length: end - start + 1 }, (_, index) => start + index);
 
 /** Public contract: retry webhook POST on HTTP 5xx. Ky 1.2.3 defaults omit POST and most 5xx codes. */

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -30,12 +30,16 @@ type SendWebhookRequest = {
   signingKey: string;
 };
 
+/** Public contract: retry webhook POST on HTTP 5xx. Ky 1.2.3 defaults omit POST and most 5xx codes. */
+const webhookRetryLimit = 3;
+const webhookRetryStatusCodes = Array.from({ length: 100 }, (_, index) => 500 + index);
+
 export const sendWebhookRequest = async ({
   hookConfig,
   payload,
   signingKey,
 }: SendWebhookRequest) => {
-  const { url, headers, retries } = hookConfig;
+  const { url, headers } = hookConfig;
 
   return ky.post(url, {
     headers: {
@@ -44,7 +48,11 @@ export const sendWebhookRequest = async ({
       ...conditional(signingKey && { 'logto-signature-sha-256': sign(signingKey, payload) }),
     },
     json: payload,
-    retry: { limit: retries ?? 3 },
+    retry: {
+      limit: webhookRetryLimit,
+      methods: ['post'],
+      statusCodes: webhookRetryStatusCodes,
+    },
     timeout: 10_000,
   });
 };

--- a/packages/integration-tests/src/tests/api/hook/hook.retry.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.retry.test.ts
@@ -37,6 +37,33 @@ describe('webhook delivery retries', () => {
     }
   });
 
+  const triggerRoleCreated = async ({
+    description,
+    expectedLog,
+  }: {
+    description: string;
+    expectedLog: {
+      errorMessage?: string;
+      hookPayload?: Record<string, unknown>;
+    };
+  }) => {
+    const hook = webHookApi.hooks.get(hookName)!;
+    const role = await createRole({ description });
+
+    try {
+      await assertHookLogResult(hook, hookEvent, expectedLog);
+
+      const logs = await getWebhookRecentLogs(
+        hook.id,
+        new URLSearchParams({ logKey: `TriggerHook.${hookEvent}`, page_size: '10' })
+      );
+
+      return { logs };
+    } finally {
+      await deleteRole(role.id);
+    }
+  };
+
   beforeAll(async () => {
     await webhookServer.listen();
   });
@@ -67,23 +94,14 @@ describe('webhook delivery retries', () => {
     async (statusCode) => {
       state.statusCode = statusCode;
 
-      const hook = webHookApi.hooks.get(hookName)!;
-      const role = await createRole({ description: `webhook-retry-${statusCode}` });
-
-      await assertHookLogResult(hook, hookEvent, {
-        errorMessage: String(statusCode),
+      const { logs } = await triggerRoleCreated({
+        description: `webhook-retry-${statusCode}`,
+        expectedLog: { errorMessage: String(statusCode) },
       });
 
-      const logs = await getWebhookRecentLogs(
-        hook.id,
-        new URLSearchParams({ logKey: `TriggerHook.${hookEvent}`, page_size: '10' })
-      );
-
       expect(state.requestCount).toBe(4);
-      expect(logs.filter(({ payload }) => payload.hookId === hook.id)).toHaveLength(1);
+      expect(logs).toHaveLength(1);
       expect(logs[0]?.payload.result).toBe(LogResult.Error);
-
-      await deleteRole(role.id);
     },
     20_000
   );
@@ -92,37 +110,24 @@ describe('webhook delivery retries', () => {
     state.statusCode = 500;
     state.succeedOnAttempt = 3;
 
-    const hook = webHookApi.hooks.get(hookName)!;
-    const role = await createRole({ description: 'webhook-retry-eventual-success' });
-
-    await assertHookLogResult(hook, hookEvent, {
-      hookPayload: { event: hookEvent },
+    const { logs } = await triggerRoleCreated({
+      description: 'webhook-retry-eventual-success',
+      expectedLog: { hookPayload: { event: hookEvent } },
     });
 
-    const logs = await getWebhookRecentLogs(
-      hook.id,
-      new URLSearchParams({ logKey: `TriggerHook.${hookEvent}`, page_size: '10' })
-    );
-
     expect(state.requestCount).toBe(3);
-    expect(logs.filter(({ payload }) => payload.hookId === hook.id)).toHaveLength(1);
-
-    await deleteRole(role.id);
+    expect(logs).toHaveLength(1);
   }, 20_000);
 
   it('does not retry 4xx responses', async () => {
     state.statusCode = 400;
 
-    const hook = webHookApi.hooks.get(hookName)!;
-    const role = await createRole({ description: 'webhook-retry-4xx' });
-
-    await assertHookLogResult(hook, hookEvent, {
-      errorMessage: '400',
+    await triggerRoleCreated({
+      description: 'webhook-retry-4xx',
+      expectedLog: { errorMessage: '400' },
     });
 
     expect(state.requestCount).toBe(1);
-
-    await deleteRole(role.id);
   });
 
   it.each(['0', '86400'])(
@@ -131,25 +136,16 @@ describe('webhook delivery retries', () => {
       state.statusCode = 503;
       state.retryAfter = retryAfter;
 
-      const hook = webHookApi.hooks.get(hookName)!;
       const startedAt = Date.now();
-      const role = await createRole({ description: `webhook-retry-after-${retryAfter}` });
-
-      await assertHookLogResult(hook, hookEvent, {
-        errorMessage: '503',
+      const { logs } = await triggerRoleCreated({
+        description: `webhook-retry-after-${retryAfter}`,
+        expectedLog: { errorMessage: '503' },
       });
 
-      const logs = await getWebhookRecentLogs(
-        hook.id,
-        new URLSearchParams({ logKey: `TriggerHook.${hookEvent}`, page_size: '10' })
-      );
-
       expect(state.requestCount).toBe(4);
-      expect(logs.filter(({ payload }) => payload.hookId === hook.id)).toHaveLength(1);
+      expect(logs).toHaveLength(1);
       expect(logs[0]?.payload.result).toBe(LogResult.Error);
       expect(Date.now() - startedAt).toBeLessThan(10_000);
-
-      await deleteRole(role.id);
     },
     20_000
   );

--- a/packages/integration-tests/src/tests/api/hook/hook.retry.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.retry.test.ts
@@ -16,6 +16,7 @@ const state = {
   requestCount: 0,
   statusCode: 200,
   succeedOnAttempt: Number.POSITIVE_INFINITY,
+  retryAfter: undefined as string | undefined,
 };
 
 describe('webhook delivery retries', () => {
@@ -27,6 +28,11 @@ describe('webhook delivery retries', () => {
 
     if (status >= 400) {
       response.statusCode = status;
+
+      if (state.retryAfter !== undefined) {
+        response.setHeader('Retry-After', state.retryAfter);
+      }
+
       response.end();
     }
   });
@@ -43,6 +49,7 @@ describe('webhook delivery retries', () => {
     state.requestCount = 0;
     state.statusCode = 200;
     state.succeedOnAttempt = Number.POSITIVE_INFINITY;
+    state.retryAfter = undefined;
 
     await webHookApi.create({
       name: hookName,
@@ -117,6 +124,35 @@ describe('webhook delivery retries', () => {
 
     await deleteRole(role.id);
   });
+
+  it.each(['0', '86400'])(
+    'retries POST 503 with Retry-After %s three times and records a single error log',
+    async (retryAfter) => {
+      state.statusCode = 503;
+      state.retryAfter = retryAfter;
+
+      const hook = webHookApi.hooks.get(hookName)!;
+      const startedAt = Date.now();
+      const role = await createRole({ description: `webhook-retry-after-${retryAfter}` });
+
+      await assertHookLogResult(hook, hookEvent, {
+        errorMessage: '503',
+      });
+
+      const logs = await getWebhookRecentLogs(
+        hook.id,
+        new URLSearchParams({ logKey: `TriggerHook.${hookEvent}`, page_size: '10' })
+      );
+
+      expect(state.requestCount).toBe(4);
+      expect(logs.filter(({ payload }) => payload.hookId === hook.id)).toHaveLength(1);
+      expect(logs[0]?.payload.result).toBe(LogResult.Error);
+      expect(Date.now() - startedAt).toBeLessThan(10_000);
+
+      await deleteRole(role.id);
+    },
+    20_000
+  );
 });
 
 /* eslint-enable @silverhand/fp/no-mutation */

--- a/packages/integration-tests/src/tests/api/hook/hook.retry.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.retry.test.ts
@@ -1,0 +1,122 @@
+/* eslint-disable @silverhand/fp/no-mutation -- mock webhook fixture state is updated per request */
+import { LogResult } from '@logto/schemas';
+
+import { getWebhookRecentLogs } from '#src/api/logs.js';
+import { createRole, deleteRole } from '#src/api/role.js';
+import { WebHookApiTest } from '#src/helpers/hook.js';
+
+import WebhookMockServer from './WebhookMockServer.js';
+import { assertHookLogResult } from './utils.js';
+
+const retryPort = 9980;
+const hookName = 'webhookRetryHook';
+const hookEvent = 'Role.Created';
+
+const state = {
+  requestCount: 0,
+  statusCode: 200,
+  succeedOnAttempt: Number.POSITIVE_INFINITY,
+};
+
+describe('webhook delivery retries', () => {
+  const webHookApi = new WebHookApiTest();
+  const webhookServer = new WebhookMockServer(retryPort, (_body, _request, response) => {
+    state.requestCount += 1;
+
+    const status = state.requestCount >= state.succeedOnAttempt ? 200 : state.statusCode;
+
+    if (status >= 400) {
+      response.statusCode = status;
+      response.end();
+    }
+  });
+
+  beforeAll(async () => {
+    await webhookServer.listen();
+  });
+
+  afterAll(async () => {
+    await webhookServer.close();
+  });
+
+  beforeEach(async () => {
+    state.requestCount = 0;
+    state.statusCode = 200;
+    state.succeedOnAttempt = Number.POSITIVE_INFINITY;
+
+    await webHookApi.create({
+      name: hookName,
+      events: [hookEvent],
+      config: { url: webhookServer.endpoint },
+    });
+  });
+
+  afterEach(async () => {
+    await webHookApi.cleanUp();
+  });
+
+  it.each([500, 501, 599])(
+    'retries POST %s responses three times and records a single error log',
+    async (statusCode) => {
+      state.statusCode = statusCode;
+
+      const hook = webHookApi.hooks.get(hookName)!;
+      const role = await createRole({ description: `webhook-retry-${statusCode}` });
+
+      await assertHookLogResult(hook, hookEvent, {
+        errorMessage: String(statusCode),
+      });
+
+      const logs = await getWebhookRecentLogs(
+        hook.id,
+        new URLSearchParams({ logKey: `TriggerHook.${hookEvent}`, page_size: '10' })
+      );
+
+      expect(state.requestCount).toBe(4);
+      expect(logs.filter(({ payload }) => payload.hookId === hook.id)).toHaveLength(1);
+      expect(logs[0]?.payload.result).toBe(LogResult.Error);
+
+      await deleteRole(role.id);
+    },
+    20_000
+  );
+
+  it('stops retrying after a successful attempt and records a single success log', async () => {
+    state.statusCode = 500;
+    state.succeedOnAttempt = 3;
+
+    const hook = webHookApi.hooks.get(hookName)!;
+    const role = await createRole({ description: 'webhook-retry-eventual-success' });
+
+    await assertHookLogResult(hook, hookEvent, {
+      hookPayload: { event: hookEvent },
+    });
+
+    const logs = await getWebhookRecentLogs(
+      hook.id,
+      new URLSearchParams({ logKey: `TriggerHook.${hookEvent}`, page_size: '10' })
+    );
+
+    expect(state.requestCount).toBe(3);
+    expect(logs.filter(({ payload }) => payload.hookId === hook.id)).toHaveLength(1);
+
+    await deleteRole(role.id);
+  }, 20_000);
+
+  it('does not retry 4xx responses', async () => {
+    state.statusCode = 400;
+
+    const hook = webHookApi.hooks.get(hookName)!;
+    const role = await createRole({ description: 'webhook-retry-4xx' });
+
+    await assertHookLogResult(hook, hookEvent, {
+      errorMessage: '400',
+    });
+
+    expect(state.requestCount).toBe(1);
+
+    await deleteRole(role.id);
+  });
+});
+
+/* eslint-enable @silverhand/fp/no-mutation */

--- a/packages/integration-tests/src/tests/api/hook/hook.retry.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.retry.test.ts
@@ -16,7 +16,6 @@ const state = {
   requestCount: 0,
   statusCode: 200,
   succeedOnAttempt: Number.POSITIVE_INFINITY,
-  retryAfter: undefined as string | undefined,
 };
 
 describe('webhook delivery retries', () => {
@@ -28,11 +27,6 @@ describe('webhook delivery retries', () => {
 
     if (status >= 400) {
       response.statusCode = status;
-
-      if (state.retryAfter !== undefined) {
-        response.setHeader('Retry-After', state.retryAfter);
-      }
-
       response.end();
     }
   });
@@ -76,7 +70,6 @@ describe('webhook delivery retries', () => {
     state.requestCount = 0;
     state.statusCode = 200;
     state.succeedOnAttempt = Number.POSITIVE_INFINITY;
-    state.retryAfter = undefined;
 
     await webHookApi.create({
       name: hookName,
@@ -89,22 +82,18 @@ describe('webhook delivery retries', () => {
     await webHookApi.cleanUp();
   });
 
-  it.each([500, 501, 599])(
-    'retries POST %s responses three times and records a single error log',
-    async (statusCode) => {
-      state.statusCode = statusCode;
+  it('retries POST 500 responses three times and records a single error log', async () => {
+    state.statusCode = 500;
 
-      const { logs } = await triggerRoleCreated({
-        description: `webhook-retry-${statusCode}`,
-        expectedLog: { errorMessage: String(statusCode) },
-      });
+    const { logs } = await triggerRoleCreated({
+      description: 'webhook-retry-500',
+      expectedLog: { errorMessage: '500' },
+    });
 
-      expect(state.requestCount).toBe(4);
-      expect(logs).toHaveLength(1);
-      expect(logs[0]?.payload.result).toBe(LogResult.Error);
-    },
-    20_000
-  );
+    expect(state.requestCount).toBe(4);
+    expect(logs).toHaveLength(1);
+    expect(logs[0]?.payload.result).toBe(LogResult.Error);
+  });
 
   it('stops retrying after a successful attempt and records a single success log', async () => {
     state.statusCode = 500;
@@ -117,7 +106,7 @@ describe('webhook delivery retries', () => {
 
     expect(state.requestCount).toBe(3);
     expect(logs).toHaveLength(1);
-  }, 20_000);
+  });
 
   it('does not retry 4xx responses', async () => {
     state.statusCode = 400;
@@ -129,26 +118,6 @@ describe('webhook delivery retries', () => {
 
     expect(state.requestCount).toBe(1);
   });
-
-  it.each(['0', '86400'])(
-    'retries POST 503 with Retry-After %s three times and records a single error log',
-    async (retryAfter) => {
-      state.statusCode = 503;
-      state.retryAfter = retryAfter;
-
-      const startedAt = Date.now();
-      const { logs } = await triggerRoleCreated({
-        description: `webhook-retry-after-${retryAfter}`,
-        expectedLog: { errorMessage: '503' },
-      });
-
-      expect(state.requestCount).toBe(4);
-      expect(logs).toHaveLength(1);
-      expect(logs[0]?.payload.result).toBe(LogResult.Error);
-      expect(Date.now() - startedAt).toBeLessThan(10_000);
-    },
-    20_000
-  );
 });
 
 /* eslint-enable @silverhand/fp/no-mutation */


### PR DESCRIPTION
## Summary

Webhook deliveries configured a Ky retry limit, but POST requests were never retried in practice.

### Background

`sendWebhookRequest` used:

```ts
ky.post(url, {
  retry: { limit: retries ?? 3 },
  timeout: 10_000,
});
```

That looked correct, but Ky 1.2.3 only retries methods in its default allowlist, and **POST is not included**:

> Automatic retries are limited to idempotent HTTP methods... POST requests are excluded from automatic retries by default because they are not idempotent.
>
> Default `methods`: `['get', 'put', 'head', 'delete', 'options', 'trace']`
>
> Source: [Ky `#retry`](https://github.com/sindresorhus/ky#retry)

Even after allowing POST, Ky’s default `statusCodes` only cover a subset of 5xx (`500`, `502`, `503`, `504`, plus some non-5xx codes). Codes such as `501` / `599` still would not retry.

Ky also honors `Retry-After` on 503 by default. On 1.2.3 that list is hardcoded (`afterStatusCodes` cannot be cleared; see [sindresorhus/ky#473](https://github.com/sindresorhus/ky/issues/473)), so `Retry-After: 0` skips further attempts and a large value can stall far beyond the 10s request timeout.

Result: receivers returning `>= 500` got a single attempt, despite the configured/public “retry up to 3 times” behavior.

### Why this change is correct

Retry policy should follow HTTP failure classes, not “retry everything”:

| Response | Meaning | Retry? |
| --- | --- | --- |
| `2xx` | Accepted | No |
| Ordinary `4xx` | Permanent client/receiver rejection (bad URL, auth, gone, etc.) | No |
| `5xx` (`500`–`599`) | Transient server-side failure | Yes |

This matches common webhook sender practice (retry transient server failures; do not retry ordinary client errors). Logto’s current path is a short in-process retry window (up to 3 retries), so it is a good fit for brief 5xx blips, not for durable multi-day delivery. Receivers should not be able to skip or stall that window via `Retry-After`. HTTP `408` and `429` are intentionally excluded from this retry policy; in particular, Logto does not adopt a rate-limiting receiver’s `Retry-After` schedule for this short in-process window.

Retrying non-idempotent POST requests makes webhook delivery at-least-once. Receivers should process webhook events idempotently because the same delivery may arrive more than once.

Ky’s API only accepts `statusCodes` as a `number[]` (no class predicate in 1.2.3), so we generate the HTTP 5xx class with `webhookRetryStatusCodes` (`500`–`599`). That is intentional: HTTP treats unrecognized codes by class (RFC 9110), and real proxies often return non-IANA 5xx values.

Deprecated `config.retries` remains a compatible send input (`0..3`, default `3`).

### Change

In `sendWebhookRequest`:

- `methods: ['post']` so webhook POSTs enter Ky retry
- `statusCodes: webhookRetryStatusCodes` (`500`–`599`) so the full 5xx class retries
- `limit: retries ?? 3` to preserve existing config compatibility
- `afterResponse` drops `Retry-After` so 503 stays on the short in-process backoff. Ky 1.2.3 ignores `afterStatusCodes: []`; the documented alternative is ky >= 1.5.0 with `retry.afterStatusCodes: []` ([ky@1.5.0](https://github.com/sindresorhus/ky/releases/tag/v1.5.0), [PR #598](https://github.com/sindresorhus/ky/pull/598), [README `#retry`](https://github.com/sindresorhus/ky#retry))

Added unit tests (real local HTTP server) and API integration tests covering `500` / `501` / `599`, `503` with `Retry-After: 0` and `86400`, stop-on-success, no `4xx` retry, `retries` passthrough, and a single recent-request log across multiple attempts.

## Testing

Unit tests, Integration tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
