### PR TITLE
fix(schemas): require context for client credentials jwt customizers

### DIFF
--- a/packages/schemas/src/types/logto-config/jwt-customizer.ts
+++ b/packages/schemas/src/types/logto-config/jwt-customizer.ts
@@ -266,9 +266,7 @@ export const customJwtFetcherGuard = z.discriminatedUnion('tokenType', [
   }),
   commonJwtCustomizerGuard.extend({
     tokenType: z.literal(LogtoJwtTokenKeyType.ClientCredentials),
-    // TODO: @xiaoyijun Make `context` required once the application context feature is fully launched
-    // and all core instances are sending `context` for client credentials requests.
-    context: jsonObjectGuard.optional(),
+    context: jsonObjectGuard,
   }),
 ]);
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Makes `context` a required field for client-credentials JWT customizers now that the application context feature is fully launched.


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
