### PR TITLE
feat(core): integrate trusted device MFA fulfillment

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
@@ -57,7 +57,10 @@ const users = {
   hasUserWithIdentity: jest.fn().mockResolvedValue(false),
 };
 
-const tenant = new MockTenant(createMockProvider(), { signInExperiences, users });
+const getEffectivePolicy = jest.fn().mockResolvedValue({ enabled: false, durationDays: 30 });
+const tenant = new MockTenant(createMockProvider(), { signInExperiences, users }, undefined, {
+  trustedDevicePolicy: { getEffectivePolicy },
+});
 const mockInteractionDetails = {
   jti: 'session-id',
   params: { client_id: 'application-id' },

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -1,0 +1,273 @@
+import {
+  InteractionEvent,
+  InteractionHookEvent,
+  MfaFactor,
+  MfaPolicy,
+  type SignInExperience,
+  type TrustedDevice,
+  VerificationType,
+} from '@logto/schemas';
+import { createMockUtils, pickDefault } from '@logto/shared/esm';
+
+import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
+import { mockUser, mockUserWithMfaVerifications } from '#src/__mocks__/user.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
+import { createMockProvider } from '#src/test-utils/oidc-provider.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import { type Interaction, type WithHooksAndLogsContext } from '../types.js';
+
+const { jest } = import.meta;
+const { mockEsmWithActual } = createMockUtils(jest);
+
+const mockEnvSetValues = {
+  isDevFeaturesEnabled: true,
+};
+
+await mockEsmWithActual('#src/env-set/index.js', () => ({
+  EnvSet: {
+    values: mockEnvSetValues,
+  },
+}));
+
+const requiredMfaSignInExperience: SignInExperience = {
+  ...mockSignInExperience,
+  adaptiveMfa: { enabled: false },
+  mfa: {
+    policy: MfaPolicy.Mandatory,
+    factors: [MfaFactor.TOTP],
+  },
+};
+
+const adaptiveMfaSignInExperience: SignInExperience = {
+  ...requiredMfaSignInExperience,
+  adaptiveMfa: { enabled: true },
+  mfa: {
+    policy: MfaPolicy.PromptAtSignInAndSignUp,
+    factors: [MfaFactor.TOTP],
+  },
+};
+
+const findDefaultSignInExperience = jest.fn().mockResolvedValue(requiredMfaSignInExperience);
+const findUserById = jest.fn().mockResolvedValue(mockUserWithMfaVerifications);
+const getEffectivePolicy = jest.fn().mockResolvedValue({ enabled: true, durationDays: 30 });
+const validateCredential = jest.fn();
+
+const tenant = new MockTenant(
+  createMockProvider(),
+  {
+    signInExperiences: { findDefaultSignInExperience },
+    users: { findUserById },
+  },
+  undefined,
+  {
+    trustedDevicePolicy: { getEffectivePolicy },
+    trustedDevices: { validateCredential },
+  }
+);
+
+const trustedDevice: TrustedDevice = {
+  tenantId: tenant.id,
+  id: 'trusteddeviceid',
+  userId: mockUserWithMfaVerifications.id,
+  secretHash: Buffer.alloc(32, 1),
+  userAgent: null,
+  ip: null,
+  country: null,
+  city: null,
+  createdAt: 1,
+  lastUsedAt: 1,
+  expiresAt: 2,
+};
+
+const ExperienceInteraction = await pickDefault(import('./experience-interaction.js'));
+
+const createInteraction = (
+  interactionResult: Record<string, unknown> = {},
+  headers?: Record<string, string>
+) => {
+  const interactionDetails = {
+    jti: 'interaction-id',
+    params: { client_id: 'application-id' },
+    result: {
+      interactionEvent: InteractionEvent.SignIn,
+      userId: mockUserWithMfaVerifications.id,
+      ...interactionResult,
+    },
+  } as unknown as Interaction;
+  const ctx = {
+    assignReleaseOnSuccessInteractionHookResult: jest.fn(),
+    assignReleaseAnywayInteractionHookResult: jest.fn(),
+    appendDataHookContext: jest.fn(),
+    appendExceptionHookContext: jest.fn(),
+    ...createContextWithRouteParameters({ headers }),
+    ...createMockLogContext(),
+    interactionDetails,
+  } as unknown as WithHooksAndLogsContext;
+
+  return {
+    ctx,
+    experienceInteraction: new ExperienceInteraction(ctx, tenant, interactionDetails),
+  };
+};
+
+const expectConventionalMfaRequired = async (
+  experienceInteraction: InstanceType<typeof ExperienceInteraction>
+) => {
+  await expect(experienceInteraction.guardMfaVerificationStatus()).rejects.toMatchError(
+    new RequestError(
+      { code: 'session.mfa.require_mfa_verification', status: 403 },
+      {
+        availableFactors: [MfaFactor.TOTP],
+        maskedIdentifiers: {},
+      }
+    )
+  );
+};
+
+describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle the mocked feature environment per test.
+    mockEnvSetValues.isDevFeaturesEnabled = true;
+    findDefaultSignInExperience.mockResolvedValue(requiredMfaSignInExperience);
+    findUserById.mockResolvedValue(mockUserWithMfaVerifications);
+    getEffectivePolicy.mockResolvedValue({ enabled: true, durationDays: 30 });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps the existing no-MFA-required early exit before trusted-device evaluation', async () => {
+    findUserById.mockResolvedValueOnce(mockUser);
+    const { experienceInteraction } = createInteraction({ userId: mockUser.id });
+
+    await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
+
+    expect(getEffectivePolicy).not.toHaveBeenCalled();
+    expect(validateCredential).not.toHaveBeenCalled();
+  });
+
+  it('keeps verified interactive MFA ahead of trusted-device evaluation', async () => {
+    const { experienceInteraction } = createInteraction({
+      verificationRecords: [
+        {
+          id: 'totp-verification-id',
+          type: VerificationType.TOTP,
+          verified: true,
+          userId: mockUserWithMfaVerifications.id,
+        },
+      ],
+    });
+
+    await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
+
+    expect(getEffectivePolicy).not.toHaveBeenCalled();
+    expect(validateCredential).not.toHaveBeenCalled();
+  });
+
+  it('restores matching interaction fulfillment before resolving effective policy', async () => {
+    findDefaultSignInExperience.mockResolvedValueOnce(adaptiveMfaSignInExperience);
+    const fulfillment = {
+      userId: mockUserWithMfaVerifications.id,
+      trustedDeviceId: trustedDevice.id,
+      fulfilledAt: 1_786_435_200_000,
+    };
+    const { ctx, experienceInteraction } = createInteraction(
+      { trustedDeviceFulfillment: fulfillment },
+      { 'x-logto-cf-bot-score': '10' }
+    );
+
+    await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
+
+    expect(experienceInteraction.toJson().trustedDeviceFulfillment).toEqual(fulfillment);
+    expect(getEffectivePolicy).not.toHaveBeenCalled();
+    expect(validateCredential).not.toHaveBeenCalled();
+    expect(ctx.assignReleaseAnywayInteractionHookResult).not.toHaveBeenCalled();
+  });
+
+  it('does not use fulfillment stored for another user', async () => {
+    getEffectivePolicy.mockResolvedValueOnce({ enabled: false, durationDays: 30 });
+    const { experienceInteraction } = createInteraction({
+      trustedDeviceFulfillment: {
+        userId: 'another-user',
+        trustedDeviceId: trustedDevice.id,
+        fulfilledAt: 1_786_435_200_000,
+      },
+    });
+
+    await expectConventionalMfaRequired(experienceInteraction);
+
+    expect(getEffectivePolicy).toHaveBeenCalledWith(mockUserWithMfaVerifications.id);
+    expect(validateCredential).not.toHaveBeenCalled();
+  });
+
+  it('falls back to conventional MFA when credential validation does not fulfill the guard', async () => {
+    const { ctx, experienceInteraction } = createInteraction();
+
+    await expectConventionalMfaRequired(experienceInteraction);
+
+    expect(getEffectivePolicy).toHaveBeenCalledWith(mockUserWithMfaVerifications.id);
+    expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
+    expect(experienceInteraction.toJson().trustedDeviceFulfillment).toBeUndefined();
+  });
+
+  it('stores valid credential fulfillment internally without exposing it publicly', async () => {
+    const fulfilledAt = 1_786_435_200_000;
+    jest.spyOn(Date, 'now').mockReturnValue(fulfilledAt);
+    validateCredential.mockResolvedValueOnce(trustedDevice);
+    const { ctx, experienceInteraction } = createInteraction();
+
+    await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
+
+    expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
+    expect(experienceInteraction.toJson().trustedDeviceFulfillment).toEqual({
+      userId: mockUserWithMfaVerifications.id,
+      trustedDeviceId: trustedDevice.id,
+      fulfilledAt,
+    });
+    expect(experienceInteraction.toSanitizedJson()).not.toHaveProperty('trustedDeviceFulfillment');
+  });
+
+  it('allows a valid trusted device to fulfill adaptive MFA', async () => {
+    findDefaultSignInExperience.mockResolvedValueOnce(adaptiveMfaSignInExperience);
+    validateCredential.mockResolvedValueOnce(trustedDevice);
+    const { ctx, experienceInteraction } = createInteraction({}, { 'x-logto-cf-bot-score': '10' });
+
+    await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
+
+    expect(experienceInteraction.toJson().trustedDeviceFulfillment).toEqual(
+      expect.objectContaining({
+        userId: mockUserWithMfaVerifications.id,
+        trustedDeviceId: trustedDevice.id,
+      })
+    );
+    expect(ctx.assignReleaseAnywayInteractionHookResult).toHaveBeenCalledWith({
+      event: InteractionHookEvent.PostSignInAdaptiveMfaTriggered,
+      payload: {
+        adaptiveMfaResult: expect.objectContaining({
+          requiresMfa: true,
+          triggeredRules: expect.arrayContaining([
+            expect.objectContaining({ rule: 'untrusted_ip' }),
+          ]) as unknown,
+        }) as unknown,
+      },
+      userId: mockUserWithMfaVerifications.id,
+    });
+  });
+
+  it('does not enable trusted-device fulfillment when dev features are disabled', async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Verify the feature-level runtime guard.
+    mockEnvSetValues.isDevFeaturesEnabled = false;
+    validateCredential.mockResolvedValueOnce(trustedDevice);
+    const { experienceInteraction } = createInteraction();
+
+    await expectConventionalMfaRequired(experienceInteraction);
+
+    expect(getEffectivePolicy).not.toHaveBeenCalled();
+    expect(validateCredential).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -13,6 +13,7 @@ import {
 import { maskEmail, maskPhone } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayload } from '#src/libraries/user.utils.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
@@ -54,6 +55,12 @@ import {
 } from './verifications/index.js';
 import { VerificationRecordsMap } from './verifications/verification-records-map.js';
 
+type TrustedDeviceFulfillmentStatus =
+  /** A matching trusted-device fulfillment was restored from interaction storage. */
+  | 'stored'
+  /** A trusted-device credential was validated and stored during the current request. */
+  | 'validated';
+
 /**
  * Interaction is a short-lived session session that is initiated when a user starts an interaction flow with the Logto platform.
  * This class is used to manage all the interaction data and status.
@@ -73,6 +80,8 @@ export default class ExperienceInteraction {
   private readonly verificationRecords = new VerificationRecordsMap();
   /** The userId of the user for the current interaction. Only available once the user is identified. */
   private userId?: string;
+  /** Internal fulfillment state for the trusted-device MFA alternative. */
+  private trustedDeviceFulfillment?: InteractionStorage['trustedDeviceFulfillment'];
   private userCache?: User;
   private readonly adaptiveMfaValidator: AdaptiveMfaValidator;
 
@@ -144,6 +153,7 @@ export default class ExperienceInteraction {
       profile = {},
       mfa = {},
       userId,
+      trustedDeviceFulfillment,
       interactionEvent,
       captcha = {
         verified: false,
@@ -153,6 +163,7 @@ export default class ExperienceInteraction {
 
     this.#interactionEvent = interactionEvent;
     this.userId = userId;
+    this.trustedDeviceFulfillment = trustedDeviceFulfillment;
     this.profile = new Profile(libraries, queries, profile, interactionContext);
     this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.captcha = captcha;
@@ -382,7 +393,17 @@ export default class ExperienceInteraction {
       return;
     }
 
+    const trustedDeviceFulfillmentStatus = await this.tryFulfillMfaWithTrustedDevice(user.id);
+
+    if (trustedDeviceFulfillmentStatus === 'stored') {
+      return;
+    }
+
     this.assignAdaptiveMfaHookResult(user.id, adaptiveMfaResult);
+
+    if (trustedDeviceFulfillmentStatus === 'validated') {
+      return;
+    }
 
     const { primaryEmail, primaryPhone } = user;
     const maskedIdentifiers: Record<string, string> = {
@@ -671,12 +692,13 @@ export default class ExperienceInteraction {
 
   /** Convert the current interaction to JSON, so that it can be stored as the OIDC provider interaction result */
   public toJson(): InteractionStorage {
-    const { interactionEvent, userId, captcha } = this;
+    const { interactionEvent, userId, trustedDeviceFulfillment, captcha } = this;
     const signInContext = this.adaptiveMfaValidator.getSignInContext();
 
     return {
       interactionEvent,
       userId,
+      trustedDeviceFulfillment,
       profile: this.profile.data,
       mfa: this.mfa.data,
       verificationRecords: this.verificationRecordsArray.map((record) => record.toJson()),
@@ -686,12 +708,52 @@ export default class ExperienceInteraction {
   }
 
   public toSanitizedJson(): SanitizedInteractionStorageData {
+    // Trusted-device fulfillment is internal authentication state. Explicitly remove it before
+    // spreading the remaining storage.
+    const { trustedDeviceFulfillment: _, ...interactionStorage } = this.toJson();
+
     return {
-      ...this.toJson(),
+      ...interactionStorage,
       profile: this.profile.sanitizedData,
       mfa: this.mfa.sanitizedData,
       verificationRecords: this.verificationRecordsArray.map((record) => record.toSanitizedJson()),
     };
+  }
+
+  private async tryFulfillMfaWithTrustedDevice(
+    userId: string
+  ): Promise<TrustedDeviceFulfillmentStatus | undefined> {
+    // Trusted-device MFA fulfillment is under development and must remain isolated from released flows.
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    if (this.trustedDeviceFulfillment?.userId === userId) {
+      return 'stored';
+    }
+
+    const {
+      libraries: { trustedDevicePolicy, trustedDevices },
+    } = this.tenant;
+    const { enabled } = await trustedDevicePolicy.getEffectivePolicy(userId);
+
+    if (!enabled) {
+      return;
+    }
+
+    const trustedDevice = await trustedDevices.validateCredential(this.ctx, userId);
+
+    if (!trustedDevice) {
+      return;
+    }
+
+    this.trustedDeviceFulfillment = {
+      userId,
+      trustedDeviceId: trustedDevice.id,
+      fulfilledAt: Date.now(),
+    };
+
+    return 'validated';
   }
 
   private assignAdaptiveMfaHookResult(userId: string, adaptiveMfaResult?: AdaptiveMfaResult) {

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -118,12 +118,21 @@ const createRequesterWithMocks = ({
     }),
   };
 
-  const tenant = new MockTenant(provider, {
-    users,
-    signInExperiences,
-    userGeoLocations,
-    userSignInCountries,
-  });
+  const tenant = new MockTenant(
+    provider,
+    {
+      users,
+      signInExperiences,
+      userGeoLocations,
+      userSignInCountries,
+    },
+    undefined,
+    {
+      trustedDevicePolicy: {
+        getEffectivePolicy: jest.fn().mockResolvedValue({ enabled: false, durationDays: 30 }),
+      },
+    }
+  );
 
   const { middleware: logMiddleware, mockAppend } = createLogMiddleware();
   const requester = createRequester({

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -197,6 +197,11 @@ export type WithHooksAndLogsContext<ContextT extends WithLogContext = WithLogCon
 export type InteractionStorage = {
   interactionEvent: InteractionEvent;
   userId?: string;
+  trustedDeviceFulfillment?: {
+    userId: string;
+    trustedDeviceId: string;
+    fulfilledAt: number;
+  };
   profile?: InteractionProfile;
   mfa?: MfaData;
   verificationRecords?: VerificationRecordData[];
@@ -210,6 +215,13 @@ export type InteractionStorage = {
 export const interactionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
+  trustedDeviceFulfillment: z
+    .object({
+      userId: z.string(),
+      trustedDeviceId: z.string(),
+      fulfilledAt: z.number(),
+    })
+    .optional(),
   profile: interactionProfileGuard.optional(),
   mfa: mfaDataGuard.optional(),
   verificationRecords: verificationRecordDataGuard.array().optional(),


### PR DESCRIPTION
## Summary
Integrate trusted-device credential validation into the existing sign-in MFA guard. Persist successful fulfillment only in internal interaction storage while keeping public interaction data unchanged. Invalid or unavailable credentials fall back to conventional MFA.

Stacked on #9405.

## Testing
Unit tests

## Checklist
- [ ] .changeset
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments