### PR TITLE
feat(schemas): add the hosted-email service-log read indexes

### DIFF
--- a/packages/schemas/alterations/next-1786414712-add-service-logs-email-indexes.ts
+++ b/packages/schemas/alterations/next-1786414712-add-service-logs-email-indexes.ts
@@ -1,0 +1,34 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    await pool.query(sql`
+      create index concurrently service_logs__email__tenant_id__created_at__id
+        on service_logs (tenant_id, created_at desc, id desc)
+        where type in ('sendEmail', 'sendEmailFailed');
+    `);
+    await pool.query(sql`
+      create index concurrently service_logs__email__tenant_id__recipient__created_at__id
+        on service_logs (tenant_id, lower(payload->'data'->>'to'), created_at desc, id desc)
+        where type in ('sendEmail', 'sendEmailFailed');
+    `);
+  },
+  up: async () => {
+    /** 'concurrently' cannot be used inside a transaction, so this up is intentionally left empty. */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently service_logs__email__tenant_id__recipient__created_at__id;
+    `);
+    await pool.query(sql`
+      drop index concurrently service_logs__email__tenant_id__created_at__id;
+    `);
+  },
+  down: async () => {
+    /** 'concurrently' cannot be used inside a transaction, so this down is intentionally left empty. */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/service_logs.sql
+++ b/packages/schemas/tables/service_logs.sql
@@ -18,4 +18,18 @@ create index service_logs__tenant_id__type__created_at
 create index service_logs__created_at
   on service_logs (created_at);
 
+/* Cloud email-logs read path: streams a tenant's sent + failed hosted-email rows in
+   (created_at desc, id desc) keyset order (in the composite index above `type` sits between
+   `tenant_id` and `created_at`, so a read spanning both email types cannot stream in time order
+   and needs a full top-N sort) */
+create index service_logs__email__tenant_id__created_at__id
+  on service_logs (tenant_id, created_at desc, id desc)
+  where type in ('sendEmail', 'sendEmailFailed');
+
+/* Cloud email-logs recipient filter: case-insensitive exact recipient lookups in the same
+   keyset order, without inspecting every email-log payload of the tenant */
+create index service_logs__email__tenant_id__recipient__created_at__id
+  on service_logs (tenant_id, lower(payload->'data'->>'to'), created_at desc, id desc)
+  where type in ('sendEmail', 'sendEmailFailed');
+
 /* no_after_each */


### PR DESCRIPTION
## Summary

Refs LOG-13966. Adds two partial indexes to `service_logs` for the hosted-email logs read surface, which pages a tenant's `sendEmail` / `sendEmailFailed` rows newest-first (keyset on `(created_at, id)`) and looks up rows by recipient address.

### What the indexes are for

- `service_logs__email__tenant_id__created_at__id` — `(tenant_id, created_at desc, id desc) where type in ('sendEmail', 'sendEmailFailed')`. In the existing `(tenant_id, type, created_at)` index, `type` sits between `tenant_id` and `created_at`, so a read spanning both email types cannot stream in `(created_at, id)` order and falls back to sorting the tenant's entire email-log history on every page.
- `service_logs__email__tenant_id__recipient__created_at__id` — `(tenant_id, lower(payload->'data'->>'to'), created_at desc, id desc)` with the same partial predicate, backing case-insensitive exact recipient lookups in the same keyset order. Without it a recipient search — including one that matches nothing — must inspect every email-log payload of the tenant.

On a seeded 250k-row scenario (195k email rows on one tenant), first/cursor pages go from a parallel seq scan + top-N sort to streaming index scans (~0.06–0.2ms, with the keyset row comparison landing in the Index Cond), and the no-match recipient probe resolves in ~0.04ms. The partial predicate keeps both indexes small and off the non-email log types, whose writes are unaffected.

The alteration builds/drops the indexes `concurrently` in `beforeUp`/`beforeDown` (outside the transaction), following the `1.38.0-1772621060-add-oidc-model-instances-grant-account-id-index.ts` precedent; no `if not exists`, per the hard-fail ruling on #8427.

## Testing

Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
