### PR TITLE
ci: rerun codeql analysis when a pull request base changes

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,10 @@ on:
       - master
       - 'push-action/**'
   pull_request:
+    # `edited` is the only event fired when a PR base changes (e.g. a stacked PR
+    # retargeting to master after its base merges); analyses are base-relative, so
+    # without a fresh run the code scanning merge requirement blocks the PR forever
+    types: [opened, synchronize, reopened, edited]
     # The branches below must be a subset of the branches above
     branches:
       - master
@@ -26,6 +30,8 @@ on:
 jobs:
   analyze:
     name: Analyze
+    # Among `edited` events only base changes need a re-scan; skip title/body edits
+    if: github.event_name != 'pull_request' || github.event.action != 'edited' || github.event.changes.base != null
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary

Fix stacked or retargeted PRs getting permanently stuck on "Merging is blocked — Waiting for Code Scanning results. Code Scanning may not be configured for the target branch."

Cause:

- The `code_scanning` rule on `master` requires a CodeQL analysis of the PR head against its current base, and analyses are base-relative — changing the base branch invalidates the previous one.
- Changing the base only emits a `pull_request` `edited` event, which this workflow did not listen to, and pushes made while the PR targeted a non-`master` base are filtered out by `branches`.
- So once the last push predates the retarget (e.g. the base PR of a stack merges and GitHub retargets the next one to `master`), no event can ever trigger a fresh analysis, and the merge requirement waits forever.

Fix:

- Listen to `edited` so retargeting to `master` immediately re-runs the analysis against the new base.
- A job-level condition skips `edited` events that are not base changes (title/body edits).
- Retargeting away from `master` (restacking) is still excluded by the existing `branches` filter, so no extra runs there.

## Testing

N/A (CI workflow change; the retarget path will be exercised by the next stacked PR).

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
