### PR TITLE
feat(schemas): add cimd grant client snapshots table

### DIFF
--- a/packages/schemas/alterations/next-1786431364-add-cimd-grant-client-snapshots-table.ts
+++ b/packages/schemas/alterations/next-1786431364-add-cimd-grant-client-snapshots-table.ts
@@ -1,0 +1,43 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+import { applyTableRls, dropTableRls } from './utils/1704934999-tables.js';
+
+/**
+ * Add the per-grant client display snapshot table for client ID metadata document (CIMD) clients.
+ * CIMD clients are unregistered URL identities without an `applications` row, and an unvetted
+ * client can rewrite its hosted document at any time — so the grant list renders the snapshot
+ * captured at consent instead of refetching the document. Rows cascade away with the Grant row.
+ */
+const alteration: AlterationScript = {
+  up: async (pool) => {
+    await pool.query(sql`
+      create table cimd_grant_client_snapshots (
+        tenant_id varchar(21) not null
+          references tenants (id) on update cascade on delete cascade,
+        grant_id varchar(128) not null,
+        grant_model_name varchar(64) not null default 'Grant',
+        client_id varchar(2048) not null,
+        name varchar(256),
+        logo_uri varchar(2048),
+        created_at timestamptz not null default(now()),
+        primary key (tenant_id, grant_id),
+        constraint cimd_grant_client_snapshots__grant_model_name
+          check (grant_model_name = 'Grant'),
+        foreign key (tenant_id, grant_model_name, grant_id)
+          references oidc_model_instances (tenant_id, model_name, id)
+          on update cascade on delete cascade
+      );
+    `);
+    await applyTableRls(pool, 'cimd_grant_client_snapshots');
+  },
+  down: async (pool) => {
+    await dropTableRls(pool, 'cimd_grant_client_snapshots');
+    await pool.query(sql`
+      drop table cimd_grant_client_snapshots;
+    `);
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/cimd_grant_client_snapshots.sql
+++ b/packages/schemas/tables/cimd_grant_client_snapshots.sql
@@ -1,0 +1,27 @@
+/* init_order = 2 */
+
+/**
+  The client identity a user approved at consent time for a client ID metadata document (CIMD)
+  client, captured per Grant. CIMD clients are unregistered URL identities without an
+  `applications` row, and an unvetted client can rewrite its hosted document at any time — so the
+  grant list renders this snapshot instead of refetching the document.
+*/
+create table cimd_grant_client_snapshots (
+  tenant_id varchar(21) not null
+    references tenants (id) on update cascade on delete cascade,
+  /** The ID of the Grant row in `oidc_model_instances`. */
+  grant_id varchar(128) not null,
+  /** Fixed discriminator so the composite foreign key can target Grant rows in the polymorphic `oidc_model_instances` table. */
+  grant_model_name varchar(64) not null default 'Grant',
+  client_id varchar(2048) not null,
+  name varchar(256),
+  logo_uri varchar(2048),
+  created_at timestamptz not null default(now()),
+  primary key (tenant_id, grant_id),
+  constraint cimd_grant_client_snapshots__grant_model_name
+    check (grant_model_name = 'Grant'),
+  /** Revoking the grant hard-deletes the Grant row, which erases the snapshot with it. */
+  foreign key (tenant_id, grant_model_name, grant_id)
+    references oidc_model_instances (tenant_id, model_name, id)
+    on update cascade on delete cascade
+);


### PR DESCRIPTION
## Summary

Add the `cimd_grant_client_snapshots` table — the per-grant display snapshot of the client identity a user approves at consent time for a CIMD client (schema only; the consent-time write lands with LOG-13932).

- The grant list must show the identity the user actually saw — an unvetted CIMD client can rewrite its hosted document at any time — and list loading must never fetch remote metadata documents.
- Mirrors the `cimd_grant_organizations` structure: tenants FK, `grant_model_name` check-pinned to `'Grant'`, composite FK to `oidc_model_instances` so revoking the grant cascades the snapshot away, and PK `(tenant_id, grant_id)` (at most one snapshot per grant).
- `client_id` varchar(2048) matches `users.cimd_client_id`; nullable `name` varchar(256) matches `applications.name` (`client_name` is optional in the document — display falls back to the identifier hostname); nullable `logo_uri` varchar(2048); `created_at` orders "latest snapshot wins" when one client holds multiple grants.
- Deliberately absent: `user_id`/membership FK (display data, not an authorization source), extra indexes (the PK backs the grant-FK cascade), and `updated_at` (write-once row, conflict-ignored on retry).
- Snapshot existence doubles as the "this grant belongs to a CIMD client" marker for the active-grants query (LOG-13935).
- No changeset: the feature is dev-gated; user-facing notes ship with the final release.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments