### PR TITLE
feat(core): store the cimd client display snapshot at consent time

### DIFF
--- a/packages/core/src/database/insert-into.test.ts
+++ b/packages/core/src/database/insert-into.test.ts
@@ -50,6 +50,15 @@ describe('buildInsertInto()', () => {
     await expect(insertInto(user)).resolves.toBe(undefined);
   });
 
+  it('supports onConflict do nothing', async () => {
+    const user: CreateUser = { id: 'foo', username: '456', applicationId: 'bar' };
+    const expectInsertIntoSql = buildExpectedInsertIntoSql(Object.keys(user));
+    const pool = createTestPool([...expectInsertIntoSql, 'on conflict do nothing'].join('\n'));
+
+    const insertInto = buildInsertIntoWithPool(pool)(Users, { onConflict: { ignore: true } });
+    await expect(insertInto(user)).resolves.toBe(undefined);
+  });
+
   it('resolves a promise with single entity when `returning` is true', async () => {
     const user: CreateUser = {
       id: 'foo',

--- a/packages/core/src/libraries/session/cimd-grant-records.test.ts
+++ b/packages/core/src/libraries/session/cimd-grant-records.test.ts
@@ -167,7 +167,7 @@ describe('consent for a cimd client', () => {
     );
   });
 
-  it('should store an absent client name and logo as null', async () => {
+  it('should leave an absent client name and logo unset for the insert to store null', async () => {
     findClient.mockResolvedValueOnce({});
     const provider = createCimdProvider(cimdInteractionDetails);
     await runConsent(provider, cimdInteractionDetails);
@@ -175,8 +175,8 @@ describe('consent for a cimd client', () => {
     expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
       grantId: grantSave.mock.calls[0]?.[0],
       clientId: cimdClientId,
-      name: null,
-      logoUri: null,
+      name: undefined,
+      logoUri: undefined,
     });
   });
 
@@ -189,7 +189,7 @@ describe('consent for a cimd client', () => {
       grantId: grantSave.mock.calls[0]?.[0],
       clientId: cimdClientId,
       name: 'a'.repeat(256),
-      logoUri: null,
+      logoUri: undefined,
     });
   });
 
@@ -202,7 +202,7 @@ describe('consent for a cimd client', () => {
       grantId: grantSave.mock.calls[0]?.[0],
       clientId: cimdClientId,
       name: `${'a'.repeat(255)}😀`,
-      logoUri: null,
+      logoUri: undefined,
     });
   });
 
@@ -215,11 +215,11 @@ describe('consent for a cimd client', () => {
       grantId: grantSave.mock.calls[0]?.[0],
       clientId: cimdClientId,
       name: 'a'.repeat(256),
-      logoUri: null,
+      logoUri: undefined,
     });
   });
 
-  it('should store an overlong logo uri as null', async () => {
+  it('should drop an overlong logo uri instead of truncating it', async () => {
     findClient.mockResolvedValueOnce({
       clientName: 'Example App',
       logoUri: `https://client.example.com/${'a'.repeat(2048)}.png`,
@@ -231,7 +231,7 @@ describe('consent for a cimd client', () => {
       grantId: grantSave.mock.calls[0]?.[0],
       clientId: cimdClientId,
       name: 'Example App',
-      logoUri: null,
+      logoUri: undefined,
     });
   });
 

--- a/packages/core/src/libraries/session/cimd-grant-records.test.ts
+++ b/packages/core/src/libraries/session/cimd-grant-records.test.ts
@@ -1,0 +1,393 @@
+import { type User } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import { errors, type Provider } from 'oidc-provider';
+import Sinon from 'sinon';
+
+import { mockUser } from '#src/__mocks__/user.js';
+import { EnvSet } from '#src/env-set/index.js';
+import type Queries from '#src/tenants/Queries.js';
+import { GrantMock, createMockProvider } from '#src/test-utils/oidc-provider.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import { consent } from './index.js';
+
+const { jest } = import.meta;
+
+const grantSave = jest.fn(async (id: string) => id);
+
+class Grant extends GrantMock {
+  static async find(id: string) {
+    return id === 'exists' ? existGrant : undefined;
+  }
+
+  id: string;
+
+  accountId?: string;
+
+  constructor() {
+    super();
+    this.id = generateStandardId();
+    this.save = async () => grantSave(this.id);
+  }
+}
+
+const existGrant = new Grant();
+
+const userQueries = {
+  findUserById: jest.fn(async (): Promise<User> => mockUser),
+  updateUserById: jest.fn(async (..._args: unknown[]) => ({ id: 'id' })),
+};
+
+const insertGrantOrganization = jest.fn();
+const findGrantOrganizationIds = jest.fn(async () => ['org_id']);
+const insertGrantClientSnapshot = jest.fn();
+
+const queries: Queries = {
+  // @ts-expect-error -- partial mock of the user queries
+  users: userQueries,
+  // @ts-expect-error -- partial mock of the cimd queries
+  cimd: {
+    grantOrganizations: {
+      insert: insertGrantOrganization,
+      findOrganizationIds: findGrantOrganizationIds,
+      exists: jest.fn(),
+    },
+    grantClientSnapshots: {
+      insert: insertGrantClientSnapshot,
+    },
+  },
+};
+const context = createContextWithRouteParameters();
+
+type Interaction = Awaited<ReturnType<Provider['interactionDetails']>>;
+
+describe('consent for a cimd client', () => {
+  const cimdClientId = 'https://client.example.com/metadata.json';
+
+  /**
+   * The gate reads only `oidc.cimdEnabled` from the tenant env set; the static flags are
+   * stubbed onto `EnvSet.values` below.
+   */
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
+  const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
+
+  const cimdInteractionDetails = {
+    session: { accountId: mockUser.id },
+    params: { client_id: cimdClientId },
+    prompt: { details: {} },
+  } as unknown as Interaction;
+
+  const findClient = jest.fn(
+    async (): Promise<unknown> => ({
+      clientName: 'Example App',
+      logoUri: 'https://client.example.com/logo.png',
+    })
+  );
+
+  const createCimdProvider = (interactionDetails: Interaction) =>
+    createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant, {
+      find: findClient,
+    });
+
+  beforeEach(() => {
+    Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      isDevFeaturesEnabled: true,
+      isOidcProviderSsrfProtectionEnabled: true,
+    });
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+    jest.clearAllMocks();
+  });
+
+  it('should write the client snapshot after the grant is saved when no organization is selected', async () => {
+    const provider = createCimdProvider(cimdInteractionDetails);
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails: cimdInteractionDetails,
+    });
+
+    expect(findClient).toHaveBeenCalledWith(cimdClientId);
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      clientId: cimdClientId,
+      name: 'Example App',
+      logoUri: 'https://client.example.com/logo.png',
+    });
+    expect(grantSave.mock.invocationCallOrder[0]).toBeLessThan(
+      insertGrantClientSnapshot.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(insertGrantOrganization).not.toHaveBeenCalled();
+  });
+
+  it('should write the client snapshot and the grant-scoped organization row after the grant is saved', async () => {
+    const provider = createCimdProvider(cimdInteractionDetails);
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails: cimdInteractionDetails,
+      cimdOrganizationId: 'org_id',
+    });
+
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      clientId: cimdClientId,
+      name: 'Example App',
+      logoUri: 'https://client.example.com/logo.png',
+    });
+    expect(insertGrantOrganization).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      organizationId: 'org_id',
+      userId: mockUser.id,
+    });
+    expect(grantSave.mock.invocationCallOrder[0]).toBeLessThan(
+      insertGrantOrganization.mock.invocationCallOrder[0] ?? 0
+    );
+  });
+
+  it('should store an absent client name and logo as null', async () => {
+    findClient.mockResolvedValueOnce({});
+    const provider = createCimdProvider(cimdInteractionDetails);
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails: cimdInteractionDetails,
+    });
+
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      clientId: cimdClientId,
+      name: null,
+      logoUri: null,
+    });
+  });
+
+  it('should truncate an overlong client name to the column bound', async () => {
+    findClient.mockResolvedValueOnce({ clientName: 'a'.repeat(300) });
+    const provider = createCimdProvider(cimdInteractionDetails);
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails: cimdInteractionDetails,
+    });
+
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      clientId: cimdClientId,
+      name: 'a'.repeat(256),
+      logoUri: null,
+    });
+  });
+
+  it('should store an overlong logo uri as null', async () => {
+    findClient.mockResolvedValueOnce({
+      clientName: 'Example App',
+      logoUri: `https://client.example.com/${'a'.repeat(2048)}.png`,
+    });
+    const provider = createCimdProvider(cimdInteractionDetails);
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails: cimdInteractionDetails,
+    });
+
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      clientId: cimdClientId,
+      name: 'Example App',
+      logoUri: null,
+    });
+  });
+
+  it('should fail the consent when the client can no longer be resolved', async () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined -- undefined is the provider's not-found result under test
+    findClient.mockResolvedValueOnce(undefined);
+    const provider = createCimdProvider(cimdInteractionDetails);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: cimdEnvSet,
+        queries,
+        interactionDetails: cimdInteractionDetails,
+      })
+    ).rejects.toMatchError(new errors.InvalidClient('client must be available'));
+    expect(insertGrantClientSnapshot).not.toHaveBeenCalled();
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
+  it('should fail the consent before the interaction result update when the snapshot write fails', async () => {
+    insertGrantClientSnapshot.mockRejectedValueOnce(new Error('write failed'));
+    const provider = createCimdProvider(cimdInteractionDetails);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: cimdEnvSet,
+        queries,
+        interactionDetails: cimdInteractionDetails,
+      })
+    ).rejects.toThrow('write failed');
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
+  it('should fail the consent when a different organization is already authorized on the grant', async () => {
+    findGrantOrganizationIds.mockResolvedValueOnce(['other_org_id']);
+    const provider = createCimdProvider(cimdInteractionDetails);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: cimdEnvSet,
+        queries,
+        interactionDetails: cimdInteractionDetails,
+        cimdOrganizationId: 'org_id',
+      })
+    ).rejects.toMatchError(
+      new errors.InvalidRequest(
+        'the grant organization binding does not match the submitted organization'
+      )
+    );
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
+  it('should fail the consent when the organization binding is missing after the write', async () => {
+    findGrantOrganizationIds.mockResolvedValueOnce([]);
+    const provider = createCimdProvider(cimdInteractionDetails);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: cimdEnvSet,
+        queries,
+        interactionDetails: cimdInteractionDetails,
+        cimdOrganizationId: 'org_id',
+      })
+    ).rejects.toMatchError(
+      new errors.InvalidRequest(
+        'the grant organization binding does not match the submitted organization'
+      )
+    );
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
+  it('should re-write the client snapshot without failing when a retried submission reuses the grant', async () => {
+    const interactionDetails = {
+      ...cimdInteractionDetails,
+      grantId: 'exists',
+    } as unknown as Interaction;
+    const provider = createCimdProvider(interactionDetails);
+
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails,
+    });
+
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: 'exists',
+      clientId: cimdClientId,
+      name: 'Example App',
+      logoUri: 'https://client.example.com/logo.png',
+    });
+    expect(insertGrantOrganization).not.toHaveBeenCalled();
+    expect(provider.interactionResult).toHaveBeenCalled();
+  });
+
+  it('should write the snapshot and occupy the organization binding before changing a reused grant', async () => {
+    const interactionDetails = {
+      ...cimdInteractionDetails,
+      grantId: 'exists',
+    } as unknown as Interaction;
+    const provider = createCimdProvider(interactionDetails);
+
+    await consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails,
+      cimdOrganizationId: 'org_id',
+    });
+
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: 'exists',
+      clientId: cimdClientId,
+      name: 'Example App',
+      logoUri: 'https://client.example.com/logo.png',
+    });
+    expect(insertGrantOrganization).toHaveBeenCalledWith({
+      grantId: 'exists',
+      organizationId: 'org_id',
+      userId: mockUser.id,
+    });
+    expect(insertGrantClientSnapshot.mock.invocationCallOrder[0]).toBeLessThan(
+      grantSave.mock.invocationCallOrder[0] ?? 0
+    );
+    expect(insertGrantOrganization.mock.invocationCallOrder[0]).toBeLessThan(
+      grantSave.mock.invocationCallOrder[0] ?? 0
+    );
+  });
+
+  it('should fail before any grant change when a reused grant carries a different organization', async () => {
+    findGrantOrganizationIds.mockResolvedValueOnce(['other_org_id']);
+    const interactionDetails = {
+      ...cimdInteractionDetails,
+      grantId: 'exists',
+    } as unknown as Interaction;
+    const provider = createCimdProvider(interactionDetails);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: cimdEnvSet,
+        queries,
+        interactionDetails,
+        cimdOrganizationId: 'org_id',
+      })
+    ).rejects.toMatchError(
+      new errors.InvalidRequest(
+        'the grant organization binding does not match the submitted organization'
+      )
+    );
+    expect(grantSave).not.toHaveBeenCalled();
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
+  it('should fail the consent before the interaction result update when the organization row write fails', async () => {
+    insertGrantOrganization.mockRejectedValueOnce(new Error('write failed'));
+    const provider = createCimdProvider(cimdInteractionDetails);
+
+    await expect(
+      consent({
+        ctx: context,
+        provider,
+        envSet: cimdEnvSet,
+        queries,
+        interactionDetails: cimdInteractionDetails,
+        cimdOrganizationId: 'org_id',
+      })
+    ).rejects.toThrow('write failed');
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/libraries/session/cimd-grant-records.test.ts
+++ b/packages/core/src/libraries/session/cimd-grant-records.test.ts
@@ -14,6 +14,9 @@ import { consent } from './index.js';
 const { jest } = import.meta;
 
 const grantSave = jest.fn(async (id: string) => id);
+const grantDestroy = jest.fn(async () => {
+  await Promise.resolve();
+});
 
 class Grant extends GrantMock {
   static async find(id: string) {
@@ -24,10 +27,13 @@ class Grant extends GrantMock {
 
   accountId?: string;
 
+  destroy: () => Promise<void>;
+
   constructor() {
     super();
     this.id = generateStandardId();
     this.save = async () => grantSave(this.id);
+    this.destroy = grantDestroy;
   }
 }
 
@@ -77,6 +83,11 @@ describe('consent for a cimd client', () => {
     prompt: { details: {} },
   } as unknown as Interaction;
 
+  const reusedGrantInteractionDetails = {
+    ...cimdInteractionDetails,
+    grantId: 'exists',
+  } as unknown as Interaction;
+
   const findClient = jest.fn(
     async (): Promise<unknown> => ({
       clientName: 'Example App',
@@ -87,6 +98,20 @@ describe('consent for a cimd client', () => {
   const createCimdProvider = (interactionDetails: Interaction) =>
     createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant, {
       find: findClient,
+    });
+
+  const runConsent = async (
+    provider: Provider,
+    interactionDetails: Interaction,
+    cimdOrganizationId?: string
+  ) =>
+    consent({
+      ctx: context,
+      provider,
+      envSet: cimdEnvSet,
+      queries,
+      interactionDetails,
+      cimdOrganizationId,
     });
 
   beforeEach(() => {
@@ -104,13 +129,7 @@ describe('consent for a cimd client', () => {
 
   it('should write the client snapshot after the grant is saved when no organization is selected', async () => {
     const provider = createCimdProvider(cimdInteractionDetails);
-    await consent({
-      ctx: context,
-      provider,
-      envSet: cimdEnvSet,
-      queries,
-      interactionDetails: cimdInteractionDetails,
-    });
+    await runConsent(provider, cimdInteractionDetails);
 
     expect(findClient).toHaveBeenCalledWith(cimdClientId);
     expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
@@ -125,16 +144,9 @@ describe('consent for a cimd client', () => {
     expect(insertGrantOrganization).not.toHaveBeenCalled();
   });
 
-  it('should write the client snapshot and the grant-scoped organization row after the grant is saved', async () => {
+  it('should occupy the organization binding before writing the client snapshot', async () => {
     const provider = createCimdProvider(cimdInteractionDetails);
-    await consent({
-      ctx: context,
-      provider,
-      envSet: cimdEnvSet,
-      queries,
-      interactionDetails: cimdInteractionDetails,
-      cimdOrganizationId: 'org_id',
-    });
+    await runConsent(provider, cimdInteractionDetails, 'org_id');
 
     expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
       grantId: grantSave.mock.calls[0]?.[0],
@@ -150,18 +162,15 @@ describe('consent for a cimd client', () => {
     expect(grantSave.mock.invocationCallOrder[0]).toBeLessThan(
       insertGrantOrganization.mock.invocationCallOrder[0] ?? 0
     );
+    expect(insertGrantOrganization.mock.invocationCallOrder[0]).toBeLessThan(
+      insertGrantClientSnapshot.mock.invocationCallOrder[0] ?? 0
+    );
   });
 
   it('should store an absent client name and logo as null', async () => {
     findClient.mockResolvedValueOnce({});
     const provider = createCimdProvider(cimdInteractionDetails);
-    await consent({
-      ctx: context,
-      provider,
-      envSet: cimdEnvSet,
-      queries,
-      interactionDetails: cimdInteractionDetails,
-    });
+    await runConsent(provider, cimdInteractionDetails);
 
     expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
       grantId: grantSave.mock.calls[0]?.[0],
@@ -174,13 +183,33 @@ describe('consent for a cimd client', () => {
   it('should truncate an overlong client name to the column bound', async () => {
     findClient.mockResolvedValueOnce({ clientName: 'a'.repeat(300) });
     const provider = createCimdProvider(cimdInteractionDetails);
-    await consent({
-      ctx: context,
-      provider,
-      envSet: cimdEnvSet,
-      queries,
-      interactionDetails: cimdInteractionDetails,
+    await runConsent(provider, cimdInteractionDetails);
+
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      clientId: cimdClientId,
+      name: 'a'.repeat(256),
+      logoUri: null,
     });
+  });
+
+  it('should keep a client name that fits the column in characters but not in code units', async () => {
+    findClient.mockResolvedValueOnce({ clientName: `${'a'.repeat(255)}😀` });
+    const provider = createCimdProvider(cimdInteractionDetails);
+    await runConsent(provider, cimdInteractionDetails);
+
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      clientId: cimdClientId,
+      name: `${'a'.repeat(255)}😀`,
+      logoUri: null,
+    });
+  });
+
+  it('should truncate at a character boundary without splitting a surrogate pair', async () => {
+    findClient.mockResolvedValueOnce({ clientName: `${'a'.repeat(256)}😀` });
+    const provider = createCimdProvider(cimdInteractionDetails);
+    await runConsent(provider, cimdInteractionDetails);
 
     expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
       grantId: grantSave.mock.calls[0]?.[0],
@@ -196,13 +225,7 @@ describe('consent for a cimd client', () => {
       logoUri: `https://client.example.com/${'a'.repeat(2048)}.png`,
     });
     const provider = createCimdProvider(cimdInteractionDetails);
-    await consent({
-      ctx: context,
-      provider,
-      envSet: cimdEnvSet,
-      queries,
-      interactionDetails: cimdInteractionDetails,
-    });
+    await runConsent(provider, cimdInteractionDetails);
 
     expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
       grantId: grantSave.mock.calls[0]?.[0],
@@ -212,58 +235,53 @@ describe('consent for a cimd client', () => {
     });
   });
 
-  it('should fail the consent when the client can no longer be resolved', async () => {
+  it('should keep a logo uri that fits the column in characters but not in code units', async () => {
+    const logoUri = `https://client.example.com/${'😀'.repeat(1015)}.png`;
+    findClient.mockResolvedValueOnce({ clientName: 'Example App', logoUri });
+    const provider = createCimdProvider(cimdInteractionDetails);
+    await runConsent(provider, cimdInteractionDetails);
+
+    expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
+      grantId: grantSave.mock.calls[0]?.[0],
+      clientId: cimdClientId,
+      name: 'Example App',
+      logoUri,
+    });
+  });
+
+  it('should fail the consent and destroy the fresh grant when the client can no longer be resolved', async () => {
     // eslint-disable-next-line unicorn/no-useless-undefined -- undefined is the provider's not-found result under test
     findClient.mockResolvedValueOnce(undefined);
     const provider = createCimdProvider(cimdInteractionDetails);
 
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: cimdEnvSet,
-        queries,
-        interactionDetails: cimdInteractionDetails,
-      })
-    ).rejects.toMatchError(new errors.InvalidClient('client must be available'));
+    await expect(runConsent(provider, cimdInteractionDetails)).rejects.toMatchError(
+      new errors.InvalidClient('client must be available')
+    );
     expect(insertGrantClientSnapshot).not.toHaveBeenCalled();
+    expect(grantDestroy).toHaveBeenCalled();
     expect(provider.interactionResult).not.toHaveBeenCalled();
   });
 
-  it('should fail the consent before the interaction result update when the snapshot write fails', async () => {
+  it('should fail the consent and destroy the fresh grant when the snapshot write fails', async () => {
     insertGrantClientSnapshot.mockRejectedValueOnce(new Error('write failed'));
     const provider = createCimdProvider(cimdInteractionDetails);
 
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: cimdEnvSet,
-        queries,
-        interactionDetails: cimdInteractionDetails,
-      })
-    ).rejects.toThrow('write failed');
+    await expect(runConsent(provider, cimdInteractionDetails)).rejects.toThrow('write failed');
+    expect(grantDestroy).toHaveBeenCalled();
     expect(provider.interactionResult).not.toHaveBeenCalled();
   });
 
-  it('should fail the consent when a different organization is already authorized on the grant', async () => {
+  it('should reject a conflicting organization without writing a snapshot and destroy the fresh grant', async () => {
     findGrantOrganizationIds.mockResolvedValueOnce(['other_org_id']);
     const provider = createCimdProvider(cimdInteractionDetails);
 
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: cimdEnvSet,
-        queries,
-        interactionDetails: cimdInteractionDetails,
-        cimdOrganizationId: 'org_id',
-      })
-    ).rejects.toMatchError(
+    await expect(runConsent(provider, cimdInteractionDetails, 'org_id')).rejects.toMatchError(
       new errors.InvalidRequest(
         'the grant organization binding does not match the submitted organization'
       )
     );
+    expect(insertGrantClientSnapshot).not.toHaveBeenCalled();
+    expect(grantDestroy).toHaveBeenCalled();
     expect(provider.interactionResult).not.toHaveBeenCalled();
   });
 
@@ -271,37 +289,31 @@ describe('consent for a cimd client', () => {
     findGrantOrganizationIds.mockResolvedValueOnce([]);
     const provider = createCimdProvider(cimdInteractionDetails);
 
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: cimdEnvSet,
-        queries,
-        interactionDetails: cimdInteractionDetails,
-        cimdOrganizationId: 'org_id',
-      })
-    ).rejects.toMatchError(
+    await expect(runConsent(provider, cimdInteractionDetails, 'org_id')).rejects.toMatchError(
       new errors.InvalidRequest(
         'the grant organization binding does not match the submitted organization'
       )
     );
+    expect(insertGrantClientSnapshot).not.toHaveBeenCalled();
+    expect(grantDestroy).toHaveBeenCalled();
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
+  it('should fail the consent and destroy the fresh grant when the organization row write fails', async () => {
+    insertGrantOrganization.mockRejectedValueOnce(new Error('write failed'));
+    const provider = createCimdProvider(cimdInteractionDetails);
+
+    await expect(runConsent(provider, cimdInteractionDetails, 'org_id')).rejects.toThrow(
+      'write failed'
+    );
+    expect(insertGrantClientSnapshot).not.toHaveBeenCalled();
+    expect(grantDestroy).toHaveBeenCalled();
     expect(provider.interactionResult).not.toHaveBeenCalled();
   });
 
   it('should re-write the client snapshot without failing when a retried submission reuses the grant', async () => {
-    const interactionDetails = {
-      ...cimdInteractionDetails,
-      grantId: 'exists',
-    } as unknown as Interaction;
-    const provider = createCimdProvider(interactionDetails);
-
-    await consent({
-      ctx: context,
-      provider,
-      envSet: cimdEnvSet,
-      queries,
-      interactionDetails,
-    });
+    const provider = createCimdProvider(reusedGrantInteractionDetails);
+    await runConsent(provider, reusedGrantInteractionDetails);
 
     expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
       grantId: 'exists',
@@ -314,20 +326,8 @@ describe('consent for a cimd client', () => {
   });
 
   it('should write the snapshot and occupy the organization binding before changing a reused grant', async () => {
-    const interactionDetails = {
-      ...cimdInteractionDetails,
-      grantId: 'exists',
-    } as unknown as Interaction;
-    const provider = createCimdProvider(interactionDetails);
-
-    await consent({
-      ctx: context,
-      provider,
-      envSet: cimdEnvSet,
-      queries,
-      interactionDetails,
-      cimdOrganizationId: 'org_id',
-    });
+    const provider = createCimdProvider(reusedGrantInteractionDetails);
+    await runConsent(provider, reusedGrantInteractionDetails, 'org_id');
 
     expect(insertGrantClientSnapshot).toHaveBeenCalledWith({
       grantId: 'exists',
@@ -348,46 +348,20 @@ describe('consent for a cimd client', () => {
     );
   });
 
-  it('should fail before any grant change when a reused grant carries a different organization', async () => {
+  it('should fail before any grant change without destroying a reused grant carrying a different organization', async () => {
     findGrantOrganizationIds.mockResolvedValueOnce(['other_org_id']);
-    const interactionDetails = {
-      ...cimdInteractionDetails,
-      grantId: 'exists',
-    } as unknown as Interaction;
-    const provider = createCimdProvider(interactionDetails);
+    const provider = createCimdProvider(reusedGrantInteractionDetails);
 
     await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: cimdEnvSet,
-        queries,
-        interactionDetails,
-        cimdOrganizationId: 'org_id',
-      })
+      runConsent(provider, reusedGrantInteractionDetails, 'org_id')
     ).rejects.toMatchError(
       new errors.InvalidRequest(
         'the grant organization binding does not match the submitted organization'
       )
     );
+    expect(insertGrantClientSnapshot).not.toHaveBeenCalled();
     expect(grantSave).not.toHaveBeenCalled();
-    expect(provider.interactionResult).not.toHaveBeenCalled();
-  });
-
-  it('should fail the consent before the interaction result update when the organization row write fails', async () => {
-    insertGrantOrganization.mockRejectedValueOnce(new Error('write failed'));
-    const provider = createCimdProvider(cimdInteractionDetails);
-
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: cimdEnvSet,
-        queries,
-        interactionDetails: cimdInteractionDetails,
-        cimdOrganizationId: 'org_id',
-      })
-    ).rejects.toThrow('write failed');
+    expect(grantDestroy).not.toHaveBeenCalled();
     expect(provider.interactionResult).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/libraries/session/cimd-grant-records.test.ts
+++ b/packages/core/src/libraries/session/cimd-grant-records.test.ts
@@ -271,6 +271,16 @@ describe('consent for a cimd client', () => {
     expect(provider.interactionResult).not.toHaveBeenCalled();
   });
 
+  it('should keep the write failure as the surfaced error when the grant cleanup also fails', async () => {
+    insertGrantClientSnapshot.mockRejectedValueOnce(new Error('write failed'));
+    grantDestroy.mockRejectedValueOnce(new Error('destroy failed'));
+    const provider = createCimdProvider(cimdInteractionDetails);
+
+    await expect(runConsent(provider, cimdInteractionDetails)).rejects.toThrow('write failed');
+    expect(grantDestroy).toHaveBeenCalled();
+    expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
   it('should reject a conflicting organization without writing a snapshot and destroy the fresh grant', async () => {
     findGrantOrganizationIds.mockResolvedValueOnce(['other_org_id']);
     const provider = createCimdProvider(cimdInteractionDetails);

--- a/packages/core/src/libraries/session/cimd-grant-records.ts
+++ b/packages/core/src/libraries/session/cimd-grant-records.ts
@@ -19,6 +19,19 @@ const snapshotLogoUriMaxLength = 2048;
 const truncateToCodePoints = (value: string, maxLength: number) =>
   Array.from(value).slice(0, maxLength).join('');
 
+type CimdGrantRecordsData = {
+  grantId: string;
+  cimdClientId?: string;
+  organizationId?: string;
+  userId: string;
+  /**
+   * The grant this consent just saved — destroyed on a failed write, since an orphan
+   * carrying the snapshot marker would surface in the grant list. Best effort: a failed
+   * cleanup is logged and the write error stays the surfaced failure.
+   */
+  freshGrant?: { destroy: () => Promise<void> };
+};
+
 /**
  * The client snapshot rides every CIMD consent: the grant list renders it instead of
  * refetching the rewritable document, and its existence marks the grant as CIMD. The
@@ -31,24 +44,7 @@ export const saveCimdGrantRecords = async (
   ctx: Context,
   provider: Provider,
   queries: Queries,
-  {
-    grantId,
-    cimdClientId,
-    organizationId,
-    userId,
-    freshGrant,
-  }: {
-    grantId: string;
-    cimdClientId?: string;
-    organizationId?: string;
-    userId: string;
-    /**
-     * The grant this consent just saved — destroyed on a failed write, since an orphan
-     * carrying the snapshot marker would surface in the grant list. Best effort: a failed
-     * cleanup is logged and the write error stays the surfaced failure.
-     */
-    freshGrant?: { destroy: () => Promise<void> };
-  }
+  { grantId, cimdClientId, organizationId, userId, freshGrant }: CimdGrantRecordsData
 ) => {
   if (!cimdClientId) {
     return;

--- a/packages/core/src/libraries/session/cimd-grant-records.ts
+++ b/packages/core/src/libraries/session/cimd-grant-records.ts
@@ -1,0 +1,98 @@
+import { conditional, trySafe } from '@silverhand/essentials';
+import type { Context } from 'koa';
+import { errors, type Provider } from 'oidc-provider';
+
+import type Queries from '#src/tenants/Queries.js';
+import assertThat from '#src/utils/assert-that.js';
+import { getConsoleLogFromContext } from '#src/utils/console.js';
+
+/** The snapshot's `name varchar(256)` bound — truncate rather than fail the consent. */
+const snapshotNameMaxLength = 256;
+
+/** The snapshot's `logo_uri varchar(2048)` bound — a truncated URL is useless, so null instead. */
+const snapshotLogoUriMaxLength = 2048;
+
+/**
+ * PostgreSQL `varchar(n)` counts code points — a UTF-16 `slice` could split a surrogate pair
+ * into a lone `�`.
+ */
+const truncateToCodePoints = (value: string, maxLength: number) =>
+  Array.from(value).slice(0, maxLength).join('');
+
+/**
+ * The client snapshot rides every CIMD consent: the grant list renders it instead of
+ * refetching the rewritable document, and its existence marks the grant as CIMD. The
+ * organization binding precedes it so a rejected submission leaves no snapshot, and must hold
+ * exactly the submitted organization — the conflict-ignored insert cannot tell a
+ * same-organization retry from a different organization landing on the grant, and the read
+ * fails closed when the row was cascade-deleted in between. No-ops for a non-CIMD client.
+ */
+export const saveCimdGrantRecords = async (
+  ctx: Context,
+  provider: Provider,
+  queries: Queries,
+  {
+    grantId,
+    cimdClientId,
+    organizationId,
+    userId,
+    freshGrant,
+  }: {
+    grantId: string;
+    cimdClientId?: string;
+    organizationId?: string;
+    userId: string;
+    /**
+     * The grant this consent just saved — destroyed on a failed write, since an orphan
+     * carrying the snapshot marker would surface in the grant list. Best effort: a failed
+     * cleanup is logged and the write error stays the surfaced failure.
+     */
+    freshGrant?: { destroy: () => Promise<void> };
+  }
+) => {
+  if (!cimdClientId) {
+    return;
+  }
+
+  try {
+    if (organizationId) {
+      await queries.cimd.grantOrganizations.insert({ grantId, organizationId, userId });
+      const organizationIds = await queries.cimd.grantOrganizations.findOrganizationIds(grantId);
+      assertThat(
+        organizationIds.length === 1 && organizationIds[0] === organizationId,
+        new errors.InvalidRequest(
+          'the grant organization binding does not match the submitted organization'
+        )
+      );
+    }
+
+    const client = await provider.Client.find(cimdClientId);
+    assertThat(client, new errors.InvalidClient('client must be available'));
+
+    const { clientName, logoUri } = client;
+
+    /** The insert builder maps an explicitly-undefined field to SQL null. */
+    await queries.cimd.grantClientSnapshots.insert({
+      grantId,
+      clientId: cimdClientId,
+      name: conditional(clientName && truncateToCodePoints(clientName, snapshotNameMaxLength)),
+      logoUri: conditional(
+        logoUri && Array.from(logoUri).length <= snapshotLogoUriMaxLength && logoUri
+      ),
+    });
+  } catch (error: unknown) {
+    if (freshGrant) {
+      await trySafe(
+        async () => freshGrant.destroy(),
+        (destroyError) => {
+          getConsoleLogFromContext(ctx).warn(
+            'Failed to destroy the grant after a failed cimd record write:',
+            destroyError
+          );
+        }
+      );
+    }
+
+    throw error;
+  }
+};

--- a/packages/core/src/libraries/session/consent.test.ts
+++ b/packages/core/src/libraries/session/consent.test.ts
@@ -1,6 +1,6 @@
 import { type User } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
-import { errors, type Provider } from 'oidc-provider';
+import { type Provider } from 'oidc-provider';
 
 import { mockUser } from '#src/__mocks__/user.js';
 import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-control.js';
@@ -44,6 +44,7 @@ const userQueries = {
 
 const insertGrantOrganization = jest.fn();
 const findGrantOrganizationIds = jest.fn(async () => ['org_id']);
+const insertGrantClientSnapshot = jest.fn();
 
 const queries: Queries = {
   // @ts-expect-error -- partial mock of the user queries
@@ -54,6 +55,9 @@ const queries: Queries = {
       insert: insertGrantOrganization,
       findOrganizationIds: findGrantOrganizationIds,
       exists: jest.fn(),
+    },
+    grantClientSnapshots: {
+      insert: insertGrantClientSnapshot,
     },
   },
 };
@@ -180,139 +184,7 @@ describe('consent', () => {
     });
   });
 
-  it('should write the grant-scoped organization row after the grant is saved', async () => {
-    const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
-    await consent({
-      ctx: context,
-      provider,
-      envSet: mockEnvSet,
-      queries,
-      interactionDetails: baseInteractionDetails,
-      cimdOrganizationId: 'org_id',
-    });
-
-    expect(insertGrantOrganization).toHaveBeenCalledWith({
-      grantId: grantSave.mock.calls[0]?.[0],
-      organizationId: 'org_id',
-      userId: mockUser.id,
-    });
-    expect(grantSave.mock.invocationCallOrder[0]).toBeLessThan(
-      insertGrantOrganization.mock.invocationCallOrder[0] ?? 0
-    );
-  });
-
-  it('should fail the consent when a different organization is already authorized on the grant', async () => {
-    findGrantOrganizationIds.mockResolvedValueOnce(['other_org_id']);
-    const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
-
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: mockEnvSet,
-        queries,
-        interactionDetails: baseInteractionDetails,
-        cimdOrganizationId: 'org_id',
-      })
-    ).rejects.toMatchError(
-      new errors.InvalidRequest(
-        'the grant organization binding does not match the submitted organization'
-      )
-    );
-    expect(provider.interactionResult).not.toHaveBeenCalled();
-  });
-
-  it('should fail the consent when the organization binding is missing after the write', async () => {
-    findGrantOrganizationIds.mockResolvedValueOnce([]);
-    const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
-
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: mockEnvSet,
-        queries,
-        interactionDetails: baseInteractionDetails,
-        cimdOrganizationId: 'org_id',
-      })
-    ).rejects.toMatchError(
-      new errors.InvalidRequest(
-        'the grant organization binding does not match the submitted organization'
-      )
-    );
-    expect(provider.interactionResult).not.toHaveBeenCalled();
-  });
-
-  it('should occupy the organization binding before changing a reused grant', async () => {
-    const interactionDetails = {
-      ...baseInteractionDetails,
-      grantId: 'exists',
-    } as unknown as Interaction;
-    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
-
-    await consent({
-      ctx: context,
-      provider,
-      envSet: mockEnvSet,
-      queries,
-      interactionDetails,
-      cimdOrganizationId: 'org_id',
-    });
-
-    expect(insertGrantOrganization).toHaveBeenCalledWith({
-      grantId: 'exists',
-      organizationId: 'org_id',
-      userId: mockUser.id,
-    });
-    expect(insertGrantOrganization.mock.invocationCallOrder[0]).toBeLessThan(
-      grantSave.mock.invocationCallOrder[0] ?? 0
-    );
-  });
-
-  it('should fail before any grant change when a reused grant carries a different organization', async () => {
-    findGrantOrganizationIds.mockResolvedValueOnce(['other_org_id']);
-    const interactionDetails = {
-      ...baseInteractionDetails,
-      grantId: 'exists',
-    } as unknown as Interaction;
-    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
-
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: mockEnvSet,
-        queries,
-        interactionDetails,
-        cimdOrganizationId: 'org_id',
-      })
-    ).rejects.toMatchError(
-      new errors.InvalidRequest(
-        'the grant organization binding does not match the submitted organization'
-      )
-    );
-    expect(grantSave).not.toHaveBeenCalled();
-    expect(provider.interactionResult).not.toHaveBeenCalled();
-  });
-
-  it('should fail the consent before the interaction result update when the organization row write fails', async () => {
-    insertGrantOrganization.mockRejectedValueOnce(new Error('write failed'));
-    const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
-
-    await expect(
-      consent({
-        ctx: context,
-        provider,
-        envSet: mockEnvSet,
-        queries,
-        interactionDetails: baseInteractionDetails,
-        cimdOrganizationId: 'org_id',
-      })
-    ).rejects.toThrow('write failed');
-    expect(provider.interactionResult).not.toHaveBeenCalled();
-  });
-
-  it('should not write any organization row without an organization selection', async () => {
+  it('should write neither the client snapshot nor an organization row for a registered client', async () => {
     const provider = createMockProvider(jest.fn().mockResolvedValue(baseInteractionDetails), Grant);
     await consent({
       ctx: context,
@@ -322,6 +194,7 @@ describe('consent', () => {
       interactionDetails: baseInteractionDetails,
     });
 
+    expect(insertGrantClientSnapshot).not.toHaveBeenCalled();
     expect(insertGrantOrganization).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -1,5 +1,5 @@
 import { jsonObjectGuard } from '@logto/schemas';
-import { conditional } from '@silverhand/essentials';
+import { conditional, trySafe } from '@silverhand/essentials';
 import type { Context } from 'koa';
 import type { PromptDetail, Provider } from 'oidc-provider';
 import { errors } from 'oidc-provider';
@@ -130,6 +130,14 @@ const snapshotNameMaxLength = 256;
 const snapshotLogoUriMaxLength = 2048;
 
 /**
+ * PostgreSQL `varchar(n)` counts characters (code points), so the column bounds must be applied
+ * the same way — a UTF-16 `slice`/`length` would split a surrogate pair at the boundary into a
+ * lone `�`, or reject a value the column actually fits.
+ */
+const truncateToCodePoints = (value: string, maxLength: number) =>
+  Array.from(value).slice(0, maxLength).join('');
+
+/**
  * Persist the grant-scoped CIMD rows: the client display snapshot on every consent, and the
  * organization binding when one was selected.
  *
@@ -142,7 +150,8 @@ const snapshotLogoUriMaxLength = 2048;
  * The organization part asserts the binding holds after the write: exactly one row, carrying
  * the submitted organization. Its conflict-ignored insert cannot tell a same-organization retry
  * from a different organization landing on the grant, and the exactly-one read also fails
- * closed when the row was cascade-deleted in between.
+ * closed when the row was cascade-deleted in between. It precedes the snapshot write so a
+ * submission rejected here leaves no snapshot behind.
  *
  * No-ops for a non-CIMD client — the rows are CIMD-only.
  */
@@ -160,29 +169,53 @@ const saveCimdGrantRecords = async (
     return;
   }
 
+  if (organizationId) {
+    await queries.cimd.grantOrganizations.insert({ grantId, organizationId, userId });
+    const organizationIds = await queries.cimd.grantOrganizations.findOrganizationIds(grantId);
+    assertThat(
+      organizationIds.length === 1 && organizationIds[0] === organizationId,
+      new errors.InvalidRequest(
+        'the grant organization binding does not match the submitted organization'
+      )
+    );
+  }
+
   const client = await provider.Client.find(cimdClientId);
   assertThat(client, new errors.InvalidClient('client must be available'));
 
   await queries.cimd.grantClientSnapshots.insert({
     grantId,
     clientId: cimdClientId,
-    name: client.clientName?.slice(0, snapshotNameMaxLength) ?? null,
+    name:
+      client.clientName === undefined
+        ? null
+        : truncateToCodePoints(client.clientName, snapshotNameMaxLength),
     logoUri:
-      client.logoUri && client.logoUri.length <= snapshotLogoUriMaxLength ? client.logoUri : null,
+      client.logoUri && Array.from(client.logoUri).length <= snapshotLogoUriMaxLength
+        ? client.logoUri
+        : null,
   });
+};
 
-  if (!organizationId) {
-    return;
+/**
+ * A fresh grant is already persisted when its records are written, so a failed write would
+ * leave an orphan Grant row — and once the snapshot marker exists, such an orphan would
+ * surface as an active CIMD grant in the grant list until pruned. Destroying the grant lets
+ * the foreign-key cascades erase whatever records were written with it; best effort — the
+ * write error stays the failure the consent surfaces.
+ */
+const saveCimdGrantRecordsForFreshGrant = async (
+  provider: Provider,
+  queries: Queries,
+  grant: { destroy: () => Promise<void> },
+  data: { grantId: string; cimdClientId?: string; organizationId?: string; userId: string }
+) => {
+  try {
+    await saveCimdGrantRecords(provider, queries, data);
+  } catch (error: unknown) {
+    await trySafe(async () => grant.destroy());
+    throw error;
   }
-
-  await queries.cimd.grantOrganizations.insert({ grantId, organizationId, userId });
-  const organizationIds = await queries.cimd.grantOrganizations.findOrganizationIds(grantId);
-  assertThat(
-    organizationIds.length === 1 && organizationIds[0] === organizationId,
-    new errors.InvalidRequest(
-      'the grant organization binding does not match the submitted organization'
-    )
-  );
 };
 
 export const consent = async ({
@@ -267,7 +300,7 @@ export const consent = async ({
 
   if (!existingGrant) {
     /** Precedes the interaction result update so a failed write fails the whole consent. */
-    await saveCimdGrantRecords(provider, queries, {
+    await saveCimdGrantRecordsForFreshGrant(provider, queries, grant, {
       grantId: finalGrantId,
       cimdClientId,
       organizationId: cimdOrganizationId,

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -118,22 +118,65 @@ const saveInteractionLastSubmissionToSession = async (
 };
 
 /**
- * Insert the grant-scoped organization row and assert the binding holds: exactly one row,
- * carrying the submitted organization. The conflict-ignored insert cannot tell a
- * same-organization retry from a different organization landing on the grant, and the
- * exactly-one read also fails closed when the row was cascade-deleted in between. No-ops
- * without an organization — the binding is CIMD-only.
+ * Must fit the `name varchar(256)` column of `cimd_grant_client_snapshots` — an overlong name
+ * is truncated rather than failing the consent over display data.
  */
-const bindCimdGrantOrganization = async (
+const snapshotNameMaxLength = 256;
+
+/**
+ * Must fit the `logo_uri varchar(2048)` column of `cimd_grant_client_snapshots` — a truncated
+ * URL is useless, so an overlong logo URI is stored as absent.
+ */
+const snapshotLogoUriMaxLength = 2048;
+
+/**
+ * Persist the grant-scoped CIMD rows: the client display snapshot on every consent, and the
+ * organization binding when one was selected.
+ *
+ * The snapshot captures the identity the user approved, read from the provider-validated
+ * metadata document — the same source the consent page rendered. An unvetted client can rewrite
+ * its hosted document at any time, so the grant list renders this row instead of refetching,
+ * and the row's existence marks the grant as CIMD. The conflict-ignored insert keeps the first
+ * write on a retried submission instead of failing.
+ *
+ * The organization part asserts the binding holds after the write: exactly one row, carrying
+ * the submitted organization. Its conflict-ignored insert cannot tell a same-organization retry
+ * from a different organization landing on the grant, and the exactly-one read also fails
+ * closed when the row was cascade-deleted in between.
+ *
+ * No-ops for a non-CIMD client — the rows are CIMD-only.
+ */
+const saveCimdGrantRecords = async (
+  provider: Provider,
   queries: Queries,
-  { organizationId, ...data }: { grantId: string; organizationId?: string; userId: string }
+  {
+    grantId,
+    cimdClientId,
+    organizationId,
+    userId,
+  }: { grantId: string; cimdClientId?: string; organizationId?: string; userId: string }
 ) => {
+  if (!cimdClientId) {
+    return;
+  }
+
+  const client = await provider.Client.find(cimdClientId);
+  assertThat(client, new errors.InvalidClient('client must be available'));
+
+  await queries.cimd.grantClientSnapshots.insert({
+    grantId,
+    clientId: cimdClientId,
+    name: client.clientName?.slice(0, snapshotNameMaxLength) ?? null,
+    logoUri:
+      client.logoUri && client.logoUri.length <= snapshotLogoUriMaxLength ? client.logoUri : null,
+  });
+
   if (!organizationId) {
     return;
   }
 
-  await queries.cimd.grantOrganizations.insert({ ...data, organizationId });
-  const organizationIds = await queries.cimd.grantOrganizations.findOrganizationIds(data.grantId);
+  await queries.cimd.grantOrganizations.insert({ grantId, organizationId, userId });
+  const organizationIds = await queries.cimd.grantOrganizations.findOrganizationIds(grantId);
   assertThat(
     organizationIds.length === 1 && organizationIds[0] === organizationId,
     new errors.InvalidRequest(
@@ -188,11 +231,12 @@ export const consent = async ({
   /**
    * Occupying the organization binding precedes every change to a reused grant, so a
    * conflicting organization fails before this round mutates the grant. A fresh grant cannot
-   * conflict, and its row must follow `grant.save()` — the row's FK needs the grant row.
+   * conflict, and its rows must follow `grant.save()` — their foreign keys need the grant row.
    */
   if (grantId && existingGrant) {
-    await bindCimdGrantOrganization(queries, {
+    await saveCimdGrantRecords(provider, queries, {
       grantId,
+      cimdClientId,
       organizationId: cimdOrganizationId,
       userId: accountId,
     });
@@ -223,8 +267,9 @@ export const consent = async ({
 
   if (!existingGrant) {
     /** Precedes the interaction result update so a failed write fails the whole consent. */
-    await bindCimdGrantOrganization(queries, {
+    await saveCimdGrantRecords(provider, queries, {
       grantId: finalGrantId,
+      cimdClientId,
       organizationId: cimdOrganizationId,
       userId: accountId,
     });

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -10,6 +10,7 @@ import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-c
 import { isCimdClient } from '#src/oidc/cimd/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
+import { getConsoleLogFromContext } from '#src/utils/console.js';
 
 import { updateInteractionResult } from './interaction.js';
 
@@ -182,19 +183,37 @@ const saveCimdGrantRecords = async (
 
 /**
  * A failed record write would orphan the already-saved grant, and once the snapshot marker
- * exists the orphan would surface in the grant list — destroy it, best effort, and let the
- * foreign-key cascades erase the written rows.
+ * exists the orphan would surface in the grant list — destroy it and let the foreign-key
+ * cascades erase the written rows. Best effort: a failed cleanup is logged, the write error
+ * stays the surfaced failure, and an uncleaned orphan expires with the grant TTL.
  */
 const saveCimdGrantRecordsForFreshGrant = async (
+  ctx: Context,
   provider: Provider,
   queries: Queries,
-  grant: { destroy: () => Promise<void> },
-  data: { grantId: string; cimdClientId?: string; organizationId?: string; userId: string }
+  {
+    grant,
+    ...data
+  }: {
+    grant: { destroy: () => Promise<void> };
+    grantId: string;
+    cimdClientId?: string;
+    organizationId?: string;
+    userId: string;
+  }
 ) => {
   try {
     await saveCimdGrantRecords(provider, queries, data);
   } catch (error: unknown) {
-    await trySafe(async () => grant.destroy());
+    await trySafe(
+      async () => grant.destroy(),
+      (destroyError) => {
+        getConsoleLogFromContext(ctx).warn(
+          'Failed to destroy the grant after a failed cimd record write:',
+          destroyError
+        );
+      }
+    );
     throw error;
   }
 };
@@ -281,7 +300,8 @@ export const consent = async ({
 
   if (!existingGrant) {
     /** Precedes the interaction result update so a failed write fails the whole consent. */
-    await saveCimdGrantRecordsForFreshGrant(provider, queries, grant, {
+    await saveCimdGrantRecordsForFreshGrant(ctx, provider, queries, {
+      grant,
       grantId: finalGrantId,
       cimdClientId,
       organizationId: cimdOrganizationId,

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -117,43 +117,26 @@ const saveInteractionLastSubmissionToSession = async (
   }
 };
 
-/**
- * Must fit the `name varchar(256)` column of `cimd_grant_client_snapshots` — an overlong name
- * is truncated rather than failing the consent over display data.
- */
+/** The snapshot's `name varchar(256)` bound — truncate rather than fail the consent. */
 const snapshotNameMaxLength = 256;
 
-/**
- * Must fit the `logo_uri varchar(2048)` column of `cimd_grant_client_snapshots` — a truncated
- * URL is useless, so an overlong logo URI is stored as absent.
- */
+/** The snapshot's `logo_uri varchar(2048)` bound — a truncated URL is useless, so null instead. */
 const snapshotLogoUriMaxLength = 2048;
 
 /**
- * PostgreSQL `varchar(n)` counts characters (code points), so the column bounds must be applied
- * the same way — a UTF-16 `slice`/`length` would split a surrogate pair at the boundary into a
- * lone `�`, or reject a value the column actually fits.
+ * PostgreSQL `varchar(n)` counts code points — a UTF-16 `slice` could split a surrogate pair
+ * into a lone `�`.
  */
 const truncateToCodePoints = (value: string, maxLength: number) =>
   Array.from(value).slice(0, maxLength).join('');
 
 /**
- * Persist the grant-scoped CIMD rows: the client display snapshot on every consent, and the
- * organization binding when one was selected.
- *
- * The snapshot captures the identity the user approved, read from the provider-validated
- * metadata document — the same source the consent page rendered. An unvetted client can rewrite
- * its hosted document at any time, so the grant list renders this row instead of refetching,
- * and the row's existence marks the grant as CIMD. The conflict-ignored insert keeps the first
- * write on a retried submission instead of failing.
- *
- * The organization part asserts the binding holds after the write: exactly one row, carrying
- * the submitted organization. Its conflict-ignored insert cannot tell a same-organization retry
- * from a different organization landing on the grant, and the exactly-one read also fails
- * closed when the row was cascade-deleted in between. It precedes the snapshot write so a
- * submission rejected here leaves no snapshot behind.
- *
- * No-ops for a non-CIMD client — the rows are CIMD-only.
+ * The client snapshot rides every CIMD consent: the grant list renders it instead of
+ * refetching the rewritable document, and its existence marks the grant as CIMD. The
+ * organization binding precedes it so a rejected submission leaves no snapshot, and must hold
+ * exactly the submitted organization — the conflict-ignored insert cannot tell a
+ * same-organization retry from a different organization landing on the grant, and the read
+ * fails closed when the row was cascade-deleted in between. No-ops for a non-CIMD client.
  */
 const saveCimdGrantRecords = async (
   provider: Provider,
@@ -198,11 +181,9 @@ const saveCimdGrantRecords = async (
 };
 
 /**
- * A fresh grant is already persisted when its records are written, so a failed write would
- * leave an orphan Grant row — and once the snapshot marker exists, such an orphan would
- * surface as an active CIMD grant in the grant list until pruned. Destroying the grant lets
- * the foreign-key cascades erase whatever records were written with it; best effort — the
- * write error stays the failure the consent surfaces.
+ * A failed record write would orphan the already-saved grant, and once the snapshot marker
+ * exists the orphan would surface in the grant list — destroy it, best effort, and let the
+ * foreign-key cascades erase the written rows.
  */
 const saveCimdGrantRecordsForFreshGrant = async (
   provider: Provider,

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -167,17 +167,16 @@ const saveCimdGrantRecords = async (
   const client = await provider.Client.find(cimdClientId);
   assertThat(client, new errors.InvalidClient('client must be available'));
 
+  const { clientName, logoUri } = client;
+
+  /** The insert builder maps an explicitly-undefined field to SQL null. */
   await queries.cimd.grantClientSnapshots.insert({
     grantId,
     clientId: cimdClientId,
-    name:
-      client.clientName === undefined
-        ? null
-        : truncateToCodePoints(client.clientName, snapshotNameMaxLength),
-    logoUri:
-      client.logoUri && Array.from(client.logoUri).length <= snapshotLogoUriMaxLength
-        ? client.logoUri
-        : null,
+    name: conditional(clientName && truncateToCodePoints(clientName, snapshotNameMaxLength)),
+    logoUri: conditional(
+      logoUri && Array.from(logoUri).length <= snapshotLogoUriMaxLength && logoUri
+    ),
   });
 };
 

--- a/packages/core/src/libraries/session/consent.ts
+++ b/packages/core/src/libraries/session/consent.ts
@@ -1,5 +1,5 @@
 import { jsonObjectGuard } from '@logto/schemas';
-import { conditional, trySafe } from '@silverhand/essentials';
+import { conditional } from '@silverhand/essentials';
 import type { Context } from 'koa';
 import type { PromptDetail, Provider } from 'oidc-provider';
 import { errors } from 'oidc-provider';
@@ -10,8 +10,8 @@ import { markAppLevelAccessControlChecked } from '#src/oidc/application-access-c
 import { isCimdClient } from '#src/oidc/cimd/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
-import { getConsoleLogFromContext } from '#src/utils/console.js';
 
+import { saveCimdGrantRecords } from './cimd-grant-records.js';
 import { updateInteractionResult } from './interaction.js';
 
 // Get the missing scopes from prompt details
@@ -118,105 +118,6 @@ const saveInteractionLastSubmissionToSession = async (
   }
 };
 
-/** The snapshot's `name varchar(256)` bound — truncate rather than fail the consent. */
-const snapshotNameMaxLength = 256;
-
-/** The snapshot's `logo_uri varchar(2048)` bound — a truncated URL is useless, so null instead. */
-const snapshotLogoUriMaxLength = 2048;
-
-/**
- * PostgreSQL `varchar(n)` counts code points — a UTF-16 `slice` could split a surrogate pair
- * into a lone `�`.
- */
-const truncateToCodePoints = (value: string, maxLength: number) =>
-  Array.from(value).slice(0, maxLength).join('');
-
-/**
- * The client snapshot rides every CIMD consent: the grant list renders it instead of
- * refetching the rewritable document, and its existence marks the grant as CIMD. The
- * organization binding precedes it so a rejected submission leaves no snapshot, and must hold
- * exactly the submitted organization — the conflict-ignored insert cannot tell a
- * same-organization retry from a different organization landing on the grant, and the read
- * fails closed when the row was cascade-deleted in between. No-ops for a non-CIMD client.
- */
-const saveCimdGrantRecords = async (
-  provider: Provider,
-  queries: Queries,
-  {
-    grantId,
-    cimdClientId,
-    organizationId,
-    userId,
-  }: { grantId: string; cimdClientId?: string; organizationId?: string; userId: string }
-) => {
-  if (!cimdClientId) {
-    return;
-  }
-
-  if (organizationId) {
-    await queries.cimd.grantOrganizations.insert({ grantId, organizationId, userId });
-    const organizationIds = await queries.cimd.grantOrganizations.findOrganizationIds(grantId);
-    assertThat(
-      organizationIds.length === 1 && organizationIds[0] === organizationId,
-      new errors.InvalidRequest(
-        'the grant organization binding does not match the submitted organization'
-      )
-    );
-  }
-
-  const client = await provider.Client.find(cimdClientId);
-  assertThat(client, new errors.InvalidClient('client must be available'));
-
-  const { clientName, logoUri } = client;
-
-  /** The insert builder maps an explicitly-undefined field to SQL null. */
-  await queries.cimd.grantClientSnapshots.insert({
-    grantId,
-    clientId: cimdClientId,
-    name: conditional(clientName && truncateToCodePoints(clientName, snapshotNameMaxLength)),
-    logoUri: conditional(
-      logoUri && Array.from(logoUri).length <= snapshotLogoUriMaxLength && logoUri
-    ),
-  });
-};
-
-/**
- * A failed record write would orphan the already-saved grant, and once the snapshot marker
- * exists the orphan would surface in the grant list — destroy it and let the foreign-key
- * cascades erase the written rows. Best effort: a failed cleanup is logged, the write error
- * stays the surfaced failure, and an uncleaned orphan expires with the grant TTL.
- */
-const saveCimdGrantRecordsForFreshGrant = async (
-  ctx: Context,
-  provider: Provider,
-  queries: Queries,
-  {
-    grant,
-    ...data
-  }: {
-    grant: { destroy: () => Promise<void> };
-    grantId: string;
-    cimdClientId?: string;
-    organizationId?: string;
-    userId: string;
-  }
-) => {
-  try {
-    await saveCimdGrantRecords(provider, queries, data);
-  } catch (error: unknown) {
-    await trySafe(
-      async () => grant.destroy(),
-      (destroyError) => {
-        getConsoleLogFromContext(ctx).warn(
-          'Failed to destroy the grant after a failed cimd record write:',
-          destroyError
-        );
-      }
-    );
-    throw error;
-  }
-};
-
 export const consent = async ({
   ctx,
   provider,
@@ -266,7 +167,7 @@ export const consent = async ({
    * conflict, and its rows must follow `grant.save()` — their foreign keys need the grant row.
    */
   if (grantId && existingGrant) {
-    await saveCimdGrantRecords(provider, queries, {
+    await saveCimdGrantRecords(ctx, provider, queries, {
       grantId,
       cimdClientId,
       organizationId: cimdOrganizationId,
@@ -299,12 +200,12 @@ export const consent = async ({
 
   if (!existingGrant) {
     /** Precedes the interaction result update so a failed write fails the whole consent. */
-    await saveCimdGrantRecordsForFreshGrant(ctx, provider, queries, {
-      grant,
+    await saveCimdGrantRecords(ctx, provider, queries, {
       grantId: finalGrantId,
       cimdClientId,
       organizationId: cimdOrganizationId,
       userId: accountId,
+      freshGrant: grant,
     });
   }
 

--- a/packages/core/src/libraries/session/session-context.test.ts
+++ b/packages/core/src/libraries/session/session-context.test.ts
@@ -32,6 +32,7 @@ const userQueries = {
 const queries = {
   users: userQueries,
   oidcSessionExtensions: { insert: oidcSessionExtensionsInsert },
+  cimd: { grantClientSnapshots: { insert: jest.fn() } },
 } as unknown as Queries;
 const context = createContextWithRouteParameters();
 
@@ -90,6 +91,9 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
   const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
 
+  /** The grant client snapshot path resolves the client for its display data. */
+  const cimdClient = { find: async (): Promise<unknown> => ({ clientName: 'Example App' }) };
+
   beforeEach(() => {
     Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
@@ -110,7 +114,11 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
       cimdClientId: null,
     }));
     const interactionDetails = buildInteractionDetails(cimdClientId);
-    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+    const provider = createMockProvider(
+      jest.fn().mockResolvedValue(interactionDetails),
+      Grant,
+      cimdClient
+    );
 
     await consent({
       ctx: context,
@@ -138,7 +146,11 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
       cimdClientId: 'https://first.example.com/metadata.json',
     }));
     const interactionDetails = buildInteractionDetails(cimdClientId);
-    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+    const provider = createMockProvider(
+      jest.fn().mockResolvedValue(interactionDetails),
+      Grant,
+      cimdClient
+    );
 
     await consent({
       ctx: context,
@@ -158,7 +170,11 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
       cimdClientId: null,
     }));
     const interactionDetails = buildInteractionDetails(cimdClientId);
-    const provider = createMockProvider(jest.fn().mockResolvedValue(interactionDetails), Grant);
+    const provider = createMockProvider(
+      jest.fn().mockResolvedValue(interactionDetails),
+      Grant,
+      cimdClient
+    );
 
     await consent({
       ctx: context,

--- a/packages/core/src/queries/cimd.ts
+++ b/packages/core/src/queries/cimd.ts
@@ -180,10 +180,7 @@ const createGrantOrganizationQueries = (pool: CommonQueryMethods) => {
 };
 
 const createGrantClientSnapshotQueries = (pool: CommonQueryMethods) => {
-  /**
-   * Idempotent so a retried consent submission does not fail — the first write wins, keeping
-   * the identity closest to what the user saw when approving.
-   */
+  /** Idempotent so a retried consent submission does not fail; the first write wins. */
   const insert = buildInsertIntoWithPool(pool)(CimdGrantClientSnapshots, {
     onConflict: { ignore: true },
   });

--- a/packages/core/src/queries/cimd.ts
+++ b/packages/core/src/queries/cimd.ts
@@ -1,5 +1,6 @@
 import { type UserScope } from '@logto/core-kit';
 import {
+  CimdGrantClientSnapshots,
   CimdGrantOrganizations,
   CimdOrganizationResourceScopes,
   CimdOrganizationScopes,
@@ -178,10 +179,23 @@ const createGrantOrganizationQueries = (pool: CommonQueryMethods) => {
   return { insert, exists, findOrganizationIds };
 };
 
+const createGrantClientSnapshotQueries = (pool: CommonQueryMethods) => {
+  /**
+   * Idempotent so a retried consent submission does not fail — the first write wins, keeping
+   * the identity closest to what the user saw when approving.
+   */
+  const insert = buildInsertIntoWithPool(pool)(CimdGrantClientSnapshots, {
+    onConflict: { ignore: true },
+  });
+
+  return { insert };
+};
+
 export const createCimdQueries = (pool: CommonQueryMethods) => ({
   userScopes: createUserScopeQueries(pool),
   resourceScopes: createResourceScopeQueries(pool),
   organizationScopes: createOrganizationScopeQueries(pool),
   organizationResourceScopes: createOrganizationResourceScopeQueries(pool),
   grantOrganizations: createGrantOrganizationQueries(pool),
+  grantClientSnapshots: createGrantClientSnapshotQueries(pool),
 });

--- a/packages/core/src/test-utils/oidc-provider.ts
+++ b/packages/core/src/test-utils/oidc-provider.ts
@@ -42,7 +42,8 @@ export abstract class GrantMock {
 
 export const createMockProvider = (
   interactionDetails?: jest.Mock,
-  Grant?: typeof GrantMock
+  Grant?: typeof GrantMock,
+  Client?: { find: (id: string) => Promise<unknown> }
 ): Provider => {
   const provider = createTestProvider('https://logto.test');
 
@@ -55,6 +56,10 @@ export const createMockProvider = (
 
   if (Grant) {
     Sinon.stub(provider, 'Grant').value(Grant);
+  }
+
+  if (Client) {
+    Sinon.stub(provider, 'Client').value(Client);
   }
 
   return provider;


### PR DESCRIPTION
## Summary

Persist a per-grant client display snapshot into `cimd_grant_client_snapshots` on every CIMD consent, so the grant list can render the metadata resolved at the successful consent submission even after the client rewrites its hosted document.

- Widen the consent callback (`bindCimdGrantOrganization` → `saveCimdGrantRecords`) from "CIMD with an organization selected" to every CIMD consent; the organization row and its exactly-one verify stay conditional inside, and both call-site orderings are preserved (occupy before mutating a reused grant, after `grant.save()` on a fresh one so a failed write fails the whole consent).
- Display data is the provider-validated metadata resolved at the consent submission; an unresolvable client fails the consent.
- The conflict-ignored insert keeps a retried submission from failing, and the row's existence later serves as the "this grant is CIMD" marker for the active-grants query (LOG-13935).
- The organization binding is occupied and verified before the snapshot write, and a failed record write on a fresh grant destroys the just-saved grant — best effort: a failed cleanup is logged and an uncleaned orphan expires with the grant TTL.
- An overlong name is truncated to the 256-character column bound (counted by code point — PostgreSQL `varchar` semantics); an overlong `logo_uri` is stored as null since a truncated URL is useless.

No changeset — dev-gated; the user-facing changeset ships with the feature release.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
