### PR TITLE
feat: expose the cimd client id on user responses

### DIFF
--- a/packages/console/src/pages/Actions/ActionDetails/utils/config.tsx
+++ b/packages/console/src/pages/Actions/ActionDetails/utils/config.tsx
@@ -46,6 +46,7 @@ const defaultPostSignInUser: JwtCustomizerUserContext = {
   createdAt: 1_704_067_200_000,
   updatedAt: 1_704_067_200_000,
   applicationId: 'app_123',
+  cimdClientId: null,
   isSuspended: false,
   hasPassword: true,
   ssoIdentities: [],

--- a/packages/core/src/libraries/hook/index.test.ts
+++ b/packages/core/src/libraries/hook/index.test.ts
@@ -68,6 +68,7 @@ const { triggerInteractionHooks, triggerTestHook, triggerDataHooks } = createHoo
       findUserById: jest.fn().mockReturnValue({
         id: 'user_id',
         username: 'user',
+        cimdClientId: 'https://client.example.com/metadata.json',
         extraField: 'not_ok',
       }),
     },
@@ -114,7 +115,11 @@ describe('triggerInteractionHooks()', () => {
         interactionEvent: 'SignIn',
         sessionId: interactionHookContext.metadata.sessionId,
         userId: '123',
-        user: { id: 'user_id', username: 'user' },
+        user: {
+          id: 'user_id',
+          username: 'user',
+          cimdClientId: 'https://client.example.com/metadata.json',
+        },
         application: { id: 'app_id' },
         createdAt: new Date(100_000).toISOString(),
       },

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -71,6 +71,7 @@ export const generateHookTestPayload = (hookId: string, event: HookEvent): HookE
       },
       profile: {},
       applicationId: 'fake-application-id',
+      cimdClientId: null,
       isSuspended: false,
       lastSignInAt: now.getTime(),
       createdAt: now.getTime(),

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -13,7 +13,19 @@
         "description": "Get profile for the user.",
         "responses": {
           "200": {
-            "description": "The profile was retrieved successfully."
+            "description": "The profile was retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cimdClientId": {
+                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`. Only returned with the `profile` scope.",
+                      "x-logto-dev-feature": true
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -46,7 +58,19 @@
         },
         "responses": {
           "200": {
-            "description": "The profile was updated successfully."
+            "description": "The profile was updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cimdClientId": {
+                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`. Only returned with the `profile` scope.",
+                      "x-logto-dev-feature": true
+                    }
+                  }
+                }
+              }
+            }
           },
           "400": {
             "description": "The request body is invalid."

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -33,6 +33,12 @@ import accountUserAssetsRoutes from './user-assets.js';
 import { getAccountCenterFilteredProfile, getScopedProfile } from './utils/get-scoped-profile.js';
 import { hasSecurityVerificationMethod } from './utils/has-security-verification-method.js';
 
+/**
+ * The Account API never returns `cimdClientId` — `getScopedProfile()` rebuilds the payload without
+ * it, so keep it out of the advertised response schema.
+ */
+const accountProfileResponseGuard = userProfileResponseGuard.omit({ cimdClientId: true }).partial();
+
 export default function accountRoutes<T extends UserRouter>(...args: RouterInitArgs<T>) {
   const [router, { queries, libraries }] = args;
   const {
@@ -50,7 +56,7 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
   router.get(
     `${accountApiPrefix}`,
     koaGuard({
-      response: userProfileResponseGuard.partial(),
+      response: accountProfileResponseGuard,
       status: [200],
     }),
     async (ctx, next) => {
@@ -70,7 +76,7 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
         username: z.string().regex(usernameRegEx).nullable().optional(),
         customData: jsonObjectGuard.optional(),
       }),
-      response: userProfileResponseGuard.partial(),
+      response: accountProfileResponseGuard,
       status: [200, 400, 401, 422],
     }),
     async (ctx, next) => {

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -33,12 +33,6 @@ import accountUserAssetsRoutes from './user-assets.js';
 import { getAccountCenterFilteredProfile, getScopedProfile } from './utils/get-scoped-profile.js';
 import { hasSecurityVerificationMethod } from './utils/has-security-verification-method.js';
 
-/**
- * The Account API never returns `cimdClientId` — `getScopedProfile()` rebuilds the payload without
- * it, so keep it out of the advertised response schema.
- */
-const accountProfileResponseGuard = userProfileResponseGuard.omit({ cimdClientId: true }).partial();
-
 export default function accountRoutes<T extends UserRouter>(...args: RouterInitArgs<T>) {
   const [router, { queries, libraries }] = args;
   const {
@@ -56,7 +50,7 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
   router.get(
     `${accountApiPrefix}`,
     koaGuard({
-      response: accountProfileResponseGuard,
+      response: userProfileResponseGuard.partial(),
       status: [200],
     }),
     async (ctx, next) => {
@@ -76,7 +70,7 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
         username: z.string().regex(usernameRegEx).nullable().optional(),
         customData: jsonObjectGuard.optional(),
       }),
-      response: accountProfileResponseGuard,
+      response: userProfileResponseGuard.partial(),
       status: [200, 400, 401, 422],
     }),
     async (ctx, next) => {

--- a/packages/core/src/routes/account/utils/get-scoped-profile.ts
+++ b/packages/core/src/routes/account/utils/get-scoped-profile.ts
@@ -43,6 +43,7 @@ export const getScopedProfile = async (
     updatedAt,
     profile: { address, ...restProfile },
     applicationId,
+    cimdClientId,
     isSuspended,
     hasPassword,
   } = transpileUserProfileResponse(user);
@@ -70,6 +71,7 @@ export const getScopedProfile = async (
           createdAt,
           updatedAt,
           applicationId,
+          cimdClientId,
           isSuspended,
           hasPassword,
         }

--- a/packages/core/src/routes/admin-user/basic.openapi.json
+++ b/packages/core/src/routes/admin-user/basic.openapi.json
@@ -35,6 +35,10 @@
                     },
                     "passwordAlgorithm": {
                       "description": "The algorithm used to hash the password. Only present when `includePasswordHash` is provided with a truthy value. `null` if the user has no password set."
+                    },
+                    "cimdClientId": {
+                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                      "x-logto-dev-feature": true
                     }
                   }
                 }
@@ -70,7 +74,19 @@
         },
         "responses": {
           "200": {
-            "description": "Updated user data for the given ID."
+            "description": "Updated user data for the given ID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cimdClientId": {
+                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                      "x-logto-dev-feature": true
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Update user",
@@ -226,7 +242,19 @@
         },
         "responses": {
           "200": {
-            "description": "User data for the newly created user."
+            "description": "User data for the newly created user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cimdClientId": {
+                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                      "x-logto-dev-feature": true
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Create user",
@@ -250,7 +278,19 @@
         },
         "responses": {
           "200": {
-            "description": "User password updated successfully."
+            "description": "User password updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cimdClientId": {
+                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                      "x-logto-dev-feature": true
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Update user password",
@@ -274,7 +314,19 @@
         },
         "responses": {
           "200": {
-            "description": "User password expiration state has been updated successfully."
+            "description": "User password expiration state has been updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cimdClientId": {
+                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                      "x-logto-dev-feature": true
+                    }
+                  }
+                }
+              }
+            }
           },
           "400": {
             "description": "Password expiration policy is not enabled in the sign-in experience settings."
@@ -339,7 +391,19 @@
         },
         "responses": {
           "200": {
-            "description": "User suspension status updated successfully."
+            "description": "User suspension status updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cimdClientId": {
+                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                      "x-logto-dev-feature": true
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Update user suspension status",

--- a/packages/core/src/routes/admin-user/search.openapi.json
+++ b/packages/core/src/routes/admin-user/search.openapi.json
@@ -4,7 +4,21 @@
       "get": {
         "responses": {
           "200": {
-            "description": "An array of users that match the given criteria."
+            "description": "An array of users that match the given criteria.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "cimdClientId": {
+                        "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                        "x-logto-dev-feature": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Get users",

--- a/packages/core/src/routes/admin-user/social.openapi.json
+++ b/packages/core/src/routes/admin-user/social.openapi.json
@@ -33,7 +33,19 @@
         "parameters": [],
         "responses": {
           "200": {
-            "description": "The identity is deleted from the user."
+            "description": "The identity is deleted from the user.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "cimdClientId": {
+                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                      "x-logto-dev-feature": true
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Delete social identity from user",

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -85,6 +85,7 @@ const mockJwtCustomizerUserContext: JwtCustomizerUserContext = {
   updatedAt: mockUser.updatedAt,
   profile: mockUser.profile,
   applicationId: mockUser.applicationId,
+  cimdClientId: mockUser.cimdClientId,
   isSuspended: mockUser.isSuspended,
   hasPassword: true,
   ssoIdentities: [],

--- a/packages/core/src/routes/experience/classes/libraries/action-result-validation.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/action-result-validation.test.ts
@@ -37,6 +37,7 @@ const actionUser: JwtCustomizerUserContext = {
   updatedAt: mockUser.updatedAt,
   profile: mockUser.profile,
   applicationId: mockUser.applicationId,
+  cimdClientId: mockUser.cimdClientId,
   isSuspended: mockUser.isSuspended,
   hasPassword: true,
   ssoIdentities: [],

--- a/packages/core/src/routes/organization/index.openapi.json
+++ b/packages/core/src/routes/organization/index.openapi.json
@@ -98,6 +98,28 @@
           }
         }
       }
+    },
+    "/api/organizations/{id}/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "cimdClientId": {
+                        "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                        "x-logto-dev-feature": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/packages/core/src/routes/role.openapi.json
+++ b/packages/core/src/routes/role.openapi.json
@@ -108,7 +108,21 @@
       "get": {
         "responses": {
           "200": {
-            "description": "An array of users who have the role assigned."
+            "description": "An array of users who have the role assigned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "cimdClientId": {
+                        "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
+                        "x-logto-dev-feature": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "summary": "Get role users",

--- a/packages/core/src/routes/swagger/utils/documents.test.ts
+++ b/packages/core/src/routes/swagger/utils/documents.test.ts
@@ -1,0 +1,168 @@
+import { type OpenAPIV3 } from 'openapi-types';
+
+import { EnvSet } from '#src/env-set/index.js';
+import { type DeepPartial } from '#src/test-utils/tenant.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import { assembleSwaggerDocument } from './documents.js';
+import { devFeatureSchemaExtension } from './general.js';
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Tests need to cover both dev-feature states.
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
+};
+
+/**
+ * Mimics the generated base document: the user payload schema comes from the env-free zod guards,
+ * so `cimdClientId` appears in `properties` and `required` without any dev-feature marker,
+ * including occurrences nested in `oneOf` branches (e.g. the JWT customizer context schemas).
+ */
+const createBaseDocument = (): OpenAPIV3.Document => ({
+  openapi: '3.0.1',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/api/users/{userId}': {
+      get: {
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['id', 'cimdClientId'],
+                  properties: {
+                    id: { type: 'string' },
+                    cimdClientId: { type: 'string', nullable: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/configs/jwt-customizer': {
+      get: {
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': {
+                schema: {
+                  oneOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        contextSample: {
+                          type: 'object',
+                          properties: {
+                            user: {
+                              type: 'object',
+                              properties: {
+                                id: { type: 'string' },
+                                cimdClientId: { type: 'string', nullable: true },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+const createMarkedPropertySchema = () =>
+  ({
+    description: 'Dev feature. The CIMD client identifier.',
+    [devFeatureSchemaExtension]: true,
+  }) satisfies OpenAPIV3.SchemaObject & Record<typeof devFeatureSchemaExtension, true>;
+
+const createSupplementDocument = (): DeepPartial<OpenAPIV3.Document> => ({
+  paths: {
+    '/api/users/{userId}': {
+      get: {
+        responses: {
+          '200': {
+            content: {
+              'application/json': {
+                schema: {
+                  properties: {
+                    cimdClientId: createMarkedPropertySchema(),
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+const assemble = () =>
+  assembleSwaggerDocument(
+    [createSupplementDocument()],
+    createBaseDocument(),
+    createContextWithRouteParameters()
+  );
+
+describe('assembleSwaggerDocument', () => {
+  afterEach(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
+  it('should prune dev feature properties from the assembled document when dev features are disabled', () => {
+    setDevFeaturesEnabled(false);
+
+    const document = assemble();
+
+    expect(JSON.stringify(document)).not.toContain('cimdClientId');
+    expect(JSON.stringify(document)).not.toContain(devFeatureSchemaExtension);
+    expect(document.paths['/api/users/{userId}']?.get?.responses['200']).toMatchObject({
+      content: {
+        'application/json': {
+          schema: {
+            required: ['id'],
+            properties: { id: { type: 'string' } },
+          },
+        },
+      },
+    });
+  });
+
+  it('should keep dev feature properties without the internal marker when dev features are enabled', () => {
+    setDevFeaturesEnabled(true);
+
+    const document = assemble();
+
+    expect(JSON.stringify(document)).not.toContain(devFeatureSchemaExtension);
+    expect(document.paths['/api/users/{userId}']?.get?.responses['200']).toMatchObject({
+      content: {
+        'application/json': {
+          schema: {
+            required: ['id', 'cimdClientId'],
+            properties: {
+              cimdClientId: { description: 'Dev feature. The CIMD client identifier.' },
+            },
+          },
+        },
+      },
+    });
+    expect(
+      JSON.stringify(document.paths['/api/configs/jwt-customizer']?.get?.responses['200'])
+    ).toContain('cimdClientId');
+  });
+});

--- a/packages/core/src/routes/swagger/utils/documents.ts
+++ b/packages/core/src/routes/swagger/utils/documents.ts
@@ -20,6 +20,7 @@ import {
   devFeatureTag,
   findSupplementFiles,
   pruneSwaggerDocument,
+  removeDevFeatureSchemaProperties,
   removeUnnecessaryOperations,
   shouldThrow,
   validateSupplement,
@@ -285,6 +286,12 @@ export const assembleSwaggerDocument = <ContextT extends IRouterParamContext>(
     baseDocument
   );
 
+  /**
+   * Supplements are pruned before merging, but the base document is generated from the env-free
+   * zod guards in `@logto/schemas` and can still carry dev-feature properties — prune the
+   * assembled result as well.
+   */
+  removeDevFeatureSchemaProperties(data);
   pruneSwaggerDocument(data);
 
   if (EnvSet.values.isUnitTest) {

--- a/packages/core/src/routes/swagger/utils/general.test.ts
+++ b/packages/core/src/routes/swagger/utils/general.test.ts
@@ -3,7 +3,11 @@ import { type OpenAPIV3 } from 'openapi-types';
 import { EnvSet } from '#src/env-set/index.js';
 import { type DeepPartial } from '#src/test-utils/tenant.js';
 
-import { devFeatureSchemaExtension, removeUnnecessaryOperations } from './general.js';
+import {
+  devFeatureSchemaExtension,
+  removeDevFeatureSchemaProperties,
+  removeUnnecessaryOperations,
+} from './general.js';
 
 const originalIsCloud = EnvSet.values.isCloud;
 const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
@@ -78,7 +82,8 @@ describe('swagger general utils', () => {
   it('should remove dev feature schema properties when dev features are disabled', () => {
     setDevFeaturesEnabled(false);
 
-    const document = removeUnnecessaryOperations(createDocument());
+    const document = createDocument();
+    removeDevFeatureSchemaProperties(document);
 
     expect(document).toMatchObject({
       paths: {
@@ -109,7 +114,8 @@ describe('swagger general utils', () => {
   it('should keep dev feature schema properties without exposing the internal marker when dev features are enabled', () => {
     setDevFeaturesEnabled(true);
 
-    const document = removeUnnecessaryOperations(createDocument());
+    const document = createDocument();
+    removeDevFeatureSchemaProperties(document);
 
     expect(document).toMatchObject({
       paths: {

--- a/packages/core/src/routes/swagger/utils/general.ts
+++ b/packages/core/src/routes/swagger/utils/general.ts
@@ -21,6 +21,17 @@ export const devFeatureTag = 'Dev feature';
 /** The OpenAPI schema extension that hides a schema property when dev features are disabled. */
 export const devFeatureSchemaExtension = 'x-logto-dev-feature';
 
+/**
+ * Schema property names that belong to in-development features. These properties are generated
+ * from the env-free zod guards in `@logto/schemas`, and supplement markers cannot reach every
+ * generated occurrence (e.g. properties nested in `oneOf` branches, which `deepmerge` appends to
+ * instead of merging into), so the assembled document is also pruned by property name.
+ */
+const devFeatureSchemaPropertyNames = new Set([
+  // DEV: CIMD (client ID metadata document) support
+  'cimdClientId',
+]);
+
 const reservedTags = new Set([cloudOnlyTag, devFeatureTag]);
 
 /**
@@ -262,9 +273,12 @@ export const validateSwaggerDocument = (document: OpenAPIV3.Document) => {
  *
  * Remove operations (path + method) that are tagged with `Cloud only` if the application is not
  * running in the cloud and remove operations with `Dev feature` tag if Logto's
- * `isDevFeaturesEnabled` flag is set to be false. It also prunes schema properties marked with
- * `x-logto-dev-feature` when dev features are disabled, and removes the internal marker when they
- * are enabled.
+ * `isDevFeaturesEnabled` flag is set to be false.
+ *
+ * Dev-feature schema properties are NOT pruned here: supplement documents run through this
+ * function before merging, and pruning `x-logto-dev-feature` markers at that point would strip
+ * them before they reach the base schema properties generated from the guards. The assembled
+ * document is pruned instead — see {@link removeDevFeatureSchemaProperties}.
  *
  * This will prevent the swagger validation from failing in the OSS environment.
  *
@@ -274,8 +288,6 @@ export const removeUnnecessaryOperations = (
   document: DeepPartial<OpenAPIV3.Document>
 ): DeepPartial<OpenAPIV3.Document> => {
   const { isCloud, isDevFeaturesEnabled } = EnvSet.values;
-
-  removeDevFeatureSchemaProperties(document);
 
   if ((isCloud && isDevFeaturesEnabled) || !document.paths) {
     return document;
@@ -336,7 +348,9 @@ const removeDevFeatureSchemaProperty = (
   propertyName: string,
   propertySchema: unknown
 ) => {
-  if (!isRecord(propertySchema) || propertySchema[devFeatureSchemaExtension] !== true) {
+  const isMarked = isRecord(propertySchema) && propertySchema[devFeatureSchemaExtension] === true;
+
+  if (!isMarked && !devFeatureSchemaPropertyNames.has(propertyName)) {
     return false;
   }
 
@@ -347,12 +361,24 @@ const removeDevFeatureSchemaProperty = (
     return true;
   }
 
-  Reflect.deleteProperty(propertySchema, devFeatureSchemaExtension);
+  if (isMarked && isRecord(propertySchema)) {
+    Reflect.deleteProperty(propertySchema, devFeatureSchemaExtension);
+  }
 
   return false;
 };
 
-const removeDevFeatureSchemaProperties = (value: unknown) => {
+/**
+ * **CAUTION**: This function mutates the input value.
+ *
+ * Recursively prune dev-feature schema properties: when dev features are disabled, properties
+ * marked with `x-logto-dev-feature` or listed in the dev-feature property names are removed
+ * (including their `required` entries); when enabled, only the internal marker is removed.
+ *
+ * Run this on the assembled document — the base schema properties generated from the env-free
+ * zod guards carry no markers, so pruning supplements alone cannot remove them.
+ */
+export const removeDevFeatureSchemaProperties = (value: unknown) => {
   if (Array.isArray(value)) {
     for (const item of value) {
       removeDevFeatureSchemaProperties(item);

--- a/packages/core/src/utils/user.test.ts
+++ b/packages/core/src/utils/user.test.ts
@@ -1,0 +1,38 @@
+import { mockUser } from '#src/__mocks__/index.js';
+
+import { transpileUserProfileResponse } from './user.js';
+
+describe('transpileUserProfileResponse', () => {
+  it('should pin the exposed user info fields', () => {
+    expect(transpileUserProfileResponse(mockUser)).toStrictEqual({
+      id: mockUser.id,
+      username: mockUser.username,
+      primaryEmail: mockUser.primaryEmail,
+      primaryPhone: mockUser.primaryPhone,
+      name: mockUser.name,
+      avatar: mockUser.avatar,
+      customData: mockUser.customData,
+      identities: mockUser.identities,
+      lastSignInAt: mockUser.lastSignInAt,
+      createdAt: mockUser.createdAt,
+      updatedAt: mockUser.updatedAt,
+      profile: mockUser.profile,
+      applicationId: mockUser.applicationId,
+      cimdClientId: mockUser.cimdClientId,
+      isSuspended: mockUser.isSuspended,
+      hasPassword: true,
+    });
+  });
+
+  it('should expose the cimd client id when the user is attributed to a cimd client', () => {
+    const cimdClientId = 'https://client.example.com/metadata.json';
+    const response = transpileUserProfileResponse({
+      ...mockUser,
+      applicationId: null,
+      cimdClientId,
+    });
+
+    expect(response.applicationId).toBeNull();
+    expect(response.cimdClientId).toBe(cimdClientId);
+  });
+});

--- a/packages/schemas/src/types/user.ts
+++ b/packages/schemas/src/types/user.ts
@@ -22,6 +22,7 @@ export const userInfoSelectFields = Object.freeze([
   'updatedAt',
   'profile',
   'applicationId',
+  'cimdClientId',
   'isSuspended',
 ] satisfies Array<keyof User>);
 


### PR DESCRIPTION
## Summary

Add `cimdClientId` to `userInfoSelectFields` so user API responses expose the CIMD client the user is attributed to from their first consent.

- All user payloads derive from this list, so the field flows to Management API user responses, `/me` profile payloads, webhook user context, and JWT customizer user data.
- `applicationId` semantics are unchanged; the two columns form a single first-consent attribution and only one is ever set.
- The Account API returns the field under the `profile` scope next to `applicationId`, keeping both halves of the attribution symmetric for the end user.
- The field ships with ungated runtime projections as an agreed release-policy exception: `userInfoSelectFields` lives in the env-free schemas package, the field is required (nullable) in `userInfoGuard`, and production values are always `null` because the writes are dev-gated. Values written while `DEV_FEATURES_ENABLED` was on remain visible after it is flipped off — accepted for an experimental flag.
- Public OpenAPI output is gated: dev-feature schema pruning now runs on the assembled document (supplement-stage pruning could never reach the guard-generated base properties), with a central dev-feature property-name registry covering occurrences that supplement markers cannot address (e.g. `oneOf` branches in the JWT customizer context schemas).

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)