### PR TITLE
feat(core,schemas): surface cimd grants on the active grants api

### DIFF
--- a/packages/core/src/libraries/session/index.test.ts
+++ b/packages/core/src/libraries/session/index.test.ts
@@ -1,11 +1,124 @@
 import { SessionGrantRevokeTarget } from '@logto/schemas';
 import type { Provider } from 'oidc-provider';
+import Sinon from 'sinon';
 
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import { type ActiveApplicationGrantInstance } from '#src/queries/oidc-model-instance.js';
 import type Queries from '#src/tenants/Queries.js';
 
 import { createSessionLibrary } from './index.js';
 
 const { jest } = import.meta;
+
+const stubDevFeaturesFlag = (isDevFeaturesEnabled: boolean) => {
+  Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isDevFeaturesEnabled });
+};
+
+describe('findUserActiveApplicationGrants', () => {
+  const findActiveApplicationGrants = jest.fn<
+    Promise<ActiveApplicationGrantInstance[]>,
+    [string, ('firstParty' | 'thirdParty')?]
+  >(async () => []);
+  const findActiveCimdGrants = jest.fn<Promise<ActiveApplicationGrantInstance[]>, [string]>(
+    async () => []
+  );
+
+  const sessionLibrary = createSessionLibrary({
+    oidcModelInstances: {
+      findUserActiveApplicationGrants: findActiveApplicationGrants,
+      findUserActiveCimdGrants: findActiveCimdGrants,
+    },
+    oidcSessionExtensions: {
+      findUserActiveSessionsWithExtensions: jest.fn(async () => []),
+      findUserActiveSessionWithExtension: jest.fn(async () => null),
+    },
+  } as unknown as Queries);
+
+  const basePayload = {
+    exp: 1_700_000_600,
+    iat: 1_700_000_000,
+    jti: 'jti',
+    kind: 'Grant',
+    accountId: 'user-id',
+  } as const;
+
+  const registeredGrantRow = {
+    id: 'grant-1',
+    payload: { ...basePayload, clientId: 'app-1' },
+    expiresAt: 1_700_000_600_000,
+    application: { id: 'app-1', name: 'App One' },
+  };
+
+  afterEach(() => {
+    Sinon.restore();
+    jest.clearAllMocks();
+  });
+
+  it('should pass registered application grants through', async () => {
+    stubDevFeaturesFlag(true);
+    findActiveApplicationGrants.mockResolvedValueOnce([registeredGrantRow]);
+
+    await expect(
+      sessionLibrary.findUserActiveApplicationGrants('user-id', 'thirdParty')
+    ).resolves.toEqual([registeredGrantRow]);
+    expect(findActiveApplicationGrants).toHaveBeenCalledWith('user-id', 'thirdParty');
+    expect(findActiveCimdGrants).toHaveBeenCalledWith('user-id');
+  });
+
+  it('should append cimd grants after the registered ones', async () => {
+    stubDevFeaturesFlag(true);
+    const cimdClientId = 'https://client.example.com/oauth/metadata.json';
+    const cimdGrantRow = {
+      id: 'cimd-grant-id',
+      payload: { ...basePayload, clientId: cimdClientId },
+      expiresAt: 1_700_000_600_000,
+      application: { id: cimdClientId, name: 'Example App' },
+    };
+
+    findActiveApplicationGrants.mockResolvedValueOnce([registeredGrantRow]);
+    findActiveCimdGrants.mockResolvedValueOnce([cimdGrantRow]);
+
+    await expect(sessionLibrary.findUserActiveApplicationGrants('user-id')).resolves.toEqual([
+      registeredGrantRow,
+      cimdGrantRow,
+    ]);
+  });
+
+  it('should not query cimd grants when dev features are disabled', async () => {
+    stubDevFeaturesFlag(false);
+
+    await sessionLibrary.findUserActiveApplicationGrants('user-id');
+
+    expect(findActiveCimdGrants).not.toHaveBeenCalled();
+  });
+
+  it('should not query cimd grants for the first-party filter', async () => {
+    stubDevFeaturesFlag(true);
+
+    await sessionLibrary.findUserActiveApplicationGrants('user-id', 'firstParty');
+
+    expect(findActiveCimdGrants).not.toHaveBeenCalled();
+    expect(findActiveApplicationGrants).toHaveBeenCalledWith('user-id', 'firstParty');
+  });
+
+  it('should throw a server error on an invalid grant payload', async () => {
+    stubDevFeaturesFlag(true);
+    findActiveApplicationGrants.mockResolvedValueOnce([
+      {
+        id: 'grant-1',
+        // Missing the required `clientId` field.
+        payload: { ...basePayload },
+        expiresAt: 1_700_000_600_000,
+        application: { id: 'app-1', name: 'App One' },
+      },
+    ]);
+
+    await expect(sessionLibrary.findUserActiveApplicationGrants('user-id')).rejects.toThrow(
+      RequestError
+    );
+  });
+});
 
 describe('revokeSessionAssociatedGrants', () => {
   const revokeAccessTokenByGrantId = jest.fn(async () => 'ok');

--- a/packages/core/src/libraries/session/index.ts
+++ b/packages/core/src/libraries/session/index.ts
@@ -7,6 +7,7 @@ import {
 import { deduplicate } from '@silverhand/essentials';
 import type { Provider, Session } from 'oidc-provider';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type SessionInstanceWithExtension } from '#src/queries/oidc-session-extensions.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -136,12 +137,17 @@ export const createSessionLibrary = (queries: Queries) => {
     userId: string,
     applicationType?: 'thirdParty' | 'firstParty'
   ) => {
-    const result = await queries.oidcModelInstances.findUserActiveApplicationGrants(
-      userId,
-      applicationType
-    );
+    const [applicationGrants, cimdGrants] = await Promise.all([
+      queries.oidcModelInstances.findUserActiveApplicationGrants(userId, applicationType),
+      // DEV: CIMD (client ID metadata document) support
+      // CIMD clients are third-party by definition, so the `firstParty` filter skips their
+      // query entirely.
+      EnvSet.values.isDevFeaturesEnabled && applicationType !== 'firstParty'
+        ? queries.oidcModelInstances.findUserActiveCimdGrants(userId)
+        : [],
+    ]);
 
-    return result.map((grant) => formatApplicationGrant(grant));
+    return [...applicationGrants, ...cimdGrants].map((grant) => formatApplicationGrant(grant));
   };
 
   const revokeSessionAssociatedGrants = async ({

--- a/packages/core/src/queries/oidc-model-instance.cimd.test.ts
+++ b/packages/core/src/queries/oidc-model-instance.cimd.test.ts
@@ -1,0 +1,72 @@
+import { CimdGrantClientSnapshots, OidcModelInstances } from '@logto/schemas';
+import { createMockPool, createMockQueryResult, sql } from '@silverhand/slonik';
+
+import { createMockOidcGrantInstance } from '#src/__mocks__/oidc-grant.js';
+import { convertToIdentifiers } from '#src/utils/sql.js';
+import type { QueryType } from '#src/utils/test-utils.js';
+import { expectSqlAssert } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
+
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return mockQuery(sql, values);
+  },
+});
+
+const { createOidcModelInstanceQueries } = await import('./oidc-model-instance.js');
+const { findUserActiveCimdGrants } = createOidcModelInstanceQueries(pool);
+
+/** In its own file because `oidc-model-instance.test.ts` is at the max-lines lint cap. */
+describe('findUserActiveCimdGrants', () => {
+  const { table, fields } = convertToIdentifiers(OidcModelInstances);
+  const { table: cimdGrantClientSnapshotTable } = convertToIdentifiers(CimdGrantClientSnapshots);
+
+  afterEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('joins the consent-time snapshot into the application shape', async () => {
+    const userId = 'user-id';
+    const expectSql = sql`
+      select ${fields.id}, ${fields.payload}, ${fields.expiresAt},
+        json_build_object(
+          'id', "cimd_grant_client_snapshots"."client_id",
+          'name', coalesce(
+            "cimd_grant_client_snapshots"."name",
+            "cimd_grant_client_snapshots"."client_id"
+          )
+        ) as application
+      from ${table}
+      inner join ${cimdGrantClientSnapshotTable}
+        on "cimd_grant_client_snapshots"."tenant_id"="oidc_model_instances"."tenant_id"
+        and "cimd_grant_client_snapshots"."grant_id"=${fields.id}
+      where ${fields.modelName}='Grant'
+        and ${fields.payload}->>'accountId'=${userId}
+        and ${fields.expiresAt} > to_timestamp($2)
+    `;
+
+    const cimdClientId = 'https://client.example.com/oauth/metadata.json';
+    const cimdGrant = {
+      ...createMockOidcGrantInstance({
+        id: 'cimd-grant-id',
+        payload: { kind: 'Grant', clientId: cimdClientId, accountId: userId },
+      }),
+      application: {
+        id: cimdClientId,
+        name: 'Example App',
+      },
+    };
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toEqual([userId, expect.any(Number)]);
+
+      return createMockQueryResult([cimdGrant as never]);
+    });
+
+    await expect(findUserActiveCimdGrants(userId)).resolves.toEqual([cimdGrant]);
+  });
+});

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -1,5 +1,5 @@
 import type { Application, OidcModelInstance, OidcModelInstancePayload } from '@logto/schemas';
-import { Applications, OidcModelInstances } from '@logto/schemas';
+import { Applications, CimdGrantClientSnapshots, OidcModelInstances } from '@logto/schemas';
 import { ConsoleLog } from '@logto/shared';
 import type { Nullable } from '@silverhand/essentials';
 import { conditional } from '@silverhand/essentials';
@@ -16,6 +16,7 @@ export type QueryResult = Pick<OidcModelInstance, 'payload' | 'consumedAt'>;
 
 const { table, fields } = convertToIdentifiers(OidcModelInstances);
 const { table: applicationTable } = convertToIdentifiers(Applications);
+const cimdGrantClientSnapshots = convertToIdentifiers(CimdGrantClientSnapshots, true);
 
 export type ActiveGrantInstance = Pick<OidcModelInstance, 'id' | 'payload' | 'expiresAt'>;
 export type ActiveApplicationGrantInstance = ActiveGrantInstance & {
@@ -297,6 +298,41 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
     `);
   };
 
+  /**
+   * Active grants of CIMD (client ID metadata document) clients, shaped like the registered
+   * application grants. They are URL identities without an `applications` row, so
+   * `findUserActiveApplicationGrants` cannot see them; a grant is a CIMD grant exactly when a
+   * consent-time snapshot row exists for it, and the snapshot carries the approved display data.
+   *
+   * The identifier URL stands in for a missing name: `client_name` is optional in the metadata
+   * document, and the snapshot write normalizes an empty one to null.
+   */
+  const findUserActiveCimdGrants = async (userId: string) => {
+    /** The snapshot table also has a `tenant_id` column, so this side of the join must qualify. */
+    const oidcModelInstanceTenantId = sql.identifier([
+      OidcModelInstances.table,
+      OidcModelInstances.fields.tenantId,
+    ]);
+
+    return pool.any<ActiveApplicationGrantInstance>(sql`
+      select ${fields.id}, ${fields.payload}, ${fields.expiresAt},
+        json_build_object(
+          'id', ${cimdGrantClientSnapshots.fields.clientId},
+          'name', coalesce(
+            ${cimdGrantClientSnapshots.fields.name},
+            ${cimdGrantClientSnapshots.fields.clientId}
+          )
+        ) as application
+      from ${table}
+      inner join ${cimdGrantClientSnapshots.table}
+        on ${cimdGrantClientSnapshots.fields.tenantId}=${oidcModelInstanceTenantId}
+        and ${cimdGrantClientSnapshots.fields.grantId}=${fields.id}
+      where ${fields.modelName}='Grant'
+        and ${fields.payload}->>'accountId'=${userId}
+        and ${fields.expiresAt} > ${convertToTimestamp()}
+    `);
+  };
+
   const findUserActiveGrantsByClientId = async (userId: string, clientId: string) => {
     return pool.any<ActiveGrantInstance>(sql`
       select ${fields.id}, ${fields.payload}, ${fields.expiresAt}
@@ -337,6 +373,7 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
     revokeInstanceByGrantId,
     revokeInstanceByUserId,
     findUserActiveApplicationGrants,
+    findUserActiveCimdGrants,
     findUserActiveGrantsByClientId,
     findUserActiveSessionUidByGrantId,
   };

--- a/packages/core/src/routes/account/grants.ts
+++ b/packages/core/src/routes/account/grants.ts
@@ -1,8 +1,13 @@
 import { UserScope } from '@logto/core-kit';
-import { AccountCenterControlValue, getUserApplicationGrantsResponseGuard } from '@logto/schemas';
+import {
+  AccountCenterControlValue,
+  getCimdCapableUserApplicationGrantsResponseGuard,
+  getUserApplicationGrantsResponseGuard,
+} from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -10,6 +15,11 @@ import assertThat from '#src/utils/assert-that.js';
 import { type UserRouter, type RouterInitArgs } from '../types.js';
 
 import { accountApiPrefix } from './constants.js';
+
+// DEV: CIMD (client ID metadata document) support
+const grantsResponseGuard = EnvSet.values.isDevFeaturesEnabled
+  ? getCimdCapableUserApplicationGrantsResponseGuard
+  : getUserApplicationGrantsResponseGuard;
 
 export default function accountGrantRoutes<T extends UserRouter>(
   ...[router, { provider, libraries }]: RouterInitArgs<T>
@@ -23,7 +33,7 @@ export default function accountGrantRoutes<T extends UserRouter>(
         appType: z.enum(['firstParty', 'thirdParty']).optional(),
       }),
       status: [200, 400, 401, 500],
-      response: getUserApplicationGrantsResponseGuard,
+      response: grantsResponseGuard,
     }),
     async (ctx, next) => {
       const { id: userId, scopes, identityVerified } = ctx.auth;

--- a/packages/core/src/routes/admin-user/grants.ts
+++ b/packages/core/src/routes/admin-user/grants.ts
@@ -1,11 +1,20 @@
-import { getUserApplicationGrantsResponseGuard } from '@logto/schemas';
+import {
+  getCimdCapableUserApplicationGrantsResponseGuard,
+  getUserApplicationGrantsResponseGuard,
+} from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 import { object, string, enum as zodEnum } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 
 import { type ManagementApiRouter, type RouterInitArgs } from '../types.js';
+
+// DEV: CIMD (client ID metadata document) support
+const grantsResponseGuard = EnvSet.values.isDevFeaturesEnabled
+  ? getCimdCapableUserApplicationGrantsResponseGuard
+  : getUserApplicationGrantsResponseGuard;
 
 export default function adminUserGrantRoutes<T extends ManagementApiRouter>(
   ...[router, tenant]: RouterInitArgs<T>
@@ -22,7 +31,7 @@ export default function adminUserGrantRoutes<T extends ManagementApiRouter>(
       query: object({
         appType: zodEnum(['firstParty', 'thirdParty']).optional(),
       }),
-      response: getUserApplicationGrantsResponseGuard,
+      response: grantsResponseGuard,
       status: [200, 500],
     }),
     async (ctx, next) => {

--- a/packages/schemas/src/types/user-sessions.ts
+++ b/packages/schemas/src/types/user-sessions.ts
@@ -111,3 +111,22 @@ export const getUserApplicationGrantsResponseGuard = z.object({
 export type GetUserApplicationGrantsResponse = z.infer<
   typeof getUserApplicationGrantsResponseGuard
 >;
+
+/**
+ * The grants response as it looks once CIMD clients can hold grants. They are URL identities
+ * without an `applications` row: the identifier URL lands in `application.id` and its name comes
+ * from the consent-time snapshot, so neither field can keep the applications table varchar
+ * bounds. Graduation folds this shape back into {@link getUserApplicationGrantsResponseGuard} —
+ * until then the published contract keeps its bounds, and the inferred response type is
+ * identical either way.
+ */
+export const getCimdCapableUserApplicationGrantsResponseGuard = z.object({
+  grants: z.array(
+    userApplicationGrantGuard.extend({
+      application: z.object({
+        id: z.string(),
+        name: z.string(),
+      }),
+    })
+  ),
+});


### PR DESCRIPTION
## Summary

Surface CIMD client grants on the active grants APIs (`GET /api/my-account/grants` and `GET /api/users/:userId/grants`), which previously dropped them by inner-joining `applications`.

- CIMD grants come from a separate, dev-feature-guarded query joining the consent-time client snapshots; the registered-application query is untouched, so behavior with dev features disabled is unchanged by construction.
- The response contract keeps its shape: every grant carries the required `application`, and a CIMD grant fills the same slot with the client identifier URL as `id` and the consent-time snapshot name as `name` (falling back to the identifier URL). Consumers tell the kinds apart by the id shape.
- The published guard and the OpenAPI supplements stay untouched. Both routes select a CIMD-capable guard — one relaxing the `applications` varchar bounds that the identifier URL exceeds — only when dev features are on, so the public document is unchanged until graduation folds the shape back in (LOG-13934).

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
