### PR TITLE
feat(console): add the email logs tab to the built-in email connector

### DIFF
--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -30,7 +30,7 @@
     "@fontsource/roboto-mono": "^5.0.0",
     "@inkeep/cxkit-react": "^0.5.66",
     "@jest/types": "^29.5.0",
-    "@logto/cloud": "0.2.5-a4e30ff",
+    "@logto/cloud": "0.2.5-cf6987f",
     "@logto/connector-kit": "workspace:^",
     "@logto/core-kit": "workspace:^",
     "@logto/language-kit": "workspace:^",

--- a/packages/console/src/cloud/hooks/use-cloud-api.ts
+++ b/packages/console/src/cloud/hooks/use-cloud-api.ts
@@ -1,5 +1,5 @@
 import type router from '@logto/cloud/routes';
-import { type tenantAuthRouter } from '@logto/cloud/routes';
+import { type emailLogsRouter, type tenantAuthRouter } from '@logto/cloud/routes';
 import { useLogto } from '@logto/react';
 import { getTenantOrganizationId } from '@logto/schemas';
 import { conditional, trySafe } from '@silverhand/essentials';
@@ -39,14 +39,22 @@ type UseCloudApiProps = {
   hideErrorToast?: boolean;
 };
 
-export const useCloudApi = ({ hideErrorToast = false }: UseCloudApiProps = {}): Client<
-  typeof router
-> => {
+/**
+ * The routers the cloud API exposes to the console under the same access token. Routers outside
+ * the default one are standalone on the cloud side (split to stay under TypeScript's
+ * type-instantiation depth limit), so the client type is selected per call site instead of
+ * intersecting them.
+ */
+type ConsoleCloudRouter = typeof router | typeof emailLogsRouter;
+
+export const useCloudApi = <R extends ConsoleCloudRouter = typeof router>({
+  hideErrorToast = false,
+}: UseCloudApiProps = {}): Client<R> => {
   const { i18n } = useTranslation();
   const { isAuthenticated, getAccessToken } = useLogto();
   const api = useMemo(
     () =>
-      new Client<typeof router>({
+      new Client<R>({
         baseUrl: window.location.origin,
         headers: async () => {
           if (isAuthenticated) {

--- a/packages/console/src/cloud/types/router.ts
+++ b/packages/console/src/cloud/types/router.ts
@@ -1,9 +1,18 @@
 import type router from '@logto/cloud/routes';
-import { type tenantAuthRouter } from '@logto/cloud/routes';
+import { type emailLogsRouter, type tenantAuthRouter } from '@logto/cloud/routes';
 import { type GuardedResponse, type RouterRoutes } from '@withtyped/client';
 
 type GetRoutes = RouterRoutes<typeof router>['get'];
 type GetTenantAuthRoutes = RouterRoutes<typeof tenantAuthRouter>['get'];
+type GetEmailLogsRoutes = RouterRoutes<typeof emailLogsRouter>['get'];
+
+/** The paginated hosted-email log page returned by the cloud email-logs endpoint. */
+export type TenantEmailLogsResponse = GuardedResponse<
+  GetEmailLogsRoutes['/api/tenants/:tenantId/email-logs']
+>;
+
+/** A single hosted-email log entry (redacted by the endpoint's response whitelist). */
+export type TenantEmailLog = TenantEmailLogsResponse['logs'][number];
 
 export type GetArrayElementType<T> = T extends Array<infer U> ? U : never;
 

--- a/packages/console/src/hooks/use-console-routes/routes/connectors.tsx
+++ b/packages/console/src/hooks/use-console-routes/routes/connectors.tsx
@@ -13,6 +13,6 @@ export const connectors = {
     { path: ':tab', element: <Connectors /> },
     { path: ':tab/create/:createType', element: <Connectors /> },
     { path: ':tab/guide/:factoryId', element: <Connectors /> },
-    { path: ':tab/:connectorId', element: <ConnectorDetails /> },
+    { path: ':tab/:connectorId/:connectorTab?', element: <ConnectorDetails /> },
   ],
 };

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/index.module.scss
@@ -1,0 +1,46 @@
+@use '@/scss/underscore' as _;
+
+.logs {
+  flex: 1;
+  margin-bottom: _.unit(2);
+}
+
+.filter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: _.unit(4);
+
+  .timeWindow {
+    display: flex;
+    align-items: center;
+  }
+
+  .title {
+    color: var(--color-text-secondary);
+    font: var(--font-body-2);
+  }
+
+  .timeRangePicker {
+    margin-inline-start: _.unit(2);
+  }
+}
+
+.messageId {
+  display: flex;
+  align-items: center;
+  gap: _.unit(1);
+
+  .messageIdValue {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+  gap: _.unit(2);
+  margin-bottom: _.unit(6);
+}

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/index.tsx
@@ -1,0 +1,174 @@
+import { useTranslation } from 'react-i18next';
+
+import { type TenantEmailLog } from '@/cloud/types/router';
+import TimeRangePicker from '@/components/AuditLogTable/components/TimeRangePicker';
+import { defaultPresetRange } from '@/components/AuditLogTable/components/TimeRangePicker/preset';
+import useAuditLogTimeWindow from '@/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window';
+import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
+import Button from '@/ds-components/Button';
+import CopyToClipboard from '@/ds-components/CopyToClipboard';
+import Search from '@/ds-components/Search';
+import Table from '@/ds-components/Table';
+import { type Column } from '@/ds-components/Table/types';
+import Tag from '@/ds-components/Tag';
+import useSearchParametersWatcher from '@/hooks/use-search-parameters-watcher';
+
+import styles from './index.module.scss';
+import useEmailLogs from './use-email-logs';
+
+/**
+ * The hosted-email send log for the built-in email connector: sent + failed rows from the
+ * cloud email-logs endpoint, windowed like the audit log (preset ranges + custom range) and
+ * cursor-paginated (the endpoint has no total count, so paging is previous/next only).
+ */
+function EmailLogs() {
+  const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+
+  // URL values are untyped; validated downstream via `isPresetRange`.
+  const initialRange: string = defaultPresetRange;
+  const [{ range, start_time, end_time, recipient }, updateSearchParameters] =
+    useSearchParametersWatcher({
+      range: initialRange,
+      start_time: '',
+      end_time: '',
+      recipient: '',
+    });
+
+  const {
+    startTime,
+    endTime,
+    pickerRangeValue,
+    customStartDate,
+    customEndDate,
+    handleRangeChange,
+    handleCustomDatesChange,
+  } = useAuditLogTimeWindow({
+    range,
+    startTimeRaw: start_time,
+    endTimeRaw: end_time,
+    updateSearchParameters,
+  });
+
+  const { logs, error, isLoading, mutate, hasNext, hasPrevious, next, previous } = useEmailLogs({
+    startTime,
+    endTime,
+    recipient,
+  });
+
+  // Column spans are proportional (the table is `table-layout: fixed`); sized by content type —
+  // recipient addresses and message ids are the long fields, language tags and status tags short.
+  const columns: Array<Column<TenantEmailLog>> = [
+    {
+      title: t('connector_details.email_logs.time'),
+      dataIndex: 'time',
+      colSpan: 3,
+      render: ({ createdAt }) => new Date(createdAt).toLocaleString(),
+    },
+    {
+      title: t('connector_details.email_logs.recipient'),
+      dataIndex: 'recipient',
+      colSpan: 4,
+      render: ({ recipient }) => recipient ?? '-',
+    },
+    {
+      title: t('connector_details.email_logs.template_type'),
+      dataIndex: 'templateType',
+      colSpan: 3,
+      render: ({ templateType }) => templateType ?? '-',
+    },
+    {
+      title: t('connector_details.email_logs.language_tag'),
+      dataIndex: 'locale',
+      colSpan: 2,
+      render: ({ locale }) => locale ?? '-',
+    },
+    {
+      title: t('connector_details.email_logs.provider_message_id'),
+      dataIndex: 'providerMessageId',
+      colSpan: 5,
+      render: ({ providerMessageId }) =>
+        providerMessageId ? (
+          <div className={styles.messageId}>
+            <span className={styles.messageIdValue} title={providerMessageId}>
+              {providerMessageId}
+            </span>
+            <CopyToClipboard variant="icon" value={providerMessageId} />
+          </div>
+        ) : (
+          '-'
+        ),
+    },
+    {
+      title: t('connector_details.email_logs.status'),
+      dataIndex: 'status',
+      colSpan: 3,
+      render: ({ status }) => (
+        <Tag type="result" status={status === 'sent' ? 'success' : 'error'}>
+          {t(
+            status === 'sent'
+              ? 'connector_details.email_logs.status_sent'
+              : 'connector_details.email_logs.status_failed'
+          )}
+        </Tag>
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <Table
+        className={styles.logs}
+        rowGroups={[{ key: 'logs', data: logs }]}
+        rowIndexKey="id"
+        columns={columns}
+        filter={
+          <div className={styles.filter}>
+            <Search
+              placeholder={t('connector_details.email_logs.recipient_placeholder')}
+              defaultValue={recipient}
+              isClearable={Boolean(recipient)}
+              onSearch={(value) => {
+                updateSearchParameters({ recipient: value });
+              }}
+              onClearSearch={() => {
+                updateSearchParameters({ recipient: '' });
+              }}
+            />
+            <div className={styles.timeWindow}>
+              <div className={styles.title}>{t('logs.filter_by')}</div>
+              <div className={styles.timeRangePicker}>
+                <TimeRangePicker
+                  value={pickerRangeValue}
+                  customStartDate={customStartDate}
+                  customEndDate={customEndDate}
+                  onChange={handleRangeChange}
+                  onCustomDatesChange={handleCustomDatesChange}
+                />
+              </div>
+            </div>
+          </div>
+        }
+        placeholder={<EmptyDataPlaceholder />}
+        isLoading={isLoading}
+        errorMessage={error instanceof Error ? error.message : undefined}
+        onRetry={async () => mutate(undefined, true)}
+      />
+      {(hasPrevious || hasNext) && (
+        <div className={styles.pagination}>
+          <Button
+            title="connector_details.email_logs.previous_page"
+            disabled={!hasPrevious}
+            onClick={previous}
+          />
+          <Button
+            title="connector_details.email_logs.next_page"
+            disabled={!hasNext}
+            onClick={next}
+          />
+        </div>
+      )}
+    </>
+  );
+}
+
+export default EmailLogs;

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/use-email-logs.ts
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/use-email-logs.ts
@@ -1,0 +1,81 @@
+import { type emailLogsRouter } from '@logto/cloud/routes';
+import { conditional } from '@silverhand/essentials';
+import { useCallback, useContext, useEffect, useState } from 'react';
+import useSWR from 'swr';
+
+import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
+import { type TenantEmailLogsResponse } from '@/cloud/types/router';
+import { TenantsContext } from '@/contexts/TenantsProvider';
+
+import { buildEmailLogsSearch } from './utils';
+
+type Props = {
+  /** Window start in epoch milliseconds; omitted when the picker has no valid start. */
+  readonly startTime?: number;
+  /** Inclusive window end in epoch milliseconds, as produced by the audit-log time window. */
+  readonly endTime?: number;
+  /** Full recipient address; the endpoint matches it case-insensitively and exactly. */
+  readonly recipient?: string;
+};
+
+/**
+ * Fetches one page of hosted-email logs for the current tenant (Cloud only). The endpoint is
+ * cursor-paginated (no total count), so paging is a cursor stack: `next` pushes the server's
+ * `nextCursor`, `previous` pops back to the prior page, and any window change resets to the
+ * first page.
+ */
+const useEmailLogs = ({ startTime, endTime, recipient }: Props) => {
+  const { currentTenantId } = useContext(TenantsContext);
+  const cloudApi = useCloudApi<typeof emailLogsRouter>({ hideErrorToast: true });
+  const [cursorStack, setCursorStack] = useState<string[]>([]);
+  const cursor = cursorStack.at(-1);
+
+  useEffect(() => {
+    setCursorStack([]);
+  }, [startTime, endTime, recipient]);
+
+  const { data, error, mutate } = useSWR<TenantEmailLogsResponse, unknown>(
+    conditional(
+      currentTenantId && [
+        'email-logs',
+        currentTenantId,
+        startTime,
+        endTime,
+        recipient ?? '',
+        cursor ?? '',
+      ]
+    ),
+    async () =>
+      cloudApi.get('/api/tenants/:tenantId/email-logs', {
+        params: { tenantId: currentTenantId },
+        search: buildEmailLogsSearch({ startTime, endTime, recipient, cursor }),
+      })
+  );
+
+  const nextCursor = data?.nextCursor ?? undefined;
+
+  const next = useCallback(() => {
+    if (nextCursor) {
+      setCursorStack((stack) => [...stack, nextCursor]);
+    }
+  }, [nextCursor]);
+
+  const previous = useCallback(() => {
+    setCursorStack((stack) => stack.slice(0, -1));
+  }, []);
+
+  return {
+    logs: data?.logs,
+    error,
+    // Loading only while the fetch is actually enabled — with no tenant id the key is null and
+    // SWR never fires, which would otherwise read as loading forever.
+    isLoading: Boolean(currentTenantId) && !data && !error,
+    mutate,
+    hasNext: Boolean(nextCursor),
+    hasPrevious: cursorStack.length > 0,
+    next,
+    previous,
+  };
+};
+
+export default useEmailLogs;

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/utils.test.ts
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/utils.test.ts
@@ -1,0 +1,38 @@
+import { buildEmailLogsSearch } from './utils';
+
+describe('buildEmailLogsSearch', () => {
+  it('converts the inclusive window end to the exclusive `to` bound', () => {
+    const search = buildEmailLogsSearch({
+      startTime: new Date('2026-08-01T00:00:00.000Z').getTime(),
+      endTime: new Date('2026-08-07T23:59:59.999Z').getTime(),
+    });
+
+    expect(search).toStrictEqual({
+      from: '2026-08-01T00:00:00.000Z',
+      to: '2026-08-08T00:00:00.000Z',
+    });
+  });
+
+  it('omits absent bounds and the cursor entirely', () => {
+    expect(buildEmailLogsSearch({})).toStrictEqual({});
+  });
+
+  it('passes the recipient through only when non-empty', () => {
+    expect(buildEmailLogsSearch({ recipient: 'user@example.com' })).toStrictEqual({
+      recipient: 'user@example.com',
+    });
+    expect(buildEmailLogsSearch({ recipient: '' })).toStrictEqual({});
+  });
+
+  it('passes the cursor through verbatim alongside the window', () => {
+    const search = buildEmailLogsSearch({
+      startTime: new Date('2026-08-01T00:00:00.000Z').getTime(),
+      cursor: 'opaque-cursor',
+    });
+
+    expect(search).toStrictEqual({
+      from: '2026-08-01T00:00:00.000Z',
+      cursor: 'opaque-cursor',
+    });
+  });
+});

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/utils.ts
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/utils.ts
@@ -1,0 +1,23 @@
+import { conditional } from '@silverhand/essentials';
+
+type WindowInput = {
+  /** Window start in epoch milliseconds; omitted when the picker has no valid start. */
+  startTime?: number;
+  /** Inclusive window end in epoch milliseconds, as produced by the audit-log time window. */
+  endTime?: number;
+  /** Full recipient address; the endpoint matches it case-insensitively and exactly. */
+  recipient?: string;
+  cursor?: string;
+};
+
+/**
+ * Translate the picker window, recipient filter, and cursor into the email-logs endpoint's
+ * search parameters. The picker window's end is inclusive; the endpoint's `to` bound is
+ * exclusive, hence the one-millisecond shift.
+ */
+export const buildEmailLogsSearch = ({ startTime, endTime, recipient, cursor }: WindowInput) => ({
+  ...conditional(startTime !== undefined && { from: new Date(startTime).toISOString() }),
+  ...conditional(endTime !== undefined && { to: new Date(endTime + 1).toISOString() }),
+  ...conditional(recipient && { recipient }),
+  ...conditional(cursor && { cursor }),
+});

--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -22,6 +22,7 @@ import Drawer from '@/components/Drawer';
 import Markdown from '@/components/Markdown';
 import PageMeta from '@/components/PageMeta';
 import UnnamedTrans from '@/components/UnnamedTrans';
+import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import { ConnectorsTabs } from '@/consts/page-tabs';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import type { RequestError } from '@/hooks/use-api';
@@ -33,6 +34,7 @@ import useTenantPathname from '@/hooks/use-tenant-pathname';
 import ConnectorContent from './ConnectorContent';
 import ConnectorTabs from './ConnectorTabs';
 import ConnectorTypeName from './ConnectorTypeName';
+import EmailLogs from './EmailLogs';
 import EmailUsage from './EmailUsage';
 import styles from './index.module.scss';
 
@@ -40,9 +42,19 @@ import styles from './index.module.scss';
 const getConnectorsPathname = (isSocial: boolean) =>
   `/connectors/${isSocial ? ConnectorsTabs.Social : ConnectorsTabs.Passwordless}`;
 
+/** Path segment of the hosted-email logs tab (`/connectors/:tab/:connectorId/email-logs`). */
+const emailLogsTab = 'email-logs';
+
+/** The hosted-email log only exists for the cloud built-in email service connector. */
+const isEmailLogsAvailable = (data?: ConnectorResponse) =>
+  isCloud &&
+  isDevFeaturesEnabled &&
+  data?.type === ConnectorType.Email &&
+  data.connectorId === ServiceConnector.Email;
+
 function ConnectorDetails() {
   const { pathname } = useLocation();
-  const { connectorId } = useParams();
+  const { connectorId, connectorTab } = useParams();
   const { createConnector } = useConnectorApi();
   const { mutate: mutateGlobal } = useSWRConfig();
   const [isDeleted, setIsDeleted] = useState(false);
@@ -71,6 +83,7 @@ function ConnectorDetails() {
   const api = useApi();
   const { navigate } = useTenantPathname();
   const isSocial = data?.type === ConnectorType.Social;
+  const showEmailLogsTab = isEmailLogsAvailable(data);
 
   const [isDeleteAlertOpen, setIsDeleteAlertOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -198,17 +211,34 @@ function ConnectorDetails() {
             }}
           />
           <TabNav>
-            <TabNavItem href={`${getConnectorsPathname(isSocial)}/${connectorId}`}>
+            <TabNavItem
+              href={`${getConnectorsPathname(isSocial)}/${connectorId}`}
+              // Mirrors the content conditional below: when the email-logs tab is unavailable the
+              // settings content is shown regardless of the URL, so settings stays the active tab.
+              isActive={!showEmailLogsTab || connectorTab !== emailLogsTab}
+            >
               {t('general.settings_nav')}
             </TabNavItem>
+            {showEmailLogsTab && (
+              <TabNavItem
+                href={`${getConnectorsPathname(isSocial)}/${connectorId}/${emailLogsTab}`}
+                isActive={connectorTab === emailLogsTab}
+              >
+                {t('connector_details.email_logs.title')}
+              </TabNavItem>
+            )}
           </TabNav>
-          <ConnectorContent
-            isDeleted={isDeleted}
-            connectorData={data}
-            onConnectorUpdated={(connector) => {
-              void mutate(connector);
-            }}
-          />
+          {showEmailLogsTab && connectorTab === emailLogsTab ? (
+            <EmailLogs />
+          ) : (
+            <ConnectorContent
+              isDeleted={isDeleted}
+              connectorData={data}
+              onConnectorUpdated={(connector) => {
+                void mutate(connector);
+              }}
+            />
+          )}
           <DeleteConnectorConfirmModal
             isOpen={isDeleteAlertOpen}
             isLoading={isDeleting}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
     "zod": "3.24.3"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-db73b11",
+    "@logto/cloud": "0.2.5-cf6987f",
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/ts-config": "6.0.0",
     "@types/adm-zip": "^0.5.5",

--- a/packages/phrases/src/locales/ar/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'ممكّن لتسجيل الدخول',
     not_in_use: 'معطّل لتسجيل الدخول',
   },
+  email_logs: {
+    title: 'سجلات البريد الإلكتروني',
+    time: 'الوقت',
+    recipient: 'المستلم',
+    recipient_placeholder: 'البحث بعنوان المستلم الكامل',
+    template_type: 'نوع القالب',
+    status: 'الحالة',
+    status_sent: 'تم الإرسال',
+    status_failed: 'فشل',
+    language_tag: 'اللغة',
+    provider_message_id: 'معرّف الرسالة لدى المزوّد',
+    previous_page: 'السابق',
+    next_page: 'التالي',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/de/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'Aktiviert für die Anmeldung',
     not_in_use: 'Deaktiviert für die Anmeldung',
   },
+  email_logs: {
+    title: 'E-Mail-Logs',
+    time: 'Zeit',
+    recipient: 'Empfänger',
+    recipient_placeholder: 'Nach vollständiger Empfängeradresse suchen',
+    template_type: 'Vorlagentyp',
+    status: 'Status',
+    status_sent: 'Gesendet',
+    status_failed: 'Fehlgeschlagen',
+    language_tag: 'Sprache',
+    provider_message_id: 'Nachrichten-ID des Anbieters',
+    previous_page: 'Zurück',
+    next_page: 'Weiter',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/en/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/connector-details.ts
@@ -86,6 +86,20 @@ const connector_details = {
     in_use: 'Enabled for sign-in ',
     not_in_use: 'Disabled for sign-in ',
   },
+  email_logs: {
+    title: 'Email logs',
+    time: 'Time',
+    recipient: 'Recipient',
+    recipient_placeholder: 'Search by full recipient address',
+    template_type: 'Template type',
+    status: 'Status',
+    status_sent: 'Sent',
+    status_failed: 'Failed',
+    language_tag: 'Language',
+    provider_message_id: 'Provider message ID',
+    previous_page: 'Previous',
+    next_page: 'Next',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/es/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'Habilitado para iniciar sesión',
     not_in_use: 'Deshabilitado para iniciar sesión',
   },
+  email_logs: {
+    title: 'Registros de correo electrónico',
+    time: 'Hora',
+    recipient: 'Destinatario',
+    recipient_placeholder: 'Buscar por dirección completa del destinatario',
+    template_type: 'Tipo de plantilla',
+    status: 'Estado',
+    status_sent: 'Enviado',
+    status_failed: 'Fallido',
+    language_tag: 'Idioma',
+    provider_message_id: 'ID del mensaje del proveedor',
+    previous_page: 'Anterior',
+    next_page: 'Siguiente',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/connector-details.ts
@@ -86,6 +86,20 @@ const connector_details = {
     in_use: 'برای ورود فعال است ',
     not_in_use: 'برای ورود غیرفعال است ',
   },
+  email_logs: {
+    title: 'گزارش‌های ایمیل',
+    time: 'زمان',
+    recipient: 'گیرنده',
+    recipient_placeholder: 'جستجو با آدرس کامل گیرنده',
+    template_type: 'نوع قالب',
+    status: 'وضعیت',
+    status_sent: 'ارسال شد',
+    status_failed: 'ناموفق',
+    language_tag: 'زبان',
+    provider_message_id: 'شناسه پیام ارائه‌دهنده',
+    previous_page: 'قبلی',
+    next_page: 'بعدی',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/fr/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'Activé pour la connexion',
     not_in_use: 'Désactivé pour la connexion',
   },
+  email_logs: {
+    title: "Journaux d'e-mails",
+    time: 'Heure',
+    recipient: 'Destinataire',
+    recipient_placeholder: 'Rechercher par adresse complète du destinataire',
+    template_type: 'Type de modèle',
+    status: 'Statut',
+    status_sent: 'Envoyé',
+    status_failed: 'Échoué',
+    language_tag: 'Langue',
+    provider_message_id: 'ID du message du fournisseur',
+    previous_page: 'Précédent',
+    next_page: 'Suivant',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/it/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/connector-details.ts
@@ -86,6 +86,20 @@ const connector_details = {
     in_use: "Abilitato per l'accesso ",
     not_in_use: "Disabilitato per l'accesso ",
   },
+  email_logs: {
+    title: 'Registri email',
+    time: 'Ora',
+    recipient: 'Destinatario',
+    recipient_placeholder: 'Cerca per indirizzo completo del destinatario',
+    template_type: 'Tipo di modello',
+    status: 'Stato',
+    status_sent: 'Inviata',
+    status_failed: 'Non riuscita',
+    language_tag: 'Lingua',
+    provider_message_id: 'ID messaggio del provider',
+    previous_page: 'Precedente',
+    next_page: 'Successivo',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/ja/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'サインインに有効',
     not_in_use: 'サインインに無効',
   },
+  email_logs: {
+    title: 'メールログ',
+    time: '時間',
+    recipient: '宛先',
+    recipient_placeholder: '受信者の完全なアドレスで検索',
+    template_type: 'テンプレートタイプ',
+    status: 'ステータス',
+    status_sent: '送信済み',
+    status_failed: '失敗',
+    language_tag: '言語',
+    provider_message_id: 'プロバイダーメッセージ ID',
+    previous_page: '前へ',
+    next_page: '次へ',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/ko/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/connector-details.ts
@@ -86,6 +86,20 @@ const connector_details = {
     in_use: '로그인에 사용 가능 ',
     not_in_use: '로그인에 사용 안 함 ',
   },
+  email_logs: {
+    title: '이메일 로그',
+    time: '시간',
+    recipient: '수신자',
+    recipient_placeholder: '수신자 전체 주소로 검색',
+    template_type: '템플릿 유형',
+    status: '상태',
+    status_sent: '전송됨',
+    status_failed: '실패',
+    language_tag: '언어',
+    provider_message_id: '제공자 메시지 ID',
+    previous_page: '이전',
+    next_page: '다음',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'Włączone dla logowania ',
     not_in_use: 'Wyłączone dla logowania ',
   },
+  email_logs: {
+    title: 'Dzienniki e-mail',
+    time: 'Czas',
+    recipient: 'Odbiorca',
+    recipient_placeholder: 'Szukaj po pełnym adresie odbiorcy',
+    template_type: 'Typ szablonu',
+    status: 'Status',
+    status_sent: 'Wysłano',
+    status_failed: 'Niepowodzenie',
+    language_tag: 'Język',
+    provider_message_id: 'ID wiadomości dostawcy',
+    previous_page: 'Poprzednia',
+    next_page: 'Następna',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'Habilitado para login',
     not_in_use: 'Desabilitado para login',
   },
+  email_logs: {
+    title: 'Logs de e-mail',
+    time: 'Hora',
+    recipient: 'Destinatário',
+    recipient_placeholder: 'Pesquisar pelo endereço completo do destinatário',
+    template_type: 'Tipo de modelo',
+    status: 'Status',
+    status_sent: 'Enviado',
+    status_failed: 'Falhou',
+    language_tag: 'Idioma',
+    provider_message_id: 'ID da mensagem do provedor',
+    previous_page: 'Anterior',
+    next_page: 'Próxima',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'Ativado para início de sessão',
     not_in_use: 'Desativado para início de sessão',
   },
+  email_logs: {
+    title: 'Registos de e-mail',
+    time: 'Hora',
+    recipient: 'Destinatário',
+    recipient_placeholder: 'Pesquisar pelo endereço completo do destinatário',
+    template_type: 'Tipo de modelo',
+    status: 'Estado',
+    status_sent: 'Enviado',
+    status_failed: 'Falhou',
+    language_tag: 'Idioma',
+    provider_message_id: 'ID da mensagem do fornecedor',
+    previous_page: 'Anterior',
+    next_page: 'Seguinte',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/ru/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'Включён для входа в систему ',
     not_in_use: 'Отключён для входа в систему ',
   },
+  email_logs: {
+    title: 'Журналы электронной почты',
+    time: 'Время',
+    recipient: 'Получатель',
+    recipient_placeholder: 'Поиск по полному адресу получателя',
+    template_type: 'Тип шаблона',
+    status: 'Статус',
+    status_sent: 'Отправлено',
+    status_failed: 'Ошибка',
+    language_tag: 'Язык',
+    provider_message_id: 'ID сообщения у провайдера',
+    previous_page: 'Назад',
+    next_page: 'Далее',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/th/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/connector-details.ts
@@ -85,6 +85,20 @@ const connector_details = {
     in_use: 'เปิดใช้งานสำหรับการเข้าสู่ระบบ ',
     not_in_use: 'ปิดใช้งานสำหรับการเข้าสู่ระบบ ',
   },
+  email_logs: {
+    title: 'บันทึกอีเมล',
+    time: 'เวลา',
+    recipient: 'ผู้รับ',
+    recipient_placeholder: 'ค้นหาด้วยที่อยู่ผู้รับแบบเต็ม',
+    template_type: 'ประเภทเทมเพลต',
+    status: 'สถานะ',
+    status_sent: 'ส่งแล้ว',
+    status_failed: 'ล้มเหลว',
+    language_tag: 'ภาษา',
+    provider_message_id: 'ID ข้อความของผู้ให้บริการ',
+    previous_page: 'ก่อนหน้า',
+    next_page: 'ถัดไป',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/connector-details.ts
@@ -87,6 +87,20 @@ const connector_details = {
     in_use: 'Oturum açma için etkin',
     not_in_use: 'Oturum açma için devre dışı',
   },
+  email_logs: {
+    title: 'E-posta kayıtları',
+    time: 'Zaman',
+    recipient: 'Alıcı',
+    recipient_placeholder: 'Alıcının tam adresiyle ara',
+    template_type: 'Şablon türü',
+    status: 'Durum',
+    status_sent: 'Gönderildi',
+    status_failed: 'Başarısız',
+    language_tag: 'Dil',
+    provider_message_id: 'Sağlayıcı mesaj kimliği',
+    previous_page: 'Önceki',
+    next_page: 'Sonraki',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/connector-details.ts
@@ -81,6 +81,20 @@ const connector_details = {
     in_use: '已启用用于登录',
     not_in_use: '已禁用用于登录',
   },
+  email_logs: {
+    title: '邮件日志',
+    time: '时间',
+    recipient: '收件人',
+    recipient_placeholder: '按完整收件人地址搜索',
+    template_type: '模板类型',
+    status: '状态',
+    status_sent: '已发送',
+    status_failed: '发送失败',
+    language_tag: '语言',
+    provider_message_id: '服务商消息 ID',
+    previous_page: '上一页',
+    next_page: '下一页',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/connector-details.ts
@@ -81,6 +81,20 @@ const connector_details = {
     in_use: '啟用登錄',
     not_in_use: '禁用登錄',
   },
+  email_logs: {
+    title: '電郵日誌',
+    time: '時間',
+    recipient: '收件人',
+    recipient_placeholder: '按完整收件人地址搜尋',
+    template_type: '範本類型',
+    status: '狀態',
+    status_sent: '已發送',
+    status_failed: '發送失敗',
+    language_tag: '語言',
+    provider_message_id: '服務商訊息 ID',
+    previous_page: '上一頁',
+    next_page: '下一頁',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/connector-details.ts
@@ -81,6 +81,20 @@ const connector_details = {
     in_use: '已啟用登錄',
     not_in_use: '已停用登錄',
   },
+  email_logs: {
+    title: '電子郵件日誌',
+    time: '時間',
+    recipient: '收件人',
+    recipient_placeholder: '依完整收件人地址搜尋',
+    template_type: '範本類型',
+    status: '狀態',
+    status_sent: '已傳送',
+    status_failed: '傳送失敗',
+    language_tag: '語言',
+    provider_message_id: '服務商訊息 ID',
+    previous_page: '上一頁',
+    next_page: '下一頁',
+  },
 };
 
 export default Object.freeze(connector_details);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3771,8 +3771,8 @@ importers:
         specifier: ^29.5.0
         version: 29.6.3
       '@logto/cloud':
-        specifier: 0.2.5-a4e30ff
-        version: 0.2.5-a4e30ff(zod@3.24.3)
+        specifier: 0.2.5-cf6987f
+        version: 0.2.5-cf6987f(zod@3.24.3)
       '@logto/connector-kit':
         specifier: workspace:^
         version: link:../toolkit/connector-kit
@@ -4303,8 +4303,8 @@ importers:
         version: 3.24.3
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-db73b11
-        version: 0.2.5-db73b11(zod@3.24.3)
+        specifier: 0.2.5-cf6987f
+        version: 0.2.5-cf6987f(zod@3.24.3)
       '@silverhand/eslint-config':
         specifier: 6.0.1
         version: 6.0.1(eslint@8.57.0)(prettier@3.5.3)(typescript@5.5.3)
@@ -6581,8 +6581,8 @@ packages:
     resolution: {integrity: sha512-jsYbimDtlLdNNHTQNmrMMC1iGL2YT+aqTHHda76OHJnHZnBxnkC+jNNdnjPnktMehMtW2Co8wAA0JM0F4UogFQ==}
     engines: {node: ^22.14.0}
 
-  '@logto/cloud@0.2.5-db73b11':
-    resolution: {integrity: sha512-mVVJRdZKE9+9T9pN6tNI+BAV/DIafwOGTAK+GV/6HM2aXnwQ3IYcjLuvQsuTTnLuCuU2dXUhHwhYdCRljxyeLg==}
+  '@logto/cloud@0.2.5-cf6987f':
+    resolution: {integrity: sha512-oU8sC5ocUvN5F++yucF/ZjqOypYuOA0O988F2L0YlOimplHwaYH0loc5t5tVS4QdzUSp68urUAqCsRAdEwvrZA==}
     engines: {node: ^22.14.0}
 
   '@logto/js@5.1.0':
@@ -7623,157 +7623,131 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -8244,28 +8218,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.3.52':
     resolution: {integrity: sha512-GCxNjTAborAmv4VV1AMZLyejHLGgIzu13tvLUFqybtU4jFxVbE2ZK4ZnPCfDlWN+eBwyRWk1oNFR2hH+66vaUQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.3.52':
     resolution: {integrity: sha512-mrvDBSkLI3Mza2qcu3uzB5JGwMBYDb1++UQ1VB0RXf2AR21/cCper4P44IpfdeqFz9XyXq18Sh3gblICUCGvig==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.3.52':
     resolution: {integrity: sha512-r9RIvKUQv7yBkpXz+QxPAucdoj8ymBlgIm5rLE0b5VmU7dlKBnpAmRBYaITdH6IXhF0pwuG+FHAd5elBcrkIwA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.3.52':
     resolution: {integrity: sha512-YRtEr7tDo0Wes3M2ZhigF4erUjWBXeFP+O+iz6ELBBmPG7B7m/lrA21eiW9/90YGnzi0iNo46shK6PfXuPhP+Q==}
@@ -12499,28 +12469,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.25.1:
     resolution: {integrity: sha512-IhxVFJoTW8wq6yLvxdPvyHv4NjzcpN1B7gjxrY3uaykQNXPHNIpChLB52+wfH+yS58zm1PL4LemUp8u9Cfp6Bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.25.1:
     resolution: {integrity: sha512-RXIaru79KrREPEd6WLXfKfIp4QzoppZvD3x7vuTKkDA64PwTzKJ2jaC43RZHRt8BmyIkRRlmywNhTRMbmkPYpA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.25.1:
     resolution: {integrity: sha512-TdcNqFsAENEEFr8fJWg0Y4fZ/nwuqTRsIr7W7t2wmDUlA8eSXVepeeONYcb+gtTj1RaXn/WgNLB45SFkz+XBZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-x64-msvc@1.25.1:
     resolution: {integrity: sha512-9KZZkmmy9oGDSrnyHuxP6iMhbsgChUiu/NSgOx+U1I/wTngBStDf2i2aGRCHvFqj19HqqBEI4WuGVQBa2V6e0A==}
@@ -13422,7 +13388,7 @@ packages:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a:
-    resolution: {gitHosted: true, integrity: sha512-WEK/83nAa+Mm1r+7pYJLxTM8K0j7GOsVQC7N/CGp//17HZ5GbGUqFQgDxVlLO5p4qE6eR0QFx0jJPhd0t+KnAQ==, tarball: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a}
+    resolution: {integrity: sha512-WEK/83nAa+Mm1r+7pYJLxTM8K0j7GOsVQC7N/CGp//17HZ5GbGUqFQgDxVlLO5p4qE6eR0QFx0jJPhd0t+KnAQ==, tarball: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a}
     version: 9.9.1
 
   on-finished@2.4.1:
@@ -17921,7 +17887,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  '@logto/cloud@0.2.5-db73b11(zod@3.24.3)':
+  '@logto/cloud@0.2.5-cf6987f(zod@3.24.3)':
     dependencies:
       '@silverhand/essentials': 2.9.3
       '@withtyped/server': 0.14.0(zod@3.24.3)
@@ -19190,7 +19156,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-consistent-default-export-name: 0.0.15
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-n: 17.2.1(eslint@8.57.0)
       eslint-plugin-no-use-extend-native: 0.5.0
       eslint-plugin-prettier: 5.1.3(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.5.3)
@@ -22747,7 +22713,7 @@ snapshots:
       enhanced-resolve: 5.16.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -22815,7 +22781,7 @@ snapshots:
       eslint: 8.57.0
       ignore: 5.3.1
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.7.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5


### PR DESCRIPTION
## Summary

Refs LOG-13967 (Phase 4.4 of hosted-email logs & observability). Adds the **Email logs** tab to the cloud built-in email connector's details page — gated `isCloud && isDevFeaturesEnabled` — rendering the tenant's hosted-email send log from the cloud email-logs endpoint.

### What changed

- **Pre-task:** `@logto/cloud` bumped `0.2.5-a4e30ff` → `0.2.5-cf6987f` in `console` + `core` (the pin moves together), bringing the `emailLogsRouter` types into `@logto/cloud/routes`.
- `cloud/hooks/use-cloud-api.ts` — `useCloudApi` gains a router type parameter (closed union, default unchanged for all existing call sites): the email-logs endpoint lives on a standalone router on the cloud side (TS type-depth split), so the client type is selected per call site instead of intersecting routers.
- `cloud/types/router.ts` — `TenantEmailLogsResponse` / `TenantEmailLog` derived from the router types.
- `pages/ConnectorDetails/` — a second tab (`/connectors/:tab/:connectorId/email-logs`, optional route segment) shown only for the built-in email service connector on cloud with dev features on; explicit `isActive` on both tabs (settings stays active whenever the email-logs tab is unavailable). Settings behavior is unchanged for every other connector.
- `pages/ConnectorDetails/EmailLogs/` — the tab: a read-only table (time, recipient, template type, language, provider message id with copy-to-clipboard, sent/failed status tag; spans sized by content type) reusing the audit-log **TimeRangePicker** (default 7d, presets to 30d, custom range for longer; window travels via the endpoint's `from`/`to` — the picker's inclusive end converts to the endpoint's exclusive bound), a **recipient search** (full-address, case-insensitive exact match — the shape the endpoint's recipient index serves; applied on submit, kept in the URL), and **cursor-stack previous/next paging** (the endpoint has no total count, so no numbered pagination).
- Provider identity (`providerName`, `error.provider`) is deliberately not displayed anywhere — which provider served a send is an internal routing detail.
- `phrases` — new `connector_details.email_logs.*` keys, translated across all supported locales.

### Expected result

With dev features on in a cloud console, the built-in email connector's page gains the Email logs tab showing sent/failed rows newest-first; everything else is byte-identical (OSS console, other connectors, dev features off).

## Testing
<img width="2754" height="508" alt="image" src="https://github.com/user-attachments/assets/26e808de-86f7-407f-9795-03e8f13d17d0" />


Unit tests

## Checklist

- [ ] `.changeset` (dev-gated; changeset lands at the Phase 5 release)
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
