### PR TITLE
fix(core): declare 400 status for account center patch API

### DIFF
--- a/packages/core/src/routes/account-center/index.openapi.json
+++ b/packages/core/src/routes/account-center/index.openapi.json
@@ -49,6 +49,9 @@
         "responses": {
           "200": {
             "description": "Updated account center settings."
+          },
+          "400": {
+            "description": "The request body is invalid. E.g. `profileFields` contains names that do not exist in the custom profile fields catalog, or contains duplicate names."
           }
         }
       }

--- a/packages/core/src/routes/account-center/index.ts
+++ b/packages/core/src/routes/account-center/index.ts
@@ -45,7 +45,7 @@ export default function accountCentersRoutes<T extends ManagementApiRouter>(
         profileFields: accountCenterProfileFieldsGuard.nullable().optional(),
       }),
       response: accountCenterApiGuard,
-      status: [200],
+      status: [200, 400],
     }),
 
     async (ctx, next) => {


### PR DESCRIPTION
## Summary

`PATCH /api/account-center` can reject invalid input with a 400 error — for example when `profileFields` references custom profile field names that do not exist, or contains duplicate names. The route only declared `status: [200]`, so the guard treated the 400 as an unexpected status code, and the API reference did not document it.

Declares `400` on the route guard and adds the corresponding response to the OpenAPI document.

## Testing

N/A