### PR TITLE
fix(core,console): drop stale profile field refs on account center save

### DIFF
--- a/.changeset/fix-stale-account-center-profile-fields.md
+++ b/.changeset/fix-stale-account-center-profile-fields.md
@@ -1,0 +1,8 @@
+---
+"@logto/core": patch
+"@logto/console": patch
+---
+
+drop deleted profile fields from account center and sign-up configs on save
+
+When a custom profile field is removed from Collect user profile, saving Account Center (or sign-up) settings no longer fails with `custom_profile_fields.entity_not_exists_with_names`. Stale field references are ignored on save, and the Console clears them from the profile fields editor.

--- a/.changeset/fix-stale-account-center-profile-fields.md
+++ b/.changeset/fix-stale-account-center-profile-fields.md
@@ -5,4 +5,4 @@
 
 drop deleted profile fields from account center and sign-up configs on save
 
-When a custom profile field is removed from Collect user profile, saving Account Center (or sign-up) settings no longer fails with `custom_profile_fields.entity_not_exists_with_names`. Stale field references are ignored on save, and the Console clears them from the profile fields editor.
+When a custom profile field is removed from Collect user profile, saving Account Center (or sign-up) settings no longer fails with `custom_profile_fields.entity_not_exists_with_names`. Stale field references are ignored on save, and deleted fields remain removable in the Console editor even when their permission control is Off.

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
@@ -1,5 +1,5 @@
 import { type CustomProfileField } from '@logto/schemas';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   Controller,
   type FieldArrayPath,
@@ -68,7 +68,7 @@ function ProfileFieldsEditBox<
   }) as Array<{ name: string }> | undefined;
   /* eslint-enable no-restricted-syntax */
 
-  const { fields, swap, remove, append } = useFieldArray({ control, name });
+  const { fields, swap, remove, append, replace } = useFieldArray({ control, name });
 
   const availableFields = useMemo(() => {
     if (!catalog) {
@@ -85,6 +85,25 @@ function ProfileFieldsEditBox<
     }
     return map;
   }, [catalog, getI18nLabel]);
+
+  const catalogNameSet = useMemo(() => new Set((catalog ?? []).map(({ name }) => name)), [catalog]);
+
+  // Drop selected fields that were removed from the catalog (e.g. deleted under Collect user
+  // profile) so they cannot remain as undeletable rows and block saving.
+  useEffect(() => {
+    if (!catalog) {
+      return;
+    }
+
+    const current = selectedValue ?? [];
+    if (current.every(({ name: fieldName }) => catalogNameSet.has(fieldName))) {
+      return;
+    }
+
+    onFieldsChange?.();
+    // eslint-disable-next-line no-restricted-syntax -- runtime shape matches the caller's array element
+    replace(current.filter(({ name: fieldName }) => catalogNameSet.has(fieldName)) as never);
+  }, [catalog, catalogNameSet, onFieldsChange, replace, selectedValue]);
 
   const hasSelectedFields = fields.length > 0;
 
@@ -108,9 +127,15 @@ function ProfileFieldsEditBox<
         {fields.map(({ id }, index) => {
           const fieldValue = selectedValue?.[index];
           const currentFieldName = fieldValue?.name;
-          const disabledReason = currentFieldName
-            ? getFieldDisabledReason?.(currentFieldName)
-            : undefined;
+          // Missing catalog fields must stay removable so admins can clear stale references even
+          // when the related account-center permission control is Off.
+          const isMissingFromCatalog = Boolean(
+            currentFieldName && catalog && !catalogNameSet.has(currentFieldName)
+          );
+          const disabledReason =
+            currentFieldName && !isMissingFromCatalog
+              ? getFieldDisabledReason?.(currentFieldName)
+              : undefined;
           const isDisabled = Boolean(disabledReason);
           return (
             <DraggableItem

--- a/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/components/ProfileFieldsEditBox/index.tsx
@@ -1,5 +1,5 @@
 import { type CustomProfileField } from '@logto/schemas';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import {
   Controller,
   type FieldArrayPath,
@@ -68,7 +68,7 @@ function ProfileFieldsEditBox<
   }) as Array<{ name: string }> | undefined;
   /* eslint-enable no-restricted-syntax */
 
-  const { fields, swap, remove, append, replace } = useFieldArray({ control, name });
+  const { fields, swap, remove, append } = useFieldArray({ control, name });
 
   const availableFields = useMemo(() => {
     if (!catalog) {
@@ -87,23 +87,6 @@ function ProfileFieldsEditBox<
   }, [catalog, getI18nLabel]);
 
   const catalogNameSet = useMemo(() => new Set((catalog ?? []).map(({ name }) => name)), [catalog]);
-
-  // Drop selected fields that were removed from the catalog (e.g. deleted under Collect user
-  // profile) so they cannot remain as undeletable rows and block saving.
-  useEffect(() => {
-    if (!catalog) {
-      return;
-    }
-
-    const current = selectedValue ?? [];
-    if (current.every(({ name: fieldName }) => catalogNameSet.has(fieldName))) {
-      return;
-    }
-
-    onFieldsChange?.();
-    // eslint-disable-next-line no-restricted-syntax -- runtime shape matches the caller's array element
-    replace(current.filter(({ name: fieldName }) => catalogNameSet.has(fieldName)) as never);
-  }, [catalog, catalogNameSet, onFieldsChange, replace, selectedValue]);
 
   const hasSelectedFields = fields.length > 0;
 

--- a/packages/core/src/libraries/custom-profile-fields/index.test.ts
+++ b/packages/core/src/libraries/custom-profile-fields/index.test.ts
@@ -94,21 +94,27 @@ describe('createCustomProfileFieldsLibrary', () => {
     expect(findCustomProfileFieldsByNames).toHaveBeenCalledWith(['inviteCode', 'company']);
   });
 
-  it('should deduplicate missing names in the validation error', async () => {
-    findCustomProfileFieldsByNames.mockResolvedValue([]);
+  it('should drop missing catalog fields while preserving existing ones', async () => {
+    findCustomProfileFieldsByNames.mockResolvedValue([{ name: 'company' }]);
 
     await expect(
-      normalizeProfileFields([{ name: 'unknown' }, { name: 'unknown' }])
-    ).rejects.toMatchObject({
-      code: 'custom_profile_fields.entity_not_exists_with_names',
-      message: 'Cannot find entities with the given names: unknown',
-    });
-    expect(findCustomProfileFieldsByNames).toHaveBeenCalledWith(['unknown']);
+      normalizeProfileFields([{ name: 'company' }, { name: 'fullname' }, { name: 'inviteCode' }])
+    ).resolves.toEqual([{ name: 'company' }]);
+    expect(findCustomProfileFieldsByNames).toHaveBeenCalledWith([
+      'company',
+      'fullname',
+      'inviteCode',
+    ]);
+  });
+
+  it('should return an empty list when every profile field is missing from the catalog', async () => {
+    findCustomProfileFieldsByNames.mockResolvedValue([]);
+
+    await expect(normalizeProfileFields([{ name: 'fullname' }])).resolves.toEqual([]);
+    expect(findCustomProfileFieldsByNames).toHaveBeenCalledWith(['fullname']);
   });
 
   it('should include duplicate names in the validation error payload', async () => {
-    findCustomProfileFieldsByNames.mockResolvedValue([{ name: 'company' }, { name: 'inviteCode' }]);
-
     await expect(
       normalizeProfileFields([
         { name: 'company' },
@@ -123,6 +129,19 @@ describe('createCustomProfileFieldsLibrary', () => {
       },
       message: 'Input is invalid. Duplicate profile field names: company, inviteCode',
     });
+    expect(findCustomProfileFieldsByNames).not.toHaveBeenCalled();
+  });
+
+  it('should reject missing names when updating the sign-in experience order', async () => {
+    findCustomProfileFieldsByNames.mockResolvedValue([]);
+
+    await expect(
+      updateCustomProfileFieldsSieOrder([{ name: 'unknown', sieOrder: 1 }])
+    ).rejects.toMatchObject({
+      code: 'custom_profile_fields.entity_not_exists_with_names',
+      message: 'Cannot find entities with the given names: unknown',
+    });
+    expect(findCustomProfileFieldsByNames).toHaveBeenCalledWith(['unknown']);
   });
 
   it('should validate names before updating the sign-in experience order', async () => {

--- a/packages/core/src/libraries/custom-profile-fields/index.ts
+++ b/packages/core/src/libraries/custom-profile-fields/index.ts
@@ -54,6 +54,24 @@ function removeProfileFieldByName(
   return profileFields.filter(({ name: fieldName }) => fieldName !== name);
 }
 
+const assertNoDuplicateProfileFieldNames = (fields: ProfileFieldsList) => {
+  const names = fields.map(({ name }) => name);
+  const uniqueNames = [...new Set(names)];
+  const duplicateNames = uniqueNames.filter(
+    (name) => names.indexOf(name) !== names.lastIndexOf(name)
+  );
+  assertThat(
+    duplicateNames.length === 0,
+    new RequestError(
+      {
+        code: 'request.invalid_input',
+        details: `Duplicate profile field names: ${duplicateNames.join(', ')}`,
+      },
+      { duplicateNames }
+    )
+  );
+};
+
 export const createCustomProfileFieldsLibrary = (queries: Queries) => {
   const {
     insertCustomProfileFields,
@@ -93,6 +111,8 @@ export const createCustomProfileFieldsLibrary = (queries: Queries) => {
       return;
     }
 
+    assertNoDuplicateProfileFieldNames(fields);
+
     const names = fields.map(({ name }) => name);
     const uniqueNames = [...new Set(names)];
     const profileFields = await findCustomProfileFieldsByNames(uniqueNames);
@@ -104,20 +124,6 @@ export const createCustomProfileFieldsLibrary = (queries: Queries) => {
         code: 'custom_profile_fields.entity_not_exists_with_names',
         names: missing.join(', '),
       })
-    );
-
-    const duplicateNames = uniqueNames.filter(
-      (name) => names.indexOf(name) !== names.lastIndexOf(name)
-    );
-    assertThat(
-      duplicateNames.length === 0,
-      new RequestError(
-        {
-          code: 'request.invalid_input',
-          details: `Duplicate profile field names: ${duplicateNames.join(', ')}`,
-        },
-        { duplicateNames }
-      )
     );
   };
 
@@ -217,6 +223,14 @@ export const createCustomProfileFieldsLibrary = (queries: Queries) => {
     }
   };
 
+  /**
+   * Normalize a configured profile-field list against the catalog.
+   *
+   * Drops references to fields that no longer exist so a concurrent catalog delete (or stale
+   * Console form state) cannot block saving account-center / sign-up config. Duplicate names are
+   * still rejected. Keep {@link validateProfileFieldsList} for APIs that intentionally address
+   * specific catalog fields (e.g. SIE order updates).
+   */
   const normalizeProfileFields = async <ProfileFields extends NormalizableProfileFields>(
     profileFields: ProfileFields
   ): Promise<ProfileFields | undefined> => {
@@ -224,8 +238,24 @@ export const createCustomProfileFieldsLibrary = (queries: Queries) => {
       return profileFields;
     }
 
-    await validateProfileFieldsList(profileFields);
-    return profileFields;
+    if (profileFields.length === 0) {
+      return profileFields;
+    }
+
+    assertNoDuplicateProfileFieldNames(profileFields);
+
+    const names = profileFields.map(({ name }) => name);
+    const uniqueNames = [...new Set(names)];
+    const catalogFields = await findCustomProfileFieldsByNames(uniqueNames);
+    const existingNames = new Set(catalogFields.map(({ name }) => name));
+    const normalized = profileFields.filter(({ name }) => existingNames.has(name));
+
+    if (normalized.length === profileFields.length) {
+      return profileFields;
+    }
+
+    // eslint-disable-next-line no-restricted-syntax -- filter keeps the same item shape as the input list
+    return normalized as ProfileFields;
   };
 
   return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a custom profile field (for example `fullname`) is deleted under **Collect user profile**, saving **Account Center** settings could fail with `custom_profile_fields.entity_not_exists_with_names` if the deleted field was still listed under **Profile fields for prebuilt account center**.

This change:

- Makes `normalizeProfileFields` drop missing catalog fields instead of rejecting the whole save (self-heals stale account-center / sign-up configs)
- Keeps deleted fields manually removable in the Console editor even when the related permission control is Off (no auto-prune on load, so Discard stays correct)

## Testing

Unit tests

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ad2490-6ba5-49b3-a55b-611cb3e22eca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ad2490-6ba5-49b3-a55b-611cb3e22eca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

