### PR TITLE
fix(core): prevent stale cache write-back after invalidation

### DIFF
--- a/.changeset/stale-cache-write-back.md
+++ b/.changeset/stale-cache-write-back.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+Fix a cache race that could serve stale configuration (e.g. sign-in experience, connectors) for up to 30 minutes after an update. A read that started before the update could write its outdated result back into the cache after the update's invalidation; cache invalidation is now awaited and outdated write-backs are discarded.

--- a/.changeset/stale-cache-write-back.md
+++ b/.changeset/stale-cache-write-back.md
@@ -1,5 +1,0 @@
----
-"@logto/core": patch
----
-
-Fix a cache race that could serve stale configuration (e.g. sign-in experience, connectors) for up to 30 minutes after an update. A read that started before the update could write its outdated result back into the cache after the update's invalidation; cache invalidation is now awaited and outdated write-backs are discarded.

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -1,3 +1,4 @@
+import { generateStandardId } from '@logto/shared';
 import { trySafe, type Optional } from '@silverhand/essentials';
 import { type ZodType } from 'zod';
 
@@ -93,12 +94,21 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
     const mutated = async function (this: unknown, ...args: Args): Promise<Return> {
       const value = await run.apply(this, args);
 
-      // We don't leverage `finally` here since we want to ensure cache deleting
-      // only happens when the original function executed successfully
-      void Promise.all(
-        types.map(async ([type, cacheKey]) =>
-          trySafe(kvCache.delete(type, cacheKey?.(...args) ?? BaseCache.defaultKey))
-        )
+      /**
+       * We don't leverage `finally` here since we want to ensure cache invalidation
+       * only happens when the original function executed successfully.
+       *
+       * The generation must be bumped before deleting, and both must be awaited: this
+       * guarantees that once this function returns, in-flight reads that computed from
+       * pre-mutation state either fail the generation check in {@link BaseCache.memoize}
+       * or have their write-back removed by the deletion below.
+       */
+      await Promise.all(
+        types.map(async ([type, cacheKey]) => {
+          const key = cacheKey?.(...args) ?? BaseCache.defaultKey;
+          await trySafe(kvCache.bumpGeneration(type, key));
+          await trySafe(kvCache.delete(type, key));
+        })
       );
 
       return value;
@@ -110,6 +120,9 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   /**
    * [Memoize](https://en.wikipedia.org/wiki/Memoization) a function and cache the result. The function execution
    * will be also cached, which means there will be only one execution at a time.
+   *
+   * Results computed before an invalidation (see {@link mutate}) are discarded instead of
+   * written back, so the cache can never serve pre-mutation data after the mutation returns.
    *
    * @param run The function to memoize.
    * @param config The object to determine how cache key will be built. See {@link CacheKeyConfig} for details.
@@ -153,9 +166,20 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
             return cachedValue;
           }
 
+          const generation = await kvCache.getGeneration(type, promiseKey);
           const value = await run.apply(this, args);
 
-          await trySafe(kvCache.set(type, promiseKey, value, getExpiresIn?.(value)));
+          // Skip the write-back when an invalidation happened while `run` was in flight,
+          // since the result may be computed from pre-mutation state.
+          if ((await kvCache.getGeneration(type, promiseKey)) === generation) {
+            await trySafe(kvCache.set(type, promiseKey, value, getExpiresIn?.(value)));
+
+            // Undo the write if an invalidation landed between the check and the write,
+            // so a stale value can never persist in the cache.
+            if ((await kvCache.getGeneration(type, promiseKey)) !== generation) {
+              await trySafe(kvCache.delete(type, promiseKey));
+            }
+          }
 
           return value;
         } finally {
@@ -172,6 +196,27 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   }
 
   abstract getValueGuard<Type extends CacheKeyOf<CacheMapT>>(type: Type): ZodType<CacheMapT[Type]>;
+
+  /**
+   * Get the current invalidation generation for the given type and key.
+   * Note: Store errors will be silently caught and result an `undefined` return.
+   *
+   * The generation is bumped by every {@link mutate} invalidation. {@link memoize} snapshots it
+   * before computing and discards results written under an outdated generation, so a read that
+   * started before a mutation can never write its stale result back into the cache.
+   */
+  protected async getGeneration(type: CacheKeyOf<CacheMapT>, key: string) {
+    return trySafe(async () => this.cacheStore.get(this.generationKey(type, key)));
+  }
+
+  /** Bump the invalidation generation for the given type and key. See {@link getGeneration}. */
+  protected async bumpGeneration(type: CacheKeyOf<CacheMapT>, key: string) {
+    return this.cacheStore.set(this.generationKey(type, key), generateStandardId());
+  }
+
+  protected generationKey(type: CacheKeyOf<CacheMapT>, key: string) {
+    return `${this.cacheKey(type, key)}:generation`;
+  }
 
   protected cacheKey(type: CacheKeyOf<CacheMapT>, key: string) {
     return `${this.tenantId}:${type}:${key}`;

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -72,15 +72,13 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   }
 
   /**
-   * Invalidate the cached value for the given type and key: bump the invalidation generation
-   * (see {@link getGeneration}), then delete the value from the inner cache store.
+   * Delete value from the inner cache store for the given type and key.
    *
-   * The generation must be bumped before deleting: an in-flight {@link memoize} read that
-   * misses the bump in its final check must have written its value back before the bump,
-   * so the deletion below is guaranteed to remove that stale write.
+   * Note this is a plain deletion: unlike {@link mutate}, it does not bump the invalidation
+   * generation, so an in-flight {@link memoize} read may still write its result back
+   * afterwards. Callers that invalidate on their own should be migrated to {@link mutate}.
    */
   async delete(type: CacheKeyOf<CacheMapT>, key: string) {
-    await trySafe(this.bumpGeneration(type, key));
     return this.cacheStore.delete(this.cacheKey(type, key));
   }
 
@@ -106,14 +104,17 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
        * We don't leverage `finally` here since we want to ensure cache invalidation
        * only happens when the original function executed successfully.
        *
-       * The invalidation is awaited so that once this function returns, the cache can no
-       * longer serve pre-mutation data; see {@link BaseCache.delete} for how in-flight
-       * reads are prevented from writing such data back.
+       * The generation must be bumped before deleting, and both must be awaited: this
+       * guarantees that once this function returns, in-flight reads that computed from
+       * pre-mutation state either fail the generation check in {@link BaseCache.memoize}
+       * or have their write-back removed by the deletion below.
        */
       await Promise.all(
-        types.map(async ([type, cacheKey]) =>
-          trySafe(kvCache.delete(type, cacheKey?.(...args) ?? BaseCache.defaultKey))
-        )
+        types.map(async ([type, cacheKey]) => {
+          const key = cacheKey?.(...args) ?? BaseCache.defaultKey;
+          await trySafe(kvCache.bumpGeneration(type, key));
+          await trySafe(kvCache.delete(type, key));
+        })
       );
 
       return value;
@@ -126,7 +127,7 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
    * [Memoize](https://en.wikipedia.org/wiki/Memoization) a function and cache the result. The function execution
    * will be also cached, which means there will be only one execution at a time.
    *
-   * Results computed before an invalidation (see {@link delete}) are discarded instead of
+   * Results computed before an invalidation (see {@link mutate}) are discarded instead of
    * written back, so stale data can never persist in the cache after an invalidation
    * returns. (A caller that joined an already in-flight execution may still receive
    * pre-invalidation data once; it is never written back.)
@@ -213,8 +214,8 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
    * Get the current invalidation generation for the given type and key.
    * Note: Store errors will be silently caught and result an `undefined` return.
    *
-   * Bumped by every {@link delete}; {@link memoize} compares snapshots of it to detect
-   * invalidations that raced with an in-flight read.
+   * Bumped by every {@link mutate} invalidation; {@link memoize} compares snapshots of it
+   * to detect invalidations that raced with an in-flight read.
    */
   protected async getGeneration(type: CacheKeyOf<CacheMapT>, key: string) {
     return trySafe(async () => this.cacheStore.get(this.generationKey(type, key)));

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -71,8 +71,16 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
     return this.cacheStore.set(this.cacheKey(type, key), JSON.stringify(value), expire);
   }
 
-  /** Delete value from the inner cache store for the given type and key. */
+  /**
+   * Invalidate the cached value for the given type and key: bump the invalidation generation
+   * (see {@link getGeneration}), then delete the value from the inner cache store.
+   *
+   * The generation must be bumped before deleting: an in-flight {@link memoize} read that
+   * misses the bump in its final check must have written its value back before the bump,
+   * so the deletion below is guaranteed to remove that stale write.
+   */
   async delete(type: CacheKeyOf<CacheMapT>, key: string) {
+    await trySafe(this.bumpGeneration(type, key));
     return this.cacheStore.delete(this.cacheKey(type, key));
   }
 
@@ -98,17 +106,14 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
        * We don't leverage `finally` here since we want to ensure cache invalidation
        * only happens when the original function executed successfully.
        *
-       * The generation must be bumped before deleting, and both must be awaited: this
-       * guarantees that once this function returns, in-flight reads that computed from
-       * pre-mutation state either fail the generation check in {@link BaseCache.memoize}
-       * or have their write-back removed by the deletion below.
+       * The invalidation is awaited so that once this function returns, the cache can no
+       * longer serve pre-mutation data; see {@link BaseCache.delete} for how in-flight
+       * reads are prevented from writing such data back.
        */
       await Promise.all(
-        types.map(async ([type, cacheKey]) => {
-          const key = cacheKey?.(...args) ?? BaseCache.defaultKey;
-          await trySafe(kvCache.bumpGeneration(type, key));
-          await trySafe(kvCache.delete(type, key));
-        })
+        types.map(async ([type, cacheKey]) =>
+          trySafe(kvCache.delete(type, cacheKey?.(...args) ?? BaseCache.defaultKey))
+        )
       );
 
       return value;
@@ -121,8 +126,10 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
    * [Memoize](https://en.wikipedia.org/wiki/Memoization) a function and cache the result. The function execution
    * will be also cached, which means there will be only one execution at a time.
    *
-   * Results computed before an invalidation (see {@link mutate}) are discarded instead of
-   * written back, so the cache can never serve pre-mutation data after the mutation returns.
+   * Results computed before an invalidation (see {@link delete}) are discarded instead of
+   * written back, so stale data can never persist in the cache after an invalidation
+   * returns. (A caller that joined an already in-flight execution may still receive
+   * pre-invalidation data once; it is never written back.)
    *
    * @param run The function to memoize.
    * @param config The object to determine how cache key will be built. See {@link CacheKeyConfig} for details.
@@ -167,18 +174,23 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
           }
 
           const generation = await kvCache.getGeneration(type, promiseKey);
+          const isInvalidated = async () =>
+            (await kvCache.getGeneration(type, promiseKey)) !== generation;
+
           const value = await run.apply(this, args);
 
           // Skip the write-back when an invalidation happened while `run` was in flight,
           // since the result may be computed from pre-mutation state.
-          if ((await kvCache.getGeneration(type, promiseKey)) === generation) {
-            await trySafe(kvCache.set(type, promiseKey, value, getExpiresIn?.(value)));
+          if (await isInvalidated()) {
+            return value;
+          }
 
-            // Undo the write if an invalidation landed between the check and the write,
-            // so a stale value can never persist in the cache.
-            if ((await kvCache.getGeneration(type, promiseKey)) !== generation) {
-              await trySafe(kvCache.delete(type, promiseKey));
-            }
+          await trySafe(kvCache.set(type, promiseKey, value, getExpiresIn?.(value)));
+
+          // Undo the write if an invalidation landed between the check and the write,
+          // so a stale value can never persist in the cache.
+          if (await isInvalidated()) {
+            await trySafe(kvCache.delete(type, promiseKey));
           }
 
           return value;
@@ -201,21 +213,27 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
    * Get the current invalidation generation for the given type and key.
    * Note: Store errors will be silently caught and result an `undefined` return.
    *
-   * The generation is bumped by every {@link mutate} invalidation. {@link memoize} snapshots it
-   * before computing and discards results written under an outdated generation, so a read that
-   * started before a mutation can never write its stale result back into the cache.
+   * Bumped by every {@link delete}; {@link memoize} compares snapshots of it to detect
+   * invalidations that raced with an in-flight read.
    */
   protected async getGeneration(type: CacheKeyOf<CacheMapT>, key: string) {
     return trySafe(async () => this.cacheStore.get(this.generationKey(type, key)));
   }
 
-  /** Bump the invalidation generation for the given type and key. See {@link getGeneration}. */
+  /**
+   * Bump the invalidation generation for the given type and key. See {@link getGeneration}.
+   *
+   * Best-effort by design: the store may drop writes while degraded (unlike deletions), in
+   * which case staleness is bounded by the value TTL, as it was before generations existed.
+   */
   protected async bumpGeneration(type: CacheKeyOf<CacheMapT>, key: string) {
     return this.cacheStore.set(this.generationKey(type, key), generateStandardId());
   }
 
   protected generationKey(type: CacheKeyOf<CacheMapT>, key: string) {
-    return `${this.cacheKey(type, key)}:generation`;
+    // The marker owns a controlled segment so free-form keys (e.g. arbitrary resource
+    // indicators) can never collide with it.
+    return `${this.tenantId}:generation:${type}:${key}`;
   }
 
   protected cacheKey(type: CacheKeyOf<CacheMapT>, key: string) {

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -1,4 +1,4 @@
-import { generateStandardId } from '@logto/shared';
+import { generateStandardShortId } from '@logto/shared';
 import { trySafe, type Optional } from '@silverhand/essentials';
 import { type ZodType } from 'zod';
 
@@ -223,11 +223,14 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   /**
    * Bump the invalidation generation for the given type and key. See {@link getGeneration}.
    *
+   * A short id suffices: the value is only ever compared against the immediately preceding
+   * one, so it needs to differ from a single known value rather than be globally unique.
+   *
    * Best-effort by design: the store may drop writes while degraded (unlike deletions), in
    * which case staleness is bounded by the value TTL, as it was before generations existed.
    */
   protected async bumpGeneration(type: CacheKeyOf<CacheMapT>, key: string) {
-    return this.cacheStore.set(this.generationKey(type, key), generateStandardId());
+    return this.cacheStore.set(this.generationKey(type, key), generateStandardShortId());
   }
 
   protected generationKey(type: CacheKeyOf<CacheMapT>, key: string) {

--- a/packages/core/src/caches/well-known.test.ts
+++ b/packages/core/src/caches/well-known.test.ts
@@ -259,37 +259,27 @@ describe('Well-known cache function wrappers', () => {
   });
 
   it('should discard a stale write-back when a mutation invalidates the cache mid-read', async () => {
-    jest.useFakeTimers();
+    const cache = new WellKnownCache(tenantId, cacheStore);
+    const update = jest.fn(async () => true);
+    const mutate = cache.mutate(update, ['custom-phrases']);
 
     const read = jest
       .fn(async (): Promise<Record<string, unknown>> => ({ foo: 'fresh' }))
-      .mockImplementationOnce(
-        async () =>
-          new Promise((resolve) => {
-            // Simulate a slow query that started before the mutation and resolves after it
-            setTimeout(() => {
-              resolve({ foo: 'stale' });
-            }, 100);
-          })
-      );
-    const update = jest.fn(async () => true);
-    const cache = new WellKnownCache(tenantId, cacheStore);
+      .mockImplementationOnce(async () => {
+        // The mutation lands while this read is still in flight, i.e. the value below
+        // was computed from pre-mutation state
+        await mutate();
+        return { foo: 'stale' };
+      });
     const memoized = cache.memoize(read, ['custom-phrases']);
-    const mutate = cache.mutate(update, ['custom-phrases']);
-
-    const staleRead = memoized();
-    await mutate();
-    jest.advanceTimersByTime(101);
 
     // The caller still receives the computed value, but it must not persist in the cache
-    expect(await staleRead).toStrictEqual({ foo: 'stale' });
+    expect(await memoized()).toStrictEqual({ foo: 'stale' });
     expect(await cache.get('custom-phrases', WellKnownCache.defaultKey)).toBeUndefined();
 
     expect(await memoized()).toStrictEqual({ foo: 'fresh' });
     expect(await cache.get('custom-phrases', WellKnownCache.defaultKey)).toStrictEqual({
       foo: 'fresh',
     });
-
-    jest.useRealTimers();
   });
 });

--- a/packages/core/src/caches/well-known.test.ts
+++ b/packages/core/src/caches/well-known.test.ts
@@ -257,4 +257,39 @@ describe('Well-known cache function wrappers', () => {
     expect(await cache.get('custom-phrases', '2+2')).toBeUndefined();
     expect(run).toBeCalledTimes(2);
   });
+
+  it('should discard a stale write-back when a mutation invalidates the cache mid-read', async () => {
+    jest.useFakeTimers();
+
+    const read = jest
+      .fn(async (): Promise<Record<string, unknown>> => ({ foo: 'fresh' }))
+      .mockImplementationOnce(
+        async () =>
+          new Promise((resolve) => {
+            // Simulate a slow query that started before the mutation and resolves after it
+            setTimeout(() => {
+              resolve({ foo: 'stale' });
+            }, 100);
+          })
+      );
+    const update = jest.fn(async () => true);
+    const cache = new WellKnownCache(tenantId, cacheStore);
+    const memoized = cache.memoize(read, ['custom-phrases']);
+    const mutate = cache.mutate(update, ['custom-phrases']);
+
+    const staleRead = memoized();
+    await mutate();
+    jest.advanceTimersByTime(101);
+
+    // The caller still receives the computed value, but it must not persist in the cache
+    expect(await staleRead).toStrictEqual({ foo: 'stale' });
+    expect(await cache.get('custom-phrases', WellKnownCache.defaultKey)).toBeUndefined();
+
+    expect(await memoized()).toStrictEqual({ foo: 'fresh' });
+    expect(await cache.get('custom-phrases', WellKnownCache.defaultKey)).toStrictEqual({
+      foo: 'fresh',
+    });
+
+    jest.useRealTimers();
+  });
 });


### PR DESCRIPTION
## Summary

Fix a race in `BaseCache` that lets a read which started before a mutation write its stale result back into the cache after the mutation's invalidation, where it persists for up to 30 minutes (default TTL). This is the root cause of most of the Integration Test flakiness, and in production it can serve stale configuration (e.g. sign-in experience, connectors) after an admin update.

- `mutate` now awaits its cache invalidation instead of firing it with `void`
- `mutate` bumps a per-key invalidation generation before deleting; `memoize` snapshots it before computing and discards results written under an outdated generation
- Callers are unaffected: `memoize` still returns the computed value and only skips the write-back when the cache was invalidated mid-read
- Out of scope: call sites that invalidate via a bare `cache.delete(...)` (resource, email-template, and custom-profile-field queries) keep their current behavior — they are unguarded and fire-and-forget today, and migrating them to `mutate` is a separate change

The race:

```mermaid
sequenceDiagram
    participant Read as In-flight read<br/>(memoize)
    participant Mut as Update<br/>(mutate)
    participant Cache as Cache (Redis)
    participant DB as Database

    Read->>Cache: get
    Cache-->>Read: miss
    Read->>DB: query
    DB-->>Read: old value
    Note over Read: write-back delayed<br/>(slow query / event-loop lag)
    Mut->>DB: write new value
    Mut-)Cache: delete key (void, not awaited)
    Note over Mut: API responds "updated"
    Read->>Cache: set old value
    Note over Cache: stale value persists for up to 30 min (TTL),<br/>served to every later read
```

<details>
<summary>Root cause analysis & stats</summary>

Of ~80 recent Integration Test runs, ~20 needed the auto rerun; `password-policy.test.js` was the failing suite in 15+ of them, and all 24 sampled failures broke at the exact same assertion (waiting for the alert `/product context .* personal information/`).

The chain:

1. Every experience test file PATCHes the sign-in experience in `beforeAll` (`updateDefaultSignInExperience`, wrapped in `wellKnownCache.mutate`).
2. At the previous file's boundary, `page.close()` aborts in-flight page requests, but their server side keeps running (the `ERR_STREAM_PREMATURE_CLOSE` noise in the job logs) and reads the sign-in experience via `wellKnownCache.memoize` — from the pre-PATCH database state.
3. If that read's cache write-back lands after the PATCH's (unawaited) invalidation, the seed-default password policy is written back into Redis with a 30-minute TTL.
4. The stale policy has `rejects.words: []`, so the server rejects `username + 'A'` with only `restricted.user_info`: the alert reads "Avoid overusing your personal information." without "product context", the regex never matches, and the test times out after 5 s. Every other step of the test behaves identically under both policies, which is why the failure always pins to that one assertion.

The other frequently rerun suites (`basic-sentinel`, `identifier-first-verification-switching`, MFA/WebAuthn) depend on the same cached row in the same way (sentinel policy, sign-in methods, and MFA config all live in the sign-in experience).

</details>

<details>
<summary>Reproduction script (before/after)</summary>

Save as `repro.mjs` at the repo root, then run `pnpm -C packages/core build:test && node repro.mjs`:

```js
/**
 * Reproduce the stale write-back race in BaseCache (memoize vs mutate).
 *
 * Timeline (mirrors an integration-test file boundary):
 *   t0  a reader starts (cache miss) -> begins DB read, sees OLD value
 *   t1  mutate() runs: DB updated to NEW value, cache invalidated
 *   t2  reader's DB read resolves late (CI load) -> tries to write OLD value back
 *   t3  subsequent reads should serve the NEW value
 */
import { BaseCache } from './packages/core/build/caches/base-cache.js';

const sleep = async (ms) => new Promise((resolve) => setTimeout(resolve, ms));

/** In-memory stand-in for Redis. */
class MemoryStore {
  data = new Map();
  async get(key) {
    return this.data.get(key);
  }
  async set(key, value) {
    this.data.set(key, value);
    return true;
  }
  async delete(key) {
    return this.data.delete(key);
  }
}

class TestCache extends BaseCache {
  name = 'Test';
  getValueGuard() {
    return { parse: (value) => value };
  }
}

const store = new MemoryStore();
const cache = new TestCache('default', store);

/** Simulated sign_in_experiences row. */
let dbValue = { words: [] }; // old policy: no custom words

const findSie = cache.memoize(async () => {
  const snapshot = dbValue; // query starts: captures current DB state
  await sleep(120); // slow query / event-loop lag under CI load
  return snapshot;
}, ['sie']);

const updateSie = cache.mutate(async (next) => {
  dbValue = next;
  await sleep(5);
  return next;
}, ['sie']);

// Server side of a request aborted at the previous test file's boundary:
// starts before the update commits.
const straggler = findSie();

await sleep(20);

// beforeAll: PATCH /sign-in-exp with the new password policy (words: [username])
await updateSie({ words: ['test_user123'] });
console.log('[t1] PATCH returned; DB now:', JSON.stringify(dbValue));
console.log('[t1] cache right after PATCH   :', store.data.get('default:sie:#') ?? '(empty)');

await straggler;
await sleep(10);
console.log('[t2] cache after straggler ends:', store.data.get('default:sie:#') ?? '(empty)');

// The test now submits the password; core reads the memoized SIE:
const seen = await findSie();
console.log('[t3] policy served to password validation:', JSON.stringify(seen));
```

On `master`:

```
[t2] cache after straggler ends: {"words":[]}            <- stale value written back
[t3] policy served to password validation: {"words":[]}  <- served for up to 30 min
```

With this fix:

```
[t2] cache after straggler ends: (empty)                 <- stale write-back discarded
[t3] policy served to password validation: {"words":["test_user123"]}
```

</details>

## Testing

Unit tests (`well-known.test.ts` reproduces the race deterministically).

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
