### PR TITLE
feat(schemas): add the service-log message-id lookup index

### DIFF
--- a/packages/schemas/alterations/next-1786512953-add-service-logs-message-id-index.ts
+++ b/packages/schemas/alterations/next-1786512953-add-service-logs-message-id-index.ts
@@ -1,0 +1,26 @@
+import { sql } from '@silverhand/slonik';
+
+import type { AlterationScript } from '../lib/types/alteration.js';
+
+const alteration: AlterationScript = {
+  beforeUp: async (pool) => {
+    await pool.query(sql`
+      create index concurrently service_logs__email__provider_message_id
+        on service_logs ((payload->>'providerMessageId'))
+        where type = 'sendEmail' and payload->>'providerMessageId' is not null;
+    `);
+  },
+  up: async () => {
+    /** 'concurrently' cannot be used inside a transaction, so this up is intentionally left empty. */
+  },
+  beforeDown: async (pool) => {
+    await pool.query(sql`
+      drop index concurrently service_logs__email__provider_message_id;
+    `);
+  },
+  down: async () => {
+    /** 'concurrently' cannot be used inside a transaction, so this down is intentionally left empty. */
+  },
+};
+
+export default alteration;

--- a/packages/schemas/tables/service_logs.sql
+++ b/packages/schemas/tables/service_logs.sql
@@ -32,4 +32,13 @@ create index service_logs__email__tenant_id__recipient__created_at__id
   on service_logs (tenant_id, lower(payload->'data'->>'to'), created_at desc, id desc)
   where type in ('sendEmail', 'sendEmailFailed');
 
+/* Cloud delivery-event webhook write path: single-row lookup of the `sendEmail` row that carries
+   the provider-assigned message id. Doubly partial on purpose — rows without a message id (all
+   history before the id was captured, and providers that return none) never enter the index, so
+   its size and per-insert maintenance stay proportional to id-carrying rows only. The strict `=`
+   in the webhook's update provably implies `is not null`, so the planner can use it. */
+create index service_logs__email__provider_message_id
+  on service_logs ((payload->>'providerMessageId'))
+  where type = 'sendEmail' and payload->>'providerMessageId' is not null;
+
 /* no_after_each */


### PR DESCRIPTION
## Summary

Refs LOG-14022. Adds the lookup index for the hosted-email delivery-event webhook (logto-io/cloud#2070): the webhook stamps provider delivery events (bounces first) onto `sendEmail` service-log rows matched by the provider-assigned message id, and that lookup must not scan the table — delivery events scale with send volume.

```sql
create index concurrently service_logs__email__provider_message_id
  on service_logs ((payload->>'providerMessageId'))
  where type = 'sendEmail' and payload->>'providerMessageId' is not null;
```

**Doubly partial on purpose — this is the cost control.** Rows without a message id (all history before capture started, and providers that return none) never enter the index, so its size and per-insert maintenance stay proportional to id-carrying rows only. Today production has zero such rows (the id stamp is still dev-gated), so the index starts essentially empty and grows only with Resend-served sends. The webhook's strict `=` provably implies `is not null`, so the planner uses the index despite the extra predicate.

Measured on a 1M-row seeded table (500k `sendEmail`, of which 100k carry a message id), exact webhook update shapes with literal parameters (matching node-postgres custom plans):

| | Before | After |
|---|---|---|
| Delivery-event update | 115 ms seq scan (1M rows filtered) | **0.7 ms** index scan |
| Unmatched message id (no-op) | same seq scan | **0.18 ms** |
| Index size | — | 3.1 MB (vs 5.8 MB without the `is not null` predicate) |
| Insert, row without id | — | unchanged (predicate check only) |
| Insert, row with id | — | unchanged within noise |

Build: `create index concurrently` in `beforeUp` (no read/write blocking; 0.5 s on the 1M-row bench), drop in `beforeDown`, `up`/`down` intentionally empty — same conventions as #9414. No `if not exists`, per the hard-fail rule.

The webhook is dev-gated on the cloud side; per LOG-14022's release notes this index must be deployed and valid (`indisvalid`) before the gate is removed.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
