### PR TITLE
feat(core,phrases): block third-party apps from mutating account data

### DIFF
--- a/.changeset/third-party-account-api-mutations.md
+++ b/.changeset/third-party-account-api-mutations.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": minor
+---
+
+block third-party applications from mutating account data through the Account API and Verification API
+
+The Account API is the user managing their own account at the identity provider, and was built for the first-party Account Center.
+
+Third-party applications now receive `403 auth.third_party_application_forbidden` when they try to change account data. Reads are unchanged, and so is every first-party application, including Account Center and Console.

--- a/.changeset/third-party-account-api-mutations.md
+++ b/.changeset/third-party-account-api-mutations.md
@@ -6,4 +6,12 @@ block third-party applications from mutating account data through the Account AP
 
 The Account API is the user managing their own account at the identity provider, and was built for the first-party Account Center.
 
-Third-party applications now receive `403 auth.third_party_application_forbidden` when they try to change account data. Reads are unchanged, and so is every first-party application, including Account Center and Console.
+Third-party applications now receive `403 auth.third_party_application_forbidden` when they try to change account data. Every first-party application is unaffected, including Account Center and Console.
+
+No read route gained a guard. Three reads do become unreachable for third-party applications as a side effect, because they require a verified user-permission verification record and the routes that mint one are now guarded:
+
+- `GET /api/my-account/grants`
+- `GET /api/my-account/sessions`
+- `GET /api/my-account/mfa-verifications/backup-codes`
+
+For a third-party application these now always return `401 verification_record.permission_denied`. Every other read is unchanged.

--- a/.changeset/third-party-account-api-mutations.md
+++ b/.changeset/third-party-account-api-mutations.md
@@ -6,7 +6,9 @@ block third-party applications from mutating account data through the Account AP
 
 The Account API is the user managing their own account at the identity provider, and was built for the first-party Account Center.
 
-Third-party applications now receive `403 auth.third_party_application_forbidden` when they try to change account data. Every first-party application is unaffected, including Account Center and Console.
+Third-party applications now receive `403 auth.third_party_application_forbidden` when they try to change account data. First-party applications are unaffected, including Account Center and Console.
+
+The check fails closed: a client identifier that no longer resolves to an application is treated as third-party. Two cases follow from that. A client identifier document (CIMD) client identifier is a URL and never names a registered application, so CIMD clients are blocked from these routes. An application that has been deleted while its access tokens are still live is blocked as well, because the token keeps authenticating after the application row is gone.
 
 No read route gained a guard. Three reads do become unreachable for third-party applications as a side effect, because they require a verified user-permission verification record and the routes that mint one are now guarded:
 
@@ -14,4 +16,4 @@ No read route gained a guard. Three reads do become unreachable for third-party 
 - `GET /api/my-account/sessions`
 - `GET /api/my-account/mfa-verifications/backup-codes`
 
-For a third-party application these now always return `401 verification_record.permission_denied`. Every other read is unchanged.
+For a third-party application these now return `401 verification_record.permission_denied` whenever Account Center is enabled, and the existing `400 account_center.not_enabled` when it is not. Every other read is unchanged.

--- a/packages/core/src/routes/account/email-and-phone.ts
+++ b/packages/core/src/routes/account/email-and-phone.ts
@@ -3,6 +3,7 @@ import { VerificationType, AccountCenterControlValue } from '@logto/schemas';
 import { z } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 import { assertUserHasRemainingIdentifier } from '#src/utils/user.js';
 
 import RequestError from '../../errors/RequestError/index.js';
@@ -32,10 +33,10 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
         email: z.string().regex(emailRegEx),
         newIdentifierVerificationRecordId: z.string(),
       }),
-      status: [204, 400, 401, 422],
+      status: [204, 400, 401, 403, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         identityVerified,
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
@@ -48,6 +49,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
       );
 
       assertThat(scopes.has(UserScope.Email), 'auth.unauthorized');
+      await assertFirstPartyClient(queries, clientId);
 
       // Validate email blocklist policy
       const { emailBlocklistPolicy } = await findDefaultSignInExperience();
@@ -78,10 +80,10 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
   router.delete(
     `${accountApiPrefix}/primary-email`,
     koaGuard({
-      status: [204, 400, 401],
+      status: [204, 400, 401, 403],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         identityVerified,
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
@@ -93,6 +95,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
       );
 
       assertThat(scopes.has(UserScope.Email), 'auth.unauthorized');
+      await assertFirstPartyClient(queries, clientId);
 
       const [user, ssoIdentities] = await Promise.all([
         findUserById(userId),
@@ -117,10 +120,10 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
         phone: z.string().regex(phoneRegEx),
         newIdentifierVerificationRecordId: z.string(),
       }),
-      status: [204, 400, 401, 422],
+      status: [204, 400, 401, 403, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         identityVerified,
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
@@ -133,6 +136,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
       );
 
       assertThat(scopes.has(UserScope.Phone), 'auth.unauthorized');
+      await assertFirstPartyClient(queries, clientId);
 
       // Check new identifier
       const newVerificationRecord = await buildVerificationRecordByIdAndType({
@@ -159,10 +163,10 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
   router.delete(
     `${accountApiPrefix}/primary-phone`,
     koaGuard({
-      status: [204, 400, 401],
+      status: [204, 400, 401, 403],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         identityVerified,
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
@@ -174,6 +178,7 @@ export default function emailAndPhoneRoutes<T extends UserRouter>(...args: Route
       );
 
       assertThat(scopes.has(UserScope.Phone), 'auth.unauthorized');
+      await assertFirstPartyClient(queries, clientId);
 
       const [user, ssoIdentities] = await Promise.all([
         findUserById(userId),

--- a/packages/core/src/routes/account/grants.ts
+++ b/packages/core/src/routes/account/grants.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import { type UserRouter, type RouterInitArgs } from '../types.js';
@@ -22,7 +23,7 @@ const grantsResponseGuard = EnvSet.values.isDevFeaturesEnabled
   : getUserApplicationGrantsResponseGuard;
 
 export default function accountGrantRoutes<T extends UserRouter>(
-  ...[router, { provider, libraries }]: RouterInitArgs<T>
+  ...[router, { provider, libraries, queries }]: RouterInitArgs<T>
 ) {
   const { session: sessionLibrary } = libraries;
 
@@ -72,13 +73,13 @@ export default function accountGrantRoutes<T extends UserRouter>(
       params: z.object({
         grantId: z.string().min(1),
       }),
-      status: [204, 400, 401, 404, 500],
+      status: [204, 400, 401, 403, 404, 500],
     }),
     async (ctx, next) => {
       const {
         params: { grantId },
       } = ctx.guard;
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       const { fields } = ctx.accountCenter;
 
       assertThat(
@@ -95,6 +96,8 @@ export default function accountGrantRoutes<T extends UserRouter>(
         scopes.has(UserScope.Sessions),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+
+      await assertFirstPartyClient(queries, clientId);
 
       await sessionLibrary.revokeUserGrantById(provider, userId, grantId);
       await trySafe(

--- a/packages/core/src/routes/account/identities.ts
+++ b/packages/core/src/routes/account/identities.ts
@@ -8,6 +8,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import type { HookContextManager } from '#src/libraries/hook/context-manager.js';
 import { buildVerificationRecordByIdAndType } from '#src/libraries/verification.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 import { assertCanDeleteSocialIdentity } from '#src/utils/user.js';
@@ -110,10 +111,10 @@ export default function identitiesRoutes<T extends UserRouter>(
       body: z.object({
         newIdentifierVerificationRecordId: z.string(),
       }),
-      status: [204, 400, 401, 422],
+      status: [204, 400, 401, 403, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         ctx.accountCenter.fields.social === AccountCenterControlValue.Edit,
         'account_center.field_not_editable'
@@ -122,6 +123,8 @@ export default function identitiesRoutes<T extends UserRouter>(
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+      await assertFirstPartyClient(queries, clientId);
+
       const user = await findUserById(userId);
       assertIdentityVerifiedIfRequired(user, identityVerified);
 
@@ -143,10 +146,10 @@ export default function identitiesRoutes<T extends UserRouter>(
       body: z.object({
         newIdentifierVerificationRecordId: z.string(),
       }),
-      status: [204, 400, 401, 422],
+      status: [204, 400, 401, 403, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         ctx.accountCenter.fields.social === AccountCenterControlValue.Edit,
         'account_center.field_not_editable'
@@ -155,6 +158,8 @@ export default function identitiesRoutes<T extends UserRouter>(
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+      await assertFirstPartyClient(queries, clientId);
+
       const user = await findUserById(userId);
       assertIdentityVerifiedIfRequired(user, identityVerified);
 
@@ -174,10 +179,10 @@ export default function identitiesRoutes<T extends UserRouter>(
     `${accountApiPrefix}/identities/:target`,
     koaGuard({
       params: z.object({ target: z.string() }),
-      status: [204, 400, 401, 404, 422],
+      status: [204, 400, 401, 403, 404, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       const { target } = ctx.guard.params;
       const { fields } = ctx.accountCenter;
       assertThat(
@@ -186,6 +191,7 @@ export default function identitiesRoutes<T extends UserRouter>(
       );
 
       assertThat(scopes.has(UserScope.Identities), 'auth.unauthorized');
+      await assertFirstPartyClient(queries, clientId);
 
       const [user, ssoIdentities] = await Promise.all([
         findUserById(userId),

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -812,7 +812,7 @@
             "description": "Permission denied, the access token does not include the `profile` scope."
           },
           "403": {
-            "description": "Permission denied, either the application is a third-party application or the avatar field is not editable for the current account center state."
+            "description": "Permission denied, the application is a third-party application."
           },
           "500": {
             "description": "Failed to upload the file to the storage provider."

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -294,7 +294,7 @@
             "description": "The new verification record is invalid."
           },
           "403": {
-            "description": "Permission denied, the verification record is invalid."
+            "description": "Permission denied, the application is a third-party application. The Account API only accepts mutations from first-party applications."
           }
         }
       },
@@ -344,7 +344,7 @@
             "description": "The new verification record is invalid."
           },
           "403": {
-            "description": "Permission denied, the verification record is invalid."
+            "description": "Permission denied, the application is a third-party application. The Account API only accepts mutations from first-party applications."
           }
         }
       },
@@ -812,7 +812,7 @@
             "description": "Permission denied, the access token does not include the `profile` scope."
           },
           "403": {
-            "description": "Permission denied for the current account center state."
+            "description": "Permission denied, either the application is a third-party application or the avatar field is not editable for the current account center state."
           },
           "500": {
             "description": "Failed to upload the file to the storage provider."

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -14,6 +14,7 @@ import { z } from 'zod';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayloadFromPassword } from '#src/libraries/user.utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 import assertThat from '#src/utils/assert-that.js';
 import { assertUserHasRemainingIdentifier, assertUsernameAllowed } from '#src/utils/user.js';
 
@@ -71,10 +72,10 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
         customData: jsonObjectGuard.optional(),
       }),
       response: userProfileResponseGuard.partial(),
-      status: [200, 400, 401, 422],
+      status: [200, 400, 401, 403, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       const { body } = ctx.guard;
       const { name, avatar, username, customData } = body;
       const { fields } = ctx.accountCenter;
@@ -99,6 +100,7 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
       if (customData !== undefined) {
         assertThat(scopes.has(UserScope.CustomData), 'auth.unauthorized');
       }
+      await assertFirstPartyClient(queries, clientId);
 
       if (username !== undefined) {
         assertThat(
@@ -144,10 +146,10 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
     koaGuard({
       body: userProfileGuard,
       response: userProfileGuard,
-      status: [200, 400],
+      status: [200, 400, 403],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes } = ctx.auth;
+      const { id: userId, scopes, clientId } = ctx.auth;
       const { body } = ctx.guard;
       const { fields } = ctx.accountCenter;
 
@@ -160,6 +162,8 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
       if (body.address !== undefined) {
         assertThat(scopes.has(UserScope.Address), 'auth.unauthorized');
       }
+
+      await assertFirstPartyClient(queries, clientId);
 
       const updatedUser = await updateUserById(userId, {
         profile: body,
@@ -178,11 +182,13 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
     `${accountApiPrefix}/password`,
     koaGuard({
       body: z.object({ password: z.string().min(1) }),
-      status: [204, 400, 401, 422],
+      status: [204, 400, 401, 403, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, identityVerified } = ctx.auth;
+      const { id: userId, identityVerified, clientId } = ctx.auth;
       const { password } = ctx.guard.body;
+
+      await assertFirstPartyClient(queries, clientId);
 
       const user = await findUserById(userId);
       if (hasSecurityVerificationMethod(user)) {
@@ -252,10 +258,10 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
         skipMfaOnSignIn: z.boolean(),
       }),
       response: userMfaSettingsResponseGuard,
-      status: [200, 400, 401],
+      status: [200, 400, 401, 403],
     }),
     async (ctx, next) => {
-      const { id: userId, identityVerified, scopes } = ctx.auth;
+      const { id: userId, identityVerified, scopes, clientId } = ctx.auth;
 
       assertThat(
         identityVerified,
@@ -265,6 +271,8 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+      await assertFirstPartyClient(queries, clientId);
+
       const { skipMfaOnSignIn } = ctx.guard.body;
       const { fields } = ctx.accountCenter;
       assertThat(

--- a/packages/core/src/routes/account/logto-config.ts
+++ b/packages/core/src/routes/account/logto-config.ts
@@ -12,6 +12,7 @@ import {
   userLogtoConfigResponseGuard,
 } from '#src/libraries/user-logto-config.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 
 import RequestError from '../../errors/RequestError/index.js';
 import assertThat from '../../utils/assert-that.js';
@@ -62,10 +63,10 @@ export default function logtoConfigRoutes<T extends UserRouter>(...args: RouterI
         passkeySignIn: userPasskeySignInDataGuard.optional(),
       }),
       response: userLogtoConfigResponseGuard,
-      status: [200, 400, 401],
+      status: [200, 400, 401, 403],
     }),
     async (ctx, next) => {
-      const { id: userId, identityVerified, scopes } = ctx.auth;
+      const { id: userId, identityVerified, scopes, clientId } = ctx.auth;
 
       assertThat(
         identityVerified,
@@ -75,6 +76,8 @@ export default function logtoConfigRoutes<T extends UserRouter>(...args: RouterI
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+      await assertFirstPartyClient(queries, clientId);
+
       const { fields } = ctx.accountCenter;
       const passkeyControl = fields.passkey ?? fields.mfa;
       assertThat(

--- a/packages/core/src/routes/account/mfa-verifications.ts
+++ b/packages/core/src/routes/account/mfa-verifications.ts
@@ -23,6 +23,7 @@ import {
 } from '#src/libraries/verification-helpers/totp-validation.js';
 import { buildVerificationRecordByIdAndType } from '#src/libraries/verification.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 import assertThat from '#src/utils/assert-that.js';
 import { transpileUserMfaVerifications } from '#src/utils/user.js';
 
@@ -85,10 +86,10 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
           codes: z.string().array(),
         }),
       ]),
-      status: [204, 400, 401, 422],
+      status: [204, 400, 401, 403, 422],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         identityVerified,
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
@@ -105,6 +106,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+      await assertFirstPartyClient(queries, clientId);
 
       const user = await findUserById(userId);
 
@@ -257,10 +259,10 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         secret: z.string(),
         code: z.string(),
       }),
-      status: [204, 400, 401],
+      status: [204, 400, 401, 403],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         identityVerified,
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
@@ -275,6 +277,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+      await assertFirstPartyClient(queries, clientId);
 
       const { mfa } = await findDefaultSignInExperience();
       assertThat(mfa.factors.includes(MfaFactor.TOTP), 'session.mfa.mfa_factor_not_enabled');
@@ -398,10 +401,10 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
       body: z.object({
         name: z.string(),
       }),
-      status: [200, 400, 401],
+      status: [200, 400, 401, 403],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         identityVerified,
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
@@ -418,6 +421,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+      await assertFirstPartyClient(queries, clientId);
 
       const user = await findUserById(userId);
       const mfaVerification = user.mfaVerifications.find(
@@ -449,10 +453,10 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
       params: z.object({
         verificationId: z.string(),
       }),
-      status: [204, 400, 401],
+      status: [204, 400, 401, 403],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       assertThat(
         identityVerified,
         new RequestError({ code: 'verification_record.permission_denied', status: 401 })
@@ -461,6 +465,7 @@ export default function mfaVerificationsRoutes<T extends UserRouter>(
         scopes.has(UserScope.Identities),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+      await assertFirstPartyClient(queries, clientId);
 
       const user = await findUserById(userId);
       const mfaVerification = user.mfaVerifications.find(

--- a/packages/core/src/routes/account/sessions.ts
+++ b/packages/core/src/routes/account/sessions.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import { type UserRouter, type RouterInitArgs } from '../types.js';
@@ -15,7 +16,7 @@ import { type UserRouter, type RouterInitArgs } from '../types.js';
 import { accountApiPrefix } from './constants.js';
 
 export default function accountSessionRoutes<T extends UserRouter>(
-  ...[router, { provider, libraries }]: RouterInitArgs<T>
+  ...[router, { provider, libraries, queries }]: RouterInitArgs<T>
 ) {
   const { session: sessionLibrary } = libraries;
 
@@ -67,11 +68,11 @@ export default function accountSessionRoutes<T extends UserRouter>(
       params: z.object({
         sessionId: z.string().min(1),
       }),
-      status: [204, 400, 401, 404, 500],
+      status: [204, 400, 401, 403, 404, 500],
     }),
     async (ctx, next) => {
       const { sessionId } = ctx.guard.params;
-      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
       const { fields } = ctx.accountCenter;
 
       assertThat(
@@ -88,6 +89,8 @@ export default function accountSessionRoutes<T extends UserRouter>(
         scopes.has(UserScope.Sessions),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+
+      await assertFirstPartyClient(queries, clientId);
 
       const session = await provider.Session.findByUid(sessionId);
 

--- a/packages/core/src/routes/account/user-assets.ts
+++ b/packages/core/src/routes/account/user-assets.ts
@@ -5,6 +5,7 @@ import { object } from 'zod';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import SystemContext from '#src/tenants/SystemContext.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 import assertThat from '#src/utils/assert-that.js';
 import { getConsoleLogFromContext } from '#src/utils/console.js';
 
@@ -14,7 +15,7 @@ import type { UserRouter, RouterInitArgs } from '../types.js';
 import { accountApiPrefix } from './constants.js';
 
 export default function accountUserAssetsRoutes<T extends UserRouter>(
-  ...[router, { id: tenantId }]: RouterInitArgs<T>
+  ...[router, { id: tenantId, queries }]: RouterInitArgs<T>
 ) {
   router.post(
     `${accountApiPrefix}/user-assets/avatar`,
@@ -26,13 +27,14 @@ export default function accountUserAssetsRoutes<T extends UserRouter>(
       status: [200, 400, 401, 403, 500],
     }),
     async (ctx, next) => {
-      const { id: userId, scopes } = ctx.auth;
+      const { id: userId, scopes, clientId } = ctx.auth;
       const { fields } = ctx.accountCenter;
 
       assertThat(
         scopes.has(UserScope.Profile),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
+      await assertFirstPartyClient(queries, clientId);
       assertThat(
         fields.avatar === AccountCenterControlValue.Edit,
         'account_center.field_not_editable'

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines */
+/* eslint-disable max-lines -- the first-party guard adds a check to every verification route */
 import { TemplateType } from '@logto/connector-kit';
 import {
   AdditionalIdentifier,

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines -- the first-party guard adds a check to every verification route */
+/* eslint-disable max-lines -- this file hosts every verification method (password, verification code, WebAuthn, social) in one router; the first-party guard pushed it just over the limit */
 import { TemplateType } from '@logto/connector-kit';
 import {
   AdditionalIdentifier,

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { TemplateType } from '@logto/connector-kit';
 import {
   AdditionalIdentifier,
@@ -14,6 +15,7 @@ import { z } from 'zod';
 
 import koaGuard from '#src/middleware/koa-guard.js';
 import { buildMessageRateGuard, withMessageRateGuard } from '#src/sentinel/message-rate-guard.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 
 import {
   buildVerificationRecordByIdAndType,
@@ -41,11 +43,13 @@ export default function verificationRoutes<T extends UserRouter>(
     koaGuard({
       body: z.object({ password: z.string().min(1) }),
       response: z.object({ verificationRecordId: z.string(), expiresAt: z.string() }),
-      status: [201, 400, 422],
+      status: [201, 400, 403, 422],
     }),
     async (ctx, next) => {
-      const { id: userId } = ctx.auth;
+      const { id: userId, clientId } = ctx.auth;
       const { password } = ctx.guard.body;
+
+      await assertFirstPartyClient(queries, clientId);
 
       const passwordVerification = PasswordVerification.create(libraries, queries, {
         type: AdditionalIdentifier.UserId,
@@ -92,11 +96,13 @@ export default function verificationRoutes<T extends UserRouter>(
           .optional(),
       }),
       response: z.object({ verificationRecordId: z.string(), expiresAt: z.string() }),
-      status: [201, 422, 429, 501],
+      status: [201, 403, 422, 429, 501],
     }),
     async (ctx, next) => {
       const { id: userId, clientId: applicationId } = ctx.auth;
       const { identifier, templateType: inputTemplateType } = ctx.guard.body;
+
+      await assertFirstPartyClient(queries, applicationId);
 
       const user = await queries.users.findUserById(userId);
       const isNewIdentifier =
@@ -170,10 +176,13 @@ export default function verificationRoutes<T extends UserRouter>(
       }),
       response: z.object({ verificationRecordId: z.string() }),
       // 501: connector not found
-      status: [200, 400, 501],
+      status: [200, 400, 403, 501],
     }),
     async (ctx, next) => {
       const { identifier, code, verificationId } = ctx.guard.body;
+      const { clientId } = ctx.auth;
+
+      await assertFirstPartyClient(queries, clientId);
 
       const codeVerification = await buildVerificationRecordByIdAndType({
         type:
@@ -297,13 +306,15 @@ export default function verificationRoutes<T extends UserRouter>(
         registrationOptions: webAuthnRegistrationOptionsGuard,
         expiresAt: z.string(),
       }),
-      status: [200],
+      status: [200, 403],
     }),
     async (ctx, next) => {
       const {
-        auth: { id: userId },
+        auth: { id: userId, clientId },
         URL: { hostname },
       } = ctx;
+
+      await assertFirstPartyClient(queries, clientId);
 
       const webAuthnVerification = WebAuthnVerification.create(libraries, queries, userId);
 
@@ -333,10 +344,13 @@ export default function verificationRoutes<T extends UserRouter>(
       response: z.object({
         verificationRecordId: z.string(),
       }),
-      status: [200, 400, 404],
+      status: [200, 400, 403, 404],
     }),
     async (ctx, next) => {
       const { verificationRecordId, payload } = ctx.guard.body;
+      const { clientId } = ctx.auth;
+
+      await assertFirstPartyClient(queries, clientId);
 
       const webAuthnVerification = await buildVerificationRecordByIdAndType({
         type: VerificationType.WebAuthn,
@@ -355,3 +369,4 @@ export default function verificationRoutes<T extends UserRouter>(
     }
   );
 }
+/* eslint-enable max-lines */

--- a/packages/core/src/utils/assert-first-party-client.test.ts
+++ b/packages/core/src/utils/assert-first-party-client.test.ts
@@ -1,0 +1,42 @@
+import RequestError from '#src/errors/RequestError/index.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+import { assertFirstPartyClient } from './assert-first-party-client.js';
+
+const { jest } = import.meta;
+
+describe('assertFirstPartyClient', () => {
+  const findApplicationById = jest.fn();
+  const { queries } = new MockTenant(undefined, {
+    applications: { findApplicationById },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should pass for a first-party application', async () => {
+    findApplicationById.mockResolvedValue({ id: 'app_id', isThirdParty: false });
+
+    await expect(assertFirstPartyClient(queries, 'app_id')).resolves.toBeUndefined();
+  });
+
+  it('should reject a third-party application', async () => {
+    findApplicationById.mockResolvedValue({ id: 'app_id', isThirdParty: true });
+
+    await expect(assertFirstPartyClient(queries, 'app_id')).rejects.toMatchObject(
+      new RequestError({ code: 'auth.third_party_application_forbidden', status: 403 })
+    );
+  });
+
+  it('should pass for an application that is not in the database', async () => {
+    findApplicationById.mockRejectedValue(new Error('not found'));
+
+    await expect(assertFirstPartyClient(queries, 'demo_app')).resolves.toBeUndefined();
+  });
+
+  it('should pass without looking up anything when the client ID is absent', async () => {
+    await expect(assertFirstPartyClient(queries)).resolves.toBeUndefined();
+    expect(findApplicationById).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/utils/assert-first-party-client.test.ts
+++ b/packages/core/src/utils/assert-first-party-client.test.ts
@@ -1,3 +1,5 @@
+import { accountCenterApplicationId } from '@logto/schemas';
+
 import RequestError from '#src/errors/RequestError/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
@@ -29,10 +31,28 @@ describe('assertFirstPartyClient', () => {
     );
   });
 
-  it('should pass for an application that is not in the database', async () => {
+  it('should pass for a built-in application without looking up anything', async () => {
+    await expect(
+      assertFirstPartyClient(queries, accountCenterApplicationId)
+    ).resolves.toBeUndefined();
+    expect(findApplicationById).not.toHaveBeenCalled();
+  });
+
+  it('should reject an application that cannot be resolved', async () => {
     findApplicationById.mockRejectedValue(new Error('not found'));
 
-    await expect(assertFirstPartyClient(queries, 'demo_app')).resolves.toBeUndefined();
+    await expect(assertFirstPartyClient(queries, 'unknown_app')).rejects.toMatchObject(
+      new RequestError({ code: 'auth.third_party_application_forbidden', status: 403 })
+    );
+  });
+
+  it('should reject a CIMD client identifier', async () => {
+    await expect(
+      assertFirstPartyClient(queries, 'https://client.example.com/metadata.json')
+    ).rejects.toMatchObject(
+      new RequestError({ code: 'auth.third_party_application_forbidden', status: 403 })
+    );
+    expect(findApplicationById).not.toHaveBeenCalled();
   });
 
   it('should pass without looking up anything when the client ID is absent', async () => {

--- a/packages/core/src/utils/assert-first-party-client.ts
+++ b/packages/core/src/utils/assert-first-party-client.ts
@@ -13,9 +13,8 @@ import type Queries from '#src/tenants/Queries.js';
  * mutation of the primary email. Call this alongside the scope check on routes that change account
  * data or mint a verification record.
  *
- * Note: CIMD clients are not covered. `isThirdPartyApplication` resolves an unregistered client
- * identifier URL to first-party through its not-found fallback, so they pass this assertion. That
- * is handled by a separate change.
+ * `isThirdPartyApplication` fails closed, so a client that cannot be resolved — including a CIMD
+ * client identifier URL, which never names a registered application — is rejected here as well.
  */
 export const assertFirstPartyClient = async (queries: Queries, clientId?: string) => {
   if (clientId !== undefined && (await isThirdPartyApplication(queries, clientId))) {

--- a/packages/core/src/utils/assert-first-party-client.ts
+++ b/packages/core/src/utils/assert-first-party-client.ts
@@ -1,0 +1,24 @@
+import RequestError from '#src/errors/RequestError/index.js';
+import { isThirdPartyApplication } from '#src/oidc/resource.js';
+import type Queries from '#src/tenants/Queries.js';
+
+/**
+ * Assert that the access token behind this request was issued to a first-party application.
+ *
+ * The Account API is the user managing their own account at the identity provider, and was built
+ * for the first-party Account Center. Third-party applications reach it because `openid` is
+ * unconditionally part of their client scopes, and the per-route scope checks reuse the OIDC claim
+ * scopes: an admin who enables `email` for a third-party application is told the application reads
+ * the user's email address, and the end user consents to "Your email address" — neither grants
+ * mutation of the primary email. Call this alongside the scope check on routes that change account
+ * data or mint a verification record.
+ *
+ * Note: CIMD clients are not covered. `isThirdPartyApplication` resolves an unregistered client
+ * identifier URL to first-party through its not-found fallback, so they pass this assertion. That
+ * is handled by a separate change.
+ */
+export const assertFirstPartyClient = async (queries: Queries, clientId?: string) => {
+  if (clientId !== undefined && (await isThirdPartyApplication(queries, clientId))) {
+    throw new RequestError({ code: 'auth.third_party_application_forbidden', status: 403 });
+  }
+};

--- a/packages/integration-tests/src/tests/api/account/third-party-guard.test.ts
+++ b/packages/integration-tests/src/tests/api/account/third-party-guard.test.ts
@@ -1,0 +1,79 @@
+import { UserScope } from '@logto/core-kit';
+
+import { enableAllAccountCenterFields } from '#src/api/account-center.js';
+import { authedAdminApi, baseApi } from '#src/api/api.js';
+import { deleteApplication } from '#src/api/application.js';
+import { getUserInfo, updatePassword, updateUser } from '#src/api/my-account.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+} from '#src/helpers/profile.js';
+import { createAppAndSignInWithPassword } from '#src/helpers/session.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateName, generatePassword } from '#src/utils.js';
+
+const buildAccountApi = async (isThirdParty: boolean, username: string, password: string) => {
+  const { app, client } = await createAppAndSignInWithPassword({
+    username,
+    password,
+    isThirdParty,
+    scopes: [UserScope.Profile],
+  });
+
+  const accessToken = await client.getAccessToken();
+
+  return {
+    app,
+    api: baseApi.extend({ headers: { Authorization: `Bearer ${accessToken}` } }),
+  };
+};
+
+describe('account API third-party guard', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await enableAllAccountCenterFields(authedAdminApi);
+  });
+
+  it('should reject account mutations from a third-party application', async () => {
+    const { user, username, password } = await createDefaultTenantUserWithPassword();
+    const { app, api } = await buildAccountApi(true, username, password);
+
+    try {
+      await expectRejects(updateUser(api, { name: generateName() }), {
+        code: 'auth.third_party_application_forbidden',
+        status: 403,
+      });
+
+      await expectRejects(updatePassword(api, undefined, generatePassword()), {
+        code: 'auth.third_party_application_forbidden',
+        status: 403,
+      });
+    } finally {
+      await Promise.all([deleteApplication(app.id), deleteDefaultTenantUser(user.id)]);
+    }
+  });
+
+  it('should keep account reads available to a third-party application', async () => {
+    const { user, username, password } = await createDefaultTenantUserWithPassword();
+    const { app, api } = await buildAccountApi(true, username, password);
+
+    try {
+      await expect(getUserInfo(api)).resolves.toMatchObject({ id: user.id });
+    } finally {
+      await Promise.all([deleteApplication(app.id), deleteDefaultTenantUser(user.id)]);
+    }
+  });
+
+  it('should keep account mutations available to a first-party application', async () => {
+    const { user, username, password } = await createDefaultTenantUserWithPassword();
+    const { app, api } = await buildAccountApi(false, username, password);
+    const name = generateName();
+
+    try {
+      await expect(updateUser(api, { name })).resolves.toMatchObject({ name });
+    } finally {
+      await Promise.all([deleteApplication(app.id), deleteDefaultTenantUser(user.id)]);
+    }
+  });
+});

--- a/packages/integration-tests/src/tests/api/account/third-party-guard.test.ts
+++ b/packages/integration-tests/src/tests/api/account/third-party-guard.test.ts
@@ -4,6 +4,7 @@ import { enableAllAccountCenterFields } from '#src/api/account-center.js';
 import { authedAdminApi, baseApi } from '#src/api/api.js';
 import { deleteApplication } from '#src/api/application.js';
 import { getUserInfo, updatePassword, updateUser } from '#src/api/my-account.js';
+import { createVerificationRecordByPassword } from '#src/api/verification-record.js';
 import { expectRejects } from '#src/helpers/index.js';
 import {
   createDefaultTenantUserWithPassword,
@@ -46,6 +47,13 @@ describe('account API third-party guard', () => {
       });
 
       await expectRejects(updatePassword(api, undefined, generatePassword()), {
+        code: 'auth.third_party_application_forbidden',
+        status: 403,
+      });
+
+      // The Verification API is a separate router with its own wiring, so cover it too. Minting a
+      // record here is what would otherwise let a third-party application reach the guarded routes.
+      await expectRejects(createVerificationRecordByPassword(api, password), {
         code: 'auth.third_party_application_forbidden',
         status: 403,
       });

--- a/packages/phrases/src/locales/ar/errors/auth.ts
+++ b/packages/phrases/src/locales/ar/errors/auth.ts
@@ -8,6 +8,8 @@ const auth = {
   jwt_sub_missing: 'القيمة `sub` مفقودة في JWT.',
   require_re_authentication: 'مطلوب إعادة المصادقة لإجراء حماية.',
   exceed_token_limit: 'تم تجاوز حد الرمز. يرجى الاتصال بالمسؤول الخاص بك.',
+  third_party_application_forbidden:
+    'لا يُسمح للتطبيقات التابعة لجهات خارجية بتعديل بيانات الحساب عبر واجهة برمجة التطبيقات هذه.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/de/errors/auth.ts
+++ b/packages/phrases/src/locales/de/errors/auth.ts
@@ -9,6 +9,8 @@ const auth = {
   require_re_authentication:
     'Zur Durchführung einer geschützten Aktion ist eine erneute Authentifizierung erforderlich.',
   exceed_token_limit: 'Token-Limit überschritten. Bitte kontaktiere deinen Administrator.',
+  third_party_application_forbidden:
+    'Drittanbieteranwendungen dürfen über diese API keine Kontodaten ändern.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/en/errors/auth.ts
+++ b/packages/phrases/src/locales/en/errors/auth.ts
@@ -7,6 +7,8 @@ const auth = {
   jwt_sub_missing: 'Missing `sub` in JWT.',
   require_re_authentication: 'Re-authentication is required to perform a protected action.',
   exceed_token_limit: 'Token limit exceeded. Please contact your administrator.',
+  third_party_application_forbidden:
+    'Third-party applications cannot modify account data through this API.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/es/errors/auth.ts
+++ b/packages/phrases/src/locales/es/errors/auth.ts
@@ -9,6 +9,8 @@ const auth = {
   require_re_authentication:
     'Se requiere una nueva autenticación para realizar una acción protegida.',
   exceed_token_limit: 'Límite de token excedido. Por favor, contacta a tu administrador.',
+  third_party_application_forbidden:
+    'Las aplicaciones de terceros no pueden modificar los datos de la cuenta a través de esta API.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/fa-ir/errors/auth.ts
+++ b/packages/phrases/src/locales/fa-ir/errors/auth.ts
@@ -8,6 +8,8 @@ const auth = {
   jwt_sub_missing: 'فیلد `sub` در JWT وجود ندارد.',
   require_re_authentication: 'برای انجام اقدام محافظت‌شده، احراز هویت مجدد لازم است.',
   exceed_token_limit: 'محدودیت توکن تجاوز شد. لطفاً با مدیر خود تماس بگیرید.',
+  third_party_application_forbidden:
+    'برنامه‌های شخص ثالث مجاز به تغییر داده‌های حساب از طریق این API نیستند.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/fr/errors/auth.ts
+++ b/packages/phrases/src/locales/fr/errors/auth.ts
@@ -9,6 +9,8 @@ const auth = {
   require_re_authentication:
     'La ré-authentification est requise pour effectuer une action protégée.',
   exceed_token_limit: 'Limite de jeton dépassée. Veuillez contacter votre administrateur.',
+  third_party_application_forbidden:
+    'Les applications tierces ne sont pas autorisées à modifier les données du compte via cette API.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/it/errors/auth.ts
+++ b/packages/phrases/src/locales/it/errors/auth.ts
@@ -9,6 +9,8 @@ const auth = {
   require_re_authentication:
     "È necessaria una nuova autenticazione per eseguire un'azione protetta.",
   exceed_token_limit: 'Limite di token superato. Contatta il tuo amministratore.',
+  third_party_application_forbidden:
+    'Le applicazioni di terze parti non possono modificare i dati dell’account tramite questa API.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/ja/errors/auth.ts
+++ b/packages/phrases/src/locales/ja/errors/auth.ts
@@ -8,6 +8,8 @@ const auth = {
   jwt_sub_missing: 'JWT 内に `sub` がありません。',
   require_re_authentication: '保護されたアクションを実行するには再認証が必要です。',
   exceed_token_limit: 'トークン制限を超えました。管理者に連絡してください。',
+  third_party_application_forbidden:
+    'サードパーティアプリケーションではこの API を通じてアカウントデータを変更できません。',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/ko/errors/auth.ts
+++ b/packages/phrases/src/locales/ko/errors/auth.ts
@@ -8,6 +8,8 @@ const auth = {
   jwt_sub_missing: 'JWT에서 `sub`를 찾을 수 없어요.',
   require_re_authentication: '보호된 작업을 수행하려면 재인증이 필요해요.',
   exceed_token_limit: '토큰 한도를 초과했습니다. 관리자에게 문의하세요.',
+  third_party_application_forbidden:
+    '서드파티 애플리케이션에서는 이 API를 통해 계정 데이터를 수정할 수 없습니다.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/pl-pl/errors/auth.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/auth.ts
@@ -8,6 +8,8 @@ const auth = {
   jwt_sub_missing: 'Brak `sub` w JWT.',
   require_re_authentication: 'Wymagane ponowne uwierzytelnienie, aby wykonać chronione działanie.',
   exceed_token_limit: 'Przekroczono limit tokenów. Skontaktuj się z administratorem.',
+  third_party_application_forbidden:
+    'Aplikacje firm trzecich nie mogą modyfikować danych konta za pomocą tego API.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/pt-br/errors/auth.ts
+++ b/packages/phrases/src/locales/pt-br/errors/auth.ts
@@ -9,6 +9,8 @@ const auth = {
   require_re_authentication: 'A reautenticação é necessária para executar uma ação protegida.',
   exceed_token_limit:
     'Limite de tokens excedido. Por favor, entre em contato com seu administrador.',
+  third_party_application_forbidden:
+    'Aplicativos de terceiros não podem modificar dados da conta por meio desta API.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/pt-pt/errors/auth.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/auth.ts
@@ -7,6 +7,8 @@ const auth = {
   jwt_sub_missing: 'Campo `sub` está ausente no JWT.',
   require_re_authentication: 'É necessária uma nova autenticação para executar uma ação protegida.',
   exceed_token_limit: 'Limite de token excedido. Por favor, contacte o seu administrador.',
+  third_party_application_forbidden:
+    'Aplicações de terceiros não podem modificar dados da conta através desta API.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/ru/errors/auth.ts
+++ b/packages/phrases/src/locales/ru/errors/auth.ts
@@ -9,6 +9,8 @@ const auth = {
   require_re_authentication:
     'Для выполнения защищенного действия требуется повторная аутентификация.',
   exceed_token_limit: 'Превышен лимит токенов. Пожалуйста, свяжитесь с администратором.',
+  third_party_application_forbidden:
+    'Сторонние приложения не могут изменять данные учётной записи через этот API.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/th/errors/auth.ts
+++ b/packages/phrases/src/locales/th/errors/auth.ts
@@ -7,6 +7,8 @@ const auth = {
   jwt_sub_missing: 'ไม่มี `sub` ใน JWT',
   require_re_authentication: 'ต้องรับรองตัวตนใหม่เพื่อดำเนินการที่ได้รับการป้องกัน',
   exceed_token_limit: 'เกินขีดจำกัดโทเค็น กรุณาติดต่อผู้ดูแลระบบของคุณ',
+  third_party_application_forbidden:
+    'แอปพลิเคชันของบุคคลที่สามไม่สามารถแก้ไขข้อมูลบัญชีผ่าน API นี้ได้',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/tr-tr/errors/auth.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/auth.ts
@@ -8,6 +8,8 @@ const auth = {
   require_re_authentication:
     'Korumalı bir işlem gerçekleştirmek için yeniden doğrulama gereklidir.',
   exceed_token_limit: 'Token limiti aşıldı. Lütfen yöneticinizle iletişime geçin.',
+  third_party_application_forbidden:
+    'Üçüncü taraf uygulamaları bu API üzerinden hesap verilerini değiştiremez.',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/zh-cn/errors/auth.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/auth.ts
@@ -7,6 +7,7 @@ const auth = {
   jwt_sub_missing: 'JWT 缺失 `sub`',
   require_re_authentication: '需要重新认证以进行受保护操作。',
   exceed_token_limit: '令牌限制已超出。请联系你的管理员。',
+  third_party_application_forbidden: '第三方应用程序不允许通过此 API 修改账户数据。',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/zh-hk/errors/auth.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/auth.ts
@@ -7,6 +7,7 @@ const auth = {
   jwt_sub_missing: 'JWT 缺失 `sub`',
   require_re_authentication: '需要重新認證以進行受保護操作。',
   exceed_token_limit: '超過 token 限制。請聯絡你的管理員。',
+  third_party_application_forbidden: '第三方應用程式不允許透過此 API 修改帳戶資料。',
 };
 
 export default Object.freeze(auth);

--- a/packages/phrases/src/locales/zh-tw/errors/auth.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/auth.ts
@@ -7,6 +7,7 @@ const auth = {
   jwt_sub_missing: 'JWT 缺失 `sub`',
   require_re_authentication: '需要重新認證以進行受保護操作。',
   exceed_token_limit: '超出 Token 限制。請聯繫你的管理員。',
+  third_party_application_forbidden: '第三方應用程式不允許透過此 API 修改帳戶資料。',
 };
 
 export default Object.freeze(auth);


### PR DESCRIPTION
## Summary

The Account API is the user managing their own account at the identity provider, and it was built for the first-party Account Center. Third-party applications can reach it today for two reasons that compound:

1. `openid` is unconditionally part of every third-party client's scopes ([`adapter.ts`](https://github.com/logto-io/logto/blob/master/packages/core/src/oidc/adapter.ts#L117-L128)), and `koaOidcAuth` gates the whole user router on `openid` alone — it never looks at whether the client is first-party.
2. The per-route authorization reuses the OIDC **claim** scopes as write permissions. An admin who enables `email` for a third-party application is told the application reads the user's email address, and the end user consents to `'Your email address'`. Neither of them is told the application can replace the primary email, set a password, delete an MFA factor, or revoke sessions.

So the capability exists, but nobody in the chain knowingly authorized it. This PR closes it.

## What changes

One helper, `assertFirstPartyClient(queries, clientId)`, called alongside the scope check that each route already has. 24 call sites:

| File | Routes |
| --- | --- |
| `account/index.ts` | `PATCH /`, `PATCH /profile`, `POST /password`, `PATCH /mfa-settings` |
| `account/email-and-phone.ts` | `POST`/`DELETE` on `/primary-email` and `/primary-phone` |
| `account/identities.ts` | `POST`, `PUT`, `DELETE /identities` |
| `account/mfa-verifications.ts` | `POST /`, `PUT /totp`, `PATCH /:id/name`, `DELETE /:id` |
| `account/sessions.ts` | `DELETE /sessions/:sessionId` |
| `account/grants.ts` | `DELETE /grants/:grantId` |
| `account/logto-config.ts` | `PATCH /logto-configs` |
| `account/user-assets.ts` | `POST /user-assets/avatar` |
| `verification/index.ts` | `/password`, `/verification-code`, `/verification-code/verify`, `/web-authn/registration`, `/web-authn/registration/verify` |

Each guarded route also gets `403` added to its `koaGuard` status list, since `koaGuard` asserts the status of `RequestError`s thrown by inner middleware and would otherwise turn the 403 into a 500 outside production.

Rebased onto #9432, which made `isThirdPartyApplication` fail closed and classify CIMD client identifier URLs as third-party. The guard inherits both: a client that cannot be resolved, and a CIMD client, are rejected rather than treated as first-party. An earlier revision of this PR called CIMD out as an open question — that is now covered here.

Deliberately **not** guarded:

- **All reads.** No read route gained a guard. Three of them do become unreachable for third-party applications as a side effect — `GET /grants`, `GET /sessions`, `GET /mfa-verifications/backup-codes` all require a verified user-permission verification record, and the routes that mint one are guarded, so those now always return `401 verification_record.permission_denied`. Called out in the changeset.
- **`/api/verifications/social` and `/social/verify`**, plus the third-party token routes in `account/third-party-tokens.ts`. That flow's API description documents it as a general application capability ("use this API to securely retrieve the stored access token and use it to access third-party APIs on behalf of the user") rather than account self-management, and `PUT /identities/:target/access-token` consumes a social verification record — guarding the social routes would kill it.
- **`POST /mfa-verifications/totp-secret/generate` and `/backup-codes/generate`.** Pure random generators that read and write nothing, and they have no existing authorization check to sit next to.

## Open questions for review

- **The social token carve-out is the one judgment call.** If we decide that flow does not belong under the Account API at all, the cleaner fix is to move it to its own prefix.
- **`index.openapi.json` is only corrected where it was wrong, not completed.** `POST /primary-email` and `POST /primary-phone` documented 403 as "the verification record is invalid" — unreachable before this PR, and now produced only by the guard — and the avatar route's 403 gained a second cause. Those three descriptions are fixed. The new 403 stays undocumented on the other ~18 routes, to keep this diff focused.
- **`POST /api/my-account/password` still has no scope check at all** — it is the only Account API route where the scope column is empty. Third-party clients can no longer reach it, but the inconsistency remains.

## Testing

- Unit tests for the helper, covering first-party, third-party, built-in, unresolvable, CIMD, and absent-client-ID cases.
- Integration test `third-party-guard.test.ts` driving a real third-party consent flow: Account API mutations rejected, `POST /api/verifications/password` rejected, reads fine, first-party control case unaffected. Not run locally — needs a running instance, so leaving it to CI.
- Full `@logto/core` unit suite: 283 suites passed. The 3 failing `sign-in-experience/guard.*` suites fail identically on a clean checkout of `master` on this machine (unbuilt local connectors), unrelated to this change.

## Breaking change

Third-party applications currently calling the guarded routes will start receiving 403. There is intentionally no configuration to re-enable it.


