### PR TITLE
fix(core): route manual cache invalidations through the guarded path

### DIFF
--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -74,12 +74,29 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   /**
    * Delete value from the inner cache store for the given type and key.
    *
-   * Note this is a plain deletion: unlike {@link mutate}, it does not bump the invalidation
-   * generation, so an in-flight {@link memoize} read may still write its result back
-   * afterwards. Callers that invalidate on their own should be migrated to {@link mutate}.
+   * Note this is a plain deletion: unlike {@link invalidate}, it does not bump the invalidation
+   * generation, so an in-flight {@link memoize} read may still write its result back afterwards.
+   * Callers invalidating after a mutation should use {@link invalidate} or {@link mutate}.
    */
   async delete(type: CacheKeyOf<CacheMapT>, key: string) {
     return this.cacheStore.delete(this.cacheKey(type, key));
+  }
+
+  /**
+   * Invalidate the cached value for the given type and key, after the mutation it reflects
+   * has been committed.
+   *
+   * The generation must be bumped before deleting, and both must be awaited: this guarantees
+   * that once this method resolves, in-flight reads that computed from pre-mutation state
+   * either fail the generation check in {@link memoize} or have their write-back removed by
+   * the deletion. Callers must therefore await it before returning to their own caller.
+   *
+   * Store errors are silently caught, as an invalidation failure degrades to staleness bounded
+   * by the value TTL rather than a failed mutation.
+   */
+  async invalidate(type: CacheKeyOf<CacheMapT>, key: string) {
+    await trySafe(this.bumpGeneration(type, key));
+    await trySafe(this.delete(type, key));
   }
 
   /**
@@ -100,21 +117,12 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
     const mutated = async function (this: unknown, ...args: Args): Promise<Return> {
       const value = await run.apply(this, args);
 
-      /**
-       * We don't leverage `finally` here since we want to ensure cache invalidation
-       * only happens when the original function executed successfully.
-       *
-       * The generation must be bumped before deleting, and both must be awaited: this
-       * guarantees that once this function returns, in-flight reads that computed from
-       * pre-mutation state either fail the generation check in {@link BaseCache.memoize}
-       * or have their write-back removed by the deletion below.
-       */
+      // We don't leverage `finally` here since we want to ensure cache invalidation
+      // only happens when the original function executed successfully.
       await Promise.all(
-        types.map(async ([type, cacheKey]) => {
-          const key = cacheKey?.(...args) ?? BaseCache.defaultKey;
-          await trySafe(kvCache.bumpGeneration(type, key));
-          await trySafe(kvCache.delete(type, key));
-        })
+        types.map(async ([type, cacheKey]) =>
+          kvCache.invalidate(type, cacheKey?.(...args) ?? BaseCache.defaultKey)
+        )
       );
 
       return value;
@@ -127,7 +135,7 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
    * [Memoize](https://en.wikipedia.org/wiki/Memoization) a function and cache the result. The function execution
    * will be also cached, which means there will be only one execution at a time.
    *
-   * Results computed before an invalidation (see {@link mutate}) are discarded instead of
+   * Results computed before an invalidation (see {@link invalidate}) are discarded instead of
    * written back, so stale data can never persist in the cache after an invalidation
    * returns. (A caller that joined an already in-flight execution may still receive
    * pre-invalidation data once; it is never written back.)
@@ -214,7 +222,7 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
    * Get the current invalidation generation for the given type and key.
    * Note: Store errors will be silently caught and result an `undefined` return.
    *
-   * Bumped by every {@link mutate} invalidation; {@link memoize} compares snapshots of it
+   * Bumped by every {@link invalidate} call; {@link memoize} compares snapshots of it
    * to detect invalidations that raced with an in-flight read.
    */
   protected async getGeneration(type: CacheKeyOf<CacheMapT>, key: string) {

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -208,20 +208,6 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   abstract getValueGuard<Type extends CacheKeyOf<CacheMapT>>(type: Type): ZodType<CacheMapT[Type]>;
 
   /**
-   * Delete value from the inner cache store for the given type and key.
-   *
-   * Note this is a plain deletion: unlike {@link invalidate}, it does not bump the invalidation
-   * generation, so an in-flight {@link memoize} read may still write its result back afterwards.
-   * Invalidating after a mutation requires {@link invalidate} or {@link mutate}.
-   *
-   * {@link memoize} intentionally uses it to undo its own write-back: bumping the generation
-   * there would make other in-flight reads discard results that are not stale.
-   */
-  protected async delete(type: CacheKeyOf<CacheMapT>, key: string) {
-    return this.cacheStore.delete(this.cacheKey(type, key));
-  }
-
-  /**
    * Get the current invalidation generation for the given type and key.
    * Note: Store errors will be silently caught and result an `undefined` return.
    *
@@ -253,5 +239,19 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
 
   protected cacheKey(type: CacheKeyOf<CacheMapT>, key: string) {
     return `${this.tenantId}:${type}:${key}`;
+  }
+
+  /**
+   * Delete value from the inner cache store for the given type and key.
+   *
+   * Note this is a plain deletion: unlike {@link invalidate}, it does not bump the invalidation
+   * generation, so an in-flight {@link memoize} read may still write its result back afterwards.
+   * Invalidating after a mutation requires {@link invalidate} or {@link mutate}.
+   *
+   * {@link memoize} intentionally uses it to undo its own write-back: bumping the generation
+   * there would make other in-flight reads discard results that are not stale.
+   */
+  private async delete(type: CacheKeyOf<CacheMapT>, key: string) {
+    return this.cacheStore.delete(this.cacheKey(type, key));
   }
 }

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -72,17 +72,6 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   }
 
   /**
-   * Delete value from the inner cache store for the given type and key.
-   *
-   * Note this is a plain deletion: unlike {@link invalidate}, it does not bump the invalidation
-   * generation, so an in-flight {@link memoize} read may still write its result back afterwards.
-   * Callers invalidating after a mutation should use {@link invalidate} or {@link mutate}.
-   */
-  async delete(type: CacheKeyOf<CacheMapT>, key: string) {
-    return this.cacheStore.delete(this.cacheKey(type, key));
-  }
-
-  /**
    * Invalidate the cached value for the given type and key, after the mutation it reflects
    * has been committed.
    *
@@ -217,6 +206,20 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
   }
 
   abstract getValueGuard<Type extends CacheKeyOf<CacheMapT>>(type: Type): ZodType<CacheMapT[Type]>;
+
+  /**
+   * Delete value from the inner cache store for the given type and key.
+   *
+   * Note this is a plain deletion: unlike {@link invalidate}, it does not bump the invalidation
+   * generation, so an in-flight {@link memoize} read may still write its result back afterwards.
+   * Invalidating after a mutation requires {@link invalidate} or {@link mutate}.
+   *
+   * {@link memoize} intentionally uses it to undo its own write-back: bumping the generation
+   * there would make other in-flight reads discard results that are not stale.
+   */
+  protected async delete(type: CacheKeyOf<CacheMapT>, key: string) {
+    return this.cacheStore.delete(this.cacheKey(type, key));
+  }
 
   /**
    * Get the current invalidation generation for the given type and key.

--- a/packages/core/src/caches/well-known.test.ts
+++ b/packages/core/src/caches/well-known.test.ts
@@ -19,7 +19,7 @@ afterEach(() => {
 });
 
 describe('Well-known cache basics', () => {
-  it('should be able to get, set, and delete values', async () => {
+  it('should be able to get, set, and invalidate values', async () => {
     const cache = new WellKnownCache(tenantId, cacheStore);
 
     await cache.set('sie', WellKnownCache.defaultKey, mockSignInExperience);
@@ -36,7 +36,7 @@ describe('Well-known cache basics', () => {
     await cache.set('resource-by-indicator', 'resource', mockResource);
     expect(await cache.get('resource-by-indicator', 'resource')).toStrictEqual(mockResource);
 
-    await cache.delete('sie', WellKnownCache.defaultKey);
+    await cache.invalidate('sie', WellKnownCache.defaultKey);
     expect(await cache.get('sie', WellKnownCache.defaultKey)).toBe(undefined);
   });
 
@@ -74,13 +74,13 @@ describe('Well-known cache basics', () => {
     ).toBe(undefined);
   });
 
-  it('should be able to get, set, and delete null value', async () => {
+  it('should be able to get, set, and invalidate null value', async () => {
     const cache = new WellKnownCache(tenantId, cacheStore);
 
     await cache.set('email-templates', 'en:SignIn', null);
     expect(await cache.get('email-templates', 'en:SignIn')).toBe(null);
 
-    await cache.delete('email-templates', 'en:SignIn');
+    await cache.invalidate('email-templates', 'en:SignIn');
     expect(await cache.get('email-templates', 'en:SignIn')).toBe(undefined);
   });
 });

--- a/packages/core/src/libraries/custom-profile-fields/index.ts
+++ b/packages/core/src/libraries/custom-profile-fields/index.ts
@@ -8,7 +8,6 @@ import {
   type UpdateCustomProfileFieldSieOrder,
 } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
-import { trySafe } from '@silverhand/essentials';
 import { sql } from '@silverhand/slonik';
 
 import { BaseCache } from '#src/caches/base-cache.js';
@@ -205,16 +204,12 @@ export const createCustomProfileFieldsLibrary = (queries: Queries) => {
     );
 
     // Invalidate caches only after the transaction commits, so concurrent readers cannot
-    // repopulate them with pre-commit data during the cache delete window.
-    const invalidations = [
-      didUpdateSignInExperience && queries.wellKnownCache.delete('sie', BaseCache.defaultKey),
+    // repopulate them with pre-commit data.
+    await Promise.all([
+      didUpdateSignInExperience && queries.wellKnownCache.invalidate('sie', BaseCache.defaultKey),
       didUpdateAccountCenter &&
-        queries.wellKnownCache.delete('account-center', BaseCache.defaultKey),
-    ].filter((value): value is Promise<void> => value !== false);
-
-    if (invalidations.length > 0) {
-      await Promise.all(invalidations.map(async (promise) => trySafe(promise)));
-    }
+        queries.wellKnownCache.invalidate('account-center', BaseCache.defaultKey),
+    ]);
   };
 
   const normalizeProfileFields = async <ProfileFields extends NormalizableProfileFields>(

--- a/packages/core/src/queries/email-templates.ts
+++ b/packages/core/src/queries/email-templates.ts
@@ -5,7 +5,6 @@ import {
   type CreateEmailTemplate,
   type TemplateType,
 } from '@logto/schemas';
-import { trySafe } from '@silverhand/essentials';
 import { sql, type CommonQueryMethods } from '@silverhand/slonik';
 
 import SchemaQueries from '#src/utils/SchemaQueries.js';
@@ -66,9 +65,9 @@ export default class EmailTemplatesQueries extends SchemaQueries<
     });
 
     // Make sure to invalidate the cache after updating email templates
-    void Promise.all(
+    await Promise.all(
       results.map(async ({ languageTag, templateType }) =>
-        trySafe(this.wellKnownCache.delete('email-templates', `${languageTag}:${templateType}`))
+        this.wellKnownCache.invalidate('email-templates', `${languageTag}:${templateType}`)
       )
     );
 
@@ -83,8 +82,9 @@ export default class EmailTemplatesQueries extends SchemaQueries<
     const result = await super.updateById(id, data, jsonbMode);
 
     // Make sure to invalidate the cache after updating email templates
-    void trySafe(
-      this.wellKnownCache.delete('email-templates', `${result.languageTag}:${result.templateType}`)
+    await this.wellKnownCache.invalidate(
+      'email-templates',
+      `${result.languageTag}:${result.templateType}`
     );
 
     return result;
@@ -95,11 +95,9 @@ export default class EmailTemplatesQueries extends SchemaQueries<
     await super.deleteById(id);
 
     // Make sure to invalidate the cache after deleting email templates
-    void trySafe(
-      this.wellKnownCache.delete(
-        'email-templates',
-        `${emailTemplate.languageTag}:${emailTemplate.templateType}`
-      )
+    await this.wellKnownCache.invalidate(
+      'email-templates',
+      `${emailTemplate.languageTag}:${emailTemplate.templateType}`
     );
   }
 
@@ -158,9 +156,9 @@ export default class EmailTemplatesQueries extends SchemaQueries<
     `);
 
     // Make sure to invalidate the cache after deleting email templates
-    void Promise.all(
+    await Promise.all(
       rows.map(async ({ languageTag, templateType }) =>
-        trySafe(this.wellKnownCache.delete('email-templates', `${languageTag}:${templateType}`))
+        this.wellKnownCache.invalidate('email-templates', `${languageTag}:${templateType}`)
       )
     );
 

--- a/packages/core/src/queries/resource.ts
+++ b/packages/core/src/queries/resource.ts
@@ -1,6 +1,5 @@
 import type { Resource, CreateResource } from '@logto/schemas';
 import { Resources } from '@logto/schemas';
-import { trySafe } from '@silverhand/essentials';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
 
@@ -88,9 +87,9 @@ export const createResourceQueries = (pool: CommonQueryMethods, wellKnownCache: 
     const previousResource = await findResourceById(id);
     const updatedResource = await updateResource({ set, where: { id }, jsonbMode });
 
-    void Promise.all(
+    await Promise.all(
       [previousResource.indicator, updatedResource.indicator].map(async (indicator) =>
-        trySafe(wellKnownCache.delete('resource-by-indicator', indicator))
+        wellKnownCache.invalidate('resource-by-indicator', indicator)
       )
     );
 
@@ -108,7 +107,7 @@ export const createResourceQueries = (pool: CommonQueryMethods, wellKnownCache: 
       throw new DeletionError(Resources.table, id);
     }
 
-    void trySafe(wellKnownCache.delete('resource-by-indicator', indicator));
+    await wellKnownCache.invalidate('resource-by-indicator', indicator);
   };
 
   return {

--- a/packages/core/src/tenants/Tenant.test.ts
+++ b/packages/core/src/tenants/Tenant.test.ts
@@ -183,7 +183,7 @@ describe('Tenant cache health check', () => {
       logtoConfigQueries.setTenantCacheExpiresAt
     );
     Sinon.stub(tenant.wellKnownCache, 'set').value(jest.fn());
-    Sinon.stub(tenant.wellKnownCache, 'delete').value(jest.fn());
+    Sinon.stub(tenant.wellKnownCache, 'invalidate').value(jest.fn());
 
     await tenant.invalidateCache();
 
@@ -206,7 +206,7 @@ describe('Tenant cache health check', () => {
       setTenantCacheExpiresAt
     );
     Sinon.stub(tenant.wellKnownCache, 'set').value(jest.fn());
-    Sinon.stub(tenant.wellKnownCache, 'delete').value(jest.fn());
+    Sinon.stub(tenant.wellKnownCache, 'invalidate').value(jest.fn());
 
     await tenant.invalidateCache();
     expect(setTenantCacheExpiresAt).toHaveBeenCalledTimes(1);
@@ -267,7 +267,7 @@ describe('Tenant cache health check', () => {
       setSigningKeyRotationAt
     );
     Sinon.stub(tenant.wellKnownCache, 'set').value(jest.fn());
-    Sinon.stub(tenant.wellKnownCache, 'delete').value(jest.fn());
+    Sinon.stub(tenant.wellKnownCache, 'invalidate').value(jest.fn());
 
     await tenant.scheduleSigningKeyRotation(1_234_567_890);
 
@@ -292,7 +292,7 @@ describe('Tenant cache health check', () => {
     const now = Date.now();
     Sinon.stub(tenant.wellKnownCache, 'get').resolves();
     Sinon.stub(tenant.wellKnownCache, 'set').value(jest.fn());
-    Sinon.stub(tenant.wellKnownCache, 'delete').value(jest.fn());
+    Sinon.stub(tenant.wellKnownCache, 'invalidate').value(jest.fn());
     Sinon.stub(tenant.queries.logtoConfigs, 'getSigningKeyRotationState').value(
       jest.fn(async () => ({ tenantCacheExpiresAt: now }))
     );


### PR DESCRIPTION
## Summary

Route the remaining manual cache invalidations through the generation-guarded path introduced in #9428, which only covered invalidations performed by `mutate`.

- Add `BaseCache.invalidate()`: bumps the invalidation generation before deleting, awaiting both, so an in-flight `memoize` read cannot write pre-mutation data back once it returns. `mutate` now delegates to it.
- Migrate the call sites that invalidated with a bare `delete()` — resource, email template and custom profile field queries — and await them instead of firing and forgetting.
- `delete()` itself stays a plain deletion, since the awaited bump would defer the store deletion past the caller's return. It is now `protected`, so the unguarded primitive is no longer reachable from outside the cache.

## Testing

tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
