### PR TITLE
fix(core): fail closed when the third-party check cannot resolve the application

### DIFF
--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -60,13 +60,6 @@ export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
 /**
  * Whether an identifier presented as a `client_id` should be attributed to a CIMD client —
  * payload builders route it under `cimdClientId` instead of `applicationId`.
- *
- * Deliberately ignores the tenant CIMD config, unlike {@link isCimdClient}: attribution
- * classifies the identifier the requester presented, and the config can flip between the moment
- * an identifier enters the system and the moment it is attributed (the tenant is rebuilt on
- * config change), which would retroactively re-route an in-flight URL identifier into
- * `applicationId` and break its registered-ids-only contract. Gate behavior with
- * {@link isCimdClient}; use this only to decide where an identifier is recorded.
  */
 export const shouldAttributeToCimd = (clientId?: string): boolean =>
   // DEV: CIMD (client ID metadata document) support

--- a/packages/core/src/oidc/grants/token-exchange/index.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.test.ts
@@ -2,6 +2,7 @@ import { type SubjectToken } from '@logto/schemas';
 import { type KoaContextWithOIDC, errors } from 'oidc-provider';
 import Sinon from 'sinon';
 
+import { mockApplication } from '#src/__mocks__/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import { createOidcContext } from '#src/test-utils/oidc-provider.js';
@@ -26,6 +27,10 @@ const mockQueries = {
   subjectTokens: {
     findSubjectToken,
     updateSubjectTokenById,
+  },
+  applications: {
+    // The organization token cases require a registered first-party application.
+    findApplicationById: async () => ({ ...mockApplication, id: clientId }),
   },
 };
 const assertUserHasApplicationAccess = jest.fn(async () => {

--- a/packages/core/src/oidc/grants/utils.ts
+++ b/packages/core/src/oidc/grants/utils.ts
@@ -35,8 +35,8 @@ type OrganizationAccessOptions = {
 /**
  * Whether the user has granted this organization to this client.
  *
- * The CIMD test must come first: `isThirdPartyApplication`'s not-found fallback reads the
- * identifier URL as first-party, which would skip the user-to-client grant check entirely.
+ * The CIMD test must come first: CIMD organization access is grant-scoped, not the
+ * application-keyed consent relation the third-party branch checks.
  */
 const isOrganizationGrantedToClient = async (
   ctx: KoaContextWithOIDC,

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -509,16 +509,22 @@ describe('getResourceServerInfo for CIMD clients', () => {
     expect(findApplicationById).not.toHaveBeenCalled();
   });
 
-  it('should keep the legacy application lookup when CIMD is not effectively enabled', async () => {
+  it('should treat the identifier url as third-party without a database lookup when CIMD is not effectively enabled', async () => {
     const findResourceByIndicator = jest.fn().mockResolvedValue({
       ...mockResource,
       indicator,
       accessTokenTtl: 3600,
     });
-    const findApplicationById = jest.fn().mockRejectedValue(new Error('not found'));
+    const findApplicationById = jest.fn();
     const findUserScopesForResourceIndicator = jest
       .fn()
       .mockResolvedValue([buildScope('scope_1', 'read:api'), buildScope('scope_2', 'write:api')]);
+    const getApplicationUserConsentResourceScopes = jest
+      .fn()
+      .mockResolvedValue([
+        { resource: { indicator }, scopes: [buildScope('scope_1', 'read:api')] },
+      ]);
+    const getApplicationUserConsentOrganizationResourceScopes = jest.fn().mockResolvedValue([]);
     const tenant = new MockTenant(undefined, {
       resources: { findResourceByIndicator },
       applications: { findApplicationById },
@@ -526,6 +532,10 @@ describe('getResourceServerInfo for CIMD clients', () => {
 
     tenant.setPartial('libraries', {
       users: { findUserScopesForResourceIndicator },
+      applications: {
+        getApplicationUserConsentResourceScopes,
+        getApplicationUserConsentOrganizationResourceScopes,
+      },
     });
 
     const provider = createProvider(tenant);
@@ -533,8 +543,8 @@ describe('getResourceServerInfo for CIMD clients', () => {
 
     const result = await getResourceServerInfo(ctx, indicator);
 
-    expect(result.scope).toBe('read:api write:api');
-    expect(findApplicationById).toHaveBeenCalledWith(cimdClientId);
+    expect(result.scope).toBe('read:api');
+    expect(findApplicationById).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -129,8 +129,7 @@ export default function initOidc(
     if (isCimdClient(envSet, clientId)) {
       /**
        * CIMD clients are unregistered: the tenant-wide ceiling replaces the per-application
-       * consent configuration, and the client identifier URL must never be used to query the
-       * applications table (which the third-party check below would do).
+       * consent configuration the third-party filter below reads.
        */
       const filteredScopes = await filterResourceScopesForTheCimdClient(queries, indicator, scopes);
 

--- a/packages/core/src/oidc/resource.test.ts
+++ b/packages/core/src/oidc/resource.test.ts
@@ -1,0 +1,50 @@
+import {
+  accountCenterApplicationId,
+  demoAppApplicationId,
+  deviceDemoAppApplicationId,
+  type Application,
+} from '@logto/schemas';
+
+import { mockApplication } from '#src/__mocks__/index.js';
+import { MockQueries } from '#src/test-utils/tenant.js';
+
+import { isThirdPartyApplication } from './resource.js';
+
+const { jest } = import.meta;
+
+describe('isThirdPartyApplication()', () => {
+  const findApplicationById = jest.fn(async (): Promise<Application> => mockApplication);
+  const queries = new MockQueries({ applications: { findApplicationById } });
+
+  afterEach(() => {
+    findApplicationById.mockClear();
+  });
+
+  it.each([demoAppApplicationId, accountCenterApplicationId, deviceDemoAppApplicationId])(
+    'should treat the built-in client %s as first-party without a database lookup',
+    async (applicationId) => {
+      await expect(isThirdPartyApplication(queries, applicationId)).resolves.toBe(false);
+      expect(findApplicationById).not.toHaveBeenCalled();
+    }
+  );
+
+  it('should return the stored flag for a registered application', async () => {
+    findApplicationById.mockResolvedValueOnce({ ...mockApplication, isThirdParty: true });
+    await expect(isThirdPartyApplication(queries, mockApplication.id)).resolves.toBe(true);
+
+    findApplicationById.mockResolvedValueOnce({ ...mockApplication, isThirdParty: false });
+    await expect(isThirdPartyApplication(queries, mockApplication.id)).resolves.toBe(false);
+  });
+
+  it('should treat a CIMD client identifier as third-party without a database lookup', async () => {
+    await expect(
+      isThirdPartyApplication(queries, 'https://client.example.com/metadata.json')
+    ).resolves.toBe(true);
+    expect(findApplicationById).not.toHaveBeenCalled();
+  });
+
+  it('should fail closed to third-party when the application cannot be resolved', async () => {
+    findApplicationById.mockRejectedValueOnce(new Error('not found'));
+    await expect(isThirdPartyApplication(queries, 'deleted_application_id')).resolves.toBe(true);
+  });
+});

--- a/packages/core/src/oidc/resource.ts
+++ b/packages/core/src/oidc/resource.ts
@@ -1,5 +1,5 @@
 import { ReservedResource } from '@logto/core-kit';
-import { type Resource } from '@logto/schemas';
+import { isBuiltInApplicationId, isCimdClientId, type Resource } from '@logto/schemas';
 import { trySafe, type Nullable } from '@silverhand/essentials';
 import { type ResourceServer } from 'oidc-provider';
 
@@ -128,10 +128,20 @@ export const findResource = async (
 };
 
 export const isThirdPartyApplication = async ({ applications }: Queries, applicationId: string) => {
-  // Demo-app not exist in the database
+  // Built-in clients have no applications row and are always first-party.
+  if (isBuiltInApplicationId(applicationId)) {
+    return false;
+  }
+
+  // A CIMD client identifier is a URL and never names a registered application.
+  if (isCimdClientId(applicationId)) {
+    return true;
+  }
+
   const application = await trySafe(async () => applications.findApplicationById(applicationId));
 
-  return application?.isThirdParty ?? false;
+  // Fail closed: an unresolvable client is never first-party.
+  return application?.isThirdParty ?? true;
 };
 
 /**

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -153,9 +153,7 @@ export const filterAndParseMissingResourceScopes = async ({
           if (isCimdClient(envSet, applicationId)) {
             /**
              * CIMD clients are unregistered: the tenant-wide ceiling replaces the
-             * per-application consent configuration, and the identifier URL must never reach
-             * `isThirdPartyApplication` (its not-found fallback would read as first-party and
-             * skip the filter entirely).
+             * per-application consent configuration the third-party filter reads.
              */
             const filteredScopes = await filterResourceScopesForTheCimdClient(
               queries,


### PR DESCRIPTION
## Summary

Make `isThirdPartyApplication` resolve CIMD clients explicitly and fail closed on everything else it cannot resolve, so a client id without an application record can never silently gain first-party privileges.

- Built-in clients (demo app, account center, device flow demo) are now explicitly recognized as first-party — previously they relied on the fail-open fallback.
- A CIMD client identifier is classified as third-party by its URL shape, without the (previously doomed) applications-table lookup. The CIMD diversions at existing call sites stay — they route to CIMD-specific behavior (tenant ceiling filtering, grant-scoped organization checks), not just a boolean.
- The not-found fallback flips from first-party to third-party: a client whose application row cannot be resolved (deleted mid-request, transient query failure) now gets the restrictive treatment (scope filtering, consent checks) instead of first-party privileges.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)