### PR TITLE
feat(core,console): open the consolidated Custom JWT and Actions script runtime

### DIFF
--- a/.changeset/script-runtime-consolidate.md
+++ b/.changeset/script-runtime-consolidate.md
@@ -5,4 +5,4 @@
 
 run Custom JWT and Actions scripts on the consolidated script runtime
 
-Self-hosted deployments execute Custom JWT and Actions scripts on a pooled worker-thread runner with a 5-second wall-clock deadline and a 128 MB memory budget, so a runaway or never-settling async script fails instead of hanging token issuance. Script return values must be JSON-serializable. On the Console, the Custom JWT and Actions editors show a warning that scripts are not sandboxed and run with server privileges.
+Self-hosted deployments execute Custom JWT and Actions scripts on a pooled worker-thread runner with a 5-second wall-clock deadline and a 128 MB memory budget, so a runaway or never-settling async script fails instead of hanging token issuance. Script return values must be JSON-serializable.

--- a/.changeset/script-runtime-consolidate.md
+++ b/.changeset/script-runtime-consolidate.md
@@ -1,0 +1,8 @@
+---
+"@logto/core": minor
+"@logto/console": minor
+---
+
+run Custom JWT and Actions scripts on the consolidated script runtime
+
+Self-hosted deployments execute Custom JWT and Actions scripts on a pooled worker-thread runner with a 5-second wall-clock deadline and a 128 MB memory budget, so a runaway or never-settling async script fails instead of hanging token issuance. Script return values must be JSON-serializable. On the Console, the Custom JWT and Actions editors show a warning that scripts are not sandboxed and run with server privileges.

--- a/packages/console/src/pages/Actions/ActionDetails/index.test.tsx
+++ b/packages/console/src/pages/Actions/ActionDetails/index.test.tsx
@@ -20,14 +20,10 @@ jest.mock('./use-data-fetch', () => ({
 }));
 
 const mockIsCloud = jest.fn(() => false);
-const mockIsDevFeaturesEnabled = jest.fn(() => true);
 
 jest.mock('@/consts/env', () => ({
   get isCloud() {
     return mockIsCloud();
-  },
-  get isDevFeaturesEnabled() {
-    return mockIsDevFeaturesEnabled();
   },
 }));
 
@@ -89,7 +85,6 @@ describe('ActionDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsCloud.mockReturnValue(false);
-    mockIsDevFeaturesEnabled.mockReturnValue(true);
   });
 
   it('renders empty placeholder for invalid route params', () => {
@@ -175,7 +170,7 @@ describe('ActionDetails', () => {
     expect(screen.getByText('main-content')).toBeTruthy();
   });
 
-  it('shows the sandbox warning for self-hosted tenants when dev features are enabled', () => {
+  it('shows the sandbox warning for self-hosted tenants', () => {
     mockedUseParams.mockReturnValue({
       actionType: LogtoActionKey.PostSignIn,
       mode: ActionPageMode.Create,
@@ -198,25 +193,6 @@ describe('ActionDetails', () => {
 
   it('hides the sandbox warning for Cloud tenants', () => {
     mockIsCloud.mockReturnValue(true);
-    mockedUseParams.mockReturnValue({
-      actionType: LogtoActionKey.PostSignIn,
-      mode: ActionPageMode.Create,
-    });
-    mockedUseDataFetch.mockReturnValue({
-      isLoading: false,
-      data: undefined,
-      mutate: mockMutate,
-      error: undefined,
-    });
-
-    render(<ActionDetails />);
-
-    expect(screen.queryByText('admin_console.actions.sandbox_warning.title')).toBeNull();
-    expect(screen.getByText('main-content')).toBeTruthy();
-  });
-
-  it('hides the sandbox warning when dev features are disabled', () => {
-    mockIsDevFeaturesEnabled.mockReturnValue(false);
     mockedUseParams.mockReturnValue({
       actionType: LogtoActionKey.PostSignIn,
       mode: ActionPageMode.Create,

--- a/packages/console/src/pages/Actions/ActionDetails/index.tsx
+++ b/packages/console/src/pages/Actions/ActionDetails/index.tsx
@@ -6,7 +6,7 @@ import { useParams } from 'react-router-dom';
 import DetailsPage from '@/components/DetailsPage';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import PageMeta from '@/components/PageMeta';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import InlineNotification from '@/ds-components/InlineNotification';
 
 import { actionCatalog } from '../constants';
@@ -42,9 +42,8 @@ function Content({ actionType, mode }: ContentProps) {
     mode === ActionPageMode.Edit && !isLoading && (error?.status === 404 || !data);
 
   const shouldShowSecurityWarning = actionType === LogtoActionKey.PostFirstFactorVerification;
-  // Script runtime consolidation (Custom JWT & Actions): OSS sandbox warning.
   // Self-hosted scripts are not sandboxed; hide on Cloud (Dynamic Workers).
-  const shouldShowSandboxWarning = isDevFeaturesEnabled && !isCloud;
+  const shouldShowSandboxWarning = !isCloud;
   // Avoid stacking two alerts: merge sandbox + action-specific security copy into one notice.
   const warningPhraseKey =
     shouldShowSandboxWarning && shouldShowSecurityWarning

--- a/packages/console/src/pages/CustomizeJwtDetails/index.test.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/index.test.tsx
@@ -18,14 +18,10 @@ jest.mock('./use-data-fetch', () => ({
 }));
 
 const mockIsCloud = jest.fn(() => false);
-const mockIsDevFeaturesEnabled = jest.fn(() => true);
 
 jest.mock('@/consts/env', () => ({
   get isCloud() {
     return mockIsCloud();
-  },
-  get isDevFeaturesEnabled() {
-    return mockIsDevFeaturesEnabled();
   },
 }));
 
@@ -68,7 +64,6 @@ describe('CustomizeJwtDetails', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsCloud.mockReturnValue(false);
-    mockIsDevFeaturesEnabled.mockReturnValue(true);
     mockedUseParams.mockReturnValue({
       tokenType: LogtoJwtTokenKeyType.AccessToken,
       action: Action.Create,
@@ -89,7 +84,7 @@ describe('CustomizeJwtDetails', () => {
     expect(screen.getByText('empty')).toBeTruthy();
   });
 
-  it('shows the sandbox warning for self-hosted tenants when dev features are enabled', () => {
+  it('shows the sandbox warning for self-hosted tenants', () => {
     render(<CustomizeJwtDetails />);
 
     expect(screen.getByText('admin_console.jwt_claims.sandbox_warning.title')).toBeTruthy();
@@ -99,15 +94,6 @@ describe('CustomizeJwtDetails', () => {
 
   it('hides the sandbox warning for Cloud tenants', () => {
     mockIsCloud.mockReturnValue(true);
-
-    render(<CustomizeJwtDetails />);
-
-    expect(screen.queryByText('admin_console.jwt_claims.sandbox_warning.title')).toBeNull();
-    expect(screen.getByText('main-content')).toBeTruthy();
-  });
-
-  it('hides the sandbox warning when dev features are disabled', () => {
-    mockIsDevFeaturesEnabled.mockReturnValue(false);
 
     render(<CustomizeJwtDetails />);
 

--- a/packages/console/src/pages/CustomizeJwtDetails/index.tsx
+++ b/packages/console/src/pages/CustomizeJwtDetails/index.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'react-router-dom';
 
 import DetailsPage from '@/components/DetailsPage';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import InlineNotification from '@/ds-components/InlineNotification';
 import { type Action } from '@/pages/CustomizeJwt/utils/type';
 
@@ -32,9 +32,8 @@ function Content({ tokenType, action }: Props) {
     [isMonacoLoaded]
   );
 
-  // Script runtime consolidation (Custom JWT & Actions): OSS sandbox warning.
   // Self-hosted scripts are not sandboxed; hide on Cloud (Dynamic Workers).
-  const shouldShowSandboxWarning = isDevFeaturesEnabled && !isCloud;
+  const shouldShowSandboxWarning = !isCloud;
 
   return (
     <DetailsPage

--- a/packages/core/src/libraries/action-telemetry.ts
+++ b/packages/core/src/libraries/action-telemetry.ts
@@ -18,10 +18,9 @@ export const actionMetricNames = Object.freeze({
 /**
  * Where a script run actually executed.
  *
- * `azure` and `cloud` are both Cloud runs, kept apart on purpose while the two remote runtimes
- * coexist behind `isDevFeaturesEnabled`: it makes the migration off Azure Functions readable in
- * the metric itself. `azure` also keeps the pre-existing series intact rather than renaming it.
- * Once LOG-13958 removes the Azure Functions runtime, `azure` goes with it.
+ * `azure` and `cloud` are both Cloud runs, kept apart on purpose: `cloud` is the Cloud script
+ * runner and `azure` the Azure Functions runtime kept as its per-region fallback, so the split
+ * makes a per-region rollback readable in the metric itself.
  */
 export type ActionRuntimeLocation = 'local' | 'azure' | 'cloud';
 

--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines -- The dev-features-gated script-run path and the legacy Azure Functions path share one setup. */
+/* eslint-disable max-lines -- The script-run path and the Azure Functions fallback share one setup. */
 import { appInsights } from '@logto/app-insights/node';
 import { LogtoActionKey } from '@logto/schemas';
 import { ResponseError } from '@withtyped/client';
@@ -45,14 +45,13 @@ const createLibrary = (tenantId = 'tenant_id') =>
   );
 
 const originalIsCloud = EnvSet.values.isCloud;
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
 
 const setIsCloud = (isCloud: boolean) => {
   // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle EnvSet for Cloud/local selection tests.
   (EnvSet.values as { isCloud: boolean }).isCloud = isCloud;
 };
 
-/** The error body the legacy Azure Functions path produces for a failed run. */
+/** The error body the Azure Functions runtime produces for a failed run. */
 const buildScriptFailureResponseError = (
   status: number,
   message: string,
@@ -76,7 +75,6 @@ describe('ActionLibrary Cloud execution routing', () => {
     library.runAction({ ...input, auditContext: { createLog } });
 
   beforeEach(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
     jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue(scriptRunnerEndpoint);
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Provide an AppInsights client for metric assertions.
     appInsights.client = {
@@ -97,7 +95,6 @@ describe('ActionLibrary Cloud execution routing', () => {
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the shared AppInsights singleton.
     appInsights.client = originalAppInsightsClient;
     setIsCloud(originalIsCloud);
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('runs the script on the Cloud script runner', async () => {
@@ -184,7 +181,7 @@ describe('ActionLibrary Cloud execution routing', () => {
     ).rejects.toMatchObject({ status: 500 });
   });
 
-  it('falls back to the legacy path when the script runner endpoint is not injected', async () => {
+  it('falls back to the Azure Functions runtime when the script runner endpoint is not injected', async () => {
     jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue('');
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
@@ -226,8 +223,8 @@ describe('ActionLibrary Cloud execution routing', () => {
         },
       })
     ).resolves.toEqual(executionResult);
-    // Dev features alone must not label an Azure Functions run as `cloud`: the metric decides
-    // when the gate can drop, so it has to read the same condition the gate does.
+    // A run served by the Azure Functions fallback must not be labelled `cloud`: the metric is
+    // what makes a per-region rollback observable, so it reads the same condition the branch does.
     expect(trackMetric).toHaveBeenNthCalledWith(1, {
       name: actionMetricNames.executionCount,
       value: 1,
@@ -322,7 +319,7 @@ describe('ActionLibrary Cloud execution routing', () => {
     );
     const metricProperties = {
       actionType: 'PostSignIn',
-      // `cloud`, not `azure`: the metric distinguishes the two remote runtimes while both exist.
+      // `cloud`, not `azure`: the metric distinguishes the script runner from its fallback.
       runtimeLocation: 'cloud',
       outcome: 'success',
       action: 'updateUser',
@@ -416,14 +413,15 @@ describe('ActionLibrary Cloud execution routing', () => {
   });
 });
 
-describe('ActionLibrary Cloud execution routing without dev features', () => {
+describe('ActionLibrary Cloud execution routing on the Azure Functions fallback', () => {
   const library = createLibrary();
   const { createLog } = createMockLogContext();
   const runAction = async <Event>(input: RunActionInput<Event>) =>
     library.runAction({ ...input, auditContext: { createLog } });
 
   beforeEach(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    // An unset script runner endpoint is what selects the Azure Functions runtime.
+    jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue('');
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Provide an AppInsights client for metric assertions.
     appInsights.client = {
       trackMetric,
@@ -443,7 +441,6 @@ describe('ActionLibrary Cloud execution routing without dev features', () => {
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the shared AppInsights singleton.
     appInsights.client = originalAppInsightsClient;
     setIsCloud(originalIsCloud);
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('throws an action error when the remote runner is not configured', async () => {

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -301,12 +301,11 @@ export class ActionLibrary {
     isTest?: boolean
   ): Promise<unknown> {
     /**
-     * The Azure Functions runtime is kept as a per-region fallback rather than retired: a script
-     * runner outage is then routed around by unsetting `SCRIPT_RUNNER_ENDPOINT` on that region's
-     * core, with no code change and no coordinated rollback.
-     *
-     * A region where the endpoint is not injected yet therefore keeps running on the function app
-     * instead of failing.
+     * The Azure Functions runtime is kept as a per-region fallback rather than retired: on a
+     * region whose untrusted function app is configured, a script runner outage is routed around
+     * by unsetting `SCRIPT_RUNNER_ENDPOINT` there, with no code change and no coordinated
+     * rollback. Where that app is not configured this runtime throws the 422 below, exactly as it
+     * does today.
      */
     const { scriptRunnerEndpoint } = EnvSet.values;
 

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -9,7 +9,6 @@ import {
   type ActionExecutionRequestBody,
 } from '@logto/schemas';
 import { got, HTTPError } from 'got';
-import { ZodError } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -17,7 +16,6 @@ import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import type { SubscriptionLibrary } from '#src/libraries/subscription.js';
 import type { LogContext, LogPayload } from '#src/middleware/koa-audit-log.js';
 import { parseAzureFunctionsResponseError } from '#src/utils/custom-jwt/index.js';
-import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import {
   buildActionTelemetryError,
@@ -35,12 +33,9 @@ import {
 import { type CloudConnectionLibrary } from './cloud-connection.js';
 import {
   buildCloudScriptFailureError,
-  buildScriptExecutionErrorBody,
   buildScriptFailureError,
-  getScriptFailureStatusCode,
   runScriptOnCloud,
   runScriptOnWorkerPool,
-  ScriptExecutionError,
 } from './script-runner/index.js';
 
 const actionFunctionName = 'runAction';
@@ -49,7 +44,7 @@ const defaultActionExecutionErrorPolicy = 'block' satisfies ActionExecutionError
  * Azure Function vm2 timeout is 3000ms. Use a slightly higher HTTP deadline so the
  * client can surface Function-side failures instead of racing the sandbox limit.
  *
- * Only used by the legacy Azure Functions path; the Cloud script runner owns its own budget.
+ * Only used by the Azure Functions runtime; the Cloud script runner owns its own budget.
  */
 const remoteActionRequestTimeout = 5000;
 
@@ -195,24 +190,19 @@ export const getActionExecutionErrorPolicyDecision = ({
 /**
  * The telemetry label for where a run executes.
  *
- * Deliberately kept in sync with the branch {@link ActionLibrary.runScriptRemotely} takes: while
- * both remote runtimes coexist behind `isDevFeaturesEnabled`, splitting `azure` from `cloud` is
- * what makes the share of traffic already served by the Cloud script runner readable in the
- * metric. Collapses back to `azure`-free once LOG-13958 removes the Azure Functions path.
- *
- * That gate gained the `scriptRunnerEndpoint` condition, so this must read it too: a region with
- * dev features on and the endpoint not injected yet runs every script on Azure Functions, and
- * labelling those `cloud` would report full adoption where there is none — the very signal the
- * LOG-13958 TODO relies on to decide when the gate can drop.
+ * Deliberately kept in sync with the branch {@link ActionLibrary.runScriptRemotely} takes, so the
+ * split between regions served by the Cloud script runner (`cloud`) and those on the Azure
+ * Functions fallback (`azure`) is readable in the metric — which is what makes a per-region
+ * rollback observable.
  */
 const getTelemetryRuntimeLocation = (): ActionRuntimeLocation => {
-  const { isCloud, isDevFeaturesEnabled, scriptRunnerEndpoint } = EnvSet.values;
+  const { isCloud, scriptRunnerEndpoint } = EnvSet.values;
 
   if (!isCloud) {
     return 'local';
   }
 
-  return isDevFeaturesEnabled && scriptRunnerEndpoint ? 'cloud' : 'azure';
+  return scriptRunnerEndpoint ? 'cloud' : 'azure';
 };
 
 const applyActionExecutionErrorPolicyDecision = (decision: ActionExecutionErrorPolicyDecision) => {
@@ -228,12 +218,6 @@ export class ActionLibrary {
     data: ActionRunnerData<Event>,
     tenantId: string
   ): Promise<unknown> {
-    // TODO (LOG-13956): drop the legacy `node:vm` path and the gate once the worker-thread
-    // runner has been manually verified and released.
-    if (!EnvSet.values.isDevFeaturesEnabled) {
-      return ActionLibrary.runScriptInLegacyVm(data);
-    }
-
     const { script, event, environmentVariables } = data;
     // No `api` capability for Actions: the payload stays `{ event, environmentVariables }`, and
     // the worker only injects `api` for the Custom JWT entry.
@@ -256,41 +240,6 @@ export class ActionLibrary {
     return result.value;
   }
 
-  /** The pre-worker-runner execution path, still serving production until the gate above lifts. */
-  private static async runScriptInLegacyVm<Event>({
-    script,
-    event,
-    environmentVariables,
-  }: ActionRunnerData<Event>): Promise<unknown> {
-    try {
-      const payload: ActionScriptPayload<Event> = {
-        event,
-        environmentVariables,
-      };
-
-      return await runScriptFunctionInLocalVm(script, actionFunctionName, payload);
-    } catch (error: unknown) {
-      if (error instanceof ScriptExecutionError) {
-        throw error;
-      }
-
-      if (error instanceof ZodError) {
-        throw new ScriptExecutionError(
-          {
-            message: 'Invalid input',
-            errors: error.errors,
-          },
-          400
-        );
-      }
-
-      throw new ScriptExecutionError(
-        buildScriptExecutionErrorBody(error),
-        getScriptFailureStatusCode(error)
-      );
-    }
-  }
-
   constructor(
     private readonly tenantId: string,
     private readonly logtoConfigs: LogtoConfigLibrary,
@@ -306,8 +255,7 @@ export class ActionLibrary {
 
   /**
    * Shared entry point for production `runAction()` and Management API dry runs.
-   * Cloud always executes remotely; OSS / self-hosted runs locally — on the worker pool behind
-   * dev features, otherwise in the legacy `node:vm`.
+   * Cloud always executes remotely; OSS / self-hosted runs locally on the worker pool.
    * Cloud remote failures must never fall back to the local runner.
    */
   async executeScript({
@@ -349,15 +297,20 @@ export class ActionLibrary {
       event: unknown;
       environmentVariables?: Record<string, string>;
     },
-    /** Whether this is a dry run. The legacy Azure Functions path has no notion of it. */
+    /** Whether this is a dry run. The Azure Functions runtime has no notion of it. */
     isTest?: boolean
   ): Promise<unknown> {
-    // TODO (LOG-13958): drop the legacy Azure Functions path and the gate once the Cloud script
-    // runner has been manually verified and released. `scriptRunnerEndpoint` additionally covers a
-    // region where the Worker endpoint is not injected yet.
-    const { isDevFeaturesEnabled, scriptRunnerEndpoint } = EnvSet.values;
+    /**
+     * The Azure Functions runtime is kept as a per-region fallback rather than retired: a script
+     * runner outage is then routed around by unsetting `SCRIPT_RUNNER_ENDPOINT` on that region's
+     * core, with no code change and no coordinated rollback.
+     *
+     * A region where the endpoint is not injected yet therefore keeps running on the function app
+     * instead of failing.
+     */
+    const { scriptRunnerEndpoint } = EnvSet.values;
 
-    if (!isDevFeaturesEnabled || !scriptRunnerEndpoint) {
+    if (!scriptRunnerEndpoint) {
       return this.runScriptOnAzureFunction(data);
     }
 
@@ -481,7 +434,13 @@ export class ActionLibrary {
     }
   }
 
-  /** The pre-script-runner remote path, still serving production until the gate above lifts. */
+  /**
+   * The Azure Functions runtime, kept as the per-region fallback for the Cloud script runner.
+   *
+   * Selected whenever `SCRIPT_RUNNER_ENDPOINT` is unset. `isTest` is deliberately not forwarded:
+   * this runtime has no notion of a dry run, and nothing is lost by it — vm2 builds a fresh VM per
+   * call, so a test run can never share state with production the way a warm isolate could.
+   */
   private async runScriptOnAzureFunction({
     script,
     actionType,

--- a/packages/core/src/libraries/action.worker-pool.test.ts
+++ b/packages/core/src/libraries/action.worker-pool.test.ts
@@ -14,7 +14,6 @@ jest.unstable_mockModule('#src/libraries/script-runner/worker-thread-script-runn
   },
 }));
 
-const { EnvSet } = await import('#src/env-set/index.js');
 const { ActionLibrary } = await import('./action.js');
 const { ossScriptLimits, ScriptExecutionError } = await import('./script-runner/index.js');
 
@@ -44,15 +43,8 @@ const catchScriptExecutionError = async (promise: Promise<unknown>) => {
 };
 
 describe('ActionLibrary worker-pool adapter', () => {
-  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-
   beforeEach(() => {
     runScript.mockReset();
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
-  });
-
-  afterAll(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('hands the runner the standard OSS limits and the allow-all egress policy', async () => {
@@ -122,85 +114,6 @@ describe('ActionLibrary worker-pool adapter', () => {
 
       expect(status).toBe(expectedStatus);
       expect(body).toEqual(expectedBody);
-    });
-  });
-
-  // TODO (LOG-13956): drop these together with the legacy `node:vm` execution path.
-  describe('the legacy `node:vm` path while dev features are disabled', () => {
-    beforeEach(() => {
-      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
-    });
-
-    it('runs the script without touching the worker pool', async () => {
-      await expect(
-        ActionLibrary.runScriptInLocalVm(
-          {
-            script: 'const runAction = ({ event }) => ({ echoed: event.user.name });',
-            event,
-            environmentVariables,
-          },
-          tenantId
-        )
-      ).resolves.toEqual({ echoed: 'Foo' });
-      expect(runScript).not.toHaveBeenCalled();
-    });
-
-    it('maps a thrown script error to the runtime status', async () => {
-      const { status, body } = await catchScriptExecutionError(
-        ActionLibrary.runScriptInLocalVm(
-          {
-            script: "const runAction = () => { throw new Error('legacy boom'); };",
-            event,
-            environmentVariables,
-          },
-          tenantId
-        )
-      );
-
-      expect(status).toBe(500);
-      expect(body).toMatchObject({ message: 'legacy boom' });
-    });
-
-    // The vm constructs the SyntaxError in the script's realm, so the host-side `instanceof`
-    // classification never fires and a compile error falls through to the runtime status. The
-    // worker runner evaluates in its own realm and is what makes syntax failures report 422.
-    it('maps a script that cannot be compiled to the runtime status', async () => {
-      const { status, body } = await catchScriptExecutionError(
-        ActionLibrary.runScriptInLocalVm(
-          {
-            script: 'const runAction = () => {',
-            event,
-            environmentVariables,
-          },
-          tenantId
-        )
-      );
-
-      expect(status).toBe(500);
-      expect(body).toMatchObject({
-        message: expect.stringContaining('Unexpected end of input') as string,
-      });
-    });
-
-    // An undeclared entry throws a ReferenceError inside the vm realm (also invisible to the
-    // host-side `instanceof`) — only an entry that exists but is not a function reaches the
-    // host-thrown TypeError and its 422.
-    it('maps a non-function entry to the type status', async () => {
-      const { status, body } = await catchScriptExecutionError(
-        ActionLibrary.runScriptInLocalVm(
-          {
-            script: 'const runAction = 1;',
-            event,
-            environmentVariables,
-          },
-          tenantId
-        )
-      );
-
-      expect(status).toBe(422);
-      expect(body).toMatchObject({
-        message: 'The script does not have a function named `runAction`',
-      });
     });
   });
 });

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -174,9 +174,9 @@ describe('JwtCustomizerLibrary.runScriptRemotely quota', () => {
   });
 });
 
-describe('JwtCustomizerLibrary.runScriptRemotely on the Azure Functions fallback', () => {
+describe('JwtCustomizerLibrary.runScriptRemotely on the legacy remote paths', () => {
   beforeEach(() => {
-    // An unset script runner endpoint is what selects the Azure Functions runtime.
+    // An unset script runner endpoint is what selects the legacy remote paths.
     jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue('');
   });
 
@@ -186,7 +186,7 @@ describe('JwtCustomizerLibrary.runScriptRemotely on the Azure Functions fallback
     jest.clearAllMocks();
   });
 
-  it('runs the script through the regional untrusted Azure Function app', async () => {
+  it('runs the script through the regional untrusted Azure Function app when configured', async () => {
     const endpoint = 'https://untrusted.example.com';
     const functionKey = 'function-key';
     const remoteRunner = nock(endpoint, {
@@ -201,16 +201,19 @@ describe('JwtCustomizerLibrary.runScriptRemotely on the Azure Functions fallback
     await expect(library.runScriptRemotely(payload)).resolves.toEqual({ foo: 'bar' });
     expect(remoteRunner.isDone()).toBe(true);
     expect(getWorkerAccessToken).not.toHaveBeenCalled();
-    // The deprecated `POST /api/services/custom-jwt` cloud endpoint is no longer reachable.
     expect(post).not.toHaveBeenCalled();
   });
 
-  it('reports a 422 when neither runtime is configured', async () => {
+  it('falls back to the deprecated custom-jwt cloud endpoint', async () => {
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
+    post.mockResolvedValueOnce({ foo: 'bar' });
 
-    await expect(library.runScriptRemotely(payload)).rejects.toMatchObject({ status: 422 });
+    await expect(library.runScriptRemotely(payload, true)).resolves.toEqual({ foo: 'bar' });
+    expect(post).toHaveBeenCalledWith('/api/services/custom-jwt', {
+      body: payload,
+      search: { isTest: 'true' },
+    });
     expect(getWorkerAccessToken).not.toHaveBeenCalled();
-    expect(post).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -53,11 +53,8 @@ const payload = Object.freeze({
 const mockScriptRun = (body?: nock.RequestBodyMatcher) =>
   nock(scriptRunnerEndpoint).post('/api/script-run', body);
 
-const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-
 describe('JwtCustomizerLibrary.runScriptRemotely', () => {
   beforeEach(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
     jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue(scriptRunnerEndpoint);
   });
 
@@ -65,7 +62,6 @@ describe('JwtCustomizerLibrary.runScriptRemotely', () => {
     nock.cleanAll();
     jest.restoreAllMocks();
     jest.clearAllMocks();
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('runs the script on the Cloud script runner', async () => {
@@ -144,7 +140,6 @@ describe('JwtCustomizerLibrary.runScriptRemotely quota', () => {
   };
 
   beforeEach(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
     jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue(scriptRunnerEndpoint);
     setIsCloud(true);
   });
@@ -153,7 +148,6 @@ describe('JwtCustomizerLibrary.runScriptRemotely quota', () => {
     nock.cleanAll();
     jest.restoreAllMocks();
     jest.clearAllMocks();
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
     setIsCloud(originalIsCloud);
   });
 
@@ -180,30 +174,19 @@ describe('JwtCustomizerLibrary.runScriptRemotely quota', () => {
   });
 });
 
-describe('JwtCustomizerLibrary.runScriptRemotely on the legacy remote paths', () => {
+describe('JwtCustomizerLibrary.runScriptRemotely on the Azure Functions fallback', () => {
   beforeEach(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    // An unset script runner endpoint is what selects the Azure Functions runtime.
+    jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue('');
   });
 
   afterEach(() => {
     nock.cleanAll();
     jest.restoreAllMocks();
     jest.clearAllMocks();
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
-  it('falls back to the legacy path when the script runner endpoint is not injected', async () => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
-    jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue('');
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
-    post.mockResolvedValueOnce({ foo: 'bar' });
-
-    await expect(library.runScriptRemotely(payload)).resolves.toEqual({ foo: 'bar' });
-    expect(getWorkerAccessToken).not.toHaveBeenCalled();
-  });
-
-  it('runs the script through the regional untrusted Azure Function app when configured', async () => {
+  it('runs the script through the regional untrusted Azure Function app', async () => {
     const endpoint = 'https://untrusted.example.com';
     const functionKey = 'function-key';
     const remoteRunner = nock(endpoint, {
@@ -217,18 +200,17 @@ describe('JwtCustomizerLibrary.runScriptRemotely on the legacy remote paths', ()
 
     await expect(library.runScriptRemotely(payload)).resolves.toEqual({ foo: 'bar' });
     expect(remoteRunner.isDone()).toBe(true);
+    expect(getWorkerAccessToken).not.toHaveBeenCalled();
+    // The deprecated `POST /api/services/custom-jwt` cloud endpoint is no longer reachable.
     expect(post).not.toHaveBeenCalled();
   });
 
-  it('falls back to the deprecated custom-jwt cloud endpoint', async () => {
+  it('reports a 422 when neither runtime is configured', async () => {
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
-    post.mockResolvedValueOnce({ foo: 'bar' });
 
-    await expect(library.runScriptRemotely(payload, true)).resolves.toEqual({ foo: 'bar' });
-    expect(post).toHaveBeenCalledWith('/api/services/custom-jwt', {
-      body: payload,
-      search: { isTest: 'true' },
-    });
+    await expect(library.runScriptRemotely(payload)).rejects.toMatchObject({ status: 422 });
+    expect(getWorkerAccessToken).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- The legacy `node:vm` and Azure Functions paths coexist with the script-runner adapters until LOG-13956 and LOG-13958 remove them. */
 import {
   adminTenantId,
   type CustomJwtErrorBody,
@@ -12,7 +11,6 @@ import {
   type JwtCustomizerOrganizationContext,
   jwtCustomizerOrganizationContextGuard,
   type LogtoJwtTokenKey,
-  type CustomJwtApiContext,
   type CustomJwtScriptPayload,
   jsonObjectGuard,
   isBuiltInApplicationId,
@@ -30,7 +28,7 @@ import {
 import deepmerge from 'deepmerge';
 import { got, HTTPError } from 'got';
 import { type UnknownObject } from 'oidc-provider';
-import { ZodError, z } from 'zod';
+import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
@@ -44,14 +42,11 @@ import {
   type CustomJwtDeployRequestBody,
   parseAzureFunctionsResponseError,
 } from '#src/utils/custom-jwt/index.js';
-import { runScriptFunctionInLocalVm } from '#src/utils/local-vm/index.js';
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
 import {
   buildCloudScriptFailureError,
-  buildScriptExecutionErrorBody,
   buildScriptFailureError,
-  getScriptFailureStatusCode,
   runScriptOnCloud,
   runScriptOnWorkerPool,
   ScriptExecutionError,
@@ -74,21 +69,9 @@ const buildAccessDeniedError = (message: string) => {
   return new ScriptExecutionError({ message, error }, scriptFailureStatusCodes.denied);
 };
 
-const apiContext: CustomJwtApiContext = Object.freeze({
-  denyAccess: (message = 'Access denied') => {
-    throw buildAccessDeniedError(message);
-  },
-});
-
 export class JwtCustomizerLibrary {
   // Convert failures to WithTyped client response errors to share the error handling logic.
   static async runScriptInLocalVm(data: CustomJwtFetcher, tenantId: string) {
-    // TODO (LOG-13956): drop the legacy `node:vm` path and the gate once the worker-thread
-    // runner has been manually verified and released.
-    if (!EnvSet.values.isDevFeaturesEnabled) {
-      return JwtCustomizerLibrary.runScriptInLegacyVm(data);
-    }
-
     /**
      * `api` is not part of the payload: functions cannot cross the structured-clone boundary, so
      * the worker constructs `denyAccess` itself and reports a denial as a `denied` failure.
@@ -135,42 +118,6 @@ export class JwtCustomizerLibrary {
     }
 
     return parsed.data;
-  }
-
-  /** The pre-worker-runner execution path, still serving production until the gate above lifts. */
-  private static async runScriptInLegacyVm(data: CustomJwtFetcher) {
-    try {
-      const payload: CustomJwtScriptPayload = {
-        ...pick(data, 'token', 'context', 'environmentVariables'),
-        api: apiContext,
-      };
-
-      const result = await runScriptFunctionInLocalVm(data.script, 'getCustomJwtClaims', payload);
-
-      // If the `result` is not a record, we cannot merge it to the existing token payload.
-      return z.record(z.unknown()).parse(result);
-    } catch (error: unknown) {
-      if (error instanceof ScriptExecutionError) {
-        throw error;
-      }
-
-      // Assuming we only use zod for request body validation
-      if (error instanceof ZodError) {
-        const { errors } = error;
-        throw new ScriptExecutionError(
-          {
-            message: 'Invalid input',
-            errors,
-          },
-          400
-        );
-      }
-
-      throw new ScriptExecutionError(
-        buildScriptExecutionErrorBody(error),
-        getScriptFailureStatusCode(error)
-      );
-    }
   }
 
   constructor(
@@ -285,12 +232,11 @@ export class JwtCustomizerLibrary {
    * @params payload.useCase - The use case of JWT customizer script, can be either `test` or `production`.
    *
    * @remarks
-   * Deliberately left outside the `isDevFeaturesEnabled` gate that {@link runScriptRemotely} is
-   * behind, so this and {@link undeployJwtCustomizerScript} keep the worker service in sync while
-   * the legacy `POST /api/services/custom-jwt` path is still one rollback away from serving
-   * production. The cost is real and accepted: with dev features on and no Azure app configured,
-   * every save, delete and Console "test" still pays a deploy whose result the script run no
-   * longer reads. Both come out with the legacy paths in LOG-13958.
+   * No script run reads the deployed worker any more: a Cloud run goes to the script runner, or to
+   * the Azure Functions runtime where `SCRIPT_RUNNER_ENDPOINT` is unset. This and
+   * {@link undeployJwtCustomizerScript} therefore still pay a deploy on every save, delete and
+   * Console "test" whose result nothing consumes. Both come out with the per-tenant worker
+   * lifecycle in LOG-13957.
    */
   async deployJwtCustomizerScript<T extends LogtoJwtTokenKey>(
     consoleLog: ConsoleLog,
@@ -398,13 +344,18 @@ export class JwtCustomizerLibrary {
     payload: CustomJwtFetcher,
     isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
-    // TODO (LOG-13958): drop the legacy remote paths and the gate once the Cloud script runner
-    // has been manually verified and released. `scriptRunnerEndpoint` additionally covers a region
-    // where the Worker endpoint is not injected yet.
-    const { isDevFeaturesEnabled, scriptRunnerEndpoint } = EnvSet.values;
+    /**
+     * The Azure Functions runtime is kept as a per-region fallback rather than retired: a script
+     * runner outage is then routed around by unsetting `SCRIPT_RUNNER_ENDPOINT` on that region's
+     * core, with no code change and no coordinated rollback.
+     *
+     * A region where the endpoint is not injected yet therefore keeps running on the function app
+     * instead of failing.
+     */
+    const { scriptRunnerEndpoint } = EnvSet.values;
 
-    if (!isDevFeaturesEnabled || !scriptRunnerEndpoint) {
-      return this.runScriptOnLegacyRuntime(payload, isTest);
+    if (!scriptRunnerEndpoint) {
+      return this.runScriptOnAzureFunction(payload);
     }
 
     /**
@@ -453,45 +404,48 @@ export class JwtCustomizerLibrary {
   }
 
   /**
-   * The pre-script-runner remote paths, still serving production until the gate above lifts:
-   * the regional untrusted Azure Function app where configured, otherwise the deprecated
-   * `POST /api/services/custom-jwt` cloud endpoint.
+   * The Azure Functions runtime, kept as the per-region fallback for the Cloud script runner.
+   *
+   * Selected whenever `SCRIPT_RUNNER_ENDPOINT` is unset. `isTest` is deliberately not forwarded:
+   * this runtime has no notion of a dry run, and nothing is lost by it — vm2 builds a fresh VM per
+   * call, so a test run can never share state with production the way a warm isolate could.
+   *
+   * The deprecated `POST /api/services/custom-jwt` cloud endpoint this used to fall back to is no
+   * longer reachable: it is on its way out with the per-tenant worker lifecycle (LOG-13957).
    */
-  private async runScriptOnLegacyRuntime(
-    payload: CustomJwtFetcher,
-    isTest?: boolean
+  private async runScriptOnAzureFunction(
+    payload: CustomJwtFetcher
   ): Promise<Optional<UnknownObject>> {
     const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
 
-    if (this.isRegionalAzureFunctionAppConfigured) {
-      try {
-        const result = await got
-          .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
-            json: payload,
-            headers: {
-              'x-functions-key': azureFunctionUntrustedAppKey,
-            },
-          })
-          .json<unknown>();
-
-        const parsedResult = jsonObjectGuard.parse(result);
-        return parsedResult;
-      } catch (error: unknown) {
-        // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
-        if (error instanceof HTTPError) {
-          throw parseAzureFunctionsResponseError(error);
-        }
-
-        throw error;
-      }
+    /**
+     * Neither runtime is reachable. Named explicitly rather than left to `new URL()` throwing an
+     * opaque `Invalid URL`, since this misconfiguration reaches the RP as an `error_description`
+     * when the customizer sets `blockIssuanceOnError`.
+     */
+    if (!this.isRegionalAzureFunctionAppConfigured) {
+      throw new ScriptExecutionError({ message: 'Remote script runner is not configured.' }, 422);
     }
 
-    // Fallback to use cloud connection to call the custom JWT API.
-    const client = await this.cloudConnection.getClient();
-    return client.post(`/api/services/custom-jwt`, {
-      body: payload,
-      search: isTest ? { isTest: 'true' } : {},
-    });
+    try {
+      const result = await got
+        .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
+          json: payload,
+          headers: {
+            'x-functions-key': azureFunctionUntrustedAppKey,
+          },
+        })
+        .json<unknown>();
+
+      return jsonObjectGuard.parse(result);
+    } catch (error: unknown) {
+      // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
+      if (error instanceof HTTPError) {
+        throw parseAzureFunctionsResponseError(error);
+      }
+
+      throw error;
+    }
   }
 
   /**
@@ -522,4 +476,3 @@ export class JwtCustomizerLibrary {
     return result.value;
   }
 }
-/* eslint-enable max-lines */

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- The legacy remote paths coexist with the script-runner adapters until LOG-13957 removes the per-tenant worker lifecycle. */
 import {
   adminTenantId,
   type CustomJwtErrorBody,
@@ -232,11 +233,12 @@ export class JwtCustomizerLibrary {
    * @params payload.useCase - The use case of JWT customizer script, can be either `test` or `production`.
    *
    * @remarks
-   * No script run reads the deployed worker any more: a Cloud run goes to the script runner, or to
-   * the Azure Functions runtime where `SCRIPT_RUNNER_ENDPOINT` is unset. This and
-   * {@link undeployJwtCustomizerScript} therefore still pay a deploy on every save, delete and
-   * Console "test" whose result nothing consumes. Both come out with the per-tenant worker
-   * lifecycle in LOG-13957.
+   * Deliberately left outside the `SCRIPT_RUNNER_ENDPOINT` selection that {@link runScriptRemotely}
+   * makes, so this and {@link undeployJwtCustomizerScript} keep the worker service in sync for a
+   * region still on the legacy `POST /api/services/custom-jwt` path. The cost is real and accepted:
+   * where the endpoint is set, every save, delete and Console "test" still pays a deploy whose
+   * result the script run no longer reads. Both come out with the per-tenant worker lifecycle in
+   * LOG-13957.
    */
   async deployJwtCustomizerScript<T extends LogtoJwtTokenKey>(
     consoleLog: ConsoleLog,
@@ -345,17 +347,17 @@ export class JwtCustomizerLibrary {
     isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
     /**
-     * The Azure Functions runtime is kept as a per-region fallback rather than retired: a script
-     * runner outage is then routed around by unsetting `SCRIPT_RUNNER_ENDPOINT` on that region's
-     * core, with no code change and no coordinated rollback.
+     * The legacy runtimes are kept as a per-region fallback rather than retired: a script runner
+     * outage is then routed around by unsetting `SCRIPT_RUNNER_ENDPOINT` on that region's core,
+     * with no code change and no coordinated rollback.
      *
-     * A region where the endpoint is not injected yet therefore keeps running on the function app
-     * instead of failing.
+     * A region where the endpoint is not injected yet therefore keeps running on the legacy
+     * runtimes instead of failing.
      */
     const { scriptRunnerEndpoint } = EnvSet.values;
 
     if (!scriptRunnerEndpoint) {
-      return this.runScriptOnAzureFunction(payload);
+      return this.runScriptOnLegacyRuntime(payload, isTest);
     }
 
     /**
@@ -404,48 +406,49 @@ export class JwtCustomizerLibrary {
   }
 
   /**
-   * The Azure Functions runtime, kept as the per-region fallback for the Cloud script runner.
+   * The legacy remote paths, kept as the per-region fallback for the Cloud script runner:
+   * the regional untrusted Azure Function app where configured, otherwise the deprecated
+   * `POST /api/services/custom-jwt` cloud endpoint.
    *
-   * Selected whenever `SCRIPT_RUNNER_ENDPOINT` is unset. `isTest` is deliberately not forwarded:
-   * this runtime has no notion of a dry run, and nothing is lost by it — vm2 builds a fresh VM per
-   * call, so a test run can never share state with production the way a warm isolate could.
-   *
-   * The deprecated `POST /api/services/custom-jwt` cloud endpoint this used to fall back to is no
-   * longer reachable: it is on its way out with the per-tenant worker lifecycle (LOG-13957).
+   * Selected whenever `SCRIPT_RUNNER_ENDPOINT` is unset. `isTest` is not forwarded to the function
+   * app: that runtime has no notion of a dry run, and nothing is lost by it — vm2 builds a fresh
+   * VM per call, so a test run can never share state with production the way a warm isolate could.
    */
-  private async runScriptOnAzureFunction(
-    payload: CustomJwtFetcher
+  private async runScriptOnLegacyRuntime(
+    payload: CustomJwtFetcher,
+    isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
     const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
 
-    /**
-     * Neither runtime is reachable. Named explicitly rather than left to `new URL()` throwing an
-     * opaque `Invalid URL`, since this misconfiguration reaches the RP as an `error_description`
-     * when the customizer sets `blockIssuanceOnError`.
-     */
-    if (!this.isRegionalAzureFunctionAppConfigured) {
-      throw new ScriptExecutionError({ message: 'Remote script runner is not configured.' }, 422);
-    }
+    if (this.isRegionalAzureFunctionAppConfigured) {
+      try {
+        const result = await got
+          .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
+            json: payload,
+            headers: {
+              'x-functions-key': azureFunctionUntrustedAppKey,
+            },
+          })
+          .json<unknown>();
 
-    try {
-      const result = await got
-        .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
-          json: payload,
-          headers: {
-            'x-functions-key': azureFunctionUntrustedAppKey,
-          },
-        })
-        .json<unknown>();
+        const parsedResult = jsonObjectGuard.parse(result);
+        return parsedResult;
+      } catch (error: unknown) {
+        // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
+        if (error instanceof HTTPError) {
+          throw parseAzureFunctionsResponseError(error);
+        }
 
-      return jsonObjectGuard.parse(result);
-    } catch (error: unknown) {
-      // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
-      if (error instanceof HTTPError) {
-        throw parseAzureFunctionsResponseError(error);
+        throw error;
       }
-
-      throw error;
     }
+
+    // Fallback to use cloud connection to call the custom JWT API.
+    const client = await this.cloudConnection.getClient();
+    return client.post(`/api/services/custom-jwt`, {
+      body: payload,
+      search: isTest ? { isTest: 'true' } : {},
+    });
   }
 
   /**
@@ -476,3 +479,5 @@ export class JwtCustomizerLibrary {
     return result.value;
   }
 }
+
+/* eslint-enable max-lines */

--- a/packages/core/src/libraries/jwt-customizer.worker-pool.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.worker-pool.test.ts
@@ -16,7 +16,6 @@ jest.unstable_mockModule('#src/libraries/script-runner/worker-thread-script-runn
   },
 }));
 
-const { EnvSet } = await import('#src/env-set/index.js');
 const { JwtCustomizerLibrary } = await import('./jwt-customizer.js');
 const { ossScriptLimits, ScriptExecutionError } = await import('./script-runner/index.js');
 
@@ -54,15 +53,8 @@ const catchScriptExecutionError = async (promise: Promise<unknown>) => {
 };
 
 describe('JwtCustomizerLibrary worker-pool adapter', () => {
-  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
-
   beforeEach(() => {
     runScript.mockReset();
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
-  });
-
-  afterAll(() => {
-    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
 
   it('hands the runner the standard OSS limits and the allow-all egress policy', async () => {
@@ -152,74 +144,6 @@ describe('JwtCustomizerLibrary worker-pool adapter', () => {
 
       expect(status).toBe(expectedStatus);
       expect(body).toEqual(expectedBody);
-    });
-  });
-
-  // TODO (LOG-13956): drop these together with the legacy `node:vm` execution path.
-  describe('the legacy `node:vm` path while dev features are disabled', () => {
-    beforeEach(() => {
-      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
-    });
-
-    it('runs the script without touching the worker pool', async () => {
-      await expect(
-        JwtCustomizerLibrary.runScriptInLocalVm(
-          {
-            ...buildData(),
-            script: 'const getCustomJwtClaims = ({ token }) => ({ echoed: token.sub });',
-          },
-          tenantId
-        )
-      ).resolves.toEqual({ echoed: 'user-id' });
-      expect(runScript).not.toHaveBeenCalled();
-    });
-
-    it('maps an access denial to the denied status with the error body', async () => {
-      const { status, body } = await catchScriptExecutionError(
-        JwtCustomizerLibrary.runScriptInLocalVm(
-          {
-            ...buildData(),
-            script: "const getCustomJwtClaims = ({ api }) => api.denyAccess('legacy blocked');",
-          },
-          tenantId
-        )
-      );
-
-      expect(status).toBe(403);
-      expect(body).toEqual({
-        message: 'legacy blocked',
-        error: { code: CustomJwtErrorCode.AccessDenied, message: 'legacy blocked' },
-      });
-    });
-
-    it('rejects a non-record value with the 400 invalid-input error', async () => {
-      const { status, body } = await catchScriptExecutionError(
-        JwtCustomizerLibrary.runScriptInLocalVm(
-          {
-            ...buildData(),
-            script: 'const getCustomJwtClaims = () => 42;',
-          },
-          tenantId
-        )
-      );
-
-      expect(status).toBe(400);
-      expect(body).toMatchObject({ message: 'Invalid input' });
-    });
-
-    it('maps a thrown script error to the runtime status', async () => {
-      const { status, body } = await catchScriptExecutionError(
-        JwtCustomizerLibrary.runScriptInLocalVm(
-          {
-            ...buildData(),
-            script: "const getCustomJwtClaims = () => { throw new Error('legacy boom'); };",
-          },
-          tenantId
-        )
-      );
-
-      expect(status).toBe(500);
-      expect(body).toMatchObject({ message: 'legacy boom' });
     });
   });
 });

--- a/packages/core/src/libraries/script-runner/run.ts
+++ b/packages/core/src/libraries/script-runner/run.ts
@@ -33,10 +33,9 @@ const sharedRunner = new WorkerThreadScriptRunner();
 /**
  * Run a user script on the shared worker pool with the standard OSS limits.
  *
- * Reachable only when `EnvSet.values.isCloud` is `false` (Cloud runs scripts remotely) and, until
- * the runner is manually verified and released, behind `isDevFeaturesEnabled` — production keeps
- * the legacy `node:vm` path. The payload must be structured-cloneable — capability APIs such as
- * `api.denyAccess` are injected by the worker and must not be part of it.
+ * Reachable only when `EnvSet.values.isCloud` is `false` — Cloud runs scripts remotely. The
+ * payload must be structured-cloneable: capability APIs such as `api.denyAccess` are injected by
+ * the worker and must not be part of it.
  */
 export const runScriptOnWorkerPool = async ({
   tenantId,


### PR DESCRIPTION
## Summary

Closes [LOG-13963](https://linear.app/silverhand/issue/LOG-13963/remove-the-dev-feature-guard-and-add-changeset).

Opens the consolidated script runtime for Custom JWT and Actions, so the new runners always serve production traffic:

- **Self-hosted / OSS** — `JwtCustomizerLibrary.runScriptInLocalVm` and `ActionLibrary.runScriptInLocalVm` always go through `WorkerThreadScriptRunner` (pooled worker threads with a 5s wall-clock deadline and a 128 MB memory budget).
- **Cloud** — both libraries call the script runner directly, and fall back to the legacy runtimes per region where `SCRIPT_RUNNER_ENDPOINT` is unset.
- **Console** — the OSS sandbox warning on the Custom JWT and Actions editors is shown for all self-hosted tenants.

Rebased onto #9447, which changed the shape of what this PR removes. Selection is now keyed on `SCRIPT_RUNNER_ENDPOINT` rather than on the dev flag, so dropping the flag leaves the per-region arrangement [LOG-13958](https://linear.app/silverhand/issue/LOG-13958/keep-azure-functions-as-a-per-region-script-runtime-fallback) settled on: the Azure Functions runtime is **kept** as the standing rollback path instead of being deleted, and a region is moved back to it by unsetting the endpoint. Rollout is [LOG-14043](https://linear.app/silverhand/issue/LOG-14043/inject-script-runner-endpoint-on-prod-regional-cores), injecting that variable on the prod regional cores.

The fallback branches themselves are left exactly as they are on master. This PR only removes the `isDevFeaturesEnabled` condition in front of them, on both libraries:

- Custom JWT keeps `runScriptOnLegacyRuntime` whole — the regional untrusted Azure Function app where configured, and the deprecated `POST /api/services/custom-jwt` cloud endpoint otherwise. That endpoint still serves every region without an untrusted function app, so it is not this PR's to drop; it goes with the per-tenant worker lifecycle in [LOG-13957](https://linear.app/silverhand/issue/LOG-13957/remove-per-tenant-worker-lifecycle) / #9439, which is stacked on top of this.
- Actions keeps `runScriptOnAzureFunction` and the 422 it already throws where no function app is configured.

So a region that has not been given `SCRIPT_RUNNER_ENDPOINT` yet behaves exactly as it does today, and LOG-14043 is not a merge blocker.

The now-unreachable `node:vm` helpers stay in the tree for [LOG-13956](https://linear.app/silverhand/issue/LOG-13956/remove-local-vm-and-nodevm-from-the-execution-path) / #9438 to remove.

## Testing

- Unit tests
