### PR TITLE
fix(core): prevent stale custom domain cache write-back after invalidation

### DIFF
--- a/packages/core/src/utils/tenant.test.ts
+++ b/packages/core/src/utils/tenant.test.ts
@@ -1,5 +1,5 @@
 import { adminTenantId, defaultTenantId } from '@logto/schemas';
-import { GlobalValues } from '@logto/shared';
+import { GlobalValues, TtlCache } from '@logto/shared';
 import { createMockUtils } from '@logto/shared/esm';
 
 const { jest } = import.meta;
@@ -21,7 +21,12 @@ mockEsm('#src/queries/domains.js', () => ({
   }),
 }));
 
-const { getTenantId } = await import('./tenant.js');
+const mockRedisCache = new TtlCache<string, string>(60_000);
+mockEsm('#src/caches/index.js', () => ({
+  redisCache: mockRedisCache,
+}));
+
+const { getTenantId, clearCustomDomainCache } = await import('./tenant.js');
 
 const getTenantIdFirstElement = async (url: URL) => {
   const [tenantId] = await getTenantId(url);
@@ -33,6 +38,7 @@ describe('getTenantId()', () => {
 
   afterEach(() => {
     process.env = backupEnv;
+    mockRedisCache.clear();
   });
 
   it('should resolve development tenant ID when needed', async () => {
@@ -177,5 +183,33 @@ describe('getTenantId()', () => {
     };
     findActiveDomain.mockResolvedValueOnce({ domain: 'logto.mock.com', tenantId: 'mock' });
     await expect(getTenantIdFirstElement(new URL('https://logto.mock.com'))).resolves.toBe('mock');
+  });
+
+  it('should discard a stale write-back when the domain cache is invalidated mid-lookup', async () => {
+    process.env = {
+      ...backupEnv,
+      ENDPOINT: 'https://foo.*.logto.mock/app',
+      NODE_ENV: 'production',
+    };
+    findActiveDomain
+      .mockImplementationOnce(async () => {
+        /**
+         * The domain mutation lands while this lookup's database read is in flight, i.e. the
+         * mapping returned below reflects pre-mutation state.
+         */
+        await clearCustomDomainCache('logto.mock.com');
+        return { domain: 'logto.mock.com', tenantId: 'stale' };
+      })
+      .mockResolvedValueOnce({ domain: 'logto.mock.com', tenantId: 'fresh' });
+
+    /** The in-flight lookup still resolves, but its result must not persist in the cache. */
+    await expect(getTenantIdFirstElement(new URL('https://logto.mock.com'))).resolves.toBe('stale');
+    await expect(getTenantIdFirstElement(new URL('https://logto.mock.com'))).resolves.toBe('fresh');
+
+    /**
+     * Served from the cache: both queued database results are already consumed, so a cache
+     * miss here would resolve to `undefined`.
+     */
+    await expect(getTenantIdFirstElement(new URL('https://logto.mock.com'))).resolves.toBe('fresh');
   });
 });

--- a/packages/core/src/utils/tenant.ts
+++ b/packages/core/src/utils/tenant.ts
@@ -46,26 +46,31 @@ const matchPathBasedTenantId = (urlSet: UrlSet, url: URL) => {
   return urlSegments[found.pathname === '/' ? 1 : endpointSegments.length];
 };
 
-const cacheKey = 'custom-domain';
 const getHostname = (url: URL | string) => (typeof url === 'string' ? url : url.hostname);
-const getDomainCacheKey = (url: URL | string) => `${cacheKey}:${getHostname(url)}`;
+const getDomainCacheKey = (url: URL | string) => `custom-domain:${getHostname(url)}`;
 /**
- * Hostnames cannot contain `:`, so the `generation` segment can never collide with a
- * {@link getDomainCacheKey} value key.
+ * The marker gets its own prefix rather than a segment inside the value keyspace: the two
+ * prefixes diverge before the hostname is appended, so no hostname — whatever the `domains`
+ * column happens to hold — can spell a key belonging to the other.
  */
-const getDomainGenerationKey = (url: URL | string) => `${cacheKey}:generation:${getHostname(url)}`;
+const getDomainGenerationKey = (url: URL | string) =>
+  `custom-domain-generation:${getHostname(url)}`;
 
 /**
  * Invalidate the cached mapping for the given custom domain after the mutation it reflects
  * has been committed.
  *
- * The generation must be bumped before deleting, and both must be awaited: this guarantees
- * that once this function resolves, an in-flight {@link getTenantIdFromCustomDomain} lookup
- * that read pre-mutation state either skips its write-back or has it removed by the deletion.
- * (The same guard as `BaseCache`, which this cache cannot build on since it is cross-tenant.)
+ * The generation must be bumped before deleting, and both must be awaited: an in-flight
+ * {@link getTenantIdFromCustomDomain} lookup that read pre-mutation state then either skips its
+ * write-back or has it removed by the deletion. Callers must therefore await it before returning
+ * to their own caller. (The same guard as `BaseCache`, which this cache cannot build on since it
+ * is cross-tenant.)
  *
- * Store errors are silently caught, as an invalidation failure degrades to staleness bounded
- * by the value TTL rather than a failed domain mutation.
+ * The guarantee is bounded by what the store can promise, and every way it degrades caps
+ * staleness at the value TTL rather than leaving it unbounded: store errors are silently caught,
+ * a read served by a lagging replica (the cluster client enables `useReplicas`) can observe a
+ * pre-bump generation, and a command that timed out client-side is not cancelled, so it may land
+ * after this resolved.
  */
 export const clearCustomDomainCache = async (url: URL | string) => {
   await trySafe(async () => redisCache.set(getDomainGenerationKey(url), generateStandardShortId()));
@@ -79,13 +84,20 @@ const getTenantIdFromCustomDomain = async (
   url: URL,
   pool: CommonQueryMethods
 ): Promise<string | undefined> => {
-  const cachedValue = await trySafe(async () => redisCache.get(getDomainCacheKey(url)));
+  /**
+   * The snapshot only has to be taken before the database read starts, so it rides along with
+   * the value read instead of costing a second round trip on a path that runs per request.
+   * Snapshotting earlier observes a superset of the invalidations it otherwise would.
+   */
+  const [cachedValue, generation] = await Promise.all([
+    trySafe(async () => redisCache.get(getDomainCacheKey(url))),
+    trySafe(async () => redisCache.get(getDomainGenerationKey(url))),
+  ]);
 
   if (cachedValue) {
     return cachedValue;
   }
 
-  const generation = await trySafe(async () => redisCache.get(getDomainGenerationKey(url)));
   const isInvalidated = async () =>
     (await trySafe(async () => redisCache.get(getDomainGenerationKey(url)))) !== generation;
 

--- a/packages/core/src/utils/tenant.ts
+++ b/packages/core/src/utils/tenant.ts
@@ -1,5 +1,5 @@
 import { adminTenantId, defaultTenantId } from '@logto/schemas';
-import { type UrlSet } from '@logto/shared';
+import { generateStandardShortId, type UrlSet } from '@logto/shared';
 import { conditionalString, trySafe } from '@silverhand/essentials';
 import { type CommonQueryMethods } from '@silverhand/slonik';
 
@@ -47,10 +47,28 @@ const matchPathBasedTenantId = (urlSet: UrlSet, url: URL) => {
 };
 
 const cacheKey = 'custom-domain';
-const getDomainCacheKey = (url: URL | string) =>
-  `${cacheKey}:${typeof url === 'string' ? url : url.hostname}`;
+const getHostname = (url: URL | string) => (typeof url === 'string' ? url : url.hostname);
+const getDomainCacheKey = (url: URL | string) => `${cacheKey}:${getHostname(url)}`;
+/**
+ * Hostnames cannot contain `:`, so the `generation` segment can never collide with a
+ * {@link getDomainCacheKey} value key.
+ */
+const getDomainGenerationKey = (url: URL | string) => `${cacheKey}:generation:${getHostname(url)}`;
 
+/**
+ * Invalidate the cached mapping for the given custom domain after the mutation it reflects
+ * has been committed.
+ *
+ * The generation must be bumped before deleting, and both must be awaited: this guarantees
+ * that once this function resolves, an in-flight {@link getTenantIdFromCustomDomain} lookup
+ * that read pre-mutation state either skips its write-back or has it removed by the deletion.
+ * (The same guard as `BaseCache`, which this cache cannot build on since it is cross-tenant.)
+ *
+ * Store errors are silently caught, as an invalidation failure degrades to staleness bounded
+ * by the value TTL rather than a failed domain mutation.
+ */
 export const clearCustomDomainCache = async (url: URL | string) => {
+  await trySafe(async () => redisCache.set(getDomainGenerationKey(url), generateStandardShortId()));
   await trySafe(async () => redisCache.delete(getDomainCacheKey(url)));
 };
 
@@ -67,15 +85,37 @@ const getTenantIdFromCustomDomain = async (
     return cachedValue;
   }
 
+  const generation = await trySafe(async () => redisCache.get(getDomainGenerationKey(url)));
+  const isInvalidated = async () =>
+    (await trySafe(async () => redisCache.get(getDomainGenerationKey(url)))) !== generation;
+
   const { findActiveDomain } = createDomainsQueries(pool);
 
   const domain = await findActiveDomain(url.hostname);
 
-  if (domain?.tenantId) {
-    await trySafe(async () => redisCache.set(getDomainCacheKey(url), domain.tenantId));
+  if (!domain?.tenantId) {
+    return;
   }
 
-  return domain?.tenantId;
+  /**
+   * Skip the write-back when an invalidation happened while the database read was in flight,
+   * since the mapping may reflect pre-mutation state.
+   */
+  if (await isInvalidated()) {
+    return domain.tenantId;
+  }
+
+  await trySafe(async () => redisCache.set(getDomainCacheKey(url), domain.tenantId));
+
+  /**
+   * Undo the write if an invalidation landed between the check and the write, so a stale
+   * mapping can never persist after {@link clearCustomDomainCache} resolves.
+   */
+  if (await isInvalidated()) {
+    await trySafe(async () => redisCache.delete(getDomainCacheKey(url)));
+  }
+
+  return domain.tenantId;
 };
 
 /**


### PR DESCRIPTION
## Summary

Apply the same stale write-back guard as #9428 to the custom domain → tenant ID cache, which is built directly on the raw Redis store instead of `BaseCache`.

- A lookup that started before a domain change could complete its cache write after `clearCustomDomainCache()` ran, resurrecting the old domain → tenant mapping for up to the 30-minute TTL. The reachable consequence is that taking a custom domain down — deleting it, the cron cleanup, or `syncDomainStatus` moving it off `Active` — does not take effect for up to 30 minutes, during which every instance keeps routing it to its original tenant. Cloud-only: OSS single-tenant returns before this path.
- `clearCustomDomainCache()` now bumps a per-domain invalidation generation before deleting, and the lookup skips (or undoes) its write-back when the generation changed while the database read was in flight.
- The guard is mirrored locally since this cache is cross-tenant and cannot build on the tenant-scoped `BaseCache`. #9436 extracts the shared protocol.
- The marker gets its own key prefix rather than a segment inside the value keyspace, so no hostname the `domains` column happens to hold can spell a key belonging to the other.
- The generation snapshot only has to complete before the database read starts, so it is issued alongside the value read rather than costing a second sequential round trip on a per-request path.

Known bounds, documented at the call site: the ordering guarantee holds while the store answers from one authoritative view and applies commands in issue order. A generation read served by a lagging replica (the cluster client enables `useReplicas`), or a client-side timeout that leaves an uncancelled command to land later, can still miss an invalidation — each capped at the value TTL, i.e. the pre-fix behaviour, never worse. Closing those needs a server-side atomic guard and belongs at the shared layer, not here.

## Testing

unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments