### PR TITLE
feat(core): support trusted device opt-in

### DIFF
--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -36,6 +36,7 @@ const createQueries = () =>
   ({
     insert: jest.fn(),
     findActiveByIdAndUserId: jest.fn(),
+    updateMetadataByIdAndUserId: jest.fn(),
     deleteExpiredByIdAndUserId: jest.fn(),
     deleteExpiredByTenant: jest.fn(),
   }) as unknown as jest.Mocked<TrustedDeviceQueries>;
@@ -185,6 +186,28 @@ describe('trusted device library', () => {
     expect(set).not.toHaveBeenCalled();
   });
 
+  it('rechecks the effective policy before each creation attempt', async () => {
+    const queries = createQueries();
+    const getEffectivePolicy = jest
+      .fn()
+      .mockResolvedValueOnce({ enabled: false, durationDays: 30 })
+      .mockResolvedValueOnce({ enabled: true, durationDays: 30 });
+    const policyLibrary = { getEffectivePolicy } as unknown as TrustedDevicePolicyLibrary;
+    const { ctx, set } = createCookieContext();
+    const record = buildTrustedDevice(Buffer.alloc(32));
+    queries.insert.mockResolvedValueOnce(record);
+    const library = createTrustedDeviceLibrary(tenantId, queries, policyLibrary, {
+      isProduction: false,
+    });
+
+    await expect(library.createCredential({ ctx, userId })).resolves.toBeUndefined();
+    await expect(library.createCredential({ ctx, userId })).resolves.toEqual(record);
+
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(2);
+    expect(queries.insert).toHaveBeenCalledTimes(1);
+    expect(set).toHaveBeenCalledTimes(1);
+  });
+
   it('uses Secure and the __Host- prefix in production', () => {
     const queries = createQueries();
     const { ctx, set } = createCookieContext();
@@ -298,6 +321,32 @@ describe('trusted device library', () => {
 
     expect(queries.deleteExpiredByIdAndUserId).toHaveBeenCalledWith(trustedDeviceId, userId);
     expect(set).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates last-used metadata and schedules opportunistic cleanup', async () => {
+    const queries = createQueries();
+    const metadata = {
+      userAgent: 'Test browser',
+      ip: '192.0.2.1',
+      country: 'US',
+      city: 'Portland',
+    };
+    const record = buildTrustedDevice(Buffer.alloc(32));
+    queries.updateMetadataByIdAndUserId.mockResolvedValueOnce(record);
+    queries.deleteExpiredByTenant.mockResolvedValueOnce(0);
+    const library = createTrustedDeviceLibrary(tenantId, queries, createPolicyLibrary(), {
+      isProduction: false,
+    });
+
+    await expect(library.updateMetadata(trustedDeviceId, userId, metadata)).resolves.toEqual(
+      record
+    );
+    expect(queries.updateMetadataByIdAndUserId).toHaveBeenCalledWith(
+      trustedDeviceId,
+      userId,
+      metadata
+    );
+    expect(queries.deleteExpiredByTenant).toHaveBeenCalledTimes(1);
   });
 
   it('deduplicates concurrent opportunistic cleanup within the cooldown', async () => {

--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -34,7 +34,7 @@ const createCookieContext = (value?: string) => {
 
 const createQueries = () =>
   ({
-    insert: jest.fn(),
+    insertIfNotExists: jest.fn(),
     findActiveByIdAndUserId: jest.fn(),
     updateMetadataByIdAndUserId: jest.fn(),
     deleteExpiredByIdAndUserId: jest.fn(),
@@ -120,7 +120,7 @@ describe('trusted device library', () => {
 
     jest.spyOn(Date, 'now').mockReturnValue(now);
 
-    queries.insert.mockImplementationOnce(async (data) => ({
+    queries.insertIfNotExists.mockImplementationOnce(async (data) => ({
       tenantId,
       userAgent: null,
       ip: null,
@@ -135,13 +135,13 @@ describe('trusted device library', () => {
     const library = createTrustedDeviceLibrary(tenantId, queries, policyLibrary, {
       isProduction: false,
     });
-    const record = await library.createCredential({ ctx, userId });
+    const record = await library.createCredential({ ctx, deviceId: trustedDeviceId, userId });
 
     if (!record) {
       throw new Error('Expected trusted-device creation to be allowed');
     }
 
-    const inserted = queries.insert.mock.calls[0]?.[0];
+    const inserted = queries.insertIfNotExists.mock.calls[0]?.[0];
     const cookieValue = set.mock.calls[0]?.[1];
     const parsed =
       typeof cookieValue === 'string' ? parseTrustedDeviceCredential(cookieValue) : null;
@@ -181,8 +181,10 @@ describe('trusted device library', () => {
       isProduction: false,
     });
 
-    await expect(library.createCredential({ ctx, userId })).resolves.toBeUndefined();
-    expect(queries.insert).not.toHaveBeenCalled();
+    await expect(
+      library.createCredential({ ctx, deviceId: trustedDeviceId, userId })
+    ).resolves.toBeUndefined();
+    expect(queries.insertIfNotExists).not.toHaveBeenCalled();
     expect(set).not.toHaveBeenCalled();
   });
 
@@ -195,17 +197,58 @@ describe('trusted device library', () => {
     const policyLibrary = { getEffectivePolicy } as unknown as TrustedDevicePolicyLibrary;
     const { ctx, set } = createCookieContext();
     const record = buildTrustedDevice(Buffer.alloc(32));
-    queries.insert.mockResolvedValueOnce(record);
+    queries.insertIfNotExists.mockResolvedValueOnce(record);
     const library = createTrustedDeviceLibrary(tenantId, queries, policyLibrary, {
       isProduction: false,
     });
 
-    await expect(library.createCredential({ ctx, userId })).resolves.toBeUndefined();
-    await expect(library.createCredential({ ctx, userId })).resolves.toEqual(record);
+    await expect(
+      library.createCredential({ ctx, deviceId: trustedDeviceId, userId })
+    ).resolves.toBeUndefined();
+    await expect(
+      library.createCredential({ ctx, deviceId: trustedDeviceId, userId })
+    ).resolves.toEqual(record);
 
     expect(getEffectivePolicy).toHaveBeenCalledTimes(2);
-    expect(queries.insert).toHaveBeenCalledTimes(1);
+    expect(queries.insertIfNotExists).toHaveBeenCalledTimes(1);
     expect(set).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes only the credential that wins concurrent creation for an interaction', async () => {
+    const queries = createQueries();
+    const firstCookie = createCookieContext();
+    const secondCookie = createCookieContext();
+    queries.insertIfNotExists
+      .mockImplementationOnce(async (data) => ({
+        tenantId,
+        userAgent: null,
+        ip: null,
+        country: null,
+        city: null,
+        createdAt: Date.now(),
+        lastUsedAt: Date.now(),
+        ...data,
+      }))
+      .mockResolvedValueOnce(null);
+    queries.deleteExpiredByTenant.mockResolvedValueOnce(0);
+    const library = createTrustedDeviceLibrary(tenantId, queries, createPolicyLibrary(), {
+      isProduction: false,
+    });
+
+    const results = await Promise.all([
+      library.createCredential({ ctx: firstCookie.ctx, deviceId: trustedDeviceId, userId }),
+      library.createCredential({ ctx: secondCookie.ctx, deviceId: trustedDeviceId, userId }),
+    ]);
+
+    expect(results[0]).toBeDefined();
+    expect(results[1]).toBeUndefined();
+    expect(queries.insertIfNotExists).toHaveBeenCalledTimes(2);
+    expect(queries.insertIfNotExists.mock.calls.map(([data]) => data.id)).toEqual([
+      trustedDeviceId,
+      trustedDeviceId,
+    ]);
+    expect(firstCookie.set).toHaveBeenCalledTimes(1);
+    expect(secondCookie.set).not.toHaveBeenCalled();
   });
 
   it('uses Secure and the __Host- prefix in production', () => {

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -237,11 +237,27 @@ export const createTrustedDeviceLibrary = (
     return trustedDevice;
   };
 
+  const updateMetadata = async (
+    trustedDeviceId: string,
+    userId: string,
+    metadata: TrustedDeviceMetadata
+  ) => {
+    const trustedDevice = await queries.updateMetadataByIdAndUserId(
+      trustedDeviceId,
+      userId,
+      metadata
+    );
+    void cleanupExpired();
+
+    return trustedDevice;
+  };
+
   return {
     cleanupExpired,
     clearCredential,
     createCredential,
     getCookieName,
+    updateMetadata,
     validateCredential,
     writeCredential,
   };

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -1,7 +1,6 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 
 import { TrustedDevices } from '@logto/schemas';
-import { generateStandardId } from '@logto/shared';
 import { trySafe } from '@silverhand/essentials';
 import { type Context } from 'koa';
 
@@ -34,6 +33,7 @@ type TrustedDeviceLibraryOptions = Readonly<{
 type CreateTrustedDeviceCredential = TrustedDeviceMetadata &
   Readonly<{
     ctx: TrustedDeviceCookieContext;
+    deviceId: string;
     userId: string;
   }>;
 
@@ -181,25 +181,37 @@ export const createTrustedDeviceLibrary = (
     return deletedCount;
   };
 
-  const createCredential = async ({ ctx, userId, ...metadata }: CreateTrustedDeviceCredential) => {
+  const createCredential = async ({
+    ctx,
+    deviceId,
+    userId,
+    ...metadata
+  }: CreateTrustedDeviceCredential) => {
     const policy = await policyLibrary.getEffectivePolicy(userId);
 
     if (!policy.enabled) {
       return;
     }
 
-    const id = generateStandardId();
     const secret = generateTrustedDeviceSecret();
     const secretHash = hashTrustedDeviceSecret(secret);
     const expiresAt = Date.now() + policy.durationDays * dayInMilliseconds;
-    const trustedDevice = await queries.insert({
-      id,
+    const trustedDevice = await queries.insertIfNotExists({
+      id: deviceId,
       userId,
       secretHash,
       expiresAt,
       ...metadata,
     });
-    const credential = { id, secret };
+
+    // Another submit with the same creation intent may have won the insert race. Only the winner
+    // writes its matching random credential, so a late response can never replace the cookie
+    // with a credential whose record was not persisted.
+    if (!trustedDevice) {
+      return;
+    }
+
+    const credential = { id: deviceId, secret };
 
     writeCredential(ctx, userId, credential, trustedDevice.expiresAt);
     void cleanupExpired();

--- a/packages/core/src/queries/trusted-device.test.ts
+++ b/packages/core/src/queries/trusted-device.test.ts
@@ -42,9 +42,10 @@ describe('trusted device queries', () => {
     jest.restoreAllMocks();
   });
 
-  it('inserts a trusted device record', async () => {
+  it('inserts a trusted device record once per device ID', async () => {
     mockQuery.mockImplementationOnce(async (query, values) => {
       expect(query).toMatch(/insert into "trusted_devices"/i);
+      expect(query).toMatch(/on conflict \("id"\) do nothing/i);
       expect(values).toEqual([
         trustedDevice.id,
         trustedDevice.userId,
@@ -60,17 +61,30 @@ describe('trusted device queries', () => {
     });
 
     await expect(
-      queries.insert({
+      queries.insertIfNotExists({
         id: trustedDevice.id,
         userId: trustedDevice.userId,
         secretHash: trustedDevice.secretHash,
-        userAgent: trustedDevice.userAgent,
-        ip: trustedDevice.ip,
-        country: trustedDevice.country,
-        city: trustedDevice.city,
+        userAgent: trustedDevice.userAgent ?? undefined,
+        ip: trustedDevice.ip ?? undefined,
+        country: trustedDevice.country ?? undefined,
+        city: trustedDevice.city ?? undefined,
         expiresAt: trustedDevice.expiresAt,
       })
     ).resolves.toEqual(trustedDevice);
+  });
+
+  it('returns null when the device ID already exists', async () => {
+    mockQuery.mockResolvedValueOnce(createMockQueryResult([]));
+
+    await expect(
+      queries.insertIfNotExists({
+        id: trustedDevice.id,
+        userId: trustedDevice.userId,
+        secretHash: trustedDevice.secretHash,
+        expiresAt: trustedDevice.expiresAt,
+      })
+    ).resolves.toBeNull();
   });
 
   it('uses the same strict active predicate for paginated list and count', async () => {

--- a/packages/core/src/queries/trusted-device.test.ts
+++ b/packages/core/src/queries/trusted-device.test.ts
@@ -126,14 +126,16 @@ describe('trusted device queries', () => {
     ).resolves.toEqual(trustedDevice);
   });
 
-  it('updates metadata without overwriting missing values and replaces a supplied location pair', async () => {
+  it('updates active-device metadata without overwriting missing values and replaces a supplied location pair', async () => {
     jest.spyOn(Date, 'now').mockReturnValue(123_000);
 
     const expectSql = sql`
       update ${table}
       set ${fields.lastUsedAt}=to_timestamp($1::double precision / 1000), ${fields.userAgent}=$2, ${fields.country}=$3, ${fields.city}=$4
-      where ${fields.id}=$5 and ${fields.userId}=$6
-      returning *
+      where ${fields.id} = $5
+        and ${fields.userId} = $6
+        and ${fields.expiresAt} > now()
+      returning ${expandFields(TrustedDevices)}
     `;
 
     mockQuery.mockImplementationOnce(async (query, values) => {
@@ -155,6 +157,24 @@ describe('trusted device queries', () => {
         country: 'CA',
       })
     ).resolves.toEqual(trustedDevice);
+  });
+
+  it('returns null when metadata cannot be updated for an inactive or missing device', async () => {
+    mockQuery.mockImplementationOnce(async (query, values) => {
+      expect(query).toMatch(/and "expires_at" > now\(\)/i);
+      expect(values).toEqual([
+        expect.any(Number),
+        null,
+        null,
+        trustedDevice.id,
+        trustedDevice.userId,
+      ]);
+      return createMockQueryResult([]);
+    });
+
+    await expect(
+      queries.updateMetadataByIdAndUserId(trustedDevice.id, trustedDevice.userId, {})
+    ).resolves.toBeNull();
   });
 
   it('deletes only the presented owned record at the expiry boundary', async () => {

--- a/packages/core/src/queries/trusted-device.ts
+++ b/packages/core/src/queries/trusted-device.ts
@@ -1,11 +1,9 @@
 import { type TrustedDevice, TrustedDevices } from '@logto/schemas';
-import { conditional } from '@silverhand/essentials';
 import { type CommonQueryMethods, sql } from '@silverhand/slonik';
 
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
-import { buildUpdateWhereWithPool } from '#src/database/update-where.js';
 import { expandFields } from '#src/database/utils.js';
-import { convertToIdentifiers, manyRows } from '#src/utils/sql.js';
+import { conditionalSql, convertToIdentifiers, manyRows } from '#src/utils/sql.js';
 
 const { table, fields } = convertToIdentifiers(TrustedDevices);
 const activePredicate = sql`${fields.expiresAt} > now()`;
@@ -26,8 +24,6 @@ export class TrustedDeviceQueries {
   public readonly insert = buildInsertIntoWithPool(this.pool)(TrustedDevices, {
     returning: true,
   });
-
-  private readonly updateMetadata = buildUpdateWhereWithPool(this.pool)(TrustedDevices, true);
 
   constructor(public readonly pool: CommonQueryMethods) {}
 
@@ -65,18 +61,22 @@ export class TrustedDeviceQueries {
     userId: string,
     { userAgent, ip, country, city }: TrustedDeviceMetadata
   ) {
-    const shouldReplaceLocation = country !== undefined || city !== undefined;
+    const metadataUpdates = [
+      sql`${fields.lastUsedAt}=to_timestamp(${Date.now()}::double precision / 1000)`,
+      conditionalSql(userAgent !== undefined, () => sql`${fields.userAgent}=${userAgent ?? null}`),
+      conditionalSql(ip !== undefined, () => sql`${fields.ip}=${ip ?? null}`),
+      sql`${fields.country}=${country ?? null}`,
+      sql`${fields.city}=${city ?? null}`,
+    ].filter(({ sql }) => sql.trim() !== '');
 
-    return this.updateMetadata({
-      set: {
-        lastUsedAt: Date.now(),
-        userAgent,
-        ip,
-        ...conditional(shouldReplaceLocation && { country: country ?? null, city: city ?? null }),
-      },
-      where: { id, userId },
-      jsonbMode: 'replace',
-    });
+    return this.pool.maybeOne<TrustedDevice>(sql`
+      update ${table}
+      set ${sql.join(metadataUpdates, sql`, `)}
+      where ${fields.id} = ${id}
+        and ${fields.userId} = ${userId}
+        and ${activePredicate}
+      returning ${expandFields(TrustedDevices)}
+    `);
   }
 
   public async deleteExpiredByIdAndUserId(id: string, userId: string) {

--- a/packages/core/src/queries/trusted-device.ts
+++ b/packages/core/src/queries/trusted-device.ts
@@ -1,9 +1,13 @@
 import { type TrustedDevice, TrustedDevices } from '@logto/schemas';
 import { type CommonQueryMethods, sql } from '@silverhand/slonik';
 
-import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import { expandFields } from '#src/database/utils.js';
-import { conditionalSql, convertToIdentifiers, manyRows } from '#src/utils/sql.js';
+import {
+  conditionalSql,
+  convertToIdentifiers,
+  convertToPrimitiveOrSql,
+  manyRows,
+} from '#src/utils/sql.js';
 
 const { table, fields } = convertToIdentifiers(TrustedDevices);
 const activePredicate = sql`${fields.expiresAt} > now()`;
@@ -15,17 +19,51 @@ export type TrustedDeviceMetadata = Readonly<{
   city?: string;
 }>;
 
+type TrustedDeviceCreation = TrustedDeviceMetadata &
+  Readonly<Pick<TrustedDevice, 'id' | 'userId' | 'secretHash' | 'expiresAt'>>;
+
 type Pagination = Readonly<{
   limit: number;
   offset: number;
 }>;
 
 export class TrustedDeviceQueries {
-  public readonly insert = buildInsertIntoWithPool(this.pool)(TrustedDevices, {
-    returning: true,
-  });
-
   constructor(public readonly pool: CommonQueryMethods) {}
+
+  public async insertIfNotExists({
+    id,
+    userId,
+    secretHash,
+    userAgent,
+    ip,
+    country,
+    city,
+    expiresAt,
+  }: TrustedDeviceCreation) {
+    return this.pool.maybeOne<TrustedDevice>(sql`
+      insert into ${table} (
+        ${fields.id},
+        ${fields.userId},
+        ${fields.secretHash},
+        ${fields.userAgent},
+        ${fields.ip},
+        ${fields.country},
+        ${fields.city},
+        ${fields.expiresAt}
+      ) values (
+        ${id},
+        ${userId},
+        ${convertToPrimitiveOrSql('secretHash', secretHash)},
+        ${userAgent ?? null},
+        ${ip ?? null},
+        ${country ?? null},
+        ${city ?? null},
+        ${convertToPrimitiveOrSql('expiresAt', expiresAt)}
+      )
+      on conflict (${fields.id}) do nothing
+      returning ${expandFields(TrustedDevices)}
+    `);
+  }
 
   public async findActiveByUserId(
     userId: string,

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -229,9 +229,7 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
       trustedDeviceId: trustedDevice.id,
       fulfilledAt,
     });
-    await expect(experienceInteraction.toSanitizedJson()).resolves.not.toHaveProperty(
-      'trustedDeviceFulfillment'
-    );
+    expect(experienceInteraction.toSanitizedJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
 
   it('allows a valid trusted device to fulfill adaptive MFA', async () => {

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -229,7 +229,9 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
       trustedDeviceId: trustedDevice.id,
       fulfilledAt,
     });
-    expect(experienceInteraction.toSanitizedJson()).not.toHaveProperty('trustedDeviceFulfillment');
+    await expect(experienceInteraction.toSanitizedJson()).resolves.not.toHaveProperty(
+      'trustedDeviceFulfillment'
+    );
   });
 
   it('allows a valid trusted device to fulfill adaptive MFA', async () => {

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 
 import { appInsights } from '@logto/app-insights/node';
+import { TemplateType } from '@logto/connector-kit';
 import {
   InteractionEvent,
   InteractionHookEvent,
@@ -18,6 +19,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayload } from '#src/libraries/user.utils.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
 import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
+import { type TrustedDeviceMetadata } from '#src/queries/trusted-device.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
@@ -60,6 +62,51 @@ type TrustedDeviceFulfillmentStatus =
   | 'stored'
   /** A trusted-device credential was validated and stored during the current request. */
   | 'validated';
+
+type SubmitOptions = Readonly<{
+  createTrustedDevice?: boolean;
+}>;
+
+const isEligibleExistingTrustedDeviceVerification = (verification: VerificationRecord) => {
+  switch (verification.type) {
+    case VerificationType.TOTP:
+    case VerificationType.WebAuthn: {
+      return verification.isVerified && !verification.isNewBindMfaVerification;
+    }
+    case VerificationType.MfaEmailVerificationCode:
+    case VerificationType.MfaPhoneVerificationCode: {
+      return verification.isVerified;
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
+const isEligibleIdentifierMfaBinding = (
+  verification: VerificationRecord,
+  profile: InteractionStorage['profile']
+) => {
+  switch (verification.type) {
+    case VerificationType.EmailVerificationCode: {
+      return (
+        verification.isVerified &&
+        verification.templateType === TemplateType.BindMfa &&
+        profile?.primaryEmail === verification.identifier.value
+      );
+    }
+    case VerificationType.PhoneVerificationCode: {
+      return (
+        verification.isVerified &&
+        verification.templateType === TemplateType.BindMfa &&
+        profile?.primaryPhone === verification.identifier.value
+      );
+    }
+    default: {
+      return false;
+    }
+  }
+};
 
 /**
  * Interaction is a short-lived session session that is initiated when a user starts an interaction flow with the Logto platform.
@@ -499,7 +546,7 @@ export default class ExperienceInteraction {
    * @throws {RequestError} with 422 if the required profile fields are missing
    **/
   // eslint-disable-next-line complexity
-  public async submit(log?: LogEntry) {
+  public async submit(log?: LogEntry, { createTrustedDevice = false }: SubmitOptions = {}) {
     const {
       queries: { users: userQueries, userSsoIdentities: userSsoIdentityQueries },
       libraries: {
@@ -664,6 +711,16 @@ export default class ExperienceInteraction {
       ...this.toJson(),
     });
 
+    // Trusted-device writes happen only after the full interaction has succeeded. They remain
+    // best effort so a persistence or cookie failure never turns a successful authentication into
+    // an error.
+    await trySafe(
+      async () => this.finalizeTrustedDevice(user.id, createTrustedDevice),
+      (error) => {
+        void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
+      }
+    );
+
     // The geo context is only recorded when the `submit()` function succeeds.
     // The recorded geo context will affect the evaluation results of the adaptive MFA afterwards.
     void trySafe(
@@ -707,17 +764,89 @@ export default class ExperienceInteraction {
     };
   }
 
-  public toSanitizedJson(): SanitizedInteractionStorageData {
+  public async toSanitizedJson(): Promise<SanitizedInteractionStorageData> {
     // Trusted-device fulfillment is internal authentication state. Explicitly remove it before
     // spreading the remaining storage.
     const { trustedDeviceFulfillment: _, ...interactionStorage } = this.toJson();
 
+    const trustedDevice = await this.getTrustedDeviceCreationAvailability();
+
     return {
       ...interactionStorage,
+      ...conditional(trustedDevice && { trustedDevice }),
       profile: this.profile.sanitizedData,
       mfa: this.mfa.sanitizedData,
       verificationRecords: this.verificationRecordsArray.map((record) => record.toSanitizedJson()),
     };
+  }
+
+  private async getTrustedDeviceCreationAvailability() {
+    // Trusted-device opt-in is under development and must remain isolated from released flows.
+    if (!EnvSet.values.isDevFeaturesEnabled || !this.userId) {
+      return;
+    }
+
+    const { enabled, durationDays } =
+      await this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(this.userId);
+
+    return {
+      canCreate: enabled,
+      ...conditional(enabled && { durationDays }),
+    };
+  }
+
+  private hasEligibleTrustedDeviceProof() {
+    const hasEligibleVerification = this.verificationRecordsArray.some(
+      (verification) =>
+        isEligibleExistingTrustedDeviceVerification(verification) ||
+        isEligibleIdentifierMfaBinding(verification, this.profile.data)
+    );
+
+    const hasEligibleBinding = this.mfa.bindMfaFactorsArray.some(
+      ({ type }) => type === MfaFactor.TOTP || type === MfaFactor.WebAuthn
+    );
+
+    return hasEligibleVerification || hasEligibleBinding;
+  }
+
+  private getTrustedDeviceMetadata(): TrustedDeviceMetadata {
+    const { ip, userAgent } = this.adaptiveMfaValidator.getSignInContext() ?? {};
+    const { country, city } = this.adaptiveMfaValidator.getCurrentContext()?.location ?? {};
+
+    return {
+      ...conditional(userAgent && { userAgent }),
+      ...conditional(ip && { ip }),
+      ...conditional(country && { country }),
+      ...conditional(city && { city }),
+    };
+  }
+
+  private async finalizeTrustedDevice(userId: string, createTrustedDevice: boolean) {
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    const {
+      libraries: { trustedDevices },
+    } = this.tenant;
+    const metadata = this.getTrustedDeviceMetadata();
+
+    if (this.trustedDeviceFulfillment?.userId === userId) {
+      if (this.#interactionEvent === InteractionEvent.SignIn) {
+        await trustedDevices.updateMetadata(
+          this.trustedDeviceFulfillment.trustedDeviceId,
+          userId,
+          metadata
+        );
+      }
+      return;
+    }
+
+    if (!createTrustedDevice || !this.hasEligibleTrustedDeviceProof()) {
+      return;
+    }
+
+    await trustedDevices.createCredential({ ctx: this.ctx, userId, ...metadata });
   }
 
   private async tryFulfillMfaWithTrustedDevice(

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -794,13 +794,20 @@ export default class ExperienceInteraction {
       libraries: { trustedDevices },
     } = this.tenant;
     const metadata = this.getTrustedDeviceMetadata();
+    const { trustedDeviceFulfillment } = this;
 
-    if (this.trustedDeviceFulfillment?.userId === user.id) {
+    if (trustedDeviceFulfillment?.userId === user.id) {
       if (this.#interactionEvent === InteractionEvent.SignIn) {
-        await trustedDevices.updateMetadata(
-          this.trustedDeviceFulfillment.trustedDeviceId,
-          user.id,
-          metadata
+        void trySafe(
+          async () =>
+            trustedDevices.updateMetadata(
+              trustedDeviceFulfillment.trustedDeviceId,
+              user.id,
+              metadata
+            ),
+          (error) => {
+            void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
+          }
         );
       }
       return;

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines */
 
 import { appInsights } from '@logto/app-insights/node';
-import { TemplateType } from '@logto/connector-kit';
 import {
   InteractionEvent,
   InteractionHookEvent,
@@ -66,47 +65,6 @@ type TrustedDeviceFulfillmentStatus =
 type SubmitOptions = Readonly<{
   createTrustedDevice?: boolean;
 }>;
-
-const isEligibleExistingTrustedDeviceVerification = (verification: VerificationRecord) => {
-  switch (verification.type) {
-    case VerificationType.TOTP:
-    case VerificationType.WebAuthn: {
-      return verification.isVerified && !verification.isNewBindMfaVerification;
-    }
-    case VerificationType.MfaEmailVerificationCode:
-    case VerificationType.MfaPhoneVerificationCode: {
-      return verification.isVerified;
-    }
-    default: {
-      return false;
-    }
-  }
-};
-
-const isEligibleIdentifierMfaBinding = (
-  verification: VerificationRecord,
-  profile: InteractionStorage['profile']
-) => {
-  switch (verification.type) {
-    case VerificationType.EmailVerificationCode: {
-      return (
-        verification.isVerified &&
-        verification.templateType === TemplateType.BindMfa &&
-        profile?.primaryEmail === verification.identifier.value
-      );
-    }
-    case VerificationType.PhoneVerificationCode: {
-      return (
-        verification.isVerified &&
-        verification.templateType === TemplateType.BindMfa &&
-        profile?.primaryPhone === verification.identifier.value
-      );
-    }
-    default: {
-      return false;
-    }
-  }
-};
 
 /**
  * Interaction is a short-lived session session that is initiated when a user starts an interaction flow with the Logto platform.
@@ -715,7 +673,7 @@ export default class ExperienceInteraction {
     // best effort so a persistence or cookie failure never turns a successful authentication into
     // an error.
     await trySafe(
-      async () => this.finalizeTrustedDevice(user.id, createTrustedDevice),
+      async () => this.finalizeTrustedDevice(updatedUser, createTrustedDevice),
       (error) => {
         void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
       }
@@ -795,11 +753,12 @@ export default class ExperienceInteraction {
     };
   }
 
-  private hasEligibleTrustedDeviceProof() {
-    const hasEligibleVerification = this.verificationRecordsArray.some(
-      (verification) =>
-        isEligibleExistingTrustedDeviceVerification(verification) ||
-        isEligibleIdentifierMfaBinding(verification, this.profile.data)
+  private async hasEligibleTrustedDeviceProof(user: User) {
+    const mfaSettings = await this.signInExperienceValidator.getMfaSettings();
+    const mfaValidator = new MfaValidator(mfaSettings, user);
+    const hasEligibleVerification = mfaValidator.hasEligibleTrustedDeviceVerification(
+      this.verificationRecordsArray,
+      this.profile.data
     );
 
     const hasEligibleBinding = this.mfa.bindMfaFactorsArray.some(
@@ -821,7 +780,7 @@ export default class ExperienceInteraction {
     };
   }
 
-  private async finalizeTrustedDevice(userId: string, createTrustedDevice: boolean) {
+  private async finalizeTrustedDevice(user: User, createTrustedDevice: boolean) {
     if (!EnvSet.values.isDevFeaturesEnabled) {
       return;
     }
@@ -831,22 +790,22 @@ export default class ExperienceInteraction {
     } = this.tenant;
     const metadata = this.getTrustedDeviceMetadata();
 
-    if (this.trustedDeviceFulfillment?.userId === userId) {
+    if (this.trustedDeviceFulfillment?.userId === user.id) {
       if (this.#interactionEvent === InteractionEvent.SignIn) {
         await trustedDevices.updateMetadata(
           this.trustedDeviceFulfillment.trustedDeviceId,
-          userId,
+          user.id,
           metadata
         );
       }
       return;
     }
 
-    if (!createTrustedDevice || !this.hasEligibleTrustedDeviceProof()) {
+    if (!createTrustedDevice || !(await this.hasEligibleTrustedDeviceProof(user))) {
       return;
     }
 
-    await trustedDevices.createCredential({ ctx: this.ctx, userId, ...metadata });
+    await trustedDevices.createCredential({ ctx: this.ctx, userId: user.id, ...metadata });
   }
 
   private async tryFulfillMfaWithTrustedDevice(

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -148,7 +148,7 @@ export default class ExperienceInteraction {
       profile = {},
       mfa = {},
       userId,
-      createTrustedDevice,
+      trustedDeviceCreation,
       trustedDeviceFulfillment,
       interactionEvent,
       captcha = {
@@ -162,7 +162,7 @@ export default class ExperienceInteraction {
     this.profile = new Profile(libraries, queries, profile, interactionContext);
     this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.trustedDevice = new TrustedDevice(ctx, tenant, {
-      createTrustedDevice,
+      trustedDeviceCreation,
       trustedDeviceFulfillment,
     });
     this.captcha = captcha;
@@ -662,6 +662,10 @@ export default class ExperienceInteraction {
     await this.triggerPostSignInAction(user.id);
 
     const { provider } = this.tenant;
+    // Do not persist a fulfilled creation intent in the final interaction result. A failed
+    // interactionResult call leaves the previously stored intent available for a retry, while a
+    // successful call makes subsequent submits a no-op for trusted-device creation.
+    const trustedDeviceCreation = this.trustedDevice.consumeCreationRequest();
 
     const redirectTo = await provider.interactionResult(this.ctx.req, this.ctx.res, {
       login: { accountId: user.id },
@@ -670,10 +674,11 @@ export default class ExperienceInteraction {
     });
 
     // Trusted-device writes happen only after the full interaction has succeeded.
-    const hasEligibleMfaProof =
-      this.trustedDevice.creationRequested &&
-      (await this.hasEligibleTrustedDeviceProof(updatedUser));
+    const hasEligibleMfaProof = trustedDeviceCreation
+      ? await this.hasEligibleTrustedDeviceProof(updatedUser)
+      : false;
     await this.trustedDevice.finalize({
+      creation: trustedDeviceCreation,
       interactionEvent: this.#interactionEvent,
       userId: user.id,
       hasEligibleMfaProof,
@@ -727,7 +732,7 @@ export default class ExperienceInteraction {
   public toSanitizedJson(): SanitizedInteractionStorageData {
     // Trusted-device intent and fulfillment are internal authentication state.
     const {
-      createTrustedDevice: _,
+      trustedDeviceCreation: _,
       trustedDeviceFulfillment: __,
       ...interactionStorage
     } = this.toJson();

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -727,7 +727,12 @@ export default class ExperienceInteraction {
     // spreading the remaining storage.
     const { trustedDeviceFulfillment: _, ...interactionStorage } = this.toJson();
 
-    const trustedDevice = await this.getTrustedDeviceCreationAvailability();
+    const trustedDevice = await trySafe(
+      async () => this.getTrustedDeviceCreationAvailability(),
+      (error) => {
+        void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
+      }
+    );
 
     return {
       ...interactionStorage,

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -673,18 +673,26 @@ export default class ExperienceInteraction {
       ...this.toJson(),
     });
 
-    // Trusted-device writes happen only after the full interaction has succeeded.
-    const hasEligibleMfaProof = trustedDeviceCreation
-      ? await this.hasEligibleTrustedDeviceProof(updatedUser)
-      : false;
-    await this.trustedDevice.finalize({
-      creation: trustedDeviceCreation,
-      interactionEvent: this.#interactionEvent,
-      userId: user.id,
-      hasEligibleMfaProof,
-      signInContext: this.adaptiveMfaValidator.getSignInContext(),
-      location: this.adaptiveMfaValidator.getCurrentContext()?.location,
-    });
+    // Trusted-device writes happen only after the full interaction has succeeded and must not
+    // turn a successful sign-in into an error.
+    await trySafe(
+      async () => {
+        const hasEligibleMfaProof = trustedDeviceCreation
+          ? await this.hasEligibleTrustedDeviceProof(updatedUser)
+          : false;
+        await this.trustedDevice.finalize({
+          creation: trustedDeviceCreation,
+          interactionEvent: this.#interactionEvent,
+          userId: user.id,
+          hasEligibleMfaProof,
+          signInContext: this.adaptiveMfaValidator.getSignInContext(),
+          location: this.adaptiveMfaValidator.getCurrentContext()?.location,
+        });
+      },
+      (error) => {
+        void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
+      }
+    );
 
     // The geo context is only recorded when the `submit()` function succeeds.
     // The recorded geo context will affect the evaluation results of the adaptive MFA afterwards.

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -13,12 +13,10 @@ import {
 import { maskEmail, maskPhone } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayload } from '#src/libraries/user.utils.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
 import { getClientIdentifierPayload } from '#src/oidc/cimd/index.js';
-import { type TrustedDeviceMetadata } from '#src/queries/trusted-device.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
@@ -48,6 +46,7 @@ import { SignInExperienceValidator } from './libraries/sign-in-experience-valida
 import { UserUpdateLibrary } from './libraries/user-update-library.js';
 import { Mfa } from './mfa.js';
 import { Profile } from './profile.js';
+import { TrustedDevice } from './trusted-device.js';
 import { toUserSocialIdentityData } from './utils.js';
 import {
   buildVerificationRecord,
@@ -55,16 +54,6 @@ import {
   type VerificationRecordMap,
 } from './verifications/index.js';
 import { VerificationRecordsMap } from './verifications/verification-records-map.js';
-
-type TrustedDeviceFulfillmentStatus =
-  /** A matching trusted-device fulfillment was restored from interaction storage. */
-  | 'stored'
-  /** A trusted-device credential was validated and stored during the current request. */
-  | 'validated';
-
-type SubmitOptions = Readonly<{
-  createTrustedDevice?: boolean;
-}>;
 
 /**
  * Interaction is a short-lived session session that is initiated when a user starts an interaction flow with the Logto platform.
@@ -80,13 +69,13 @@ export default class ExperienceInteraction {
   readonly profile: Profile;
   /** The user linked MFA data in the current interaction that needs to be stored to database. */
   readonly mfa: Mfa;
+  /** Trusted-device intent, fulfillment, and credential lifecycle for the current interaction. */
+  readonly trustedDevice: TrustedDevice;
 
   /** The user verification record list for the current interaction. */
   private readonly verificationRecords = new VerificationRecordsMap();
   /** The userId of the user for the current interaction. Only available once the user is identified. */
   private userId?: string;
-  /** Internal fulfillment state for the trusted-device MFA alternative. */
-  private trustedDeviceFulfillment?: InteractionStorage['trustedDeviceFulfillment'];
   private userCache?: User;
   private readonly adaptiveMfaValidator: AdaptiveMfaValidator;
 
@@ -142,6 +131,7 @@ export default class ExperienceInteraction {
       this.#interactionEvent = interactionData;
       this.profile = new Profile(libraries, queries, {}, interactionContext);
       this.mfa = new Mfa(libraries, queries, {}, interactionContext);
+      this.trustedDevice = new TrustedDevice(ctx, tenant, {});
       return;
     }
 
@@ -158,6 +148,7 @@ export default class ExperienceInteraction {
       profile = {},
       mfa = {},
       userId,
+      createTrustedDevice,
       trustedDeviceFulfillment,
       interactionEvent,
       captcha = {
@@ -168,9 +159,12 @@ export default class ExperienceInteraction {
 
     this.#interactionEvent = interactionEvent;
     this.userId = userId;
-    this.trustedDeviceFulfillment = trustedDeviceFulfillment;
     this.profile = new Profile(libraries, queries, profile, interactionContext);
     this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
+    this.trustedDevice = new TrustedDevice(ctx, tenant, {
+      createTrustedDevice,
+      trustedDeviceFulfillment,
+    });
     this.captcha = captcha;
     for (const record of verificationRecords) {
       const instance = buildVerificationRecord(libraries, queries, record);
@@ -398,7 +392,7 @@ export default class ExperienceInteraction {
       return;
     }
 
-    const trustedDeviceFulfillmentStatus = await this.tryFulfillMfaWithTrustedDevice(user.id);
+    const trustedDeviceFulfillmentStatus = await this.trustedDevice.tryFulfillMfa(user.id);
 
     if (trustedDeviceFulfillmentStatus === 'stored') {
       return;
@@ -443,6 +437,12 @@ export default class ExperienceInteraction {
    */
   public async guardIdentifiedUser() {
     await this.getIdentifiedUser();
+  }
+
+  /** Record an explicit trusted-device opt-in after validating eligible MFA proof. */
+  public async requestTrustedDeviceCreation() {
+    const user = await this.getIdentifiedUser();
+    this.trustedDevice.requestCreation(await this.hasEligibleTrustedDeviceProof(user));
   }
 
   /**
@@ -504,7 +504,7 @@ export default class ExperienceInteraction {
    * @throws {RequestError} with 422 if the required profile fields are missing
    **/
   // eslint-disable-next-line complexity
-  public async submit(log?: LogEntry, { createTrustedDevice = false }: SubmitOptions = {}) {
+  public async submit(log?: LogEntry) {
     const {
       queries: { users: userQueries, userSsoIdentities: userSsoIdentityQueries },
       libraries: {
@@ -669,15 +669,17 @@ export default class ExperienceInteraction {
       ...this.toJson(),
     });
 
-    // Trusted-device writes happen only after the full interaction has succeeded. They remain
-    // best effort so a persistence or cookie failure never turns a successful authentication into
-    // an error.
-    await trySafe(
-      async () => this.finalizeTrustedDevice(updatedUser, createTrustedDevice),
-      (error) => {
-        void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
-      }
-    );
+    // Trusted-device writes happen only after the full interaction has succeeded.
+    const hasEligibleMfaProof =
+      this.trustedDevice.creationRequested &&
+      (await this.hasEligibleTrustedDeviceProof(updatedUser));
+    await this.trustedDevice.finalize({
+      interactionEvent: this.#interactionEvent,
+      userId: user.id,
+      hasEligibleMfaProof,
+      signInContext: this.adaptiveMfaValidator.getSignInContext(),
+      location: this.adaptiveMfaValidator.getCurrentContext()?.location,
+    });
 
     // The geo context is only recorded when the `submit()` function succeeds.
     // The recorded geo context will affect the evaluation results of the adaptive MFA afterwards.
@@ -707,13 +709,13 @@ export default class ExperienceInteraction {
 
   /** Convert the current interaction to JSON, so that it can be stored as the OIDC provider interaction result */
   public toJson(): InteractionStorage {
-    const { interactionEvent, userId, trustedDeviceFulfillment, captcha } = this;
+    const { interactionEvent, userId, captcha } = this;
     const signInContext = this.adaptiveMfaValidator.getSignInContext();
 
     return {
       interactionEvent,
       userId,
-      trustedDeviceFulfillment,
+      ...this.trustedDevice.data,
       profile: this.profile.data,
       mfa: this.mfa.data,
       verificationRecords: this.verificationRecordsArray.map((record) => record.toJson()),
@@ -722,39 +724,19 @@ export default class ExperienceInteraction {
     };
   }
 
-  public async toSanitizedJson(): Promise<SanitizedInteractionStorageData> {
-    // Trusted-device fulfillment is internal authentication state. Explicitly remove it before
-    // spreading the remaining storage.
-    const { trustedDeviceFulfillment: _, ...interactionStorage } = this.toJson();
-
-    const trustedDevice = await trySafe(
-      async () => this.getTrustedDeviceCreationAvailability(),
-      (error) => {
-        void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
-      }
-    );
+  public toSanitizedJson(): SanitizedInteractionStorageData {
+    // Trusted-device intent and fulfillment are internal authentication state.
+    const {
+      createTrustedDevice: _,
+      trustedDeviceFulfillment: __,
+      ...interactionStorage
+    } = this.toJson();
 
     return {
       ...interactionStorage,
-      ...conditional(trustedDevice && { trustedDevice }),
       profile: this.profile.sanitizedData,
       mfa: this.mfa.sanitizedData,
       verificationRecords: this.verificationRecordsArray.map((record) => record.toSanitizedJson()),
-    };
-  }
-
-  private async getTrustedDeviceCreationAvailability() {
-    // Trusted-device opt-in is under development and must remain isolated from released flows.
-    if (!EnvSet.values.isDevFeaturesEnabled || !this.userId) {
-      return;
-    }
-
-    const { enabled, durationDays } =
-      await this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(this.userId);
-
-    return {
-      canCreate: enabled,
-      ...conditional(enabled && { durationDays }),
     };
   }
 
@@ -771,89 +753,6 @@ export default class ExperienceInteraction {
     );
 
     return hasEligibleVerification || hasEligibleBinding;
-  }
-
-  private getTrustedDeviceMetadata(): TrustedDeviceMetadata {
-    const { ip, userAgent } = this.adaptiveMfaValidator.getSignInContext() ?? {};
-    const { country, city } = this.adaptiveMfaValidator.getCurrentContext()?.location ?? {};
-
-    return {
-      ...conditional(userAgent && { userAgent }),
-      ...conditional(ip && { ip }),
-      ...conditional(country && { country }),
-      ...conditional(city && { city }),
-    };
-  }
-
-  private async finalizeTrustedDevice(user: User, createTrustedDevice: boolean) {
-    if (!EnvSet.values.isDevFeaturesEnabled) {
-      return;
-    }
-
-    const {
-      libraries: { trustedDevices },
-    } = this.tenant;
-    const metadata = this.getTrustedDeviceMetadata();
-    const { trustedDeviceFulfillment } = this;
-
-    if (trustedDeviceFulfillment?.userId === user.id) {
-      if (this.#interactionEvent === InteractionEvent.SignIn) {
-        void trySafe(
-          async () =>
-            trustedDevices.updateMetadata(
-              trustedDeviceFulfillment.trustedDeviceId,
-              user.id,
-              metadata
-            ),
-          (error) => {
-            void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
-          }
-        );
-      }
-      return;
-    }
-
-    if (!createTrustedDevice || !(await this.hasEligibleTrustedDeviceProof(user))) {
-      return;
-    }
-
-    await trustedDevices.createCredential({ ctx: this.ctx, userId: user.id, ...metadata });
-  }
-
-  private async tryFulfillMfaWithTrustedDevice(
-    userId: string
-  ): Promise<TrustedDeviceFulfillmentStatus | undefined> {
-    // Trusted-device MFA fulfillment is under development and must remain isolated from released flows.
-    if (!EnvSet.values.isDevFeaturesEnabled) {
-      return;
-    }
-
-    if (this.trustedDeviceFulfillment?.userId === userId) {
-      return 'stored';
-    }
-
-    const {
-      libraries: { trustedDevicePolicy, trustedDevices },
-    } = this.tenant;
-    const { enabled } = await trustedDevicePolicy.getEffectivePolicy(userId);
-
-    if (!enabled) {
-      return;
-    }
-
-    const trustedDevice = await trustedDevices.validateCredential(this.ctx, userId);
-
-    if (!trustedDevice) {
-      return;
-    }
-
-    this.trustedDeviceFulfillment = {
-      userId,
-      trustedDeviceId: trustedDevice.id,
-      fulfilledAt: Date.now(),
-    };
-
-    return 'validated';
   }
 
   private assignAdaptiveMfaHookResult(userId: string, adaptiveMfaResult?: AdaptiveMfaResult) {

--- a/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
@@ -10,6 +10,7 @@ import { type Optional } from '@silverhand/essentials';
 
 import { isNoSkipMfaPolicy } from '#src/libraries/sign-in-experience/mfa-policy.js';
 
+import { type InteractionProfile } from '../../types.js';
 import { getAllUserEnabledMfaVerifications } from '../helpers.js';
 import { type BackupCodeVerification } from '../verifications/backup-code-verification.js';
 import {
@@ -136,18 +137,36 @@ export class MfaValidator {
   }
 
   isMfaVerified(verificationRecords: VerificationRecord[]) {
-    const verifiedMfaVerificationRecords = verificationRecords.filter(
+    return this.getVerifiedMfaVerificationRecords(verificationRecords).length > 0;
+  }
+
+  hasEligibleTrustedDeviceVerification(
+    verificationRecords: VerificationRecord[],
+    currentProfile?: InteractionProfile
+  ) {
+    return this.getVerifiedMfaVerificationRecords(verificationRecords, currentProfile).some(
+      ({ type }) => type !== VerificationType.BackupCode
+    );
+  }
+
+  private getVerifiedMfaVerificationRecords(
+    verificationRecords: VerificationRecord[],
+    currentProfile?: InteractionProfile
+  ) {
+    const userEnabledMfaVerifications = getAllUserEnabledMfaVerifications(
+      this.mfaSettings,
+      this.user,
+      currentProfile
+    );
+
+    return verificationRecords.filter(
       (verification) =>
         isMfaVerificationRecord(verification) &&
         verification.isVerified &&
         // New bind MFA verification can not be used for verification
         !verification.isNewBindMfaVerification &&
         // Check if the verification type is enabled in the user's MFA settings
-        this.userEnabledMfaVerifications.includes(
-          mfaVerificationTypeToMfaFactorMap[verification.type]
-        )
+        userEnabledMfaVerifications.includes(mfaVerificationTypeToMfaFactorMap[verification.type])
     );
-
-    return verifiedMfaVerificationRecords.length > 0;
   }
 }

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -1,0 +1,174 @@
+import { appInsights } from '@logto/app-insights/node';
+import { InteractionEvent } from '@logto/schemas';
+import { conditional, trySafe } from '@silverhand/essentials';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import type TenantContext from '#src/tenants/TenantContext.js';
+import assertThat from '#src/utils/assert-that.js';
+import { buildAppInsightsTelemetry } from '#src/utils/request.js';
+
+import { type InteractionStorage, type WithHooksAndLogsContext } from '../types.js';
+
+type TrustedDeviceFulfillmentStatus =
+  /** A matching trusted-device fulfillment was restored from interaction storage. */
+  | 'stored'
+  /** A trusted-device credential was validated and stored during the current request. */
+  | 'validated';
+
+type TrustedDeviceData = Pick<
+  InteractionStorage,
+  'createTrustedDevice' | 'trustedDeviceFulfillment'
+>;
+
+type FinalizeOptions = {
+  interactionEvent: InteractionEvent;
+  userId: string;
+  hasEligibleMfaProof: boolean;
+  signInContext?: {
+    ip?: string;
+    userAgent?: string;
+  };
+  location?: {
+    country?: string;
+    city?: string;
+  };
+};
+
+/**
+ * Owns trusted-device interaction state and coordinates credential fulfillment and creation.
+ */
+export class TrustedDevice {
+  #createTrustedDevice?: boolean;
+  #fulfillment?: InteractionStorage['trustedDeviceFulfillment'];
+
+  constructor(
+    private readonly ctx: WithHooksAndLogsContext,
+    private readonly tenant: TenantContext,
+    data: TrustedDeviceData
+  ) {
+    this.#createTrustedDevice = data.createTrustedDevice;
+    this.#fulfillment = data.trustedDeviceFulfillment;
+  }
+
+  get data(): TrustedDeviceData {
+    return {
+      ...conditional(this.#createTrustedDevice && { createTrustedDevice: true }),
+      ...conditional(this.#fulfillment && { trustedDeviceFulfillment: this.#fulfillment }),
+    };
+  }
+
+  get creationRequested() {
+    return this.#createTrustedDevice === true;
+  }
+
+  requestCreation(hasEligibleMfaProof: boolean) {
+    assertThat(
+      hasEligibleMfaProof,
+      new RequestError({ code: 'session.mfa.require_mfa_verification', status: 403 })
+    );
+
+    this.#createTrustedDevice = true;
+  }
+
+  async getCreationAvailability(userId?: string) {
+    // Trusted-device opt-in is under development and must remain isolated from released flows.
+    if (!EnvSet.values.isDevFeaturesEnabled || !userId) {
+      return;
+    }
+
+    const { enabled, durationDays } =
+      await this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(userId);
+
+    return {
+      canCreate: enabled,
+      ...conditional(enabled && { durationDays }),
+    };
+  }
+
+  async tryFulfillMfa(userId: string): Promise<TrustedDeviceFulfillmentStatus | undefined> {
+    // Trusted-device MFA fulfillment is under development and must remain isolated from released flows.
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    if (this.#fulfillment?.userId === userId) {
+      return 'stored';
+    }
+
+    const {
+      libraries: { trustedDevicePolicy, trustedDevices },
+    } = this.tenant;
+    const { enabled } = await trustedDevicePolicy.getEffectivePolicy(userId);
+
+    if (!enabled) {
+      return;
+    }
+
+    const trustedDevice = await trustedDevices.validateCredential(this.ctx, userId);
+
+    if (!trustedDevice) {
+      return;
+    }
+
+    this.#fulfillment = {
+      userId,
+      trustedDeviceId: trustedDevice.id,
+      fulfilledAt: Date.now(),
+    };
+
+    return 'validated';
+  }
+
+  async finalize({
+    interactionEvent,
+    userId,
+    hasEligibleMfaProof,
+    signInContext,
+    location,
+  }: FinalizeOptions) {
+    if (!EnvSet.values.isDevFeaturesEnabled) {
+      return;
+    }
+
+    await trySafe(
+      async () => {
+        const {
+          libraries: { trustedDevices },
+        } = this.tenant;
+        const { ip, userAgent } = signInContext ?? {};
+        const { country, city } = location ?? {};
+        const metadata = {
+          ...conditional(userAgent && { userAgent }),
+          ...conditional(ip && { ip }),
+          ...conditional(country && { country }),
+          ...conditional(city && { city }),
+        };
+
+        const fulfillment = this.#fulfillment;
+
+        if (fulfillment?.userId === userId) {
+          if (interactionEvent === InteractionEvent.SignIn) {
+            void trySafe(
+              async () =>
+                trustedDevices.updateMetadata(fulfillment.trustedDeviceId, userId, metadata),
+              (error) => {
+                void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
+              }
+            );
+          }
+          return;
+        }
+
+        if (!this.#createTrustedDevice || !hasEligibleMfaProof) {
+          return;
+        }
+
+        await trustedDevices.createCredential({ ctx: this.ctx, userId, ...metadata });
+      },
+      (error) => {
+        void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
+      }
+    );
+  }
+}

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -1,5 +1,6 @@
 import { appInsights } from '@logto/app-insights/node';
 import { InteractionEvent } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
@@ -18,10 +19,11 @@ type TrustedDeviceFulfillmentStatus =
 
 type TrustedDeviceData = Pick<
   InteractionStorage,
-  'createTrustedDevice' | 'trustedDeviceFulfillment'
+  'trustedDeviceCreation' | 'trustedDeviceFulfillment'
 >;
 
 type FinalizeOptions = {
+  creation?: InteractionStorage['trustedDeviceCreation'];
   interactionEvent: InteractionEvent;
   userId: string;
   hasEligibleMfaProof: boolean;
@@ -39,7 +41,7 @@ type FinalizeOptions = {
  * Owns trusted-device interaction state and coordinates credential fulfillment and creation.
  */
 export class TrustedDevice {
-  #createTrustedDevice?: boolean;
+  #creation?: InteractionStorage['trustedDeviceCreation'];
   #fulfillment?: InteractionStorage['trustedDeviceFulfillment'];
 
   constructor(
@@ -47,19 +49,15 @@ export class TrustedDevice {
     private readonly tenant: TenantContext,
     data: TrustedDeviceData
   ) {
-    this.#createTrustedDevice = data.createTrustedDevice;
+    this.#creation = data.trustedDeviceCreation;
     this.#fulfillment = data.trustedDeviceFulfillment;
   }
 
   get data(): TrustedDeviceData {
     return {
-      ...conditional(this.#createTrustedDevice && { createTrustedDevice: true }),
+      ...conditional(this.#creation && { trustedDeviceCreation: this.#creation }),
       ...conditional(this.#fulfillment && { trustedDeviceFulfillment: this.#fulfillment }),
     };
-  }
-
-  get creationRequested() {
-    return this.#createTrustedDevice === true;
   }
 
   requestCreation(hasEligibleMfaProof: boolean) {
@@ -68,7 +66,15 @@ export class TrustedDevice {
       new RequestError({ code: 'session.mfa.require_mfa_verification', status: 403 })
     );
 
-    this.#createTrustedDevice = true;
+    this.#creation ||= { deviceId: generateStandardId() };
+  }
+
+  consumeCreationRequest() {
+    const creation = this.#creation;
+
+    this.#creation = undefined;
+
+    return creation;
   }
 
   async getCreationAvailability(userId?: string) {
@@ -121,6 +127,7 @@ export class TrustedDevice {
   }
 
   async finalize({
+    creation,
     interactionEvent,
     userId,
     hasEligibleMfaProof,
@@ -160,11 +167,16 @@ export class TrustedDevice {
           return;
         }
 
-        if (!this.#createTrustedDevice || !hasEligibleMfaProof) {
+        if (!creation || !hasEligibleMfaProof) {
           return;
         }
 
-        await trustedDevices.createCredential({ ctx: this.ctx, userId, ...metadata });
+        await trustedDevices.createCredential({
+          ctx: this.ctx,
+          deviceId: creation.deviceId,
+          userId,
+          ...metadata,
+        });
       },
       (error) => {
         void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));

--- a/packages/core/src/routes/experience/experience.openapi.json
+++ b/packages/core/src/routes/experience/experience.openapi.json
@@ -103,6 +103,20 @@
         "operationId": "SubmitInteraction",
         "summary": "Submit interaction",
         "description": "Submit the current interaction. <br/>- Submit the verified user identity to the OIDC provider for further authentication (SignIn and Register). <br/>- Update the user's profile data if any (SignIn and Register). <br/>- Reset the password and clear all the interaction records (ForgotPassword).",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "createTrustedDevice": {
+                    "description": "Dev feature. Whether the user explicitly opts in to trust this device after an eligible MFA verification or binding.",
+                    "x-logto-dev-feature": true
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "The interaction has been successfully submitted."
@@ -126,7 +140,19 @@
         "description": "Get the public interaction data.",
         "responses": {
           "200": {
-            "description": "The public interaction data has been successfully retrieved."
+            "description": "The public interaction data has been successfully retrieved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "trustedDevice": {
+                      "description": "Dev feature. Trusted-device creation availability for the identified user and current effective policy.",
+                      "x-logto-dev-feature": true
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/packages/core/src/routes/experience/experience.openapi.json
+++ b/packages/core/src/routes/experience/experience.openapi.json
@@ -103,20 +103,6 @@
         "operationId": "SubmitInteraction",
         "summary": "Submit interaction",
         "description": "Submit the current interaction. <br/>- Submit the verified user identity to the OIDC provider for further authentication (SignIn and Register). <br/>- Update the user's profile data if any (SignIn and Register). <br/>- Reset the password and clear all the interaction records (ForgotPassword).",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "properties": {
-                  "createTrustedDevice": {
-                    "description": "Dev feature. Whether the user explicitly opts in to trust this device after an eligible MFA verification or binding.",
-                    "x-logto-dev-feature": true
-                  }
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "The interaction has been successfully submitted."

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { appInsights } from '@logto/app-insights/node';
 import { TemplateType } from '@logto/connector-kit';
 import {
   InteractionEvent,
@@ -993,6 +994,21 @@ describe('POST /experience/submit', () => {
     expect(response.status).toBe(200);
     expect(response.body).toMatchObject({ trustedDevice: { canCreate: false } });
     expect(response.body.trustedDevice).not.toHaveProperty('durationDays');
+  });
+
+  it('should omit trusted-device availability when the policy lookup fails', async () => {
+    setDevFeaturesEnabled(true);
+    const policyError = new Error('trusted-device policy lookup failed');
+    const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
+    const { requester, getEffectivePolicy } = createRequesterWithMocks();
+    getEffectivePolicy.mockRejectedValueOnce(policyError);
+
+    const response = await requester.get('/experience/interaction');
+
+    expect(response.status).toBe(200);
+    expect(response.body).not.toHaveProperty('trustedDevice');
+    expect(trackException).toHaveBeenCalledWith(policyError, expect.any(Object));
+    trackException.mockRestore();
   });
 
   it('should omit trusted-device interaction data and behavior when dev features are disabled', async () => {

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -7,13 +7,19 @@ import {
   SignInIdentifier,
   VerificationType,
   type Mfa,
+  type User,
 } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 import type { Middleware } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
-import { mockUser, mockUserTotpMfaVerification } from '#src/__mocks__/user.js';
+import {
+  mockUser,
+  mockUserBackupCodeMfaVerification,
+  mockUserTotpMfaVerification,
+  mockUserWebAuthnMfaVerification,
+} from '#src/__mocks__/user.js';
 import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
@@ -23,6 +29,58 @@ import { createRequester } from '#src/utils/test-utils.js';
 const { jest } = import.meta;
 
 const experienceRoutes = await pickDefault(import('./index.js'));
+
+const eligibleTrustedDeviceVerificationCases: Array<{
+  name: string;
+  factor: MfaFactor;
+  mfaVerification?: User['mfaVerifications'][number];
+  verificationRecord: Record<string, unknown>;
+}> = [
+  {
+    name: 'TOTP',
+    factor: MfaFactor.TOTP,
+    mfaVerification: mockUserTotpMfaVerification,
+    verificationRecord: {
+      id: 'totp-verification-id',
+      type: VerificationType.TOTP,
+      userId: mockUser.id,
+      verified: true,
+    },
+  },
+  {
+    name: 'WebAuthn',
+    factor: MfaFactor.WebAuthn,
+    mfaVerification: mockUserWebAuthnMfaVerification,
+    verificationRecord: {
+      id: 'webauthn-verification-id',
+      type: VerificationType.WebAuthn,
+      userId: mockUser.id,
+      verified: true,
+    },
+  },
+  {
+    name: 'email OTP',
+    factor: MfaFactor.EmailVerificationCode,
+    verificationRecord: {
+      id: 'email-mfa-verification-id',
+      type: VerificationType.MfaEmailVerificationCode,
+      identifier: { type: SignInIdentifier.Email, value: mockUser.primaryEmail },
+      templateType: TemplateType.MfaVerification,
+      verified: true,
+    },
+  },
+  {
+    name: 'SMS OTP',
+    factor: MfaFactor.PhoneVerificationCode,
+    verificationRecord: {
+      id: 'phone-mfa-verification-id',
+      type: VerificationType.MfaPhoneVerificationCode,
+      identifier: { type: SignInIdentifier.Phone, value: mockUser.primaryPhone },
+      templateType: TemplateType.MfaVerification,
+      verified: true,
+    },
+  },
+];
 
 const createLogMiddleware = (): {
   middleware: Middleware<unknown, IRouterParamContext>;
@@ -50,6 +108,7 @@ const createRequesterWithMocks = ({
   passwordExpiration = { enabled: false },
   interactionResult = {},
   persistInteractionResult = false,
+  trustedDevicePolicy = { enabled: false, durationDays: 30 },
 }: {
   interactionEvent?: InteractionEvent;
   adaptiveMfaEnabled?: boolean;
@@ -59,6 +118,7 @@ const createRequesterWithMocks = ({
   passwordExpiration?: { enabled: boolean; validPeriodDays?: number };
   interactionResult?: Record<string, unknown>;
   persistInteractionResult?: boolean;
+  trustedDevicePolicy?: { enabled: boolean; durationDays: number };
 } = {}) => {
   const mockedInteractionDetails: {
     params: { client_id: string };
@@ -117,6 +177,10 @@ const createRequesterWithMocks = ({
       passwordExpiration,
     }),
   };
+  const getEffectivePolicy = jest.fn().mockResolvedValue(trustedDevicePolicy);
+  const validateCredential = jest.fn();
+  const createCredential = jest.fn();
+  const updateMetadata = jest.fn();
 
   const tenant = new MockTenant(
     provider,
@@ -129,8 +193,9 @@ const createRequesterWithMocks = ({
     undefined,
     {
       trustedDevicePolicy: {
-        getEffectivePolicy: jest.fn().mockResolvedValue({ enabled: false, durationDays: 30 }),
+        getEffectivePolicy,
       },
+      trustedDevices: { validateCredential, createCredential, updateMetadata },
     }
   );
 
@@ -141,7 +206,18 @@ const createRequesterWithMocks = ({
     middlewares: [logMiddleware],
   });
 
-  return { requester, userGeoLocations, userSignInCountries, mockAppend, users };
+  return {
+    requester,
+    userGeoLocations,
+    userSignInCountries,
+    mockAppend,
+    users,
+    provider,
+    getEffectivePolicy,
+    validateCredential,
+    createCredential,
+    updateMetadata,
+  };
 };
 
 const createMfaRequiredRequester = () => {
@@ -477,6 +553,270 @@ describe('POST /experience/submit', () => {
     expect(userSignInCountries.upsertUserSignInCountry).toHaveBeenCalledWith(mockUser.id, 'JP');
   });
 
+  it.each(eligibleTrustedDeviceVerificationCases)(
+    'should create a trusted device after eligible $name verification and explicit opt-in',
+    async ({ factor, mfaVerification, verificationRecord }) => {
+      setDevFeaturesEnabled(true);
+      const user = {
+        ...mockUser,
+        mfaVerifications: mfaVerification ? [mfaVerification] : [],
+      };
+      const { requester, createCredential } = createRequesterWithMocks({
+        user,
+        mfa: { policy: MfaPolicy.Mandatory, factors: [factor] },
+        interactionResult: { verificationRecords: [verificationRecord] },
+        trustedDevicePolicy: { enabled: true, durationDays: 30 },
+      });
+
+      const response = await requester
+        .post('/experience/submit')
+        .set('User-Agent', 'Trusted device test browser')
+        .set('x-logto-cf-country', 'us')
+        .set('x-logto-cf-city', 'Portland')
+        .send({ createTrustedDevice: true });
+
+      expect(response.status).toBe(200);
+      const payload = createCredential.mock.calls[0]?.[0] as
+        | {
+            ctx?: unknown;
+            userId?: string;
+            userAgent?: string;
+            ip?: string;
+            country?: string;
+            city?: string;
+          }
+        | undefined;
+      expect(payload).toMatchObject({
+        userId: user.id,
+        userAgent: 'Trusted device test browser',
+        country: 'US',
+        city: 'Portland',
+      });
+      expect(payload?.ctx).toBeDefined();
+      expect(typeof payload?.ip).toBe('string');
+    }
+  );
+
+  it('should default trusted-device intent to false', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const response = await requester.post('/experience/submit');
+
+    expect(response.status).toBe(200);
+    expect(createCredential).not.toHaveBeenCalled();
+  });
+
+  it('should not treat trusted-device intent as MFA proof', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+
+    expect(response.status).toBe(403);
+    expect(createCredential).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'TOTP',
+      mfaData: {
+        mfaEnabled: true,
+        totp: { type: MfaFactor.TOTP, secret: 'totp-secret' },
+      },
+      factor: MfaFactor.TOTP,
+    },
+    {
+      name: 'WebAuthn',
+      mfaData: {
+        mfaEnabled: true,
+        webAuthn: [
+          {
+            type: MfaFactor.WebAuthn,
+            rpId: 'logto.test',
+            credentialId: 'credential-id',
+            publicKey: 'public-key',
+            counter: 0,
+            agent: 'test-agent',
+            transports: [],
+          },
+        ],
+      },
+      factor: MfaFactor.WebAuthn,
+    },
+  ])(
+    'should create a trusted device after eligible $name binding and explicit opt-in',
+    async ({ mfaData, factor }) => {
+      setDevFeaturesEnabled(true);
+      const { requester, createCredential } = createRequesterWithMocks({
+        interactionEvent: InteractionEvent.Register,
+        mfa: { policy: MfaPolicy.Mandatory, factors: [factor] },
+        interactionResult: { mfa: mfaData },
+        trustedDevicePolicy: { enabled: true, durationDays: 30 },
+      });
+
+      const response = await requester
+        .post('/experience/submit')
+        .send({ createTrustedDevice: true });
+
+      expect(response.status).toBe(200);
+      expect(createCredential).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: mockUser.id })
+      );
+    }
+  );
+
+  it('should exclude backup-code verification from trusted-device creation', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification, mockUserBackupCodeMfaVerification],
+    };
+    const { requester, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: {
+        policy: MfaPolicy.Mandatory,
+        factors: [MfaFactor.TOTP, MfaFactor.BackupCode],
+      },
+      interactionResult: {
+        verificationRecords: [
+          {
+            id: 'backup-code-verification-id',
+            type: VerificationType.BackupCode,
+            userId: user.id,
+            code: 'code',
+          },
+        ],
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+
+    expect(response.status).toBe(200);
+    expect(createCredential).not.toHaveBeenCalled();
+  });
+
+  it('should update a fulfilling trusted device best effort without creating a duplicate', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, createCredential, updateMetadata } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        trustedDeviceFulfillment: {
+          userId: user.id,
+          trustedDeviceId: 'trusted-device-id',
+          fulfilledAt: Date.now(),
+        },
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+    updateMetadata.mockRejectedValueOnce(new Error('trusted-device metadata update failed'));
+
+    const response = await requester
+      .post('/experience/submit')
+      .set('x-logto-cf-country', 'US')
+      .send({ createTrustedDevice: true });
+
+    expect(response.status).toBe(200);
+    expect(updateMetadata).toHaveBeenCalledWith(
+      'trusted-device-id',
+      user.id,
+      expect.objectContaining({ country: 'US' })
+    );
+    expect(createCredential).not.toHaveBeenCalled();
+  });
+
+  it('should keep submit successful when trusted-device creation fails', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+    createCredential.mockRejectedValueOnce(new Error('trusted-device creation failed'));
+
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+
+    expect(response.status).toBe(200);
+    expect(createCredential).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not create a trusted device when the complete interaction fails', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, provider, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+    (provider.interactionResult as jest.Mock).mockRejectedValueOnce(
+      new Error('interaction submission failed')
+    );
+
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+
+    expect(response.status).toBe(500);
+    expect(createCredential).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       name: 'email',
@@ -506,7 +846,7 @@ describe('POST /experience/submit', () => {
         mfaVerifications: [],
       };
 
-      const { requester, users, mockAppend } = createRequesterWithMocks({
+      const { requester, users, mockAppend, createCredential } = createRequesterWithMocks({
         adaptiveMfaEnabled: true,
         user,
         mfa: {
@@ -529,6 +869,7 @@ describe('POST /experience/submit', () => {
           ],
         },
         persistInteractionResult: true,
+        trustedDevicePolicy: { enabled: true, durationDays: 30 },
       });
 
       const bindResponse = await requester.post('/experience/profile/mfa').send({
@@ -539,7 +880,8 @@ describe('POST /experience/submit', () => {
 
       const submitResponse = await requester
         .post('/experience/submit')
-        .set('x-logto-cf-bot-score', '10');
+        .set('x-logto-cf-bot-score', '10')
+        .send({ createTrustedDevice: true });
       expect(submitResponse.status).toBe(200);
 
       expect(users.updateUserById).toHaveBeenCalledWith(
@@ -553,7 +895,78 @@ describe('POST /experience/submit', () => {
         )
         .find(Boolean);
       expect(adaptiveMfaResult?.requiresMfa).toBe(true);
+      expect(createCredential).toHaveBeenCalledWith(expect.objectContaining({ userId: user.id }));
     }
   );
+
+  it('should expose only trusted-device creation availability for an identified user', async () => {
+    setDevFeaturesEnabled(true);
+    const { requester, getEffectivePolicy } = createRequesterWithMocks({
+      interactionResult: {
+        trustedDeviceFulfillment: {
+          userId: mockUser.id,
+          trustedDeviceId: 'internal-device-id',
+          fulfilledAt: Date.now(),
+        },
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const response = await requester.get('/experience/interaction');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      trustedDevice: { canCreate: true, durationDays: 30 },
+    });
+    expect(response.body).not.toHaveProperty('trustedDeviceFulfillment');
+    expect(getEffectivePolicy).toHaveBeenCalledWith(mockUser.id);
+  });
+
+  it('should expose disabled creation without a duration when effective policy disallows it', async () => {
+    setDevFeaturesEnabled(true);
+    const { requester } = createRequesterWithMocks({
+      trustedDevicePolicy: { enabled: false, durationDays: 30 },
+    });
+
+    const response = await requester.get('/experience/interaction');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ trustedDevice: { canCreate: false } });
+    expect(response.body.trustedDevice).not.toHaveProperty('durationDays');
+  });
+
+  it('should omit trusted-device interaction data and behavior when dev features are disabled', async () => {
+    setDevFeaturesEnabled(false);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, createCredential, getEffectivePolicy } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const interactionResponse = await requester.get('/experience/interaction');
+    const submitResponse = await requester
+      .post('/experience/submit')
+      .send({ createTrustedDevice: true });
+
+    expect(interactionResponse.status).toBe(200);
+    expect(interactionResponse.body).not.toHaveProperty('trustedDevice');
+    expect(submitResponse.status).toBe(200);
+    expect(getEffectivePolicy).not.toHaveBeenCalled();
+    expect(createCredential).not.toHaveBeenCalled();
+  });
 });
 /* eslint-enable max-lines */

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -29,6 +29,8 @@ import { createMockProvider } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
+import { MfaValidator } from './classes/libraries/mfa-validator.js';
+
 const { jest } = import.meta;
 
 const experienceRoutes = await pickDefault(import('./index.js'));
@@ -992,6 +994,47 @@ describe('POST /experience/submit', () => {
     expect(response.status).toBe(200);
     expect(createCredential).toHaveBeenCalledTimes(1);
     expect(trackException).toHaveBeenCalledWith(creationError, expect.any(Object));
+  });
+
+  it('should keep submit successful when trusted-device proof eligibility fails', async () => {
+    setDevFeaturesEnabled(true);
+    const eligibilityError = new Error('trusted-device proof eligibility failed');
+    const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
+    const hasEligibleTrustedDeviceVerification = jest
+      .spyOn(MfaValidator.prototype, 'hasEligibleTrustedDeviceVerification')
+      .mockReturnValueOnce(true)
+      .mockImplementationOnce(() => {
+        throw eligibilityError;
+      });
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      persistInteractionResult: true,
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
+    const submitResponse = await requester.post('/experience/submit');
+
+    expect(optInResponse.status).toBe(204);
+    expect(submitResponse.status).toBe(200);
+    expect(hasEligibleTrustedDeviceVerification).toHaveBeenCalledTimes(2);
+    expect(createCredential).not.toHaveBeenCalled();
+    expect(trackException).toHaveBeenCalledWith(eligibilityError, expect.any(Object));
   });
 
   it('should not create a trusted device when the complete interaction fails', async () => {

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -585,6 +585,7 @@ describe('POST /experience/submit', () => {
       const payload = createCredential.mock.calls[0]?.[0] as
         | {
             ctx?: unknown;
+            deviceId?: string;
             userId?: string;
             userAgent?: string;
             ip?: string;
@@ -598,10 +599,97 @@ describe('POST /experience/submit', () => {
         country: 'US',
         city: 'Portland',
       });
+      expect(typeof payload?.deviceId).toBe('string');
       expect(payload?.ctx).toBeDefined();
       expect(typeof payload?.ip).toBe('string');
     }
   );
+
+  it('should consume trusted-device creation intent after a successful submit', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, provider, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      persistInteractionResult: true,
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
+    const repeatedOptInResponse = await requester.post('/experience/profile/mfa/trusted-device');
+    const firstSubmitResponse = await requester.post('/experience/submit');
+    const retrySubmitResponse = await requester.post('/experience/submit');
+
+    expect(optInResponse.status).toBe(204);
+    expect(repeatedOptInResponse.status).toBe(204);
+    expect(firstSubmitResponse.status).toBe(200);
+    expect(retrySubmitResponse.status).toBe(200);
+    const interactionResultCalls = (provider.interactionResult as jest.Mock).mock.calls;
+    const firstOptInResult = interactionResultCalls[0]?.[2] as Record<string, unknown> | undefined;
+    const repeatedOptInResult = interactionResultCalls[1]?.[2] as
+      | Record<string, unknown>
+      | undefined;
+    const firstSubmitResult = interactionResultCalls[2]?.[2] as Record<string, unknown> | undefined;
+    expect(firstOptInResult?.trustedDeviceCreation).toEqual(
+      repeatedOptInResult?.trustedDeviceCreation
+    );
+    expect(firstSubmitResult).not.toHaveProperty('trustedDeviceCreation');
+    expect(createCredential).toHaveBeenCalledTimes(1);
+    expect(createCredential).toHaveBeenCalledWith(expect.objectContaining({ userId: user.id }));
+    const creationPayload = createCredential.mock.calls[0]?.[0] as
+      | { deviceId?: unknown }
+      | undefined;
+    expect(typeof creationPayload?.deviceId).toBe('string');
+  });
+
+  it('should use one idempotency key for concurrent submits restored from the same interaction', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        trustedDeviceCreation: { deviceId: 'trusted-device-id' },
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const responses = await Promise.all([
+      requester.post('/experience/submit'),
+      requester.post('/experience/submit'),
+    ]);
+
+    expect(responses.map(({ status }) => status)).toEqual([200, 200]);
+    expect(createCredential).toHaveBeenCalledTimes(2);
+    expect(createCredential.mock.calls.map(([{ deviceId }]) => deviceId)).toEqual([
+      'trusted-device-id',
+      'trusted-device-id',
+    ]);
+  });
 
   it('should default trusted-device intent to false', async () => {
     setDevFeaturesEnabled(true);
@@ -1027,7 +1115,7 @@ describe('POST /experience/submit', () => {
     setDevFeaturesEnabled(true);
     const { requester, getEffectivePolicy } = createRequesterWithMocks({
       interactionResult: {
-        createTrustedDevice: true,
+        trustedDeviceCreation: { deviceId: 'internal-device-id' },
         trustedDeviceFulfillment: {
           userId: mockUser.id,
           trustedDeviceId: 'internal-device-id',
@@ -1044,7 +1132,7 @@ describe('POST /experience/submit', () => {
       trustedDevice: { canCreate: true, durationDays: 30 },
     });
     expect(response.body).not.toHaveProperty('trustedDeviceFulfillment');
-    expect(response.body).not.toHaveProperty('createTrustedDevice');
+    expect(response.body).not.toHaveProperty('trustedDeviceCreation');
     expect(getEffectivePolicy).toHaveBeenCalledWith(mockUser.id);
   });
 

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -723,6 +723,66 @@ describe('POST /experience/submit', () => {
     expect(createCredential).not.toHaveBeenCalled();
   });
 
+  it('should exclude a verified MFA factor that is disabled in the sign-in experience', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [] },
+      interactionResult: {
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+
+    expect(response.status).toBe(200);
+    expect(createCredential).not.toHaveBeenCalled();
+  });
+
+  it('should not treat a BindMfa-templated profile identifier as an MFA binding', async () => {
+    setDevFeaturesEnabled(true);
+    const primaryEmail = 'profile-only@logto.dev';
+    const user = {
+      ...mockUser,
+      primaryEmail: null,
+      mfaVerifications: [],
+    };
+    const { requester, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [] },
+      interactionResult: {
+        profile: { primaryEmail },
+        verificationRecords: [
+          {
+            id: 'email-verification-id',
+            type: VerificationType.EmailVerificationCode,
+            identifier: { type: SignInIdentifier.Email, value: primaryEmail },
+            templateType: TemplateType.BindMfa,
+            verified: true,
+          },
+        ],
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+
+    expect(response.status).toBe(200);
+    expect(createCredential).not.toHaveBeenCalled();
+  });
+
   it('should update a fulfilling trusted device best effort without creating a duplicate', async () => {
     setDevFeaturesEnabled(true);
     const user = {

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -22,6 +22,8 @@ import {
   mockUserWebAuthnMfaVerification,
 } from '#src/__mocks__/user.js';
 import { EnvSet } from '#src/env-set/index.js';
+import koaErrorHandler from '#src/middleware/koa-error-handler.js';
+import koaI18next from '#src/middleware/koa-i18next.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { createMockProvider } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -204,7 +206,7 @@ const createRequesterWithMocks = ({
   const requester = createRequester({
     anonymousRoutes: experienceRoutes,
     tenantContext: tenant,
-    middlewares: [logMiddleware],
+    middlewares: [koaI18next(), koaErrorHandler(), logMiddleware],
   });
 
   return {
@@ -277,6 +279,7 @@ describe('POST /experience/submit', () => {
   afterEach(() => {
     setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
     jest.useRealTimers();
+    jest.restoreAllMocks();
   });
 
   it('should record geo context when dev features are disabled', async () => {
@@ -643,6 +646,7 @@ describe('POST /experience/submit', () => {
     const response = await requester.post('/experience/profile/mfa/trusted-device');
 
     expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({ code: 'session.mfa.require_mfa_verification' });
     expect(createCredential).not.toHaveBeenCalled();
   });
 
@@ -789,6 +793,8 @@ describe('POST /experience/submit', () => {
 
   it('should update a fulfilling trusted device best effort without creating a duplicate', async () => {
     setDevFeaturesEnabled(true);
+    const metadataError = new Error('trusted-device metadata update failed');
+    const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
     const user = {
       ...mockUser,
       mfaVerifications: [mockUserTotpMfaVerification],
@@ -805,7 +811,7 @@ describe('POST /experience/submit', () => {
       },
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
-    updateMetadata.mockRejectedValueOnce(new Error('trusted-device metadata update failed'));
+    updateMetadata.mockRejectedValueOnce(metadataError);
 
     const response = await requester.post('/experience/submit').set('x-logto-cf-country', 'US');
 
@@ -815,6 +821,27 @@ describe('POST /experience/submit', () => {
       user.id,
       expect.objectContaining({ country: 'US' })
     );
+    expect(createCredential).not.toHaveBeenCalled();
+    expect(trackException).toHaveBeenCalledWith(metadataError, expect.any(Object));
+  });
+
+  it('should not update trusted-device metadata from another user fulfillment', async () => {
+    setDevFeaturesEnabled(true);
+    const { requester, createCredential, updateMetadata } = createRequesterWithMocks({
+      interactionResult: {
+        trustedDeviceFulfillment: {
+          userId: 'another-user-id',
+          trustedDeviceId: 'another-user-trusted-device-id',
+          fulfilledAt: Date.now(),
+        },
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const response = await requester.post('/experience/submit');
+
+    expect(response.status).toBe(200);
+    expect(updateMetadata).not.toHaveBeenCalled();
     expect(createCredential).not.toHaveBeenCalled();
   });
 
@@ -846,6 +873,8 @@ describe('POST /experience/submit', () => {
 
   it('should keep submit successful when trusted-device creation fails', async () => {
     setDevFeaturesEnabled(true);
+    const creationError = new Error('trusted-device creation failed');
+    const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
     const user = {
       ...mockUser,
       mfaVerifications: [mockUserTotpMfaVerification],
@@ -866,7 +895,7 @@ describe('POST /experience/submit', () => {
       persistInteractionResult: true,
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
-    createCredential.mockRejectedValueOnce(new Error('trusted-device creation failed'));
+    createCredential.mockRejectedValueOnce(creationError);
 
     const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
     const response = await requester.post('/experience/submit');
@@ -874,6 +903,7 @@ describe('POST /experience/submit', () => {
     expect(optInResponse.status).toBe(204);
     expect(response.status).toBe(200);
     expect(createCredential).toHaveBeenCalledTimes(1);
+    expect(trackException).toHaveBeenCalledWith(creationError, expect.any(Object));
   });
 
   it('should not create a trusted device when the complete interaction fails', async () => {

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -818,6 +818,32 @@ describe('POST /experience/submit', () => {
     expect(createCredential).not.toHaveBeenCalled();
   });
 
+  it('should omit trusted-device location when the current context has none', async () => {
+    setDevFeaturesEnabled(true);
+    const { requester, updateMetadata } = createRequesterWithMocks({
+      interactionResult: {
+        trustedDeviceFulfillment: {
+          userId: mockUser.id,
+          trustedDeviceId: 'trusted-device-id',
+          fulfilledAt: Date.now(),
+        },
+      },
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const response = await requester.post('/experience/submit');
+    const metadata = updateMetadata.mock.calls[0]?.[2] as Record<string, unknown> | undefined;
+
+    expect(response.status).toBe(200);
+    expect(updateMetadata).toHaveBeenCalledWith(
+      'trusted-device-id',
+      mockUser.id,
+      expect.any(Object)
+    );
+    expect(metadata).not.toHaveProperty('country');
+    expect(metadata).not.toHaveProperty('city');
+  });
+
   it('should keep submit successful when trusted-device creation fails', async () => {
     setDevFeaturesEnabled(true);
     const user = {

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -566,16 +566,18 @@ describe('POST /experience/submit', () => {
         user,
         mfa: { policy: MfaPolicy.Mandatory, factors: [factor] },
         interactionResult: { verificationRecords: [verificationRecord] },
+        persistInteractionResult: true,
         trustedDevicePolicy: { enabled: true, durationDays: 30 },
       });
 
+      const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
       const response = await requester
         .post('/experience/submit')
         .set('User-Agent', 'Trusted device test browser')
         .set('x-logto-cf-country', 'us')
-        .set('x-logto-cf-city', 'Portland')
-        .send({ createTrustedDevice: true });
+        .set('x-logto-cf-city', 'Portland');
 
+      expect(optInResponse.status).toBe(204);
       expect(response.status).toBe(200);
       const payload = createCredential.mock.calls[0]?.[0] as
         | {
@@ -638,7 +640,7 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+    const response = await requester.post('/experience/profile/mfa/trusted-device');
 
     expect(response.status).toBe(403);
     expect(createCredential).not.toHaveBeenCalled();
@@ -679,13 +681,14 @@ describe('POST /experience/submit', () => {
         interactionEvent: InteractionEvent.Register,
         mfa: { policy: MfaPolicy.Mandatory, factors: [factor] },
         interactionResult: { mfa: mfaData },
+        persistInteractionResult: true,
         trustedDevicePolicy: { enabled: true, durationDays: 30 },
       });
 
-      const response = await requester
-        .post('/experience/submit')
-        .send({ createTrustedDevice: true });
+      const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
+      const response = await requester.post('/experience/submit');
 
+      expect(optInResponse.status).toBe(204);
       expect(response.status).toBe(200);
       expect(createCredential).toHaveBeenCalledWith(
         expect.objectContaining({ userId: mockUser.id })
@@ -718,9 +721,9 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+    const response = await requester.post('/experience/profile/mfa/trusted-device');
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(403);
     expect(createCredential).not.toHaveBeenCalled();
   });
 
@@ -746,9 +749,9 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+    const response = await requester.post('/experience/profile/mfa/trusted-device');
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(403);
     expect(createCredential).not.toHaveBeenCalled();
   });
 
@@ -778,9 +781,9 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+    const response = await requester.post('/experience/profile/mfa/trusted-device');
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(403);
     expect(createCredential).not.toHaveBeenCalled();
   });
 
@@ -804,10 +807,7 @@ describe('POST /experience/submit', () => {
     });
     updateMetadata.mockRejectedValueOnce(new Error('trusted-device metadata update failed'));
 
-    const response = await requester
-      .post('/experience/submit')
-      .set('x-logto-cf-country', 'US')
-      .send({ createTrustedDevice: true });
+    const response = await requester.post('/experience/submit').set('x-logto-cf-country', 'US');
 
     expect(response.status).toBe(200);
     expect(updateMetadata).toHaveBeenCalledWith(
@@ -863,12 +863,15 @@ describe('POST /experience/submit', () => {
           },
         ],
       },
+      persistInteractionResult: true,
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
     createCredential.mockRejectedValueOnce(new Error('trusted-device creation failed'));
 
-    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
+    const response = await requester.post('/experience/submit');
 
+    expect(optInResponse.status).toBe(204);
     expect(response.status).toBe(200);
     expect(createCredential).toHaveBeenCalledTimes(1);
   });
@@ -892,14 +895,17 @@ describe('POST /experience/submit', () => {
           },
         ],
       },
+      persistInteractionResult: true,
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
+    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
     (provider.interactionResult as jest.Mock).mockRejectedValueOnce(
       new Error('interaction submission failed')
     );
 
-    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+    const response = await requester.post('/experience/submit');
 
+    expect(optInResponse.status).toBe(204);
     expect(response.status).toBe(500);
     expect(createCredential).not.toHaveBeenCalled();
   });
@@ -965,10 +971,11 @@ describe('POST /experience/submit', () => {
       });
       expect(bindResponse.status).toBe(204);
 
+      const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
       const submitResponse = await requester
         .post('/experience/submit')
-        .set('x-logto-cf-bot-score', '10')
-        .send({ createTrustedDevice: true });
+        .set('x-logto-cf-bot-score', '10');
+      expect(optInResponse.status).toBe(204);
       expect(submitResponse.status).toBe(200);
 
       expect(users.updateUserById).toHaveBeenCalledWith(
@@ -990,6 +997,7 @@ describe('POST /experience/submit', () => {
     setDevFeaturesEnabled(true);
     const { requester, getEffectivePolicy } = createRequesterWithMocks({
       interactionResult: {
+        createTrustedDevice: true,
         trustedDeviceFulfillment: {
           userId: mockUser.id,
           trustedDeviceId: 'internal-device-id',
@@ -1006,6 +1014,7 @@ describe('POST /experience/submit', () => {
       trustedDevice: { canCreate: true, durationDays: 30 },
     });
     expect(response.body).not.toHaveProperty('trustedDeviceFulfillment');
+    expect(response.body).not.toHaveProperty('createTrustedDevice');
     expect(getEffectivePolicy).toHaveBeenCalledWith(mockUser.id);
   });
 
@@ -1060,12 +1069,15 @@ describe('POST /experience/submit', () => {
     });
 
     const interactionResponse = await requester.get('/experience/interaction');
+    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
     const submitResponse = await requester
       .post('/experience/submit')
-      .send({ createTrustedDevice: true });
+      .set('Content-Type', 'text/plain')
+      .send('released submit payload');
 
     expect(interactionResponse.status).toBe(200);
     expect(interactionResponse.body).not.toHaveProperty('trustedDevice');
+    expect(optInResponse.status).toBe(404);
     expect(submitResponse.status).toBe(200);
     expect(getEffectivePolicy).not.toHaveBeenCalled();
     expect(createCredential).not.toHaveBeenCalled();

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -10,15 +10,17 @@
  * The experience APIs can be used by developers to build custom user interaction experiences.
  */
 
+import { appInsights } from '@logto/app-insights/node';
 import { identificationApiPayloadGuard, InteractionEvent } from '@logto/schemas';
+import { conditional, trySafe } from '@silverhand/essentials';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaInteractionDetails from '#src/middleware/koa-interaction-details.js';
 import assertThat from '#src/utils/assert-that.js';
+import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import { type AnonymousRouter, type RouterInitArgs } from '../types.js';
 
@@ -170,9 +172,6 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
   experienceRouter.post(
     `${experienceRoutes.prefix}/submit`,
     koaGuard({
-      body: z.object({
-        createTrustedDevice: z.boolean().optional(),
-      }),
       status: [200, 400, 403, 404, 422],
       response: z
         .object({
@@ -182,13 +181,10 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
     }),
     async (ctx, next) => {
       const { createLog, experienceInteraction } = ctx;
-      const createTrustedDevice = EnvSet.values.isDevFeaturesEnabled
-        ? ctx.guard.body.createTrustedDevice
-        : undefined;
 
       const log = createLog(`Interaction.${experienceInteraction.interactionEvent}.Submit`);
 
-      await ctx.experienceInteraction.submit(log, { createTrustedDevice });
+      await ctx.experienceInteraction.submit(log);
 
       log.append({
         interaction: ctx.experienceInteraction.toJson(),
@@ -208,8 +204,20 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
     }),
     async (ctx, next) => {
       const { experienceInteraction } = ctx;
+      const trustedDevice = await trySafe(
+        async () =>
+          experienceInteraction.trustedDevice.getCreationAvailability(
+            experienceInteraction.identifiedUserId
+          ),
+        (error) => {
+          void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));
+        }
+      );
 
-      ctx.body = await experienceInteraction.toSanitizedJson();
+      ctx.body = {
+        ...experienceInteraction.toSanitizedJson(),
+        ...conditional(trustedDevice && { trustedDevice }),
+      };
       ctx.status = 200;
       return next();
     }

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -14,6 +14,7 @@ import { identificationApiPayloadGuard, InteractionEvent } from '@logto/schemas'
 import type Router from 'koa-router';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaInteractionDetails from '#src/middleware/koa-interaction-details.js';
@@ -169,6 +170,9 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
   experienceRouter.post(
     `${experienceRoutes.prefix}/submit`,
     koaGuard({
+      body: z.object({
+        createTrustedDevice: z.boolean().optional(),
+      }),
       status: [200, 400, 403, 404, 422],
       response: z
         .object({
@@ -178,10 +182,13 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
     }),
     async (ctx, next) => {
       const { createLog, experienceInteraction } = ctx;
+      const createTrustedDevice = EnvSet.values.isDevFeaturesEnabled
+        ? ctx.guard.body.createTrustedDevice
+        : undefined;
 
       const log = createLog(`Interaction.${experienceInteraction.interactionEvent}.Submit`);
 
-      await ctx.experienceInteraction.submit(log);
+      await ctx.experienceInteraction.submit(log, { createTrustedDevice });
 
       log.append({
         interaction: ctx.experienceInteraction.toJson(),
@@ -202,7 +209,7 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
     async (ctx, next) => {
       const { experienceInteraction } = ctx;
 
-      ctx.body = experienceInteraction.toSanitizedJson();
+      ctx.body = await experienceInteraction.toSanitizedJson();
       ctx.status = 200;
       return next();
     }

--- a/packages/core/src/routes/experience/profile-routes.openapi.json
+++ b/packages/core/src/routes/experience/profile-routes.openapi.json
@@ -162,6 +162,28 @@
         }
       }
     },
+    "/api/experience/profile/mfa/trusted-device": {
+      "post": {
+        "operationId": "RequestTrustedDeviceCreation",
+        "summary": "Request trusted device creation",
+        "description": "Record the user's explicit opt-in to trust the current device after eligible MFA verification or binding. The trusted-device credential is created only after the interaction is successfully submitted.",
+        "tags": ["Dev feature"],
+        "responses": {
+          "204": {
+            "description": "The trusted-device creation request has been recorded for the current interaction."
+          },
+          "400": {
+            "description": "Trusted-device creation is not supported for the current interaction event."
+          },
+          "403": {
+            "description": "An eligible MFA verification or binding is required before requesting trusted-device creation."
+          },
+          "404": {
+            "description": "The user has not been identified yet."
+          }
+        }
+      }
+    },
     "/api/experience/profile/mfa/mfa-suggestion-skipped": {
       "post": {
         "operationId": "SkipMfaSuggestion",

--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -12,6 +12,7 @@ import { type MiddlewareType } from 'koa';
 import type Router from 'koa-router';
 import { object, z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -270,6 +271,25 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
       return next();
     }
   );
+
+  // Trusted-device opt-in is under development. Keep the route out of released API surfaces.
+  if (EnvSet.values.isDevFeaturesEnabled) {
+    router.post(
+      `${experienceRoutes.mfa}/trusted-device`,
+      koaGuard({ status: [204, 400, 403, 404] }),
+      verifiedInteractionGuard(),
+      async (ctx, next) => {
+        const { experienceInteraction } = ctx;
+
+        await experienceInteraction.requestTrustedDeviceCreation();
+        await experienceInteraction.save();
+
+        ctx.status = 204;
+
+        return next();
+      }
+    );
+  }
 
   // Mark optional additional MFA binding suggestion as skipped.
   router.post(

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -6,6 +6,7 @@ import {
   secretEnterpriseSsoConnectorRelationPayloadGuard,
   secretSocialConnectorRelationPayloadGuard,
   type User,
+  TrustedDevices,
   Users,
   UserSsoIdentities,
   type UserSsoIdentity,
@@ -197,7 +198,9 @@ export type WithHooksAndLogsContext<ContextT extends WithLogContext = WithLogCon
 export type InteractionStorage = {
   interactionEvent: InteractionEvent;
   userId?: string;
-  createTrustedDevice?: boolean;
+  trustedDeviceCreation?: {
+    deviceId: string;
+  };
   trustedDeviceFulfillment?: {
     userId: string;
     trustedDeviceId: string;
@@ -216,7 +219,11 @@ export type InteractionStorage = {
 export const interactionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
-  createTrustedDevice: z.boolean().optional(),
+  trustedDeviceCreation: z
+    .object({
+      deviceId: TrustedDevices.guard.shape.id,
+    })
+    .optional(),
   trustedDeviceFulfillment: z
     .object({
       userId: z.string(),

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -237,6 +237,10 @@ export const interactionStorageGuard = z.object({
 export type SanitizedInteractionStorageData = {
   interactionEvent: InteractionEvent;
   userId?: string;
+  trustedDevice?: {
+    canCreate: boolean;
+    durationDays?: number;
+  };
   profile?: SanitizedInteractionProfile;
   verificationRecords?: SanitizedVerificationRecordData[];
   mfa?: SanitizedMfaData;
@@ -254,6 +258,12 @@ export type SanitizedInteractionStorageData = {
 export const sanitizedInteractionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
+  trustedDevice: z
+    .object({
+      canCreate: z.boolean(),
+      durationDays: z.number().optional(),
+    })
+    .optional(),
   profile: sanitizedInteractionProfileGuard,
   verificationRecords: publicVerificationRecordDataGuard.array().optional(),
   mfa: sanitizedMfaDataGuard.optional(),

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -197,6 +197,7 @@ export type WithHooksAndLogsContext<ContextT extends WithLogContext = WithLogCon
 export type InteractionStorage = {
   interactionEvent: InteractionEvent;
   userId?: string;
+  createTrustedDevice?: boolean;
   trustedDeviceFulfillment?: {
     userId: string;
     trustedDeviceId: string;
@@ -215,6 +216,7 @@ export type InteractionStorage = {
 export const interactionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
+  createTrustedDevice: z.boolean().optional(),
   trustedDeviceFulfillment: z
     .object({
       userId: z.string(),


### PR DESCRIPTION
## Summary
Add explicit trusted-device opt-in to the Experience submit API and expose effective creation availability in public interaction data. Create eligible credentials only after the complete interaction succeeds, update successful trusted-device usage metadata, and keep both post-submit operations best effort.

## Testing
Unit tests

Integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments