### PR TITLE
refactor(core): extract the cache invalidation generation guard

### DIFF
--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -1,7 +1,7 @@
-import { generateStandardShortId } from '@logto/shared';
 import { trySafe, type Optional } from '@silverhand/essentials';
 import { type ZodType } from 'zod';
 
+import { invalidateWithGeneration, snapshotGeneration, type GuardedKeys } from './generation.js';
 import { type CacheStore } from './types.js';
 import { cacheConsole } from './utils.js';
 
@@ -73,19 +73,11 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
 
   /**
    * Invalidate the cached value for the given type and key, after the mutation it reflects
-   * has been committed.
-   *
-   * The generation must be bumped before deleting, and both must be awaited: this guarantees
-   * that once this method resolves, in-flight reads that computed from pre-mutation state
-   * either fail the generation check in {@link memoize} or have their write-back removed by
-   * the deletion. Callers must therefore await it before returning to their own caller.
-   *
-   * Store errors are silently caught, as an invalidation failure degrades to staleness bounded
-   * by the value TTL rather than a failed mutation.
+   * has been committed. See {@link invalidateWithGeneration} for the ordering guarantee it
+   * provides, which requires callers to await it before returning to their own caller.
    */
   async invalidate(type: CacheKeyOf<CacheMapT>, key: string) {
-    await trySafe(this.bumpGeneration(type, key));
-    await trySafe(this.delete(type, key));
+    await invalidateWithGeneration(this.cacheStore, this.guardedKeys(type, key));
   }
 
   /**
@@ -171,25 +163,16 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
             return cachedValue;
           }
 
-          const generation = await kvCache.getGeneration(type, promiseKey);
-          const isInvalidated = async () =>
-            (await kvCache.getGeneration(type, promiseKey)) !== generation;
+          const writeBackIfFresh = await snapshotGeneration(
+            kvCache.cacheStore,
+            kvCache.guardedKeys(type, promiseKey)
+          );
 
           const value = await run.apply(this, args);
 
-          // Skip the write-back when an invalidation happened while `run` was in flight,
-          // since the result may be computed from pre-mutation state.
-          if (await isInvalidated()) {
-            return value;
-          }
-
-          await trySafe(kvCache.set(type, promiseKey, value, getExpiresIn?.(value)));
-
-          // Undo the write if an invalidation landed between the check and the write,
-          // so a stale value can never persist in the cache.
-          if (await isInvalidated()) {
-            await trySafe(kvCache.delete(type, promiseKey));
-          }
+          await writeBackIfFresh(async () =>
+            kvCache.set(type, promiseKey, value, getExpiresIn?.(value))
+          );
 
           return value;
         } finally {
@@ -207,51 +190,16 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
 
   abstract getValueGuard<Type extends CacheKeyOf<CacheMapT>>(type: Type): ZodType<CacheMapT[Type]>;
 
-  /**
-   * Get the current invalidation generation for the given type and key.
-   * Note: Store errors will be silently caught and result an `undefined` return.
-   *
-   * Bumped by every {@link invalidate} call; {@link memoize} compares snapshots of it
-   * to detect invalidations that raced with an in-flight read.
-   */
-  protected async getGeneration(type: CacheKeyOf<CacheMapT>, key: string) {
-    return trySafe(async () => this.cacheStore.get(this.generationKey(type, key)));
-  }
-
-  /**
-   * Bump the invalidation generation for the given type and key. See {@link getGeneration}.
-   *
-   * A short id suffices: the value is only ever compared against the immediately preceding
-   * one, so it needs to differ from a single known value rather than be globally unique.
-   *
-   * Best-effort by design: the store may drop writes while degraded (unlike deletions), in
-   * which case staleness is bounded by the value TTL, as it was before generations existed.
-   */
-  protected async bumpGeneration(type: CacheKeyOf<CacheMapT>, key: string) {
-    return this.cacheStore.set(this.generationKey(type, key), generateStandardShortId());
-  }
-
-  protected generationKey(type: CacheKeyOf<CacheMapT>, key: string) {
-    // The marker owns a controlled segment so free-form keys (e.g. arbitrary resource
-    // indicators) can never collide with it.
-    return `${this.tenantId}:generation:${type}:${key}`;
+  protected guardedKeys(type: CacheKeyOf<CacheMapT>, key: string): GuardedKeys {
+    return {
+      value: this.cacheKey(type, key),
+      // The marker owns a controlled segment so free-form keys (e.g. arbitrary resource
+      // indicators) can never collide with it.
+      generation: `${this.tenantId}:generation:${type}:${key}`,
+    };
   }
 
   protected cacheKey(type: CacheKeyOf<CacheMapT>, key: string) {
     return `${this.tenantId}:${type}:${key}`;
-  }
-
-  /**
-   * Delete value from the inner cache store for the given type and key.
-   *
-   * Note this is a plain deletion: unlike {@link invalidate}, it does not bump the invalidation
-   * generation, so an in-flight {@link memoize} read may still write its result back afterwards.
-   * Invalidating after a mutation requires {@link invalidate} or {@link mutate}.
-   *
-   * {@link memoize} intentionally uses it to undo its own write-back: bumping the generation
-   * there would make other in-flight reads discard results that are not stale.
-   */
-  private async delete(type: CacheKeyOf<CacheMapT>, key: string) {
-    return this.cacheStore.delete(this.cacheKey(type, key));
   }
 }

--- a/packages/core/src/caches/base-cache.ts
+++ b/packages/core/src/caches/base-cache.ts
@@ -117,9 +117,10 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
    * will be also cached, which means there will be only one execution at a time.
    *
    * Results computed before an invalidation (see {@link invalidate}) are discarded instead of
-   * written back, so stale data can never persist in the cache after an invalidation
-   * returns. (A caller that joined an already in-flight execution may still receive
-   * pre-invalidation data once; it is never written back.)
+   * written back, so stale data does not persist in the cache after an invalidation returns,
+   * within the bounds documented on {@link invalidateWithGeneration}. (A caller that joined an
+   * already in-flight execution may still receive pre-invalidation data once; it is never
+   * written back.)
    *
    * @param run The function to memoize.
    * @param config The object to determine how cache key will be built. See {@link CacheKeyConfig} for details.
@@ -169,10 +170,10 @@ export abstract class BaseCache<CacheMapT extends Record<string, unknown>> {
           );
 
           const value = await run.apply(this, args);
+          // Resolved outside the write-back, which swallows what it throws.
+          const expiresIn = getExpiresIn?.(value);
 
-          await writeBackIfFresh(async () =>
-            kvCache.set(type, promiseKey, value, getExpiresIn?.(value))
-          );
+          await writeBackIfFresh(async () => kvCache.set(type, promiseKey, value, expiresIn));
 
           return value;
         } finally {

--- a/packages/core/src/caches/generation.test.ts
+++ b/packages/core/src/caches/generation.test.ts
@@ -5,6 +5,30 @@ import { invalidateWithGeneration, snapshotGeneration, type GuardedKeys } from '
 const keys: GuardedKeys = { value: 'value', generation: 'generation' };
 const createStore = () => new TtlCache<string, string>(60_000);
 
+/**
+ * Records the write operations in the order they were issued, so the tests can pin the
+ * ordering the guard rests on rather than just its end state.
+ */
+const createRecordingStore = () => {
+  const store = createStore();
+  const operations: string[] = [];
+
+  return {
+    operations,
+    get: async (key: string) => store.get(key),
+    set: async (key: string, value: string) => {
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+      operations.push(`set:${key}`);
+      store.set(key, value);
+    },
+    delete: async (key: string) => {
+      // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+      operations.push(`delete:${key}`);
+      store.delete(key);
+    },
+  };
+};
+
 describe('invalidateWithGeneration()', () => {
   it('should drop the cached value', async () => {
     const store = createStore();
@@ -13,6 +37,14 @@ describe('invalidateWithGeneration()', () => {
     await invalidateWithGeneration(store, keys);
 
     expect(store.get(keys.value)).toBeUndefined();
+  });
+
+  it('should bump the generation before dropping the value', async () => {
+    const store = createRecordingStore();
+
+    await invalidateWithGeneration(store, keys);
+
+    expect(store.operations).toStrictEqual([`set:${keys.generation}`, `delete:${keys.value}`]);
   });
 });
 
@@ -50,6 +82,27 @@ describe('snapshotGeneration()', () => {
     });
 
     expect(store.get(keys.value)).toBeUndefined();
+  });
+
+  it('should undo with a plain deletion, leaving the generation untouched', async () => {
+    const store = createRecordingStore();
+    const writeBackIfFresh = await snapshotGeneration(store, keys);
+
+    await writeBackIfFresh(async () => {
+      await invalidateWithGeneration(store, keys);
+      await store.set(keys.value, 'stale');
+    });
+
+    /**
+     * Only the invalidation inside the write-back may bump the generation; a bump from the undo
+     * itself would make other in-flight reads discard results that are not stale.
+     */
+    expect(store.operations).toStrictEqual([
+      `set:${keys.generation}`,
+      `delete:${keys.value}`,
+      `set:${keys.value}`,
+      `delete:${keys.value}`,
+    ]);
   });
 
   it('should keep guarding across consecutive invalidations', async () => {

--- a/packages/core/src/caches/generation.test.ts
+++ b/packages/core/src/caches/generation.test.ts
@@ -1,0 +1,67 @@
+import { TtlCache } from '@logto/shared';
+
+import { invalidateWithGeneration, snapshotGeneration, type GuardedKeys } from './generation.js';
+
+const keys: GuardedKeys = { value: 'value', generation: 'generation' };
+const createStore = () => new TtlCache<string, string>(60_000);
+
+describe('invalidateWithGeneration()', () => {
+  it('should drop the cached value', async () => {
+    const store = createStore();
+    store.set(keys.value, 'cached');
+
+    await invalidateWithGeneration(store, keys);
+
+    expect(store.get(keys.value)).toBeUndefined();
+  });
+});
+
+describe('snapshotGeneration()', () => {
+  it('should write back when no invalidation happened', async () => {
+    const store = createStore();
+    const writeBackIfFresh = await snapshotGeneration(store, keys);
+
+    await writeBackIfFresh(async () => {
+      store.set(keys.value, 'fresh');
+    });
+
+    expect(store.get(keys.value)).toBe('fresh');
+  });
+
+  it('should skip the write back when an invalidation landed while the value was computed', async () => {
+    const store = createStore();
+    const writeBackIfFresh = await snapshotGeneration(store, keys);
+
+    await invalidateWithGeneration(store, keys);
+    await writeBackIfFresh(async () => {
+      store.set(keys.value, 'stale');
+    });
+
+    expect(store.get(keys.value)).toBeUndefined();
+  });
+
+  it('should undo the write back when an invalidation lands between the check and the write', async () => {
+    const store = createStore();
+    const writeBackIfFresh = await snapshotGeneration(store, keys);
+
+    await writeBackIfFresh(async () => {
+      await invalidateWithGeneration(store, keys);
+      store.set(keys.value, 'stale');
+    });
+
+    expect(store.get(keys.value)).toBeUndefined();
+  });
+
+  it('should keep guarding across consecutive invalidations', async () => {
+    const store = createStore();
+    await invalidateWithGeneration(store, keys);
+
+    const writeBackIfFresh = await snapshotGeneration(store, keys);
+    await invalidateWithGeneration(store, keys);
+    await writeBackIfFresh(async () => {
+      store.set(keys.value, 'stale');
+    });
+
+    expect(store.get(keys.value)).toBeUndefined();
+  });
+});

--- a/packages/core/src/caches/generation.ts
+++ b/packages/core/src/caches/generation.ts
@@ -7,9 +7,9 @@ import { type CacheStore } from './types.js';
  * The pair of store keys a guarded cache entry occupies: the value itself, and the marker
  * tracking the invalidations it has been through.
  *
- * The two keys must never collide, so whoever builds them has to reserve a controlled segment
- * for the generation marker: free-form keys (a resource indicator, a hostname) would otherwise
- * be able to spell one out.
+ * The two keyspaces must be disjoint by construction, since the free-form part of a key (a
+ * resource indicator, a hostname) is not ours to constrain: either give the marker its own
+ * prefix, or place its segment ahead of everything free-form.
  */
 export type GuardedKeys = {
   value: string;
@@ -27,17 +27,23 @@ const readGeneration = async (store: CacheStore, keys: GuardedKeys) =>
 /**
  * Invalidate a guarded cache entry, after the mutation it reflects has been committed.
  *
- * The generation must be bumped before deleting, and both must be awaited: this guarantees
- * that once this function resolves, in-flight reads that computed from pre-mutation state
- * either fail the check in {@link snapshotGeneration} or have their write-back removed by the
- * deletion. Callers must therefore await it before returning to their own caller.
+ * The generation must be bumped before deleting, and both must be awaited: once this function
+ * resolves, in-flight reads that computed from pre-mutation state either fail the check in
+ * {@link snapshotGeneration} or have their write-back removed by the deletion. Callers must
+ * therefore await it before returning to their own caller.
+ *
+ * That holds while the store answers from one authoritative view and applies commands in the
+ * order they were issued, which is what a single Redis instance gives us. Three ways it
+ * degrades, all of which cap staleness at the value TTL rather than leaving it unbounded:
+ * store errors are silently caught here; a generation read served by a lagging replica (the
+ * cluster client enables `useReplicas`) can miss a bump that already landed on the primary;
+ * and a command that timed out client-side is not cancelled, so a write-back that appeared to
+ * fail may still land after this resolved. Closing the last two needs a server-side atomic
+ * guard (both keys in one slot, compared and written in a single primary-side operation).
  *
  * A short id suffices as the generation value: it is only ever compared against the
  * immediately preceding one, so it needs to differ from a single known value rather than be
  * globally unique.
- *
- * Store errors are silently caught, as a failed invalidation degrades to staleness bounded by
- * the value TTL rather than a failed mutation.
  */
 export const invalidateWithGeneration = async (store: CacheStore, keys: GuardedKeys) => {
   await trySafe(async () => store.set(keys.generation, generateStandardShortId()));
@@ -53,11 +59,15 @@ export const invalidateWithGeneration = async (store: CacheStore, keys: GuardedK
  * not to cache its result (a miss it does not want to remember, say) simply never calls it.
  *
  * That undo is a plain deletion rather than a full {@link invalidateWithGeneration}: bumping
- * the generation here would make other in-flight reads discard results that are not stale.
+ * the generation here would make other in-flight reads discard results that are not stale. It
+ * removes whatever the key holds, which may be a fresher value written by a reader that started
+ * after the invalidation — one extra miss, never staleness.
  *
- * Guarding is best-effort in one direction only: the store may drop the generation write while
- * degraded (unlike deletions), in which case staleness stays bounded by the value TTL, as it
- * was before generations existed. It never reports a spurious invalidation.
+ * Guarding is best-effort, and its two failure directions are not symmetric. A dropped
+ * generation write leaves staleness bounded by the value TTL, as it was before generations
+ * existed. A generation read that fails, times out, or lands on a lagging replica can instead
+ * report an invalidation that never happened, since {@link readGeneration} cannot tell that
+ * apart from an absent marker; that costs at most a skipped or undone write-back.
  */
 export const snapshotGeneration = async (store: CacheStore, keys: GuardedKeys) => {
   const generation = await readGeneration(store, keys);

--- a/packages/core/src/caches/generation.ts
+++ b/packages/core/src/caches/generation.ts
@@ -1,0 +1,77 @@
+import { generateStandardShortId } from '@logto/shared';
+import { trySafe } from '@silverhand/essentials';
+
+import { type CacheStore } from './types.js';
+
+/**
+ * The pair of store keys a guarded cache entry occupies: the value itself, and the marker
+ * tracking the invalidations it has been through.
+ *
+ * The two keys must never collide, so whoever builds them has to reserve a controlled segment
+ * for the generation marker: free-form keys (a resource indicator, a hostname) would otherwise
+ * be able to spell one out.
+ */
+export type GuardedKeys = {
+  value: string;
+  generation: string;
+};
+
+/**
+ * Read the current invalidation generation. Store errors are silently caught and read as
+ * `undefined`, which compares equal to another failed read: a store that cannot answer must
+ * not be taken as evidence that an invalidation happened.
+ */
+const readGeneration = async (store: CacheStore, keys: GuardedKeys) =>
+  trySafe(async () => store.get(keys.generation));
+
+/**
+ * Invalidate a guarded cache entry, after the mutation it reflects has been committed.
+ *
+ * The generation must be bumped before deleting, and both must be awaited: this guarantees
+ * that once this function resolves, in-flight reads that computed from pre-mutation state
+ * either fail the check in {@link snapshotGeneration} or have their write-back removed by the
+ * deletion. Callers must therefore await it before returning to their own caller.
+ *
+ * A short id suffices as the generation value: it is only ever compared against the
+ * immediately preceding one, so it needs to differ from a single known value rather than be
+ * globally unique.
+ *
+ * Store errors are silently caught, as a failed invalidation degrades to staleness bounded by
+ * the value TTL rather than a failed mutation.
+ */
+export const invalidateWithGeneration = async (store: CacheStore, keys: GuardedKeys) => {
+  await trySafe(async () => store.set(keys.generation, generateStandardShortId()));
+  await trySafe(async () => store.delete(keys.value));
+};
+
+/**
+ * Snapshot the invalidation generation before computing a value, and return the write-back to
+ * run once it has been computed.
+ *
+ * The returned function performs the write only if no invalidation landed since the snapshot,
+ * and undoes it if one lands between that check and the write itself. A caller that decides
+ * not to cache its result (a miss it does not want to remember, say) simply never calls it.
+ *
+ * That undo is a plain deletion rather than a full {@link invalidateWithGeneration}: bumping
+ * the generation here would make other in-flight reads discard results that are not stale.
+ *
+ * Guarding is best-effort in one direction only: the store may drop the generation write while
+ * degraded (unlike deletions), in which case staleness stays bounded by the value TTL, as it
+ * was before generations existed. It never reports a spurious invalidation.
+ */
+export const snapshotGeneration = async (store: CacheStore, keys: GuardedKeys) => {
+  const generation = await readGeneration(store, keys);
+  const isInvalidated = async () => (await readGeneration(store, keys)) !== generation;
+
+  return async (writeBack: () => Promise<unknown>) => {
+    if (await isInvalidated()) {
+      return;
+    }
+
+    await trySafe(writeBack);
+
+    if (await isInvalidated()) {
+      await trySafe(async () => store.delete(keys.value));
+    }
+  };
+};

--- a/packages/core/src/utils/tenant.ts
+++ b/packages/core/src/utils/tenant.ts
@@ -1,8 +1,13 @@
 import { adminTenantId, defaultTenantId } from '@logto/schemas';
-import { generateStandardShortId, type UrlSet } from '@logto/shared';
+import { type UrlSet } from '@logto/shared';
 import { conditionalString, trySafe } from '@silverhand/essentials';
 import { type CommonQueryMethods } from '@silverhand/slonik';
 
+import {
+  invalidateWithGeneration,
+  snapshotGeneration,
+  type GuardedKeys,
+} from '#src/caches/generation.js';
 import { redisCache } from '#src/caches/index.js';
 import { EnvSet, getTenantEndpoint } from '#src/env-set/index.js';
 import { createDomainsQueries } from '#src/queries/domains.js';
@@ -46,35 +51,28 @@ const matchPathBasedTenantId = (urlSet: UrlSet, url: URL) => {
   return urlSegments[found.pathname === '/' ? 1 : endpointSegments.length];
 };
 
-const getHostname = (url: URL | string) => (typeof url === 'string' ? url : url.hostname);
-const getDomainCacheKey = (url: URL | string) => `custom-domain:${getHostname(url)}`;
 /**
  * The marker gets its own prefix rather than a segment inside the value keyspace: the two
  * prefixes diverge before the hostname is appended, so no hostname — whatever the `domains`
  * column happens to hold — can spell a key belonging to the other.
  */
-const getDomainGenerationKey = (url: URL | string) =>
-  `custom-domain-generation:${getHostname(url)}`;
+const getDomainKeys = (url: URL | string): GuardedKeys => {
+  const hostname = typeof url === 'string' ? url : url.hostname;
+
+  return {
+    value: `custom-domain:${hostname}`,
+    generation: `custom-domain-generation:${hostname}`,
+  };
+};
 
 /**
  * Invalidate the cached mapping for the given custom domain after the mutation it reflects
- * has been committed.
- *
- * The generation must be bumped before deleting, and both must be awaited: an in-flight
- * {@link getTenantIdFromCustomDomain} lookup that read pre-mutation state then either skips its
- * write-back or has it removed by the deletion. Callers must therefore await it before returning
- * to their own caller. (The same guard as `BaseCache`, which this cache cannot build on since it
- * is cross-tenant.)
- *
- * The guarantee is bounded by what the store can promise, and every way it degrades caps
- * staleness at the value TTL rather than leaving it unbounded: store errors are silently caught,
- * a read served by a lagging replica (the cluster client enables `useReplicas`) can observe a
- * pre-bump generation, and a command that timed out client-side is not cancelled, so it may land
- * after this resolved.
+ * has been committed. See {@link invalidateWithGeneration} for the ordering guarantee it
+ * provides and the bounds it comes with, and note it requires callers to await it before
+ * returning to their own caller.
  */
 export const clearCustomDomainCache = async (url: URL | string) => {
-  await trySafe(async () => redisCache.set(getDomainGenerationKey(url), generateStandardShortId()));
-  await trySafe(async () => redisCache.delete(getDomainCacheKey(url)));
+  await invalidateWithGeneration(redisCache, getDomainKeys(url));
 };
 
 /**
@@ -84,48 +82,31 @@ const getTenantIdFromCustomDomain = async (
   url: URL,
   pool: CommonQueryMethods
 ): Promise<string | undefined> => {
+  const keys = getDomainKeys(url);
   /**
    * The snapshot only has to be taken before the database read starts, so it rides along with
    * the value read instead of costing a second round trip on a path that runs per request.
    * Snapshotting earlier observes a superset of the invalidations it otherwise would.
    */
-  const [cachedValue, generation] = await Promise.all([
-    trySafe(async () => redisCache.get(getDomainCacheKey(url))),
-    trySafe(async () => redisCache.get(getDomainGenerationKey(url))),
+  const [cachedValue, writeBackIfFresh] = await Promise.all([
+    trySafe(async () => redisCache.get(keys.value)),
+    snapshotGeneration(redisCache, keys),
   ]);
 
   if (cachedValue) {
     return cachedValue;
   }
 
-  const isInvalidated = async () =>
-    (await trySafe(async () => redisCache.get(getDomainGenerationKey(url)))) !== generation;
-
   const { findActiveDomain } = createDomainsQueries(pool);
 
   const domain = await findActiveDomain(url.hostname);
 
+  // A missing mapping is left uncached, so probes for unknown hostnames cannot fill the store.
   if (!domain?.tenantId) {
     return;
   }
 
-  /**
-   * Skip the write-back when an invalidation happened while the database read was in flight,
-   * since the mapping may reflect pre-mutation state.
-   */
-  if (await isInvalidated()) {
-    return domain.tenantId;
-  }
-
-  await trySafe(async () => redisCache.set(getDomainCacheKey(url), domain.tenantId));
-
-  /**
-   * Undo the write if an invalidation landed between the check and the write, so a stale
-   * mapping can never persist after {@link clearCustomDomainCache} resolves.
-   */
-  if (await isInvalidated()) {
-    await trySafe(async () => redisCache.delete(getDomainCacheKey(url)));
-  }
+  await writeBackIfFresh(async () => redisCache.set(keys.value, domain.tenantId));
 
   return domain.tenantId;
 };


### PR DESCRIPTION
## Summary

Extract the invalidation generation guard shared by `BaseCache` and the custom domain cache into `caches/generation.ts`, so the ordering it depends on has a single home.

- Stacked on #9434. Both caches carried their own copy of the same protocol — bump the generation before deleting, snapshot it before computing, skip or undo the write-back if it moved — down to near-identical comments explaining why each step is ordered that way. Duplicating a proof is how it drifts.
- `snapshotGeneration()` returns the write-back to run once the value is computed, so call sites keep their read linear, and a caller that does not want to cache its result (the custom domain lookup, on a miss) simply never calls it.
- Key formats are byte-identical on both sides, so no stored entry is invalidated by this change.
- `BaseCache.delete()` is dropped — no caller was left once both paths moved to the shared module.
- `getExpiresIn` is resolved before the write-back closure rather than inside it, keeping a throw from it visible instead of swallowed by the closure's `trySafe`.

The module documents what the guard actually promises rather than an absolute guarantee: it holds while the store answers from one authoritative view and applies commands in issue order, and degrades — capped at the value TTL — under lagging replica reads (`useReplicas` is enabled on the cluster client), uncancelled commands that land after a client-side timeout, and dropped generation writes. A generation read that fails or is stale can also report an invalidation that never happened, costing a skipped write-back rather than staleness. Closing the first two needs a server-side atomic guard (both keys in one slot, compared and written primary-side); that belongs in its own change now that there is one place to put it.

Tests pin the two properties the design rests on, neither of which any existing suite could detect: bump-before-delete ordering, and the undo being a plain deletion that leaves the generation untouched. Both were verified red by mutating the implementation.

## Testing

unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments