### PR TITLE
refactor(core): drop the per-tenant JWT customizer worker deployment

### DIFF
--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -177,7 +177,9 @@ describe('JwtCustomizerLibrary.runScriptRemotely quota', () => {
 
     jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue('');
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
-    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('function-key');
+    jest
+      .spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get')
+      .mockReturnValue('function-key');
     getSubscriptionData.mockResolvedValueOnce({ quota: { customJwtEnabled: false } });
 
     await expect(library.runScriptRemotely(payload)).resolves.toBeUndefined();

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -9,7 +9,6 @@ import { isAccessDeniedError, parseCustomJwtResponseError } from '#src/utils/cus
 
 import type { CloudConnectionLibrary } from './cloud-connection.js';
 import { JwtCustomizerLibrary } from './jwt-customizer.js';
-import type { LogtoConfigLibrary } from './logto-config.js';
 import type { ScopeLibrary } from './scope.js';
 import type { SubscriptionLibrary } from './subscription.js';
 import type { UserLibrary } from './user.js';
@@ -32,7 +31,6 @@ const createLibrary = (tenantId = 'test-tenant') =>
   new JwtCustomizerLibrary(
     tenantId,
     {} as Queries,
-    {} as LogtoConfigLibrary,
     cloudConnection,
     { getSubscriptionData } as unknown as SubscriptionLibrary,
     {} as UserLibrary,

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -172,9 +172,9 @@ describe('JwtCustomizerLibrary.runScriptRemotely quota', () => {
   });
 });
 
-describe('JwtCustomizerLibrary.runScriptRemotely on the legacy remote paths', () => {
+describe('JwtCustomizerLibrary.runScriptRemotely on the Azure Functions fallback', () => {
   beforeEach(() => {
-    // An unset script runner endpoint is what selects the legacy remote paths.
+    // An unset script runner endpoint is what selects the Azure Functions runtime.
     jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue('');
   });
 
@@ -184,7 +184,7 @@ describe('JwtCustomizerLibrary.runScriptRemotely on the legacy remote paths', ()
     jest.clearAllMocks();
   });
 
-  it('runs the script through the regional untrusted Azure Function app when configured', async () => {
+  it('runs the script through the regional untrusted Azure Function app', async () => {
     const endpoint = 'https://untrusted.example.com';
     const functionKey = 'function-key';
     const remoteRunner = nock(endpoint, {
@@ -202,16 +202,11 @@ describe('JwtCustomizerLibrary.runScriptRemotely on the legacy remote paths', ()
     expect(post).not.toHaveBeenCalled();
   });
 
-  it('falls back to the deprecated custom-jwt cloud endpoint', async () => {
+  it('reports a 422 when neither runtime is configured', async () => {
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
     jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
-    post.mockResolvedValueOnce({ foo: 'bar' });
 
-    await expect(library.runScriptRemotely(payload, true)).resolves.toEqual({ foo: 'bar' });
-    expect(post).toHaveBeenCalledWith('/api/services/custom-jwt', {
-      body: payload,
-      search: { isTest: 'true' },
-    });
+    await expect(library.runScriptRemotely(payload)).rejects.toMatchObject({ status: 422 });
     expect(getWorkerAccessToken).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -170,6 +170,28 @@ describe('JwtCustomizerLibrary.runScriptRemotely quota', () => {
     await expect(adminLibrary.runScriptRemotely(payload)).resolves.toEqual({ foo: 'bar' });
     expect(getSubscriptionData).not.toHaveBeenCalled();
   });
+
+  it('skips the Azure Functions fallback when the plan does not include custom JWT', async () => {
+    const endpoint = 'https://untrusted.example.com';
+    const remoteRunner = nock(endpoint).post('/api/custom-jwt').reply(200, { foo: 'bar' });
+
+    jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue('');
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('function-key');
+    getSubscriptionData.mockResolvedValueOnce({ quota: { customJwtEnabled: false } });
+
+    await expect(library.runScriptRemotely(payload)).resolves.toBeUndefined();
+    expect(remoteRunner.isDone()).toBe(false);
+  });
+
+  it('does not throw 422 for a downgraded tenant when neither runtime is configured', async () => {
+    jest.spyOn(EnvSet.values, 'scriptRunnerEndpoint', 'get').mockReturnValue('');
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
+    getSubscriptionData.mockResolvedValueOnce({ quota: { customJwtEnabled: false } });
+
+    await expect(library.runScriptRemotely(payload)).resolves.toBeUndefined();
+  });
 });
 
 describe('JwtCustomizerLibrary.runScriptRemotely on the Azure Functions fallback', () => {

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -214,19 +214,6 @@ export class JwtCustomizerLibrary {
     isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
     /**
-     * The Azure Functions runtime is kept as a per-region fallback rather than retired: on a
-     * region whose untrusted function app is configured, a script runner outage is routed around
-     * by unsetting `SCRIPT_RUNNER_ENDPOINT` there, with no code change and no coordinated
-     * rollback. Where that app is not configured this runtime throws a 422, matching what
-     * `ActionLibrary` already does.
-     */
-    const { scriptRunnerEndpoint } = EnvSet.values;
-
-    if (!scriptRunnerEndpoint) {
-      return this.runScriptOnAzureFunction(payload);
-    }
-
-    /**
      * The plan quota is enforced here rather than left to the transport: the runner only verifies
      * audience and scope, so without this check the script of a downgraded tenant would keep
      * running and injecting its claims into every issued token.
@@ -238,9 +225,26 @@ export class JwtCustomizerLibrary {
      * `ActionLibrary.runAction` does for its own quota check: a plan downgrade must not break
      * token issuance. The caller reads this as "no custom claims", so a customizer configured
      * with `blockIssuanceOnError` still gets its token — the quota is not a script error.
+     *
+     * Checked before runtime selection so a downgraded tenant never reaches Azure Functions
+     * either: that path throws a 422 when the function app is unset, which would otherwise
+     * break issuance when `blockIssuanceOnError` is on.
      */
     if (!(await this.isCustomJwtEnabledByQuota())) {
       return;
+    }
+
+    /**
+     * The Azure Functions runtime is kept as a per-region fallback rather than retired: on a
+     * region whose untrusted function app is configured, a script runner outage is routed around
+     * by unsetting `SCRIPT_RUNNER_ENDPOINT` there, with no code change and no coordinated
+     * rollback. Where that app is not configured this runtime throws a 422, matching what
+     * `ActionLibrary` already does.
+     */
+    const { scriptRunnerEndpoint } = EnvSet.values;
+
+    if (!scriptRunnerEndpoint) {
+      return this.runScriptOnAzureFunction(payload);
     }
 
     /**

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- The legacy remote paths coexist with the script-runner adapters until LOG-13957 removes the per-tenant worker lifecycle. */
 import {
   adminTenantId,
   type CustomJwtErrorBody,
@@ -215,17 +214,16 @@ export class JwtCustomizerLibrary {
     isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
     /**
-     * The legacy runtimes are kept as a per-region fallback rather than retired: a script runner
-     * outage is then routed around by unsetting `SCRIPT_RUNNER_ENDPOINT` on that region's core,
-     * with no code change and no coordinated rollback.
-     *
-     * A region where the endpoint is not injected yet therefore keeps running on the legacy
-     * runtimes instead of failing.
+     * The Azure Functions runtime is kept as a per-region fallback rather than retired: on a
+     * region whose untrusted function app is configured, a script runner outage is routed around
+     * by unsetting `SCRIPT_RUNNER_ENDPOINT` there, with no code change and no coordinated
+     * rollback. Where that app is not configured this runtime throws a 422, matching what
+     * `ActionLibrary` already does.
      */
     const { scriptRunnerEndpoint } = EnvSet.values;
 
     if (!scriptRunnerEndpoint) {
-      return this.runScriptOnLegacyRuntime(payload, isTest);
+      return this.runScriptOnAzureFunction(payload);
     }
 
     /**
@@ -274,49 +272,45 @@ export class JwtCustomizerLibrary {
   }
 
   /**
-   * The legacy remote paths, kept as the per-region fallback for the Cloud script runner:
-   * the regional untrusted Azure Function app where configured, otherwise the deprecated
-   * `POST /api/services/custom-jwt` cloud endpoint.
+   * The Azure Functions runtime, kept as the per-region fallback for the Cloud script runner.
    *
-   * Selected whenever `SCRIPT_RUNNER_ENDPOINT` is unset. `isTest` is not forwarded to the function
-   * app: that runtime has no notion of a dry run, and nothing is lost by it — vm2 builds a fresh
-   * VM per call, so a test run can never share state with production the way a warm isolate could.
+   * Selected whenever `SCRIPT_RUNNER_ENDPOINT` is unset. `isTest` is deliberately not forwarded:
+   * this runtime has no notion of a dry run, and nothing is lost by it — vm2 builds a fresh VM per
+   * call, so a test run can never share state with production the way a warm isolate could.
    */
-  private async runScriptOnLegacyRuntime(
-    payload: CustomJwtFetcher,
-    isTest?: boolean
+  private async runScriptOnAzureFunction(
+    payload: CustomJwtFetcher
   ): Promise<Optional<UnknownObject>> {
     const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
 
-    if (this.isRegionalAzureFunctionAppConfigured) {
-      try {
-        const result = await got
-          .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
-            json: payload,
-            headers: {
-              'x-functions-key': azureFunctionUntrustedAppKey,
-            },
-          })
-          .json<unknown>();
-
-        const parsedResult = jsonObjectGuard.parse(result);
-        return parsedResult;
-      } catch (error: unknown) {
-        // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
-        if (error instanceof HTTPError) {
-          throw parseAzureFunctionsResponseError(error);
-        }
-
-        throw error;
-      }
+    /**
+     * Neither runtime is reachable. Named explicitly rather than left to `new URL()` throwing an
+     * opaque `Invalid URL`, since this misconfiguration reaches the RP as an `error_description`
+     * when the customizer sets `blockIssuanceOnError`.
+     */
+    if (!this.isRegionalAzureFunctionAppConfigured) {
+      throw new ScriptExecutionError({ message: 'Remote script runner is not configured.' }, 422);
     }
 
-    // Fallback to use cloud connection to call the custom JWT API.
-    const client = await this.cloudConnection.getClient();
-    return client.post(`/api/services/custom-jwt`, {
-      body: payload,
-      search: isTest ? { isTest: 'true' } : {},
-    });
+    try {
+      const result = await got
+        .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
+          json: payload,
+          headers: {
+            'x-functions-key': azureFunctionUntrustedAppKey,
+          },
+        })
+        .json<unknown>();
+
+      return jsonObjectGuard.parse(result);
+    } catch (error: unknown) {
+      // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
+      if (error instanceof HTTPError) {
+        throw parseAzureFunctionsResponseError(error);
+      }
+
+      throw error;
+    }
   }
 
   /**
@@ -347,5 +341,3 @@ export class JwtCustomizerLibrary {
     return result.value;
   }
 }
-
-/* eslint-enable max-lines */

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -6,43 +6,26 @@ import {
   jwtCustomizerUserContextGuard,
   userInfoSelectFields,
   type CustomJwtFetcher,
-  type JwtCustomizerType,
   type JwtCustomizerUserContext,
   type JwtCustomizerApplicationContext,
   type JwtCustomizerOrganizationContext,
   jwtCustomizerOrganizationContextGuard,
-  type LogtoJwtTokenKey,
   type CustomJwtScriptPayload,
   jsonObjectGuard,
   isBuiltInApplicationId,
   buildBuiltInApplicationDataForTenant,
 } from '@logto/schemas';
-import { type ConsoleLog } from '@logto/shared';
-import {
-  assert,
-  deduplicate,
-  type Optional,
-  pick,
-  pickState,
-  trySafe,
-} from '@silverhand/essentials';
-import deepmerge from 'deepmerge';
+import { deduplicate, type Optional, pick, pickState, trySafe } from '@silverhand/essentials';
 import { got, HTTPError } from 'got';
 import { type UnknownObject } from 'oidc-provider';
 import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
-import RequestError from '#src/errors/RequestError/index.js';
-import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import { type ScopeLibrary } from '#src/libraries/scope.js';
 import { type SubscriptionLibrary } from '#src/libraries/subscription.js';
 import { type UserLibrary } from '#src/libraries/user.js';
 import type Queries from '#src/tenants/Queries.js';
-import {
-  getJwtCustomizerScripts,
-  type CustomJwtDeployRequestBody,
-  parseAzureFunctionsResponseError,
-} from '#src/utils/custom-jwt/index.js';
+import { parseAzureFunctionsResponseError } from '#src/utils/custom-jwt/index.js';
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
 import {
@@ -124,7 +107,6 @@ export class JwtCustomizerLibrary {
   constructor(
     private readonly tenantId: string,
     private readonly queries: Queries,
-    private readonly logtoConfigs: LogtoConfigLibrary,
     private readonly cloudConnection: CloudConnectionLibrary,
     private readonly subscription: SubscriptionLibrary,
     private readonly userLibrary: UserLibrary,
@@ -218,120 +200,6 @@ export class JwtCustomizerLibrary {
     }
 
     return jwtCustomizerOrganizationContextGuard.parse(organization);
-  }
-
-  /**
-   * This method is used to deploy the give JWT customizer scripts to the cloud worker service.
-   *
-   * @remarks Since cloud worker service deploy all the JWT customizer scripts at once,
-   * and the latest JWT customizer updates needs to be deployed ahead before saving it to the database,
-   * we need to merge the input payload with the existing JWT customizer scripts.
-   *
-   * @params payload - The latest JWT customizer payload needs to be deployed.
-   * @params payload.key - The tokenType of the JWT customizer.
-   * @params payload.value - JWT customizer value
-   * @params payload.useCase - The use case of JWT customizer script, can be either `test` or `production`.
-   *
-   * @remarks
-   * Deliberately left outside the `SCRIPT_RUNNER_ENDPOINT` selection that {@link runScriptRemotely}
-   * makes, so this and {@link undeployJwtCustomizerScript} keep the worker service in sync for a
-   * region still on the legacy `POST /api/services/custom-jwt` path. The cost is real and accepted:
-   * where the endpoint is set, every save, delete and Console "test" still pays a deploy whose
-   * result the script run no longer reads. Both come out with the per-tenant worker lifecycle in
-   * LOG-13957.
-   */
-  async deployJwtCustomizerScript<T extends LogtoJwtTokenKey>(
-    consoleLog: ConsoleLog,
-    payload: {
-      key: T;
-      value: JwtCustomizerType[T];
-      useCase: 'test' | 'production';
-    }
-  ) {
-    if (!EnvSet.values.isCloud) {
-      consoleLog.warn(
-        'Early terminate `deployJwtCustomizerScript` since we do not provide dedicated computing resource for OSS version.'
-      );
-      return;
-    }
-
-    if (this.isRegionalAzureFunctionAppConfigured) {
-      consoleLog.info(
-        'Skipping Cloudflare Workers deployment since regional Azure Function App is configured.'
-      );
-      return;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment, @typescript-eslint/prefer-ts-expect-error
-    // @ts-ignore TS2589: caused by router type growth from @logto/cloud
-    const [client, jwtCustomizers] = await Promise.all([
-      this.cloudConnection.getClient(),
-      this.logtoConfigs.getJwtCustomizers(consoleLog),
-    ]);
-
-    const customizerScriptsFromDatabase = getJwtCustomizerScripts(jwtCustomizers);
-
-    const newCustomizerScripts: CustomJwtDeployRequestBody = {
-      /**
-       * There are at most 4 custom JWT scripts in the `CustomJwtDeployRequestBody`-typed object,
-       * and can be indexed by `data[CustomJwtType][UseCase]`.
-       *
-       * Per our design, each script will be deployed as a API endpoint in the Cloudflare
-       * worker service. A production script will be deployed to `/api/custom-jwt`
-       * endpoint and a test script will be deployed to `/api/custom-jwt/test` endpoint.
-       *
-       * If the current use case is `test`, then the script should be deployed to a `/test` endpoint;
-       * otherwise, the script should be deployed to the `/api/custom-jwt` endpoint and overwrite
-       * previous handler of the API endpoint.
-       */
-      [payload.key]: { [payload.useCase]: payload.value.script },
-    };
-
-    await client.put(`/api/services/custom-jwt/worker`, {
-      body: deepmerge(customizerScriptsFromDatabase, newCustomizerScripts),
-    });
-  }
-
-  async undeployJwtCustomizerScript<T extends LogtoJwtTokenKey>(consoleLog: ConsoleLog, key: T) {
-    if (!EnvSet.values.isCloud) {
-      consoleLog.warn(
-        'Early terminate `undeployJwtCustomizerScript` since we do not deploy the script to dedicated computing resource for OSS version.'
-      );
-      return;
-    }
-
-    if (this.isRegionalAzureFunctionAppConfigured) {
-      consoleLog.info(
-        'Skipping Cloudflare Workers undeployment since regional Azure Function App is configured.'
-      );
-      return;
-    }
-
-    const [client, jwtCustomizers] = await Promise.all([
-      this.cloudConnection.getClient(),
-      this.logtoConfigs.getJwtCustomizers(consoleLog),
-    ]);
-
-    assert(jwtCustomizers[key], new RequestError({ code: 'entity.not_exists', name: key }));
-
-    // Undeploy the worker directly if the only JWT customizer is being deleted.
-    if (Object.entries(jwtCustomizers).length === 1) {
-      await client.delete(`/api/services/custom-jwt/worker`);
-      return;
-    }
-
-    // Remove the JWT customizer script (of given `key`) from the existing JWT customizer scripts and redeploy.
-    const customizerScriptsFromDatabase = getJwtCustomizerScripts(jwtCustomizers);
-    const newCustomizerScripts: CustomJwtDeployRequestBody = {
-      [key]: {
-        production: undefined,
-        test: undefined,
-      },
-    };
-
-    await client.put(`/api/services/custom-jwt/worker`, {
-      body: deepmerge(customizerScriptsFromDatabase, newCustomizerScripts),
-    });
   }
 
   /**

--- a/packages/core/src/routes/logto-config/jwt-customizer.test.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.test.ts
@@ -3,7 +3,6 @@ import {
   LogtoJwtTokenKeyType,
   type JwtCustomizerTestRequestBody,
 } from '@logto/schemas';
-import { ConsoleLog } from '@logto/shared';
 import { pickDefault } from '@logto/shared/esm';
 import { pick } from '@silverhand/essentials';
 
@@ -30,12 +29,7 @@ describe('configs JWT customizer routes', () => {
     undefined,
     { logtoConfigs: logtoConfigQueries },
     undefined,
-    {
-      jwtCustomizers: {
-        deployJwtCustomizerScript: jest.fn(),
-        undeployJwtCustomizerScript: jest.fn(),
-      },
-    },
+    undefined,
     mockLogtoConfigsLibrary
   );
 
@@ -64,15 +58,6 @@ describe('configs JWT customizer routes', () => {
       value: payload,
     });
     const response = await routeRequester.put(`/configs/jwt-customizer/access-token`).send(payload);
-
-    expect(tenantContext.libraries.jwtCustomizers.deployJwtCustomizerScript).toHaveBeenCalledWith(
-      expect.any(ConsoleLog),
-      {
-        key: LogtoJwtTokenKey.AccessToken,
-        value: payload,
-        useCase: 'production',
-      }
-    );
 
     expect(mockLogtoConfigsLibrary.upsertJwtCustomizer).toHaveBeenCalledWith(
       LogtoJwtTokenKey.AccessToken,
@@ -110,15 +95,6 @@ describe('configs JWT customizer routes', () => {
       .patch('/configs/jwt-customizer/access-token')
       .send(mockJwtCustomizerConfigForAccessToken.value);
 
-    expect(tenantContext.libraries.jwtCustomizers.deployJwtCustomizerScript).toHaveBeenCalledWith(
-      expect.any(ConsoleLog),
-      {
-        key: LogtoJwtTokenKey.AccessToken,
-        value: mockJwtCustomizerConfigForAccessToken.value,
-        useCase: 'production',
-      }
-    );
-
     expect(mockLogtoConfigsLibrary.updateJwtCustomizer).toHaveBeenCalledWith(
       LogtoJwtTokenKey.AccessToken,
       mockJwtCustomizerConfigForAccessToken.value
@@ -151,10 +127,6 @@ describe('configs JWT customizer routes', () => {
 
   it('DELETE /configs/jwt-customizer/:tokenType should delete the record', async () => {
     const response = await routeRequester.delete('/configs/jwt-customizer/client-credentials');
-    expect(tenantContext.libraries.jwtCustomizers.undeployJwtCustomizerScript).toHaveBeenCalledWith(
-      expect.any(ConsoleLog),
-      LogtoJwtTokenKey.ClientCredentials
-    );
     expect(logtoConfigQueries.deleteJwtCustomizer).toHaveBeenCalledWith(
       LogtoJwtTokenKey.ClientCredentials
     );
@@ -174,10 +146,6 @@ describe('configs JWT customizer routes', () => {
     };
 
     await routeRequester.post('/configs/jwt-customizer/test').send(payload);
-
-    expect(tenantContext.libraries.jwtCustomizers.deployJwtCustomizerScript).toHaveBeenCalledTimes(
-      0
-    );
 
     expect(clientPostSpy).toHaveBeenCalledTimes(0);
 

--- a/packages/core/src/routes/logto-config/jwt-customizer.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.ts
@@ -40,7 +40,7 @@ const getJwtTokenKeyAndBody = (tokenPath: LogtoJwtTokenKeyType, body: unknown) =
 export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRouter>(
   ...[
     router,
-    { id: tenantId, queries, logtoConfigs, cloudConnection, libraries },
+    { id: tenantId, queries, logtoConfigs, libraries },
   ]: RouterInitArgs<T>
 ) {
   const { getRowsByKeys, deleteJwtCustomizer } = queries.logtoConfigs;

--- a/packages/core/src/routes/logto-config/jwt-customizer.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.ts
@@ -81,16 +81,6 @@ export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRo
 
       const { key, body } = getJwtTokenKeyAndBody(tokenTypePath, rawBody);
 
-      // Deploy first to avoid the case where the JWT customizer was saved to DB but not deployed successfully.
-      // Apply Cloudflare Workers deployment when doing integration tests on Cloud.
-      if (!isIntegrationTest || isCloud) {
-        await libraries.jwtCustomizers.deployJwtCustomizerScript(getConsoleLogFromContext(ctx), {
-          key,
-          value: body,
-          useCase: 'production',
-        });
-      }
-
       const { rows } = await getRowsByKeys([key]);
 
       const jwtCustomizer = await upsertJwtCustomizer(key, body);
@@ -119,23 +109,11 @@ export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRo
     }),
     koaQuotaGuard({ key: 'customJwtEnabled', quota: libraries.quota }),
     async (ctx, next) => {
-      const { isCloud, isIntegrationTest } = EnvSet.values;
-
       const {
         params: { tokenTypePath },
         body: rawBody,
       } = ctx.guard;
       const { key, body } = getJwtTokenKeyAndBody(tokenTypePath, rawBody);
-
-      // Deploy first to avoid the case where the JWT customizer was saved to DB but not deployed successfully.
-      // Apply Cloudflare Workers deployment when doing integration tests on Cloud.
-      if (!isIntegrationTest || isCloud) {
-        await libraries.jwtCustomizers.deployJwtCustomizerScript(getConsoleLogFromContext(ctx), {
-          key,
-          value: body,
-          useCase: 'production',
-        });
-      }
 
       ctx.body = await updateJwtCustomizer(key, body);
 
@@ -190,8 +168,6 @@ export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRo
       status: [204, 404],
     }),
     async (ctx, next) => {
-      const { isCloud, isIntegrationTest } = EnvSet.values;
-
       const {
         params: { tokenTypePath },
       } = ctx.guard;
@@ -200,15 +176,6 @@ export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRo
         tokenTypePath === LogtoJwtTokenKeyType.AccessToken
           ? LogtoJwtTokenKey.AccessToken
           : LogtoJwtTokenKey.ClientCredentials;
-
-      // Undeploy the script first to avoid the case where the JWT customizer was deleted from DB but worker script not updated successfully.
-      // Apply Cloudflare Workers deployment when doing integration tests on Cloud.
-      if (!isIntegrationTest || isCloud) {
-        await libraries.jwtCustomizers.undeployJwtCustomizerScript(
-          getConsoleLogFromContext(ctx),
-          tokenKey
-        );
-      }
 
       await deleteJwtCustomizer(tokenKey);
       ctx.status = 204;
@@ -228,23 +195,9 @@ export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRo
       const { body } = ctx.guard;
 
       try {
-        if (EnvSet.values.isCloud) {
-          // Deploy the test script if needed.(Only for cloud worker service)
-          await libraries.jwtCustomizers.deployJwtCustomizerScript(getConsoleLogFromContext(ctx), {
-            key:
-              body.tokenType === LogtoJwtTokenKeyType.AccessToken
-                ? LogtoJwtTokenKey.AccessToken
-                : LogtoJwtTokenKey.ClientCredentials,
-            value: body,
-            useCase: 'test',
-          });
-
-          ctx.body = await libraries.jwtCustomizers.runScriptRemotely(body, true);
-        } else {
-          ctx.body = removeUndefinedKeys(
-            await JwtCustomizerLibrary.runScriptLocally(body, tenantId)
-          );
-        }
+        ctx.body = EnvSet.values.isCloud
+          ? await libraries.jwtCustomizers.runScriptRemotely(body, true)
+          : removeUndefinedKeys(await JwtCustomizerLibrary.runScriptLocally(body, tenantId));
       } catch (error: unknown) {
         /**
          * Both execution paths surface failures as a withtyped `ResponseError`:

--- a/packages/core/src/routes/logto-config/jwt-customizer.ts
+++ b/packages/core/src/routes/logto-config/jwt-customizer.ts
@@ -38,10 +38,7 @@ const getJwtTokenKeyAndBody = (tokenPath: LogtoJwtTokenKeyType, body: unknown) =
 };
 
 export default function logtoConfigJwtCustomizerRoutes<T extends ManagementApiRouter>(
-  ...[
-    router,
-    { id: tenantId, queries, logtoConfigs, libraries },
-  ]: RouterInitArgs<T>
+  ...[router, { id: tenantId, queries, logtoConfigs, libraries }]: RouterInitArgs<T>
 ) {
   const { getRowsByKeys, deleteJwtCustomizer } = queries.logtoConfigs;
   const { upsertJwtCustomizer, getJwtCustomizer, getJwtCustomizers, updateJwtCustomizer } =

--- a/packages/core/src/tenants/Libraries.ts
+++ b/packages/core/src/tenants/Libraries.ts
@@ -47,7 +47,6 @@ export default class Libraries {
   jwtCustomizers = new JwtCustomizerLibrary(
     this.tenantId,
     this.queries,
-    this.logtoConfigs,
     this.cloudConnection,
     this.subscription,
     this.users,

--- a/packages/core/src/utils/custom-jwt/index.ts
+++ b/packages/core/src/utils/custom-jwt/index.ts
@@ -2,8 +2,6 @@ import {
   type CustomJwtErrorBody,
   customJwtErrorBodyGuard,
   CustomJwtErrorCode,
-  LogtoJwtTokenKey,
-  type JwtCustomizerType,
 } from '@logto/schemas';
 import { conditional, trySafe } from '@silverhand/essentials';
 import { ResponseError } from '@withtyped/client';
@@ -11,17 +9,6 @@ import { type HTTPError } from 'got';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
-
-import { type CustomJwtDeployRequestBody } from './types.js';
-
-export * from './types.js';
-
-export const getJwtCustomizerScripts = (jwtCustomizers: Partial<JwtCustomizerType>) => {
-  // eslint-disable-next-line no-restricted-syntax -- enable to infer the type using `Object.fromEntries`
-  return Object.fromEntries(
-    Object.values(LogtoJwtTokenKey).map((key) => [key, { production: jwtCustomizers[key]?.script }])
-  ) as CustomJwtDeployRequestBody;
-};
 
 /**
  * Parse the withtyped ResponseError body.

--- a/packages/core/src/utils/custom-jwt/types.ts
+++ b/packages/core/src/utils/custom-jwt/types.ts
@@ -1,8 +1,0 @@
-import type router from '@logto/cloud/routes';
-import { type GuardedPayload, type RouterRoutes } from '@withtyped/client';
-
-type PutRoutes = RouterRoutes<typeof router>['put'];
-
-export type CustomJwtDeployRequestBody = GuardedPayload<
-  PutRoutes['/api/services/custom-jwt/worker']
->['body'];


### PR DESCRIPTION
## Summary

Part of [LOG-13957](https://linear.app/silverhand/issue/LOG-13957/remove-per-tenant-worker-lifecycle) — the Core half. Stacked on #9433.

With Custom JWT runs going through the script runner, the per-tenant Cloudflare Worker no longer serves any run: it is deployed on every save/delete/test and then never read. This removes Core's side of that lifecycle, and with it the last caller of the deprecated cloud endpoint the worker sat behind.

- Drop `JwtCustomizerLibrary.deployJwtCustomizerScript` and `undeployJwtCustomizerScript`, along with their `PUT|DELETE /api/services/custom-jwt/worker` cloud client calls.
- Drop the deploy/undeploy calls from `PUT`, `PATCH`, `DELETE /configs/jwt-customizer/:tokenTypePath` and `POST /configs/jwt-customizer/test`, so saving, deleting and testing a customizer no longer wait on a worker deployment.
- Drop the `POST /api/services/custom-jwt` branch of `runScriptOnLegacyRuntime`. That endpoint dispatched to the per-tenant worker, so it goes with it. The remaining branch is the regional untrusted Azure Function app, so the method is renamed `runScriptOnAzureFunction`, loses the now-dead `isTest` forwarding, and throws a named 422 where no function app is configured — the same shape `ActionLibrary.runScriptOnAzureFunction` already has.
- Remove the now-unused `CustomJwtDeployRequestBody` type, `getJwtCustomizerScripts`, and the `LogtoConfigLibrary` constructor dependency.

`isRegionalAzureFunctionAppConfigured` stays: the Azure Functions fallback still reads it, it just no longer gates a worker deployment.

Merge order matters in both directions. #9433 goes first, since it is the base. The Cloud counterpart — deleting `POST /api/services/custom-jwt`, the `PUT|DELETE .../worker` routes, the deploy pipeline and the `jwt-customizer-template` package — must land *after* this, because Core still calls that endpoint until this merges.

Do not merge until [LOG-14043](https://linear.app/silverhand/issue/LOG-14043/inject-script-runner-endpoint-on-prod-regional-cores) is verified on every prod regional core. Until `SCRIPT_RUNNER_ENDPOINT` is injected, regions without an untrusted Azure Function app still fall through to `POST /api/services/custom-jwt`, which serves the per-tenant worker this PR stops deploying. An edited customizer would keep serving the previous script; a newly created one would have nothing deployed.

## Testing

- Unit tests
