### PR TITLE
fix(console): add a solid background to the dev status badge

### DIFF
--- a/packages/console/src/containers/ConsoleContent/_dev-status-spacing.scss
+++ b/packages/console/src/containers/ConsoleContent/_dev-status-spacing.scss
@@ -2,7 +2,7 @@
 
 $dev-status-bottom-offset-factor: 3;
 $dev-status-gap-factor: 3;
-$dev-status-height-factor: 5;
+$dev-status-height-factor: 7;
 
 $dev-status-bottom-offset: _.unit($dev-status-bottom-offset-factor);
 $dev-status-reserved-space: _.unit(

--- a/packages/console/src/containers/ConsoleContent/index.module.scss
+++ b/packages/console/src/containers/ConsoleContent/index.module.scss
@@ -32,6 +32,10 @@
   position: absolute;
   bottom: devStatusSpacing.$dev-status-bottom-offset;
   inset-inline-start: _.unit(4);
+  padding: _.unit(1) _.unit(3);
+  border-radius: 999px;
+  background: var(--color-layer-1);
+  box-shadow: var(--shadow-2);
 }
 
 .daisy {


### PR DESCRIPTION
## Summary

Give the floating "Dev features enabled" badge in the console a solid pill background so it no longer reads as text bleeding over the page content.

- White (`--color-layer-1`) rounded pill with `shadow-2`, matching the tag look used elsewhere.
- Bumped the sidebar's reserved bottom space to match the badge's new height, so the last menu item and the OSS card stay clear of it.

## Testing

tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
