### PR TITLE
fix(console): polish email log locale and message id columns

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/index.tsx
@@ -1,3 +1,4 @@
+import { conditionalArray } from '@silverhand/essentials';
 import { useTranslation } from 'react-i18next';
 
 import { type TenantEmailLog } from '@/cloud/types/router';
@@ -55,9 +56,13 @@ function EmailLogs() {
     recipient,
   });
 
+  // Providers like Cloudflare return no message id; when no loaded row carries one, drop the
+  // column entirely instead of rendering a dash-only column.
+  const hasProviderMessageId = Boolean(logs?.some(({ providerMessageId }) => providerMessageId));
+
   // Column spans are proportional (the table is `table-layout: fixed`); sized by content type —
   // recipient addresses and message ids are the long fields, language tags and status tags short.
-  const columns: Array<Column<TenantEmailLog>> = [
+  const columns: Array<Column<TenantEmailLog>> = conditionalArray(
     {
       title: t('connector_details.email_logs.time'),
       dataIndex: 'time',
@@ -80,9 +85,11 @@ function EmailLogs() {
       title: t('connector_details.email_logs.language_tag'),
       dataIndex: 'locale',
       colSpan: 2,
-      render: ({ locale }) => locale ?? '-',
+      // The email renderer defaults to `en` when the payload carries no locale (e.g. connector
+      // test emails), so show the effective language instead of a dash.
+      render: ({ locale }) => locale ?? 'en',
     },
-    {
+    hasProviderMessageId && {
       title: t('connector_details.email_logs.provider_message_id'),
       dataIndex: 'providerMessageId',
       colSpan: 5,
@@ -111,8 +118,8 @@ function EmailLogs() {
           )}
         </Tag>
       ),
-    },
-  ];
+    }
+  );
 
   return (
     <>


### PR DESCRIPTION
## Summary
Two UX fixes for the built-in email connector's Email logs tab, from the bug bash (LOG-14027):

1. **Language falls back to `en`** — connector test emails (and any send without an explicit locale) store no locale, but the cloud email renderer defaults to English, so the column now shows the effective language instead of a dash.
2. **The Message ID column is hidden when no loaded row carries a provider message id** — providers like Cloudflare return none, which previously produced an all-dash column. The column renders only when at least one row on the page has an id; rows without one still show a dash on mixed pages.

Both changes are client-side only, inside the dev-gated Email logs surface — no endpoint or phrase changes.

## Testing
Tested locally

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments