### PR TITLE
feat(core): add the Azure Functions script fallback behind a dev guard

### DIFF
--- a/packages/core/src/libraries/action-telemetry.ts
+++ b/packages/core/src/libraries/action-telemetry.ts
@@ -18,8 +18,9 @@ export const actionMetricNames = Object.freeze({
 /**
  * Where a script run actually executed.
  *
- * `cloud` is the Cloud script-run path. `azure` remains on the type until LOG-13958 removes the
- * Azure Functions runtime and the leftover metric series.
+ * `cloud` is the Cloud script-run path; `azure` is the Azure Functions fallback, selected per
+ * region by `AZURE_FUNCTION_UNTRUSTED_APP_ENDPOINT` / `_KEY`. Keeping the two apart is what makes
+ * a per-region rollback observable in the metric.
  */
 export type ActionRuntimeLocation = 'local' | 'azure' | 'cloud';
 

--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -1,6 +1,8 @@
+/* eslint-disable max-lines -- The script-run path and the Azure Functions fallback share one setup. */
 import { appInsights } from '@logto/app-insights/node';
 import { LogtoActionKey } from '@logto/schemas';
 import { ResponseError } from '@withtyped/client';
+import nock from 'nock';
 
 import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
@@ -356,3 +358,171 @@ describe('ActionLibrary Cloud execution routing', () => {
     expect(runScriptInLocalVm).not.toHaveBeenCalled();
   });
 });
+
+describe('ActionLibrary Azure Functions fallback', () => {
+  const library = createLibrary();
+  const { createLog } = createMockLogContext();
+  const runAction = async <Event>(input: RunActionInput<Event>) =>
+    library.runAction({ ...input, auditContext: { createLog } });
+
+  const endpoint = 'https://untrusted.example.com';
+  const functionKey = 'function-key';
+
+  /** Configure the regional Azure Function app, which is what selects the fallback. */
+  const configureAzureFunctionApp = () => {
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+  };
+
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  beforeEach(() => {
+    setIsCloud(true);
+    // The fallback selection is dev-gated until LOG-13958 verifies it.
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Provide an App Insights client for metric assertions.
+    appInsights.client = {
+      trackMetric,
+      trackException: jest.fn(),
+    } as unknown as NonNullable<typeof appInsights.client>;
+    getSubscriptionData.mockResolvedValue({
+      quota: {
+        actionsEnabled: true,
+      },
+    } as Awaited<ReturnType<SubscriptionLibrary['getSubscriptionData']>>);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the shared App Insights singleton.
+    appInsights.client = originalAppInsightsClient;
+    setIsCloud(originalIsCloud);
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  it('stays on the script-run endpoint when dev features are off', async () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    configureAzureFunctionApp();
+    post.mockResolvedValueOnce({ value: { action: 'continue' } });
+
+    // Production behavior is unchanged while the gate is on, even where the app is configured.
+    await expect(
+      library.runScriptRemotely({
+        actionType: LogtoActionKey.PostSignIn,
+        script: 'const runAction = () => ({ action: "continue" });',
+        event: { key: LogtoActionKey.PostSignIn },
+      })
+    ).resolves.toEqual({ action: 'continue' });
+
+    expect(post).toHaveBeenCalled();
+  });
+
+  it('uses the script-run endpoint when no Azure Function app is configured', async () => {
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
+    post.mockResolvedValueOnce({ value: { action: 'continue' } });
+
+    await expect(
+      library.runScriptRemotely({
+        actionType: LogtoActionKey.PostSignIn,
+        script: 'const runAction = () => ({ action: "continue" });',
+        event: { key: LogtoActionKey.PostSignIn },
+      })
+    ).resolves.toEqual({ action: 'continue' });
+
+    expect(post).toHaveBeenCalled();
+  });
+
+  it('routes the run to the Azure Function endpoint with the execution payload', async () => {
+    const script = 'const runAction = () => ({ action: "updateUser", user: { name: "Bar" } });';
+    const event = {
+      key: LogtoActionKey.PostSignIn,
+      interactionEvent: 'SignIn',
+      user: {
+        id: 'foo',
+        name: 'Foo',
+      },
+    };
+    const environmentVariables = { NAME_SUFFIX: ' updated' };
+    const executionResult = {
+      action: 'updateUser',
+      user: {
+        name: 'Bar',
+      },
+    };
+    const matchRunnerPayload = jest.fn((_body: unknown) => true);
+    const remoteRunner = nock(endpoint, {
+      reqheaders: {
+        'x-functions-key': functionKey,
+      },
+    })
+      .post('/api/actions', matchRunnerPayload)
+      .reply(200, executionResult);
+
+    configureAzureFunctionApp();
+    getAction.mockResolvedValueOnce({
+      enabled: true,
+      script,
+      environmentVariables,
+    });
+
+    await expect(
+      runAction({
+        key: LogtoActionKey.PostSignIn,
+        event,
+      })
+    ).resolves.toEqual(executionResult);
+    expect(remoteRunner.isDone()).toBe(true);
+    // The fallback talks to the function app directly; the cloud hop is not taken.
+    expect(post).not.toHaveBeenCalled();
+    expect(matchRunnerPayload.mock.calls[0]?.[0]).toMatchObject({
+      script,
+      actionType: LogtoActionKey.PostSignIn,
+      event,
+      environmentVariables,
+    });
+    expect(trackMetric).toHaveBeenNthCalledWith(1, {
+      name: actionMetricNames.executionCount,
+      value: 1,
+      properties: {
+        actionType: 'PostSignIn',
+        // `azure`, not `cloud`: the metric is what makes a per-region rollback observable.
+        runtimeLocation: 'azure',
+        outcome: 'success',
+        action: 'updateUser',
+      },
+    });
+  });
+
+  it('applies allow-mode policy when the Azure Function run fails', async () => {
+    const remoteRunner = nock(endpoint, {
+      reqheaders: {
+        'x-functions-key': functionKey,
+      },
+    })
+      .post('/api/actions')
+      .reply(500, {
+        message: 'Remote runner failed',
+      });
+
+    configureAzureFunctionApp();
+    getAction.mockResolvedValueOnce({
+      enabled: true,
+      onExecutionError: 'allow',
+      script: 'const runAction = () => ({ action: "continue" });',
+    });
+    const runScriptInLocalVm = jest.spyOn(ActionLibrary, 'runScriptInLocalVm');
+
+    await expect(
+      runAction({
+        key: LogtoActionKey.PostSignIn,
+        event: {},
+      })
+    ).resolves.toBeUndefined();
+    expect(remoteRunner.isDone()).toBe(true);
+    expect(runScriptInLocalVm).not.toHaveBeenCalled();
+  });
+});
+/* eslint-enable max-lines */

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -8,12 +8,14 @@ import {
   type ActionExecutionErrorPolicy,
   type ActionExecutionRequestBody,
 } from '@logto/schemas';
+import { got, HTTPError } from 'got';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import type { LogtoConfigLibrary } from '#src/libraries/logto-config.js';
 import type { SubscriptionLibrary } from '#src/libraries/subscription.js';
 import type { LogContext, LogPayload } from '#src/middleware/koa-audit-log.js';
+import { parseAzureFunctionsResponseError } from '#src/utils/custom-jwt/index.js';
 
 import {
   buildActionTelemetryError,
@@ -39,6 +41,13 @@ import {
 
 const actionFunctionName = 'runAction';
 const defaultActionExecutionErrorPolicy = 'block' satisfies ActionExecutionErrorPolicy;
+/**
+ * Azure Function vm2 timeout is 3000ms. Use a slightly higher HTTP deadline so the
+ * client can surface Function-side failures instead of racing the sandbox limit.
+ *
+ * Only used by the Azure Functions fallback; the Cloud script runner owns its own budget.
+ */
+const remoteActionRequestTimeout = 5000;
 
 export type ActionExecutionErrorFallback = {
   action: 'rejectInvalidCredentials';
@@ -182,11 +191,18 @@ export const getActionExecutionErrorPolicyDecision = ({
 /**
  * The telemetry label for where a run executes.
  *
- * Cloud runs always go through the script-run endpoint (`cloud`). `azure` remains on the type
- * until LOG-13958 removes the Azure Functions runtime and the leftover series.
+ * Kept in sync with the branch {@link ActionLibrary.runScriptRemotely} takes, so the split between
+ * regions already served by the script runner (`cloud`) and those still on the Azure Functions
+ * fallback (`azure`) stays readable in the metric — which is what makes a per-region rollback
+ * observable.
  */
-const getTelemetryRuntimeLocation = (): ActionRuntimeLocation =>
-  EnvSet.values.isCloud ? 'cloud' : 'local';
+const getTelemetryRuntimeLocation = (isAzureFallbackActive: boolean): ActionRuntimeLocation => {
+  if (!EnvSet.values.isCloud) {
+    return 'local';
+  }
+
+  return isAzureFallbackActive ? 'azure' : 'cloud';
+};
 
 const applyActionExecutionErrorPolicyDecision = (decision: ActionExecutionErrorPolicyDecision) => {
   if (decision.action === 'throw') {
@@ -229,6 +245,23 @@ export class ActionLibrary {
     private readonly subscription: SubscriptionLibrary,
     private readonly cloudConnection: CloudConnectionLibrary
   ) {}
+
+  /**
+   * Whether this region runs scripts on the untrusted Azure Function app rather than the Cloud
+   * script runner. See {@link runScriptOnAzureFunction}.
+   *
+   * TODO (LOG-13958): drop the `isDevFeaturesEnabled` gate once the fallback has been verified.
+   * Until then the selection is dev-only, so production keeps going to the script runner
+   * unconditionally — the behavior LOG-13963 released.
+   */
+  get isRegionalAzureFunctionAppConfigured(): boolean {
+    const { isDevFeaturesEnabled, azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } =
+      EnvSet.values;
+
+    return Boolean(
+      isDevFeaturesEnabled && azureFunctionUntrustedAppKey && azureFunctionUntrustedAppEndpoint
+    );
+  }
 
   /**
    * Shared entry point for production `runAction()` and Management API dry runs.
@@ -277,6 +310,12 @@ export class ActionLibrary {
     /** Whether this is a dry run (Console "test"). */
     isTest?: boolean
   ): Promise<unknown> {
+    // Break-glass fallback: a region that still has the untrusted Azure Function app configured
+    // keeps running scripts there. See {@link runScriptOnAzureFunction}.
+    if (this.isRegionalAzureFunctionAppConfigured) {
+      return this.runScriptOnAzureFunction(data);
+    }
+
     const { script, event, environmentVariables } = data;
 
     /**
@@ -327,7 +366,9 @@ export class ActionLibrary {
     };
     const onExecutionError = action.onExecutionError ?? defaultActionExecutionErrorPolicy;
     const runtimeLocation = EnvSet.values.isCloud ? 'remote' : 'local';
-    const telemetryRuntimeLocation = getTelemetryRuntimeLocation();
+    const telemetryRuntimeLocation = getTelemetryRuntimeLocation(
+      this.isRegionalAzureFunctionAppConfigured
+    );
     const log = createLog(getActionLogKey(key), { independent: true });
 
     log.append({
@@ -392,6 +433,57 @@ export class ActionLibrary {
       return result;
     } finally {
       trackActionExecutionMetrics({ durationMs, properties: telemetryProperties });
+    }
+  }
+
+  /**
+   * The pre-script-runner runtime, kept as the fallback for a Dynamic Workers outage.
+   *
+   * Selected per region by {@link isRegionalAzureFunctionAppConfigured}: unsetting
+   * `AZURE_FUNCTION_UNTRUSTED_APP_ENDPOINT` / `_KEY` on a core deployment moves it to the script
+   * runner, and setting them again moves it back — no code change, no coordinated rollback, and
+   * one region at a time.
+   *
+   * `isTest` is deliberately not forwarded: this runtime has no notion of a dry run. Nothing is
+   * lost by it — vm2 builds a fresh VM per call, so a test run can never share state with
+   * production the way a warm isolate could.
+   */
+  private async runScriptOnAzureFunction({
+    script,
+    actionType,
+    event,
+    environmentVariables,
+  }: {
+    script: string;
+    actionType: LogtoActionKey;
+    event: unknown;
+    environmentVariables?: Record<string, string>;
+  }): Promise<unknown> {
+    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
+
+    try {
+      return await got
+        // The remote runner must invoke `runAction` from the supplied script.
+        .post(new URL('/api/actions', azureFunctionUntrustedAppEndpoint), {
+          json: {
+            script,
+            actionType,
+            event,
+            environmentVariables,
+          },
+          headers: {
+            'x-functions-key': azureFunctionUntrustedAppKey,
+          },
+          // Got@14 expects a Delays object; bound the whole request slightly above the AF VM timeout.
+          timeout: { request: remoteActionRequestTimeout },
+        })
+        .json<unknown>();
+    } catch (error: unknown) {
+      if (error instanceof HTTPError) {
+        throw parseAzureFunctionsResponseError(error);
+      }
+
+      throw error;
     }
   }
 

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -1,7 +1,9 @@
 import { CustomJwtErrorCode, LogtoJwtTokenKeyType } from '@logto/schemas';
 import { assert } from '@silverhand/essentials';
 import { ResponseError } from '@withtyped/client';
+import nock from 'nock';
 
+import { EnvSet } from '#src/env-set/index.js';
 import type Queries from '#src/tenants/Queries.js';
 import { isAccessDeniedError, parseCustomJwtResponseError } from '#src/utils/custom-jwt/index.js';
 
@@ -124,5 +126,60 @@ describe('JwtCustomizerLibrary.runScriptRemotely', () => {
     post.mockRejectedValueOnce(error);
 
     await expect(library.runScriptRemotely(payload)).rejects.toBe(error);
+  });
+});
+
+describe('JwtCustomizerLibrary Azure Functions fallback', () => {
+  const endpoint = 'https://untrusted.example.com';
+  const functionKey = 'function-key';
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  beforeEach(() => {
+    // The fallback selection is dev-gated until LOG-13958 verifies it.
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  it('stays on the script-run endpoint when dev features are off', async () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+    post.mockResolvedValueOnce({ value: { foo: 'bar' } });
+
+    // Production behavior is unchanged while the gate is on, even where the app is configured.
+    await expect(library.runScriptRemotely(payload)).resolves.toEqual({ foo: 'bar' });
+    expect(post).toHaveBeenCalled();
+  });
+
+  it('runs the script on the regional untrusted Azure Function app when configured', async () => {
+    const remoteRunner = nock(endpoint, {
+      reqheaders: { 'x-functions-key': functionKey },
+    })
+      .post('/api/custom-jwt')
+      .reply(200, { foo: 'bar' });
+
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+
+    // A dry run takes the same path: this runtime has no notion of `isTest`.
+    await expect(library.runScriptRemotely(payload, true)).resolves.toEqual({ foo: 'bar' });
+    expect(remoteRunner.isDone()).toBe(true);
+    // The fallback talks to the function app directly; the cloud hop is not taken.
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('uses the script-run endpoint when no Azure Function app is configured', async () => {
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue('');
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue('');
+    post.mockResolvedValueOnce({ value: { foo: 'bar' } });
+
+    await expect(library.runScriptRemotely(payload)).resolves.toEqual({ foo: 'bar' });
+    expect(post).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -11,6 +11,7 @@ import {
   jwtCustomizerOrganizationContextGuard,
   type LogtoJwtTokenKey,
   type CustomJwtScriptPayload,
+  jsonObjectGuard,
   isBuiltInApplicationId,
   buildBuiltInApplicationDataForTenant,
 } from '@logto/schemas';
@@ -24,6 +25,7 @@ import {
   trySafe,
 } from '@silverhand/essentials';
 import deepmerge from 'deepmerge';
+import { got, HTTPError } from 'got';
 import { type UnknownObject } from 'oidc-provider';
 import { z } from 'zod';
 
@@ -36,6 +38,7 @@ import type Queries from '#src/tenants/Queries.js';
 import {
   getJwtCustomizerScripts,
   type CustomJwtDeployRequestBody,
+  parseAzureFunctionsResponseError,
 } from '#src/utils/custom-jwt/index.js';
 
 import { type CloudConnectionLibrary } from './cloud-connection.js';
@@ -128,6 +131,22 @@ export class JwtCustomizerLibrary {
     const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
 
     return Boolean(azureFunctionUntrustedAppKey && azureFunctionUntrustedAppEndpoint);
+  }
+
+  /**
+   * Whether a script run should go to the untrusted Azure Function app instead of the Cloud
+   * script runner. See {@link runScriptOnAzureFunction}.
+   *
+   * Narrower than {@link isRegionalAzureFunctionAppConfigured}, which also governs whether the
+   * per-tenant Cloudflare worker is deployed: that behavior shipped long ago and must not change
+   * here.
+   *
+   * TODO (LOG-13958): drop the `isDevFeaturesEnabled` gate once the fallback has been verified.
+   * Until then the selection is dev-only, so production keeps going to the script runner
+   * unconditionally — the behavior LOG-13963 released.
+   */
+  private get isAzureFunctionScriptFallbackActive(): boolean {
+    return Boolean(EnvSet.values.isDevFeaturesEnabled) && this.isRegionalAzureFunctionAppConfigured;
   }
 
   /**
@@ -336,6 +355,12 @@ export class JwtCustomizerLibrary {
     payload: CustomJwtFetcher,
     isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
+    // Break-glass fallback: a region that still has the untrusted Azure Function app configured
+    // keeps running scripts there. See {@link runScriptOnAzureFunction}.
+    if (this.isAzureFunctionScriptFallbackActive) {
+      return this.runScriptOnAzureFunction(payload);
+    }
+
     /**
      * `api` is not part of the payload — it carries a function and cannot travel over the wire.
      * The runner merges it in inside the isolate and reports a denial as a `denied` failure,
@@ -344,6 +369,44 @@ export class JwtCustomizerLibrary {
     const value = await this.postScriptRun(payload, isTest);
 
     return JwtCustomizerLibrary.parseScriptResultValue(value);
+  }
+
+  /**
+   * The pre-script-runner runtime, kept as the fallback for a Dynamic Workers outage.
+   *
+   * Selected per region by {@link isRegionalAzureFunctionAppConfigured}: unsetting
+   * `AZURE_FUNCTION_UNTRUSTED_APP_ENDPOINT` / `_KEY` on a core deployment moves it to the script
+   * runner, and setting them again moves it back — no code change, no coordinated rollback, and
+   * one region at a time.
+   *
+   * `isTest` is deliberately not forwarded: this runtime has no notion of a dry run. Nothing is
+   * lost by it — vm2 builds a fresh VM per call, so a test run can never share state with
+   * production the way a warm isolate could.
+   */
+  private async runScriptOnAzureFunction(
+    payload: CustomJwtFetcher
+  ): Promise<Optional<UnknownObject>> {
+    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
+
+    try {
+      const result = await got
+        .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
+          json: payload,
+          headers: {
+            'x-functions-key': azureFunctionUntrustedAppKey,
+          },
+        })
+        .json<unknown>();
+
+      return jsonObjectGuard.parse(result);
+    } catch (error: unknown) {
+      // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
+      if (error instanceof HTTPError) {
+        throw parseAzureFunctionsResponseError(error);
+      }
+
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes [LOG-13958](https://linear.app/silverhand/issue/LOG-13958).

Keeps the untrusted Azure Functions runtime as a **per-region fallback** for the Dynamic Workers script runner, so a runner outage is routed around with an env change instead of a code rollback.

Selection is `isRegionalAzureFunctionAppConfigured` — a core deployment with `AZURE_FUNCTION_UNTRUSTED_APP_ENDPOINT` / `_KEY` set runs scripts on the function app; unsetting them moves that region to the script runner. Because core is deployed per region, this is finer-grained than a global flag: one region can be moved without touching the others.

**Gated on `isDevFeaturesEnabled` for now.** Production keeps going to the script runner unconditionally — exactly the behavior #9433 releases — until this has been verified. Removing the gate is a follow-up.

Stacked on #9433 (LOG-13963), which must merge first.

## Notes

- **Why core and not cloud.** #8241 deliberately moved the Azure Functions call out of cloud into core in Jan 2026 to remove a cross-region hop. Cloud also holds a single `AZURE_FUNCTION_UNTRUSTED_APP_*` pair while core is per-region, so a cloud-side fallback would send an EU tenant's script to whichever region cloud happens to point at — and on the path that only runs when something is already broken.
- **Custom JWT uses a separate predicate.** `isRegionalAzureFunctionAppConfigured` there also governs whether the per-tenant Cloudflare worker is deployed. That behavior shipped long ago, so the dev gate is applied through a new `isAzureFunctionScriptFallbackActive` rather than by narrowing the existing getter.
- **`isTest` is not forwarded** — this runtime has no notion of a dry run. Nothing is lost: vm2 builds a fresh VM per call, so a test run can never share state with production the way a warm isolate could.
- **Telemetry keeps `azure` and `cloud` distinct**, which is what makes a per-region rollback observable in `core/action/execution_count`.

## Testing

Both branches of the gate, in `action.cloud.test.ts` and `jwt-customizer.cloud.test.ts`: dev features off stays on script-run even where the app is configured; dev features on routes to the function app with the right payload, key, and `azure` telemetry; allow-mode policy still applies when the function app fails.