### PR TITLE
feat(core): keep Azure Functions as a per-region script runtime fallback

### DIFF
--- a/packages/core/src/libraries/action.cloud.test.ts
+++ b/packages/core/src/libraries/action.cloud.test.ts
@@ -81,6 +81,7 @@ describe('ActionLibrary Cloud execution routing', () => {
   });
 
   afterEach(() => {
+    nock.cleanAll();
     jest.restoreAllMocks();
     jest.clearAllMocks();
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the shared AppInsights singleton.
@@ -360,6 +361,45 @@ describe('ActionLibrary Cloud execution routing', () => {
       action: 'rejectInvalidCredentials',
     });
     expect(runScriptInLocalVm).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the Azure Function app on a region that still has one configured', async () => {
+    setIsCloud(true);
+    const endpoint = 'https://untrusted.example.com';
+    const functionKey = 'function-key';
+    const script = 'const runAction = () => ({ action: "updateUser", user: { name: "Bar" } });';
+    const executionResult = { action: 'updateUser', user: { name: 'Bar' } };
+    const remoteRunner = nock(endpoint, {
+      reqheaders: { 'x-functions-key': functionKey },
+    })
+      .post('/api/actions')
+      .reply(200, executionResult);
+
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+    getAction.mockResolvedValueOnce({ enabled: true, script });
+
+    await expect(
+      runAction({
+        key: LogtoActionKey.PostSignIn,
+        event: { key: LogtoActionKey.PostSignIn },
+      })
+    ).resolves.toEqual(executionResult);
+
+    expect(remoteRunner.isDone()).toBe(true);
+    // The fallback talks to the function app directly; the script runner is not called.
+    expect(post).not.toHaveBeenCalled();
+    expect(trackMetric).toHaveBeenNthCalledWith(1, {
+      name: actionMetricNames.executionCount,
+      value: 1,
+      properties: {
+        actionType: 'PostSignIn',
+        // `azure`, not `cloud`: the metric is what makes a per-region rollback observable.
+        runtimeLocation: 'azure',
+        outcome: 'success',
+        action: 'updateUser',
+      },
+    });
   });
 });
 

--- a/packages/core/src/libraries/action.ts
+++ b/packages/core/src/libraries/action.ts
@@ -196,17 +196,17 @@ export const getActionExecutionErrorPolicyDecision = ({
 /**
  * The telemetry label for where a run executes.
  *
- * Deliberately kept in sync with the branch {@link ActionLibrary.runScriptRemotely} takes: while
- * both remote runtimes coexist behind `isDevFeaturesEnabled`, splitting `azure` from `cloud` is
- * what makes the share of traffic already served by the Cloud script runner readable in the
- * metric. Collapses back to `azure`-free once LOG-13958 removes the Azure Functions path.
+ * Deliberately kept in sync with the branch {@link ActionLibrary.runScriptRemotely} takes, so the
+ * split between regions served by the Cloud script runner (`cloud`) and those on the Azure
+ * Functions fallback (`azure`) is readable in the metric — which is what makes a per-region
+ * rollback observable.
  */
-const getTelemetryRuntimeLocation = (): ActionRuntimeLocation => {
+const getTelemetryRuntimeLocation = (isAzureFallbackActive: boolean): ActionRuntimeLocation => {
   if (!EnvSet.values.isCloud) {
     return 'local';
   }
 
-  return EnvSet.values.isDevFeaturesEnabled ? 'cloud' : 'azure';
+  return isAzureFallbackActive ? 'azure' : 'cloud';
 };
 
 const applyActionExecutionErrorPolicyDecision = (decision: ActionExecutionErrorPolicyDecision) => {
@@ -299,6 +299,16 @@ export class ActionLibrary {
   }
 
   /**
+   * Whether a Cloud run goes to the Azure Functions runtime rather than the script runner.
+   *
+   * Unconditional while dev features are off — production's behavior today — and per region once
+   * they are on. Read by both the execution branch and the telemetry label, which must agree.
+   */
+  get isAzureFunctionRuntimeSelected(): boolean {
+    return !EnvSet.values.isDevFeaturesEnabled || this.isRegionalAzureFunctionAppConfigured;
+  }
+
+  /**
    * Shared entry point for production `runAction()` and Management API dry runs.
    * Cloud always executes remotely; OSS / self-hosted runs locally — on the worker pool behind
    * dev features, otherwise in the legacy `node:vm`.
@@ -343,12 +353,19 @@ export class ActionLibrary {
       event: unknown;
       environmentVariables?: Record<string, string>;
     },
-    /** Whether this is a dry run. The legacy Azure Functions path has no notion of it. */
+    /** Whether this is a dry run. The Azure Functions path has no notion of it. */
     isTest?: boolean
   ): Promise<unknown> {
-    // TODO (LOG-13958): drop the legacy Azure Functions path and the gate once the Cloud script
-    // runner has been manually verified and released.
-    if (!EnvSet.values.isDevFeaturesEnabled) {
+    /**
+     * The Azure Functions runtime is kept as a per-region fallback rather than retired: a script
+     * runner outage is then routed around by setting `AZURE_FUNCTION_UNTRUSTED_APP_ENDPOINT` /
+     * `_KEY` on that region's core, with no code change and no coordinated rollback.
+     *
+     * With dev features off this is unconditional, which is production's behavior today. With
+     * them on, the app is used only where it is configured, so the script runner can be exercised
+     * by unsetting it — the arrangement LOG-13963 will make the only one once the gate comes out.
+     */
+    if (this.isAzureFunctionRuntimeSelected) {
       return this.runScriptOnAzureFunction(data);
     }
 
@@ -402,7 +419,9 @@ export class ActionLibrary {
     };
     const onExecutionError = action.onExecutionError ?? defaultActionExecutionErrorPolicy;
     const runtimeLocation = EnvSet.values.isCloud ? 'remote' : 'local';
-    const telemetryRuntimeLocation = getTelemetryRuntimeLocation();
+    const telemetryRuntimeLocation = getTelemetryRuntimeLocation(
+      this.isAzureFunctionRuntimeSelected
+    );
     const log = createLog(getActionLogKey(key), { independent: true });
 
     log.append({
@@ -470,7 +489,14 @@ export class ActionLibrary {
     }
   }
 
-  /** The pre-script-runner remote path, still serving production until the gate above lifts. */
+  /**
+   * The Azure Functions runtime, kept as the per-region fallback for the Cloud script runner.
+   *
+   * Selected by {@link isRegionalAzureFunctionAppConfigured} once dev features are on, and
+   * unconditionally while they are off. `isTest` is deliberately not forwarded: this runtime has
+   * no notion of a dry run, and nothing is lost by it — vm2 builds a fresh VM per call, so a test
+   * run can never share state with production the way a warm isolate could.
+   */
   private async runScriptOnAzureFunction({
     script,
     actionType,

--- a/packages/core/src/libraries/jwt-customizer.cloud.test.ts
+++ b/packages/core/src/libraries/jwt-customizer.cloud.test.ts
@@ -54,6 +54,8 @@ describe('JwtCustomizerLibrary.runScriptRemotely', () => {
   });
 
   afterEach(() => {
+    nock.cleanAll();
+    jest.restoreAllMocks();
     jest.clearAllMocks();
     Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
   });
@@ -133,6 +135,25 @@ describe('JwtCustomizerLibrary.runScriptRemotely', () => {
     post.mockRejectedValueOnce(error);
 
     await expect(library.runScriptRemotely(payload)).rejects.toBe(error);
+  });
+
+  it('falls back to the Azure Function app on a region that still has one configured', async () => {
+    const endpoint = 'https://untrusted.example.com';
+    const functionKey = 'function-key';
+    const remoteRunner = nock(endpoint, {
+      reqheaders: { 'x-functions-key': functionKey },
+    })
+      .post('/api/custom-jwt')
+      .reply(200, { foo: 'bar' });
+
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppEndpoint', 'get').mockReturnValue(endpoint);
+    jest.spyOn(EnvSet.values, 'azureFunctionUntrustedAppKey', 'get').mockReturnValue(functionKey);
+
+    // A dry run takes the same path: this runtime has no notion of `isTest`.
+    await expect(library.runScriptRemotely(payload, true)).resolves.toEqual({ foo: 'bar' });
+    expect(remoteRunner.isDone()).toBe(true);
+    // The fallback talks to the function app directly; the script runner is not called.
+    expect(post).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/libraries/jwt-customizer.ts
+++ b/packages/core/src/libraries/jwt-customizer.ts
@@ -395,10 +395,22 @@ export class JwtCustomizerLibrary {
     payload: CustomJwtFetcher,
     isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
-    // TODO (LOG-13958): drop the legacy remote paths and the gate once the Cloud script runner
-    // has been manually verified and released.
+    /**
+     * The Azure Functions runtime is kept as a per-region fallback rather than retired: a script
+     * runner outage is then routed around by setting `AZURE_FUNCTION_UNTRUSTED_APP_ENDPOINT` /
+     * `_KEY` on that region's core, with no code change and no coordinated rollback.
+     *
+     * With dev features off this keeps the whole legacy selection, which is production's behavior
+     * today. With them on, only the Azure Functions branch survives as the fallback — the
+     * deprecated `POST /api/services/custom-jwt` cloud endpoint is on its way out (LOG-13957) and
+     * must not be reachable from the new arrangement.
+     */
     if (!EnvSet.values.isDevFeaturesEnabled) {
       return this.runScriptOnLegacyRuntime(payload, isTest);
+    }
+
+    if (this.isRegionalAzureFunctionAppConfigured) {
+      return this.runScriptOnAzureFunction(payload);
     }
 
     /**
@@ -415,34 +427,15 @@ export class JwtCustomizerLibrary {
    * The pre-script-runner remote paths, still serving production until the gate above lifts:
    * the regional untrusted Azure Function app where configured, otherwise the deprecated
    * `POST /api/services/custom-jwt` cloud endpoint.
+   *
+   * Only the first of the two survives the gate — see {@link runScriptOnAzureFunction}.
    */
   private async runScriptOnLegacyRuntime(
     payload: CustomJwtFetcher,
     isTest?: boolean
   ): Promise<Optional<UnknownObject>> {
-    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
-
     if (this.isRegionalAzureFunctionAppConfigured) {
-      try {
-        const result = await got
-          .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
-            json: payload,
-            headers: {
-              'x-functions-key': azureFunctionUntrustedAppKey,
-            },
-          })
-          .json<unknown>();
-
-        const parsedResult = jsonObjectGuard.parse(result);
-        return parsedResult;
-      } catch (error: unknown) {
-        // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
-        if (error instanceof HTTPError) {
-          throw parseAzureFunctionsResponseError(error);
-        }
-
-        throw error;
-      }
+      return this.runScriptOnAzureFunction(payload);
     }
 
     // Fallback to use cloud connection to call the custom JWT API.
@@ -451,6 +444,40 @@ export class JwtCustomizerLibrary {
       body: payload,
       search: isTest ? { isTest: 'true' } : {},
     });
+  }
+
+  /**
+   * The Azure Functions runtime, kept as the per-region fallback for the Cloud script runner.
+   *
+   * Selected by {@link isRegionalAzureFunctionAppConfigured}. `isTest` is deliberately not
+   * forwarded: this runtime has no notion of a dry run, and nothing is lost by it — vm2 builds a
+   * fresh VM per call, so a test run can never share state with production the way a warm isolate
+   * could.
+   */
+  private async runScriptOnAzureFunction(
+    payload: CustomJwtFetcher
+  ): Promise<Optional<UnknownObject>> {
+    const { azureFunctionUntrustedAppKey, azureFunctionUntrustedAppEndpoint } = EnvSet.values;
+
+    try {
+      const result = await got
+        .post(new URL('/api/custom-jwt', azureFunctionUntrustedAppEndpoint), {
+          json: payload,
+          headers: {
+            'x-functions-key': azureFunctionUntrustedAppKey,
+          },
+        })
+        .json<unknown>();
+
+      return jsonObjectGuard.parse(result);
+    } catch (error: unknown) {
+      // Convert got HTTPError to WithTyped client ResponseError for unified error handling.
+      if (error instanceof HTTPError) {
+        throw parseAzureFunctionsResponseError(error);
+      }
+
+      throw error;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes [LOG-13958](https://linear.app/silverhand/issue/LOG-13958).

Reworks the Azure Functions runtime from a path being retired into a **configurable per-region fallback** for the Cloud script runner. A runner outage is then routed around by setting `AZURE_FUNCTION_UNTRUSTED_APP_ENDPOINT` / `_KEY` on that region's core — no code change, no coordinated rollback, and one region at a time, since core is deployed per region while cloud is not.

**Production is unchanged.** The rework sits behind the existing `isDevFeaturesEnabled` gate:

| | dev off (production) | dev on |
|---|---|---|
| before | Azure Functions | script runner |
| after | Azure Functions | Azure Functions where configured, else script runner |

The dev-on column is what LOG-13963 (#9433) will release once the gate comes out. That PR is on hold until this is verified, so the two ship together.

## Notes

- **Why core and not cloud.** #8241 deliberately moved this call out of cloud into core in Jan 2026 to remove a cross-region hop. Cloud also holds a single `AZURE_FUNCTION_UNTRUSTED_APP_*` pair while core is per-region, so a cloud-side fallback would send an EU tenant's script to whichever region cloud points at — on the path that only runs when something is already broken.
- **Custom JWT keeps its legacy selection under the gate.** With dev features on, only the Azure Functions branch survives; the deprecated `POST /api/services/custom-jwt` cloud endpoint is on its way out (LOG-13957) and must not be reachable from the new arrangement.
- **`isTest` is not forwarded** — this runtime has no notion of a dry run. Nothing is lost: vm2 builds a fresh VM per call, so a test run can never share state with production the way a warm isolate could.
- **Telemetry now follows the branch actually taken** rather than the dev flag, so `azure` vs `cloud` in `core/action/execution_count` shows which regions are on which runtime.

## Testing

Added to the dev-on suites in `action.cloud.test.ts` and `jwt-customizer.cloud.test.ts`: with the function app configured, the run goes there with the right payload and key, the script runner is not called, and Actions reports `runtimeLocation: 'azure'`. The existing dev-off suites are untouched and still assert today's production behavior.