### PR TITLE
refactor: extract shared device display info

### DIFF
--- a/packages/shared/src/utils/session.test.ts
+++ b/packages/shared/src/utils/session.test.ts
@@ -1,6 +1,56 @@
 import { describe, expect, it } from 'vitest';
 
-import { getSessionDisplayInfo, normalizeUserApplicationGrantGroups } from './session.js';
+import {
+  getDeviceDisplayInfo,
+  getSessionDisplayInfo,
+  normalizeUserApplicationGrantGroups,
+} from './session.js';
+
+describe('getDeviceDisplayInfo()', () => {
+  it.each([
+    {
+      name: 'Chrome on Apple Macintosh',
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+    },
+    {
+      name: 'Mobile Safari on Apple iPhone',
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1',
+    },
+  ])('should derive $name from a common user agent', ({ name, userAgent }) => {
+    expect(getDeviceDisplayInfo({ userAgent }).name).toBe(name);
+  });
+
+  it('should tolerate a malformed user agent and preserve available location metadata', () => {
+    expect(
+      getDeviceDisplayInfo({
+        userAgent: '\u0000not-a-user-agent',
+        city: 'Paris',
+      })
+    ).toEqual({
+      browserName: undefined,
+      city: 'Paris',
+      country: undefined,
+      deviceModel: undefined,
+      location: 'Paris',
+      name: undefined,
+      osName: undefined,
+    });
+  });
+
+  it('should return empty display fields when metadata is missing', () => {
+    expect(getDeviceDisplayInfo({})).toEqual({
+      browserName: undefined,
+      city: undefined,
+      country: undefined,
+      deviceModel: undefined,
+      location: undefined,
+      name: undefined,
+      osName: undefined,
+    });
+  });
+});
 
 describe('getSessionDisplayInfo()', () => {
   it('should parse user agent, location, and ip from sign-in context', () => {

--- a/packages/shared/src/utils/session.ts
+++ b/packages/shared/src/utils/session.ts
@@ -1,10 +1,14 @@
 import { UAParser } from 'ua-parser-js';
 
-type SignInContext = {
-  readonly ip?: string;
+/** Raw metadata used to derive a device title and approximate location. */
+export type DeviceDisplayMetadata = {
   readonly userAgent?: string;
   readonly country?: string;
   readonly city?: string;
+};
+
+type SignInContext = DeviceDisplayMetadata & {
+  readonly ip?: string;
 };
 
 type SessionWithLastSubmission = {
@@ -19,12 +23,16 @@ type ParsedUserAgentInfo = {
   readonly deviceModel?: string;
 };
 
-export type SessionDisplayInfo = ParsedUserAgentInfo & {
+/** Normalized device information shared by session and device-management views. */
+export type DeviceDisplayInfo = ParsedUserAgentInfo & {
   readonly name?: string;
   readonly location?: string;
-  readonly ip?: string;
   readonly city?: string;
   readonly country?: string;
+};
+
+export type SessionDisplayInfo = DeviceDisplayInfo & {
+  readonly ip?: string;
 };
 
 type UserApplicationGrant = {
@@ -78,7 +86,7 @@ const getParsedUserAgentInfo = (userAgent?: string): ParsedUserAgentInfo => {
   };
 };
 
-const formatSessionDeviceName = ({ browserName, osName, deviceModel }: ParsedUserAgentInfo) => {
+const formatDeviceName = ({ browserName, osName, deviceModel }: ParsedUserAgentInfo) => {
   if (browserName && deviceModel) {
     return `${browserName} on ${deviceModel}`;
   }
@@ -98,21 +106,25 @@ const formatSessionDeviceName = ({ browserName, osName, deviceModel }: ParsedUse
   return osName;
 };
 
-const formatSessionLocation = ({ country, city }: SignInContext) => {
+const formatDeviceLocation = ({ country, city }: DeviceDisplayMetadata) => {
   const location = [city, country].filter(Boolean).join(', ');
 
   return location || undefined;
 };
 
-const normalizeSessionInfo = (signInContext: SignInContext): SessionDisplayInfo => {
-  const parsed = getParsedUserAgentInfo(signInContext.userAgent);
+/** Derive reusable browser, operating-system, device, and location display information. */
+export const getDeviceDisplayInfo = ({
+  userAgent,
+  country,
+  city,
+}: DeviceDisplayMetadata): DeviceDisplayInfo => {
+  const parsed = getParsedUserAgentInfo(userAgent);
 
   return {
-    name: formatSessionDeviceName(parsed),
-    location: formatSessionLocation(signInContext),
-    ip: signInContext.ip,
-    city: signInContext.city,
-    country: signInContext.country,
+    name: formatDeviceName(parsed),
+    location: formatDeviceLocation({ country, city }),
+    city,
+    country,
     ...parsed,
   };
 };
@@ -120,7 +132,14 @@ const normalizeSessionInfo = (signInContext: SignInContext): SessionDisplayInfo 
 export const getSessionDisplayInfo = (session: SessionWithLastSubmission): SessionDisplayInfo => {
   const signInContext = session.lastSubmission?.signInContext;
 
-  return isSignInContext(signInContext) ? normalizeSessionInfo(signInContext) : {};
+  if (!isSignInContext(signInContext)) {
+    return {};
+  }
+
+  return {
+    ...getDeviceDisplayInfo(signInContext),
+    ip: signInContext.ip,
+  };
 };
 
 export const normalizeUserApplicationGrantGroups = (


### PR DESCRIPTION
## Summary

Extract reusable device display formatting from the existing user-session utility. Existing user-session display now delegates to `getDeviceDisplayInfo({ userAgent, country, city })`, allowing trusted-device management surfaces to reuse the same browser, operating-system, device-model, and location presentation.

## Testing

Unit tests

## Checklist

- [ ] .changeset
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments