### PR TITLE
fix(core): invalidate resource cache when setting default resource

### DIFF
--- a/packages/core/src/queries/resource.test.ts
+++ b/packages/core/src/queries/resource.test.ts
@@ -26,6 +26,7 @@ const {
   findResourceById,
   findResourceByIndicator,
   insertResource,
+  setDefaultResource,
   updateResourceById,
   deleteResourceById,
 } = createResourceQueries(pool, wellKnownCache);
@@ -284,6 +285,91 @@ describe('resource query', () => {
       ...mockResource,
       accessTokenTtl: updatedAccessTokenTtl,
     });
+  });
+
+  it('setDefaultResource invalidates cached resources for both defaults', async () => {
+    const previousDefault = {
+      ...mockResource,
+      id: 'previous_default',
+      indicator: 'https://previous.dev/api',
+      isDefault: true,
+    };
+    const newDefault = { ...mockResource, isDefault: true };
+    const { id, indicator } = mockResource;
+    const expectFindByIndicatorSql = sql`
+      select ${sql.join(Object.values(fields), sql`, `)}
+      from ${table}
+      where ${fields.indicator}=$1
+    `;
+    const expectUnsetDefaultSql = sql`
+      update ${table}
+        set ${fields.isDefault}=false
+        where ${fields.isDefault}=true
+        returning ${fields.indicator};
+    `;
+    const expectSetDefaultSql = sql`
+      update ${table}
+        set ${fields.isDefault}=true
+        where ${fields.id}=$1
+        returning *;
+    `;
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectFindByIndicatorSql.sql);
+      expect(values).toEqual([previousDefault.indicator]);
+
+      return createMockQueryResult([previousDefault]);
+    });
+
+    await expect(findResourceByIndicator(previousDefault.indicator)).resolves.toEqual(
+      previousDefault
+    );
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectFindByIndicatorSql.sql);
+      expect(values).toEqual([indicator]);
+
+      return createMockQueryResult([mockResource]);
+    });
+
+    await expect(findResourceByIndicator(indicator)).resolves.toEqual(mockResource);
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectUnsetDefaultSql.sql);
+      expect(values).toEqual([]);
+
+      return createMockQueryResult([{ indicator: previousDefault.indicator }]);
+    });
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSetDefaultSql.sql);
+      expect(values).toEqual([id]);
+
+      return createMockQueryResult([newDefault]);
+    });
+
+    await expect(setDefaultResource(id)).resolves.toEqual(newDefault);
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectFindByIndicatorSql.sql);
+      expect(values).toEqual([previousDefault.indicator]);
+
+      return createMockQueryResult([{ ...previousDefault, isDefault: false }]);
+    });
+
+    await expect(findResourceByIndicator(previousDefault.indicator)).resolves.toEqual({
+      ...previousDefault,
+      isDefault: false,
+    });
+
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectFindByIndicatorSql.sql);
+      expect(values).toEqual([indicator]);
+
+      return createMockQueryResult([newDefault]);
+    });
+
+    await expect(findResourceByIndicator(indicator)).resolves.toEqual(newDefault);
   });
 
   it('deleteResourceById', async () => {

--- a/packages/core/src/queries/resource.ts
+++ b/packages/core/src/queries/resource.ts
@@ -38,25 +38,34 @@ export const createResourceQueries = (pool: CommonQueryMethods, wellKnownCache: 
     `);
 
   const setDefaultResource = async (id: string) => {
-    return pool.transaction(async (connection) => {
-      await connection.query(sql`
+    const { previousDefaults, resource } = await pool.transaction(async (connection) => {
+      const previousDefaults = await connection.any<Pick<Resource, 'indicator'>>(sql`
         update ${table}
           set ${fields.isDefault}=false
-          where ${fields.isDefault}=true;
+          where ${fields.isDefault}=true
+          returning ${fields.indicator};
       `);
-      const returning = await connection.maybeOne<Resource>(sql`
+      const resource = await connection.maybeOne<Resource>(sql`
         update ${table}
           set ${fields.isDefault}=true
           where ${fields.id}=${id}
           returning *;
       `);
 
-      if (!returning) {
+      if (!resource) {
         throw new UpdateError(Resources, { set: { isDefault: true }, where: { id } });
       }
 
-      return returning;
+      return { previousDefaults, resource };
     });
+
+    await Promise.all(
+      [...previousDefaults, resource].map(async ({ indicator }) =>
+        wellKnownCache.invalidate('resource-by-indicator', indicator)
+      )
+    );
+
+    return resource;
   };
 
   const findResourceById = buildFindEntityByIdWithPool(pool)(Resources);


### PR DESCRIPTION
## Summary

`setDefaultResource` flips `isDefault` on the previous and the new default rows inside a transaction, but never invalidates the memoized `resource-by-indicator` cache, which holds full `Resource` rows (including `isDefault`) for up to 30 minutes.

- Return the demoted rows' indicators from the transaction, then invalidate both the previous and the new default's cache entries through the guarded `wellKnownCache.invalidate`, mirroring `updateResourceById`.
- Invalidation runs after the transaction commits, so concurrent reads cannot re-fill the cache with pre-commit rows.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments