### PR TITLE
fix(core): keep session alive when revoking third-party app grants

### DIFF
--- a/.changeset/great-onions-refuse.md
+++ b/.changeset/great-onions-refuse.md
@@ -4,4 +4,4 @@
 
 fix revoking a user's third-party app authorization also signing the user out of that browser session
 
-Revoking now only affects the app being revoked — its tokens are invalidated and it must go through consent again on the next sign-in — while the browser's single sign-on session stays intact.
+Revoking now only invalidates the revoked app's tokens and requires it to go through consent again on the next sign-in. The browser's single sign-on session stays intact.

--- a/.changeset/great-onions-refuse.md
+++ b/.changeset/great-onions-refuse.md
@@ -1,0 +1,7 @@
+---
+'@logto/core': patch
+---
+
+fix revoking a user's third-party app authorization also dropping that browser's single sign-on session
+
+Revoking a third-party application grant (from the Console user details page, the Management API, or the Account API) rotated the identifier of the OIDC session the grant belonged to. Since revocation runs outside any browser request, the rotated session cookie could never reach the user agent, so the browser's single sign-on session was silently orphaned: applications that already held tokens kept working until the tokens expired, but the next authorization request from that browser — for any application — forced the user to enter their credentials again instead of signing in silently. The revocation now only removes the grant's authorization entry from the session: the affected third-party app loses its tokens and must re-consent on the next sign-in, while the browser's single sign-on session stays intact.

--- a/.changeset/great-onions-refuse.md
+++ b/.changeset/great-onions-refuse.md
@@ -2,6 +2,6 @@
 '@logto/core': patch
 ---
 
-fix revoking a user's third-party app authorization also dropping that browser's single sign-on session
+fix revoking a user's third-party app authorization also signing the user out of that browser session
 
-Revoking a third-party application grant (from the Console user details page, the Management API, or the Account API) rotated the identifier of the OIDC session the grant belonged to. Since revocation runs outside any browser request, the rotated session cookie could never reach the user agent, so the browser's single sign-on session was silently orphaned: applications that already held tokens kept working until the tokens expired, but the next authorization request from that browser — for any application — forced the user to enter their credentials again instead of signing in silently. The revocation now only removes the grant's authorization entry from the session: the affected third-party app loses its tokens and must re-consent on the next sign-in, while the browser's single sign-on session stays intact.
+Revoking now only affects the app being revoked — its tokens are invalidated and it must go through consent again on the next sign-in — while the browser's single sign-on session stays intact.

--- a/packages/core/src/libraries/session/index.test.ts
+++ b/packages/core/src/libraries/session/index.test.ts
@@ -264,7 +264,7 @@ describe('removeUserSessionAuthorizationByGrantId', () => {
     jest.clearAllMocks();
   });
 
-  it('should remove matching authorization and persist session', async () => {
+  it('should remove matching authorization and persist session without resetting its identifier', async () => {
     findUserActiveSessionUidByGrantId.mockResolvedValueOnce({ sessionUid: 'session-id' });
     findByUid.mockResolvedValueOnce({
       accountId: 'user-id',
@@ -277,7 +277,9 @@ describe('removeUserSessionAuthorizationByGrantId', () => {
 
     expect(findUserActiveSessionUidByGrantId).toHaveBeenCalledWith('user-id', 'grant-id');
     expect(findByUid).toHaveBeenCalledWith('session-id');
-    expect(resetIdentifier).toHaveBeenCalled();
+    // Rotating the identifier would orphan the browser session cookie and silently
+    // drop the browser's SSO session; grant revocation must keep the session alive.
+    expect(resetIdentifier).not.toHaveBeenCalled();
     expect(persist).toHaveBeenCalled();
   });
 
@@ -359,7 +361,7 @@ describe('removeUserSessionAuthorizationsByGrantIds', () => {
     expect(findUserActiveSessionUidByGrantId).toHaveBeenNthCalledWith(2, 'user-id', 'grant-2');
     expect(findByUid).toHaveBeenCalledTimes(1);
     expect(findByUid).toHaveBeenCalledWith('session-1');
-    expect(resetIdentifier).toHaveBeenCalledTimes(1);
+    expect(resetIdentifier).not.toHaveBeenCalled();
     expect(persist).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       succeededGrantIds: ['grant-1', 'grant-2'],

--- a/packages/core/src/libraries/session/index.ts
+++ b/packages/core/src/libraries/session/index.ts
@@ -87,9 +87,6 @@ const removeSessionAuthorizationsByGrantIds = async (
     return;
   }
 
-  // Align with oidc-provider client-scoped end-session branch:
-  // delete matched authorization entry + reset session identifier.
-  // oidc-provider/lib/actions/end_session.js
   const grantIdSet = new Set(grantIds);
   const authorizationEntries = Object.entries(session.authorizations);
   const filteredEntries = authorizationEntries.filter(
@@ -100,12 +97,18 @@ const removeSessionAuthorizationsByGrantIds = async (
     return;
   }
 
+  /**
+   * Unlike the client-scoped `end_session` branch in oidc-provider
+   * (lib/actions/end_session.js), this path must not rotate the session identifier via
+   * `resetIdentifier()`: revocation runs outside any browser request context, so the
+   * rotated cookie could never reach the user agent and the browser's SSO session would
+   * be silently orphaned — already-issued tokens keep working (session-bound token
+   * checks and ID token `sid` claims go through `session.uid`, which rotation never
+   * touches), but the next authorization request from that browser would force a full
+   * re-authentication instead of single sign-on.
+   */
   // eslint-disable-next-line @silverhand/fp/no-mutation
   session.authorizations = Object.fromEntries(filteredEntries);
-  // `end_session` also clears `session.state`, but that state is specific to
-  // the interactive logout flow context. Management API revocation has no such
-  // OIDC route state, so we only apply authorization cleanup + identifier reset.
-  session.resetIdentifier();
   await session.persist();
 };
 


### PR DESCRIPTION
## Summary

Fixes [LOG-14030](https://linear.app/silverhand/issue/LOG-14030/revoking-a-third-party-app-grant-force-logs-the-user-out-of-that): revoking a user's third-party app grant (Console user details page, `DELETE /api/users/:userId/grants/:grantId`, or the Account API self-serve revocation) silently dropped the browser's single sign-on session.

- Root cause: `removeSessionAuthorizationsByGrantIds` called `session.resetIdentifier()` after removing the authorization entry. This pattern was copied from oidc-provider's client-scoped `end_session` branch, but that branch runs in a browser request context where the response carries the rotated cookie back; the Management/Account API paths have no browser channel, so the user's cookie ends up pointing at a destroyed record.
- Observable impact: applications that already hold tokens keep working (session-bound token checks and ID token `sid` claims go through `session.uid`, which rotation never touches — only the primary key `id` referenced by the cookie changes), so nothing appears broken right away. The next authorization request from that browser — for any application — then forces the user to enter credentials again instead of signing in silently.
- Fix: keep removing the matched authorization entries and persisting the session, but skip the identifier rotation.
- Forced re-consent is unaffected: both the grant and the session authorization entry are gone, so the next authorization request for that app always goes through consent again.
- Token revocation is unchanged: `revokeUserGrantById` → `revokeGrantChain` still invalidates the app's refresh/access token chain immediately — the rotation contributed nothing to that; its only observable effect was breaking SSO.

### How to verify

In one browser: sign in to the demo app, complete a third-party app authorization, then revoke that app in the Account Center (or Console). Trigger a new authorization request from the same browser (e.g. the third-party app signs in again): before this fix the user lands on the credentials page; with the fix they skip straight to the consent screen.

## Testing

Unit tests updated to assert the session identifier is no longer reset.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments