### PR TITLE
fix(core): revalidate consent-time user scopes against the current client scope

### DIFF
--- a/.changeset/eighty-jokes-repeat.md
+++ b/.changeset/eighty-jokes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@logto/core": patch
+---
+
+fix consent submission granting user scopes that were removed while the consent screen was open

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -26,7 +26,11 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { interactionPrefix } from '../const.js';
 
-import { buildResourceScopesToReject, filterAndParseMissingResourceScopes } from './utils.js';
+import {
+  buildResourceScopesToReject,
+  filterAndParseMissingResourceScopes,
+  revalidateConsentClient,
+} from './utils.js';
 
 const { InvalidClient, InvalidRedirectUri, InvalidRequest } = errors;
 
@@ -58,7 +62,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const {
         session,
-        params: { client_id: applicationId, redirect_uri: redirectUri },
+        params: { client_id: applicationId, redirect_uri: redirectUri, scope },
         prompt,
       } = interactionDetails;
 
@@ -73,25 +77,18 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const cimd = isCimdClient(envSet, applicationId);
 
-      if (cimd) {
-        /**
-         * The oidc-provider resume path re-runs `checkClient` (re-fetching the metadata
-         * document when its cache has expired) but not `check_redirect_uri`, so a URI removed
-         * from the current document would still receive the authorization code. Re-assert it
-         * here against whatever document the cache serves at submission time — best effort,
-         * not airtight: a cache expiry between this check and resume can still swap in a
-         * changed document unchecked. It narrows the exposure from the whole login-to-consent
-         * span to that cache-boundary race.
-         */
-        const client = await provider.Client.find(applicationId);
-        assertThat(client, new InvalidClient('client must be available'));
-        assertThat(
-          typeof redirectUri === 'string' && client.redirectUriAllowed(redirectUri),
-          new InvalidRedirectUri(
-            'redirect_uri must still be allowed by the client metadata document'
-          )
-        );
-      }
+      const { missingOIDCScope = [], missingResourceScopes: allMissingResourceScopes = {} } =
+        getMissingScopes(prompt);
+
+      await revalidateConsentClient({
+        provider,
+        queries,
+        applicationId,
+        cimd,
+        redirectUri,
+        requestedScope: scope,
+        missingOIDCScope,
+      });
 
       // Grant the organizations to the application if the user has selected the organizations
       if (organizationIds?.length) {
@@ -117,9 +114,6 @@ export default function consentRoutes<T extends IRouterParamContext>(
           );
         }
       }
-
-      const { missingOIDCScope = [], missingResourceScopes: allMissingResourceScopes = {} } =
-        getMissingScopes(prompt);
 
       /* === Rebuild resource scopes === */
       // The resource scopes saved in the prompt details lost the organization information.

--- a/packages/core/src/routes/interaction/consent/utils.test.ts
+++ b/packages/core/src/routes/interaction/consent/utils.test.ts
@@ -1,4 +1,72 @@
-import { buildResourceScopesToReject } from './utils.js';
+import { ReservedScope, UserScope } from '@logto/core-kit';
+
+import { buildResourceScopesToReject, findStaleOidcScopes } from './utils.js';
+
+describe('findStaleOidcScopes', () => {
+  const clientScope = [ReservedScope.OpenId, ReservedScope.OfflineAccess, UserScope.Profile].join(
+    ' '
+  );
+
+  it('should return nothing when every requested OIDC scope is still allowed', () => {
+    expect(
+      findStaleOidcScopes({
+        clientScope,
+        requestedScope: `${ReservedScope.OpenId} ${UserScope.Profile}`,
+        missingOIDCScope: [UserScope.Profile],
+      })
+    ).toEqual([]);
+  });
+
+  it('should flag a requested user scope the current client scope no longer allows', () => {
+    expect(
+      findStaleOidcScopes({
+        clientScope,
+        requestedScope: `${ReservedScope.OpenId} ${UserScope.Profile} ${UserScope.Email}`,
+        missingOIDCScope: [UserScope.Profile],
+      })
+    ).toEqual([UserScope.Email]);
+  });
+
+  it('should flag a snapshot scope even when it no longer derives from the scope parameter', () => {
+    expect(
+      findStaleOidcScopes({
+        clientScope,
+        requestedScope: ReservedScope.OpenId,
+        missingOIDCScope: [UserScope.Email],
+      })
+    ).toEqual([UserScope.Email]);
+  });
+
+  it('should ignore resource scope names in the scope parameter', () => {
+    expect(
+      findStaleOidcScopes({
+        clientScope,
+        requestedScope: `${ReservedScope.OpenId} read:resource`,
+        missingOIDCScope: [],
+      })
+    ).toEqual([]);
+  });
+
+  it('should validate the snapshot alone when the scope parameter is not a string', () => {
+    expect(
+      findStaleOidcScopes({
+        clientScope,
+        requestedScope: undefined,
+        missingOIDCScope: [UserScope.Profile, UserScope.Email],
+      })
+    ).toEqual([UserScope.Email]);
+  });
+
+  it('should deduplicate scopes present in both the request and the snapshot', () => {
+    expect(
+      findStaleOidcScopes({
+        clientScope,
+        requestedScope: `${UserScope.Email} ${UserScope.Organizations}`,
+        missingOIDCScope: [UserScope.Email, UserScope.Organizations],
+      })
+    ).toEqual([UserScope.Email, UserScope.Organizations]);
+  });
+});
 
 describe('buildResourceScopesToReject', () => {
   it('should reject the remainder of a partially granted group', () => {

--- a/packages/core/src/routes/interaction/consent/utils.test.ts
+++ b/packages/core/src/routes/interaction/consent/utils.test.ts
@@ -1,6 +1,14 @@
 import { ReservedScope, UserScope } from '@logto/core-kit';
+import { errors } from 'oidc-provider';
 
-import { buildResourceScopesToReject, findStaleOidcScopes } from './utils.js';
+import type Queries from '#src/tenants/Queries.js';
+import { createMockProvider } from '#src/test-utils/oidc-provider.js';
+
+import {
+  buildResourceScopesToReject,
+  findStaleOidcScopes,
+  revalidateConsentClient,
+} from './utils.js';
 
 describe('findStaleOidcScopes', () => {
   const clientScope = [ReservedScope.OpenId, ReservedScope.OfflineAccess, UserScope.Profile].join(
@@ -102,5 +110,115 @@ describe('buildResourceScopesToReject', () => {
         'https://api.example.com': [],
       }
     );
+  });
+});
+
+describe('revalidateConsentClient', () => {
+  const clientScope = [ReservedScope.OpenId, ReservedScope.OfflineAccess, UserScope.Profile].join(
+    ' '
+  );
+  const cimdClientId = 'https://client.example.com/metadata.json';
+  const redirectUri = 'https://client.example.com/callback';
+
+  it('should reject a CIMD submission whose redirect uri the current document no longer allows, without consulting the application registry', async () => {
+    const findApplicationById = jest.fn().mockRejectedValue(new Error('should not be called'));
+    const provider = createMockProvider(undefined, undefined, {
+      find: async () => ({ scope: clientScope, redirectUriAllowed: () => false }),
+    });
+
+    await expect(
+      revalidateConsentClient({
+        provider,
+        queries: { applications: { findApplicationById } } as unknown as Queries,
+        applicationId: cimdClientId,
+        cimd: true,
+        redirectUri,
+        requestedScope: ReservedScope.OpenId,
+        missingOIDCScope: [],
+      })
+    ).rejects.toThrow(errors.InvalidRedirectUri);
+
+    expect(findApplicationById).not.toHaveBeenCalled();
+  });
+
+  it('should reject a CIMD submission when the tenant ceiling no longer allows a snapshot scope', async () => {
+    const provider = createMockProvider(undefined, undefined, {
+      find: async () => ({ scope: clientScope, redirectUriAllowed: () => true }),
+    });
+
+    await expect(
+      revalidateConsentClient({
+        provider,
+        queries: { applications: { findApplicationById: jest.fn() } } as unknown as Queries,
+        applicationId: cimdClientId,
+        cimd: true,
+        redirectUri,
+        requestedScope: `${ReservedScope.OpenId} ${UserScope.Email}`,
+        missingOIDCScope: [UserScope.Email],
+      })
+    ).rejects.toThrow(errors.InvalidScope);
+  });
+
+  it('should pass a CIMD submission whose redirect uri and scopes are still allowed', async () => {
+    const provider = createMockProvider(undefined, undefined, {
+      find: async () => ({ scope: clientScope, redirectUriAllowed: () => true }),
+    });
+
+    await expect(
+      revalidateConsentClient({
+        provider,
+        queries: { applications: { findApplicationById: jest.fn() } } as unknown as Queries,
+        applicationId: cimdClientId,
+        cimd: true,
+        redirectUri,
+        requestedScope: `${ReservedScope.OpenId} ${UserScope.Profile}`,
+        missingOIDCScope: [UserScope.Profile],
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('should skip revalidation for a first-party application', async () => {
+    const find = jest.fn();
+    const provider = createMockProvider(undefined, undefined, { find });
+
+    await expect(
+      revalidateConsentClient({
+        provider,
+        queries: {
+          applications: {
+            findApplicationById: jest.fn().mockResolvedValue({ isThirdParty: false }),
+          },
+        } as unknown as Queries,
+        applicationId: 'registered-app-id',
+        cimd: false,
+        redirectUri,
+        requestedScope: ReservedScope.OpenId,
+        missingOIDCScope: [],
+      })
+    ).resolves.toBeUndefined();
+
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it('should reject a third-party application submission when a snapshot scope is no longer allowed', async () => {
+    const provider = createMockProvider(undefined, undefined, {
+      find: async () => ({ scope: clientScope, redirectUriAllowed: () => true }),
+    });
+
+    await expect(
+      revalidateConsentClient({
+        provider,
+        queries: {
+          applications: {
+            findApplicationById: jest.fn().mockResolvedValue({ isThirdParty: true }),
+          },
+        } as unknown as Queries,
+        applicationId: 'registered-app-id',
+        cimd: false,
+        redirectUri,
+        requestedScope: `${ReservedScope.OpenId} ${UserScope.Email}`,
+        missingOIDCScope: [UserScope.Email],
+      })
+    ).rejects.toThrow(errors.InvalidScope);
   });
 });

--- a/packages/core/src/routes/interaction/consent/utils.test.ts
+++ b/packages/core/src/routes/interaction/consent/utils.test.ts
@@ -10,6 +10,8 @@ import {
   revalidateConsentClient,
 } from './utils.js';
 
+const { jest } = import.meta;
+
 describe('findStaleOidcScopes', () => {
   const clientScope = [ReservedScope.OpenId, ReservedScope.OfflineAccess, UserScope.Profile].join(
     ' '

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -1,6 +1,7 @@
-import { ReservedResource } from '@logto/core-kit';
+import { ReservedResource, ReservedScope, UserScope } from '@logto/core-kit';
 import { type MissingResourceScopes, type Scope, missingResourceScopesGuard } from '@logto/schemas';
-import { errors } from 'oidc-provider';
+import { deduplicate } from '@silverhand/essentials';
+import { type Provider, errors } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
 import { isCimdClient } from '#src/oidc/cimd/index.js';
@@ -14,7 +15,7 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-const { InvalidTarget } = errors;
+const { InvalidClient, InvalidRedirectUri, InvalidScope, InvalidTarget } = errors;
 
 /**
  * Parse the missing resource scopes info with details. We need to display the resource name and scope details on the consent page.
@@ -83,6 +84,93 @@ const parseMissingResourceScopesInfo = async (
       // Filter out if all resource scopes are not found (should not happen)
       .filter(({ scopes }) => scopes.length > 0)
       .map((resourceWithGroups) => missingResourceScopesGuard.parse(resourceWithGroups))
+  );
+};
+
+/** Find the requested or snapshot OIDC scopes that the client's current scope no longer allows. */
+export const findStaleOidcScopes = ({
+  clientScope,
+  requestedScope,
+  missingOIDCScope,
+}: {
+  clientScope: string | undefined;
+  requestedScope: unknown;
+  missingOIDCScope: string[];
+}): string[] => {
+  /** Mirrors the provider `scopes` configuration, keeping resource scope names out of the comparison. */
+  const oidcScopes = new Set<string>([
+    ...Object.values(ReservedScope),
+    ...Object.values(UserScope),
+  ]);
+  const allowedScopes = new Set(clientScope?.split(' '));
+  const requestedOidcScopes =
+    typeof requestedScope === 'string'
+      ? requestedScope.split(' ').filter((scope) => oidcScopes.has(scope))
+      : [];
+
+  return deduplicate([...requestedOidcScopes, ...missingOIDCScope]).filter(
+    (scope) => !allowedScopes.has(scope)
+  );
+};
+
+/**
+ * The scopes a submission grants were validated at interaction creation, up to 1 hour ago, and
+ * the provider's resume stack never re-runs `checkScope` — re-assert them against the freshly
+ * resolved client before anything is written. Resource scopes re-check their own source tables
+ * in `filterAndParseMissingResourceScopes`.
+ */
+export const revalidateConsentClient = async ({
+  provider,
+  queries,
+  applicationId,
+  cimd,
+  redirectUri,
+  requestedScope,
+  missingOIDCScope,
+}: {
+  provider: Provider;
+  queries: Queries;
+  applicationId: string;
+  cimd: boolean;
+  redirectUri: unknown;
+  requestedScope: unknown;
+  missingOIDCScope: string[];
+}) => {
+  if (!(await isThirdPartyApplication(queries, applicationId))) {
+    return;
+  }
+
+  const client = await provider.Client.find(applicationId);
+  assertThat(client, new InvalidClient('client must be available'));
+
+  if (cimd) {
+    /**
+     * The oidc-provider resume path re-runs `checkClient` (re-fetching the metadata document
+     * when its cache has expired) but not `check_redirect_uri`, so a URI removed from the
+     * current document would still receive the authorization code. Re-assert it here against
+     * whatever document the cache serves at submission time — best effort, not airtight: a
+     * cache expiry between this check and resume can still swap in a changed document
+     * unchecked. It narrows the exposure from the whole login-to-consent span to that
+     * cache-boundary race.
+     */
+    assertThat(
+      typeof redirectUri === 'string' && client.redirectUriAllowed(redirectUri),
+      new InvalidRedirectUri('redirect_uri must still be allowed by the client metadata document')
+    );
+  }
+
+  const staleOidcScopes = findStaleOidcScopes({
+    clientScope: client.scope,
+    requestedScope,
+    missingOIDCScope,
+  });
+
+  assertThat(
+    staleOidcScopes.length === 0,
+    new InvalidScope(
+      'requested scope is no longer allowed for the client',
+      staleOidcScopes.join(' ')
+    )
   );
 };
 

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -136,7 +136,8 @@ export const revalidateConsentClient = async ({
   requestedScope: unknown;
   missingOIDCScope: string[];
 }) => {
-  if (!(await isThirdPartyApplication(queries, applicationId))) {
+  /** A CIMD client is third-party by definition; only registered ids consult the classifier. */
+  if (!cimd && !(await isThirdPartyApplication(queries, applicationId))) {
     return;
   }
 

--- a/packages/integration-tests/src/tests/api/interaction/consent/scope-revalidation.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/consent/scope-revalidation.test.ts
@@ -1,0 +1,101 @@
+import { UserScope } from '@logto/core-kit';
+import { ApplicationType, ApplicationUserConsentScopeType, SignInIdentifier } from '@logto/schemas';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import {
+  assignUserConsentScopes,
+  deleteUserConsentScopes,
+} from '#src/api/application-user-consent-scope.js';
+import { createApplicationWithSecret, deleteApplication } from '#src/api/application.js';
+import { consent } from '#src/api/interaction.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateNewUser } from '#src/helpers/user.js';
+
+describe('consent scope revalidation', () => {
+  const redirectUri = 'http://example.com';
+
+  const bootstrapConsentFlow = async (requestedScopes: string[]) => {
+    const application = await createApplicationWithSecret(
+      'consent-scope-revalidation-app',
+      ApplicationType.Traditional,
+      {
+        isThirdParty: true,
+        oidcClientMetadata: {
+          redirectUris: [redirectUri],
+          postLogoutRedirectUris: [],
+        },
+      }
+    );
+
+    await assignUserConsentScopes(application.id, {
+      userScopes: [UserScope.Profile, UserScope.Email],
+    });
+
+    const { userProfile, user } = await generateNewUser({ username: true, password: true });
+
+    const client = await initExperienceClient({
+      config: {
+        appId: application.id,
+        appSecret: application.secret,
+        scopes: requestedScopes,
+      },
+      redirectUri,
+    });
+
+    const { verificationId } = await client.verifyPassword({
+      identifier: {
+        type: SignInIdentifier.Username,
+        value: userProfile.username,
+      },
+      password: userProfile.password,
+    });
+
+    await client.identifyUser({ verificationId });
+
+    const { redirectTo } = await client.submitInteraction();
+    await client.processSession(redirectTo, false);
+
+    return { application, user, client };
+  };
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+  });
+
+  it('should reject the submission when a requested user scope was removed mid-interaction', async () => {
+    const { application, user, client } = await bootstrapConsentFlow([
+      UserScope.Profile,
+      UserScope.Email,
+    ]);
+
+    await deleteUserConsentScopes(
+      application.id,
+      ApplicationUserConsentScopeType.UserScopes,
+      UserScope.Email
+    );
+
+    await expectRejects(client.send(consent), {
+      code: 'oidc.invalid_scope',
+      status: 400,
+    });
+
+    await Promise.all([deleteApplication(application.id), deleteUser(user.id)]);
+  });
+
+  it('should keep the submission working when the removed scope was never requested', async () => {
+    const { application, user, client } = await bootstrapConsentFlow([UserScope.Profile]);
+
+    await deleteUserConsentScopes(
+      application.id,
+      ApplicationUserConsentScopeType.UserScopes,
+      UserScope.Email
+    );
+
+    const { redirectTo } = await client.send(consent);
+    await client.manualConsent(redirectTo);
+
+    await Promise.all([deleteApplication(application.id), deleteUser(user.id)]);
+  });
+});

--- a/packages/integration-tests/src/tests/api/interaction/consent/scope-revalidation.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/consent/scope-revalidation.test.ts
@@ -1,5 +1,6 @@
 import { UserScope } from '@logto/core-kit';
 import { ApplicationType, ApplicationUserConsentScopeType, SignInIdentifier } from '@logto/schemas';
+import ky from 'ky';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import {
@@ -8,8 +9,8 @@ import {
 } from '#src/api/application-user-consent-scope.js';
 import { createApplicationWithSecret, deleteApplication } from '#src/api/application.js';
 import { consent } from '#src/api/interaction.js';
+import { logtoUrl } from '#src/constants.js';
 import { initExperienceClient } from '#src/helpers/client.js';
-import { expectRejects } from '#src/helpers/index.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 
@@ -76,10 +77,14 @@ describe('consent scope revalidation', () => {
       UserScope.Email
     );
 
-    await expectRejects(client.send(consent), {
-      code: 'oidc.invalid_scope',
-      status: 400,
+    const response = await ky.post(`${logtoUrl}/api/interaction/consent`, {
+      headers: { cookie: client.interactionCookie },
+      json: {},
+      throwHttpErrors: false,
     });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: 'oidc.invalid_scope' });
 
     await Promise.all([deleteApplication(application.id), deleteUser(user.id)]);
   });


### PR DESCRIPTION
## Summary

Revalidate the OIDC user scopes a consent submission grants against the client's current scope, for both registered third-party applications and CIMD clients.

- The consent POST wrote the `missingOIDCScope` snapshot (captured at interaction creation, up to 1 hour earlier) into the grant unchecked.
- Third-party and CIMD clients rebuild their OP scope list from their source tables on every resolution, and the provider's resume stack re-runs `checkClient` but never `checkScope`, so a user scope removed mid-interaction still reached the grant and the issued tokens.
- The submission now re-asserts the requested and snapshot OIDC scopes against the freshly resolved client before anything is written, rejecting with `invalid_scope` the way a fresh authorization request would be rejected.
- Resource scopes already re-check their source tables on submission and are unchanged.

Closes LOG-13991.

## Testing

Unit tests and integration tests.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
