### PR TITLE
fix(core): update oidc-provider to upstream v9.11.3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,7 +83,7 @@
     "lru-cache": "^11.0.0",
     "nanoid": "^5.0.9",
     "node-forge": "^1.3.1",
-    "oidc-provider": "github:logto-io/node-oidc-provider#e04834716e4bfee9f74e8d2e919cae21b2295a8a",
+    "oidc-provider": "github:logto-io/node-oidc-provider#513c523c0e68ee6112da8c871cce86204a136163",
     "openapi-types": "^12.1.3",
     "otplib": "^12.0.1",
     "p-map": "^7.0.2",

--- a/packages/core/src/include.d/oidc-provider/lib-keep/helpers/epoch_time.d.ts
+++ b/packages/core/src/include.d/oidc-provider/lib-keep/helpers/epoch_time.d.ts
@@ -1,4 +1,0 @@
-// https://github.com/panva/node-oidc-provider/blob/cf2069cbb31a6a855876e95157372d25dde2511c/lib/helpers/epoch_time.js
-declare module 'oidc-provider/lib/helpers/epoch_time.js' {
-  export default function epochTime(): number;
-}

--- a/packages/core/src/include.d/oidc-provider/lib-keep/helpers/grant_common.d.ts
+++ b/packages/core/src/include.d/oidc-provider/lib-keep/helpers/grant_common.d.ts
@@ -1,4 +1,4 @@
-// https://github.com/logto-io/node-oidc-provider/blob/7722ac95d77cd62a41528aec4eb711b3d12589d4/lib/helpers/grant_common.js
+// https://github.com/logto-io/node-oidc-provider/blob/513c523c0e68ee6112da8c871cce86204a136163/lib/helpers/grant_common.js
 declare module 'oidc-provider/lib/helpers/grant_common.js' {
   import { type X509Certificate } from 'node:crypto';
 
@@ -73,13 +73,13 @@ declare module 'oidc-provider/lib/helpers/grant_common.js' {
 
   /**
    * Binds the token to the DPoP proof key when a proof is present: runs replay detection
-   * (unless `allowReplay` is enabled) and sets the `jkt` thumbprint.
+   * (via `checkDpopReplay`, a no-op when `features.dPoP.allowReplay` is enabled) and sets the
+   * `jkt` thumbprint.
    */
   export function applyDpopBinding(
     ctx: KoaContextWithOIDC,
     dPoP: { jti: string; thumbprint: string } | undefined,
-    at: { setThumbprint(name: 'jkt', input: string): void },
-    allowReplay: boolean
+    at: { setThumbprint(name: 'jkt', input: string): void }
   ): Promise<void>;
 
   /**

--- a/packages/core/src/include.d/oidc-provider/lib-keep/helpers/validate_dpop.d.ts
+++ b/packages/core/src/include.d/oidc-provider/lib-keep/helpers/validate_dpop.d.ts
@@ -1,9 +1,18 @@
-// https://github.com/logto-io/node-oidc-provider/blob/d60ae9bd6d089e69f3a243119c6d87db25e837ce/lib/helpers/validate_dpop.js
+// https://github.com/logto-io/node-oidc-provider/blob/513c523c0e68ee6112da8c871cce86204a136163/lib/helpers/validate_dpop.js
 declare module 'oidc-provider/lib/helpers/validate_dpop.js' {
   import { type Optional } from '@silverhand/essentials';
   import type { KoaContextWithOIDC } from 'oidc-provider';
 
-  export const CHALLENGE_OK_WINDOW: number;
+  /**
+   * Rejects a replayed DPoP proof (`jti` seen before) with the given error class. A no-op when
+   * no proof is present or `features.dPoP.allowReplay` is enabled.
+   */
+  export function checkDpopReplay(
+    ctx: KoaContextWithOIDC,
+    dPoP: { jti: string } | undefined,
+    clientId: string,
+    ErrorClass: new (description: string) => Error
+  ): Promise<void>;
 
   export default function dpopValidate(
     ctx: KoaContextWithOIDC,

--- a/packages/core/src/include.d/oidc-provider/lib-keep/shared/check_rar.d.ts
+++ b/packages/core/src/include.d/oidc-provider/lib-keep/shared/check_rar.d.ts
@@ -1,4 +1,4 @@
-// https://github.com/logto-io/node-oidc-provider/blob/d60ae9bd6d089e69f3a243119c6d87db25e837ce/lib/shared/check_rar.js
+// https://github.com/logto-io/node-oidc-provider/blob/513c523c0e68ee6112da8c871cce86204a136163/lib/shared/check_rar.js
 declare module 'oidc-provider/lib/shared/check_rar.js' {
   import type { KoaContextWithOIDC } from 'oidc-provider';
 

--- a/packages/core/src/oidc/grants/client-credentials.test.ts
+++ b/packages/core/src/oidc/grants/client-credentials.test.ts
@@ -15,7 +15,6 @@ jest.unstable_mockModule('#src/oidc/oidc-provider-internals.js', () => ({
   getProviderConfiguration: jest.fn().mockReturnValue({
     features: {
       mTLS: { getCertificate: jest.fn() },
-      dPoP: { allowReplay: false },
     },
     scopes: new Set(['foo', 'bar']),
   }),

--- a/packages/core/src/oidc/grants/client-credentials.ts
+++ b/packages/core/src/oidc/grants/client-credentials.ts
@@ -81,7 +81,6 @@ export const buildHandler: (
   const {
     features: {
       mTLS: { getCertificate },
-      dPoP: { allowReplay },
     },
     scopes: statics,
   } = getProviderConfiguration(ctx.oidc.provider);
@@ -178,7 +177,7 @@ export const buildHandler: (
     token.setThumbprint('x5t', cert);
   }
 
-  await applyDpopBinding(ctx, dPoP, token, allowReplay);
+  await applyDpopBinding(ctx, dPoP, token);
   checkDpopRequired(ctx, dPoP);
 
   ctx.oidc.entity('ClientCredentials', token);

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -43,18 +43,16 @@ import {
   certificateThumbprint,
   checkAccountMismatch,
   checkAttestBinding,
+  checkDpopReplay,
   checkDpopRequired,
   checkRar,
   createAccessToken,
-  CHALLENGE_OK_WINDOW,
   difference,
   dpopValidate,
-  epochTime,
   getProviderConfiguration,
   type GrantTypeHandler,
   issueIdToken,
   pluralize,
-  type ReplayDetectionClass,
   resolveResource,
   revoke,
   validateAccount,
@@ -133,13 +131,12 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     features: {
       userinfo,
       mTLS: { getCertificate },
-      dPoP: { allowReplay },
       resourceIndicators,
       richAuthorizationRequests,
     },
   } = getProviderConfiguration(provider);
 
-  const { RefreshToken, AccessToken, ReplayDetection } = provider;
+  const { RefreshToken, AccessToken } = provider;
 
   const dPoP = await dpopValidate(ctx);
 
@@ -194,16 +191,7 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     }
   }
 
-  if (dPoP && !allowReplay) {
-    // eslint-disable-next-line no-restricted-syntax -- widen with the static method missing from the typings, see `ReplayDetectionClass`
-    const unique = await (ReplayDetection as ReplayDetectionClass).unique(
-      client.clientId,
-      dPoP.jti,
-      epochTime() + CHALLENGE_OK_WINDOW
-    );
-
-    assertThat(unique, new InvalidGrant('DPoP proof JWT Replay detected'));
-  }
+  await checkDpopReplay(ctx, dPoP, client.clientId, InvalidGrant);
 
   if (refreshToken.jkt && (!dPoP || refreshToken.jkt !== dPoP.thumbprint)) {
     throw new InvalidGrant('failed jkt verification');

--- a/packages/core/src/oidc/grants/token-exchange/index.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.ts
@@ -93,7 +93,6 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
       userinfo,
       resourceIndicators,
       mTLS: { getCertificate },
-      dPoP: { allowReplay },
     },
     scopes: oidcScopes,
     findAccount,
@@ -153,7 +152,7 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     ...(subjectTokenId ? { subjectTokenId } : {}),
   };
 
-  await applyDpopBinding(ctx, dPoP, accessToken, allowReplay);
+  await applyDpopBinding(ctx, dPoP, accessToken);
   checkDpopRequired(ctx, dPoP);
 
   const cert = checkMtlsCert(ctx, getCertificate);

--- a/packages/core/src/oidc/oidc-provider-internals.ts
+++ b/packages/core/src/oidc/oidc-provider-internals.ts
@@ -9,7 +9,6 @@ import instance from 'oidc-provider/lib/helpers/weak_cache.js';
 export { default as difference } from 'oidc-provider/lib/helpers/_/difference.js';
 export { default as certificateThumbprint } from 'oidc-provider/lib/helpers/certificate_thumbprint.js';
 export { checkAttestBinding } from 'oidc-provider/lib/helpers/check_attest_binding.js';
-export { default as epochTime } from 'oidc-provider/lib/helpers/epoch_time.js';
 export { pluralize } from 'oidc-provider/lib/helpers/formatters.js';
 export {
   applyDpopBinding,
@@ -27,7 +26,7 @@ export { default as resolveResource } from 'oidc-provider/lib/helpers/resolve_re
 export { default as revoke } from 'oidc-provider/lib/helpers/revoke.js';
 export {
   default as dpopValidate,
-  CHALLENGE_OK_WINDOW,
+  checkDpopReplay,
 } from 'oidc-provider/lib/helpers/validate_dpop.js';
 export { default as validatePresence } from 'oidc-provider/lib/helpers/validate_presence.js';
 export { default as checkRar } from 'oidc-provider/lib/shared/check_rar.js';
@@ -38,18 +37,5 @@ export { default as checkResource } from 'oidc-provider/lib/shared/check_resourc
  * callback. `@types/oidc-provider` still describes the pre-v9 two-parameter signature.
  */
 export type GrantTypeHandler = (ctx: KoaContextWithOIDC) => Promise<void>;
-
-/**
- * The `ReplayDetection` model class with its static `unique` method. `@types/oidc-provider`
- * declares `unique` only as an instance method, but the runtime implements it as a static method
- * of the class. Do not declare the missing static via module augmentation: the typings export the
- * model classes with `export type` on purpose, and a value declaration would make
- * `import { ReplayDetection } from 'oidc-provider'` pass type checking while failing at runtime.
- *
- * See https://github.com/logto-io/node-oidc-provider/blob/d60ae9bd6d089e69f3a243119c6d87db25e837ce/lib/models/replay_detection.js
- */
-export type ReplayDetectionClass = Provider['ReplayDetection'] & {
-  unique: (iss: string, jti: string, exp?: number) => Promise<boolean>;
-};
 
 export const getProviderConfiguration = (provider: Provider) => instance(provider).configuration;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4243,8 +4243,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       oidc-provider:
-        specifier: github:logto-io/node-oidc-provider#e04834716e4bfee9f74e8d2e919cae21b2295a8a
-        version: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a
+        specifier: github:logto-io/node-oidc-provider#513c523c0e68ee6112da8c871cce86204a136163
+        version: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/513c523c0e68ee6112da8c871cce86204a136163
       openapi-types:
         specifier: ^12.1.3
         version: 12.1.3
@@ -6535,12 +6535,6 @@ packages:
   '@koa/cors@5.0.0':
     resolution: {integrity: sha512-x/iUDjcS90W69PryLDIMgFyV21YLTnG9zOpPXS7Bkt2b8AsY3zZsIpOLBkYr9fBcF3HbkKaER5hOBZLfpLgYNw==}
     engines: {node: '>= 14.0.0'}
-
-  '@koa/router@15.7.0':
-    resolution: {integrity: sha512-WaAlk4TOl/O0rhTpOR0l052gz03syPMmI6Pe2gd7v3ubjfv5UcSGcnb0Y/J5NNC/ln+5FiUqPJTc/a15I+XqAA==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      koa: ^2.16.4
 
   '@levischuck/tiny-cbor@0.2.2':
     resolution: {integrity: sha512-f5CnPw997Y2GQ8FAvtuVVC19FX8mwNNC+1XJcIi16n/LTJifKO6QBgGLgN3YEmqtGMk17SKSuoWES3imJVxAVw==}
@@ -10889,10 +10883,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  eta@4.6.0:
-    resolution: {integrity: sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==}
-    engines: {node: '>=20'}
-
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -11525,10 +11515,6 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
-  http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
-
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -11594,10 +11580,6 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
-    engines: {node: '>=0.10.0'}
-
-  iconv-lite@0.7.3:
-    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   icss-utils@5.1.0:
@@ -12215,6 +12197,9 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
 
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
@@ -13412,9 +13397,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a:
-    resolution: {gitHosted: true, integrity: sha512-WEK/83nAa+Mm1r+7pYJLxTM8K0j7GOsVQC7N/CGp//17HZ5GbGUqFQgDxVlLO5p4qE6eR0QFx0jJPhd0t+KnAQ==, tarball: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a}
-    version: 9.9.1
+  oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/513c523c0e68ee6112da8c871cce86204a136163:
+    resolution: {gitHosted: true, integrity: sha512-KaUwCyEEDSZILL2ua2f9SsQ2oSrgq04JAmkQzq2gj7VJyREH3zQS14G7MhfDYxEKjAhO4JZ6bUGzZjW/0Q5pEg==, tarball: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/513c523c0e68ee6112da8c871cce86204a136163}
+    version: 9.11.3
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
@@ -14120,10 +14105,6 @@ packages:
     resolution: {integrity: sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==}
     engines: {node: '>=12'}
 
-  quick-lru@7.3.0:
-    resolution: {integrity: sha512-k9lSsjl36EJdK7I06v7APZCbyGT2vMTsYSRX1Q2nbYmnkBqgUhRkAuzH08Ciotteu/PLJmIF2+tti7o3C/ts2g==}
-    engines: {node: '>=18'}
-
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -14135,10 +14116,6 @@ packages:
   raw-body@3.0.0:
     resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
-
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
 
   react-animate-height@3.0.4:
     resolution: {integrity: sha512-k+mBS8yCzpFp+7BdrHsL5bXd6CO/2bYO2SvRGKfxK+Ss3nzplAJLlgnd6Zhcxe/avdpy/CgcziicFj7pIHgG5g==}
@@ -14912,10 +14889,6 @@ packages:
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
-    engines: {node: '>= 0.8'}
-
-  statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
@@ -17013,7 +16986,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17835,16 +17808,6 @@ snapshots:
     dependencies:
       vary: 1.1.2
 
-  '@koa/router@15.7.0(koa@3.2.1)':
-    dependencies:
-      debug: 4.4.3
-      http-errors: 2.0.1
-      koa: 3.2.1
-      koa-compose: 4.1.0
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@levischuck/tiny-cbor@0.2.2': {}
 
   '@lit-labs/ssr-dom-shim@1.2.0': {}
@@ -18204,7 +18167,7 @@ snapshots:
 
   '@puppeteer/browsers@2.10.0':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -18217,7 +18180,7 @@ snapshots:
 
   '@puppeteer/browsers@2.6.1':
     dependencies:
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.0.0)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -20404,7 +20367,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.7.0(typescript@5.5.3)
       '@typescript-eslint/utils': 7.7.0(eslint@8.57.0)(typescript@5.5.3)
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.0.0)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.5.3)
     optionalDependencies:
@@ -20416,7 +20379,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.7.0(typescript@5.9.3)
       '@typescript-eslint/utils': 7.7.0(eslint@8.57.0)(typescript@5.9.3)
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.0.0)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.9.3)
     optionalDependencies:
@@ -20430,7 +20393,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.7.0
       '@typescript-eslint/visitor-keys': 7.7.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.0.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.9
@@ -20445,7 +20408,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.7.0
       '@typescript-eslint/visitor-keys': 7.7.0
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.0.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.9
@@ -21034,7 +20997,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22250,21 +22213,17 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
-  debug@4.4.1(supports-color@10.0.0):
-    dependencies:
-      ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.0.0
-
   debug@4.4.1(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 5.5.0
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@10.0.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.0.0
 
   decamelize-keys@1.1.1:
     dependencies:
@@ -23099,8 +23058,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  eta@4.6.0: {}
-
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
@@ -23169,7 +23126,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -23282,7 +23239,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 5.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -23329,7 +23286,7 @@ snapshots:
 
   follow-redirects@1.16.0(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
 
   for-each@0.3.3:
     dependencies:
@@ -23425,7 +23382,7 @@ snapshots:
   gaxios@6.1.1:
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.0.0)
       is-stream: 2.0.1
       node-fetch: 2.7.0
     transitivePeerDependencies:
@@ -23503,7 +23460,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 5.0.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -23871,33 +23828,25 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  http-errors@2.0.1:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      toidentifier: 1.0.1
-
   http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 3.0.1
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-middleware@3.0.7:
     dependencies:
       '@types/http-proxy': 1.17.15
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-object: 5.0.0
@@ -23921,21 +23870,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.3
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6(supports-color@10.0.0):
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -23968,10 +23910,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: 2.1.2
-
-  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -24772,6 +24710,8 @@ snapshots:
 
   jose@6.2.3: {}
 
+  jose@6.2.8: {}
+
   joycon@3.1.1: {}
 
   js-base64@3.7.5: {}
@@ -24834,7 +24774,7 @@ snapshots:
       form-data: 4.0.6
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.0.0)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.24
       parse5: 7.3.0
@@ -26108,7 +26048,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       decode-named-character-reference: 1.2.0
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -26130,7 +26070,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       decode-named-character-reference: 1.0.1
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -26152,7 +26092,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -26479,18 +26419,11 @@ snapshots:
 
   obug@2.1.1: {}
 
-  oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/e04834716e4bfee9f74e8d2e919cae21b2295a8a:
+  oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/513c523c0e68ee6112da8c871cce86204a136163:
     dependencies:
-      '@koa/cors': 5.0.0
-      '@koa/router': 15.7.0(koa@3.2.1)
-      debug: 4.4.3
-      eta: 4.6.0
-      jose: 6.2.3
-      jsesc: 3.1.0
+      debug: 4.4.3(supports-color@10.0.0)
+      jose: 6.2.8
       koa: 3.2.1
-      nanoid: 5.1.16
-      quick-lru: 7.3.0
-      raw-body: 3.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -26681,10 +26614,10 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       get-uri: 6.0.1
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.0.0)
       pac-resolver: 7.0.1
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -27115,9 +27048,9 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.0.0)
       lru-cache: 7.18.3
       pac-proxy-agent: 7.1.0
       proxy-from-env: 1.1.0
@@ -27146,7 +27079,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.6.1
       chromium-bidi: 0.8.0(devtools-protocol@0.0.1367902)
-      debug: 4.4.1(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@10.0.0)
       devtools-protocol: 0.0.1367902
       typed-query-selector: 2.12.0
       ws: 8.21.0
@@ -27160,7 +27093,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.10.0
       chromium-bidi: 3.0.0(devtools-protocol@0.0.1425554)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       devtools-protocol: 0.0.1425554
       typed-query-selector: 2.12.0
       ws: 8.21.0
@@ -27219,8 +27152,6 @@ snapshots:
 
   quick-lru@6.1.1: {}
 
-  quick-lru@7.3.0: {}
-
   range-parser@1.2.1: {}
 
   raw-body@2.5.2:
@@ -27235,13 +27166,6 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.6.3
-      unpipe: 1.0.0
-
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.3
       unpipe: 1.0.0
 
   react-animate-height@3.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -27697,7 +27621,7 @@ snapshots:
 
   require-in-the-middle@7.2.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       module-details-from-path: 1.0.3
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -28069,7 +27993,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@10.0.0)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -28164,8 +28088,6 @@ snapshots:
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
-
-  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 


### PR DESCRIPTION
## Summary

Bump the oidc-provider fork pin onto the upstream v9.11.3 sync (logto-io/node-oidc-provider#35) and align the ported grants with upstream's centralized DPoP replay detection.

- The pin moves `e0483471` → `513c523c`, picking up the upstream v9.9.1 → v9.11.3 delta and the fork's `ensureSessionSave` guard — device flow requests without an existing session respond with their intended error instead of HTTP 500.
- Upstream centralized token-endpoint DPoP replay detection in `checkDpopReplay`, which reads `features.dPoP.allowReplay` itself: `applyDpopBinding` lost its `allowReplay` parameter, so the client-credentials and token-exchange call sites drop the argument, and the refresh-token grant replaces its inline replay block with the same `checkDpopReplay` call upstream's grant now uses. Replay detection behavior is unchanged (same window, same error, same `allowReplay` gating).
- Seam and shims track the consumed surface: `checkDpopReplay` re-exported; `CHALLENGE_OK_WINDOW`, `epochTime`, and the `ReplayDetectionClass` widening type retired with their last consumer.
- Upstream's other grant-adjacent fixes need no mirroring: the `token_find.js` fix ships in the lib itself, and Logto's grant registration already builds per-registration parameter arrays, so it never had the shared-parameter mutation the upstream fix addresses.

## Testing

Tested locally — the OIDC unit suites (16 suites, 218 tests) pass against the new pin; integration suites run in CI.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
