### PR TITLE
test(test): stabilize flaky webauthn experience tests

### DIFF
--- a/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
@@ -225,7 +225,7 @@ describe('Experience - suggest additional MFA after WebAuthn binding as sign-in 
     // The page is `create-passkey` (sign-in passkey flow), not `mfa-binding/WebAuthn`,
     // so we click the button directly instead of using `toCreatePasskey()`.
     await experience.page.waitForNetworkIdle();
-    await experience.toClickButton('Create a passkey');
+    await experience.toClick('button:not([disabled])', 'Create a passkey', false);
 
     // Should suggest binding additional MFA factor
     await experience.waitForPathname('mfa-binding');
@@ -271,7 +271,7 @@ describe('Experience - suggest additional MFA after WebAuthn binding as sign-in 
     // The page is `create-passkey` (sign-in passkey flow), not `mfa-binding/WebAuthn`,
     // so we click the button directly instead of using `toCreatePasskey()`.
     await experience.page.waitForNetworkIdle();
-    await experience.toClickButton('Create a passkey');
+    await experience.toClick('button:not([disabled])', 'Create a passkey', false);
 
     // After binding WebAuthn with passkey sign-in enabled, backend suggests binding additional MFA factors
     await experience.waitForPathname('mfa-binding');

--- a/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
@@ -135,6 +135,15 @@ describe('Passkey sign-in', () => {
     await resetPasskeySignInSettings();
   });
 
+  afterEach(async () => {
+    /**
+     * Cases in this suite override the MFA policy and passkey sign-in settings mid-test;
+     * restore the baseline so one failed case cannot leak its settings into the next.
+     */
+    await enableMandatoryMfaWithWebAuthn();
+    await resetPasskeySignInSettings();
+  });
+
   it('should prompt enable MFA if new registered user has no MFA but has bound sign-in passkey', async () => {
     await updateSignInExperience({
       mfa: {
@@ -162,22 +171,27 @@ describe('Passkey sign-in', () => {
 
     // Bind a sign-in passkey during registration
     await experience.waitForPathname('create-passkey');
-    await experience.toClickButton('Create a passkey');
+    /**
+     * The "Create a passkey" button stays disabled (and a click on it is silently swallowed)
+     * until the WebAuthn registration options have been fetched.
+     */
+    await experience.page.waitForNetworkIdle();
+    await experience.toClick('button:not([disabled])', 'Create a passkey', false);
 
     // After passkey is created, user should be prompted to enable MFA since the user has no MFA factor bound but has a sign-in passkey
     await experience.waitForPathname('mfa-onboarding');
-    await experience.toClick('button', 'Enable 2-step verification');
+    await experience.toClick('button', 'Enable 2-step verification', false);
+    await experience.waitForPathname('mfa-binding');
 
-    // SKip enabling MFA
-    await experience.toClick('div[role=button][class$=skipButton]');
+    // Skip enabling MFA
+    await experience.toClick('div[role=button][class$=skipButton]', undefined, false);
 
+    await experience.waitForUrl(demoAppUrl);
     await experience.page.waitForNetworkIdle();
     const userId = await experience.getUserIdFromDemoAppPage();
     await experience.clearVirtualAuthenticator();
     await experience.verifyThenEnd();
 
-    await enableMandatoryMfaWithWebAuthn();
-    await resetPasskeySignInSettings();
     await deleteUser(userId);
   });
 
@@ -220,8 +234,8 @@ describe('Passkey sign-in', () => {
     // Wait for the page and passkey sign-in button to load
     await waitFor(1000);
 
-    // Click the "Continue with passkey" button
-    await experience.toClick('button', 'Continue with passkey');
+    // Click the "Continue with passkey" button; `verifyThenEnd` below waits for the demo app URL
+    await experience.toClick('button', 'Continue with passkey', false);
 
     // Step 5: Verify the user is signed in successfully without MFA verification prompt
     // If MFA was not skipped, the user would be redirected to the MFA verification page

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -3,11 +3,14 @@ import { appendPath } from '@silverhand/essentials';
 
 import { logtoUrl, mockSocialAuthPageUrl } from '#src/constants.js';
 import { readConnectorMessage } from '#src/helpers/index.js';
-import { dcls } from '#src/utils.js';
+import { dcls, waitFor } from '#src/utils.js';
 
 import ExpectPage from './expect-page.js';
 
 const demoAppUrl = appendPath(new URL(logtoUrl), 'demo-app');
+
+/** Aligned with puppeteer's default navigation timeout. */
+const defaultUrlWaitTimeout = 30_000;
 
 /** Remove the query string together with the `?` from a URL string. */
 const stripQuery = (url: string) => url.split('?')[0];
@@ -96,24 +99,21 @@ export default class ExpectExperience extends ExpectPage {
     this.#ongoing = { type, initialUrl };
   }
 
-  async waitForUrl(url: URL, retry = 3) {
-    // eslint-disable-next-line @silverhand/fp/no-let
-    let retries = retry;
-
-    do {
-      if (this.page.url() === url.href) {
-        return;
-      }
-
-      // eslint-disable-next-line no-await-in-loop
-      await this.page.waitForNavigation({ waitUntil: 'networkidle0' });
-    } while (retries--); // eslint-disable-line @silverhand/fp/no-mutation
+  /**
+   * Poll the page URL until it exactly matches the given URL.
+   *
+   * Polling covers client-side route changes and full page loads alike, keeps working when
+   * the navigation completed before this call, and does not rely on `networkidle0`, which
+   * in-flight connections can starve beyond the navigation timeout.
+   */
+  async waitForUrl(url: URL, timeout?: number) {
+    await this.waitForUrlToMatch((current) => current === url.href, `to be ${url.href}`, timeout);
   }
 
-  async waitForPathname(pathname: string, retry = 3, appId = demoAppApplicationId) {
+  async waitForPathname(pathname: string, timeout?: number, appId = demoAppApplicationId) {
     const url = this.buildExperienceUrl(pathname);
     url.searchParams.set('app_id', appId);
-    return this.waitForUrl(url, retry);
+    return this.waitForUrl(url, timeout);
   }
 
   /**
@@ -318,6 +318,32 @@ export default class ExpectExperience extends ExpectPage {
       }),
     ]);
     return { favicon, appleFavicon };
+  }
+
+  /**
+   * Poll the page URL until it satisfies the given predicate; throw if it still does not
+   * after the timeout.
+   *
+   * @param match The predicate to test the page URL against.
+   * @param expectation A human-readable description of the expected URL for the error message.
+   */
+  protected async waitForUrlToMatch(
+    match: (url: string) => boolean,
+    expectation: string,
+    timeout = defaultUrlWaitTimeout
+  ) {
+    const deadline = Date.now() + timeout;
+
+    while (!match(this.page.url())) {
+      if (Date.now() > deadline) {
+        this.throwError(
+          `Timed out (${timeout}ms) waiting for the page URL ${expectation}. Current URL: ${this.page.url()}`
+        );
+      }
+
+      // eslint-disable-next-line no-await-in-loop
+      await waitFor(100);
+    }
   }
 
   /** Build a full experience URL from a pathname. */

--- a/packages/integration-tests/src/ui-helpers/expect-webauthn-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-webauthn-experience.ts
@@ -51,16 +51,32 @@ export default class ExpectWebAuthnExperience extends ExpectMfaExperience {
 
   async toCreatePasskey() {
     this.toBeAt('mfa-binding/WebAuthn');
-    // Wait for the WebAuthn options have been prepared.
-    await this.page.waitForNetworkIdle();
-    await this.toClick('button', 'Create a passkey');
+    await this.toClickCeremonyButton('Create a passkey');
   }
 
   async toVerifyViaPasskey() {
     this.toBeAt('mfa-verification/WebAuthn');
+    await this.toClickCeremonyButton('Verify via passkey');
+  }
+
+  /**
+   * Click a WebAuthn ceremony button and wait for the ceremony and the follow-up interaction
+   * requests to complete.
+   *
+   * The destination differs per flow (a client-side route change or a full redirect chain back
+   * to the app), so completion is detected by leaving the current URL instead of by a
+   * `waitForNavigation` watcher; the trailing network-idle wait lets the destination page
+   * settle like the previous navigation-coupled click did.
+   */
+  private async toClickCeremonyButton(buttonText: string) {
     // Wait for the WebAuthn options have been prepared.
     await this.page.waitForNetworkIdle();
-    await this.toClick('button', 'Verify via passkey');
+
+    const ceremonyUrl = this.page.url();
+    // A click on a disabled button is silently swallowed, so wait until it is interactive.
+    await this.toClick('button:not([disabled])', buttonText, false);
+    await this.waitForUrlToMatch((url) => url !== ceremonyUrl, `to leave ${ceremonyUrl}`);
+    await this.page.waitForNetworkIdle();
   }
 
   private async getCdpClient() {


### PR DESCRIPTION
## Summary

Stabilize the flaky WebAuthn experience tests, which intermittently fail on CI with a 30s navigation timeout right after clicking a WebAuthn ceremony button and then trigger the rerun-on-failure workflow on unrelated PRs.

- `waitForUrl` / `waitForPathname` now poll `page.url()` instead of `waitForNavigation({ waitUntil: 'networkidle0' })`, and throw with the actual URL on timeout instead of silently returning.
  - Polling works the same for client-side route changes and full page loads, cannot miss an already-completed navigation, and does not depend on network idleness.
- WebAuthn ceremony clicks no longer race a `waitForNavigation` watcher; they wait for a concrete signal instead (leaving the ceremony page in the shared helpers, or the destination pathname in the tests).
- Ceremony buttons are clicked via `button:not([disabled])`: the "Create a passkey" button on `/create-passkey` is disabled until the registration options request resolves, and clicking a disabled button is silently swallowed — the direct cause of the timeouts at `webauthn/index.test.ts:165`.
- The "Passkey sign-in" suite restores the MFA/passkey config in `afterEach` instead of at the end of the test body, so a failed case cannot leak its config into the next one (the `Expected .../mfa-binding/WebAuthn / Received .../create-passkey` follow-up failures).

## Testing

Integration tests; verified by the CI runs on this PR (the affected suites run in both `run-logto (experience, *)` matrix jobs).

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
