### PR TITLE
test(test): stabilize flaky password policy experience test

### DIFF
--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -231,8 +231,9 @@ export default class ExpectExperience extends ExpectPage {
       } else {
         // Reject the password and assert the error message
         // eslint-disable-next-line no-await-in-loop
-        await this.toMatchAlert(
-          typeof errorMessage === 'string' ? new RegExp(errorMessage, 'i') : errorMessage
+        await this.toMatchPasswordRejection(
+          typeof errorMessage === 'string' ? new RegExp(errorMessage, 'i') : errorMessage,
+          password
         );
       }
     }
@@ -323,6 +324,30 @@ export default class ExpectExperience extends ExpectPage {
   /** Build a full experience URL from a pathname. */
   protected buildExperienceUrl(pathname = '') {
     return appendPath(this.options.endpoint, pathname);
+  }
+
+  /**
+   * Assert that the password form shows a rejection alert matching the given pattern.
+   *
+   * The alert only updates after a full server round-trip, which can exceed the default 5s
+   * timeout under CI load, so wait longer here. On timeout, report what the page actually
+   * shows — the current alert text and whether a submission is still in flight — since that
+   * is what separates a slow response from a wrong rejection message or a swallowed submit.
+   */
+  protected async toMatchPasswordRejection(expected: RegExp, password: string) {
+    try {
+      await this.toMatchAlert(expected, { timeout: 10_000 });
+    } catch {
+      const alert = await this.page.$('*[role=alert]');
+      const alertText = await alert?.evaluate(({ textContent }) => textContent);
+      const pendingSubmit = await this.page.$('button[type=submit][disabled]');
+
+      this.throwError(
+        `Expected the alert to match ${String(expected)} for password "${password}", but ${
+          alertText ? `the alert reads "${alertText}"` : 'no alert is present'
+        } (submission in flight: ${String(Boolean(pendingSubmit))}).`
+      );
+    }
   }
 
   protected throwNoOngoingExperienceError() {

--- a/packages/integration-tests/src/ui-helpers/expect-page.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-page.ts
@@ -60,12 +60,15 @@ export default class ExpectPage {
   }
 
   /**
-   * Click on the `<button type="submit">` element on the page.
+   * Click on the `<button type="submit">` element on the page, once it is enabled.
+   *
+   * A disabled submit button (e.g. while a previous submission is still in flight) swallows
+   * clicks silently, so wait for it to be enabled instead of clicking right away.
    *
    * @param shouldNavigate Whether the click should trigger a navigation. Defaults to `true`.
    */
   async toClickSubmit(shouldNavigate = true) {
-    return this.toClick('button[type=submit]', undefined, shouldNavigate);
+    return this.toClick('button[type=submit]:not([disabled])', undefined, shouldNavigate);
   }
 
   /**
@@ -133,9 +136,13 @@ export default class ExpectPage {
    * Expect the page to match an element with `role="alert"` and optionally with the given text.
    *
    * @param text The text to match, if provided.
+   * @param options.timeout The maximum time to wait for the element, overriding the default.
    */
-  async toMatchAlert(text?: string | RegExp): Promise<ElementHandle> {
-    return expect(this.page).toMatchElement('*[role=alert]', { text });
+  async toMatchAlert(
+    text?: string | RegExp,
+    options?: { timeout?: number }
+  ): Promise<ElementHandle> {
+    return expect(this.page).toMatchElement('*[role=alert]', { text, ...options });
   }
 
   /**


### PR DESCRIPTION
## Summary

Stabilize the flaky `password-policy.test.ts` experience test, currently the most frequent Integration Test rerun trigger: 11 failed jobs in the last day of CI runs, always at the same assertion (the `/product context .* personal information/` alert at `password-policy.test.ts:51`, timing out after 5 s).

- Password rejection assertions wait up to 10 s instead of the 5 s default: the alert only updates after a full API round-trip, which can exceed 5 s under CI load.
- On timeout they throw with what the page actually shows — the current alert text and whether a submission is still in flight — instead of a bare `Element not found`, so any residual failure identifies its own cause (slow response vs. wrong rejection message vs. swallowed click).
- `toClickSubmit` clicks `button[type=submit]:not([disabled])`: submit buttons are disabled while a submission is in flight, and clicking a disabled button is silently swallowed — the same failure class as the WebAuthn fix in #9454. This also covers `basic-sentinel` and the other suites that submit forms through the shared helpers.

<details>
<summary>Why not the stale-cache race from #9428</summary>

Every failing run in the sampled window (2026-08-12T13:04Z → 2026-08-13T07:47Z, 80 runs, 11 failed `run-logto (experience, *)` jobs with this signature, including two on `master`) is a descendant of the generation-guard fix (#9436, `220c204257`), and the failure rate is unchanged from before the fix landed. A stale seed policy also cannot produce this signature: it would fail at the `'12345678'` → "at least 3 types" step first (seed `characterTypes.min` is 1, so the client-side fast check would not reject it), yet all sampled failures pass every earlier step and pin to the last assertion. The remaining candidate causes are client-side, which is what the diagnostics on timeout are for: if the flake persists, the failure message now shows the actual alert text and submission state instead of requiring another round of guessing.

</details>

## Testing

Integration tests; verified by the CI runs on this PR (the affected suites run in both `run-logto (experience, *)` matrix jobs).

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
