### PR TITLE
fix(core): handle optional OpenAPI request bodies

### DIFF
--- a/packages/core/src/routes/swagger/index.test.ts
+++ b/packages/core/src/routes/swagger/index.test.ts
@@ -266,6 +266,32 @@ describe('GET /swagger.json', () => {
     });
   });
 
+  it('should mark a request body as optional when its guard accepts undefined', async () => {
+    const optionalBodyRouter = new Router();
+    optionalBodyRouter.post(
+      '/mock',
+      koaGuard({
+        body: object({
+          name: string().optional(),
+        }).optional(),
+      }),
+      () => ({})
+    );
+    const swaggerRequest = createSwaggerRequest([optionalBodyRouter]);
+
+    const response = await swaggerRequest.get('/swagger.json');
+
+    expect(response.body.paths).toMatchObject({
+      '/api/mock': {
+        post: {
+          requestBody: {
+            required: false,
+          },
+        },
+      },
+    });
+  });
+
   it('should fall back to default when no response guard found', async () => {
     const swaggerRequest = createSwaggerRequest([mockRouter]);
     const response = await swaggerRequest.get('/swagger.json');

--- a/packages/core/src/routes/swagger/utils/general.test.ts
+++ b/packages/core/src/routes/swagger/utils/general.test.ts
@@ -73,6 +73,34 @@ const createDevFeatureOperationDocument = (): DeepPartial<OpenAPIV3.Document> =>
   },
 });
 
+const createDevFeatureOnlyRequestBodyDocument = (): DeepPartial<OpenAPIV3.Document> => ({
+  openapi: '3.0.1',
+  info: {
+    title: 'Test',
+    version: '1.0.0',
+  },
+  paths: {
+    '/api/mock': {
+      post: {
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['beta'],
+                properties: {
+                  beta: createDevFeatureBooleanSchema(),
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
 describe('swagger general utils', () => {
   afterEach(() => {
     Reflect.set(EnvSet.values, 'isCloud', originalIsCloud);
@@ -134,6 +162,36 @@ describe('swagger general utils', () => {
                   },
                 },
               },
+            },
+          },
+        },
+      },
+    });
+    expect(JSON.stringify(document)).not.toContain(devFeatureSchemaExtension);
+  });
+
+  it('should remove a request body that contains only disabled dev feature properties', () => {
+    setDevFeaturesEnabled(false);
+
+    const document = createDevFeatureOnlyRequestBodyDocument();
+    removeDevFeatureSchemaProperties(document);
+
+    expect(document.paths?.['/api/mock']?.post).not.toHaveProperty('requestBody');
+  });
+
+  it('should keep a dev-only request body when dev features are enabled', () => {
+    setDevFeaturesEnabled(true);
+
+    const document = createDevFeatureOnlyRequestBodyDocument();
+    removeDevFeatureSchemaProperties(document);
+
+    expect(document.paths?.['/api/mock']?.post?.requestBody).toMatchObject({
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            properties: {
+              beta: { type: 'boolean' },
             },
           },
         },

--- a/packages/core/src/routes/swagger/utils/general.ts
+++ b/packages/core/src/routes/swagger/utils/general.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines -- Dev-feature pruning shares traversal logic with the existing OpenAPI document utilities. */
+
 import assert from 'node:assert';
 import fs from 'node:fs/promises';
 import path from 'node:path';
@@ -368,6 +370,65 @@ const removeDevFeatureSchemaProperty = (
   return false;
 };
 
+const isEmptyJsonObjectRequestBody = (value: unknown) => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const { content } = value;
+
+  if (!isRecord(content) || Object.keys(content).length !== 1) {
+    return false;
+  }
+
+  const jsonContent = content['application/json'];
+
+  if (!isRecord(jsonContent) || !isRecord(jsonContent.schema)) {
+    return false;
+  }
+
+  const { properties } = jsonContent.schema;
+
+  return isRecord(properties) && Object.keys(properties).length === 0;
+};
+
+const pruneDevFeatureSchemaProperties = (value: unknown): boolean => {
+  if (Array.isArray(value)) {
+    return value.map((item) => pruneDevFeatureSchemaProperties(item)).some(Boolean);
+  }
+
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const schema = value;
+  const { properties } = schema;
+  const hasPrunedProperty = isRecord(properties)
+    ? Object.entries(properties)
+        .map(([propertyName, propertySchema]) =>
+          removeDevFeatureSchemaProperty(schema, properties, propertyName, propertySchema)
+        )
+        .some(Boolean)
+    : false;
+
+  Reflect.deleteProperty(schema, devFeatureSchemaExtension);
+
+  const hasPrunedChild = Object.entries(schema)
+    .map(([key, item]) => {
+      const hasPrunedDescendant = pruneDevFeatureSchemaProperties(item);
+
+      if (key === 'requestBody' && hasPrunedDescendant && isEmptyJsonObjectRequestBody(item)) {
+        Reflect.deleteProperty(schema, key);
+        return true;
+      }
+
+      return hasPrunedDescendant;
+    })
+    .some(Boolean);
+
+  return hasPrunedProperty || hasPrunedChild;
+};
+
 /**
  * **CAUTION**: This function mutates the input value.
  *
@@ -379,34 +440,7 @@ const removeDevFeatureSchemaProperty = (
  * zod guards carry no markers, so pruning supplements alone cannot remove them.
  */
 export const removeDevFeatureSchemaProperties = (value: unknown) => {
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      removeDevFeatureSchemaProperties(item);
-    }
-
-    return;
-  }
-
-  if (!isRecord(value)) {
-    return;
-  }
-
-  const schema = value;
-  const { properties } = schema;
-
-  if (isRecord(properties)) {
-    for (const [propertyName, propertySchema] of Object.entries(properties)) {
-      if (removeDevFeatureSchemaProperty(schema, properties, propertyName, propertySchema)) {
-        continue;
-      }
-    }
-  }
-
-  Reflect.deleteProperty(schema, devFeatureSchemaExtension);
-
-  for (const item of Object.values(schema)) {
-    removeDevFeatureSchemaProperties(item);
-  }
+  pruneDevFeatureSchemaProperties(value);
 };
 
 export const shouldThrow = () => !EnvSet.values.isProduction || EnvSet.values.isIntegrationTest;
@@ -439,6 +473,8 @@ export const pruneSwaggerDocument = (document: OpenAPIV3.Document) => {
 
   prune(document);
 };
+
+/* eslint-enable max-lines */
 
 /**
  * Check if the given router is a Management API router. The function will check if the router

--- a/packages/core/src/routes/swagger/utils/operation.ts
+++ b/packages/core/src/routes/swagger/utils/operation.ts
@@ -55,7 +55,7 @@ const buildOperation = (
   ];
 
   const requestBody = body && {
-    required: true,
+    required: !body.isOptional(),
     content: {
       'application/json': {
         schema: zodTypeToSwagger(body),


### PR DESCRIPTION
## Summary

- derive the generated OpenAPI request body requirement from whether its body guard accepts an omitted value
- remove empty request body containers after every schema property has been filtered out
- prevent generated clients from requiring empty body arguments

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
