### PR TITLE
fix(core): assert the subject token class in token exchange

### DIFF
--- a/.changeset/silver-moons-attend.md
+++ b/.changeset/silver-moons-attend.md
@@ -1,0 +1,9 @@
+---
+'@logto/core': patch
+---
+
+validate the subject token class in token exchange
+
+The `access_token` subject path of the token exchange grant falls back to JWT verification when the token is not a known opaque token. That fallback checked only the signature and the issuer, so any JWT signed by the tenant's keys was accepted as an access token — including an OIDC ID token, which is an authentication assertion and carries no API authorization. A client with token exchange enabled could therefore submit an ID token as `subject_token` and receive an API access token for that user.
+
+The JWT subject token is now required to carry the RFC 9068 `at+jwt` type header and a `client_id` claim before the account is resolved. Both are set unconditionally on every JWT access token Logto issues, so legitimate subject tokens are unaffected; ID tokens are rejected with `invalid_grant`.

--- a/packages/core/src/oidc/grants/token-exchange/account.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.test.ts
@@ -1,0 +1,112 @@
+import { errors, type Provider } from 'oidc-provider';
+
+import type Queries from '#src/tenants/Queries.js';
+
+import { TokenExchangeTokenType } from './types.js';
+
+const { jest } = import.meta;
+
+const mockJwtVerify = jest.fn();
+
+jest.unstable_mockModule('jose', () => ({
+  jwtVerify: mockJwtVerify,
+}));
+
+const { validateSubjectToken } = await import('./account.js');
+
+const { InvalidGrant } = errors;
+
+const accountId = 'some_account_id';
+const sourceClientId = 'some_source_client_id';
+
+/** The JWT branch is only reached when the opaque lookup misses. */
+const mockAccessToken = {
+  find: async () => null,
+} as unknown as Provider['AccessToken'];
+
+const mockQueries = {
+  subjectTokens: { findSubjectToken: jest.fn() },
+  personalAccessTokens: { findByValue: jest.fn() },
+} as unknown as Queries;
+
+const validateJwtSubjectToken = async () =>
+  validateSubjectToken({
+    queries: mockQueries,
+    subjectToken: 'some_jwt_token',
+    subjectTokenType: TokenExchangeTokenType.AccessToken,
+    AccessToken: mockAccessToken,
+    jwtVerificationOptions: {
+      localJWKSet: jest.fn() as never,
+      issuer: 'https://logto.test/oidc',
+    },
+  });
+
+describe('validateSubjectToken() JWT token class', () => {
+  afterEach(() => {
+    mockJwtVerify.mockReset();
+  });
+
+  it('should accept a JWT access token', async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      protectedHeader: { alg: 'ES384', typ: 'at+jwt' },
+      payload: { sub: accountId, client_id: sourceClientId },
+    });
+
+    await expect(validateJwtSubjectToken()).resolves.toEqual({ userId: accountId });
+  });
+
+  it('should accept the `application/at+jwt` media type form', async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      protectedHeader: { alg: 'ES384', typ: 'application/at+jwt' },
+      payload: { sub: accountId, client_id: sourceClientId },
+    });
+
+    await expect(validateJwtSubjectToken()).resolves.toEqual({ userId: accountId });
+  });
+
+  /**
+   * An ID token is signed by the same keys under the same issuer, so signature verification alone
+   * cannot separate it from an access token. Accepting one here would let an authentication-only
+   * credential be converted into an API access token.
+   */
+  it('should reject a genuine ID token declared as an access token', async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      protectedHeader: { alg: 'ES384' },
+      payload: { sub: accountId, aud: sourceClientId },
+    });
+
+    await expect(validateJwtSubjectToken()).rejects.toMatchError(
+      new InvalidGrant('subject token is not an access token')
+    );
+  });
+
+  it('should reject a JWT with a non access token `typ` header', async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      protectedHeader: { alg: 'ES384', typ: 'logout+jwt' },
+      payload: { sub: accountId, client_id: sourceClientId },
+    });
+
+    await expect(validateJwtSubjectToken()).rejects.toMatchError(
+      new InvalidGrant('subject token is not an access token')
+    );
+  });
+
+  it('should reject a JWT with the access token `typ` but no `client_id` claim', async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      protectedHeader: { alg: 'ES384', typ: 'at+jwt' },
+      payload: { sub: accountId },
+    });
+
+    await expect(validateJwtSubjectToken()).rejects.toMatchError(
+      new InvalidGrant('subject token is not an access token')
+    );
+  });
+
+  it('should reject a JWT that fails signature verification', async () => {
+    mockJwtVerify.mockRejectedValueOnce(new Error('invalid signature'));
+
+    await expect(validateJwtSubjectToken()).rejects.toMatchError(
+      new InvalidGrant('invalid subject token')
+    );
+  });
+});

--- a/packages/core/src/oidc/grants/token-exchange/account.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.ts
@@ -42,8 +42,25 @@ const validateImpersonationToken = async (
 };
 
 /**
+ * The JOSE `typ` header value that RFC 9068 assigns to OAuth 2.0 JWT access tokens. Every signed
+ * JWT access token issued by the provider carries it, while ID tokens (and any other same-issuer
+ * JWT) do not.
+ */
+const jwtAccessTokenType = 'at+jwt';
+
+/**
  * Validates a JWT access token using the issuer's JWK set.
  * JWT access tokens can be exchanged multiple times (not consumption-tracked).
+ *
+ * @remarks
+ * A valid signature from the tenant's JWK set is NOT sufficient: ID tokens are signed by the same
+ * keys under the same issuer, so verifying only the signature would let an authentication-purpose
+ * ID token (e.g. one held by a third-party application that was granted `openid` alone) be
+ * submitted as an access-token subject and converted into an API access token. The token class is
+ * therefore asserted explicitly before the subject is trusted.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc8725.html#section-3.12 | RFC 8725 §3.12} for the
+ * general requirement that different kinds of JWTs from one issuer stay mutually exclusive.
  */
 const validateJwtAccessToken = async (
   subjectToken: string,
@@ -52,7 +69,18 @@ const validateJwtAccessToken = async (
   const { localJWKSet, issuer } = jwtVerificationOptions;
 
   try {
-    const { payload } = await jwtVerify(subjectToken, localJWKSet, { issuer });
+    const { payload, protectedHeader } = await jwtVerify(subjectToken, localJWKSet, { issuer });
+
+    // The media type may appear with or without the `application/` prefix. @see RFC 7515 §4.1.9.
+    assertThat(
+      protectedHeader.typ?.toLowerCase().replace(/^application\//, '') === jwtAccessTokenType,
+      new InvalidGrant('subject token is not an access token')
+    );
+    // Defense in depth: every JWT access token carries `client_id`, no ID token does.
+    assertThat(
+      typeof payload.client_id === 'string',
+      new InvalidGrant('subject token is not an access token')
+    );
     assertThat(payload.sub, new InvalidGrant('subject token does not contain a valid `sub` claim'));
 
     // JWT access tokens are not consumption-tracked, so no subjectTokenId is returned.

--- a/packages/core/src/oidc/grants/token-exchange/index.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.test.ts
@@ -45,6 +45,12 @@ const clientId = 'some_client_id';
 const subjectTokenId = 'some_token_id';
 const accountId = 'some_account_id';
 
+/** A verified JWT access token, as `jose` would return it for a token issued by the provider. */
+const mockVerifiedAccessToken = (payload: Record<string, unknown> = {}) => ({
+  protectedHeader: { alg: 'ES384', typ: 'at+jwt' },
+  payload: { sub: accountId, client_id: 'some_source_client_id', ...payload },
+});
+
 type Client = InstanceType<KoaContextWithOIDC['oidc']['provider']['Client']>;
 
 const validClient: Client = {
@@ -300,22 +306,24 @@ describe('token exchange', () => {
 
     it('should throw when JWT does not contain sub claim', async () => {
       const ctx = createPreparedJwtContext();
-      mockJwtVerify.mockResolvedValueOnce({ payload: {} });
+      mockJwtVerify.mockResolvedValueOnce(mockVerifiedAccessToken({ sub: undefined }));
       await expect(mockHandler()(ctx)).rejects.toMatchError(
         new errors.InvalidGrant('subject token does not contain a valid `sub` claim')
       );
     });
 
+    // The token-class assertions on the JWT subject token live in `account.test.ts`.
+
     it('should throw when account cannot be found', async () => {
       const ctx = createPreparedJwtContext();
-      mockJwtVerify.mockResolvedValueOnce({ payload: { sub: accountId } });
+      mockJwtVerify.mockResolvedValueOnce(mockVerifiedAccessToken());
       Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves();
       await expect(mockHandler()(ctx)).rejects.toThrow(errors.InvalidGrant);
     });
 
     it('should not consume the token (allow multiple exchanges)', async () => {
       const ctx = createPreparedJwtContext();
-      mockJwtVerify.mockResolvedValueOnce({ payload: { sub: accountId } });
+      mockJwtVerify.mockResolvedValueOnce(mockVerifiedAccessToken());
       Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
         accountId,
       });
@@ -396,7 +404,7 @@ describe('token exchange', () => {
       // Mock AccessToken.find to return undefined (not found)
       Sinon.stub(ctx.oidc.provider.AccessToken, 'find').resolves();
       // Mock jwtVerify to succeed
-      mockJwtVerify.mockResolvedValueOnce({ payload: { sub: accountId } });
+      mockJwtVerify.mockResolvedValueOnce(mockVerifiedAccessToken());
       Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({
         accountId,
       });


### PR DESCRIPTION
## Summary

The `access_token` subject path of the token exchange grant falls back to JWT verification when the subject token is not a known opaque token. That fallback verified only the signature and the `issuer`, then trusted `payload.sub`:

```ts
const { payload } = await jwtVerify(subjectToken, localJWKSet, { issuer });
return { userId: payload.sub };
```

ID tokens are signed by the same keys under the same issuer, so a same-issuer JWT passed this check regardless of what kind of token it actually was. An ID token is an authentication assertion scoped to its RP and carries no API authorization, so it should never be usable as an access-token subject.

This PR asserts the token class before the account is resolved:

- the JOSE `typ` header must be `at+jwt` (RFC 9068), accepting the `application/at+jwt` media type form
- `client_id` must be present, as a second discriminator

Both are set unconditionally by oidc-provider's JWT format for every signed access token we issue (`typ` at `lib/models/formats/jwt.js:161`, `client_id` at `:127`), so legitimate subject tokens are unaffected. Mismatches are rejected with `invalid_grant`.

Relevant guidance: RFC 8693 §2.1/§3 (validate per the declared `subject_token_type`), RFC 8725 §3.12 (different JWT kinds from one issuer must stay mutually exclusive), RFC 9068.

## Testing

New `account.test.ts` unit-tests `validateSubjectToken` directly: accepts `at+jwt` and `application/at+jwt`; rejects an ID token, a foreign `typ`, a missing `client_id`, and a bad signature. The existing `jose` mocks in `index.test.ts` were updated to return the header the code now reads.

Verified the new cases fail when the assertions are removed. Full suite: 3 files / 29 tests passing, lint clean. Existing integration tests for token exchange use opaque tokens and do not touch this branch.

## Checklist

- [x] `.changeset` added
- [ ] Related issue linked
