### PR TITLE
fix(core): require a first-party subject token in token exchange

### DIFF
--- a/.changeset/olive-pumas-shave.md
+++ b/.changeset/olive-pumas-shave.md
@@ -1,0 +1,11 @@
+---
+'@logto/core': patch
+---
+
+require token exchange subject tokens to come from a first-party application
+
+Token exchange does not inherit the subject token's audience or scopes — the issued token carries the receiver's authorization for the user, which for a first-party receiver means every scope the user's roles grant. The subject token's issuing client was previously discarded, so an access token held by a third-party application could be presented to any token-exchange-enabled client and converted into the user's full first-party authorization, turning a narrowly consented credential into a much broader one.
+
+The subject token must now have been issued to a first-party application, on both the opaque and the JWT path. Third-party applications are already barred from enabling token exchange as the receiver; this closes the same boundary on the subject side. Unresolvable clients are rejected.
+
+**Breaking**: if you deliberately exchange access tokens issued to third-party applications, those requests now fail with `invalid_grant`. Use a first-party application to obtain the subject token instead.

--- a/.changeset/olive-pumas-shave.md
+++ b/.changeset/olive-pumas-shave.md
@@ -6,6 +6,6 @@ require token exchange subject tokens to come from a first-party application
 
 Token exchange does not inherit the subject token's audience or scopes — the issued token carries the receiver's authorization for the user, which for a first-party receiver means every scope the user's roles grant. The subject token's issuing client was previously discarded, so an access token held by a third-party application could be presented to any token-exchange-enabled client and converted into the user's full first-party authorization, turning a narrowly consented credential into a much broader one.
 
-The subject token must now have been issued to a first-party application, on both the opaque and the JWT path. Third-party applications are already barred from enabling token exchange as the receiver; this closes the same boundary on the subject side. Unresolvable clients are rejected.
+The subject token must now have been issued to a first-party application, on both the opaque and the JWT path. Third-party applications are already barred from enabling token exchange as the receiver; this closes the same boundary on the subject side. A subject token whose issuing client no longer exists is rejected as well.
 
 **Breaking**: if you deliberately exchange access tokens issued to third-party applications, those requests now fail with `invalid_grant`. Use a first-party application to obtain the subject token instead.

--- a/packages/core/src/oidc/grants/token-exchange/account.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.test.ts
@@ -1,6 +1,8 @@
+import { Applications } from '@logto/schemas';
 import { errors, type Provider } from 'oidc-provider';
 
 import { mockApplication } from '#src/__mocks__/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
 import { TokenExchangeTokenType } from './types.js';
@@ -161,6 +163,17 @@ describe('validateSubjectToken() subject token client', () => {
     await expect(validateAccessTokenSubject(AccessToken)).rejects.toMatchError(notFirstParty);
   });
 
+  it('should accept a JWT access token issued to a first-party application', async () => {
+    mockJwtVerify.mockResolvedValueOnce({
+      protectedHeader: { alg: 'ES384', typ: 'at+jwt' },
+      payload: { sub: accountId, client_id: sourceClientId },
+    });
+
+    await expect(validateJwtSubjectToken()).resolves.toEqual({ userId: accountId });
+    // The claim carrying the issuing client, not the subject, is what gets checked.
+    expect(findApplicationById).toHaveBeenCalledWith(sourceClientId);
+  });
+
   it('should reject a JWT access token issued to a third-party application', async () => {
     findApplicationById.mockResolvedValueOnce({
       ...mockApplication,
@@ -173,23 +186,48 @@ describe('validateSubjectToken() subject token client', () => {
     });
 
     await expect(validateJwtSubjectToken()).rejects.toMatchError(notFirstParty);
+    expect(findApplicationById).toHaveBeenCalledWith(sourceClientId);
   });
 
-  it('should reject when the issuing client cannot be resolved', async () => {
-    findApplicationById.mockRejectedValueOnce(new Error('not found'));
+  it('should reject when the issuing client no longer exists', async () => {
+    findApplicationById.mockRejectedValueOnce(
+      new RequestError({
+        code: 'entity.not_exists_with_id',
+        name: Applications.table,
+        id: sourceClientId,
+        status: 404,
+      })
+    );
     mockJwtVerify.mockResolvedValueOnce({
       protectedHeader: { alg: 'ES384', typ: 'at+jwt' },
       payload: { sub: accountId, client_id: sourceClientId },
     });
 
-    await expect(validateJwtSubjectToken()).rejects.toMatchError(notFirstParty);
+    await expect(validateJwtSubjectToken()).rejects.toMatchError(
+      new InvalidGrant('subject token was issued to an unknown client')
+    );
+  });
+
+  /**
+   * `invalid_grant` reads as permanent, so a database hiccup must not be reported as one: the
+   * failure propagates and surfaces as a 500 that clients can retry and operators can diagnose.
+   */
+  it('should surface an unexpected lookup failure instead of rejecting the grant', async () => {
+    const error = new Error('connection terminated unexpectedly');
+    findApplicationById.mockRejectedValueOnce(error);
+    mockJwtVerify.mockResolvedValueOnce({
+      protectedHeader: { alg: 'ES384', typ: 'at+jwt' },
+      payload: { sub: accountId, client_id: sourceClientId },
+    });
+
+    await expect(validateJwtSubjectToken()).rejects.toBe(error);
   });
 
   it('should reject an opaque access token with no client binding', async () => {
     const AccessToken = mockOpaqueToken({ accountId, isExpired: false });
 
     await expect(validateAccessTokenSubject(AccessToken)).rejects.toMatchError(
-      new InvalidGrant('invalid subject token')
+      new InvalidGrant('subject token is not bound to an issuing client')
     );
   });
 });

--- a/packages/core/src/oidc/grants/token-exchange/account.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.test.ts
@@ -1,5 +1,6 @@
 import { errors, type Provider } from 'oidc-provider';
 
+import { mockApplication } from '#src/__mocks__/index.js';
 import type Queries from '#src/tenants/Queries.js';
 
 import { TokenExchangeTokenType } from './types.js';
@@ -19,31 +20,44 @@ const { InvalidGrant } = errors;
 const accountId = 'some_account_id';
 const sourceClientId = 'some_source_client_id';
 
-/** The JWT branch is only reached when the opaque lookup misses. */
-const mockAccessToken = {
-  find: async () => null,
-} as unknown as Provider['AccessToken'];
+const findApplicationById = jest.fn(async (id: string) => ({
+  ...mockApplication,
+  id,
+  isThirdParty: false,
+}));
 
 const mockQueries = {
   subjectTokens: { findSubjectToken: jest.fn() },
   personalAccessTokens: { findByValue: jest.fn() },
+  applications: { findApplicationById },
 } as unknown as Queries;
 
-const validateJwtSubjectToken = async () =>
+/** The JWT branch is only reached when the opaque lookup misses. */
+const mockNoOpaqueToken = {
+  find: async () => null,
+} as unknown as Provider['AccessToken'];
+
+const mockOpaqueToken = (token: Record<string, unknown>) =>
+  ({ find: async () => token }) as unknown as Provider['AccessToken'];
+
+const validateAccessTokenSubject = async (AccessToken = mockNoOpaqueToken) =>
   validateSubjectToken({
     queries: mockQueries,
     subjectToken: 'some_jwt_token',
     subjectTokenType: TokenExchangeTokenType.AccessToken,
-    AccessToken: mockAccessToken,
+    AccessToken,
     jwtVerificationOptions: {
       localJWKSet: jest.fn() as never,
       issuer: 'https://logto.test/oidc',
     },
   });
 
+const validateJwtSubjectToken = async () => validateAccessTokenSubject();
+
 describe('validateSubjectToken() JWT token class', () => {
   afterEach(() => {
     mockJwtVerify.mockReset();
+    findApplicationById.mockClear();
   });
 
   it('should accept a JWT access token', async () => {
@@ -106,6 +120,75 @@ describe('validateSubjectToken() JWT token class', () => {
     mockJwtVerify.mockRejectedValueOnce(new Error('invalid signature'));
 
     await expect(validateJwtSubjectToken()).rejects.toMatchError(
+      new InvalidGrant('invalid subject token')
+    );
+  });
+});
+
+describe('validateSubjectToken() subject token client', () => {
+  const notFirstParty = new InvalidGrant(
+    'subject token was not issued to a first-party application'
+  );
+
+  afterEach(() => {
+    mockJwtVerify.mockReset();
+    findApplicationById.mockClear();
+  });
+
+  it('should accept an opaque access token issued to a first-party application', async () => {
+    const AccessToken = mockOpaqueToken({
+      accountId,
+      clientId: sourceClientId,
+      isExpired: false,
+    });
+
+    await expect(validateAccessTokenSubject(AccessToken)).resolves.toEqual({ userId: accountId });
+    expect(findApplicationById).toHaveBeenCalledWith(sourceClientId);
+  });
+
+  it('should reject an opaque access token issued to a third-party application', async () => {
+    findApplicationById.mockResolvedValueOnce({
+      ...mockApplication,
+      id: sourceClientId,
+      isThirdParty: true,
+    });
+    const AccessToken = mockOpaqueToken({
+      accountId,
+      clientId: sourceClientId,
+      isExpired: false,
+    });
+
+    await expect(validateAccessTokenSubject(AccessToken)).rejects.toMatchError(notFirstParty);
+  });
+
+  it('should reject a JWT access token issued to a third-party application', async () => {
+    findApplicationById.mockResolvedValueOnce({
+      ...mockApplication,
+      id: sourceClientId,
+      isThirdParty: true,
+    });
+    mockJwtVerify.mockResolvedValueOnce({
+      protectedHeader: { alg: 'ES384', typ: 'at+jwt' },
+      payload: { sub: accountId, client_id: sourceClientId },
+    });
+
+    await expect(validateJwtSubjectToken()).rejects.toMatchError(notFirstParty);
+  });
+
+  it('should reject when the issuing client cannot be resolved', async () => {
+    findApplicationById.mockRejectedValueOnce(new Error('not found'));
+    mockJwtVerify.mockResolvedValueOnce({
+      protectedHeader: { alg: 'ES384', typ: 'at+jwt' },
+      payload: { sub: accountId, client_id: sourceClientId },
+    });
+
+    await expect(validateJwtSubjectToken()).rejects.toMatchError(notFirstParty);
+  });
+
+  it('should reject an opaque access token with no client binding', async () => {
+    const AccessToken = mockOpaqueToken({ accountId, isExpired: false });
+
+    await expect(validateAccessTokenSubject(AccessToken)).rejects.toMatchError(
       new InvalidGrant('invalid subject token')
     );
   });

--- a/packages/core/src/oidc/grants/token-exchange/account.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.ts
@@ -5,7 +5,7 @@ import { type Provider, errors } from 'oidc-provider';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { isThirdPartyApplication } from '../../resource.js';
+import { resolveIsThirdPartyApplication } from '../../resource.js';
 
 import { TokenExchangeTokenType } from './types.js';
 
@@ -117,7 +117,7 @@ const validateOpaqueAccessToken = async (
 
   // Every access token is bound to the client it was issued to; treat a token without that binding
   // as unusable rather than falling back to a less restrictive path.
-  assertThat(token.clientId, new InvalidGrant('invalid subject token'));
+  assertThat(token.clientId, new InvalidGrant('subject token is not bound to an issuing client'));
 
   // Opaque access tokens are not consumption-tracked, so no subjectTokenId is returned.
   // This allows the same token to be exchanged multiple times (e.g., by different services).
@@ -137,11 +137,21 @@ const validateOpaqueAccessToken = async (
  * Third-party applications are already barred from enabling token exchange as the receiver
  * (`assertThirdPartyApplicationTokenExchangeDisabled` in the application routes); this closes the
  * same boundary on the subject side.
+ *
+ * A lookup that fails outright is not treated as a rejection: `invalid_grant` reads as permanent, so
+ * a database hiccup would turn every legitimate exchange into an error clients do not retry and
+ * cannot diagnose. Those errors propagate and surface as a 500 instead.
  */
 const assertFirstPartySubjectTokenClient = async (queries: Queries, clientId: string) => {
-  // `isThirdPartyApplication` fails closed: an unresolvable client is never treated as first-party.
+  const isThirdParty = await resolveIsThirdPartyApplication(queries, clientId);
+
+  // A deleted or otherwise unknown client cannot be shown to be first-party, so it is rejected.
   assertThat(
-    !(await isThirdPartyApplication(queries, clientId)),
+    isThirdParty !== undefined,
+    new InvalidGrant('subject token was issued to an unknown client')
+  );
+  assertThat(
+    !isThirdParty,
     new InvalidGrant('subject token was not issued to a first-party application')
   );
 };

--- a/packages/core/src/oidc/grants/token-exchange/account.ts
+++ b/packages/core/src/oidc/grants/token-exchange/account.ts
@@ -5,6 +5,8 @@ import { type Provider, errors } from 'oidc-provider';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { isThirdPartyApplication } from '../../resource.js';
+
 import { TokenExchangeTokenType } from './types.js';
 
 const { InvalidGrant } = errors;
@@ -65,7 +67,7 @@ const jwtAccessTokenType = 'at+jwt';
 const validateJwtAccessToken = async (
   subjectToken: string,
   jwtVerificationOptions: NonNullable<ValidateSubjectTokenParams['jwtVerificationOptions']>
-): Promise<{ userId: string }> => {
+): Promise<{ userId: string; clientId: string }> => {
   const { localJWKSet, issuer } = jwtVerificationOptions;
 
   try {
@@ -85,7 +87,7 @@ const validateJwtAccessToken = async (
 
     // JWT access tokens are not consumption-tracked, so no subjectTokenId is returned.
     // This allows the same token to be exchanged multiple times (e.g., by different services).
-    return { userId: payload.sub };
+    return { userId: payload.sub, clientId: payload.client_id };
   } catch (error) {
     if (error instanceof errors.OIDCProviderError) {
       throw error;
@@ -101,7 +103,7 @@ const validateJwtAccessToken = async (
 const validateOpaqueAccessToken = async (
   subjectToken: string,
   AccessToken: Provider['AccessToken']
-): Promise<{ userId: string } | undefined> => {
+): Promise<{ userId: string; clientId: string } | undefined> => {
   // eslint-disable-next-line unicorn/no-array-callback-reference -- AccessToken.find is not an array method
   const token = await trySafe(async () => AccessToken.find(subjectToken));
   if (!token?.accountId) {
@@ -113,9 +115,35 @@ const validateOpaqueAccessToken = async (
     throw new InvalidGrant('subject token is expired');
   }
 
+  // Every access token is bound to the client it was issued to; treat a token without that binding
+  // as unusable rather than falling back to a less restrictive path.
+  assertThat(token.clientId, new InvalidGrant('invalid subject token'));
+
   // Opaque access tokens are not consumption-tracked, so no subjectTokenId is returned.
   // This allows the same token to be exchanged multiple times (e.g., by different services).
-  return { userId: token.accountId };
+  return { userId: token.accountId, clientId: token.clientId };
+};
+
+/**
+ * Asserts that the subject token was issued to a first-party application.
+ *
+ * @remarks
+ * Token exchange does not inherit the subject token's audience or scopes: the issued token carries
+ * the receiver's authorization for the user, which for a first-party receiver means every scope the
+ * user's roles grant. A third-party application only ever holds credentials the user consented to
+ * for that application, so letting one of its access tokens act as the subject would turn a narrow,
+ * consented credential into the user's full first-party authorization.
+ *
+ * Third-party applications are already barred from enabling token exchange as the receiver
+ * (`assertThirdPartyApplicationTokenExchangeDisabled` in the application routes); this closes the
+ * same boundary on the subject side.
+ */
+const assertFirstPartySubjectTokenClient = async (queries: Queries, clientId: string) => {
+  // `isThirdPartyApplication` fails closed: an unresolvable client is never treated as first-party.
+  assertThat(
+    !(await isThirdPartyApplication(queries, clientId)),
+    new InvalidGrant('subject token was not issued to a first-party application')
+  );
 };
 
 /** Prefix used by impersonation tokens. */
@@ -148,12 +176,15 @@ export const validateSubjectToken = async ({
     // First, try to find the token as an opaque access token
     const opaqueResult = await validateOpaqueAccessToken(subjectToken, AccessToken);
     if (opaqueResult) {
-      return opaqueResult;
+      await assertFirstPartySubjectTokenClient(queries, opaqueResult.clientId);
+      return { userId: opaqueResult.userId };
     }
 
     // If not found as opaque token, try to verify as JWT
     assertThat(jwtVerificationOptions, new InvalidGrant('JWT verification options are required'));
-    return validateJwtAccessToken(subjectToken, jwtVerificationOptions);
+    const jwtResult = await validateJwtAccessToken(subjectToken, jwtVerificationOptions);
+    await assertFirstPartySubjectTokenClient(queries, jwtResult.clientId);
+    return { userId: jwtResult.userId };
   }
 
   if (subjectTokenType === TokenExchangeTokenType.PersonalAccessToken) {

--- a/packages/core/src/oidc/grants/token-exchange/index.test.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.test.ts
@@ -366,6 +366,7 @@ describe('token exchange', () => {
       // Mock AccessToken.find to return a valid token
       Sinon.stub(ctx.oidc.provider.AccessToken, 'find').resolves({
         accountId,
+        clientId,
         isExpired: false,
       });
       Sinon.stub(getProviderConfiguration(ctx.oidc.provider), 'findAccount').resolves({

--- a/packages/core/src/oidc/resource.test.ts
+++ b/packages/core/src/oidc/resource.test.ts
@@ -1,14 +1,16 @@
 import {
   accountCenterApplicationId,
+  Applications,
   demoAppApplicationId,
   deviceDemoAppApplicationId,
   type Application,
 } from '@logto/schemas';
 
 import { mockApplication } from '#src/__mocks__/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
 
-import { isThirdPartyApplication } from './resource.js';
+import { isThirdPartyApplication, resolveIsThirdPartyApplication } from './resource.js';
 
 const { jest } = import.meta;
 
@@ -46,5 +48,60 @@ describe('isThirdPartyApplication()', () => {
   it('should fail closed to third-party when the application cannot be resolved', async () => {
     findApplicationById.mockRejectedValueOnce(new Error('not found'));
     await expect(isThirdPartyApplication(queries, 'deleted_application_id')).resolves.toBe(true);
+  });
+});
+
+describe('resolveIsThirdPartyApplication()', () => {
+  const findApplicationById = jest.fn(async (): Promise<Application> => mockApplication);
+  const queries = new MockQueries({ applications: { findApplicationById } });
+
+  afterEach(() => {
+    findApplicationById.mockClear();
+  });
+
+  it.each([demoAppApplicationId, accountCenterApplicationId, deviceDemoAppApplicationId])(
+    'should treat the built-in client %s as first-party without a database lookup',
+    async (applicationId) => {
+      await expect(resolveIsThirdPartyApplication(queries, applicationId)).resolves.toBe(false);
+      expect(findApplicationById).not.toHaveBeenCalled();
+    }
+  );
+
+  it('should treat a CIMD client identifier as third-party without a database lookup', async () => {
+    await expect(
+      resolveIsThirdPartyApplication(queries, 'https://client.example.com/metadata.json')
+    ).resolves.toBe(true);
+    expect(findApplicationById).not.toHaveBeenCalled();
+  });
+
+  it('should return the stored flag for a registered application', async () => {
+    findApplicationById.mockResolvedValueOnce({ ...mockApplication, isThirdParty: true });
+    await expect(resolveIsThirdPartyApplication(queries, mockApplication.id)).resolves.toBe(true);
+
+    findApplicationById.mockResolvedValueOnce({ ...mockApplication, isThirdParty: false });
+    await expect(resolveIsThirdPartyApplication(queries, mockApplication.id)).resolves.toBe(false);
+  });
+
+  it('should return undefined when the application does not exist', async () => {
+    findApplicationById.mockRejectedValueOnce(
+      new RequestError({
+        code: 'entity.not_exists_with_id',
+        name: Applications.table,
+        id: 'deleted_application_id',
+        status: 404,
+      })
+    );
+
+    await expect(
+      resolveIsThirdPartyApplication(queries, 'deleted_application_id')
+    ).resolves.toBeUndefined();
+  });
+
+  /** A transient failure must stay distinguishable from a client that genuinely does not exist. */
+  it('should rethrow an unexpected lookup failure', async () => {
+    const error = new Error('connection terminated unexpectedly');
+    findApplicationById.mockRejectedValueOnce(error);
+
+    await expect(resolveIsThirdPartyApplication(queries, mockApplication.id)).rejects.toBe(error);
   });
 });

--- a/packages/core/src/oidc/resource.ts
+++ b/packages/core/src/oidc/resource.ts
@@ -4,6 +4,7 @@ import { trySafe, type Nullable } from '@silverhand/essentials';
 import { type ResourceServer } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -127,7 +128,20 @@ export const findResource = async (
   return queries.resources.findResourceByIndicator(indicator);
 };
 
-export const isThirdPartyApplication = async ({ applications }: Queries, applicationId: string) => {
+/**
+ * Resolve whether the given client is third-party, or `undefined` when no application matches the
+ * identifier.
+ *
+ * @remarks
+ * Unlike {@link isThirdPartyApplication}, a failed lookup (a database outage, say) is rethrown
+ * rather than folded into "third-party", so callers can tell "this client does not exist" from "we
+ * could not find out". Use this when the answer drives a hard reject and a transient failure must
+ * not masquerade as a client error.
+ */
+export const resolveIsThirdPartyApplication = async (
+  { applications }: Queries,
+  applicationId: string
+): Promise<boolean | undefined> => {
   // Built-in clients have no applications row and are always first-party.
   if (isBuiltInApplicationId(applicationId)) {
     return false;
@@ -138,10 +152,25 @@ export const isThirdPartyApplication = async ({ applications }: Queries, applica
     return true;
   }
 
-  const application = await trySafe(async () => applications.findApplicationById(applicationId));
+  try {
+    const application = await applications.findApplicationById(applicationId);
+    return application.isThirdParty;
+  } catch (error: unknown) {
+    if (error instanceof RequestError && error.code === 'entity.not_exists_with_id') {
+      return undefined;
+    }
+
+    throw error;
+  }
+};
+
+export const isThirdPartyApplication = async (queries: Queries, applicationId: string) => {
+  const isThirdParty = await trySafe(async () =>
+    resolveIsThirdPartyApplication(queries, applicationId)
+  );
 
   // Fail closed: an unresolvable client is never first-party.
-  return application?.isThirdParty ?? true;
+  return isThirdParty ?? true;
 };
 
 /**


### PR DESCRIPTION
> Stacked on #9457 — base is `fix/token-exchange-subject-token-class`. Review that one first.

## Summary

Token exchange does not inherit the subject token's audience or scopes. The issued token carries the **receiver's** authorization for the user, and since third-party applications cannot enable token exchange, the receiver is always first-party — meaning every scope the user's roles grant on the target resource.

`validateSubjectToken` discarded the subject token's issuing client (`token.clientId` on the opaque path, `payload.client_id` on the JWT path). Any access token belonging to user U was therefore interchangeable, regardless of which client it was issued to. A third-party application only ever holds credentials the user consented to for that application, so one of its access tokens could be presented to a token-exchange-enabled client and widened into the user's full first-party authorization.

This PR surfaces the issuing client from both paths and requires it to be first-party, reusing the CIMD and built-in client handling in `oidc/resource.ts`. Opaque tokens with no client binding are rejected rather than falling through to the JWT path.

`assertThirdPartyApplicationTokenExchangeDisabled` in the application routes already bars third-party applications from being the receiver; this closes the same boundary on the subject side.

### Lookup failures stay distinguishable

`isThirdPartyApplication` folds every lookup failure into "third-party", so a database hiccup is indistinguishable from a deleted application. That was tolerable where the result only fed `checkOrganizationAccess`, but here it decides a hard reject on the token endpoint: a transient fault would surface as `invalid_grant`, which reads as permanent — clients do not retry it and the logs do not explain it.

`resolveIsThirdPartyApplication` returns `undefined` for a client that genuinely has no application row and rethrows anything else. `isThirdPartyApplication` now wraps it, so existing callers keep failing closed. The subject token check uses the strict variant: an unknown client is still rejected, an unexpected failure surfaces as a 500.

## Breaking change

Exchanging an access token issued to a third-party application now fails with `invalid_grant`. The documented service-to-service delegation flow is unaffected — the subject token there is one your own first-party application received. Called out in the changeset.

## Not in scope

- **Scope intersection between subject and issued token.** Delegation typically trades a token for resource X for one for resource Y, so the scope sets are legitimately disjoint; intersecting would break the normal flow. Downscoping in Logto comes from `resource` plus the user's roles.
- **Requiring the receiver to be a confidential client.** A first-party public client (Native/SPA) can enable token exchange today, which makes "knows the client_id" sufficient to be a receiver. Worth tightening separately, with a migration path for existing configurations.
- **`actor_token`.** `handleActorToken` accepts any opaque access token with `openid` scope regardless of its issuing client — the same shape this PR closes on the subject side. It is left alone deliberately: the actor's subject only lands in the issued token's `act.sub`, which is delegation provenance and confers no authorization, so a third-party actor token widens nothing. Adding the check would be a breaking change to a released flow with no security gain; if the claim ever becomes authorization-bearing, it should be revisited then.

## Testing

`account.test.ts` covers the client check on both paths: opaque and JWT tokens from a first-party app accepted (asserting the issuing client, not the subject, is the value looked up); opaque and JWT tokens from a third-party app rejected; a deleted client rejected; an unexpected lookup failure propagated rather than converted into `invalid_grant`; opaque token with no client binding rejected. Verified they fail when the assertion is removed, and when it is passed the wrong claim.

`resource.test.ts` covers `resolveIsThirdPartyApplication` directly, including that a missing row and a failed query take different exits.

One existing fixture needed a real `clientId` on the stubbed opaque token — every `AccessToken` is client-bound in practice.

Full `oidc` suite: 17 files / 238 tests passing, lint clean.
