### PR TITLE
feat(core): add trusted device audit logs and webhooks

### DIFF
--- a/packages/console/src/consts/logs.test.ts
+++ b/packages/console/src/consts/logs.test.ts
@@ -7,4 +7,11 @@ describe('action audit log event titles', () => {
       'Action.PostSignIn': 'Execute post sign-in action',
     });
   });
+
+  it('exposes trusted-device event titles', () => {
+    expect(auditLogEventTitle).toMatchObject({
+      'TrustedDevice.Created': 'Create trusted device',
+      'TrustedDevice.Used': 'Use trusted device',
+    });
+  });
 });

--- a/packages/console/src/consts/logs.ts
+++ b/packages/console/src/consts/logs.ts
@@ -95,6 +95,8 @@ export const auditLogEventTitle = Object.freeze({
   'SamlApplication.Callback': 'Handle SAML application callback',
   'Action.PostFirstFactorVerification': 'Execute post first-factor verification action',
   'Action.PostSignIn': 'Execute post sign-in action',
+  'TrustedDevice.Created': 'Create trusted device',
+  'TrustedDevice.Used': 'Use trusted device',
 } satisfies Partial<Record<Exclude<AuditLogKey, interaction.DeprecatedInteractionLogKey>, string>>);
 
 export const logEventTitle: Record<string, Optional<string>> & {

--- a/packages/console/src/consts/webhooks.test.ts
+++ b/packages/console/src/consts/webhooks.test.ts
@@ -1,6 +1,18 @@
 import { InteractionHookEvent } from '@logto/schemas';
 
+const mockIsDevFeaturesEnabled = jest.fn(() => true);
+
+jest.mock('@/consts/env', () => ({
+  get isDevFeaturesEnabled() {
+    return mockIsDevFeaturesEnabled();
+  },
+}));
+
 describe('webhook event visibility', () => {
+  beforeEach(() => {
+    mockIsDevFeaturesEnabled.mockReturnValue(true);
+  });
+
   afterEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
@@ -10,5 +22,24 @@ describe('webhook event visibility', () => {
     const { interactionHookEvents } = await import('./webhooks');
 
     expect(interactionHookEvents).toContain(InteractionHookEvent.PostSignInAdaptiveMfaTriggered);
+  });
+
+  it('groups trusted-device events when dev features are enabled', async () => {
+    const { schemaGroupedDataHookEvents } = await import('./webhooks');
+
+    expect(schemaGroupedDataHookEvents).toContainEqual([
+      'TrustedDevice',
+      ['TrustedDevice.Created', 'TrustedDevice.Deleted'],
+    ]);
+  });
+
+  it('hides trusted-device events from available events when dev features are disabled', async () => {
+    mockIsDevFeaturesEnabled.mockReturnValue(false);
+    const { availableHookEvents, schemaGroupedDataHookEvents } = await import('./webhooks');
+
+    expect(availableHookEvents).not.toEqual(
+      expect.arrayContaining(['TrustedDevice.Created', 'TrustedDevice.Deleted'])
+    );
+    expect(schemaGroupedDataHookEvents.map(([schema]) => schema)).not.toContain('TrustedDevice');
   });
 });

--- a/packages/console/src/consts/webhooks.ts
+++ b/packages/console/src/consts/webhooks.ts
@@ -1,13 +1,17 @@
 import { type AdminConsoleKey } from '@logto/phrases';
 import {
   DataHookSchema,
+  devFeatureHookEvents,
   InteractionHookEvent,
   hookEvents,
   type DataHookEvent,
 } from '@logto/schemas';
 
+import { isDevFeaturesEnabled } from '@/consts/env';
+
 export const dataHookEventsLabel = Object.freeze({
   [DataHookSchema.User]: 'webhooks.schemas.user',
+  [DataHookSchema.TrustedDevice]: 'webhooks.schemas.trusted_device',
   [DataHookSchema.Organization]: 'webhooks.schemas.organization',
   [DataHookSchema.Role]: 'webhooks.schemas.role',
   [DataHookSchema.Scope]: 'webhooks.schemas.scope',
@@ -16,10 +20,15 @@ export const dataHookEventsLabel = Object.freeze({
 } satisfies Record<DataHookSchema, AdminConsoleKey>);
 
 export const interactionHookEvents = Object.values(InteractionHookEvent);
+const interactionHookEventSet = new Set<string>(interactionHookEvents);
+const devFeatureHookEventSet = new Set<string>(devFeatureHookEvents);
 
-const dataHookEvents: DataHookEvent[] = hookEvents.filter(
-  // eslint-disable-next-line no-restricted-syntax
-  (event): event is DataHookEvent => !interactionHookEvents.includes(event as InteractionHookEvent)
+export const availableHookEvents = hookEvents.filter(
+  (event) => isDevFeaturesEnabled || !devFeatureHookEventSet.has(event)
+);
+
+const dataHookEvents: DataHookEvent[] = availableHookEvents.filter(
+  (event): event is DataHookEvent => !interactionHookEventSet.has(event)
 );
 
 const isDataHookSchema = (schema: string): schema is DataHookSchema =>
@@ -46,11 +55,12 @@ const hookEventSchemaOrder: {
   [key in DataHookSchema]: number;
 } = {
   [DataHookSchema.User]: 0,
-  [DataHookSchema.Organization]: 1,
-  [DataHookSchema.Role]: 2,
-  [DataHookSchema.OrganizationRole]: 3,
-  [DataHookSchema.Scope]: 4,
-  [DataHookSchema.OrganizationScope]: 5,
+  [DataHookSchema.TrustedDevice]: 1,
+  [DataHookSchema.Organization]: 2,
+  [DataHookSchema.Role]: 3,
+  [DataHookSchema.OrganizationRole]: 4,
+  [DataHookSchema.Scope]: 5,
+  [DataHookSchema.OrganizationScope]: 6,
 };
 
 export const schemaGroupedDataHookEvents = Array.from(schemaGroupedDataHookEventsMap.entries())

--- a/packages/console/src/pages/WebhookDetails/WebhookLogs/index.tsx
+++ b/packages/console/src/pages/WebhookDetails/WebhookLogs/index.tsx
@@ -1,4 +1,4 @@
-import { hookEvents, type Log } from '@logto/schemas';
+import { type Log } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { useTranslation } from 'react-i18next';
 import { useOutletContext } from 'react-router-dom';
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import EventSelector from '@/components/AuditLogTable/components/EventSelector';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import { defaultPageSize } from '@/consts';
+import { availableHookEvents } from '@/consts/webhooks';
 import Table from '@/ds-components/Table';
 import Tag from '@/ds-components/Tag';
 import { type RequestError } from '@/hooks/use-api';
@@ -20,7 +21,7 @@ import { buildHookEventLogKey, getHookEventKey } from '../utils';
 
 import styles from './index.module.scss';
 
-const hookLogEventOptions = hookEvents.map((event) => ({
+const hookLogEventOptions = availableHookEvents.map((event) => ({
   title: event,
   value: buildHookEventLogKey(event),
 }));

--- a/packages/core/src/libraries/hook/context-manager.ts
+++ b/packages/core/src/libraries/hook/context-manager.ts
@@ -7,6 +7,7 @@ import {
   type DataHookEvent,
   type InteractionApiMetadata,
   type ManagementApiContext,
+  type TrustedDeviceEventData,
   userInfoSelectFields,
   type ExceptionHookEvent,
 } from '@logto/schemas';
@@ -28,6 +29,8 @@ export type HookMetadata = {
 export type HookContext = {
   /** Data details */
   data?: unknown;
+  /** Include the request IP in this event's webhook payload. */
+  includeRequestIp?: boolean;
 } & Partial<ManagementApiContext> &
   Record<string, unknown>;
 
@@ -60,6 +63,8 @@ type DataHookContextMap = {
   'User.Created': UserContext;
   'User.Data.Updated': UserContext;
   'User.Deleted': UserContext;
+  'TrustedDevice.Created': { data: TrustedDeviceEventData };
+  'TrustedDevice.Deleted': { data: TrustedDeviceEventData };
 };
 
 export class HookContextManager {

--- a/packages/core/src/libraries/hook/index.test.ts
+++ b/packages/core/src/libraries/hook/index.test.ts
@@ -389,4 +389,37 @@ describe('triggerDataHooks()', () => {
       signingKey: dataHook.signingKey,
     });
   });
+
+  it('should omit request IP from trusted-device lifecycle payloads', async () => {
+    jest.useFakeTimers().setSystemTime(100_000);
+    const trustedDeviceHook: Hook = {
+      ...dataHook,
+      event: 'TrustedDevice.Created',
+      events: ['TrustedDevice.Created'],
+    };
+    findAllHooks.mockResolvedValueOnce([trustedDeviceHook]);
+    const hooksManager = new HookContextManager({ userAgent: 'ua', ip: 'request-ip' });
+    const data = { id: 'device-id', userId: 'user-id', expiresAt: 200_000 };
+
+    hooksManager.appendDataHookContext('TrustedDevice.Created', {
+      data,
+      includeRequestIp: false,
+    });
+
+    await triggerDataHooks(new ConsoleLog(), hooksManager);
+
+    expect(sendWebhookRequest).toHaveBeenCalledWith({
+      hookConfig: trustedDeviceHook.config,
+      payload: {
+        hookId: trustedDeviceHook.id,
+        event: 'TrustedDevice.Created',
+        createdAt: new Date(100_000).toISOString(),
+        data,
+        userAgent: 'ua',
+      },
+      signingKey: trustedDeviceHook.signingKey,
+    });
+
+    jest.useRealTimers();
+  });
 });

--- a/packages/core/src/libraries/hook/index.ts
+++ b/packages/core/src/libraries/hook/index.ts
@@ -265,12 +265,13 @@ export const createHookLibrary = (queries: Queries) => {
 
     // Fetch application detail if available
     const { applicationId } = metadata;
+    const { ip, ...metadataWithoutIp } = metadata;
     const application =
       foundHooks.length > 0 && applicationId
         ? await trySafe(async () => findApplicationById(applicationId))
         : undefined;
 
-    return contextArray.flatMap(({ event, ...rest }) => {
+    return contextArray.flatMap(({ event, includeRequestIp = true, ...rest }) => {
       const hooks = foundHooks.filter(
         ({ event: hookEvent, events, enabled }) =>
           enabled && (events.length > 0 ? events.includes(event) : event === hookEvent)
@@ -279,7 +280,8 @@ export const createHookLibrary = (queries: Queries) => {
       const payload = {
         event,
         createdAt: new Date().toISOString(),
-        ...metadata,
+        ...metadataWithoutIp,
+        ...conditional(includeRequestIp && { ip }),
         ...conditional(
           application && { application: pick(application, 'id', 'type', 'name', 'description') }
         ),

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -3,6 +3,7 @@ import {
   InteractionHookEvent,
   managementApiHooksRegistration,
   type HookConfig,
+  type ExceptionHookEvent,
   type HookEvent,
   type HookEventPayload,
   type ManagementApiContext,
@@ -95,6 +96,8 @@ export const generateHookTestPayload = (hookId: string, event: HookEvent): HookE
 
   const isInteractionHookEvent = (event: HookEvent): event is InteractionHookEvent =>
     Object.values<string>(InteractionHookEvent).includes(event);
+  const isExceptionHookEvent = (event: HookEvent): event is ExceptionHookEvent =>
+    ['Identifier.Lockout', 'Message.RateLimited', 'Grant.LimitExceeded'].includes(event);
 
   const basicPayload = {
     hookId,
@@ -107,6 +110,14 @@ export const generateHookTestPayload = (hookId: string, event: HookEvent): HookE
       event,
       ...basicPayload,
       ...interactionHookContext,
+    };
+  }
+
+  if (isExceptionHookEvent(event)) {
+    return {
+      event,
+      ...basicPayload,
+      ...dataHookContext,
     };
   }
 

--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Credential and lifecycle behavior share security-sensitive fixtures. */
 import { createHash } from 'node:crypto';
 
 import type { TrustedDevice } from '@logto/schemas';
@@ -37,6 +38,7 @@ const createQueries = () =>
     insertIfNotExists: jest.fn(),
     findActiveByIdAndUserId: jest.fn(),
     updateMetadataByIdAndUserId: jest.fn(),
+    deleteByIdAndUserId: jest.fn(),
     deleteExpiredByIdAndUserId: jest.fn(),
     deleteExpiredByTenant: jest.fn(),
   }) as unknown as jest.Mocked<TrustedDeviceQueries>;
@@ -268,6 +270,52 @@ describe('trusted device library', () => {
     );
   });
 
+  it('queues a redacted deletion webhook only after deleting an existing record', async () => {
+    const queries = createQueries();
+    const trustedDevice = {
+      ...buildTrustedDevice(Buffer.alloc(32, 1)),
+      ip: '192.0.2.1',
+      userAgent: 'private user agent',
+    };
+    const ctx = { appendDataHookContext: jest.fn() };
+    queries.deleteByIdAndUserId.mockResolvedValueOnce(trustedDevice).mockResolvedValueOnce(null);
+    const library = createTrustedDeviceLibrary(tenantId, queries, createPolicyLibrary());
+
+    await expect(library.deleteByIdAndUserId(ctx, trustedDeviceId, userId)).resolves.toEqual(
+      trustedDevice
+    );
+    await expect(
+      library.deleteByIdAndUserId(ctx, trustedDeviceId, userId)
+    ).resolves.toBeUndefined();
+
+    expect(ctx.appendDataHookContext).toHaveBeenCalledTimes(1);
+    expect(ctx.appendDataHookContext).toHaveBeenCalledWith('TrustedDevice.Deleted', {
+      data: {
+        id: trustedDeviceId,
+        userId,
+        expiresAt: trustedDevice.expiresAt,
+      },
+      includeRequestIp: false,
+    });
+    expect(JSON.stringify(ctx.appendDataHookContext.mock.calls)).not.toContain('192.0.2.1');
+    expect(JSON.stringify(ctx.appendDataHookContext.mock.calls)).not.toContain(
+      'private user agent'
+    );
+    expect(JSON.stringify(ctx.appendDataHookContext.mock.calls)).not.toContain('secretHash');
+  });
+
+  it('does not queue a deletion webhook when the delete query fails', async () => {
+    const queries = createQueries();
+    const error = new Error('delete failed');
+    const ctx = { appendDataHookContext: jest.fn() };
+    queries.deleteByIdAndUserId.mockRejectedValueOnce(error);
+    const library = createTrustedDeviceLibrary(tenantId, queries, createPolicyLibrary());
+
+    await expect(library.deleteByIdAndUserId(ctx, trustedDeviceId, userId)).rejects.toBe(error);
+
+    expect(ctx.appendDataHookContext).not.toHaveBeenCalled();
+  });
+
   it('reads the unsigned user-specific cookie and validates the active record hash', async () => {
     const secret = generateTrustedDeviceSecret();
     const secretHash = hashTrustedDeviceSecret(secret);
@@ -420,3 +468,4 @@ describe('trusted device library', () => {
     expect(queries.deleteExpiredByTenant).toHaveBeenCalledTimes(2);
   });
 });
+/* eslint-enable max-lines */

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -1,12 +1,13 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 
-import { TrustedDevices } from '@logto/schemas';
+import { TrustedDevices, type TrustedDevice, type TrustedDeviceEventData } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 import { type Context } from 'koa';
 
 import { EnvSet } from '#src/env-set/index.js';
 import type { TrustedDeviceMetadata, TrustedDeviceQueries } from '#src/queries/trusted-device.js';
 
+import type { HookContextManager } from './hook/context-manager.js';
 import type { createTrustedDevicePolicyLibrary } from './trusted-device-policy.js';
 
 const trustedDeviceSecretByteLength = 32;
@@ -38,6 +39,14 @@ type CreateTrustedDeviceCredential = TrustedDeviceMetadata &
   }>;
 
 type TrustedDevicePolicyLibrary = ReturnType<typeof createTrustedDevicePolicyLibrary>;
+
+type TrustedDeviceLifecycleContext = Pick<HookContextManager, 'appendDataHookContext'>;
+
+export const getTrustedDeviceEventData = ({
+  id,
+  userId,
+  expiresAt,
+}: TrustedDevice): TrustedDeviceEventData => ({ id, userId, expiresAt });
 
 export const getTrustedDeviceCookieName = (
   tenantId: string,
@@ -264,10 +273,31 @@ export const createTrustedDeviceLibrary = (
     return trustedDevice;
   };
 
+  const deleteByIdAndUserId = async (
+    ctx: TrustedDeviceLifecycleContext,
+    id: string,
+    userId: string
+  ) => {
+    const trustedDevice = await queries.deleteByIdAndUserId(id, userId);
+
+    if (!trustedDevice) {
+      return;
+    }
+
+    ctx.appendDataHookContext('TrustedDevice.Deleted', {
+      data: getTrustedDeviceEventData(trustedDevice),
+      // Trusted-device lifecycle payloads intentionally exclude the request IP.
+      includeRequestIp: false,
+    });
+
+    return trustedDevice;
+  };
+
   return {
     cleanupExpired,
     clearCredential,
     createCredential,
+    deleteByIdAndUserId,
     getCookieName,
     updateMetadata,
     validateCredential,

--- a/packages/core/src/middleware/koa-audit-log.test.ts
+++ b/packages/core/src/middleware/koa-audit-log.test.ts
@@ -19,7 +19,8 @@ const { jest } = import.meta;
 await mockIdGenerators();
 
 const insertLog = jest.fn();
-const queries = { logs: { insertLog } } as unknown as Queries;
+const insertLogIfNotExists = jest.fn();
+const queries = { logs: { insertLog, insertLogIfNotExists } } as unknown as Queries;
 
 const { default: koaLog } = await import('./koa-audit-log.js');
 const { default: RequestError } = await import('#src/errors/RequestError/index.js');
@@ -78,6 +79,62 @@ describe('koaAuditLog middleware', () => {
         key: logKey,
         result: LogResult.Success,
         ip,
+        userAgent,
+        userAgentParsed,
+      },
+    });
+  });
+
+  it('should omit the request IP for entries that opt out of it', async () => {
+    const ctx: TestContext = createTestContext({ 'user-agent': userAgent });
+    ctx.request.ip = ip;
+
+    const next = async () => {
+      const log = ctx.createLog('TrustedDevice.Created', { includeRequestIp: false });
+      log.append(mockPayload);
+    };
+
+    await koaLog(queries)(ctx, next);
+
+    expect(insertLog).toHaveBeenCalledWith({
+      id: mockId,
+      key: 'TrustedDevice.Created',
+      payload: {
+        ...mockPayload,
+        key: 'TrustedDevice.Created',
+        result: LogResult.Success,
+        userAgent,
+        userAgentParsed,
+      },
+    });
+  });
+
+  it('should reuse a conflict-safe log ID for retries with an idempotency key', async () => {
+    const idempotencyKey = 'trusted-usage-id';
+    const createRetry = async () => {
+      const ctx: TestContext = createTestContext({ 'user-agent': userAgent });
+      ctx.request.ip = ip;
+
+      await koaLog(queries)(ctx, async () => {
+        const log = ctx.createLog('TrustedDevice.Used', {
+          includeRequestIp: false,
+          idempotencyKey,
+        });
+        log.append(mockPayload);
+      });
+    };
+
+    await Promise.all([createRetry(), createRetry()]);
+
+    expect(insertLog).not.toHaveBeenCalled();
+    expect(insertLogIfNotExists).toHaveBeenCalledTimes(2);
+    expect(insertLogIfNotExists).toHaveBeenNthCalledWith(2, {
+      id: idempotencyKey,
+      key: 'TrustedDevice.Used',
+      payload: {
+        ...mockPayload,
+        key: 'TrustedDevice.Used',
+        result: LogResult.Success,
         userAgent,
         userAgentParsed,
       },

--- a/packages/core/src/middleware/koa-audit-log.ts
+++ b/packages/core/src/middleware/koa-audit-log.ts
@@ -37,7 +37,9 @@ export class LogEntry {
 
   constructor(
     public readonly key: LogKey,
-    public readonly independent = false
+    public readonly independent = false,
+    public readonly includeRequestIp = true,
+    public readonly idempotencyKey?: string
   ) {
     this.payload = {
       key,
@@ -67,6 +69,10 @@ export type LogPayload = Partial<LogContextPayload>;
 export type CreateLogOptions = {
   /** Keep this entry's own result when the remainder of the request fails. */
   independent?: boolean;
+  /** Include the request IP in this entry's common audit context. */
+  includeRequestIp?: boolean;
+  /** Reuse a stable log ID so retries insert this audit event at most once. */
+  idempotencyKey?: string;
 };
 
 export type LogContext = {
@@ -149,13 +155,16 @@ export function assertLogContext<ContextT>(ctx: ContextT): asserts ctx is Contex
  * @see {@link LogContextPayload} for the basic type suggestion of log data.
  */
 export default function koaAuditLog<StateT, ContextT extends IRouterParamContext, ResponseBodyT>({
-  logs: { insertLog },
+  logs: { insertLog, insertLogIfNotExists },
 }: Queries): MiddlewareType<StateT, WithLogContext<ContextT>, ResponseBodyT> {
   return async (ctx, next) => {
     const entries: LogEntry[] = [];
 
-    ctx.createLog = (key: LogKey, { independent = false } = {}) => {
-      const entry = new LogEntry(key, independent);
+    ctx.createLog = (
+      key: LogKey,
+      { independent = false, includeRequestIp = true, idempotencyKey } = {}
+    ) => {
+      const entry = new LogEntry(key, independent, includeRequestIp, idempotencyKey);
       // eslint-disable-next-line @silverhand/fp/no-mutating-methods
       entries.push(entry);
 
@@ -206,19 +215,24 @@ export default function koaAuditLog<StateT, ContextT extends IRouterParamContext
         })()
       );
       const basePayload = removeUndefinedKeys({
-        ip,
         userAgent: userAgentValue,
         ...conditional(userAgentParsed && { userAgentParsed }),
         ...conditional(signInContext && { signInContext }),
       });
 
       await Promise.all(
-        entries.map(async ({ payload }) => {
+        entries.map(async ({ payload, includeRequestIp, idempotencyKey }) => {
           // Apply the recursive filter at the final insertion boundary too, so common context
           // added through `prependAllLogEntries()` can never bypass sensitive-key masking.
-          const fullPayload = sanitizeLogContextPayload({ ...basePayload, ...payload });
-          return insertLog({
-            id: generateStandardId(),
+          const fullPayload = sanitizeLogContextPayload({
+            ...conditional(includeRequestIp && { ip }),
+            ...basePayload,
+            ...payload,
+          });
+          const insert = idempotencyKey ? insertLogIfNotExists : insertLog;
+
+          return insert({
+            id: idempotencyKey ?? generateStandardId(),
             key: payload.key,
             payload: fullPayload,
           });

--- a/packages/core/src/middleware/koa-guard.ts
+++ b/packages/core/src/middleware/koa-guard.ts
@@ -49,6 +49,8 @@ export type GuardConfig<QueryT, BodyT, ParametersT, ResponseT, FilesT> = {
    * @example z.object({ key1: z.string() })
    */
   response?: ZodType<ResponseT, ZodTypeDef, unknown>;
+  /** Override the response schema used for OpenAPI without changing runtime validation. */
+  responseForOpenApi?: ZodType<unknown, ZodTypeDef, unknown>;
   /**
    * Guard response status code. It produces a `ServerError` (500) if the response does not satisfy
    * any of the given value(s).
@@ -151,6 +153,7 @@ export default function koaGuard<
   body,
   params,
   response,
+  responseForOpenApi,
   status,
   files,
 }: GuardConfig<
@@ -255,7 +258,7 @@ export default function koaGuard<
 
   // Intended
   // eslint-disable-next-line @silverhand/fp/no-mutation
-  guardMiddleware.config = { query, body, params, response, status };
+  guardMiddleware.config = { query, body, params, response, responseForOpenApi, status };
 
   return guardMiddleware;
 }

--- a/packages/core/src/queries/log.ts
+++ b/packages/core/src/queries/log.ts
@@ -81,6 +81,9 @@ const buildLogConditionSql = (logCondition: LogCondition) =>
 
 export const createLogQueries = (pool: CommonQueryMethods) => {
   const insertLog = buildInsertIntoWithPool(pool)(Logs);
+  const insertLogIfNotExists = buildInsertIntoWithPool(pool)(Logs, {
+    onConflict: { ignore: true },
+  });
 
   const countLogs = async (
     condition: LogCondition,
@@ -135,6 +138,7 @@ export const createLogQueries = (pool: CommonQueryMethods) => {
 
   return {
     insertLog,
+    insertLogIfNotExists,
     countLogs,
     findLogs,
     findLogById,

--- a/packages/core/src/queries/trusted-device.test.ts
+++ b/packages/core/src/queries/trusted-device.test.ts
@@ -176,6 +176,7 @@ describe('trusted device queries', () => {
   it('returns null when metadata cannot be updated for an inactive or missing device', async () => {
     mockQuery.mockImplementationOnce(async (query, values) => {
       expect(query).toMatch(/and "expires_at" > now\(\)/i);
+      expect(query).not.toMatch(/"last_used_at" < to_timestamp/i);
       expect(values).toEqual([
         expect.any(Number),
         null,

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -1,0 +1,317 @@
+import { appInsights } from '@logto/app-insights/node';
+import { InteractionEvent, type TrustedDevice as TrustedDeviceModel } from '@logto/schemas';
+
+import { EnvSet } from '#src/env-set/index.js';
+import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
+
+import { type WithHooksAndLogsContext } from '../types.js';
+
+import { TrustedDevice } from './trusted-device.js';
+
+const { jest } = import.meta;
+
+const userId = 'user-id';
+const trustedDeviceId = 'trusteddeviceid';
+const trustedDevice: TrustedDeviceModel = {
+  tenantId: 'tenant-id',
+  id: trustedDeviceId,
+  userId,
+  secretHash: Buffer.alloc(32, 1),
+  userAgent: 'private user agent',
+  ip: '192.0.2.1',
+  country: 'US',
+  city: 'Portland',
+  createdAt: 1,
+  lastUsedAt: 1,
+  expiresAt: 2,
+};
+
+const createContext = (interactionId = 'interaction-id') => {
+  const { mockAppend, ...logContext } = createMockLogContext();
+  const appendDataHookContext = jest.fn();
+  const ctx = {
+    ...createContextWithRouteParameters(),
+    ...logContext,
+    appendDataHookContext,
+    appendExceptionHookContext: jest.fn(),
+    assignReleaseOnSuccessInteractionHookResult: jest.fn(),
+    assignReleaseAnywayInteractionHookResult: jest.fn(),
+    interactionDetails: { jti: interactionId },
+  } as unknown as WithHooksAndLogsContext;
+
+  return { ctx, appendDataHookContext, createLog: jest.mocked(logContext.createLog), mockAppend };
+};
+
+const createSubject = ({
+  data,
+  createResult,
+  updateResult,
+  validateResult,
+  interactionId,
+}: {
+  data: ConstructorParameters<typeof TrustedDevice>[2];
+  createResult?: TrustedDeviceModel;
+  updateResult?: TrustedDeviceModel;
+  validateResult?: TrustedDeviceModel;
+  interactionId?: string;
+}) => {
+  const context = createContext(interactionId);
+  const createCredential = jest.fn().mockResolvedValue(createResult);
+  const updateMetadata = jest.fn().mockResolvedValue(updateResult);
+  const validateCredential = jest.fn().mockResolvedValue(validateResult);
+  const tenant = new MockTenant(undefined, undefined, undefined, {
+    trustedDevicePolicy: {
+      getEffectivePolicy: jest.fn().mockResolvedValue({ enabled: true, durationDays: 30 }),
+    },
+    trustedDevices: { createCredential, updateMetadata, validateCredential },
+  });
+
+  return {
+    ...context,
+    createCredential,
+    updateMetadata,
+    validateCredential,
+    subject: new TrustedDevice(context.ctx, tenant, data),
+  };
+};
+
+describe('Experience trusted-device lifecycle events', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Exercise the guarded feature in isolation.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = true;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore the process-wide test environment.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+      originalIsDevFeaturesEnabled;
+    jest.restoreAllMocks();
+  });
+
+  it('emits Created audit and webhook events only for the successful insert winner', async () => {
+    const winner = createSubject({
+      data: {},
+      createResult: trustedDevice,
+    });
+    const loser = createSubject({ data: {} });
+    const options = {
+      creation: { deviceId: trustedDeviceId },
+      interactionEvent: InteractionEvent.SignIn,
+      userId,
+      hasEligibleMfaProof: true,
+      signInContext: { ip: '198.51.100.2', userAgent: 'request user agent' },
+    };
+
+    await winner.subject.finalize(options);
+    await loser.subject.finalize(options);
+
+    expect(winner.createLog).toHaveBeenCalledWith('TrustedDevice.Created', {
+      includeRequestIp: false,
+    });
+    expect(winner.mockAppend).toHaveBeenCalledWith({
+      userId,
+      data: { id: trustedDeviceId, userId, expiresAt: trustedDevice.expiresAt },
+    });
+    expect(winner.appendDataHookContext).toHaveBeenCalledWith('TrustedDevice.Created', {
+      data: { id: trustedDeviceId, userId, expiresAt: trustedDevice.expiresAt },
+      includeRequestIp: false,
+    });
+    expect(loser.createLog).not.toHaveBeenCalled();
+    expect(loser.appendDataHookContext).not.toHaveBeenCalled();
+
+    const emittedPayload = JSON.stringify([
+      winner.mockAppend.mock.calls,
+      winner.appendDataHookContext.mock.calls,
+    ]);
+    expect(emittedPayload).not.toContain('192.0.2.1');
+    expect(emittedPayload).not.toContain('198.51.100.2');
+    expect(emittedPayload).not.toContain('private user agent');
+    expect(emittedPayload).not.toContain('secretHash');
+  });
+
+  it('writes Used audit only after a successful active-device metadata update', async () => {
+    const success = createSubject({
+      data: {
+        trustedDeviceFulfillment: {
+          userId,
+          trustedDeviceId,
+          fulfilledAt: 1,
+        },
+      },
+      updateResult: trustedDevice,
+    });
+    const inactive = createSubject({
+      data: {
+        trustedDeviceFulfillment: {
+          userId,
+          trustedDeviceId,
+          fulfilledAt: 1,
+        },
+      },
+    });
+    const options = {
+      interactionEvent: InteractionEvent.SignIn,
+      userId,
+      hasEligibleMfaProof: false,
+    };
+
+    await Promise.all([success.subject.finalize(options), inactive.subject.finalize(options)]);
+
+    expect(success.updateMetadata).toHaveBeenCalledWith(trustedDeviceId, userId, {});
+    expect(success.createLog).toHaveBeenCalledTimes(1);
+    expect(success.createLog.mock.calls[0]?.[0]).toBe('TrustedDevice.Used');
+    expect(success.createLog.mock.calls[0]?.[1]).toMatchObject({ includeRequestIp: false });
+    expect(success.createLog.mock.calls[0]?.[1]?.idempotencyKey).toHaveLength(21);
+    expect(success.mockAppend).toHaveBeenCalledWith({
+      userId,
+      data: { id: trustedDeviceId, userId, expiresAt: trustedDevice.expiresAt },
+    });
+    expect(success.appendDataHookContext).not.toHaveBeenCalled();
+    expect(inactive.createLog).not.toHaveBeenCalled();
+  });
+
+  it('keeps distinct same-millisecond fulfillments observable when they finish out of order', async () => {
+    const earlier = createSubject({
+      data: {
+        trustedDeviceFulfillment: {
+          userId,
+          trustedDeviceId,
+          fulfilledAt: 123_000,
+        },
+      },
+      updateResult: trustedDevice,
+      interactionId: 'earlier-interaction-id',
+    });
+    const later = createSubject({
+      data: {
+        trustedDeviceFulfillment: {
+          userId,
+          trustedDeviceId,
+          fulfilledAt: 123_000,
+        },
+      },
+      updateResult: trustedDevice,
+      interactionId: 'later-interaction-id',
+    });
+    const options = {
+      interactionEvent: InteractionEvent.SignIn,
+      userId,
+      hasEligibleMfaProof: false,
+    };
+
+    await later.subject.finalize(options);
+    await earlier.subject.finalize(options);
+
+    const laterIdempotencyKey = later.createLog.mock.calls[0]?.[1]?.idempotencyKey;
+    const earlierIdempotencyKey = earlier.createLog.mock.calls[0]?.[1]?.idempotencyKey;
+    expect(laterIdempotencyKey).toHaveLength(21);
+    expect(earlierIdempotencyKey).toHaveLength(21);
+    expect(earlierIdempotencyKey).not.toBe(laterIdempotencyKey);
+  });
+
+  it('uses one audit-log key across requests racing before fulfillment is stored', async () => {
+    const first = createSubject({
+      data: {},
+      updateResult: trustedDevice,
+      validateResult: trustedDevice,
+      interactionId: 'shared-interaction-id',
+    });
+    const second = createSubject({
+      data: {},
+      updateResult: trustedDevice,
+      validateResult: trustedDevice,
+      interactionId: 'shared-interaction-id',
+    });
+
+    await expect(
+      Promise.all([first.subject.tryFulfillMfa(userId), second.subject.tryFulfillMfa(userId)])
+    ).resolves.toEqual(['validated', 'validated']);
+
+    const options = {
+      interactionEvent: InteractionEvent.SignIn,
+      userId,
+      hasEligibleMfaProof: false,
+    };
+    await Promise.all([first.subject.finalize(options), second.subject.finalize(options)]);
+
+    const firstIdempotencyKey = first.createLog.mock.calls[0]?.[1]?.idempotencyKey;
+    const secondIdempotencyKey = second.createLog.mock.calls[0]?.[1]?.idempotencyKey;
+    expect(first.validateCredential).toHaveBeenCalledTimes(1);
+    expect(second.validateCredential).toHaveBeenCalledTimes(1);
+    expect(firstIdempotencyKey).toHaveLength(21);
+    expect(secondIdempotencyKey).toBe(firstIdempotencyKey);
+  });
+
+  it('reuses one audit-log idempotency key for concurrent or sequential fulfillment retries', async () => {
+    const fulfillment = {
+      userId,
+      trustedDeviceId,
+      fulfilledAt: 123_000,
+    };
+    const usage = createSubject({
+      data: { trustedDeviceFulfillment: fulfillment },
+      updateResult: trustedDevice,
+    });
+    const options = {
+      interactionEvent: InteractionEvent.SignIn,
+      userId,
+      hasEligibleMfaProof: false,
+    };
+
+    await Promise.all([usage.subject.finalize(options), usage.subject.finalize(options)]);
+    await usage.subject.finalize(options);
+
+    expect(usage.updateMetadata).toHaveBeenCalledTimes(3);
+    expect(usage.createLog).toHaveBeenCalledTimes(3);
+    const idempotencyKeys = usage.createLog.mock.calls.map(
+      ([, options]) => options?.idempotencyKey
+    );
+    expect(idempotencyKeys[0]).toHaveLength(21);
+    expect(new Set(idempotencyKeys)).toHaveProperty('size', 1);
+  });
+
+  it('keeps post-submit failures non-blocking and emits no lifecycle event', async () => {
+    const error = new Error('trusted-device write failed');
+    const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
+    const creation = createSubject({ data: {} });
+    creation.createCredential.mockRejectedValueOnce(error);
+    const usage = createSubject({
+      data: {
+        trustedDeviceFulfillment: {
+          userId,
+          trustedDeviceId,
+          fulfilledAt: 1,
+        },
+      },
+    });
+    usage.updateMetadata.mockRejectedValueOnce(error);
+
+    await expect(
+      creation.subject.finalize({
+        creation: { deviceId: trustedDeviceId },
+        interactionEvent: InteractionEvent.SignIn,
+        userId,
+        hasEligibleMfaProof: true,
+      })
+    ).resolves.toBeUndefined();
+    await expect(
+      usage.subject.finalize({
+        interactionEvent: InteractionEvent.SignIn,
+        userId,
+        hasEligibleMfaProof: false,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(creation.createLog).not.toHaveBeenCalled();
+    expect(creation.appendDataHookContext).not.toHaveBeenCalled();
+    expect(usage.createLog).not.toHaveBeenCalled();
+    expect(usage.appendDataHookContext).not.toHaveBeenCalled();
+    expect(trackException).toHaveBeenCalledTimes(2);
+    expect(trackException).toHaveBeenCalledWith(error, expect.any(Object));
+  });
+});

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -1,10 +1,14 @@
+import { createHash } from 'node:crypto';
+
 import { appInsights } from '@logto/app-insights/node';
-import { InteractionEvent } from '@logto/schemas';
+import { InteractionEvent, type TrustedDevice as TrustedDeviceModel } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { getTrustedDeviceEventData } from '#src/libraries/trusted-device.js';
+import { type TrustedDeviceMetadata } from '#src/queries/trusted-device.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
@@ -21,6 +25,14 @@ type TrustedDeviceData = Pick<
   InteractionStorage,
   'trustedDeviceCreation' | 'trustedDeviceFulfillment'
 >;
+
+type TrustedDeviceFulfillment = NonNullable<InteractionStorage['trustedDeviceFulfillment']>;
+
+const buildTrustedDeviceUsageLogId = (tenantId: string, interactionId: string) =>
+  createHash('sha256')
+    .update(`TrustedDevice.Used:${tenantId}:${interactionId}`)
+    .digest('base64url')
+    .slice(0, 21);
 
 type FinalizeOptions = {
   creation?: InteractionStorage['trustedDeviceCreation'];
@@ -42,7 +54,7 @@ type FinalizeOptions = {
  */
 export class TrustedDevice {
   #creation?: InteractionStorage['trustedDeviceCreation'];
-  #fulfillment?: InteractionStorage['trustedDeviceFulfillment'];
+  #fulfillment?: TrustedDeviceFulfillment;
 
   constructor(
     private readonly ctx: WithHooksAndLogsContext,
@@ -140,9 +152,6 @@ export class TrustedDevice {
 
     await trySafe(
       async () => {
-        const {
-          libraries: { trustedDevices },
-        } = this.tenant;
         const { ip, userAgent } = signInContext ?? {};
         const { country, city } = location ?? {};
         const metadata = {
@@ -155,32 +164,85 @@ export class TrustedDevice {
         const fulfillment = this.#fulfillment;
 
         if (fulfillment?.userId === userId) {
-          if (interactionEvent === InteractionEvent.SignIn) {
-            void trySafe(
-              async () =>
-                trustedDevices.updateMetadata(fulfillment.trustedDeviceId, userId, metadata),
-              (error) => {
-                void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
-              }
-            );
-          }
+          await this.#finalizeFulfillment(fulfillment, interactionEvent, userId, metadata);
           return;
         }
 
-        if (!creation || !hasEligibleMfaProof) {
-          return;
-        }
-
-        await trustedDevices.createCredential({
-          ctx: this.ctx,
-          deviceId: creation.deviceId,
-          userId,
-          ...metadata,
-        });
+        await this.#finalizeCreation(creation, hasEligibleMfaProof, userId, metadata);
       },
       (error) => {
         void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
       }
     );
+  }
+
+  async #finalizeFulfillment(
+    fulfillment: TrustedDeviceFulfillment,
+    interactionEvent: InteractionEvent,
+    userId: string,
+    metadata: TrustedDeviceMetadata
+  ) {
+    if (interactionEvent !== InteractionEvent.SignIn) {
+      return;
+    }
+
+    const trustedDevice = await this.tenant.libraries.trustedDevices.updateMetadata(
+      fulfillment.trustedDeviceId,
+      userId,
+      metadata
+    );
+
+    if (trustedDevice) {
+      this.#appendAuditLog(
+        'TrustedDevice.Used',
+        trustedDevice,
+        buildTrustedDeviceUsageLogId(this.tenant.id, this.ctx.interactionDetails.jti)
+      );
+    }
+  }
+
+  async #finalizeCreation(
+    creation: InteractionStorage['trustedDeviceCreation'],
+    hasEligibleMfaProof: boolean,
+    userId: string,
+    metadata: TrustedDeviceMetadata
+  ) {
+    if (!creation || !hasEligibleMfaProof) {
+      return;
+    }
+
+    const trustedDevice = await this.tenant.libraries.trustedDevices.createCredential({
+      ctx: this.ctx,
+      deviceId: creation.deviceId,
+      userId,
+      ...metadata,
+    });
+
+    if (!trustedDevice) {
+      return;
+    }
+
+    const data = getTrustedDeviceEventData(trustedDevice);
+
+    this.#appendAuditLog('TrustedDevice.Created', trustedDevice);
+    this.ctx.appendDataHookContext('TrustedDevice.Created', {
+      data,
+      // Trusted-device lifecycle payloads intentionally exclude the request IP.
+      includeRequestIp: false,
+    });
+  }
+
+  #appendAuditLog(
+    key: 'TrustedDevice.Created' | 'TrustedDevice.Used',
+    trustedDevice: TrustedDeviceModel,
+    idempotencyKey?: string
+  ) {
+    const data = getTrustedDeviceEventData(trustedDevice);
+    const log = this.ctx.createLog(key, {
+      includeRequestIp: false,
+      ...conditional(idempotencyKey && { idempotencyKey }),
+    });
+
+    log.append({ userId: data.userId, data });
   }
 }

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -885,6 +885,7 @@ describe('POST /experience/submit', () => {
     setDevFeaturesEnabled(true);
     const metadataError = new Error('trusted-device metadata update failed');
     const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
+    const fulfilledAt = Date.now();
     const user = {
       ...mockUser,
       mfaVerifications: [mockUserTotpMfaVerification],
@@ -896,7 +897,7 @@ describe('POST /experience/submit', () => {
         trustedDeviceFulfillment: {
           userId: user.id,
           trustedDeviceId: 'trusted-device-id',
-          fulfilledAt: Date.now(),
+          fulfilledAt,
         },
       },
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
@@ -937,12 +938,13 @@ describe('POST /experience/submit', () => {
 
   it('should omit trusted-device location when the current context has none', async () => {
     setDevFeaturesEnabled(true);
+    const fulfilledAt = Date.now();
     const { requester, updateMetadata } = createRequesterWithMocks({
       interactionResult: {
         trustedDeviceFulfillment: {
           userId: mockUser.id,
           trustedDeviceId: 'trusted-device-id',
-          fulfilledAt: Date.now(),
+          fulfilledAt,
         },
       },
       trustedDevicePolicy: { enabled: true, durationDays: 30 },

--- a/packages/core/src/routes/hook.test.ts
+++ b/packages/core/src/routes/hook.test.ts
@@ -2,7 +2,9 @@
 import {
   InteractionHookEvent,
   LogResult,
+  devFeatureHookEvents,
   hook,
+  hookEvents,
   type CreateHook,
   type Hook,
   type HookConfig,
@@ -11,6 +13,7 @@ import {
 } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 import { subDays } from 'date-fns';
+import Router from 'koa-router';
 
 import {
   mockCreatedAtForHook,
@@ -19,26 +22,33 @@ import {
   mockNanoIdForHook,
   mockTenantIdForHook,
 } from '#src/__mocks__/hook.js';
+import { EnvSet } from '#src/env-set/index.js';
 import { createMockQuotaLibrary } from '#src/test-utils/quota.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
+import { buildRouterObjects } from './swagger/utils/operation.js';
+import { type ManagementApiRouter } from './types.js';
+
 const { jest } = import.meta;
+
+const findAllHooks = jest.fn(async (): Promise<Hook[]> => mockHookList);
+const findHookById = jest.fn(async (id: string): Promise<Hook> => {
+  const hook = mockHookList.find((hook) => hook.id === id);
+  if (!hook) {
+    throw new Error('Not found');
+  }
+  return hook;
+});
 
 const hooks = {
   getTotalNumberOfHooks: async (): Promise<{ count: number }> => ({ count: mockHookList.length }),
-  findAllHooks: async (): Promise<Hook[]> => mockHookList,
+  findAllHooks,
   insertHook: async (data: CreateHook): Promise<Hook> => ({
     ...mockHook,
     ...data,
   }),
-  findHookById: async (id: string): Promise<Hook> => {
-    const hook = mockHookList.find((hook) => hook.id === id);
-    if (!hook) {
-      throw new Error('Not found');
-    }
-    return hook;
-  },
+  findHookById,
   updateHookById: async (id: string, data: Partial<CreateHook>): Promise<Hook> => {
     const targetHook = mockHookList.find((hook) => hook.id === id) ?? mockHook;
     return {
@@ -89,7 +99,24 @@ const tenantContext = new MockTenant(undefined, mockQueries, undefined, mockLibr
 const hookRoutes = await pickDefault(import('./hook.js'));
 
 describe('hook routes', () => {
-  const hookRequest = createRequester({ authedRoutes: hookRoutes, tenantContext });
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  const createHookRequester = (isDevFeaturesEnabled: boolean) => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Build route guards for the requested feature environment.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+      isDevFeaturesEnabled;
+
+    try {
+      return createRequester({ authedRoutes: hookRoutes, tenantContext });
+    } finally {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore process-wide configuration after route initialization.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+        originalIsDevFeaturesEnabled;
+    }
+  };
+
+  const hookRequest = createHookRequester(true);
+  const nonDevHookRequest = createHookRequester(false);
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -335,6 +362,152 @@ describe('hook routes', () => {
       events: payload.events,
       config: payload.config,
     });
+  });
+
+  it('allows trusted-device webhook events when dev features are enabled', async () => {
+    const response = await hookRequest.post('/hooks').send({
+      name: 'trustedDeviceHook',
+      events: ['TrustedDevice.Created', 'TrustedDevice.Deleted'],
+      config: { url: 'https://example.com' },
+    });
+
+    expect(response.status).toEqual(201);
+    expect(response.body.events).toEqual(['TrustedDevice.Created', 'TrustedDevice.Deleted']);
+  });
+
+  it('rejects trusted-device webhook events when dev features are disabled', async () => {
+    const targetMockHook = mockHookList[0] ?? mockHook;
+    const payload = {
+      events: ['TrustedDevice.Created'],
+      config: { url: 'https://example.com' },
+    };
+
+    const [createResponse, testResponse, updateResponse] = await Promise.all([
+      nonDevHookRequest.post('/hooks').send({ name: 'trustedDeviceHook', ...payload }),
+      nonDevHookRequest.post(`/hooks/${targetMockHook.id}/test`).send(payload),
+      nonDevHookRequest.patch(`/hooks/${targetMockHook.id}`).send({ events: payload.events }),
+    ]);
+
+    expect([createResponse.status, testResponse.status, updateResponse.status]).toEqual([
+      400, 400, 400,
+    ]);
+  });
+
+  it('returns stored dev-event hooks when dev features are later disabled', async () => {
+    const storedDevHook: Hook = {
+      ...mockHook,
+      event: null,
+      events: ['TrustedDevice.Created'],
+    };
+    findAllHooks.mockResolvedValueOnce([storedDevHook]);
+    findHookById.mockResolvedValueOnce(storedDevHook);
+
+    const [listResponse, detailResponse] = await Promise.all([
+      nonDevHookRequest.get('/hooks'),
+      nonDevHookRequest.get(`/hooks/${storedDevHook.id}`),
+    ]);
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body).toEqual([storedDevHook]);
+    expect(detailResponse.status).toBe(200);
+    expect(detailResponse.body).toEqual(storedDevHook);
+  });
+
+  it('describes only available hook events in OpenAPI request and response schemas', () => {
+    const router: ManagementApiRouter = new Router();
+
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Build the OpenAPI fixture for a non-dev environment.
+    (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = false;
+    try {
+      hookRoutes(router, tenantContext);
+    } finally {
+      // eslint-disable-next-line @silverhand/fp/no-mutation -- Restore process-wide configuration after route initialization.
+      (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled =
+        originalIsDevFeaturesEnabled;
+    }
+
+    const routeObjects = buildRouterObjects([router]);
+    const getRequestBody = (method: string, path: string) =>
+      routeObjects.find((route) => route.method === method && route.path === path)?.operation
+        .requestBody;
+    const getResponses = (method: string, path: string) =>
+      routeObjects.find((route) => route.method === method && route.path === path)?.operation
+        .responses;
+    const devFeatureHookEventSet = new Set<string>(devFeatureHookEvents);
+    const availableEvents = hookEvents.filter((event) => !devFeatureHookEventSet.has(event));
+    const expectedEventSchema = {
+      type: 'string',
+      enum: availableEvents,
+    };
+    const expectedEventsSchema = {
+      type: 'array',
+      items: expectedEventSchema,
+    };
+    const expectedResponseProperties = {
+      event: { ...expectedEventSchema, nullable: true },
+      events: expectedEventsSchema,
+    };
+
+    expect(getRequestBody('post', '/api/hooks')).toMatchObject({
+      content: {
+        'application/json': {
+          schema: {
+            properties: {
+              event: expectedEventSchema,
+              events: expectedEventsSchema,
+            },
+          },
+        },
+      },
+    });
+    expect(getRequestBody('post', '/api/hooks/{id}/test')).toMatchObject({
+      content: {
+        'application/json': {
+          schema: { properties: { events: expectedEventsSchema } },
+        },
+      },
+    });
+    expect(getRequestBody('patch', '/api/hooks/{id}')).toMatchObject({
+      content: {
+        'application/json': {
+          schema: {
+            properties: {
+              event: { ...expectedEventSchema, nullable: true },
+              events: expectedEventsSchema,
+            },
+          },
+        },
+      },
+    });
+
+    expect(getResponses('get', '/api/hooks')).toMatchObject({
+      200: {
+        content: {
+          'application/json': {
+            schema: {
+              type: 'array',
+              items: { properties: expectedResponseProperties },
+            },
+          },
+        },
+      },
+    });
+    for (const [method, path, status] of [
+      ['get', '/api/hooks/{id}', 200],
+      ['post', '/api/hooks', 201],
+      ['patch', '/api/hooks/{id}', 200],
+      ['patch', '/api/hooks/{id}/signing-key', 200],
+    ] as const) {
+      expect(getResponses(method, path)).toMatchObject({
+        [status]: {
+          content: {
+            'application/json': {
+              schema: { properties: expectedResponseProperties },
+            },
+          },
+        },
+      });
+    }
   });
 
   it('POST /hooks should fail when no events are provided', async () => {

--- a/packages/core/src/routes/hook.ts
+++ b/packages/core/src/routes/hook.ts
@@ -3,10 +3,10 @@ import {
   Logs,
   ProductEvent,
   type WebhookLogPrefix,
+  devFeatureHookEvents,
   hook,
   hookConfigGuard,
-  hookEventGuard,
-  hookEventsGuard,
+  hookEvents,
   hookResponseGuard,
   type Hook,
   type HookResponse,
@@ -16,6 +16,7 @@ import { conditional, deduplicate, yes } from '@silverhand/essentials';
 import { subDays } from 'date-fns';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
@@ -27,13 +28,31 @@ import { captureEvent } from '../utils/posthog.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 
-const nonemptyUniqueHookEventsGuard = hookEventsGuard
-  .nonempty()
-  .transform((events) => deduplicate(events));
+const devFeatureHookEventSet = new Set<string>(devFeatureHookEvents);
+const isHookEventAvailable = (event: string) =>
+  EnvSet.values.isDevFeaturesEnabled || !devFeatureHookEventSet.has(event);
 
 export default function hookRoutes<T extends ManagementApiRouter>(
   ...[router, { id: tenantId, queries, libraries }]: RouterInitArgs<T>
 ) {
+  const availableHookEvents = [
+    hookEvents[0],
+    ...hookEvents.slice(1).filter((event) => isHookEventAvailable(event)),
+  ] satisfies [string, ...string[]];
+  const availableHookEventGuard = z.enum(availableHookEvents);
+  const nonemptyUniqueHookEventsGuard = availableHookEventGuard
+    .array()
+    .nonempty()
+    .transform((events) => deduplicate(events));
+  const availableHookOpenApiGuard = Hooks.guard.extend({
+    event: availableHookEventGuard.nullable(),
+    events: availableHookEventGuard.array(),
+  });
+  const availableHookResponseOpenApiGuard = hookResponseGuard.extend({
+    event: availableHookEventGuard.nullable(),
+    events: availableHookEventGuard.array(),
+  });
+
   const {
     hooks: {
       getTotalNumberOfHooks,
@@ -62,6 +81,9 @@ export default function hookRoutes<T extends ManagementApiRouter>(
     koaGuard({
       query: z.object({ includeExecutionStats: z.string().optional() }),
       response: hookResponseGuard.partial({ executionStats: true }).array(),
+      responseForOpenApi: availableHookResponseOpenApiGuard
+        .partial({ executionStats: true })
+        .array(),
       status: 200,
     }),
     async (ctx, next) => {
@@ -101,6 +123,7 @@ export default function hookRoutes<T extends ManagementApiRouter>(
       params: z.object({ id: z.string() }),
       query: z.object({ includeExecutionStats: z.string().optional() }),
       response: hookResponseGuard.partial({ executionStats: true }),
+      responseForOpenApi: availableHookResponseOpenApiGuard.partial({ executionStats: true }),
       status: [200, 404],
     }),
     async (ctx, next) => {
@@ -184,10 +207,11 @@ export default function hookRoutes<T extends ManagementApiRouter>(
     koaQuotaGuard({ key: 'hooksLimit', quota }),
     koaGuard({
       body: Hooks.createGuard.omit({ id: true, signingKey: true }).extend({
-        event: hookEventGuard.optional(),
+        event: availableHookEventGuard.optional(),
         events: nonemptyUniqueHookEventsGuard.optional(),
       }),
       response: Hooks.guard,
+      responseForOpenApi: availableHookOpenApiGuard,
       status: [201, 400],
     }),
     koaReportSubscriptionUpdates({
@@ -243,10 +267,12 @@ export default function hookRoutes<T extends ManagementApiRouter>(
       body: Hooks.createGuard
         .omit({ id: true, signingKey: true })
         .extend({
+          event: availableHookEventGuard.nullable().optional(),
           events: nonemptyUniqueHookEventsGuard,
         })
         .partial(),
       response: Hooks.guard,
+      responseForOpenApi: availableHookOpenApiGuard,
       status: [200, 404],
     }),
     async (ctx, next) => {
@@ -266,6 +292,7 @@ export default function hookRoutes<T extends ManagementApiRouter>(
     koaGuard({
       params: z.object({ id: z.string() }),
       response: Hooks.guard,
+      responseForOpenApi: availableHookOpenApiGuard,
       status: [200, 404],
     }),
     async (ctx, next) => {

--- a/packages/core/src/routes/swagger/utils/operation.ts
+++ b/packages/core/src/routes/swagger/utils/operation.ts
@@ -42,7 +42,7 @@ const buildOperation = (
   const guard = stack.find((function_): function_ is WithGuardConfig<IMiddleware> =>
     isGuardMiddleware(function_)
   );
-  const { params, query, body, response, status } = guard?.config ?? {};
+  const { params, query, body, response, responseForOpenApi, status } = guard?.config ?? {};
 
   const pathParameters = buildParameters(params, 'path', path);
 
@@ -64,6 +64,7 @@ const buildOperation = (
   };
 
   const hasInputGuard = Boolean(params ?? query ?? body);
+  const documentedResponse = responseForOpenApi ?? response;
 
   const responses: OpenAPIV3.ResponsesObject = Object.fromEntries(
     deduplicate(
@@ -82,7 +83,7 @@ const buildOperation = (
             description,
             content: {
               'application/json': {
-                schema: response && zodTypeToSwagger(response),
+                schema: documentedResponse && zodTypeToSwagger(documentedResponse),
               },
             },
           },

--- a/packages/integration-tests/src/helpers/hook.ts
+++ b/packages/integration-tests/src/helpers/hook.ts
@@ -1,6 +1,13 @@
-import { type CreateHook, type Hook, type HookConfig, type HookEvent } from '@logto/schemas';
+import {
+  devFeatureHookEvents,
+  type CreateHook,
+  type Hook,
+  type HookConfig,
+  type HookEvent,
+} from '@logto/schemas';
 
 import { authedAdminApi } from '#src/api/api.js';
+import { isDevFeaturesEnabled } from '#src/constants.js';
 
 type HookCreationPayload = Pick<Hook, 'name' | 'events'> & {
   config: HookConfig;
@@ -18,7 +25,10 @@ export const getHookCreationPayload = (
   },
 });
 
-export const getSupportedHookEvents = (events: HookEvent[]): HookEvent[] => events;
+const devFeatureHookEventSet = new Set<HookEvent>(devFeatureHookEvents);
+
+export const getSupportedHookEvents = (events: HookEvent[]): HookEvent[] =>
+  isDevFeaturesEnabled ? events : events.filter((event) => !devFeatureHookEventSet.has(event));
 
 export class WebHookApiTest {
   readonly #hooks = new Map<string, Hook>();

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.experience.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.experience.test.ts
@@ -121,7 +121,9 @@ describe('experience api hook trigger', () => {
       }),
       webHookApi.create({
         name: 'dataHookEventListener',
-        events: hookEvents.filter((event) => !(event in InteractionHookEvent)),
+        events: getSupportedHookEvents(
+          hookEvents.filter((event) => !(event in InteractionHookEvent))
+        ),
         config: { url: webHookMockServer.endpoint },
       }),
       webHookApi.create({

--- a/packages/phrases/src/locales/ar/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/webhooks.ts
@@ -6,6 +6,7 @@ const webhooks = {
   schemas: {
     interaction: 'تفاعل المستخدم',
     user: 'المستخدم',
+    trusted_device: 'جهاز موثوق',
     organization: 'المؤسسة',
     role: 'الدور',
     scope: 'الصلاحية',

--- a/packages/phrases/src/locales/de/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'Nutzerinteraktion',
     user: 'Benutzer',
+    trusted_device: 'Vertrauenswürdiges Gerät',
     organization: 'Organisation',
     role: 'Rolle',
     scope: 'Berechtigung',

--- a/packages/phrases/src/locales/en/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/webhooks.ts
@@ -6,6 +6,7 @@ const webhooks = {
   schemas: {
     interaction: 'User interaction',
     user: 'User',
+    trusted_device: 'Trusted device',
     organization: 'Organization',
     role: 'Role',
     scope: 'Permission',

--- a/packages/phrases/src/locales/es/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'Interacción de usuario',
     user: 'Usuario',
+    trusted_device: 'Dispositivo de confianza',
     organization: 'Organización',
     role: 'Rol',
     scope: 'Permiso',

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'تعامل کاربر',
     user: 'کاربر',
+    trusted_device: 'دستگاه مورد اعتماد',
     organization: 'سازمان',
     role: 'نقش',
     scope: 'مجوز',

--- a/packages/phrases/src/locales/fr/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'Interaction utilisateur',
     user: 'Utilisateur',
+    trusted_device: 'Appareil de confiance',
     organization: 'Organisation',
     role: 'Rôle',
     scope: 'Permission',

--- a/packages/phrases/src/locales/it/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'Interazione utente',
     user: 'Utente',
+    trusted_device: 'Dispositivo attendibile',
     organization: 'Organizzazione',
     role: 'Ruolo',
     scope: 'Permesso',

--- a/packages/phrases/src/locales/ja/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/webhooks.ts
@@ -6,6 +6,7 @@ const webhooks = {
   schemas: {
     interaction: 'ユーザーインタラクション',
     user: 'ユーザー',
+    trusted_device: '信頼済みデバイス',
     organization: '組織',
     role: 'ロール',
     scope: '権限',

--- a/packages/phrases/src/locales/ko/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/webhooks.ts
@@ -6,6 +6,7 @@ const webhooks = {
   schemas: {
     interaction: '사용자 상호 작용',
     user: '사용자',
+    trusted_device: '신뢰할 수 있는 기기',
     organization: '조직',
     role: '역할',
     scope: '권한',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'Interakcja użytkownika',
     user: 'Użytkownik',
+    trusted_device: 'Zaufane urządzenie',
     organization: 'Organizacja',
     role: 'Rola',
     scope: 'Uprawnienie',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'Interac\u00E7\u00E3o do usu\u00E1rio',
     user: 'Usu\u00E1rio',
+    trusted_device: 'Dispositivo confi\u00E1vel',
     organization: 'Organiza\u00E7\u00E3o',
     role: 'Fun\u00E7\u00E3o',
     scope: 'Permiss\u00E3o',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/webhooks.ts
@@ -6,6 +6,7 @@ const webhooks = {
   schemas: {
     interaction: 'Interação do utilizador',
     user: 'Utilizador',
+    trusted_device: 'Dispositivo de confiança',
     organization: 'Organização',
     role: 'Função',
     scope: 'Permissão',

--- a/packages/phrases/src/locales/ru/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'Взаимодействие пользователя',
     user: 'Пользователь',
+    trusted_device: 'Доверенное устройство',
     organization: 'Организация',
     role: 'Роль',
     scope: 'Разрешение',

--- a/packages/phrases/src/locales/th/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'ปฏิสัมพันธ์ของผู้ใช้',
     user: 'ผู้ใช้',
+    trusted_device: 'อุปกรณ์ที่เชื่อถือได้',
     organization: 'องค์กร',
     role: 'บทบาท',
     scope: 'สิทธิ์',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/webhooks.ts
@@ -7,6 +7,7 @@ const webhooks = {
   schemas: {
     interaction: 'Kullanıcı etkileşimi',
     user: 'Kullanıcı',
+    trusted_device: 'Güvenilir cihaz',
     organization: 'Kuruluş',
     role: 'Rol',
     scope: 'İzin',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/webhooks.ts
@@ -6,6 +6,7 @@ const webhooks = {
   schemas: {
     interaction: '用户交互',
     user: '用户',
+    trusted_device: '可信设备',
     organization: '组织',
     role: '角色',
     scope: '权限',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/webhooks.ts
@@ -6,6 +6,7 @@ const webhooks = {
   schemas: {
     interaction: '用戶互動',
     user: '用戶',
+    trusted_device: '受信任裝置',
     organization: '組織',
     role: '角色',
     scope: '權限',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/webhooks.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/webhooks.ts
@@ -6,6 +6,7 @@ const webhooks = {
   schemas: {
     interaction: '使用者互動',
     user: '使用者',
+    trusted_device: '受信任裝置',
     organization: '組織',
     role: '角色',
     scope: '權限',

--- a/packages/schemas/src/foundations/jsonb-types/hooks.ts
+++ b/packages/schemas/src/foundations/jsonb-types/hooks.ts
@@ -19,6 +19,7 @@ export enum InteractionHookEvent {
 // DataHookEvent
 export enum DataHookSchema {
   User = 'User',
+  TrustedDevice = 'TrustedDevice',
   Role = 'Role',
   Scope = 'Scope',
   Organization = 'Organization',
@@ -39,7 +40,7 @@ type BasicDataHookEvent = `${DataHookSchema}.${DataHookBasicMutationType}`;
 
 // Custom DataHook mutable schemas
 type CustomDataHookMutableSchema =
-  | `${DataHookSchema}.Data`
+  | `${Exclude<DataHookSchema, DataHookSchema.TrustedDevice>}.Data`
   | `${DataHookSchema.User}.SuspensionStatus`
   | `${DataHookSchema.Role}.Scopes`
   | `${DataHookSchema.Organization}.Membership`
@@ -55,6 +56,14 @@ export type ExceptionHookEvent =
 
 export type DataHookEvent = BasicDataHookEvent | DataHookPropertyUpdateEvent;
 
+/** Data hook events that are available only while their feature is under development. */
+export const devFeatureHookEvents = Object.freeze([
+  'TrustedDevice.Created',
+  'TrustedDevice.Deleted',
+] as const satisfies readonly DataHookEvent[]);
+
+export type DevFeatureHookEvent = (typeof devFeatureHookEvents)[number];
+
 /** The hook event values that can be registered. */
 export const hookEvents = Object.freeze([
   InteractionHookEvent.PostRegister,
@@ -65,6 +74,7 @@ export const hookEvents = Object.freeze([
   'User.Deleted',
   'User.Data.Updated',
   'User.SuspensionStatus.Updated',
+  ...devFeatureHookEvents,
   'Role.Created',
   'Role.Deleted',
   'Role.Data.Updated',

--- a/packages/schemas/src/types/hook.ts
+++ b/packages/schemas/src/types/hook.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { Hooks, type Application, type User } from '../db-entries/index.js';
+import { Hooks, type Application, type TrustedDevice, type User } from '../db-entries/index.js';
 import {
   type ExceptionHookEvent,
   type DataHookEvent,
@@ -100,6 +100,9 @@ export type DataHookEventPayload = {
 } & Partial<InteractionApiContextPayload> &
   Partial<ManagementApiContext> &
   Record<string, unknown>;
+
+/** The intentionally limited trusted-device projection exposed by lifecycle events. */
+export type TrustedDeviceEventData = Pick<TrustedDevice, 'id' | 'userId' | 'expiresAt'>;
 
 /**
  * A key-remapping omit instead of the built-in `Omit`: on a type carrying a string index

--- a/packages/schemas/src/types/log/index.ts
+++ b/packages/schemas/src/types/log/index.ts
@@ -4,6 +4,7 @@ import type * as interaction from './interaction.js';
 import type * as jwtCustomizer from './jwt-customizer.js';
 import type * as saml from './saml.js';
 import type * as token from './token.js';
+import type * as trustedDevice from './trusted-device.js';
 
 export * as interaction from './interaction.js';
 export * as token from './token.js';
@@ -11,6 +12,7 @@ export * as hook from './hook.js';
 export * as action from './action.js';
 export * as jwtCustomizer from './jwt-customizer.js';
 export * as saml from './saml.js';
+export * as trustedDevice from './trusted-device.js';
 
 /** Fallback for empty or unrecognized log keys. */
 export const LogKeyUnknown = 'Unknown';
@@ -21,6 +23,7 @@ export type WebhookLogKey = hook.LogKey;
 export type ActionLogKey = action.LogKey;
 export type JwtCustomizerLogKey = jwtCustomizer.LogKey;
 export type SamlLogKey = saml.LogKey;
+export type TrustedDeviceLogKey = trustedDevice.LogKey;
 
 /**
  * The union type of all available audit log keys.
@@ -34,7 +37,8 @@ export type AuditLogKey =
   | TokenLogKey
   | SamlLogKey
   | ActionLogKey
-  | JwtCustomizerLogKey;
+  | JwtCustomizerLogKey
+  | TrustedDeviceLogKey;
 
 /**
  * The union type of all available log keys.
@@ -48,6 +52,7 @@ export type AuditLogPrefix =
   | saml.Prefix
   | action.Prefix
   | jwtCustomizer.Prefix
+  | trustedDevice.Prefix
   | typeof LogKeyUnknown;
 
 export type WebhookLogPrefix = hook.Type;

--- a/packages/schemas/src/types/log/trusted-device.ts
+++ b/packages/schemas/src/types/log/trusted-device.ts
@@ -1,0 +1,10 @@
+export type Prefix = 'TrustedDevice';
+
+export const prefix: Prefix = 'TrustedDevice';
+
+export enum Type {
+  Created = 'Created',
+  Used = 'Used',
+}
+
+export type LogKey = `${Prefix}.${Type}`;


### PR DESCRIPTION
## Summary
- add trusted-device Created and Used audit logs after successful Experience API lifecycle operations
- add Created and Deleted webhooks with a shared explicit-deletion method and request-IP-free payloads
- add event schemas, Console mappings, localized labels, registration filtering, and focused lifecycle tests

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments