### PR TITLE
fix(core): revalidate user scopes against the current client scope at issuance

### DIFF
--- a/.changeset/tidy-bats-listen.md
+++ b/.changeset/tidy-bats-listen.md
@@ -1,0 +1,7 @@
+---
+'@logto/core': patch
+---
+
+stop issuing user scopes a third-party application is no longer configured for
+
+Removing a user scope from a third-party application's consent settings only affected new authorization requests — anything already recorded in a user's grant kept being issued. Refresh token exchanges now drop the scopes that are no longer allowed, and an authorization that resumes on an existing grant is rejected with `invalid_scope`.

--- a/.changeset/tidy-bats-listen.md
+++ b/.changeset/tidy-bats-listen.md
@@ -4,4 +4,4 @@
 
 stop issuing user scopes a third-party application is no longer configured for
 
-Removing a user scope from a third-party application's consent settings only affected new authorization requests — anything already recorded in a user's grant kept being issued. Refresh token exchanges now drop the scopes that are no longer allowed, and an authorization that resumes on an existing grant is rejected with `invalid_scope`.
+Removing a user scope from a third-party application's consent settings used to affect only new authorization requests, and scopes already in a user's grant kept being issued. Now a refresh token exchange drops the removed scopes, and an authorization resuming on an existing grant fails with `invalid_scope`.

--- a/.changeset/tidy-bats-listen.md
+++ b/.changeset/tidy-bats-listen.md
@@ -4,4 +4,4 @@
 
 stop issuing user scopes a third-party application is no longer configured for
 
-Removing a user scope from a third-party application's consent settings used to affect only new authorization requests, and scopes already in a user's grant kept being issued. Now a refresh token exchange drops the removed scopes, an authorization resuming on an existing grant fails with `invalid_scope`, and an organization token request is rejected once the organizations scope is removed.
+Removing a user scope from a third-party application's consent settings used to affect only new authorization requests, and scopes already in a user's grant kept being issued. Now a refresh token exchange drops the removed scopes, an authorization resuming on an existing grant fails with `invalid_scope`, and an organization token request is rejected with `insufficient_scope` once the organizations scope is removed.

--- a/.changeset/tidy-bats-listen.md
+++ b/.changeset/tidy-bats-listen.md
@@ -4,4 +4,4 @@
 
 stop issuing user scopes a third-party application is no longer configured for
 
-Removing a user scope from a third-party application's consent settings used to affect only new authorization requests, and scopes already in a user's grant kept being issued. Now a refresh token exchange drops the removed scopes, and an authorization resuming on an existing grant fails with `invalid_scope`.
+Removing a user scope from a third-party application's consent settings used to affect only new authorization requests, and scopes already in a user's grant kept being issued. Now a refresh token exchange drops the removed scopes, an authorization resuming on an existing grant fails with `invalid_scope`, and an organization token request is rejected once the organizations scope is removed.

--- a/packages/core/src/oidc/client-scope.test.ts
+++ b/packages/core/src/oidc/client-scope.test.ts
@@ -1,0 +1,88 @@
+import { ReservedScope, UserScope } from '@logto/core-kit';
+import { type KoaContextWithOIDC } from 'oidc-provider';
+
+import { getOidcScopesNoLongerAllowed } from './client-scope.js';
+
+type Grant = InstanceType<KoaContextWithOIDC['oidc']['provider']['Grant']>;
+type Client = NonNullable<KoaContextWithOIDC['oidc']['client']>;
+
+/** Mirrors the real `getOIDCScopeFiltered`: the granted OP scopes intersected with the request. */
+const asGrant = (grantedOidcScope: string) =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal grant stub scoped to the method the helper reads
+  ({
+    getOIDCScopeFiltered: (filter: Set<string>) =>
+      grantedOidcScope
+        .split(' ')
+        .filter((scope) => filter.has(scope))
+        .join(' '),
+  }) as Grant;
+
+const asClient = (scope?: string) =>
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub scoped to the field the helper reads
+  ({ clientId: 'client_id', scope }) as Client;
+
+const thirdPartyClient = asClient(
+  [ReservedScope.OpenId, ReservedScope.OfflineAccess, UserScope.Profile].join(' ')
+);
+
+describe('getOidcScopesNoLongerAllowed', () => {
+  it('reports a granted user scope the client is no longer configured for', () => {
+    expect(
+      getOidcScopesNoLongerAllowed(
+        asGrant([ReservedScope.OpenId, UserScope.Profile, UserScope.Email].join(' ')),
+        thirdPartyClient,
+        new Set([ReservedScope.OpenId, UserScope.Profile, UserScope.Email])
+      )
+    ).toEqual([UserScope.Email]);
+  });
+
+  it('reports nothing when every granted scope is still allowed', () => {
+    expect(
+      getOidcScopesNoLongerAllowed(
+        asGrant([ReservedScope.OpenId, UserScope.Profile].join(' ')),
+        thirdPartyClient,
+        new Set([ReservedScope.OpenId, UserScope.Profile])
+      )
+    ).toEqual([]);
+  });
+
+  it('ignores a no-longer-allowed scope the request does not ask for', () => {
+    expect(
+      getOidcScopesNoLongerAllowed(
+        asGrant([ReservedScope.OpenId, UserScope.Email].join(' ')),
+        thirdPartyClient,
+        new Set([ReservedScope.OpenId])
+      )
+    ).toEqual([]);
+  });
+
+  it('leaves resource and organization scope names alone', () => {
+    expect(
+      getOidcScopesNoLongerAllowed(
+        asGrant(ReservedScope.OpenId),
+        thirdPartyClient,
+        new Set([ReservedScope.OpenId, 'read:api', 'write:api'])
+      )
+    ).toEqual([]);
+  });
+
+  it('reports nothing for a client that carries no scope metadata', () => {
+    expect(
+      getOidcScopesNoLongerAllowed(
+        asGrant([ReservedScope.OpenId, UserScope.Email].join(' ')),
+        asClient(),
+        new Set([ReservedScope.OpenId, UserScope.Email])
+      )
+    ).toEqual([]);
+  });
+
+  it('reports nothing when the request resolved no grant', () => {
+    expect(
+      getOidcScopesNoLongerAllowed(
+        undefined,
+        thirdPartyClient,
+        new Set([ReservedScope.OpenId, UserScope.Email])
+      )
+    ).toEqual([]);
+  });
+});

--- a/packages/core/src/oidc/client-scope.test.ts
+++ b/packages/core/src/oidc/client-scope.test.ts
@@ -76,6 +76,16 @@ describe('getOidcScopesNoLongerAllowed', () => {
     ).toEqual([]);
   });
 
+  it('reports nothing for a client whose scope metadata is an empty string', () => {
+    expect(
+      getOidcScopesNoLongerAllowed(
+        asGrant([ReservedScope.OpenId, UserScope.Email].join(' ')),
+        asClient(''),
+        new Set([ReservedScope.OpenId, UserScope.Email])
+      )
+    ).toEqual([]);
+  });
+
   it('reports nothing when the request resolved no grant', () => {
     expect(
       getOidcScopesNoLongerAllowed(

--- a/packages/core/src/oidc/client-scope.ts
+++ b/packages/core/src/oidc/client-scope.ts
@@ -1,0 +1,27 @@
+import { type KoaContextWithOIDC } from 'oidc-provider';
+
+type Grant = InstanceType<KoaContextWithOIDC['oidc']['provider']['Grant']>;
+type Client = NonNullable<KoaContextWithOIDC['oidc']['client']>;
+
+/**
+ * The OP scopes an existing Grant would serve for this request that the client is no longer
+ * configured for. Resource and organization scope names never appear in `client.scope`, and a
+ * first-party client carries no `scope` metadata at all — neither is narrowed.
+ */
+export const getOidcScopesNoLongerAllowed = (
+  grant: Grant | undefined,
+  client: Client | undefined,
+  requestedScopes: Set<string>
+): string[] => {
+  const clientScopes = client?.scope?.split(' ');
+
+  if (!grant || !clientScopes) {
+    return [];
+  }
+
+  return grant
+    .getOIDCScopeFiltered(requestedScopes)
+    .split(' ')
+    .filter(Boolean)
+    .filter((scope) => !clientScopes.includes(scope));
+};

--- a/packages/core/src/oidc/client-scope.ts
+++ b/packages/core/src/oidc/client-scope.ts
@@ -6,16 +6,19 @@ type Client = NonNullable<KoaContextWithOIDC['oidc']['client']>;
 /**
  * The OP scopes an existing Grant would serve for this request that the client is no longer
  * configured for. Resource and organization scope names never appear in `client.scope`, and a
- * first-party client carries no `scope` metadata at all — neither is narrowed.
+ * first-party client carries no `scope` metadata at all; neither is narrowed.
+ *
+ * The consent-submission counterpart is `findStaleOidcScopes` in the consent route utils, which
+ * runs before a Grant exists and classifies OP scopes by allowlist instead.
  */
 export const getOidcScopesNoLongerAllowed = (
   grant: Grant | undefined,
   client: Client | undefined,
   requestedScopes: Set<string>
 ): string[] => {
-  const clientScopes = client?.scope?.split(' ');
+  const clientScopes = new Set(client?.scope?.split(' ').filter(Boolean));
 
-  if (!grant || !clientScopes) {
+  if (!grant || clientScopes.size === 0) {
     return [];
   }
 
@@ -23,5 +26,5 @@ export const getOidcScopesNoLongerAllowed = (
     .getOIDCScopeFiltered(requestedScopes)
     .split(' ')
     .filter(Boolean)
-    .filter((scope) => !clientScopes.includes(scope));
+    .filter((scope) => !clientScopes.has(scope));
 };

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -414,6 +414,88 @@ describe('refresh token grant', () => {
     expect(claims.mock.calls[0][1]).toBe(requestScope);
   });
 
+  it('should stop issuing a user scope the client is no longer configured for', async () => {
+    const grantedScopes = ['openid', 'profile', 'email'];
+    const claims = jest.fn().mockResolvedValue({ sub: accountId });
+    const ctx = createOidcContext({
+      ...validOidcContext,
+      requestParamScopes: new Set(grantedScopes),
+      // No `organization_id`: this exercises the plain refresh path with an ID token.
+      params: { refresh_token: 'some_refresh_token', scope: grantedScopes.join(' ') },
+      /** A third-party client whose consent configuration no longer carries `email`. */
+      client: { ...validClient, scope: 'openid offline_access profile' } as unknown as Client,
+      account: { accountId, claims },
+    });
+    stubRefreshToken(ctx, {
+      scope: grantedScopes.join(' '),
+      scopes: new Set(grantedScopes),
+    });
+    stubGrant(ctx, {
+      getOIDCScopeFiltered: jest.fn((filter: Set<string>) =>
+        grantedScopes.filter((scope) => filter.has(scope)).join(' ')
+      ),
+      getRejectedOIDCClaims: jest.fn().mockReturnValue([]),
+    });
+    stubAccount(ctx);
+    /** The real `IdToken` constructor rejects the mocked plain-object client. */
+    class StubIdToken {
+      scope?: string;
+      mask?: unknown;
+      rejected?: unknown;
+      set = jest.fn();
+      issue = jest.fn().mockResolvedValue('stub_id_token');
+    }
+    Sinon.stub(ctx.oidc.provider, 'IdToken').value(StubIdToken);
+
+    const entityStub = Sinon.stub(ctx.oidc, 'entity');
+    await expect(mockHandler()(ctx)).resolves.toBeUndefined();
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- `entity()` args are typed `unknown`; the assertions below narrow them
+    const [key, value] = entityStub.lastCall.args;
+    expect(key).toBe('AccessToken');
+    expect(value).toMatchObject({ scope: 'openid profile' });
+    // The dropped scope must not reach the ID token claims either.
+    expect(claims.mock.calls[0][1]).toBe('openid profile');
+  });
+
+  it('should issue every granted scope the client still allows', async () => {
+    const grantedScopes = ['openid', 'profile'];
+    const ctx = createOidcContext({
+      ...validOidcContext,
+      requestParamScopes: new Set(grantedScopes),
+      params: { refresh_token: 'some_refresh_token', scope: grantedScopes.join(' ') },
+      client: { ...validClient, scope: 'openid offline_access profile' } as unknown as Client,
+      account: { accountId, claims: jest.fn().mockResolvedValue({ sub: accountId }) },
+    });
+    stubRefreshToken(ctx, {
+      scope: grantedScopes.join(' '),
+      scopes: new Set(grantedScopes),
+    });
+    stubGrant(ctx, {
+      getOIDCScopeFiltered: jest.fn((filter: Set<string>) =>
+        grantedScopes.filter((scope) => filter.has(scope)).join(' ')
+      ),
+      getRejectedOIDCClaims: jest.fn().mockReturnValue([]),
+    });
+    stubAccount(ctx);
+    class StubIdToken {
+      scope?: string;
+      mask?: unknown;
+      rejected?: unknown;
+      set = jest.fn();
+      issue = jest.fn().mockResolvedValue('stub_id_token');
+    }
+    Sinon.stub(ctx.oidc.provider, 'IdToken').value(StubIdToken);
+
+    const entityStub = Sinon.stub(ctx.oidc, 'entity');
+    await expect(mockHandler()(ctx)).resolves.toBeUndefined();
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- `entity()` args are typed `unknown`; the assertions below narrow them
+    const [key, value] = entityStub.lastCall.args;
+    expect(key).toBe('AccessToken');
+    expect(value).toMatchObject({ scope: 'openid profile' });
+  });
+
   it('should not explode when everything looks fine', async () => {
     const ctx = createPreparedContext();
     const tenant = new MockTenant();

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -535,6 +535,47 @@ describe('refresh token grant', () => {
     });
   });
 
+  it('should reject an organization token when the client no longer allows the organizations scope', async () => {
+    const requested = [UserScope.Organizations, UserScope.Email];
+    const ctx = createOidcContext({
+      ...validOidcContext,
+      requestParamScopes: new Set(requested),
+      params: {
+        refresh_token: 'some_refresh_token',
+        organization_id: 'some_org_id',
+        scope: requested.join(' '),
+      },
+      client: {
+        ...validClient,
+        scope: ['openid', 'offline_access', UserScope.Email].join(' '),
+      } as unknown as Client,
+    });
+    stubRefreshToken(ctx, {
+      scope: requested.join(' '),
+      scopes: new Set(requested),
+    });
+    stubGrant(ctx, {
+      getOIDCScopeFiltered: jest.fn((filter: Set<string>) =>
+        requested.filter((scope) => filter.has(scope)).join(' ')
+      ),
+    });
+    stubAccount(ctx);
+    const tenant = new MockTenant();
+    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
+    Sinon.stub(tenant.queries.applications, 'findApplicationById').resolves(mockApplication);
+    Sinon.stub(tenant.queries.organizations, 'getMfaStatus').resolves({
+      isMfaRequired: false,
+      hasMfaConfigured: false,
+    });
+
+    await expect(mockHandler(tenant)(ctx)).rejects.toMatchError(
+      new errors.InsufficientScope(
+        'requested scope is no longer allowed for the client',
+        UserScope.Organizations
+      )
+    );
+  });
+
   it('should not explode when everything looks fine', async () => {
     const ctx = createPreparedContext();
     const tenant = new MockTenant();

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -496,6 +496,56 @@ describe('refresh token grant', () => {
     expect(value).toMatchObject({ scope: 'openid profile' });
   });
 
+  it('should keep an organization scope sharing its name with a no-longer-allowed user scope', async () => {
+    const requested = [UserScope.Organizations, UserScope.Email];
+    const ctx = createOidcContext({
+      ...validOidcContext,
+      requestParamScopes: new Set(requested),
+      params: {
+        refresh_token: 'some_refresh_token',
+        organization_id: 'some_org_id',
+        scope: requested.join(' '),
+      },
+      /** `email` is no longer in the consent configuration, but is also an organization role scope. */
+      client: {
+        ...validClient,
+        scope: ['openid', 'offline_access', UserScope.Organizations].join(' '),
+      } as unknown as Client,
+    });
+    stubRefreshToken(ctx, {
+      scope: requested.join(' '),
+      scopes: new Set(requested),
+    });
+    stubGrant(ctx, {
+      getOIDCScopeFiltered: jest.fn((filter: Set<string>) =>
+        requested.filter((scope) => filter.has(scope)).join(' ')
+      ),
+    });
+    stubAccount(ctx);
+    const tenant = new MockTenant();
+
+    Sinon.stub(tenant.queries.organizations.relations.users, 'exists').resolves(true);
+    Sinon.stub(tenant.queries.applications, 'findApplicationById').resolves(mockApplication);
+    Sinon.stub(tenant.queries.organizations.relations.usersRoles, 'getUserScopes').resolves([
+      { tenantId: 'default', id: 'email', name: UserScope.Email, description: null },
+    ]);
+    Sinon.stub(tenant.queries.organizations, 'getMfaStatus').resolves({
+      isMfaRequired: false,
+      hasMfaConfigured: false,
+    });
+
+    const entityStub = Sinon.stub(ctx.oidc, 'entity');
+    await expect(mockHandler(tenant)(ctx)).resolves.toBeUndefined();
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- `entity()` args are typed `unknown`; the assertions below narrow them
+    const [key, value] = entityStub.lastCall.args;
+    expect(key).toBe('AccessToken');
+    expect(value).toMatchObject({
+      scope: UserScope.Email,
+      aud: 'urn:logto:organization:some_org_id',
+    });
+  });
+
   it('should not explode when everything looks fine', async () => {
     const ctx = createPreparedContext();
     const tenant = new MockTenant();

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -142,6 +142,18 @@ const stubAccount = (ctx: KoaContextWithOIDC, overrideAccountId = accountId) => 
   });
 };
 
+/** The real `IdToken` constructor rejects the mocked plain-object client. */
+class StubIdToken {
+  scope?: string;
+  mask?: unknown;
+  rejected?: unknown;
+  set = jest.fn();
+  issue = jest.fn().mockResolvedValue('stub_id_token');
+}
+
+const stubIdToken = (ctx: KoaContextWithOIDC) =>
+  Sinon.stub(ctx.oidc.provider, 'IdToken').value(StubIdToken);
+
 const createAccessDeniedError = (message: string, statusCode: number) => {
   const error = new errors.AccessDenied(message);
   // eslint-disable-next-line @silverhand/fp/no-mutation
@@ -396,15 +408,7 @@ describe('refresh token grant', () => {
     });
     stubGrant(ctx, { getRejectedOIDCClaims: jest.fn().mockReturnValue([]) });
     stubAccount(ctx);
-    /** The real `IdToken` constructor rejects the mocked plain-object client. */
-    class StubIdToken {
-      scope?: string;
-      mask?: unknown;
-      rejected?: unknown;
-      set = jest.fn();
-      issue = jest.fn().mockResolvedValue('stub_id_token');
-    }
-    Sinon.stub(ctx.oidc.provider, 'IdToken').value(StubIdToken);
+    stubIdToken(ctx);
     const tenant = new MockTenant();
 
     await expect(mockHandler(tenant)(ctx)).resolves.toBeUndefined();
@@ -437,15 +441,7 @@ describe('refresh token grant', () => {
       getRejectedOIDCClaims: jest.fn().mockReturnValue([]),
     });
     stubAccount(ctx);
-    /** The real `IdToken` constructor rejects the mocked plain-object client. */
-    class StubIdToken {
-      scope?: string;
-      mask?: unknown;
-      rejected?: unknown;
-      set = jest.fn();
-      issue = jest.fn().mockResolvedValue('stub_id_token');
-    }
-    Sinon.stub(ctx.oidc.provider, 'IdToken').value(StubIdToken);
+    stubIdToken(ctx);
 
     const entityStub = Sinon.stub(ctx.oidc, 'entity');
     await expect(mockHandler()(ctx)).resolves.toBeUndefined();
@@ -478,14 +474,7 @@ describe('refresh token grant', () => {
       getRejectedOIDCClaims: jest.fn().mockReturnValue([]),
     });
     stubAccount(ctx);
-    class StubIdToken {
-      scope?: string;
-      mask?: unknown;
-      rejected?: unknown;
-      set = jest.fn();
-      issue = jest.fn().mockResolvedValue('stub_id_token');
-    }
-    Sinon.stub(ctx.oidc.provider, 'IdToken').value(StubIdToken);
+    stubIdToken(ctx);
 
     const entityStub = Sinon.stub(ctx.oidc, 'entity');
     await expect(mockHandler()(ctx)).resolves.toBeUndefined();

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -37,6 +37,7 @@ import { errors, type Provider } from 'oidc-provider';
 import { type EnvSet } from '#src/env-set/index.js';
 import { assertUserHasApplicationAccessForOidc } from '#src/oidc/application-access-control.js';
 import { isCimdClient } from '#src/oidc/cimd/index.js';
+import { getOidcScopesNoLongerAllowed } from '#src/oidc/client-scope.js';
 import {
   applyMtlsBinding,
   buildTokenResponse,
@@ -305,7 +306,16 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
   }
 
   /** The scopes requested by the client. If not provided, use the scopes from the refresh token. */
-  const scope = params.scope ? requestParamScopes : refreshToken.scopes;
+  const requestedScope = params.scope ? requestParamScopes : refreshToken.scopes;
+  /**
+   * Dropped rather than rejected: the client usually sends no `scope` on refresh, so rejecting
+   * would turn a configuration change into an outage it has no way to fix.
+   */
+  const scopesNoLongerAllowed = getOidcScopesNoLongerAllowed(grant, client, requestedScope);
+  const scope =
+    scopesNoLongerAllowed.length > 0
+      ? new Set([...requestedScope].filter((name) => !scopesNoLongerAllowed.includes(name)))
+      : requestedScope;
   await checkRar(ctx, noop);
 
   // Note, issue organization token only if `params.resource` is not present.

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -306,16 +306,16 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
   }
 
   /** The scopes requested by the client. If not provided, use the scopes from the refresh token. */
-  const requestedScope = params.scope ? requestParamScopes : refreshToken.scopes;
+  const scope = params.scope ? requestParamScopes : refreshToken.scopes;
   /**
    * Dropped rather than rejected: the client usually sends no `scope` on refresh, so rejecting
    * would turn a configuration change into an outage it has no way to fix.
+   *
+   * Kept separate from `scope`, which resource and organization issuance match by name — a scope
+   * name there may collide with an OP scope name.
    */
-  const scopesNoLongerAllowed = getOidcScopesNoLongerAllowed(grant, client, requestedScope);
-  const scope =
-    scopesNoLongerAllowed.length > 0
-      ? new Set([...requestedScope].filter((name) => !scopesNoLongerAllowed.includes(name)))
-      : requestedScope;
+  const scopesNoLongerAllowed = getOidcScopesNoLongerAllowed(grant, client, scope);
+  const oidcScope = new Set([...scope].filter((name) => !scopesNoLongerAllowed.includes(name)));
   await checkRar(ctx, noop);
 
   // Note, issue organization token only if `params.resource` is not present.
@@ -381,7 +381,7 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
       );
     } else {
       at.claims = refreshToken.claims;
-      at.scope = grant.getOIDCScopeFiltered(scope);
+      at.scope = grant.getOIDCScopeFiltered(oidcScope);
     }
   }
 
@@ -399,7 +399,7 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     at,
     grant,
     { conformIdTokenClaims, userinfo },
-    scope
+    oidcScope
   );
 
   ctx.body = buildTokenResponse(at, accessToken, {

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -242,6 +242,19 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
   ) {
     throw new InsufficientScope('refresh token missing required scope', UserScope.Organizations);
   }
+
+  /** Keyed on the token's own scopes: the request may omit `scope` and still pass `organization_id`. */
+  if (
+    organizationId &&
+    getOidcScopesNoLongerAllowed(grant, client, refreshToken.scopes).includes(
+      UserScope.Organizations
+    )
+  ) {
+    throw new InsufficientScope(
+      'requested scope is no longer allowed for the client',
+      UserScope.Organizations
+    );
+  }
   /* === End RFC 0001 === */
 
   if (

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -81,17 +81,28 @@ class MockCimdEnvSet extends EnvSet {
 
 const cimdEnvSet = new MockCimdEnvSet(defaultTenantId, EnvSet.values.dbUrl);
 
-const createTestClient = (): KoaContextWithOIDC['oidc']['client'] => {
+const createTestClient = (scope?: string): KoaContextWithOIDC['oidc']['client'] => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal client stub for OIDC context testing
   return {
     clientId,
+    scope,
     metadata: () => ({ appLevelAccessControlEnabled: true }),
   } as KoaContextWithOIDC['oidc']['client'];
 };
 
-const mockGrantFound = (provider: KoaContextWithOIDC['oidc']['provider']) => {
+const mockGrantFound = (
+  provider: KoaContextWithOIDC['oidc']['provider'],
+  /** Mirrors the real `getOIDCScopeFiltered`: the granted OP scopes intersected with the request. */
+  grantedOidcScope = ''
+) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal grant stub for OIDC context testing
-  const grant = {} as Awaited<ReturnType<typeof provider.Grant.find>>;
+  const grant = {
+    getOIDCScopeFiltered: (filter: Set<string>) =>
+      grantedOidcScope
+        .split(' ')
+        .filter((scope) => filter.has(scope))
+        .join(' '),
+  } as Awaited<ReturnType<typeof provider.Grant.find>>;
 
   return jest.spyOn(provider.Grant, 'find').mockResolvedValueOnce(grant);
 };
@@ -391,6 +402,71 @@ describe('oidc provider init', () => {
     await expect(configuration.loadExistingGrant(ctx)).resolves.toBeDefined();
     expect(grantIdFor).toHaveBeenCalledWith(clientId);
     expect(findGrant).toHaveBeenCalledWith('session_grant_id');
+  });
+
+  it('should reject a granted user scope the client is no longer configured for', async () => {
+    const tenant = new MockTenant();
+
+    tenant.setPartial('libraries', {
+      applicationAccessControl: { assertUserHasApplicationAccess: jest.fn() },
+    });
+
+    const provider = createProvider(tenant);
+    mockGrantFound(provider, 'openid email');
+    const configuration = getProviderConfiguration(provider);
+    const ctx = createOidcContext({
+      provider,
+      account: { accountId, claims: async () => ({ sub: accountId }) },
+      client: createTestClient('openid offline_access'),
+      requestParamScopes: new Set(['openid', 'email']),
+      result: { consent: { grantId: 'grant_id' } },
+    } as Partial<KoaContextWithOIDC['oidc']>);
+
+    await expect(configuration.loadExistingGrant(ctx)).rejects.toMatchError(
+      new errors.InvalidScope('requested scope is not allowed', 'email')
+    );
+  });
+
+  it('should serve a granted user scope the client still allows', async () => {
+    const tenant = new MockTenant();
+
+    tenant.setPartial('libraries', {
+      applicationAccessControl: { assertUserHasApplicationAccess: jest.fn() },
+    });
+
+    const provider = createProvider(tenant);
+    mockGrantFound(provider, 'openid email');
+    const configuration = getProviderConfiguration(provider);
+    const ctx = createOidcContext({
+      provider,
+      account: { accountId, claims: async () => ({ sub: accountId }) },
+      client: createTestClient('openid offline_access email'),
+      requestParamScopes: new Set(['openid', 'email']),
+      result: { consent: { grantId: 'grant_id' } },
+    } as Partial<KoaContextWithOIDC['oidc']>);
+
+    await expect(configuration.loadExistingGrant(ctx)).resolves.toBeDefined();
+  });
+
+  it('should not restrict a client that carries no scope metadata', async () => {
+    const tenant = new MockTenant();
+
+    tenant.setPartial('libraries', {
+      applicationAccessControl: { assertUserHasApplicationAccess: jest.fn() },
+    });
+
+    const provider = createProvider(tenant);
+    mockGrantFound(provider, 'openid email');
+    const configuration = getProviderConfiguration(provider);
+    const ctx = createOidcContext({
+      provider,
+      account: { accountId, claims: async () => ({ sub: accountId }) },
+      client: createTestClient(),
+      requestParamScopes: new Set(['openid', 'email']),
+      result: { consent: { grantId: 'grant_id' } },
+    } as Partial<KoaContextWithOIDC['oidc']>);
+
+    await expect(configuration.loadExistingGrant(ctx)).resolves.toBeDefined();
   });
 
   it('should defer application access check to consent prompt when no existing grant is loaded', async () => {

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -423,7 +423,7 @@ describe('oidc provider init', () => {
     } as Partial<KoaContextWithOIDC['oidc']>);
 
     await expect(configuration.loadExistingGrant(ctx)).rejects.toMatchError(
-      new errors.InvalidScope('requested scope is not allowed', 'email')
+      new errors.InvalidScope('requested scope is no longer allowed for the client', 'email')
     );
   });
 

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -373,7 +373,7 @@ export default function initOidc(
 
         if (scopesNoLongerAllowed.length > 0) {
           throw new errors.InvalidScope(
-            'requested scope is not allowed',
+            'requested scope is no longer allowed for the client',
             scopesNoLongerAllowed.join(' ')
           );
         }

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -57,6 +57,7 @@ import {
 } from './application-access-control.js';
 import { buildClientIdMetadataDocumentFeature, isCimdClient } from './cimd/index.js';
 import { filterResourceScopesForTheCimdClient } from './cimd/resource-scopes.js';
+import { getOidcScopesNoLongerAllowed } from './client-scope.js';
 import defaults from './defaults.js';
 import { deviceFlowConfig, defaultDeviceCodeTtl } from './device-flow.js';
 import {
@@ -357,7 +358,27 @@ export default function initOidc(
       }
 
       if (grantId) {
-        return provider.Grant.find(String(grantId));
+        const grant = await provider.Grant.find(String(grantId));
+
+        /**
+         * The resume and device verification stacks reload the client but never re-run
+         * `check_scope`, and the consent prompt counts scopes already in the Grant as encountered.
+         * Reject the way a new authorization request for the same scopes would be.
+         */
+        const scopesNoLongerAllowed = getOidcScopesNoLongerAllowed(
+          grant,
+          client,
+          ctx.oidc.requestParamScopes
+        );
+
+        if (scopesNoLongerAllowed.length > 0) {
+          throw new errors.InvalidScope(
+            'requested scope is not allowed',
+            scopesNoLongerAllowed.join(' ')
+          );
+        }
+
+        return grant;
       }
     },
     extraParams: Object.values(ExtraParamsKey),

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -87,7 +87,12 @@ const parseMissingResourceScopesInfo = async (
   );
 };
 
-/** Find the requested or snapshot OIDC scopes that the client's current scope no longer allows. */
+/**
+ * Find the requested or snapshot OIDC scopes that the client's current scope no longer allows.
+ *
+ * The issuance-time counterpart is `getOidcScopesNoLongerAllowed` in `#src/oidc/client-scope.js`,
+ * which narrows against an existing Grant instead of this pre-Grant allowlist.
+ */
 export const findStaleOidcScopes = ({
   clientScope,
   requestedScope,

--- a/packages/integration-tests/src/helpers/session.ts
+++ b/packages/integration-tests/src/helpers/session.ts
@@ -60,11 +60,9 @@ export const assertRefreshTokenInvalidGrant = async (options: {
   );
 };
 
-export const assertRefreshTokenValid = async (options: {
-  clientId: string;
-  refreshToken: string;
-}): Promise<void> => {
-  await fetchTokenByRefreshToken(
+/** Exchange a refresh token at the token endpoint and return the parsed token response. */
+export const refreshTokens = async (options: { clientId: string; refreshToken: string }) =>
+  fetchTokenByRefreshToken(
     {
       clientId: options.clientId,
       tokenEndpoint,
@@ -73,12 +71,18 @@ export const assertRefreshTokenValid = async (options: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async (...args: Parameters<typeof fetch>): Promise<any> => {
       const response = await fetch(...args);
-      assert(response.ok, new Error('Refresh token exchange failed'));
+      assert(response.ok, new Error(`Refresh token exchange failed with ${response.status}`));
 
-      // Response body is not needed for the assertion.
-      return {};
+      const body: unknown = await response.json();
+      return body;
     }
   );
+
+export const assertRefreshTokenValid = async (options: {
+  clientId: string;
+  refreshToken: string;
+}): Promise<void> => {
+  await refreshTokens(options);
 };
 
 export const createAppAndSignInWithPassword = async ({

--- a/packages/integration-tests/src/tests/api/oidc/refresh-token-client-scope.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/refresh-token-client-scope.test.ts
@@ -1,0 +1,69 @@
+import { ReservedScope, UserScope } from '@logto/core-kit';
+import { decodeIdToken, fetchTokenByRefreshToken } from '@logto/js';
+import { ApplicationUserConsentScopeType } from '@logto/schemas';
+import { assert } from '@silverhand/essentials';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { deleteUserConsentScopes } from '#src/api/application-user-consent-scope.js';
+import { deleteApplication } from '#src/api/application.js';
+import { defaultConfig } from '#src/client/index.js';
+import { createAppAndSignInWithPassword } from '#src/helpers/session.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateNewUser } from '#src/helpers/user.js';
+
+const tokenEndpoint = `${defaultConfig.endpoint}/oidc/token`;
+
+/** Refresh without a `scope` parameter, which is what an SDK sends by default. */
+const refresh = async (clientId: string, refreshToken: string) =>
+  fetchTokenByRefreshToken(
+    { clientId, tokenEndpoint, refreshToken },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (...args: Parameters<typeof fetch>): Promise<any> => {
+      const response = await fetch(...args);
+      assert(response.ok, new Error(`Refresh token exchange failed with ${response.status}`));
+
+      return response.json();
+    }
+  );
+
+describe('user scopes at refresh', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+  });
+
+  it('should stop issuing a user scope removed from the application consent configuration', async () => {
+    const { user, userProfile } = await generateNewUser({
+      username: true,
+      password: true,
+      primaryEmail: true,
+    });
+    const { app, refreshToken } = await createAppAndSignInWithPassword({
+      username: userProfile.username,
+      password: userProfile.password,
+      isThirdParty: true,
+      scopes: [ReservedScope.OpenId, UserScope.Profile, UserScope.Email],
+    });
+    assert(refreshToken, new Error('No refresh token issued'));
+
+    const granted = await refresh(app.id, refreshToken);
+    assert(granted.idToken, new Error('No ID token issued'));
+    expect(granted.scope.split(' ')).toContain(UserScope.Email);
+    expect(decodeIdToken(granted.idToken)).toHaveProperty('email', userProfile.primaryEmail);
+
+    await deleteUserConsentScopes(
+      app.id,
+      ApplicationUserConsentScopeType.UserScopes,
+      UserScope.Email
+    );
+
+    // The rotated token, since the first refresh consumed the original one.
+    const narrowed = await refresh(app.id, granted.refreshToken ?? refreshToken);
+    assert(narrowed.idToken, new Error('No ID token issued'));
+    expect(narrowed.scope.split(' ')).not.toContain(UserScope.Email);
+    expect(decodeIdToken(narrowed.idToken)).not.toHaveProperty('email');
+    // The rest of the consent configuration is untouched.
+    expect(narrowed.scope.split(' ')).toContain(UserScope.Profile);
+
+    await Promise.all([deleteApplication(app.id), deleteUser(user.id)]);
+  });
+});

--- a/packages/integration-tests/src/tests/api/oidc/refresh-token-client-scope.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/refresh-token-client-scope.test.ts
@@ -1,30 +1,14 @@
 import { ReservedScope, UserScope } from '@logto/core-kit';
-import { decodeIdToken, fetchTokenByRefreshToken } from '@logto/js';
+import { decodeIdToken } from '@logto/js';
 import { ApplicationUserConsentScopeType } from '@logto/schemas';
 import { assert } from '@silverhand/essentials';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { deleteUserConsentScopes } from '#src/api/application-user-consent-scope.js';
 import { deleteApplication } from '#src/api/application.js';
-import { defaultConfig } from '#src/client/index.js';
-import { createAppAndSignInWithPassword } from '#src/helpers/session.js';
+import { createAppAndSignInWithPassword, refreshTokens } from '#src/helpers/session.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
-
-const tokenEndpoint = `${defaultConfig.endpoint}/oidc/token`;
-
-/** Refresh without a `scope` parameter, which is what an SDK sends by default. */
-const refresh = async (clientId: string, refreshToken: string) =>
-  fetchTokenByRefreshToken(
-    { clientId, tokenEndpoint, refreshToken },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async (...args: Parameters<typeof fetch>): Promise<any> => {
-      const response = await fetch(...args);
-      assert(response.ok, new Error(`Refresh token exchange failed with ${response.status}`));
-
-      return response.json();
-    }
-  );
 
 describe('user scopes at refresh', () => {
   beforeAll(async () => {
@@ -45,7 +29,7 @@ describe('user scopes at refresh', () => {
     });
     assert(refreshToken, new Error('No refresh token issued'));
 
-    const granted = await refresh(app.id, refreshToken);
+    const granted = await refreshTokens({ clientId: app.id, refreshToken });
     assert(granted.idToken, new Error('No ID token issued'));
     expect(granted.scope.split(' ')).toContain(UserScope.Email);
     expect(decodeIdToken(granted.idToken)).toHaveProperty('email', userProfile.primaryEmail);
@@ -57,7 +41,10 @@ describe('user scopes at refresh', () => {
     );
 
     // The rotated token, since the first refresh consumed the original one.
-    const narrowed = await refresh(app.id, granted.refreshToken ?? refreshToken);
+    const narrowed = await refreshTokens({
+      clientId: app.id,
+      refreshToken: granted.refreshToken ?? refreshToken,
+    });
     assert(narrowed.idToken, new Error('No ID token issued'));
     expect(narrowed.scope.split(' ')).not.toContain(UserScope.Email);
     expect(decodeIdToken(narrowed.idToken)).not.toHaveProperty('email');


### PR DESCRIPTION
## Summary

`check_scope` only guards the authorization request. Every issuance after it reads the OIDC scopes back from the grant, so a user scope removed from a third-party or CIMD client's configuration kept being served until the grant was revoked. Only third-party and CIMD clients carry a scope allowlist; first-party applications have none and are untouched.

- **Refresh**: the no-longer-allowed scopes are dropped from the access token and the ID token claims. Dropped rather than rejected, since the client usually sends no `scope` on refresh and could not recover from a rejection.
- **Organization tokens**: a refresh carrying `organization_id` is rejected with `insufficient_scope` once `urn:logto:scope:organizations` leaves the client's configuration, keeping the capability in line with the narrowed claims.
- **Resume and device resume**: rejected with `invalid_scope`, so a code can no longer be minted carrying such a scope. Redemption itself is unchanged; closing the 60-second authorization-code and 10-minute device-code windows would mean owning two more upstream grant handlers.
- Resource and organization scopes keep the unnarrowed requested set, since their names may collide with an OP scope name.

Closes LOG-14033. Closes LOG-14081.

## Testing

Unit tests and integration tests. The resume path and the organization token gate are covered by unit tests only.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
