### PR TITLE
feat(core): add user trusted device management APIs

### DIFF
--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -278,18 +278,26 @@ describe('trusted device library', () => {
       userAgent: 'private user agent',
     };
     const ctx = { appendDataHookContext: jest.fn() };
+    const managementApiContext = {
+      path: `/api/users/${userId}/trusted-devices/${trustedDeviceId}`,
+      method: 'DELETE',
+      status: 204,
+      params: { userId, trustedDeviceId },
+      matchedRoute: '/api/users/:userId/trusted-devices/:trustedDeviceId',
+    };
     queries.deleteByIdAndUserId.mockResolvedValueOnce(trustedDevice).mockResolvedValueOnce(null);
     const library = createTrustedDeviceLibrary(tenantId, queries, createPolicyLibrary());
 
-    await expect(library.deleteByIdAndUserId(ctx, trustedDeviceId, userId)).resolves.toEqual(
-      trustedDevice
-    );
+    await expect(
+      library.deleteByIdAndUserId(ctx, trustedDeviceId, userId, managementApiContext)
+    ).resolves.toEqual(trustedDevice);
     await expect(
       library.deleteByIdAndUserId(ctx, trustedDeviceId, userId)
     ).resolves.toBeUndefined();
 
     expect(ctx.appendDataHookContext).toHaveBeenCalledTimes(1);
     expect(ctx.appendDataHookContext).toHaveBeenCalledWith('TrustedDevice.Deleted', {
+      ...managementApiContext,
       data: {
         id: trustedDeviceId,
         userId,

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -1,13 +1,18 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 
-import { TrustedDevices, type TrustedDevice, type TrustedDeviceEventData } from '@logto/schemas';
+import {
+  TrustedDevices,
+  type ManagementApiContext,
+  type TrustedDevice,
+  type TrustedDeviceEventData,
+} from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 import { type Context } from 'koa';
 
 import { EnvSet } from '#src/env-set/index.js';
 import type { TrustedDeviceMetadata, TrustedDeviceQueries } from '#src/queries/trusted-device.js';
 
-import type { HookContext, HookContextManager } from './hook/context-manager.js';
+import type { HookContextManager } from './hook/context-manager.js';
 import type { createTrustedDevicePolicyLibrary } from './trusted-device-policy.js';
 
 const trustedDeviceSecretByteLength = 32;
@@ -277,7 +282,7 @@ export const createTrustedDeviceLibrary = (
     ctx: TrustedDeviceLifecycleContext,
     id: string,
     userId: string,
-    hookContext: Omit<HookContext, 'data' | 'includeRequestIp'> = {}
+    hookContext: Partial<ManagementApiContext> = {}
   ) => {
     const trustedDevice = await queries.deleteByIdAndUserId(id, userId);
 

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -7,7 +7,7 @@ import { type Context } from 'koa';
 import { EnvSet } from '#src/env-set/index.js';
 import type { TrustedDeviceMetadata, TrustedDeviceQueries } from '#src/queries/trusted-device.js';
 
-import type { HookContextManager } from './hook/context-manager.js';
+import type { HookContext, HookContextManager } from './hook/context-manager.js';
 import type { createTrustedDevicePolicyLibrary } from './trusted-device-policy.js';
 
 const trustedDeviceSecretByteLength = 32;
@@ -276,7 +276,8 @@ export const createTrustedDeviceLibrary = (
   const deleteByIdAndUserId = async (
     ctx: TrustedDeviceLifecycleContext,
     id: string,
-    userId: string
+    userId: string,
+    hookContext: Omit<HookContext, 'data' | 'includeRequestIp'> = {}
   ) => {
     const trustedDevice = await queries.deleteByIdAndUserId(id, userId);
 
@@ -285,6 +286,7 @@ export const createTrustedDeviceLibrary = (
     }
 
     ctx.appendDataHookContext('TrustedDevice.Deleted', {
+      ...hookContext,
       data: getTrustedDeviceEventData(trustedDevice),
       // Trusted-device lifecycle payloads intentionally exclude the request IP.
       includeRequestIp: false,

--- a/packages/core/src/routes/admin-user/index.ts
+++ b/packages/core/src/routes/admin-user/index.ts
@@ -10,6 +10,7 @@ import adminUserRoleRoutes from './role.js';
 import adminUserSearchRoutes from './search.js';
 import adminUserSessionRoutes from './session.js';
 import adminUserSocialRoutes from './social.js';
+import adminUserTrustedDeviceRoutes from './trusted-device.js';
 
 export default function adminUserRoutes<T extends ManagementApiRouter>(...args: RouterInitArgs<T>) {
   adminUserBasicsRoutes(...args);
@@ -22,4 +23,5 @@ export default function adminUserRoutes<T extends ManagementApiRouter>(...args: 
   adminUserPersonalAccessTokenRoutes(...args);
   adminUserEnterpriseSsoRoutes(...args);
   adminUserSessionRoutes(...args);
+  adminUserTrustedDeviceRoutes(...args);
 }

--- a/packages/core/src/routes/admin-user/trusted-device.openapi-disabled.test.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.openapi-disabled.test.ts
@@ -1,0 +1,16 @@
+import { EnvSet } from '#src/env-set/index.js';
+
+Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+
+const { buildManagementApiBaseDocument, getSupplementDocuments } = await import(
+  '../swagger/utils/documents.js'
+);
+
+it('filters trusted-device OpenAPI when dev features are disabled', async () => {
+  const documents = await getSupplementDocuments('admin-user');
+  const baseDocument = buildManagementApiBaseDocument(new Map(), new Set(), 'https://logto.test');
+
+  expect(JSON.stringify(documents)).not.toContain('/api/users/{userId}/trusted-devices');
+  expect(baseDocument.components?.parameters).not.toHaveProperty('trustedDeviceId');
+  expect(baseDocument.components?.parameters).not.toHaveProperty('trustedDeviceId-root');
+});

--- a/packages/core/src/routes/admin-user/trusted-device.openapi-enabled.test.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.openapi-enabled.test.ts
@@ -1,0 +1,16 @@
+import { EnvSet } from '#src/env-set/index.js';
+
+Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+
+const { buildManagementApiBaseDocument, getSupplementDocuments } = await import(
+  '../swagger/utils/documents.js'
+);
+
+it('keeps trusted-device OpenAPI when dev features are enabled', async () => {
+  const documents = await getSupplementDocuments('admin-user');
+  const baseDocument = buildManagementApiBaseDocument(new Map(), new Set(), 'https://logto.test');
+
+  expect(JSON.stringify(documents)).toContain('/api/users/{userId}/trusted-devices');
+  expect(baseDocument.components?.parameters).toHaveProperty('trustedDeviceId');
+  expect(baseDocument.components?.parameters).toHaveProperty('trustedDeviceId-root');
+});

--- a/packages/core/src/routes/admin-user/trusted-device.openapi.json
+++ b/packages/core/src/routes/admin-user/trusted-device.openapi.json
@@ -1,0 +1,34 @@
+{
+  "paths": {
+    "/api/users/{userId}/trusted-devices": {
+      "get": {
+        "tags": ["Dev feature"],
+        "summary": "Get user trusted devices",
+        "description": "Retrieve a paginated list of active trusted devices for the user.",
+        "responses": {
+          "200": {
+            "description": "A paginated list of the user's active trusted devices."
+          },
+          "404": {
+            "description": "The user was not found."
+          }
+        }
+      }
+    },
+    "/api/users/{userId}/trusted-devices/{trustedDeviceId}": {
+      "delete": {
+        "tags": ["Dev feature"],
+        "summary": "Delete a user trusted device",
+        "description": "Delete a trusted device that belongs to the user.",
+        "responses": {
+          "204": {
+            "description": "The trusted device was deleted successfully."
+          },
+          "404": {
+            "description": "The user or trusted device was not found."
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/routes/admin-user/trusted-device.test.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.test.ts
@@ -125,7 +125,13 @@ describe('admin user trusted device routes', () => {
 
     expect(response.status).toBe(204);
     expect(findUserById).toHaveBeenCalledWith(userId);
-    expect(deleteByIdAndUserId).toHaveBeenCalledWith(expect.any(Object), trustedDeviceId, userId);
+    expect(deleteByIdAndUserId).toHaveBeenCalledWith(expect.any(Object), trustedDeviceId, userId, {
+      path: `/users/${userId}/trusted-devices/${trustedDeviceId}`,
+      method: 'DELETE',
+      status: 204,
+      params: { userId, trustedDeviceId },
+      matchedRoute: '/users/:userId/trusted-devices/:trustedDeviceId',
+    });
   });
 
   it('returns 404 when the trusted device is missing or belongs to another user', async () => {

--- a/packages/core/src/routes/admin-user/trusted-device.test.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.test.ts
@@ -4,6 +4,7 @@ import { pickDefault } from '@logto/shared/esm';
 import { mockUser } from '#src/__mocks__/index.js';
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { koaManagementApiHooks } from '#src/middleware/koa-management-api-hooks.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
@@ -35,6 +36,7 @@ const mockedQueries = {
     findActiveByUserId: jest.fn(
       async (): Promise<[number, readonly TrustedDevice[]]> => [1, [trustedDevice]]
     ),
+    deleteByIdAndUserId: jest.fn(async (): Promise<TrustedDevice> => trustedDevice),
   },
 } satisfies Partial2<Queries>;
 
@@ -45,7 +47,8 @@ const mockedLibraries = {
 } satisfies Partial2<Libraries>;
 
 const { findUserById } = mockedQueries.users;
-const { findActiveByUserId } = mockedQueries.trustedDevices;
+const { findActiveByUserId, deleteByIdAndUserId: deleteTrustedDeviceRecordByIdAndUserId } =
+  mockedQueries.trustedDevices;
 const { deleteByIdAndUserId } = mockedLibraries.trustedDevices;
 
 const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
@@ -130,6 +133,44 @@ describe('admin user trusted device routes', () => {
       params: { userId, trustedDeviceId },
       matchedRoute: '/users/:userId/trusted-devices/:trustedDeviceId',
     });
+  });
+
+  it('appends the deletion hook with Management API context', async () => {
+    const triggerDataHooks = jest.fn();
+    const tenantContext = new MockTenant(undefined, mockedQueries, undefined, {
+      hooks: { triggerDataHooks },
+    });
+    const requester = createRequester({
+      middlewares: [koaManagementApiHooks(tenantContext.libraries.hooks)],
+      authedRoutes: adminUserTrustedDeviceRoutes,
+      tenantContext,
+    });
+
+    const response = await requester.delete(`/users/${userId}/trusted-devices/${trustedDeviceId}`);
+
+    expect(response.status).toBe(204);
+    expect(deleteTrustedDeviceRecordByIdAndUserId).toHaveBeenCalledWith(trustedDeviceId, userId);
+    expect(triggerDataHooks).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        dataHookContextArray: [
+          {
+            event: 'TrustedDevice.Deleted',
+            path: `/users/${userId}/trusted-devices/${trustedDeviceId}`,
+            method: 'DELETE',
+            status: 204,
+            params: { userId, trustedDeviceId },
+            matchedRoute: '/users/:userId/trusted-devices/:trustedDeviceId',
+            data: {
+              id: trustedDeviceId,
+              userId,
+              expiresAt: trustedDevice.expiresAt,
+            },
+            includeRequestIp: false,
+          },
+        ],
+      })
+    );
   });
 
   it('returns 404 when the trusted device is missing or belongs to another user', async () => {

--- a/packages/core/src/routes/admin-user/trusted-device.test.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.test.ts
@@ -1,0 +1,183 @@
+import { type TrustedDevice, defaultTenantId } from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockUser } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import type Libraries from '#src/tenants/Libraries.js';
+import type Queries from '#src/tenants/Queries.js';
+import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+import { getSupplementDocuments } from '../swagger/utils/documents.js';
+
+const { jest } = import.meta;
+
+const userId = mockUser.id;
+const trustedDeviceId = 'device-id';
+const trustedDevice: TrustedDevice = {
+  tenantId: defaultTenantId,
+  id: trustedDeviceId,
+  userId,
+  secretHash: Buffer.alloc(32, 1),
+  userAgent: 'Mozilla/5.0 test browser',
+  ip: '192.0.2.1',
+  country: 'US',
+  city: 'San Francisco',
+  createdAt: 1000,
+  lastUsedAt: 2000,
+  expiresAt: 3000,
+};
+
+const mockedQueries = {
+  users: {
+    findUserById: jest.fn(async () => mockUser),
+  },
+  trustedDevices: {
+    findActiveByUserId: jest.fn(
+      async (): Promise<[number, readonly TrustedDevice[]]> => [1, [trustedDevice]]
+    ),
+  },
+} satisfies Partial2<Queries>;
+
+const mockedLibraries = {
+  trustedDevices: {
+    deleteByIdAndUserId: jest.fn(async (): Promise<TrustedDevice | undefined> => trustedDevice),
+  },
+} satisfies Partial2<Libraries>;
+
+const { findUserById } = mockedQueries.users;
+const { findActiveByUserId } = mockedQueries.trustedDevices;
+const { deleteByIdAndUserId } = mockedLibraries.trustedDevices;
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Tests cover route registration in both feature states.
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
+};
+
+const adminUserTrustedDeviceRoutes = await pickDefault(import('./trusted-device.js'));
+
+const createTrustedDeviceRequester = (isDevFeaturesEnabled = true) => {
+  setDevFeaturesEnabled(isDevFeaturesEnabled);
+
+  return createRequester({
+    authedRoutes: adminUserTrustedDeviceRoutes,
+    tenantContext: new MockTenant(undefined, mockedQueries, undefined, mockedLibraries),
+  });
+};
+
+describe('admin user trusted device routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
+  it('returns a paginated and redacted list of active trusted devices', async () => {
+    const response = await createTrustedDeviceRequester()
+      .get(`/users/${userId}/trusted-devices`)
+      .query({ page: 2, page_size: 1 });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['total-number']).toBe('1');
+    expect(response.headers.link).toContain('rel="first"');
+    expect(response.body).toEqual([
+      {
+        id: trustedDevice.id,
+        userAgent: trustedDevice.userAgent,
+        country: trustedDevice.country,
+        city: trustedDevice.city,
+        createdAt: trustedDevice.createdAt,
+        lastUsedAt: trustedDevice.lastUsedAt,
+        expiresAt: trustedDevice.expiresAt,
+      },
+    ]);
+    expect(response.text).not.toContain('secretHash');
+    expect(response.text).not.toContain(trustedDevice.ip);
+    expect(findUserById).toHaveBeenCalledWith(userId);
+    expect(findActiveByUserId).toHaveBeenCalledWith(userId, { limit: 1, offset: 1 });
+  });
+
+  it('returns 404 without querying devices when the user does not exist', async () => {
+    findUserById.mockRejectedValueOnce(new RequestError({ code: 'entity.not_found', status: 404 }));
+
+    const response = await createTrustedDeviceRequester().get(`/users/${userId}/trusted-devices`);
+
+    expect(response.status).toBe(404);
+    expect(findActiveByUserId).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid pagination', async () => {
+    const response = await createTrustedDeviceRequester().get(
+      `/users/${userId}/trusted-devices?page=0`
+    );
+
+    expect(response.status).toBe(400);
+    expect(findUserById).not.toHaveBeenCalled();
+    expect(findActiveByUserId).not.toHaveBeenCalled();
+  });
+
+  it('deletes an owned trusted device through the shared lifecycle library', async () => {
+    const response = await createTrustedDeviceRequester().delete(
+      `/users/${userId}/trusted-devices/${trustedDeviceId}`
+    );
+
+    expect(response.status).toBe(204);
+    expect(findUserById).toHaveBeenCalledWith(userId);
+    expect(deleteByIdAndUserId).toHaveBeenCalledWith(expect.any(Object), trustedDeviceId, userId);
+  });
+
+  it('returns 404 when the trusted device is missing or belongs to another user', async () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined -- Jest requires an explicit resolved value for this typed mock.
+    deleteByIdAndUserId.mockResolvedValueOnce(undefined);
+
+    const response = await createTrustedDeviceRequester().delete(
+      `/users/${userId}/trusted-devices/${trustedDeviceId}`
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 without deleting when the user does not exist', async () => {
+    findUserById.mockRejectedValueOnce(new RequestError({ code: 'entity.not_found', status: 404 }));
+
+    const response = await createTrustedDeviceRequester().delete(
+      `/users/${userId}/trusted-devices/${trustedDeviceId}`
+    );
+
+    expect(response.status).toBe(404);
+    expect(deleteByIdAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('does not register the routes when dev features are disabled', async () => {
+    const response = await createTrustedDeviceRequester(false).get(
+      `/users/${userId}/trusted-devices`
+    );
+
+    expect(response.status).toBe(404);
+    expect(findUserById).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin user trusted device OpenAPI', () => {
+  afterEach(() => {
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
+  it('filters trusted-device operations when dev features are disabled', async () => {
+    setDevFeaturesEnabled(false);
+
+    const documents = await getSupplementDocuments('admin-user');
+
+    expect(JSON.stringify(documents)).not.toContain('/api/users/{userId}/trusted-devices');
+  });
+
+  it('keeps trusted-device operations when dev features are enabled', async () => {
+    setDevFeaturesEnabled(true);
+
+    const documents = await getSupplementDocuments('admin-user');
+
+    expect(JSON.stringify(documents)).toContain('/api/users/{userId}/trusted-devices');
+  });
+});

--- a/packages/core/src/routes/admin-user/trusted-device.test.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.test.ts
@@ -9,8 +9,6 @@ import type Queries from '#src/tenants/Queries.js';
 import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
 import { createRequester } from '#src/utils/test-utils.js';
 
-import { getSupplementDocuments } from '../swagger/utils/documents.js';
-
 const { jest } = import.meta;
 
 const userId = mockUser.id;
@@ -163,27 +161,5 @@ describe('admin user trusted device routes', () => {
 
     expect(response.status).toBe(404);
     expect(findUserById).not.toHaveBeenCalled();
-  });
-});
-
-describe('admin user trusted device OpenAPI', () => {
-  afterEach(() => {
-    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
-  });
-
-  it('filters trusted-device operations when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
-
-    const documents = await getSupplementDocuments('admin-user');
-
-    expect(JSON.stringify(documents)).not.toContain('/api/users/{userId}/trusted-devices');
-  });
-
-  it('keeps trusted-device operations when dev features are enabled', async () => {
-    setDevFeaturesEnabled(true);
-
-    const documents = await getSupplementDocuments('admin-user');
-
-    expect(JSON.stringify(documents)).toContain('/api/users/{userId}/trusted-devices');
   });
 });

--- a/packages/core/src/routes/admin-user/trusted-device.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.ts
@@ -1,0 +1,82 @@
+import { trustedDeviceResponseGuard } from '@logto/schemas';
+import { z } from 'zod';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import koaGuard from '#src/middleware/koa-guard.js';
+import koaPagination from '#src/middleware/koa-pagination.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
+
+export default function adminUserTrustedDeviceRoutes<T extends ManagementApiRouter>(
+  ...[router, tenant]: RouterInitArgs<T>
+) {
+  // DEV: MFA trusted device management
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
+  const {
+    queries: {
+      trustedDevices,
+      users: { findUserById },
+    },
+    libraries: { trustedDevices: trustedDeviceLibrary },
+  } = tenant;
+
+  router.get(
+    '/users/:userId/trusted-devices',
+    koaPagination(),
+    koaGuard({
+      params: z.object({ userId: z.string() }),
+      response: trustedDeviceResponseGuard.array(),
+      status: [200, 400, 404],
+    }),
+    async (ctx, next) => {
+      const { userId } = ctx.guard.params;
+      const { limit, offset } = ctx.pagination;
+
+      await findUserById(userId);
+      const [totalNumber, records] = await trustedDevices.findActiveByUserId(userId, {
+        limit,
+        offset,
+      });
+
+      ctx.pagination.totalCount = totalNumber;
+      ctx.body = records;
+
+      return next();
+    }
+  );
+
+  router.delete(
+    '/users/:userId/trusted-devices/:trustedDeviceId',
+    koaGuard({
+      params: z.object({ userId: z.string(), trustedDeviceId: z.string() }),
+      status: [204, 404],
+    }),
+    async (ctx, next) => {
+      const { userId, trustedDeviceId } = ctx.guard.params;
+
+      await findUserById(userId);
+      const trustedDevice = await trustedDeviceLibrary.deleteByIdAndUserId(
+        ctx,
+        trustedDeviceId,
+        userId
+      );
+
+      assertThat(
+        trustedDevice,
+        new RequestError({
+          code: 'entity.not_found',
+          status: 404,
+        })
+      );
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/admin-user/trusted-device.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { buildManagementApiContext } from '#src/libraries/hook/utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaPagination from '#src/middleware/koa-pagination.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -60,10 +61,12 @@ export default function adminUserTrustedDeviceRoutes<T extends ManagementApiRout
       const { userId, trustedDeviceId } = ctx.guard.params;
 
       await findUserById(userId);
+      ctx.status = 204;
       const trustedDevice = await trustedDeviceLibrary.deleteByIdAndUserId(
         ctx,
         trustedDeviceId,
-        userId
+        userId,
+        buildManagementApiContext(ctx)
       );
 
       assertThat(
@@ -73,8 +76,6 @@ export default function adminUserTrustedDeviceRoutes<T extends ManagementApiRout
           status: 404,
         })
       );
-
-      ctx.status = 204;
 
       return next();
     }

--- a/packages/core/src/routes/admin-user/trusted-device.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.ts
@@ -1,4 +1,5 @@
-import { trustedDeviceResponseGuard } from '@logto/schemas';
+import { trustedDeviceResponseGuard, type TrustedDeviceResponse } from '@logto/schemas';
+import { pick } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import { EnvSet } from '#src/env-set/index.js';
@@ -45,7 +46,19 @@ export default function adminUserTrustedDeviceRoutes<T extends ManagementApiRout
       });
 
       ctx.pagination.totalCount = totalNumber;
-      ctx.body = records;
+      ctx.body = records.map(
+        (record) =>
+          pick(
+            record,
+            'id',
+            'userAgent',
+            'country',
+            'city',
+            'createdAt',
+            'lastUsedAt',
+            'expiresAt'
+          ) satisfies TrustedDeviceResponse
+      );
 
       return next();
     }

--- a/packages/core/src/routes/admin-user/trusted-device.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.ts
@@ -33,7 +33,7 @@ export default function adminUserTrustedDeviceRoutes<T extends ManagementApiRout
     koaGuard({
       params: z.object({ userId: z.string() }),
       response: trustedDeviceResponseGuard.array(),
-      status: [200, 400, 404],
+      status: [200, 404],
     }),
     async (ctx, next) => {
       const { userId } = ctx.guard.params;

--- a/packages/core/src/routes/swagger/utils/documents.ts
+++ b/packages/core/src/routes/swagger/utils/documents.ts
@@ -55,6 +55,7 @@ const managementApiIdentifiableEntityNames = Object.freeze(
     'email-template',
     'one-time-token',
     'session',
+    'trusted-device',
     'grant'
   )
 );

--- a/packages/core/src/routes/swagger/utils/documents.ts
+++ b/packages/core/src/routes/swagger/utils/documents.ts
@@ -55,7 +55,7 @@ const managementApiIdentifiableEntityNames = Object.freeze(
     'email-template',
     'one-time-token',
     'session',
-    'trusted-device',
+    EnvSet.values.isDevFeaturesEnabled && 'trusted-device',
     'grant'
   )
 );

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -208,6 +208,17 @@ export const updatePersonalAccessToken = async (
 export const deletePersonalAccessTokenLegacy = async (userId: string, name: string) =>
   authedAdminApi.delete(`users/${userId}/personal-access-tokens/${name}`);
 
+export const updatePersonalAccessTokenLegacy = async (
+  userId: string,
+  name: string,
+  body: Record<string, unknown>
+) =>
+  authedAdminApi
+    .patch(`users/${userId}/personal-access-tokens/${name}`, {
+      json: body,
+    })
+    .json<PersonalAccessToken>();
+
 export const getUserTrustedDevicesResponse = async (
   userId: string,
   searchParams?: URLSearchParams
@@ -224,17 +235,6 @@ export const getUserTrustedDevices = async (userId: string, searchParams?: URLSe
 
 export const deleteUserTrustedDevice = async (userId: string, trustedDeviceId: string) =>
   authedAdminApi.delete(`users/${userId}/trusted-devices/${trustedDeviceId}`);
-
-export const updatePersonalAccessTokenLegacy = async (
-  userId: string,
-  name: string,
-  body: Record<string, unknown>
-) =>
-  authedAdminApi
-    .patch(`users/${userId}/personal-access-tokens/${name}`, {
-      json: body,
-    })
-    .json<PersonalAccessToken>();
 
 export const getUserIdentity = async (
   userId: string,

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -13,6 +13,7 @@ import type {
   PersonalAccessToken,
   Role,
   SessionGrantRevokeTarget,
+  TrustedDeviceResponse,
   User,
   UserProfileResponse,
   UserSsoIdentity,
@@ -206,6 +207,23 @@ export const updatePersonalAccessToken = async (
 
 export const deletePersonalAccessTokenLegacy = async (userId: string, name: string) =>
   authedAdminApi.delete(`users/${userId}/personal-access-tokens/${name}`);
+
+export const getUserTrustedDevicesResponse = async (
+  userId: string,
+  searchParams?: URLSearchParams
+) =>
+  authedAdminApi.get(`users/${userId}/trusted-devices`, {
+    searchParams,
+  });
+
+export const getUserTrustedDevices = async (userId: string, searchParams?: URLSearchParams) => {
+  const response = await getUserTrustedDevicesResponse(userId, searchParams);
+
+  return response.json<TrustedDeviceResponse[]>();
+};
+
+export const deleteUserTrustedDevice = async (userId: string, trustedDeviceId: string) =>
+  authedAdminApi.delete(`users/${userId}/trusted-devices/${trustedDeviceId}`);
 
 export const updatePersonalAccessTokenLegacy = async (
   userId: string,

--- a/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
@@ -1,0 +1,152 @@
+import { defaultTenantId, type TrustedDeviceResponse } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import { assertEnv } from '@silverhand/essentials';
+import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
+
+import {
+  deleteUser,
+  deleteUserTrustedDevice,
+  getUserTrustedDevices,
+  getUserTrustedDevicesResponse,
+} from '#src/api/admin-user.js';
+import api from '#src/api/api.js';
+import { createUserByAdmin } from '#src/helpers/index.js';
+
+const insertTrustedDevice = async (
+  pool: DatabasePool,
+  {
+    id,
+    userId,
+    createdAt,
+    expiresAt,
+  }: Readonly<{ id: string; userId: string; createdAt: number; expiresAt: number }>
+) =>
+  pool.query(sql`
+    insert into trusted_devices (
+      tenant_id,
+      id,
+      user_id,
+      secret_hash,
+      user_agent,
+      ip,
+      country,
+      city,
+      created_at,
+      last_used_at,
+      expires_at
+    ) values (
+      ${defaultTenantId},
+      ${id},
+      ${userId},
+      ${sql.binary(Buffer.alloc(32, 1))},
+      ${'Mozilla/5.0 integration test'},
+      ${'192.0.2.1'},
+      ${'US'},
+      ${'San Francisco'},
+      to_timestamp(${createdAt}::double precision / 1000),
+      to_timestamp(${createdAt}::double precision / 1000),
+      to_timestamp(${expiresAt}::double precision / 1000)
+    )
+  `);
+
+const pool = await createPool(assertEnv('DB_URL'), {
+  interceptors: createInterceptorsPreset(),
+});
+
+describe('admin user trusted devices', () => {
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('requires Management API authorization', async () => {
+    const response = await api.get('users/missing/trusted-devices', {
+      throwHttpErrors: false,
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('lists only active owned records with pagination and deletes only owned records', async () => {
+    const [user, otherUser] = await Promise.all([createUserByAdmin(), createUserByAdmin()]);
+    const now = Date.now();
+    const olderDeviceId = generateStandardId();
+    const newerDeviceId = generateStandardId();
+    const expiredDeviceId = generateStandardId();
+    const otherUserDeviceId = generateStandardId();
+
+    try {
+      await Promise.all([
+        insertTrustedDevice(pool, {
+          id: olderDeviceId,
+          userId: user.id,
+          createdAt: now - 2000,
+          expiresAt: now + 60_000,
+        }),
+        insertTrustedDevice(pool, {
+          id: newerDeviceId,
+          userId: user.id,
+          createdAt: now - 1000,
+          expiresAt: now + 60_000,
+        }),
+        insertTrustedDevice(pool, {
+          id: expiredDeviceId,
+          userId: user.id,
+          createdAt: now - 3000,
+          expiresAt: now - 1000,
+        }),
+        insertTrustedDevice(pool, {
+          id: otherUserDeviceId,
+          userId: otherUser.id,
+          createdAt: now,
+          expiresAt: now + 60_000,
+        }),
+      ]);
+
+      const firstPageResponse = await getUserTrustedDevicesResponse(
+        user.id,
+        new URLSearchParams({ page: '1', page_size: '1' })
+      );
+      const firstPage = await firstPageResponse.json<TrustedDeviceResponse[]>();
+
+      expect(firstPageResponse.headers.get('Total-Number')).toBe('2');
+      expect(firstPageResponse.headers.get('Link')).toContain('rel="next"');
+      expect(firstPage).toEqual([
+        {
+          id: newerDeviceId,
+          userAgent: 'Mozilla/5.0 integration test',
+          country: 'US',
+          city: 'San Francisco',
+          createdAt: now - 1000,
+          lastUsedAt: now - 1000,
+          expiresAt: now + 60_000,
+        },
+      ]);
+      expect(JSON.stringify(firstPage)).not.toContain('192.0.2.1');
+      expect(JSON.stringify(firstPage)).not.toContain('secretHash');
+
+      await expect(deleteUserTrustedDevice(user.id, otherUserDeviceId)).rejects.toHaveProperty(
+        'response.status',
+        404
+      );
+      expect(await getUserTrustedDevices(otherUser.id)).toHaveLength(1);
+
+      await expect(deleteUserTrustedDevice(user.id, newerDeviceId)).resolves.toHaveProperty(
+        'status',
+        204
+      );
+      expect(await getUserTrustedDevices(user.id)).toEqual([
+        expect.objectContaining({ id: olderDeviceId }),
+      ]);
+      await expect(deleteUserTrustedDevice(user.id, newerDeviceId)).rejects.toHaveProperty(
+        'response.status',
+        404
+      );
+    } finally {
+      await Promise.all([deleteUser(user.id), deleteUser(otherUser.id)]);
+    }
+  });
+
+  it('returns 404 for an unknown user', async () => {
+    await expect(getUserTrustedDevices('missing')).rejects.toHaveProperty('response.status', 404);
+  });
+});

--- a/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
@@ -11,6 +11,7 @@ import {
 } from '#src/api/admin-user.js';
 import api from '#src/api/api.js';
 import { createUserByAdmin } from '#src/helpers/index.js';
+import { devFeatureTest } from '#src/utils.js';
 
 const insertTrustedDevice = async (
   pool: DatabasePool,
@@ -53,7 +54,7 @@ const pool = await createPool(assertEnv('DB_URL'), {
   interceptors: createInterceptorsPreset(),
 });
 
-describe('admin user trusted devices', () => {
+devFeatureTest.describe('admin user trusted devices', () => {
   afterAll(async () => {
     await pool.end();
   });

--- a/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
@@ -50,11 +50,17 @@ const insertTrustedDevice = async (
     )
   `);
 
-const pool = await createPool(assertEnv('DB_URL'), {
-  interceptors: createInterceptorsPreset(),
-});
-
 devFeatureTest.describe('admin user trusted devices', () => {
+  // eslint-disable-next-line @silverhand/fp/no-let -- Initialized only when this dev-feature suite runs.
+  let pool: DatabasePool;
+
+  beforeAll(async () => {
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- The matching afterAll closes this suite-scoped pool.
+    pool = await createPool(assertEnv('DB_URL'), {
+      interceptors: createInterceptorsPreset(),
+    });
+  });
+
   afterAll(async () => {
     await pool.end();
   });

--- a/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
@@ -9,7 +9,6 @@ import {
   getUserTrustedDevices,
   getUserTrustedDevicesResponse,
 } from '#src/api/admin-user.js';
-import api from '#src/api/api.js';
 import { createUserByAdmin } from '#src/helpers/index.js';
 import { devFeatureTest } from '#src/utils.js';
 
@@ -63,14 +62,6 @@ devFeatureTest.describe('admin user trusted devices', () => {
 
   afterAll(async () => {
     await pool.end();
-  });
-
-  it('requires Management API authorization', async () => {
-    const response = await api.get('users/missing/trusted-devices', {
-      throwHttpErrors: false,
-    });
-
-    expect(response.status).toBe(401);
   });
 
   it('lists only active owned records with pagination and deletes only owned records', async () => {

--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -36,3 +36,4 @@ export * from './custom-profile-fields.js';
 export * from './secrets.js';
 export * from './user-logto-config.js';
 export * from './user-sessions.js';
+export * from './trusted-device.js';

--- a/packages/schemas/src/types/trusted-device.ts
+++ b/packages/schemas/src/types/trusted-device.ts
@@ -1,0 +1,17 @@
+import { type z } from 'zod';
+
+import { TrustedDevices } from '../db-entries/index.js';
+
+/** Public trusted-device metadata returned by user management APIs. */
+export const trustedDeviceResponseGuard = TrustedDevices.guard.pick({
+  id: true,
+  userAgent: true,
+  country: true,
+  city: true,
+  createdAt: true,
+  lastUsedAt: true,
+  expiresAt: true,
+});
+
+/** Public trusted-device metadata returned by user management APIs. */
+export type TrustedDeviceResponse = z.infer<typeof trustedDeviceResponseGuard>;

--- a/packages/schemas/src/types/trusted-device.ts
+++ b/packages/schemas/src/types/trusted-device.ts
@@ -13,5 +13,4 @@ export const trustedDeviceResponseGuard = TrustedDevices.guard.pick({
   expiresAt: true,
 });
 
-/** Public trusted-device metadata returned by user management APIs. */
 export type TrustedDeviceResponse = z.infer<typeof trustedDeviceResponseGuard>;


### PR DESCRIPTION
## Summary
Add Management API endpoints to list a user's active trusted devices with standard pagination and delete an owned record through the shared lifecycle handler. Return only redacted trusted-device metadata and update the public response schema and OpenAPI documentation.

## Testing
Unit tests

Integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments