### PR TITLE
feat(account,console,core): add trusted device account management

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,6 +41,8 @@ jobs:
     env:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: ${{ matrix.dev-features-enabled }}
+      # Allow production-mode tests to simulate TLS termination for Secure cookies.
+      TRUST_PROXY_HEADER: 1
       # Allow Console tests to use the local backchannel logout mock server.
       OIDC_PROVIDER_SSRF_PROTECTION_DISABLED: ${{ matrix.target == 'console' }}
       # Key encryption key (KEK) for the secret vault used in integration tests

--- a/packages/account/src/App.tsx
+++ b/packages/account/src/App.tsx
@@ -1,5 +1,6 @@
 import LogtoSignature from '@experience/shared/components/LogtoSignature';
-import { LogtoProvider, ReservedScope, useLogto, UserScope } from '@logto/react';
+import { ReservedScope, UserScope } from '@logto/core-kit';
+import { LogtoProvider, useLogto } from '@logto/react';
 import { accountCenterApplicationId, SignInIdentifier } from '@logto/schemas';
 import classNames from 'classnames';
 import { useContext, useMemo } from 'react';
@@ -293,6 +294,7 @@ const App = () => (
           UserScope.Identities,
           UserScope.CustomData,
           UserScope.Sessions,
+          UserScope.TrustedDevices,
         ],
       }}
     >

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.test.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.test.ts
@@ -1,0 +1,38 @@
+const mockIsDevFeaturesEnabled = jest.fn(() => true);
+
+jest.mock('@/consts/env', () => ({
+  get isDevFeaturesEnabled() {
+    return mockIsDevFeaturesEnabled();
+  },
+}));
+
+const getSessionManagementFieldKeys = async () => {
+  const { accountCenterSections } = await import('./constants');
+  const accountSecuritySection = accountCenterSections.find(({ key }) => key === 'accountSecurity');
+  const sessionManagementGroup = accountSecuritySection?.groups.find(
+    ({ key }) => key === 'sessionManagement'
+  );
+
+  return sessionManagementGroup?.items.map(({ key }) => key);
+};
+
+describe('Account Center field sections', () => {
+  beforeEach(() => {
+    mockIsDevFeaturesEnabled.mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('shows an independent trusted-device permission under session management', async () => {
+    await expect(getSessionManagementFieldKeys()).resolves.toEqual(['session', 'trustedDevice']);
+  });
+
+  it('hides the trusted-device permission when dev features are disabled', async () => {
+    mockIsDevFeaturesEnabled.mockReturnValue(false);
+
+    await expect(getSessionManagementFieldKeys()).resolves.toEqual(['session']);
+  });
+});

--- a/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.ts
+++ b/packages/console/src/pages/SignInExperience/PageContent/AccountCenter/constants.ts
@@ -1,4 +1,7 @@
 import type { AdminConsoleKey } from '@logto/phrases';
+import { conditionalArray } from '@silverhand/essentials';
+
+import { isDevFeaturesEnabled } from '@/consts/env';
 
 import type { AccountCenterFieldKey } from '../../types';
 
@@ -59,6 +62,13 @@ export const accountCenterSections: AccountCenterFieldSection[] = [
             key: 'session',
             title: 'sign_in_exp.account_center.fields.sessions',
           },
+          // DEV: MFA trusted device management
+          ...conditionalArray<AccountCenterFieldItem>(
+            isDevFeaturesEnabled && {
+              key: 'trustedDevice',
+              title: 'sign_in_exp.account_center.fields.trusted_devices',
+            }
+          ),
         ],
       },
     ],

--- a/packages/console/src/pages/SignInExperience/types.test.ts
+++ b/packages/console/src/pages/SignInExperience/types.test.ts
@@ -50,4 +50,26 @@ describe('SignInExperience types utils', () => {
 
     expect(normalizedFields).toHaveProperty('passkey', AccountCenterControlValue.Edit);
   });
+
+  it('omits the default trusted-device field when the original config did not set it', () => {
+    const normalizedFields = normalizeAccountCenterFieldsForSubmit(createAccountCenterFields(), {
+      session: AccountCenterControlValue.Edit,
+    });
+
+    expect(normalizedFields).not.toHaveProperty('trustedDevice');
+  });
+
+  it('keeps the trusted-device field when enabled or already persisted', () => {
+    expect(
+      normalizeAccountCenterFieldsForSubmit(
+        createAccountCenterFields({ trustedDevice: AccountCenterControlValue.Edit }),
+        {}
+      )
+    ).toHaveProperty('trustedDevice', AccountCenterControlValue.Edit);
+    expect(
+      normalizeAccountCenterFieldsForSubmit(createAccountCenterFields(), {
+        trustedDevice: AccountCenterControlValue.Off,
+      })
+    ).toHaveProperty('trustedDevice', AccountCenterControlValue.Off);
+  });
 });

--- a/packages/console/src/pages/SignInExperience/types.ts
+++ b/packages/console/src/pages/SignInExperience/types.ts
@@ -36,7 +36,24 @@ export enum SignInExperienceTab {
   Content = 'content',
 }
 
-const accountCenterFieldKeys: Array<keyof AccountCenterFieldControl> = [
+export type AccountCenterFieldKey = keyof Pick<
+  AccountCenterFieldControl,
+  | 'email'
+  | 'phone'
+  | 'social'
+  | 'password'
+  | 'mfa'
+  | 'passkey'
+  | 'username'
+  | 'name'
+  | 'avatar'
+  | 'profile'
+  | 'customData'
+  | 'session'
+  | 'trustedDevice'
+>;
+
+const accountCenterFieldKeys: AccountCenterFieldKey[] = [
   'email',
   'phone',
   'social',
@@ -49,9 +66,8 @@ const accountCenterFieldKeys: Array<keyof AccountCenterFieldControl> = [
   'profile',
   'customData',
   'session',
+  'trustedDevice',
 ] as const;
-
-export type AccountCenterFieldKey = (typeof accountCenterFieldKeys)[number];
 
 export type AccountCenterFormValues = {
   enabled: boolean;
@@ -100,13 +116,18 @@ export const normalizeAccountCenterFieldsForSubmit = (
   fields: AccountCenterFormValues['fields'],
   originalFields?: AccountCenterConfig['fields']
 ): AccountCenterFieldControl => {
-  const { passkey, ...fieldsWithoutPasskey } = fields;
+  const { passkey, trustedDevice, ...stableFields } = fields;
 
-  if (originalFields?.passkey === undefined && passkey === AccountCenterControlValue.Off) {
-    return fieldsWithoutPasskey;
-  }
-
-  return fields;
+  return {
+    ...stableFields,
+    ...(originalFields?.passkey !== undefined || passkey !== AccountCenterControlValue.Off
+      ? { passkey }
+      : {}),
+    ...(originalFields?.trustedDevice !== undefined ||
+    trustedDevice !== AccountCenterControlValue.Off
+      ? { trustedDevice }
+      : {}),
+  };
 };
 
 /**

--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -39,7 +39,6 @@ const createQueries = () =>
     findActiveByIdAndUserId: jest.fn(),
     updateMetadataByIdAndUserId: jest.fn(),
     deleteByIdAndUserId: jest.fn(),
-    deleteExpiredByIdAndUserId: jest.fn(),
     deleteExpiredByTenant: jest.fn(),
   }) as unknown as jest.Mocked<TrustedDeviceQueries>;
 
@@ -399,26 +398,22 @@ describe('trusted device library', () => {
 
     await expect(library.validateCredential(ctx, userId)).resolves.toBeUndefined();
     expect(set).toHaveBeenCalledTimes(1);
-    expect(queries.deleteExpiredByIdAndUserId).not.toHaveBeenCalled();
   });
 
-  it('silently attempts exact cleanup for a missing or expired presented record', async () => {
+  it('clears a credential for a missing or expired record', async () => {
     const secret = generateTrustedDeviceSecret();
     const queries = createQueries();
     const { ctx, set } = createCookieContext(
       serializeTrustedDeviceCredential({ id: trustedDeviceId, secret })
     );
     queries.findActiveByIdAndUserId.mockResolvedValueOnce(null);
-    queries.deleteExpiredByIdAndUserId.mockResolvedValueOnce(1);
 
     const library = createTrustedDeviceLibrary(tenantId, queries, createPolicyLibrary(), {
       isProduction: false,
     });
 
     await expect(library.validateCredential(ctx, userId)).resolves.toBeUndefined();
-    await Promise.resolve();
 
-    expect(queries.deleteExpiredByIdAndUserId).toHaveBeenCalledWith(trustedDeviceId, userId);
     expect(set).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -250,7 +250,6 @@ export const createTrustedDeviceLibrary = (
     const trustedDevice = await queries.findActiveByIdAndUserId(credential.id, userId);
 
     if (!trustedDevice) {
-      void trySafe(async () => queries.deleteExpiredByIdAndUserId(credential.id, userId));
       clearCredential(ctx, userId);
       return;
     }

--- a/packages/core/src/queries/trusted-device.test.ts
+++ b/packages/core/src/queries/trusted-device.test.ts
@@ -192,25 +192,6 @@ describe('trusted device queries', () => {
     ).resolves.toBeNull();
   });
 
-  it('deletes only the presented owned record at the expiry boundary', async () => {
-    const expectSql = sql`
-      delete from ${table}
-      where ${fields.id} = $1
-        and ${fields.userId} = $2
-        and ${fields.expiresAt} <= now()
-    `;
-
-    mockQuery.mockImplementationOnce(async (query, values) => {
-      expectSqlAssert(query, expectSql.sql);
-      expect(values).toEqual([trustedDevice.id, trustedDevice.userId]);
-      return createMockQueryResult([trustedDevice]);
-    });
-
-    await expect(
-      queries.deleteExpiredByIdAndUserId(trustedDevice.id, trustedDevice.userId)
-    ).resolves.toBe(1);
-  });
-
   it('deletes a record only when both its ID and owner match', async () => {
     const expectSql = sql`
       delete from ${table}

--- a/packages/core/src/queries/trusted-device.ts
+++ b/packages/core/src/queries/trusted-device.ts
@@ -117,17 +117,6 @@ export class TrustedDeviceQueries {
     `);
   }
 
-  public async deleteExpiredByIdAndUserId(id: string, userId: string) {
-    const { rowCount } = await this.pool.query<TrustedDevice>(sql`
-      delete from ${table}
-      where ${fields.id} = ${id}
-        and ${fields.userId} = ${userId}
-        and ${fields.expiresAt} <= now()
-    `);
-
-    return rowCount;
-  }
-
   public async deleteByIdAndUserId(id: string, userId: string) {
     return this.pool.maybeOne<TrustedDevice>(sql`
       delete from ${table}

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -783,6 +783,47 @@
         }
       }
     },
+    "/api/my-account/trusted-devices": {
+      "get": {
+        "tags": ["Dev feature"],
+        "operationId": "GetTrustedDevices",
+        "summary": "Get trusted devices",
+        "description": "Retrieve a paginated list of active trusted devices for the signed-in user. A logto-verification-id in header and the trusted-devices scope are required. Each entry includes isCurrent, which is true only when the browser's trusted-device cookie passes full credential validation for that record.",
+        "responses": {
+          "200": {
+            "description": "A paginated list of the signed-in user's active trusted devices."
+          },
+          "401": {
+            "description": "Permission denied, the verification record is invalid or the access token does not include the trusted-devices scope."
+          }
+        }
+      }
+    },
+    "/api/my-account/trusted-devices/{trustedDeviceId}": {
+      "delete": {
+        "tags": ["Dev feature"],
+        "operationId": "DeleteTrustedDeviceById",
+        "summary": "Delete a trusted device",
+        "description": "Delete a trusted device owned by the signed-in user. Deleting the current trusted device clears its cookie without ending the login session.",
+        "responses": {
+          "204": {
+            "description": "The trusted device was deleted successfully."
+          },
+          "400": {
+            "description": "The field is not editable."
+          },
+          "401": {
+            "description": "Permission denied, the verification record is invalid or the access token does not include the trusted-devices scope."
+          },
+          "403": {
+            "description": "The request was made by a third-party application."
+          },
+          "404": {
+            "description": "The trusted device was not found or does not belong to the signed-in user."
+          }
+        }
+      }
+    },
     "/api/my-account/user-assets/avatar": {
       "post": {
         "operationId": "UploadAccountAvatar",

--- a/packages/core/src/routes/account/index.ts
+++ b/packages/core/src/routes/account/index.ts
@@ -30,6 +30,7 @@ import mfaVerificationsRoutes from './mfa-verifications.js';
 import koaAccountCenter from './middlewares/koa-account-center.js';
 import accountSessionRoutes from './sessions.js';
 import thirdPartyTokensRoutes from './third-party-tokens.js';
+import accountTrustedDeviceRoutes from './trusted-device.js';
 import accountUserAssetsRoutes from './user-assets.js';
 import { getAccountCenterFilteredProfile, getScopedProfile } from './utils/get-scoped-profile.js';
 import { hasSecurityVerificationMethod } from './utils/has-security-verification-method.js';
@@ -307,6 +308,7 @@ export default function accountRoutes<T extends UserRouter>(...args: RouterInitA
   identitiesRoutes(...args);
   mfaVerificationsRoutes(...args);
   accountSessionRoutes(...args);
+  accountTrustedDeviceRoutes(...args);
   accountGrantRoutes(...args);
   accountUserAssetsRoutes(...args);
 }

--- a/packages/core/src/routes/account/trusted-device.test.ts
+++ b/packages/core/src/routes/account/trusted-device.test.ts
@@ -1,0 +1,256 @@
+import { UserScope } from '@logto/core-kit';
+import { AccountCenterControlValue, type TrustedDevice, defaultTenantId } from '@logto/schemas';
+import { pickDefault } from '@logto/shared/esm';
+
+import { mockUser } from '#src/__mocks__/index.js';
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import koaErrorHandler from '#src/middleware/koa-error-handler.js';
+import koaI18next from '#src/middleware/koa-i18next.js';
+import type Libraries from '#src/tenants/Libraries.js';
+import type Queries from '#src/tenants/Queries.js';
+import { MockTenant, type Partial2 } from '#src/test-utils/tenant.js';
+import { createRequester } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const assertFirstPartyClient = jest.fn(async () => true);
+jest.unstable_mockModule('#src/utils/assert-first-party-client.js', () => ({
+  assertFirstPartyClient,
+}));
+
+const trustedDeviceId = 'trusteddeviceid';
+const otherTrustedDeviceId = 'othertrusteddeviceid';
+const trustedDevice: TrustedDevice = {
+  tenantId: defaultTenantId,
+  id: trustedDeviceId,
+  userId: mockUser.id,
+  secretHash: Buffer.alloc(32, 1),
+  userAgent: 'Mozilla/5.0 test browser',
+  ip: '192.0.2.1',
+  country: 'US',
+  city: 'San Francisco',
+  createdAt: 1000,
+  lastUsedAt: 2000,
+  expiresAt: 3000,
+};
+const otherTrustedDevice: TrustedDevice = {
+  ...trustedDevice,
+  id: otherTrustedDeviceId,
+};
+
+const findActiveByUserId = jest.fn(
+  async (): Promise<[number, readonly TrustedDevice[]]> => [2, [trustedDevice, otherTrustedDevice]]
+);
+const validateCredential = jest.fn(async (): Promise<TrustedDevice | undefined> => trustedDevice);
+const deleteByIdAndUserId = jest.fn(async (): Promise<TrustedDevice | undefined> => trustedDevice);
+const clearCredential = jest.fn();
+
+const mockedQueries = {
+  trustedDevices: { findActiveByUserId },
+} satisfies Partial2<Queries>;
+
+const mockedLibraries = {
+  trustedDevices: { validateCredential, deleteByIdAndUserId, clearCredential },
+} satisfies Partial2<Libraries>;
+
+const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
+  // eslint-disable-next-line @silverhand/fp/no-mutation -- Tests cover route registration in both feature states.
+  (EnvSet.values as { isDevFeaturesEnabled: boolean }).isDevFeaturesEnabled = isDevFeaturesEnabled;
+};
+
+const trustedDeviceRoutes = await pickDefault(import('./trusted-device.js'));
+
+const buildRequester = ({
+  field = AccountCenterControlValue.Edit,
+  identityVerified = true,
+  scopes = new Set([UserScope.TrustedDevices]),
+  clientId,
+  isDevFeaturesEnabled = true,
+}: {
+  field?: AccountCenterControlValue;
+  identityVerified?: boolean;
+  scopes?: Set<string>;
+  clientId?: string;
+  isDevFeaturesEnabled?: boolean;
+} = {}) => {
+  setDevFeaturesEnabled(isDevFeaturesEnabled);
+
+  return createRequester({
+    middlewares: [koaI18next(), koaErrorHandler()],
+    authedRoutes: [
+      (router) => {
+        router.use(async (ctx, next) => {
+          ctx.auth = {
+            ...ctx.auth,
+            id: mockUser.id,
+            identityVerified,
+            scopes,
+            clientId,
+          };
+          ctx.accountCenter = {
+            enabled: true,
+            fields: { trustedDevice: field },
+          };
+          ctx.appendDataHookContext = jest.fn();
+
+          return next();
+        });
+      },
+      trustedDeviceRoutes as never,
+    ],
+    tenantContext: new MockTenant(undefined, mockedQueries, undefined, mockedLibraries),
+  });
+};
+
+describe('account trusted device routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    validateCredential.mockResolvedValue(trustedDevice);
+    deleteByIdAndUserId.mockResolvedValue(trustedDevice);
+    setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
+  });
+
+  it('returns a paginated, redacted list and marks only the validated credential as current', async () => {
+    const response = await buildRequester({ field: AccountCenterControlValue.ReadOnly })
+      .get('/my-account/trusted-devices')
+      .query({ page: 2, page_size: 1 });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['total-number']).toBe('2');
+    expect(response.headers.link).toContain('rel="first"');
+    expect(response.body).toEqual([
+      {
+        id: trustedDevice.id,
+        userAgent: trustedDevice.userAgent,
+        country: trustedDevice.country,
+        city: trustedDevice.city,
+        createdAt: trustedDevice.createdAt,
+        lastUsedAt: trustedDevice.lastUsedAt,
+        expiresAt: trustedDevice.expiresAt,
+        isCurrent: true,
+      },
+      {
+        id: otherTrustedDevice.id,
+        userAgent: otherTrustedDevice.userAgent,
+        country: otherTrustedDevice.country,
+        city: otherTrustedDevice.city,
+        createdAt: otherTrustedDevice.createdAt,
+        lastUsedAt: otherTrustedDevice.lastUsedAt,
+        expiresAt: otherTrustedDevice.expiresAt,
+        isCurrent: false,
+      },
+    ]);
+    expect(response.text).not.toContain('secretHash');
+    expect(response.text).not.toContain(trustedDevice.ip);
+    expect(validateCredential).toHaveBeenCalledWith(expect.any(Object), mockUser.id);
+    expect(findActiveByUserId).toHaveBeenCalledWith(mockUser.id, { limit: 1, offset: 1 });
+  });
+
+  it('does not infer the current device from a record ID when credential validation fails', async () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined -- Jest requires an explicit resolved value for this typed mock.
+    validateCredential.mockResolvedValueOnce(undefined);
+
+    const response = await buildRequester().get('/my-account/trusted-devices');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      expect.objectContaining({ id: trustedDeviceId, isCurrent: false }),
+      expect.objectContaining({ id: otherTrustedDeviceId, isCurrent: false }),
+    ]);
+  });
+
+  it.each([
+    {
+      name: 'identity is not verified',
+      options: { identityVerified: false },
+      code: 'verification_record.permission_denied',
+    },
+    {
+      name: 'trusted-devices scope is missing',
+      options: { scopes: new Set<string>() },
+      code: 'auth.unauthorized',
+    },
+    {
+      name: 'trusted-device permission is off',
+      options: { field: AccountCenterControlValue.Off },
+      code: 'account_center.field_not_enabled',
+    },
+  ])('rejects GET when $name', async ({ options, code }) => {
+    const response = await buildRequester(options).get('/my-account/trusted-devices');
+
+    expect(response.status).toBe(code === 'account_center.field_not_enabled' ? 400 : 401);
+    expect(response.body).toHaveProperty('code', code);
+    expect(findActiveByUserId).not.toHaveBeenCalled();
+  });
+
+  it('deletes an owned remote device without clearing the current credential', async () => {
+    deleteByIdAndUserId.mockResolvedValueOnce(otherTrustedDevice);
+
+    const response = await buildRequester().delete(
+      `/my-account/trusted-devices/${otherTrustedDeviceId}`
+    );
+
+    expect(response.status).toBe(204);
+    expect(deleteByIdAndUserId).toHaveBeenCalledWith(
+      expect.any(Object),
+      otherTrustedDeviceId,
+      mockUser.id
+    );
+    expect(clearCredential).not.toHaveBeenCalled();
+  });
+
+  it('clears the trusted-device cookie when deleting the current device', async () => {
+    const response = await buildRequester().delete(
+      `/my-account/trusted-devices/${trustedDeviceId}`
+    );
+
+    expect(response.status).toBe(204);
+    expect(clearCredential).toHaveBeenCalledWith(expect.any(Object), mockUser.id);
+  });
+
+  it('rejects DELETE for read-only permission', async () => {
+    const response = await buildRequester({ field: AccountCenterControlValue.ReadOnly }).delete(
+      `/my-account/trusted-devices/${trustedDeviceId}`
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty('code', 'account_center.field_not_editable');
+    expect(deleteByIdAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('rejects DELETE from a third-party application', async () => {
+    assertFirstPartyClient.mockRejectedValueOnce(
+      new RequestError({ code: 'auth.third_party_application_forbidden', status: 403 })
+    );
+
+    const response = await buildRequester({ clientId: 'third-party-application' }).delete(
+      `/my-account/trusted-devices/${trustedDeviceId}`
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.body).toHaveProperty('code', 'auth.third_party_application_forbidden');
+    expect(deleteByIdAndUserId).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for a missing or non-owned trusted device', async () => {
+    // eslint-disable-next-line unicorn/no-useless-undefined -- Jest requires an explicit resolved value for this typed mock.
+    deleteByIdAndUserId.mockResolvedValueOnce(undefined);
+
+    const response = await buildRequester().delete('/my-account/trusted-devices/nonowned');
+
+    expect(response.status).toBe(404);
+    expect(clearCredential).not.toHaveBeenCalled();
+  });
+
+  it('does not register the routes when dev features are disabled', async () => {
+    const response = await buildRequester({ isDevFeaturesEnabled: false }).get(
+      '/my-account/trusted-devices'
+    );
+
+    expect(response.status).toBe(404);
+    expect(validateCredential).not.toHaveBeenCalled();
+    expect(findActiveByUserId).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/routes/account/trusted-device.ts
+++ b/packages/core/src/routes/account/trusted-device.ts
@@ -1,0 +1,127 @@
+import { UserScope } from '@logto/core-kit';
+import {
+  AccountCenterControlValue,
+  accountTrustedDeviceResponseGuard,
+  type AccountTrustedDeviceResponse,
+} from '@logto/schemas';
+import { pick } from '@silverhand/essentials';
+import { z } from 'zod';
+
+import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
+import koaGuard from '#src/middleware/koa-guard.js';
+import koaPagination from '#src/middleware/koa-pagination.js';
+import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
+import assertThat from '#src/utils/assert-that.js';
+
+import { type UserRouter, type RouterInitArgs } from '../types.js';
+
+import { accountApiPrefix } from './constants.js';
+
+export default function accountTrustedDeviceRoutes<T extends UserRouter>(
+  ...[router, { libraries, queries }]: RouterInitArgs<T>
+) {
+  // DEV: MFA trusted device management
+  if (!EnvSet.values.isDevFeaturesEnabled) {
+    return;
+  }
+
+  const { trustedDevices } = queries;
+  const { trustedDevices: trustedDeviceLibrary } = libraries;
+
+  router.get(
+    `${accountApiPrefix}/trusted-devices`,
+    koaPagination(),
+    koaGuard({
+      response: accountTrustedDeviceResponseGuard.array(),
+      status: [200, 400, 401, 500],
+    }),
+    async (ctx, next) => {
+      const { id: userId, scopes, identityVerified } = ctx.auth;
+      const { fields } = ctx.accountCenter;
+
+      assertThat(
+        identityVerified,
+        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
+      );
+      assertThat(
+        fields.trustedDevice === AccountCenterControlValue.Edit ||
+          fields.trustedDevice === AccountCenterControlValue.ReadOnly,
+        'account_center.field_not_enabled'
+      );
+      assertThat(
+        scopes.has(UserScope.TrustedDevices),
+        new RequestError({ code: 'auth.unauthorized', status: 401 })
+      );
+      const { limit, offset } = ctx.pagination;
+      const [currentTrustedDevice, [totalNumber, records]] = await Promise.all([
+        trustedDeviceLibrary.validateCredential(ctx, userId),
+        trustedDevices.findActiveByUserId(userId, { limit, offset }),
+      ]);
+
+      ctx.pagination.totalCount = totalNumber;
+      ctx.body = records.map(
+        (record) =>
+          ({
+            ...pick(
+              record,
+              'id',
+              'userAgent',
+              'country',
+              'city',
+              'createdAt',
+              'lastUsedAt',
+              'expiresAt'
+            ),
+            isCurrent: record.id === currentTrustedDevice?.id,
+          }) satisfies AccountTrustedDeviceResponse
+      );
+
+      return next();
+    }
+  );
+
+  router.delete(
+    `${accountApiPrefix}/trusted-devices/:trustedDeviceId`,
+    koaGuard({
+      params: z.object({ trustedDeviceId: z.string().min(1) }),
+      status: [204, 400, 401, 403, 404, 500],
+    }),
+    async (ctx, next) => {
+      const { trustedDeviceId } = ctx.guard.params;
+      const { id: userId, scopes, identityVerified, clientId } = ctx.auth;
+      const { fields } = ctx.accountCenter;
+
+      assertThat(
+        identityVerified,
+        new RequestError({ code: 'verification_record.permission_denied', status: 401 })
+      );
+      assertThat(
+        fields.trustedDevice === AccountCenterControlValue.Edit,
+        'account_center.field_not_editable'
+      );
+      assertThat(
+        scopes.has(UserScope.TrustedDevices),
+        new RequestError({ code: 'auth.unauthorized', status: 401 })
+      );
+      await assertFirstPartyClient(queries, clientId);
+
+      const currentTrustedDevice = await trustedDeviceLibrary.validateCredential(ctx, userId);
+      const trustedDevice = await trustedDeviceLibrary.deleteByIdAndUserId(
+        ctx,
+        trustedDeviceId,
+        userId
+      );
+
+      assertThat(trustedDevice, new RequestError({ code: 'entity.not_found', status: 404 }));
+
+      if (trustedDevice.id === currentTrustedDevice?.id) {
+        trustedDeviceLibrary.clearCredential(ctx, userId);
+      }
+
+      ctx.status = 204;
+
+      return next();
+    }
+  );
+}

--- a/packages/core/src/routes/swagger/utils/documents.ts
+++ b/packages/core/src/routes/swagger/utils/documents.ts
@@ -182,13 +182,17 @@ export const buildExperienceApiBaseDocument = (
 });
 
 // ID parameters for account API entities.
-const userApiIdentifiableEntityNames = Object.freeze([
-  'profile',
-  'verification',
-  'connector',
-  'session',
-  'grant',
-]);
+const userApiIdentifiableEntityNames = Object.freeze(
+  condArray<string>(
+    'profile',
+    'verification',
+    'connector',
+    'session',
+    // DEV: MFA trusted device management
+    EnvSet.values.isDevFeaturesEnabled && 'trusted-device',
+    'grant'
+  )
+);
 
 export const buildUserApiBaseDocument = (
   pathMap: Map<string, OpenAPIV3.PathItemObject>,

--- a/packages/integration-tests/src/api/my-account.ts
+++ b/packages/integration-tests/src/api/my-account.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountTrustedDeviceResponse,
   GetAccountUserSessionsResponse,
   GetUserApplicationGrantsResponse,
   GetThirdPartyAccessTokenResponse,
@@ -256,5 +257,34 @@ export const deleteSession = async (
         options?.revokeGrantsTarget && { revokeGrantsTarget: options.revokeGrantsTarget }
       ),
     }),
+    headers: { [verificationRecordIdHeader]: verificationRecordId },
+  });
+
+export const getTrustedDevicesResponse = async (
+  api: KyInstance,
+  verificationRecordId: string,
+  searchParams?: URLSearchParams
+) =>
+  api.get('api/my-account/trusted-devices', {
+    searchParams,
+    headers: { [verificationRecordIdHeader]: verificationRecordId },
+  });
+
+export const getTrustedDevices = async (
+  api: KyInstance,
+  verificationRecordId: string,
+  searchParams?: URLSearchParams
+) => {
+  const response = await getTrustedDevicesResponse(api, verificationRecordId, searchParams);
+
+  return response.json<AccountTrustedDeviceResponse[]>();
+};
+
+export const deleteTrustedDevice = async (
+  api: KyInstance,
+  trustedDeviceId: string,
+  verificationRecordId: string
+) =>
+  api.delete(`api/my-account/trusted-devices/${trustedDeviceId}`, {
     headers: { [verificationRecordIdHeader]: verificationRecordId },
   });

--- a/packages/integration-tests/src/tests/api/account/trusted-device.test.ts
+++ b/packages/integration-tests/src/tests/api/account/trusted-device.test.ts
@@ -1,0 +1,353 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+import { UserScope } from '@logto/core-kit';
+import {
+  AccountCenterControlValue,
+  defaultTenantId,
+  type AccountTrustedDeviceResponse,
+  type User,
+} from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import { assert, assertEnv } from '@silverhand/essentials';
+import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
+import { type KyInstance } from 'ky';
+
+import { updateAccountCenter } from '#src/api/account-center.js';
+import { baseApi } from '#src/api/api.js';
+import {
+  deleteTrustedDevice,
+  getSessions,
+  getTrustedDevices,
+  getTrustedDevicesResponse,
+} from '#src/api/my-account.js';
+import { createVerificationRecordByPassword } from '#src/api/verification-record.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  createDefaultTenantUserWithPassword,
+  deleteDefaultTenantUser,
+  initClientAndSignInForDefaultTenant,
+} from '#src/helpers/profile.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { devFeatureTest } from '#src/utils.js';
+
+type TestUser = Readonly<{
+  user: User;
+  password: string;
+  accessToken: string;
+  api: KyInstance;
+  verificationRecordId: string;
+}>;
+
+const getTrustedDeviceCookieName = (userId: string) => {
+  const subjectHash = createHash('sha256')
+    .update(`${defaultTenantId}:${userId}`)
+    .digest('base64url');
+
+  return `__Host-logto-trusted-device-${subjectHash}`;
+};
+
+const createCredential = (id: string) => {
+  const secret = randomBytes(32).toString('base64url');
+  const secretHash = createHash('sha256').update(Buffer.from(secret, 'base64url')).digest();
+
+  return { id, secret, secretHash };
+};
+
+const buildApiWithCredential = (accessToken: string, userId: string, id: string, secret: string) =>
+  baseApi.extend({
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Cookie: `${getTrustedDeviceCookieName(userId)}=${id}.${secret}`,
+      'X-Forwarded-Proto': 'https',
+    },
+  });
+
+const createTestUser = async (
+  scopes: UserScope[] = [UserScope.TrustedDevices]
+): Promise<TestUser> => {
+  const { user, username, password } = await createDefaultTenantUserWithPassword();
+  const client = await initClientAndSignInForDefaultTenant(username, password, { scopes });
+  const accessToken = await client.getAccessToken();
+  const api = baseApi.extend({ headers: { Authorization: `Bearer ${accessToken}` } });
+  const verificationRecordId = await createVerificationRecordByPassword(api, password);
+
+  return { user, password, accessToken, api, verificationRecordId };
+};
+
+devFeatureTest.describe('account trusted device management', () => {
+  /* eslint-disable @silverhand/fp/no-let -- Integration setup resources are initialized in hooks. */
+  let pool: DatabasePool;
+  let owner: TestUser;
+  let anotherUser: TestUser;
+  let ownerWithoutTrustedDevicesScope: TestUser;
+  let currentCredential: ReturnType<typeof createCredential>;
+  let remoteCredential: ReturnType<typeof createCredential>;
+  /* eslint-enable @silverhand/fp/no-let */
+
+  const insertTrustedDevice = async ({
+    id,
+    secretHash,
+    userId,
+    createdAt,
+  }: Readonly<{
+    id: string;
+    secretHash: Uint8Array;
+    userId: string;
+    createdAt: number;
+  }>) => {
+    await pool.query(sql`
+      insert into trusted_devices (
+        tenant_id,
+        id,
+        user_id,
+        secret_hash,
+        user_agent,
+        ip,
+        country,
+        city,
+        created_at,
+        last_used_at,
+        expires_at
+      ) values (
+        ${defaultTenantId},
+        ${id},
+        ${userId},
+        ${sql.binary(Buffer.from(secretHash))},
+        ${'Integration test browser'},
+        ${'192.0.2.1'},
+        ${'US'},
+        ${'San Francisco'},
+        to_timestamp(${createdAt}::double precision / 1000),
+        to_timestamp(${createdAt + 100}::double precision / 1000),
+        to_timestamp(${Date.now() + 24 * 60 * 60 * 1000}::double precision / 1000)
+      )
+    `);
+  };
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+
+    /* eslint-disable @silverhand/fp/no-mutation -- Initialize integration resources once. */
+    pool = await createPool(assertEnv('DB_URL'), {
+      interceptors: createInterceptorsPreset(),
+    });
+    owner = await createTestUser([UserScope.TrustedDevices, UserScope.Sessions]);
+    anotherUser = await createTestUser();
+    ownerWithoutTrustedDevicesScope = await createTestUser([]);
+    /* eslint-enable @silverhand/fp/no-mutation */
+  });
+
+  beforeEach(async () => {
+    await updateAccountCenter({
+      enabled: true,
+      fields: { trustedDevice: AccountCenterControlValue.Edit },
+    });
+    await pool.query(sql`
+      delete from trusted_devices
+      where user_id in (${owner.user.id}, ${anotherUser.user.id})
+    `);
+
+    const now = Date.now();
+    /* eslint-disable @silverhand/fp/no-mutation -- Refresh per-test credentials and records. */
+    currentCredential = createCredential(generateStandardId());
+    remoteCredential = createCredential(generateStandardId());
+    /* eslint-enable @silverhand/fp/no-mutation */
+
+    await Promise.all([
+      insertTrustedDevice({
+        ...currentCredential,
+        userId: owner.user.id,
+        createdAt: now,
+      }),
+      insertTrustedDevice({
+        ...remoteCredential,
+        userId: owner.user.id,
+        createdAt: now - 1000,
+      }),
+    ]);
+  });
+
+  afterAll(async () => {
+    await pool.query(sql`
+      delete from trusted_devices
+      where user_id in (${owner.user.id}, ${anotherUser.user.id})
+    `);
+    await Promise.all([
+      deleteDefaultTenantUser(owner.user.id),
+      deleteDefaultTenantUser(anotherUser.user.id),
+      deleteDefaultTenantUser(ownerWithoutTrustedDevicesScope.user.id),
+    ]);
+    await pool.end();
+  });
+
+  it('returns paginated redacted records and marks only a fully validated credential as current', async () => {
+    const api = buildApiWithCredential(
+      owner.accessToken,
+      owner.user.id,
+      currentCredential.id,
+      currentCredential.secret
+    );
+    const firstPageResponse = await getTrustedDevicesResponse(
+      api,
+      owner.verificationRecordId,
+      new URLSearchParams({ page: '1', page_size: '1' })
+    );
+    const firstPage = await firstPageResponse.json<AccountTrustedDeviceResponse[]>();
+    const [firstDevice] = firstPage;
+    assert(firstDevice, new Error('Expected the first trusted-device page'));
+
+    expect(firstPageResponse.headers.get('total-number')).toBe('2');
+    expect(firstPageResponse.headers.get('link')).toContain('rel="next"');
+    expect(firstPage).toEqual([
+      expect.objectContaining({ id: currentCredential.id, isCurrent: true }),
+    ]);
+    expect(firstDevice).toMatchObject({
+      id: currentCredential.id,
+      userAgent: 'Integration test browser',
+      country: 'US',
+      city: 'San Francisco',
+      isCurrent: true,
+    });
+    expect(typeof firstDevice.createdAt).toBe('number');
+    expect(typeof firstDevice.lastUsedAt).toBe('number');
+    expect(typeof firstDevice.expiresAt).toBe('number');
+    expect(JSON.stringify(firstPage)).not.toContain('192.0.2.1');
+    expect(JSON.stringify(firstPage)).not.toContain('secretHash');
+
+    const secondPage = await getTrustedDevices(
+      api,
+      owner.verificationRecordId,
+      new URLSearchParams({ page: '2', page_size: '1' })
+    );
+    expect(secondPage).toEqual([
+      expect.objectContaining({ id: remoteCredential.id, isCurrent: false }),
+    ]);
+  });
+
+  it('never marks a record current when the cookie ID matches but the secret is invalid', async () => {
+    const api = buildApiWithCredential(
+      owner.accessToken,
+      owner.user.id,
+      currentCredential.id,
+      randomBytes(32).toString('base64url')
+    );
+
+    const devices = await getTrustedDevices(api, owner.verificationRecordId);
+
+    expect(devices).toHaveLength(2);
+    expect(devices.every(({ isCurrent }) => !isCurrent)).toBeTruthy();
+  });
+
+  it('requires identity verification and the trusted-devices scope', async () => {
+    await expectRejects(getTrustedDevices(owner.api, ''), {
+      code: 'verification_record.permission_denied',
+      status: 401,
+    });
+    await expectRejects(
+      getTrustedDevices(
+        ownerWithoutTrustedDevicesScope.api,
+        ownerWithoutTrustedDevicesScope.verificationRecordId
+      ),
+      { code: 'auth.unauthorized', status: 401 }
+    );
+  });
+
+  it('enforces independent Off, ReadOnly, and Edit permissions', async () => {
+    await updateAccountCenter({
+      fields: { trustedDevice: AccountCenterControlValue.Off },
+    });
+    await expectRejects(getTrustedDevices(owner.api, owner.verificationRecordId), {
+      code: 'account_center.field_not_enabled',
+      status: 400,
+    });
+
+    await updateAccountCenter({
+      fields: { trustedDevice: AccountCenterControlValue.ReadOnly },
+    });
+    await expect(getTrustedDevices(owner.api, owner.verificationRecordId)).resolves.toHaveLength(2);
+    await expectRejects(
+      deleteTrustedDevice(owner.api, remoteCredential.id, owner.verificationRecordId),
+      { code: 'account_center.field_not_editable', status: 400 }
+    );
+
+    await updateAccountCenter({
+      fields: { trustedDevice: AccountCenterControlValue.Edit },
+    });
+    await expect(
+      deleteTrustedDevice(owner.api, remoteCredential.id, owner.verificationRecordId)
+    ).resolves.toHaveProperty('status', 204);
+  });
+
+  it('constrains removal to the authenticated owner', async () => {
+    await expectRejects(
+      deleteTrustedDevice(anotherUser.api, remoteCredential.id, anotherUser.verificationRecordId),
+      { code: 'entity.not_found', status: 404 }
+    );
+
+    const devices = await getTrustedDevices(owner.api, owner.verificationRecordId);
+    expect(devices.map(({ id }) => id)).toContain(remoteCredential.id);
+  });
+
+  it('clears the credential but preserves the login session when removing the current record', async () => {
+    await updateAccountCenter({
+      fields: {
+        session: AccountCenterControlValue.ReadOnly,
+        trustedDevice: AccountCenterControlValue.Edit,
+      },
+    });
+    const api = buildApiWithCredential(
+      owner.accessToken,
+      owner.user.id,
+      currentCredential.id,
+      currentCredential.secret
+    );
+
+    const response = await deleteTrustedDevice(
+      api,
+      currentCredential.id,
+      owner.verificationRecordId
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('set-cookie')).toContain(
+      `${getTrustedDeviceCookieName(owner.user.id)}=;`
+    );
+    await expect(getSessions(owner.api, owner.verificationRecordId)).resolves.toHaveProperty(
+      'sessions'
+    );
+  });
+
+  it('leaves a remote cookie untouched on removal and clears it when it is later presented', async () => {
+    const currentApi = buildApiWithCredential(
+      owner.accessToken,
+      owner.user.id,
+      currentCredential.id,
+      currentCredential.secret
+    );
+
+    const deletionResponse = await deleteTrustedDevice(
+      currentApi,
+      remoteCredential.id,
+      owner.verificationRecordId
+    );
+    expect(deletionResponse.headers.get('set-cookie')).toBeNull();
+
+    const removedDeviceApi = buildApiWithCredential(
+      owner.accessToken,
+      owner.user.id,
+      remoteCredential.id,
+      remoteCredential.secret
+    );
+    const listResponse = await getTrustedDevicesResponse(
+      removedDeviceApi,
+      owner.verificationRecordId
+    );
+    const devices = await listResponse.json<Array<{ isCurrent: boolean }>>();
+
+    assert(devices.length > 0, new Error('Expected the remaining trusted device'));
+    expect(devices.every(({ isCurrent }) => !isCurrent)).toBeTruthy();
+    expect(listResponse.headers.get('set-cookie')).toContain(
+      `${getTrustedDeviceCookieName(owner.user.id)}=;`
+    );
+  });
+});

--- a/packages/phrases/src/locales/ar/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/sign-in-exp/index.ts
@@ -184,6 +184,7 @@ const sign_in_exp = {
       custom_data: 'بيانات مخصصة',
       custom_data_description: 'تحكم في الوصول إلى بيانات JSON المخصصة المخزنة للمستخدم.',
       sessions: 'إدارة الجلسات',
+      trusted_devices: 'الأجهزة الموثوقة',
     },
     profile_fields: {
       title: 'حقول الملف الشخصي لمركز الحساب الجاهز',

--- a/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/sign-in-exp/index.ts
@@ -187,6 +187,7 @@ const sign_in_exp = {
       custom_data_description:
         'Steuern Sie den Zugriff auf benutzerdefinierte JSON-Daten, die beim Benutzer gespeichert sind.',
       sessions: 'Sitzungen',
+      trusted_devices: 'Vertrauenswürdige Geräte',
     },
     profile_fields: {
       title: 'Profilfelder für vorgefertigtes Konto-Center',

--- a/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/sign-in-exp/index.ts
@@ -187,6 +187,7 @@ const sign_in_exp = {
       custom_data: 'Custom data',
       custom_data_description: 'Control access to custom JSON data stored on the user.',
       sessions: 'Sessions',
+      trusted_devices: 'Trusted devices',
     },
     profile_fields: {
       title: 'Profile fields for prebuilt account center',

--- a/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/sign-in-exp/index.ts
@@ -191,6 +191,7 @@ const sign_in_exp = {
       custom_data_description:
         'Controla el acceso a los datos JSON personalizados almacenados en el usuario.',
       sessions: 'Sesiones',
+      trusted_devices: 'Dispositivos de confianza',
     },
     profile_fields: {
       title: 'Campos de perfil para el centro de cuenta prediseñado',

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/sign-in-exp/index.ts
@@ -187,6 +187,7 @@ const sign_in_exp = {
       custom_data: 'داده‌های سفارشی',
       custom_data_description: 'کنترل دسترسی به داده‌های JSON سفارشی ذخیره‌شده روی کاربر.',
       sessions: 'نشست‌ها',
+      trusted_devices: 'دستگاه‌های مورد اعتماد',
     },
     profile_fields: {
       title: 'فیلدهای پروفایل برای مرکز حساب از پیش‌ساخته',

--- a/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/sign-in-exp/index.ts
@@ -190,6 +190,7 @@ const sign_in_exp = {
       custom_data_description:
         'Contrôlez l’accès aux données JSON personnalisées stockées sur l’utilisateur.',
       sessions: 'Sessions',
+      trusted_devices: 'Appareils de confiance',
     },
     profile_fields: {
       title: 'Champs de profil pour le centre de compte prédéfini',

--- a/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/sign-in-exp/index.ts
@@ -188,6 +188,7 @@ const sign_in_exp = {
       custom_data_description:
         'Controlla l’accesso ai dati JSON personalizzati archiviati sull’utente.',
       sessions: 'Sessioni',
+      trusted_devices: 'Dispositivi attendibili',
     },
     profile_fields: {
       title: 'Campi del profilo per il centro account predefinito',

--- a/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/sign-in-exp/index.ts
@@ -187,6 +187,7 @@ const sign_in_exp = {
       custom_data_description:
         'ユーザーに保存されているカスタム JSON データへのアクセスを制御します。',
       sessions: 'セッション',
+      trusted_devices: '信頼済みデバイス',
     },
     profile_fields: {
       title: 'ビルトインアカウントセンターのプロフィールフィールド',

--- a/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/sign-in-exp/index.ts
@@ -183,6 +183,7 @@ const sign_in_exp = {
       custom_data: '사용자 정의 데이터',
       custom_data_description: '사용자에 저장된 사용자 정의 JSON 데이터에 대한 접근을 제어합니다.',
       sessions: '세션',
+      trusted_devices: '신뢰할 수 있는 기기',
     },
     profile_fields: {
       title: '사전 구축된 계정 센터의 프로필 필드',

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/sign-in-exp/index.ts
@@ -187,6 +187,7 @@ const sign_in_exp = {
       custom_data_description:
         'Kontroluj dostęp do niestandardowych danych JSON przechowywanych przy użytkowniku.',
       sessions: 'Sesje',
+      trusted_devices: 'Zaufane urządzenia',
     },
     profile_fields: {
       title: 'Pola profilu dla gotowego centrum konta',

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/sign-in-exp/index.ts
@@ -188,6 +188,7 @@ const sign_in_exp = {
       custom_data_description:
         'Controle o acesso aos dados JSON personalizados armazenados no usuário.',
       sessions: 'Sessões',
+      trusted_devices: 'Dispositivos confiáveis',
     },
     profile_fields: {
       title: 'Campos de perfil para o centro de conta pré-construído',

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/sign-in-exp/index.ts
@@ -189,6 +189,7 @@ const sign_in_exp = {
       custom_data_description:
         'Controle o acesso aos dados JSON personalizados guardados no utilizador.',
       sessions: 'Sessões',
+      trusted_devices: 'Dispositivos de confiança',
     },
     profile_fields: {
       title: 'Campos de perfil para o centro de conta pré-construído',

--- a/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/sign-in-exp/index.ts
@@ -187,6 +187,7 @@ const sign_in_exp = {
       custom_data_description:
         'Управляйте доступом к пользовательским JSON-данным, хранящимся у пользователя.',
       sessions: 'Сессии',
+      trusted_devices: 'Доверенные устройства',
     },
     profile_fields: {
       title: 'Поля профиля для готового центра учётной записи',

--- a/packages/phrases/src/locales/th/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/sign-in-exp/index.ts
@@ -185,6 +185,7 @@ const sign_in_exp = {
       custom_data: 'ข้อมูลแบบกำหนดเอง',
       custom_data_description: 'ควบคุมการเข้าถึงข้อมูล JSON แบบกำหนดเองที่เก็บไว้กับผู้ใช้.',
       sessions: 'การจัดการเซสชัน',
+      trusted_devices: 'อุปกรณ์ที่เชื่อถือได้',
     },
     profile_fields: {
       title: 'ฟิลด์โปรไฟล์สำหรับศูนย์บัญชีที่สร้างไว้ล่วงหน้า',

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/sign-in-exp/index.ts
@@ -187,6 +187,7 @@ const sign_in_exp = {
       custom_data: 'Özel veriler',
       custom_data_description: 'Kullanıcıda saklanan özel JSON verilerine erişimi kontrol edin.',
       sessions: 'Oturumlar',
+      trusted_devices: 'Güvenilir cihazlar',
     },
     profile_fields: {
       title: 'Önceden oluşturulmuş hesap merkezi için profil alanları',

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/sign-in-exp/index.ts
@@ -180,6 +180,7 @@ const sign_in_exp = {
       custom_data: '自定义数据',
       custom_data_description: '控制对存储在用户上的自定义 JSON 数据的访问。',
       sessions: '会话',
+      trusted_devices: '可信设备',
     },
     profile_fields: {
       title: '预构建账户中心的资料字段',

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/sign-in-exp/index.ts
@@ -180,6 +180,7 @@ const sign_in_exp = {
       custom_data: '自訂資料',
       custom_data_description: '控制對儲存在使用者上的自訂 JSON 資料的存取權。',
       sessions: '會話',
+      trusted_devices: '受信任裝置',
     },
     profile_fields: {
       title: '預構建帳戶中心的檔案欄位',

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/index.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/sign-in-exp/index.ts
@@ -180,6 +180,7 @@ const sign_in_exp = {
       custom_data: '自訂資料',
       custom_data_description: '控制對儲存在使用者上的自訂 JSON 資料的存取。',
       sessions: '會話',
+      trusted_devices: '受信任裝置',
     },
     profile_fields: {
       title: '預建帳戶中心的檔案欄位',

--- a/packages/schemas/src/types/trusted-device.ts
+++ b/packages/schemas/src/types/trusted-device.ts
@@ -1,4 +1,4 @@
-import { type z } from 'zod';
+import { z } from 'zod';
 
 import { TrustedDevices } from '../db-entries/index.js';
 
@@ -14,3 +14,10 @@ export const trustedDeviceResponseGuard = TrustedDevices.guard.pick({
 });
 
 export type TrustedDeviceResponse = z.infer<typeof trustedDeviceResponseGuard>;
+
+/** Account API trusted-device metadata with current-browser state. */
+export const accountTrustedDeviceResponseGuard = trustedDeviceResponseGuard.extend({
+  isCurrent: z.boolean(),
+});
+
+export type AccountTrustedDeviceResponse = z.infer<typeof accountTrustedDeviceResponseGuard>;


### PR DESCRIPTION
## Summary

- add paginated Account API endpoints to list and remove trusted devices with independent permissions, identity verification, ownership checks, and first-party mutation protection
- authorize trusted-device management with the dedicated trusted-device scope and request it from Hosted Account Center
- expose trusted-device controls in Console and keep Account API schemas, OpenAPI, and localized controls aligned

## Testing

Unit tests
Integration tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
