### PR TITLE
fix(console): hide the dynamic app entrance once enabled

### DIFF
--- a/packages/console/src/components/Guide/hooks.tsx
+++ b/packages/console/src/components/Guide/hooks.tsx
@@ -8,7 +8,9 @@ import { isCloud as isCloudEnv, isDevFeaturesEnabled, isProtectedAppEnabled } fr
 import { thirdPartyApp } from '@/consts/external-links';
 import TextLink from '@/ds-components/TextLink';
 import useDocumentationUrl from '@/hooks/use-documentation-url';
+import useDynamicApp from '@/hooks/use-dynamic-app';
 import {
+  dynamicAppGuideId,
   thirdPartyAppCategory,
   type AppGuideCategory,
   type StructuredAppGuideMetadata,
@@ -42,18 +44,25 @@ export const useAppGuideMetadata = (): {
 } => {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const { getDocumentationUrl } = useDocumentationUrl();
+  const { enabled: isDynamicAppEnabled, isLoading: isDynamicAppLoading } = useDynamicApp();
 
   const appGuides = useMemo(
     () =>
       guides.filter(
-        ({ metadata: { target, isCloud, isDevFeature } }) =>
+        ({ id, metadata: { target, isCloud, isDevFeature } }) =>
           target !== 'API' &&
           (isCloudEnv ||
             !isCloud ||
             (isProtectedAppEnabled && target === ApplicationType.Protected)) &&
-          (isDevFeaturesEnabled || !isDevFeature)
+          (isDevFeaturesEnabled || !isDevFeature) &&
+          /**
+           * The dynamic app card only offers to turn the feature on, so it is pointless once
+           * enabled. It also stays hidden while the config is in flight, otherwise it would flash
+           * in and out for tenants that already enabled it.
+           */
+          (id !== dynamicAppGuideId || !(isDynamicAppEnabled || isDynamicAppLoading))
       ),
-    []
+    [isDynamicAppEnabled, isDynamicAppLoading]
   );
 
   const getFilteredAppGuideMetadata = useCallback(


### PR DESCRIPTION
## Summary

Hide the dynamic app guide card in the application creation surfaces once the tenant-level CIMD switch is on.

- The card only offers to enable the feature, so it is pointless (and re-triggers the same confirm modal) after it is enabled.
- Filtering happens in `useAppGuideMetadata`, which backs every guide surface: the creation modal, keyword search results, the third-party guide library, the empty-state library and the guide drawer.
- The card stays hidden until the tenant config is loaded and reports the feature as disabled, so it never flashes in and out while the request is in flight.

## Testing

Tested locally.

## Checklist

- [x] `.changeset` (N/A, dev feature only)
- [ ] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments