### PR TITLE
feat(core,phrases,toolkit): add trusted device user scope

### DIFF
--- a/packages/core/src/oidc/scope.test.ts
+++ b/packages/core/src/oidc/scope.test.ts
@@ -136,11 +136,19 @@ describe('OIDC getUserClaims()', () => {
     ).toEqual([...profileExpectation, 'custom_data', 'identities', 'sso_identities']);
   });
 
-  it('should ignore account API session scope in getUserClaims()', () => {
+  it('should ignore account API management scopes in getUserClaims()', () => {
     expect(
       getAcceptedUserClaims({
         use: use.idToken,
-        scope: 'openid profile urn:logto:scope:sessions',
+        scope: 'openid profile urn:logto:scope:sessions urn:logto:scope:trusted_devices',
+        rejected: [],
+      })
+    ).toEqual(profileExpectation);
+
+    expect(
+      getAcceptedUserClaims({
+        use: use.userinfo,
+        scope: 'openid profile urn:logto:scope:sessions urn:logto:scope:trusted_devices',
         rejected: [],
       })
     ).toEqual(profileExpectation);

--- a/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
@@ -119,6 +119,7 @@ describe('OIDC discovery', () => {
           "urn:logto:scope:organizations",
           "urn:logto:scope:organization_roles",
           "urn:logto:scope:sessions",
+          "urn:logto:scope:trusted_devices",
         ],
         "subject_types_supported": [
           "public",

--- a/packages/phrases-experience/src/locales/ar/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/ar/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'أدوار المنظمة الخاصة بك',
     address: 'عنوانك',
     'urn:logto:scope:sessions': 'جلساتك النشطة',
+    'urn:logto:scope:trusted_devices': 'أجهزتك الموثوقة',
   },
 };
 

--- a/packages/phrases-experience/src/locales/cs/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/cs/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Role v tvé organizaci',
     address: 'Tvá adresa',
     'urn:logto:scope:sessions': 'Tvé aktivní relace',
+    'urn:logto:scope:trusted_devices': 'Tvá důvěryhodná zařízení',
   },
 };
 

--- a/packages/phrases-experience/src/locales/de/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/de/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Deine Rollen in der Organisation',
     address: 'Deine Adresse',
     'urn:logto:scope:sessions': 'Deine aktiven Sitzungen',
+    'urn:logto:scope:trusted_devices': 'Deine vertrauenswürdigen Geräte',
   },
 };
 

--- a/packages/phrases-experience/src/locales/en/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/en/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Your organization roles',
     address: 'Your address',
     'urn:logto:scope:sessions': 'Your active sessions',
+    'urn:logto:scope:trusted_devices': 'Your trusted devices',
   },
 };
 

--- a/packages/phrases-experience/src/locales/es/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/es/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Tus roles en la organización',
     address: 'Tu dirección',
     'urn:logto:scope:sessions': 'Tus sesiones activas',
+    'urn:logto:scope:trusted_devices': 'Tus dispositivos de confianza',
   },
 };
 

--- a/packages/phrases-experience/src/locales/fa-ir/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/fa-ir/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'نقش‌های سازمانی شما',
     address: 'نشانی شما',
     'urn:logto:scope:sessions': 'نشست‌های فعال شما',
+    'urn:logto:scope:trusted_devices': 'دستگاه‌های مورد اعتماد شما',
   },
 };
 

--- a/packages/phrases-experience/src/locales/fr/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/fr/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': "Vos rôles dans l'organisation",
     address: 'Votre adresse',
     'urn:logto:scope:sessions': 'Vos sessions actives',
+    'urn:logto:scope:trusted_devices': 'Vos appareils de confiance',
   },
 };
 

--- a/packages/phrases-experience/src/locales/it/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/it/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'I tuoi ruoli organizzativi',
     address: 'Il tuo indirizzo',
     'urn:logto:scope:sessions': 'Le tue sessioni attive',
+    'urn:logto:scope:trusted_devices': 'I tuoi dispositivi attendibili',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ja/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/ja/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'あなたの組織の役割',
     address: 'あなたの住所',
     'urn:logto:scope:sessions': 'あなたのアクティブセッション',
+    'urn:logto:scope:trusted_devices': 'あなたの信頼済みデバイス',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ko/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/ko/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': '조직 역할',
     address: '주소',
     'urn:logto:scope:sessions': '활성 세션',
+    'urn:logto:scope:trusted_devices': '신뢰할 수 있는 기기',
   },
 };
 

--- a/packages/phrases-experience/src/locales/pl-pl/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Twoje role w organizacji',
     address: 'Twój adres',
     'urn:logto:scope:sessions': 'Twoje aktywne sesje',
+    'urn:logto:scope:trusted_devices': 'Twoje zaufane urządzenia',
   },
 };
 

--- a/packages/phrases-experience/src/locales/pt-br/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/pt-br/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Seus papéis na organização',
     address: 'Seu endereço',
     'urn:logto:scope:sessions': 'Suas sessões ativas',
+    'urn:logto:scope:trusted_devices': 'Seus dispositivos confiáveis',
   },
 };
 

--- a/packages/phrases-experience/src/locales/pt-pt/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Os teus papéis na organização',
     address: 'A tua morada',
     'urn:logto:scope:sessions': 'As tuas sessões ativas',
+    'urn:logto:scope:trusted_devices': 'Os teus dispositivos de confiança',
   },
 };
 

--- a/packages/phrases-experience/src/locales/ru/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/ru/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Ваши организационные роли',
     address: 'Ваш адрес',
     'urn:logto:scope:sessions': 'Ваши активные сессии',
+    'urn:logto:scope:trusted_devices': 'Ваши доверенные устройства',
   },
 };
 

--- a/packages/phrases-experience/src/locales/th/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/th/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'บทบาทในองค์กรของคุณ',
     address: 'ที่อยู่ของคุณ',
     'urn:logto:scope:sessions': 'เซสชันที่ใช้งานอยู่ของคุณ',
+    'urn:logto:scope:trusted_devices': 'อุปกรณ์ที่เชื่อถือได้ของคุณ',
   },
 };
 

--- a/packages/phrases-experience/src/locales/tr-tr/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Organizasyon rollerin',
     address: 'Adresin',
     'urn:logto:scope:sessions': 'Aktif oturumların',
+    'urn:logto:scope:trusted_devices': 'Güvenilir cihazların',
   },
 };
 

--- a/packages/phrases-experience/src/locales/uk-ua/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': 'Ваша роль організації',
     address: 'Ваша адреса',
     'urn:logto:scope:sessions': 'Ваші активні сесії',
+    'urn:logto:scope:trusted_devices': 'Ваші довірені пристрої',
   },
 };
 

--- a/packages/phrases-experience/src/locales/zh-cn/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': '你的组织角色',
     address: '你的地址',
     'urn:logto:scope:sessions': '你的活跃会话',
+    'urn:logto:scope:trusted_devices': '你的可信设备',
   },
 };
 

--- a/packages/phrases-experience/src/locales/zh-hk/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': '你的組織角色',
     address: '你的地址',
     'urn:logto:scope:sessions': '你的活動會話',
+    'urn:logto:scope:trusted_devices': '你的受信任裝置',
   },
 };
 

--- a/packages/phrases-experience/src/locales/zh-tw/user-scopes.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/user-scopes.ts
@@ -10,6 +10,7 @@ const user_scopes = {
     'urn:logto:scope:organization_roles': '你的組織角色',
     address: '你的地址',
     'urn:logto:scope:sessions': '你的有效會話',
+    'urn:logto:scope:trusted_devices': '你的受信任裝置',
   },
 };
 

--- a/packages/toolkit/core-kit/src/openid.ts
+++ b/packages/toolkit/core-kit/src/openid.ts
@@ -144,6 +144,13 @@ export enum UserScope {
    * Not included in user claims, even when the scope is requested, as it's not meant for ID token or userinfo endpoint.
    */
   Sessions = 'urn:logto:scope:sessions',
+  /**
+   * Scope for user's trusted devices.
+   *
+   * Only used for trusted-device management via account API.
+   * Not included in user claims, even when the scope is requested, as it's not meant for ID token or userinfo endpoint.
+   */
+  TrustedDevices = 'urn:logto:scope:trusted_devices',
 }
 
 /**
@@ -186,6 +193,7 @@ export const idTokenClaims: Readonly<Record<UserScope, UserClaim[]>> = Object.fr
   [UserScope.CustomData]: [],
   [UserScope.Identities]: [],
   [UserScope.Sessions]: [],
+  [UserScope.TrustedDevices]: [],
 });
 
 /**


### PR DESCRIPTION
## Summary

Add a dedicated trusted-device user scope so Account API authorization can follow least privilege without broadening the existing sessions scope.

Expose the scope through OIDC discovery, keep it out of ID token and UserInfo claims, and provide consent descriptions for every Experience locale.

## Testing

Unit tests
Integration tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments