### PR TITLE
chore(toolkit): add trusted device scope changeset

### DIFF
--- a/.changeset/hip-ties-talk.md
+++ b/.changeset/hip-ties-talk.md
@@ -1,0 +1,5 @@
+---
+"@logto/core-kit": minor
+---
+
+add `UserScope.TrustedDevices` for authorizing trusted-device management


### PR DESCRIPTION
## Summary

Add the `@logto/core-kit` release entry for `UserScope.TrustedDevices`.

This PR is stacked on #9470. Keep it as a draft until the complete trusted-device capability is ready to release.

## Testing

N/A

## Checklist

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments