### PR TITLE
chore: remove dev feature guard for cimd

### DIFF
--- a/.changeset/release-cimd-support.md
+++ b/.changeset/release-cimd-support.md
@@ -1,0 +1,15 @@
+---
+"@logto/core": minor
+"@logto/schemas": minor
+"@logto/console": minor
+"@logto/experience": minor
+"@logto/account": minor
+"@logto/phrases": minor
+"@logto/phrases-experience": minor
+---
+
+add dynamic app support (OAuth Client ID Metadata Documents)
+
+The dynamic app lets compatible public clients, such as MCP clients, connect to your tenant without registering an application. Following the OAuth Client ID Metadata Documents (CIMD) draft, such a client presents a public HTTPS URL as its `client_id`, and Logto fetches the client metadata from that URL.
+
+Enable it from the dynamic app card in the third-party app section on the create application page in Console. The switch is tenant-level and off by default, and requires the OIDC provider SSRF protection to be active. Control what dynamic app clients can request with the permission settings on the dynamic app page.

--- a/packages/console/src/assets/docs/guides/third-party-dynamic-app/index.ts
+++ b/packages/console/src/assets/docs/guides/third-party-dynamic-app/index.ts
@@ -12,7 +12,6 @@ const metadata: Readonly<GuideMetadata> = Object.freeze({
     'Allow compatible public clients to connect without registration, using the CIMD specification.',
   target: ApplicationType.Traditional,
   isThirdParty: true,
-  isDevFeature: true,
   isBeta: true,
 });
 

--- a/packages/console/src/hooks/use-console-routes/routes/applications.tsx
+++ b/packages/console/src/hooks/use-console-routes/routes/applications.tsx
@@ -3,7 +3,6 @@ import { Navigate, type RouteObject } from 'react-router-dom';
 import { safeLazy } from 'react-safe-lazy';
 
 import { ApplicationDetailsTabs } from '@/consts';
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { dynamicAppId } from '@/types/applications';
 
 const Applications = safeLazy(async () => import('@/pages/Applications'));
@@ -21,8 +20,7 @@ export const applications: RouteObject = {
     },
     { path: 'create', element: <Applications /> },
     { path: ':id/guide/:guideId', element: <ApplicationDetails /> },
-    // DEV: dynamic app (CIMD)
-    isDevFeaturesEnabled && {
+    {
       path: dynamicAppId,
       children: [
         { index: true, element: <Navigate replace to={ApplicationDetailsTabs.Settings} /> },

--- a/packages/console/src/hooks/use-dynamic-app.ts
+++ b/packages/console/src/hooks/use-dynamic-app.ts
@@ -2,7 +2,6 @@ import { type CimdConfig } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import useSWR from 'swr';
 
-import { isDevFeaturesEnabled } from '@/consts/env';
 import { type RequestError } from '@/hooks/use-api';
 
 export const cimdConfigEndpoint = 'api/configs/cimd';
@@ -10,12 +9,12 @@ export const cimdConfigEndpoint = 'api/configs/cimd';
 /** The dynamic app (CIMD) is a tenant-level feature switch rather than an application entity. */
 const useDynamicApp = (shouldFetch = true) => {
   const { data, error, mutate } = useSWR<CimdConfig, RequestError>(
-    conditional(isDevFeaturesEnabled && shouldFetch && cimdConfigEndpoint)
+    conditional(shouldFetch && cimdConfigEndpoint)
   );
 
   return {
     enabled: Boolean(data?.enabled),
-    isLoading: isDevFeaturesEnabled && shouldFetch && !data && !error,
+    isLoading: shouldFetch && !data && !error,
     error,
     mutate,
   };

--- a/packages/core/src/event-listeners/authorization-success.test.ts
+++ b/packages/core/src/event-listeners/authorization-success.test.ts
@@ -1,8 +1,6 @@
 import { appInsights } from '@logto/app-insights/node';
 import { LogResult, type ExceptionHookEvent } from '@logto/schemas';
-import Sinon from 'sinon';
 
-import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { MockQueries } from '#src/test-utils/tenant.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
@@ -258,18 +256,12 @@ describe('createAuthorizationSuccessListener', () => {
   describe('grant limit webhook payload for a cimd client', () => {
     const cimdClientId = 'https://client.example.com/metadata.json';
 
-    afterEach(() => {
-      Sinon.restore();
-    });
-
     /**
      * No grant-ceiling source exists for CIMD clients today, so this locks the payload contract
      * for any future one: the identifier routes by namespace, keeping `applicationId`
      * registered-only by construction.
      */
     it('should attribute the identifier under the dedicated key', async () => {
-      Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isDevFeaturesEnabled: true });
-
       const { provider } = createMockProvider();
       const findUserActiveGrantsByClientId = jest.fn(async () => [
         {

--- a/packages/core/src/event-listeners/grant.test.ts
+++ b/packages/core/src/event-listeners/grant.test.ts
@@ -1,8 +1,6 @@
 import type { LogKey } from '@logto/schemas';
 import { LogResult, token } from '@logto/schemas';
-import Sinon from 'sinon';
 
-import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { stringifyError } from '#src/utils/format.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
@@ -24,10 +22,6 @@ const entities = {
 };
 
 const baseCallArgs = { applicationId, sessionId, userId };
-
-const stubDevFeaturesFlag = (isDevFeaturesEnabled: boolean) => {
-  Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isDevFeaturesEnabled });
-};
 
 const cimdClientId = 'https://client.example.com/metadata.json';
 
@@ -150,12 +144,10 @@ describe('grantSuccessListener', () => {
 
 describe('grantSuccessListener with a cimd client identifier', () => {
   afterEach(() => {
-    Sinon.restore();
     jest.clearAllMocks();
   });
 
   it('should log a cimd client identifier under the dedicated key', () => {
-    stubDevFeaturesFlag(true);
     const ctx = buildCimdContext();
 
     // @ts-expect-error pass complex type check to mock ctx directly
@@ -168,33 +160,16 @@ describe('grantSuccessListener with a cimd client identifier', () => {
       params: { grant_type: 'refresh_token' },
     });
   });
-
-  it('should keep a url-shaped identifier under applicationId when the dev features flag is off', () => {
-    stubDevFeaturesFlag(false);
-    const ctx = buildCimdContext();
-
-    // @ts-expect-error pass complex type check to mock ctx directly
-    grantListener(ctx);
-    expect(log.mockAppend).toHaveBeenCalledWith({
-      applicationId: cimdClientId,
-      sessionId,
-      userId,
-      tokenTypes: [token.TokenType.AccessToken],
-      params: { grant_type: 'refresh_token' },
-    });
-  });
 });
 
 describe('grantErrorListener with an unresolved client', () => {
   const error = new Error('client metadata fetch failed');
 
   afterEach(() => {
-    Sinon.restore();
     jest.clearAllMocks();
   });
 
   it('should attribute a cimd-namespace client_id from params when the client is not resolved', () => {
-    stubDevFeaturesFlag(true);
     const params = { grant_type: 'authorization_code', client_id: cimdClientId };
     const ctx = buildUnresolvedClientContext(params);
 
@@ -210,23 +185,7 @@ describe('grantErrorListener with an unresolved client', () => {
   });
 
   it('should keep an unresolved non-cimd client_id unattributed', () => {
-    stubDevFeaturesFlag(true);
     const params = { grant_type: 'authorization_code', client_id: 'app-typo' };
-    const ctx = buildUnresolvedClientContext(params);
-
-    // @ts-expect-error pass complex type check to mock ctx directly
-    grantListener(ctx, error);
-    expect(log.mockAppend).toHaveBeenCalledWith({
-      result: LogResult.Error,
-      tokenTypes: [],
-      error: stringifyError(error),
-      params,
-    });
-  });
-
-  it('should keep an unresolved url-shaped client_id unattributed when the dev features flag is off', () => {
-    stubDevFeaturesFlag(false);
-    const params = { grant_type: 'authorization_code', client_id: cimdClientId };
     const ctx = buildUnresolvedClientContext(params);
 
     // @ts-expect-error pass complex type check to mock ctx directly
@@ -245,7 +204,6 @@ describe('grantErrorListener with an unresolved client', () => {
    * `params` for forensics.
    */
   it('should keep an assertion-only failure unattributed while params carry the assertion', () => {
-    stubDevFeaturesFlag(true);
     const params = {
       grant_type: 'authorization_code',
       client_assertion: 'header.payload.signature',

--- a/packages/core/src/libraries/session/cimd-grant-records.test.ts
+++ b/packages/core/src/libraries/session/cimd-grant-records.test.ts
@@ -117,7 +117,6 @@ describe('consent for a cimd client', () => {
   beforeEach(() => {
     Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
-      isDevFeaturesEnabled: true,
       isOidcProviderSsrfProtectionEnabled: true,
     });
   });

--- a/packages/core/src/libraries/session/index.test.ts
+++ b/packages/core/src/libraries/session/index.test.ts
@@ -1,8 +1,6 @@
 import { SessionGrantRevokeTarget } from '@logto/schemas';
 import type { Provider } from 'oidc-provider';
-import Sinon from 'sinon';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type ActiveApplicationGrantInstance } from '#src/queries/oidc-model-instance.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -10,10 +8,6 @@ import type Queries from '#src/tenants/Queries.js';
 import { createSessionLibrary } from './index.js';
 
 const { jest } = import.meta;
-
-const stubDevFeaturesFlag = (isDevFeaturesEnabled: boolean) => {
-  Sinon.stub(EnvSet, 'values').value({ ...EnvSet.values, isDevFeaturesEnabled });
-};
 
 describe('findUserActiveApplicationGrants', () => {
   const findActiveApplicationGrants = jest.fn<
@@ -51,12 +45,10 @@ describe('findUserActiveApplicationGrants', () => {
   };
 
   afterEach(() => {
-    Sinon.restore();
     jest.clearAllMocks();
   });
 
   it('should pass registered application grants through', async () => {
-    stubDevFeaturesFlag(true);
     findActiveApplicationGrants.mockResolvedValueOnce([registeredGrantRow]);
 
     await expect(
@@ -67,7 +59,6 @@ describe('findUserActiveApplicationGrants', () => {
   });
 
   it('should append cimd grants after the registered ones', async () => {
-    stubDevFeaturesFlag(true);
     const cimdClientId = 'https://client.example.com/oauth/metadata.json';
     const cimdGrantRow = {
       id: 'cimd-grant-id',
@@ -85,17 +76,7 @@ describe('findUserActiveApplicationGrants', () => {
     ]);
   });
 
-  it('should not query cimd grants when dev features are disabled', async () => {
-    stubDevFeaturesFlag(false);
-
-    await sessionLibrary.findUserActiveApplicationGrants('user-id');
-
-    expect(findActiveCimdGrants).not.toHaveBeenCalled();
-  });
-
   it('should not query cimd grants for the first-party filter', async () => {
-    stubDevFeaturesFlag(true);
-
     await sessionLibrary.findUserActiveApplicationGrants('user-id', 'firstParty');
 
     expect(findActiveCimdGrants).not.toHaveBeenCalled();
@@ -103,7 +84,6 @@ describe('findUserActiveApplicationGrants', () => {
   });
 
   it('should throw a server error on an invalid grant payload', async () => {
-    stubDevFeaturesFlag(true);
     findActiveApplicationGrants.mockResolvedValueOnce([
       {
         id: 'grant-1',

--- a/packages/core/src/libraries/session/index.ts
+++ b/packages/core/src/libraries/session/index.ts
@@ -7,7 +7,6 @@ import {
 import { deduplicate } from '@silverhand/essentials';
 import type { Provider, Session } from 'oidc-provider';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type SessionInstanceWithExtension } from '#src/queries/oidc-session-extensions.js';
 import type Queries from '#src/tenants/Queries.js';
@@ -139,12 +138,11 @@ export const createSessionLibrary = (queries: Queries) => {
   ) => {
     const [applicationGrants, cimdGrants] = await Promise.all([
       queries.oidcModelInstances.findUserActiveApplicationGrants(userId, applicationType),
-      // DEV: CIMD (client ID metadata document) support
       // CIMD clients are third-party by definition, so the `firstParty` filter skips their
       // query entirely.
-      EnvSet.values.isDevFeaturesEnabled && applicationType !== 'firstParty'
-        ? queries.oidcModelInstances.findUserActiveCimdGrants(userId)
-        : [],
+      applicationType === 'firstParty'
+        ? []
+        : queries.oidcModelInstances.findUserActiveCimdGrants(userId),
     ]);
 
     return [...applicationGrants, ...cimdGrants].map((grant) => formatApplicationGrant(grant));

--- a/packages/core/src/libraries/session/session-context.test.ts
+++ b/packages/core/src/libraries/session/session-context.test.ts
@@ -97,7 +97,6 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
   beforeEach(() => {
     Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
-      isDevFeaturesEnabled: true,
       isOidcProviderSsrfProtectionEnabled: true,
     });
   });

--- a/packages/core/src/middleware/koa-app-access-control.test.ts
+++ b/packages/core/src/middleware/koa-app-access-control.test.ts
@@ -115,7 +115,7 @@ describe('koaAppAccessControl middleware', () => {
     const cimdClientId = 'https://client.example.com/metadata.json';
 
     /**
-     * The gate reads only `oidc.cimdEnabled` from the tenant env set; the static flags are
+     * The gate reads only `oidc.cimdEnabled` from the tenant env set; the static SSRF flag is
      * stubbed onto `EnvSet.values` below.
      */
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- minimal env-set stub scoped to the field the gate reads
@@ -124,7 +124,6 @@ describe('koaAppAccessControl middleware', () => {
     beforeEach(() => {
       Sinon.stub(EnvSet, 'values').value({
         ...EnvSet.values,
-        isDevFeaturesEnabled: true,
         isOidcProviderSsrfProtectionEnabled: true,
       });
     });

--- a/packages/core/src/middleware/koa-auto-consent.test.ts
+++ b/packages/core/src/middleware/koa-auto-consent.test.ts
@@ -74,7 +74,6 @@ const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
 const stubCimdStaticFlags = () =>
   Sinon.stub(EnvSet, 'values').value({
     ...EnvSet.values,
-    isDevFeaturesEnabled: true,
     isOidcProviderSsrfProtectionEnabled: true,
   });
 

--- a/packages/core/src/oidc/adapter.test.ts
+++ b/packages/core/src/oidc/adapter.test.ts
@@ -183,12 +183,10 @@ describe('postgres Adapter', () => {
  * classes asserted below share the identities of the ones the adapter throws.
  */
 const loadClientAdapter = async ({
-  isDevFeaturesEnabled = true,
   isOidcProviderSsrfProtectionEnabled = true,
   cimdEnabled = true,
   findApplicationById,
 }: {
-  isDevFeaturesEnabled?: boolean;
   isOidcProviderSsrfProtectionEnabled?: boolean;
   cimdEnabled?: boolean;
   findApplicationById: jest.Mock;
@@ -196,7 +194,7 @@ const loadClientAdapter = async ({
   jest.resetModules();
   mockEsm('#src/env-set/index.js', () => ({
     EnvSet: {
-      values: { isDevFeaturesEnabled, isOidcProviderSsrfProtectionEnabled },
+      values: { isOidcProviderSsrfProtectionEnabled },
     },
   }));
 
@@ -238,7 +236,6 @@ describe('client adapter `find` fallback contract', () => {
   it.each([
     ['CIMD is disabled for the tenant', { cimdEnabled: false }],
     ['SSRF protection is off', { isOidcProviderSsrfProtectionEnabled: false }],
-    ['the dev features flag is off', { isDevFeaturesEnabled: false }],
   ])('looks a CIMD client ID up as a registered application when %s', async (_, flags) => {
     const findApplicationById = jest.fn().mockRejectedValue(new Error('not found'));
     const { findClient, errors } = await loadClientAdapter({ ...flags, findApplicationById });

--- a/packages/core/src/oidc/cimd/index.test.ts
+++ b/packages/core/src/oidc/cimd/index.test.ts
@@ -8,14 +8,11 @@ import type Queries from '#src/tenants/Queries.js';
 const { jest } = import.meta;
 const { mockEsm } = createMockUtils(jest);
 
-const loadCimdModule = async ({
-  isDevFeaturesEnabled = true,
-  isOidcProviderSsrfProtectionEnabled = true,
-} = {}) => {
+const loadCimdModule = async ({ isOidcProviderSsrfProtectionEnabled = true } = {}) => {
   jest.resetModules();
   mockEsm('#src/env-set/index.js', () => ({
     EnvSet: {
-      values: { isDevFeaturesEnabled, isOidcProviderSsrfProtectionEnabled },
+      values: { isOidcProviderSsrfProtectionEnabled },
     },
   }));
 
@@ -84,14 +81,9 @@ const loadEnabledFeature = async ({
 };
 
 describe('isCimdEffectivelyEnabled', () => {
-  it('is enabled only when all three conditions hold', async () => {
+  it('is enabled only when both conditions hold', async () => {
     const { isCimdEffectivelyEnabled } = await loadCimdModule();
     expect(isCimdEffectivelyEnabled(buildEnvSet(true))).toBe(true);
-  });
-
-  it('is disabled when the dev features flag is off', async () => {
-    const { isCimdEffectivelyEnabled } = await loadCimdModule({ isDevFeaturesEnabled: false });
-    expect(isCimdEffectivelyEnabled(buildEnvSet(true))).toBe(false);
   });
 
   it('is disabled when the tenant config is off', async () => {
@@ -121,11 +113,6 @@ describe('shouldAttributeToCimd', () => {
     expect(shouldAttributeToCimd()).toBe(false);
   });
 
-  it('does not attribute when the dev features flag is off', async () => {
-    const { shouldAttributeToCimd } = await loadCimdModule({ isDevFeaturesEnabled: false });
-    expect(shouldAttributeToCimd(cimdClientId)).toBe(false);
-  });
-
   it('attributes even when cimd is not effectively enabled for the tenant', async () => {
     const { shouldAttributeToCimd } = await loadCimdModule({
       isOidcProviderSsrfProtectionEnabled: false,
@@ -148,13 +135,6 @@ describe('getClientIdentifierPayload', () => {
     const { getClientIdentifierPayload } = await loadCimdModule();
     expect(getClientIdentifierPayload('app-id')).toStrictEqual({
       applicationId: 'app-id',
-    });
-  });
-
-  it('keeps a url-shaped identifier under applicationId when the dev features flag is off', async () => {
-    const { getClientIdentifierPayload } = await loadCimdModule({ isDevFeaturesEnabled: false });
-    expect(getClientIdentifierPayload(cimdClientId)).toStrictEqual({
-      applicationId: cimdClientId,
     });
   });
 
@@ -198,15 +178,6 @@ describe('buildClientIdMetadataDocumentFeature', () => {
     ).toMatchObject({
       clientIdMetadataDocument: { enabled: true, ack: 'draft-02' },
     });
-  });
-
-  it('does not wire the feature at all when the dev features flag is off', async () => {
-    const { buildClientIdMetadataDocumentFeature } = await loadCimdModule({
-      isDevFeaturesEnabled: false,
-    });
-    expect(
-      buildClientIdMetadataDocumentFeature(buildEnvSet(true), buildCimdQueries())
-    ).toBeUndefined();
   });
 
   it('does not wire the feature when not effectively enabled', async () => {

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -39,9 +39,8 @@ const assertClientIdWithinLengthBound = (clientId: string) => {
 };
 
 /**
- * Whether CIMD is effectively enabled for the tenant. All three conditions must hold:
+ * Whether CIMD is effectively enabled for the tenant. Both conditions must hold:
  *
- * - The development features flag is on (release guard);
  * - The tenant has enabled CIMD in its configs;
  * - The provider SSRF protection is active — CIMD forces outbound fetches, so it hard-requires
  *   the SSRF-protected dispatcher. Disabling the protection (self-hosted only) turns CIMD off
@@ -52,18 +51,14 @@ const assertClientIdWithinLengthBound = (clientId: string) => {
  * changes, so every predicate consumer observes the same value for the provider's lifetime.
  */
 export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
-  // DEV: CIMD (client ID metadata document) support
-  EnvSet.values.isDevFeaturesEnabled &&
-  envSet.oidc.cimdEnabled &&
-  EnvSet.values.isOidcProviderSsrfProtectionEnabled;
+  envSet.oidc.cimdEnabled && EnvSet.values.isOidcProviderSsrfProtectionEnabled;
 
 /**
  * Whether an identifier presented as a `client_id` should be attributed to a CIMD client —
  * payload builders route it under `cimdClientId` instead of `applicationId`.
  */
 export const shouldAttributeToCimd = (clientId?: string): boolean =>
-  // DEV: CIMD (client ID metadata document) support
-  clientId !== undefined && EnvSet.values.isDevFeaturesEnabled && isCimdClientId(clientId);
+  clientId !== undefined && isCimdClientId(clientId);
 
 /** At most one identifier is set — a registered application id or a CIMD client identifier. */
 export type ClientIdentifierPayload = {

--- a/packages/core/src/oidc/extra-token-claims.test.ts
+++ b/packages/core/src/oidc/extra-token-claims.test.ts
@@ -322,22 +322,12 @@ describe('getExtraTokenClaimsForJwtCustomization', () => {
   describe('log attribution for a cimd client identifier', () => {
     const cimdClientId = 'https://client.example.com/metadata.json';
 
-    it('routes the identifier to the dedicated key when dev features are enabled', async () => {
+    it('routes the identifier to the dedicated key', async () => {
       const logEntry = await runJwtCustomizationWithClientId(cimdClientId);
 
       const payload: unknown = logEntry.append.mock.calls[0]?.[0];
       expect(payload).toHaveProperty('cimdClientId', cimdClientId);
       expect(payload).not.toHaveProperty('applicationId');
-    });
-
-    it('keeps the url-shaped identifier under applicationId when dev features are disabled', async () => {
-      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
-
-      const logEntry = await runJwtCustomizationWithClientId(cimdClientId);
-
-      expect(logEntry.append).toHaveBeenCalledWith(
-        expect.objectContaining({ applicationId: cimdClientId })
-      );
     });
   });
 });

--- a/packages/core/src/routes/account/grants.ts
+++ b/packages/core/src/routes/account/grants.ts
@@ -1,13 +1,8 @@
 import { UserScope } from '@logto/core-kit';
-import {
-  AccountCenterControlValue,
-  getCimdCapableUserApplicationGrantsResponseGuard,
-  getUserApplicationGrantsResponseGuard,
-} from '@logto/schemas';
+import { AccountCenterControlValue, getUserApplicationGrantsResponseGuard } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
@@ -16,11 +11,6 @@ import assertThat from '#src/utils/assert-that.js';
 import { type UserRouter, type RouterInitArgs } from '../types.js';
 
 import { accountApiPrefix } from './constants.js';
-
-// DEV: CIMD (client ID metadata document) support
-const grantsResponseGuard = EnvSet.values.isDevFeaturesEnabled
-  ? getCimdCapableUserApplicationGrantsResponseGuard
-  : getUserApplicationGrantsResponseGuard;
 
 export default function accountGrantRoutes<T extends UserRouter>(
   ...[router, { provider, libraries, queries }]: RouterInitArgs<T>
@@ -34,7 +24,7 @@ export default function accountGrantRoutes<T extends UserRouter>(
         appType: z.enum(['firstParty', 'thirdParty']).optional(),
       }),
       status: [200, 400, 401, 500],
-      response: grantsResponseGuard,
+      response: getUserApplicationGrantsResponseGuard,
     }),
     async (ctx, next) => {
       const { id: userId, scopes, identityVerified } = ctx.auth;

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -19,8 +19,7 @@
                 "schema": {
                   "properties": {
                     "cimdClientId": {
-                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`. Only returned with the `profile` scope.",
-                      "x-logto-dev-feature": true
+                      "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`. Only returned with the `profile` scope."
                     }
                   }
                 }
@@ -64,8 +63,7 @@
                 "schema": {
                   "properties": {
                     "cimdClientId": {
-                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`. Only returned with the `profile` scope.",
-                      "x-logto-dev-feature": true
+                      "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`. Only returned with the `profile` scope."
                     }
                   }
                 }

--- a/packages/core/src/routes/admin-user/basic.openapi.json
+++ b/packages/core/src/routes/admin-user/basic.openapi.json
@@ -37,8 +37,7 @@
                       "description": "The algorithm used to hash the password. Only present when `includePasswordHash` is provided with a truthy value. `null` if the user has no password set."
                     },
                     "cimdClientId": {
-                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                      "x-logto-dev-feature": true
+                      "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                     }
                   }
                 }
@@ -80,8 +79,7 @@
                 "schema": {
                   "properties": {
                     "cimdClientId": {
-                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                      "x-logto-dev-feature": true
+                      "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                     }
                   }
                 }
@@ -248,8 +246,7 @@
                 "schema": {
                   "properties": {
                     "cimdClientId": {
-                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                      "x-logto-dev-feature": true
+                      "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                     }
                   }
                 }
@@ -284,8 +281,7 @@
                 "schema": {
                   "properties": {
                     "cimdClientId": {
-                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                      "x-logto-dev-feature": true
+                      "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                     }
                   }
                 }
@@ -320,8 +316,7 @@
                 "schema": {
                   "properties": {
                     "cimdClientId": {
-                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                      "x-logto-dev-feature": true
+                      "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                     }
                   }
                 }
@@ -397,8 +392,7 @@
                 "schema": {
                   "properties": {
                     "cimdClientId": {
-                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                      "x-logto-dev-feature": true
+                      "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                     }
                   }
                 }

--- a/packages/core/src/routes/admin-user/grants.ts
+++ b/packages/core/src/routes/admin-user/grants.ts
@@ -1,20 +1,11 @@
-import {
-  getCimdCapableUserApplicationGrantsResponseGuard,
-  getUserApplicationGrantsResponseGuard,
-} from '@logto/schemas';
+import { getUserApplicationGrantsResponseGuard } from '@logto/schemas';
 import { trySafe } from '@silverhand/essentials';
 import { object, string, enum as zodEnum } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 
 import { type ManagementApiRouter, type RouterInitArgs } from '../types.js';
-
-// DEV: CIMD (client ID metadata document) support
-const grantsResponseGuard = EnvSet.values.isDevFeaturesEnabled
-  ? getCimdCapableUserApplicationGrantsResponseGuard
-  : getUserApplicationGrantsResponseGuard;
 
 export default function adminUserGrantRoutes<T extends ManagementApiRouter>(
   ...[router, tenant]: RouterInitArgs<T>
@@ -31,7 +22,7 @@ export default function adminUserGrantRoutes<T extends ManagementApiRouter>(
       query: object({
         appType: zodEnum(['firstParty', 'thirdParty']).optional(),
       }),
-      response: grantsResponseGuard,
+      response: getUserApplicationGrantsResponseGuard,
       status: [200, 500],
     }),
     async (ctx, next) => {

--- a/packages/core/src/routes/admin-user/search.openapi.json
+++ b/packages/core/src/routes/admin-user/search.openapi.json
@@ -11,8 +11,7 @@
                   "items": {
                     "properties": {
                       "cimdClientId": {
-                        "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                        "x-logto-dev-feature": true
+                        "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                       }
                     }
                   }

--- a/packages/core/src/routes/admin-user/social.openapi.json
+++ b/packages/core/src/routes/admin-user/social.openapi.json
@@ -39,8 +39,7 @@
                 "schema": {
                   "properties": {
                     "cimdClientId": {
-                      "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                      "x-logto-dev-feature": true
+                      "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                     }
                   }
                 }

--- a/packages/core/src/routes/cimd.openapi.json
+++ b/packages/core/src/routes/cimd.openapi.json
@@ -3,9 +3,6 @@
     {
       "name": "CIMD",
       "description": "Endpoints for managing the tenant-wide permission ceiling of OAuth Client ID Metadata Document (CIMD) clients. CIMD clients are unregistered, so the ceiling applies to all of them; the enablement switch itself lives under `/api/configs/cimd`."
-    },
-    {
-      "name": "Dev feature"
     }
   ],
   "paths": {

--- a/packages/core/src/routes/cimd.ts
+++ b/packages/core/src/routes/cimd.ts
@@ -5,7 +5,6 @@ import {
 } from '@logto/schemas';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import assertThat from '#src/utils/assert-that.js';
@@ -20,10 +19,6 @@ import type { ManagementApiRouter, RouterInitArgs } from './types.js';
 export default function cimdRoutes<T extends ManagementApiRouter>(
   ...[router, tenant]: RouterInitArgs<T>
 ) {
-  if (!EnvSet.values.isDevFeaturesEnabled) {
-    return;
-  }
-
   const { queries, libraries } = tenant;
   const {
     resources: { findResourceById },

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -16,7 +16,6 @@ import { type IRouterParamContext } from 'koa-router';
 import { errors } from 'oidc-provider';
 import { z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import { consent, getMissingScopes } from '#src/libraries/session/index.js';
 import koaAppAccessControl from '#src/middleware/koa-app-access-control.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -333,7 +332,6 @@ export default function consentRoutes<T extends IRouterParamContext>(
         );
       }
 
-      // DEV: CIMD (client ID metadata document) support
       /**
        * Authorization already validated the value against the same client, so a failing check
        * here means the registered set changed mid-flow (for CIMD clients the metadata document
@@ -341,7 +339,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
        * a redirect target the client no longer registers. Render-time only — issuance stays
        * guarded by the consent POST re-assert.
        */
-      if (EnvSet.values.isDevFeaturesEnabled && typeof redirectUri === 'string') {
+      if (typeof redirectUri === 'string') {
         const client = await provider.Client.find(clientId);
         assertThat(client, new InvalidClient('client must be available'));
         assertThat(

--- a/packages/core/src/routes/logto-config/cimd.ts
+++ b/packages/core/src/routes/logto-config/cimd.ts
@@ -15,10 +15,6 @@ import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
 export default function logtoConfigCimdRoutes<T extends ManagementApiRouter>(
   ...[router, tenant]: RouterInitArgs<T>
 ) {
-  if (!EnvSet.values.isDevFeaturesEnabled) {
-    return;
-  }
-
   const { id: tenantId } = tenant;
   const { getCimdConfig, upsertCimdConfig } = tenant.queries.logtoConfigs;
 

--- a/packages/core/src/routes/logto-config/logto-config.openapi.json
+++ b/packages/core/src/routes/logto-config/logto-config.openapi.json
@@ -556,7 +556,6 @@
     },
     "/api/configs/cimd": {
       "get": {
-        "tags": ["Dev feature"],
         "summary": "Get CIMD config",
         "description": "Get the tenant-level OAuth Client ID Metadata Document (CIMD) configuration. A missing configuration resolves to the disabled state.",
         "responses": {
@@ -566,7 +565,6 @@
         }
       },
       "patch": {
-        "tags": ["Dev feature"],
         "summary": "Update CIMD config",
         "description": "Update the tenant-level OAuth Client ID Metadata Document (CIMD) switch. Enabling requires the OIDC provider SSRF protection to be active.",
         "responses": {

--- a/packages/core/src/routes/organization/index.openapi.json
+++ b/packages/core/src/routes/organization/index.openapi.json
@@ -109,8 +109,7 @@
                   "items": {
                     "properties": {
                       "cimdClientId": {
-                        "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                        "x-logto-dev-feature": true
+                        "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                       }
                     }
                   }

--- a/packages/core/src/routes/role.openapi.json
+++ b/packages/core/src/routes/role.openapi.json
@@ -115,8 +115,7 @@
                   "items": {
                     "properties": {
                       "cimdClientId": {
-                        "description": "Dev feature. The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`.",
-                        "x-logto-dev-feature": true
+                        "description": "The identifier of the CIMD (client ID metadata document) client from the user's first consent. `null` unless the user's first consent was granted to a CIMD client. Mutually exclusive with `applicationId`."
                       }
                     }
                   }

--- a/packages/core/src/routes/swagger/utils/documents.test.ts
+++ b/packages/core/src/routes/swagger/utils/documents.test.ts
@@ -15,9 +15,9 @@ const setDevFeaturesEnabled = (isDevFeaturesEnabled: boolean) => {
 };
 
 /**
- * Mimics the generated base document: the user payload schema comes from the env-free zod guards,
- * so `cimdClientId` appears in `properties` and `required` without any dev-feature marker,
- * including occurrences nested in `oneOf` branches (e.g. the JWT customizer context schemas).
+ * Mimics the generated base document: the payload schema comes from the env-free zod guards, so
+ * the dev-feature property appears in `properties` and `required` without any marker — only the
+ * supplement carries it, and it reaches the base property when the documents merge.
  */
 const createBaseDocument = (): OpenAPIV3.Document => ({
   openapi: '3.0.1',
@@ -35,45 +35,11 @@ const createBaseDocument = (): OpenAPIV3.Document => ({
               'application/json': {
                 schema: {
                   type: 'object',
-                  required: ['id', 'cimdClientId'],
+                  required: ['id', 'betaFlag'],
                   properties: {
                     id: { type: 'string' },
-                    cimdClientId: { type: 'string', nullable: true },
+                    betaFlag: { type: 'string', nullable: true },
                   },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    '/api/configs/jwt-customizer': {
-      get: {
-        responses: {
-          '200': {
-            description: 'ok',
-            content: {
-              'application/json': {
-                schema: {
-                  oneOf: [
-                    {
-                      type: 'object',
-                      properties: {
-                        contextSample: {
-                          type: 'object',
-                          properties: {
-                            user: {
-                              type: 'object',
-                              properties: {
-                                id: { type: 'string' },
-                                cimdClientId: { type: 'string', nullable: true },
-                              },
-                            },
-                          },
-                        },
-                      },
-                    },
-                  ],
                 },
               },
             },
@@ -86,7 +52,7 @@ const createBaseDocument = (): OpenAPIV3.Document => ({
 
 const createMarkedPropertySchema = () =>
   ({
-    description: 'Dev feature. The CIMD client identifier.',
+    description: 'Dev feature. The beta flag.',
     [devFeatureSchemaExtension]: true,
   }) satisfies OpenAPIV3.SchemaObject & Record<typeof devFeatureSchemaExtension, true>;
 
@@ -100,7 +66,7 @@ const createSupplementDocument = (): DeepPartial<OpenAPIV3.Document> => ({
               'application/json': {
                 schema: {
                   properties: {
-                    cimdClientId: createMarkedPropertySchema(),
+                    betaFlag: createMarkedPropertySchema(),
                   },
                 },
               },
@@ -129,7 +95,7 @@ describe('assembleSwaggerDocument', () => {
 
     const document = assemble();
 
-    expect(JSON.stringify(document)).not.toContain('cimdClientId');
+    expect(JSON.stringify(document)).not.toContain('betaFlag');
     expect(JSON.stringify(document)).not.toContain(devFeatureSchemaExtension);
     expect(document.paths['/api/users/{userId}']?.get?.responses['200']).toMatchObject({
       content: {
@@ -153,16 +119,13 @@ describe('assembleSwaggerDocument', () => {
       content: {
         'application/json': {
           schema: {
-            required: ['id', 'cimdClientId'],
+            required: ['id', 'betaFlag'],
             properties: {
-              cimdClientId: { description: 'Dev feature. The CIMD client identifier.' },
+              betaFlag: { description: 'Dev feature. The beta flag.' },
             },
           },
         },
       },
     });
-    expect(
-      JSON.stringify(document.paths['/api/configs/jwt-customizer']?.get?.responses['200'])
-    ).toContain('cimdClientId');
   });
 });

--- a/packages/core/src/routes/swagger/utils/general.ts
+++ b/packages/core/src/routes/swagger/utils/general.ts
@@ -21,17 +21,6 @@ export const devFeatureTag = 'Dev feature';
 /** The OpenAPI schema extension that hides a schema property when dev features are disabled. */
 export const devFeatureSchemaExtension = 'x-logto-dev-feature';
 
-/**
- * Schema property names that belong to in-development features. These properties are generated
- * from the env-free zod guards in `@logto/schemas`, and supplement markers cannot reach every
- * generated occurrence (e.g. properties nested in `oneOf` branches, which `deepmerge` appends to
- * instead of merging into), so the assembled document is also pruned by property name.
- */
-const devFeatureSchemaPropertyNames = new Set([
-  // DEV: CIMD (client ID metadata document) support
-  'cimdClientId',
-]);
-
 const reservedTags = new Set([cloudOnlyTag, devFeatureTag]);
 
 /**
@@ -51,12 +40,8 @@ const tagMap = new Map([
   ['saml', 'SAML applications auth flow'],
   ['one-time-tokens', 'One-time tokens'],
   ['custom-profile-fields', 'Custom profile fields'],
+  ['cimd', 'CIMD'],
 ]);
-
-if (EnvSet.values.isDevFeaturesEnabled) {
-  // DEV: CIMD (client ID metadata document) support
-  tagMap.set('cimd', 'CIMD');
-}
 
 /**
  * Build a tag name from the given absolute path. The function will get the root component name
@@ -350,7 +335,7 @@ const removeDevFeatureSchemaProperty = (
 ) => {
   const isMarked = isRecord(propertySchema) && propertySchema[devFeatureSchemaExtension] === true;
 
-  if (!isMarked && !devFeatureSchemaPropertyNames.has(propertyName)) {
+  if (!isMarked) {
     return false;
   }
 
@@ -361,7 +346,7 @@ const removeDevFeatureSchemaProperty = (
     return true;
   }
 
-  if (isMarked && isRecord(propertySchema)) {
+  if (isRecord(propertySchema)) {
     Reflect.deleteProperty(propertySchema, devFeatureSchemaExtension);
   }
 
@@ -372,8 +357,8 @@ const removeDevFeatureSchemaProperty = (
  * **CAUTION**: This function mutates the input value.
  *
  * Recursively prune dev-feature schema properties: when dev features are disabled, properties
- * marked with `x-logto-dev-feature` or listed in the dev-feature property names are removed
- * (including their `required` entries); when enabled, only the internal marker is removed.
+ * marked with `x-logto-dev-feature` are removed (including their `required` entries); when
+ * enabled, only the internal marker is removed.
  *
  * Run this on the assembled document — the base schema properties generated from the env-free
  * zod guards carry no markers, so pruning supplements alone cannot remove them.

--- a/packages/core/src/routes/swagger/utils/operation-id.ts
+++ b/packages/core/src/routes/swagger/utils/operation-id.ts
@@ -27,15 +27,6 @@ const methodToVerb = Object.freeze({
 
 type RouteDictionary = Record<`${OpenAPIV3.HttpMethods} ${string}`, string>;
 
-const devFeatureCustomRoutes: Readonly<RouteDictionary> = Object.freeze({
-  // DEV: CIMD (client ID metadata document) support
-  'get /configs/cimd': 'GetCimdConfig',
-  'patch /configs/cimd': 'UpdateCimdConfig',
-  'get /cimd/user-consent-scopes': 'ListCimdUserConsentScopes',
-  'post /cimd/user-consent-scopes': 'AssignCimdUserConsentScopes',
-  'delete /cimd/user-consent-scopes/:scopeType/:scopeId': 'DeleteCimdUserConsentScope',
-});
-
 export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   // Authn
   'get /authn/hasura': 'GetHasuraAuth',
@@ -122,7 +113,12 @@ export const customRoutes: Readonly<RouteDictionary> = Object.freeze({
   'get /configs/actions/:actionType': 'GetAction',
   'delete /configs/actions/:actionType': 'DeleteAction',
   'post /configs/actions/test': 'TestAction',
-  ...(EnvSet.values.isDevFeaturesEnabled ? devFeatureCustomRoutes : {}),
+  // CIMD (client ID metadata document)
+  'get /configs/cimd': 'GetCimdConfig',
+  'patch /configs/cimd': 'UpdateCimdConfig',
+  'get /cimd/user-consent-scopes': 'ListCimdUserConsentScopes',
+  'post /cimd/user-consent-scopes': 'AssignCimdUserConsentScopes',
+  'delete /cimd/user-consent-scopes/:scopeType/:scopeId': 'DeleteCimdUserConsentScope',
 } satisfies RouteDictionary); // Key assertion doesn't work without `satisfies`
 
 /**
@@ -135,12 +131,10 @@ export const throwByDifference = (builtCustomRoutes: Set<string>) => {
     return;
   }
 
-  const expectedRoutes = Object.entries(customRoutes).filter(
-    ([path]) => EnvSet.values.isDevFeaturesEnabled || !(path in devFeatureCustomRoutes)
-  );
-
-  if (shouldThrow() && builtCustomRoutes.size !== expectedRoutes.length) {
-    const missingRoutes = expectedRoutes.filter(([path]) => !builtCustomRoutes.has(path));
+  if (shouldThrow() && builtCustomRoutes.size !== Object.keys(customRoutes).length) {
+    const missingRoutes = Object.entries(customRoutes).filter(
+      ([path]) => !builtCustomRoutes.has(path)
+    );
 
     if (missingRoutes.length > 0) {
       throw new Error(
@@ -149,9 +143,7 @@ export const throwByDifference = (builtCustomRoutes: Set<string>) => {
       );
     }
 
-    const extraRoutes = [...builtCustomRoutes].filter(
-      (path) => !expectedRoutes.some(([expectedPath]) => expectedPath === path)
-    );
+    const extraRoutes = [...builtCustomRoutes].filter((path) => !(path in customRoutes));
 
     if (extraRoutes.length > 0) {
       throw new Error(

--- a/packages/integration-tests/src/tests/api/cimd.test.ts
+++ b/packages/integration-tests/src/tests/api/cimd.test.ts
@@ -1,7 +1,6 @@
 import { UserScope } from '@logto/core-kit';
 import { ApplicationUserConsentScopeType } from '@logto/schemas';
 
-import { authedAdminApi } from '#src/api/api.js';
 import {
   assignCimdUserConsentScopes,
   deleteCimdUserConsentScope,
@@ -11,9 +10,8 @@ import { OrganizationScopeApi } from '#src/api/organization-scope.js';
 import { createResource, deleteResource } from '#src/api/resource.js';
 import { createScope } from '#src/api/scope.js';
 import { expectRejects } from '#src/helpers/index.js';
-import { devFeatureDisabledTest, devFeatureTest } from '#src/utils.js';
 
-devFeatureTest.describe('CIMD user consent scopes', () => {
+describe('CIMD user consent scopes', () => {
   const organizationScopes = new Map<string, string>();
   const resourceScopes = new Map<string, string>();
   const organizationResourceScopes = new Map<string, string>();
@@ -202,15 +200,5 @@ devFeatureTest.describe('CIMD user consent scopes', () => {
     ).toBeFalsy();
     expect(result.organizationResourceScopes.length).toBe(0);
     expect(result.userScopes.includes(UserScope.Email)).toBeFalsy();
-  });
-});
-
-devFeatureDisabledTest.describe('CIMD routes when dev features are disabled', () => {
-  it('should not expose the CIMD user consent scope routes', async () => {
-    const response = await authedAdminApi.get('cimd/user-consent-scopes', {
-      throwHttpErrors: false,
-    });
-
-    expect(response.status).toBe(404);
   });
 });

--- a/packages/integration-tests/src/tests/api/logto-config-cimd.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config-cimd.test.ts
@@ -1,8 +1,6 @@
-import { authedAdminApi } from '#src/api/api.js';
 import { getCimdConfig, updateCimdConfig } from '#src/api/logto-config.js';
-import { devFeatureDisabledTest, devFeatureTest } from '#src/utils.js';
 
-devFeatureTest.describe('CIMD config', () => {
+describe('CIMD config', () => {
   afterAll(async () => {
     // Leave the tenant with the default-off state so other suites see a clean provider config.
     await updateCimdConfig({ enabled: false });
@@ -21,13 +19,5 @@ devFeatureTest.describe('CIMD config', () => {
     await expect(updateCimdConfig({})).resolves.toEqual({ enabled: true });
 
     await expect(updateCimdConfig({ enabled: false })).resolves.toEqual({ enabled: false });
-  });
-});
-
-devFeatureDisabledTest.describe('CIMD config routes when dev features are disabled', () => {
-  it('should not expose the CIMD config routes', async () => {
-    const response = await authedAdminApi.get('configs/cimd', { throwHttpErrors: false });
-
-    expect(response.status).toBe(404);
   });
 });

--- a/packages/schemas/src/types/user-sessions.ts
+++ b/packages/schemas/src/types/user-sessions.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-import { Applications } from '../db-entries/index.js';
 import { oidcSessionInstancePayloadGuard } from '../foundations/index.js';
 
 import { jwtCustomizerUserInteractionContextGuard } from './logto-config/jwt-customizer.js';
@@ -96,9 +95,15 @@ export const userApplicationGrantGuard = z.object({
   id: z.string(),
   payload: userApplicationGrantPayloadGuard,
   expiresAt: z.number(),
-  application: Applications.guard.pick({
-    id: true,
-    name: true,
+  /**
+   * A CIMD (client ID metadata document) grant fills this slot with a URL identity that has no
+   * `applications` row: the identifier URL lands in `id` and `name` comes from the consent-time
+   * snapshot, so neither field can keep the applications table varchar bounds. Consumers tell
+   * the kinds apart by the id shape.
+   */
+  application: z.object({
+    id: z.string(),
+    name: z.string(),
   }),
 });
 
@@ -111,22 +116,3 @@ export const getUserApplicationGrantsResponseGuard = z.object({
 export type GetUserApplicationGrantsResponse = z.infer<
   typeof getUserApplicationGrantsResponseGuard
 >;
-
-/**
- * The grants response as it looks once CIMD clients can hold grants. They are URL identities
- * without an `applications` row: the identifier URL lands in `application.id` and its name comes
- * from the consent-time snapshot, so neither field can keep the applications table varchar
- * bounds. Graduation folds this shape back into {@link getUserApplicationGrantsResponseGuard} —
- * until then the published contract keeps its bounds, and the inferred response type is
- * identical either way.
- */
-export const getCimdCapableUserApplicationGrantsResponseGuard = z.object({
-  grants: z.array(
-    userApplicationGrantGuard.extend({
-      application: z.object({
-        id: z.string(),
-        name: z.string(),
-      }),
-    })
-  ),
-});


### PR DESCRIPTION
## Summary

Remove the CIMD (OAuth Client ID Metadata Document) dev feature guard and release the feature. The tenant-level switch stays off by default.

- Remove every CIMD `isDevFeaturesEnabled` guard across core, console, and integration tests.
- Fold the CIMD-capable grants response shape into `userApplicationGrantGuard` and delete `getCimdCapableUserApplicationGrantsResponseGuard` (deferred from LOG-13935).
- Strip the `"Dev feature"` tags and `x-logto-dev-feature` markers from the CIMD OpenAPI docs; the `CIMD` tag and custom operation IDs are published unconditionally.
- Remove the CIMD-introduced `devFeatureSchemaPropertyNames` pruning and the now-empty `devFeatureCustomRoutes` mechanism, matching earlier graduations.
- Add the user-facing changeset covering every package the feature touched.

## Testing

Tested locally.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)