### PR TITLE
feat(console): adopt audit-logs pagination footer for email logs

### DIFF
--- a/packages/connectors/connector-logto-email/package.json
+++ b/packages/connectors/connector-logto-email/package.json
@@ -53,7 +53,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-a4e30ff",
+    "@logto/cloud": "0.2.5-94350d3",
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/ts-config": "6.0.0",
     "@types/node": "^22.14.0",

--- a/packages/console/package.json
+++ b/packages/console/package.json
@@ -30,7 +30,7 @@
     "@fontsource/roboto-mono": "^5.0.0",
     "@inkeep/cxkit-react": "^0.5.66",
     "@jest/types": "^29.5.0",
-    "@logto/cloud": "0.2.5-cf6987f",
+    "@logto/cloud": "0.2.5-94350d3",
     "@logto/connector-kit": "workspace:^",
     "@logto/core-kit": "workspace:^",
     "@logto/language-kit": "workspace:^",

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/index.module.scss
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/index.module.scss
@@ -2,7 +2,7 @@
 
 .logs {
   flex: 1;
-  margin-bottom: _.unit(2);
+  margin-bottom: _.unit(6);
 }
 
 .filter {
@@ -36,11 +36,4 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-}
-
-.pagination {
-  display: flex;
-  justify-content: flex-end;
-  gap: _.unit(2);
-  margin-bottom: _.unit(6);
 }

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/index.tsx
@@ -6,7 +6,7 @@ import TimeRangePicker from '@/components/AuditLogTable/components/TimeRangePick
 import { defaultPresetRange } from '@/components/AuditLogTable/components/TimeRangePicker/preset';
 import useAuditLogTimeWindow from '@/components/AuditLogTable/components/TimeRangePicker/use-audit-log-time-window';
 import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
-import Button from '@/ds-components/Button';
+import { defaultPageSize } from '@/consts';
 import CopyToClipboard from '@/ds-components/CopyToClipboard';
 import Search from '@/ds-components/Search';
 import Table from '@/ds-components/Table';
@@ -20,15 +20,18 @@ import useEmailLogs from './use-email-logs';
 /**
  * The hosted-email send log for the built-in email connector: sent + failed rows from the
  * cloud email-logs endpoint, windowed like the audit log (preset ranges + custom range) and
- * cursor-paginated (the endpoint has no total count, so paging is previous/next only).
+ * paginated with the audit log's footer (page-based; the numbered jumper degrades to
+ * previous/next when the total count is capped).
  */
 function EmailLogs() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
+  const pageSize = defaultPageSize;
 
   // URL values are untyped; validated downstream via `isPresetRange`.
   const initialRange: string = defaultPresetRange;
-  const [{ range, start_time, end_time, recipient }, updateSearchParameters] =
+  const [{ page, range, start_time, end_time, recipient }, updateSearchParameters] =
     useSearchParametersWatcher({
+      page: 1,
       range: initialRange,
       start_time: '',
       end_time: '',
@@ -50,10 +53,12 @@ function EmailLogs() {
     updateSearchParameters,
   });
 
-  const { logs, error, isLoading, mutate, hasNext, hasPrevious, next, previous } = useEmailLogs({
+  const { logs, totalCount, isTotalCountCapped, error, isLoading, mutate } = useEmailLogs({
     startTime,
     endTime,
     recipient,
+    page,
+    pageSize,
   });
 
   // Providers like Cloudflare return no message id; when no loaded row carries one, drop the
@@ -122,59 +127,52 @@ function EmailLogs() {
   );
 
   return (
-    <>
-      <Table
-        className={styles.logs}
-        rowGroups={[{ key: 'logs', data: logs }]}
-        rowIndexKey="id"
-        columns={columns}
-        filter={
-          <div className={styles.filter}>
-            <Search
-              placeholder={t('connector_details.email_logs.recipient_placeholder')}
-              defaultValue={recipient}
-              isClearable={Boolean(recipient)}
-              onSearch={(value) => {
-                updateSearchParameters({ recipient: value });
-              }}
-              onClearSearch={() => {
-                updateSearchParameters({ recipient: '' });
-              }}
-            />
-            <div className={styles.timeWindow}>
-              <div className={styles.title}>{t('logs.filter_by')}</div>
-              <div className={styles.timeRangePicker}>
-                <TimeRangePicker
-                  value={pickerRangeValue}
-                  customStartDate={customStartDate}
-                  customEndDate={customEndDate}
-                  onChange={handleRangeChange}
-                  onCustomDatesChange={handleCustomDatesChange}
-                />
-              </div>
+    <Table
+      className={styles.logs}
+      rowGroups={[{ key: 'logs', data: logs }]}
+      rowIndexKey="id"
+      columns={columns}
+      filter={
+        <div className={styles.filter}>
+          <Search
+            placeholder={t('connector_details.email_logs.recipient_placeholder')}
+            defaultValue={recipient}
+            isClearable={Boolean(recipient)}
+            onSearch={(value) => {
+              updateSearchParameters({ recipient: value, page: undefined });
+            }}
+            onClearSearch={() => {
+              updateSearchParameters({ recipient: '', page: undefined });
+            }}
+          />
+          <div className={styles.timeWindow}>
+            <div className={styles.title}>{t('logs.filter_by')}</div>
+            <div className={styles.timeRangePicker}>
+              <TimeRangePicker
+                value={pickerRangeValue}
+                customStartDate={customStartDate}
+                customEndDate={customEndDate}
+                onChange={handleRangeChange}
+                onCustomDatesChange={handleCustomDatesChange}
+              />
             </div>
           </div>
-        }
-        placeholder={<EmptyDataPlaceholder />}
-        isLoading={isLoading}
-        errorMessage={error instanceof Error ? error.message : undefined}
-        onRetry={async () => mutate(undefined, true)}
-      />
-      {(hasPrevious || hasNext) && (
-        <div className={styles.pagination}>
-          <Button
-            title="connector_details.email_logs.previous_page"
-            disabled={!hasPrevious}
-            onClick={previous}
-          />
-          <Button
-            title="connector_details.email_logs.next_page"
-            disabled={!hasNext}
-            onClick={next}
-          />
         </div>
-      )}
-    </>
+      }
+      placeholder={<EmptyDataPlaceholder />}
+      pagination={{
+        page,
+        totalCount,
+        isTotalCountCapped,
+        pageSize,
+        onChange: (page) => {
+          updateSearchParameters({ page });
+        },
+      }}
+      isLoading={isLoading}
+      errorMessage={error instanceof Error ? error.message : undefined}
+      onRetry={async () => mutate(undefined, true)}
+    />
   );
 }
 

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/use-email-logs.ts
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/use-email-logs.ts
@@ -1,6 +1,6 @@
 import { type emailLogsRouter } from '@logto/cloud/routes';
 import { conditional } from '@silverhand/essentials';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import useSWR from 'swr';
 
 import { useCloudApi } from '@/cloud/hooks/use-cloud-api';
@@ -16,23 +16,20 @@ type Props = {
   readonly endTime?: number;
   /** Full recipient address; the endpoint matches it case-insensitively and exactly. */
   readonly recipient?: string;
+  /** 1-based page index, owned by the URL search parameters. */
+  readonly page: number;
+  /** Rows per page; the caller shares one binding between this fetch and the footer's math. */
+  readonly pageSize: number;
 };
 
 /**
  * Fetches one page of hosted-email logs for the current tenant (Cloud only). The endpoint is
- * cursor-paginated (no total count), so paging is a cursor stack: `next` pushes the server's
- * `nextCursor`, `previous` pops back to the prior page, and any window change resets to the
- * first page.
+ * page-based with a capped total count — the same pagination contract the audit-log table
+ * consumes.
  */
-const useEmailLogs = ({ startTime, endTime, recipient }: Props) => {
+const useEmailLogs = ({ startTime, endTime, recipient, page, pageSize }: Props) => {
   const { currentTenantId } = useContext(TenantsContext);
   const cloudApi = useCloudApi<typeof emailLogsRouter>({ hideErrorToast: true });
-  const [cursorStack, setCursorStack] = useState<string[]>([]);
-  const cursor = cursorStack.at(-1);
-
-  useEffect(() => {
-    setCursorStack([]);
-  }, [startTime, endTime, recipient]);
 
   const { data, error, mutate } = useSWR<TenantEmailLogsResponse, unknown>(
     conditional(
@@ -42,39 +39,26 @@ const useEmailLogs = ({ startTime, endTime, recipient }: Props) => {
         startTime,
         endTime,
         recipient ?? '',
-        cursor ?? '',
+        page,
+        pageSize,
       ]
     ),
     async () =>
       cloudApi.get('/api/tenants/:tenantId/email-logs', {
         params: { tenantId: currentTenantId },
-        search: buildEmailLogsSearch({ startTime, endTime, recipient, cursor }),
+        search: buildEmailLogsSearch({ startTime, endTime, recipient, page, pageSize }),
       })
   );
 
-  const nextCursor = data?.nextCursor ?? undefined;
-
-  const next = useCallback(() => {
-    if (nextCursor) {
-      setCursorStack((stack) => [...stack, nextCursor]);
-    }
-  }, [nextCursor]);
-
-  const previous = useCallback(() => {
-    setCursorStack((stack) => stack.slice(0, -1));
-  }, []);
-
   return {
     logs: data?.logs,
+    totalCount: data?.totalCount,
+    isTotalCountCapped: data?.isTotalCountCapped,
     error,
     // Loading only while the fetch is actually enabled — with no tenant id the key is null and
     // SWR never fires, which would otherwise read as loading forever.
     isLoading: Boolean(currentTenantId) && !data && !error,
     mutate,
-    hasNext: Boolean(nextCursor),
-    hasPrevious: cursorStack.length > 0,
-    next,
-    previous,
   };
 };
 

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/utils.test.ts
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/utils.test.ts
@@ -5,34 +5,52 @@ describe('buildEmailLogsSearch', () => {
     const search = buildEmailLogsSearch({
       startTime: new Date('2026-08-01T00:00:00.000Z').getTime(),
       endTime: new Date('2026-08-07T23:59:59.999Z').getTime(),
+      page: 1,
+      pageSize: 20,
     });
 
     expect(search).toStrictEqual({
       from: '2026-08-01T00:00:00.000Z',
       to: '2026-08-08T00:00:00.000Z',
+      page: '1',
+      page_size: '20',
     });
   });
 
-  it('omits absent bounds and the cursor entirely', () => {
-    expect(buildEmailLogsSearch({})).toStrictEqual({});
-  });
-
-  it('passes the recipient through only when non-empty', () => {
-    expect(buildEmailLogsSearch({ recipient: 'user@example.com' })).toStrictEqual({
-      recipient: 'user@example.com',
-    });
-    expect(buildEmailLogsSearch({ recipient: '' })).toStrictEqual({});
-  });
-
-  it('passes the cursor through verbatim alongside the window', () => {
+  it('emits a lone start bound without inventing the other', () => {
     const search = buildEmailLogsSearch({
       startTime: new Date('2026-08-01T00:00:00.000Z').getTime(),
-      cursor: 'opaque-cursor',
+      recipient: 'user@example.com',
+      page: 2,
+      pageSize: 20,
     });
 
     expect(search).toStrictEqual({
       from: '2026-08-01T00:00:00.000Z',
-      cursor: 'opaque-cursor',
+      recipient: 'user@example.com',
+      page: '2',
+      page_size: '20',
+    });
+  });
+
+  it('omits absent bounds while always paging', () => {
+    expect(buildEmailLogsSearch({ page: 3, pageSize: 20 })).toStrictEqual({
+      page: '3',
+      page_size: '20',
+    });
+  });
+
+  it('passes the recipient through only when non-empty', () => {
+    expect(
+      buildEmailLogsSearch({ recipient: 'user@example.com', page: 1, pageSize: 20 })
+    ).toStrictEqual({
+      recipient: 'user@example.com',
+      page: '1',
+      page_size: '20',
+    });
+    expect(buildEmailLogsSearch({ recipient: '', page: 1, pageSize: 20 })).toStrictEqual({
+      page: '1',
+      page_size: '20',
     });
   });
 });

--- a/packages/console/src/pages/ConnectorDetails/EmailLogs/utils.ts
+++ b/packages/console/src/pages/ConnectorDetails/EmailLogs/utils.ts
@@ -7,17 +7,27 @@ type WindowInput = {
   endTime?: number;
   /** Full recipient address; the endpoint matches it case-insensitively and exactly. */
   recipient?: string;
-  cursor?: string;
+  /** 1-based page index. */
+  page: number;
+  /** Rows per page, forwarded as the endpoint's `page_size`. */
+  pageSize: number;
 };
 
 /**
- * Translate the picker window, recipient filter, and cursor into the email-logs endpoint's
+ * Translate the picker window, recipient filter, and page into the email-logs endpoint's
  * search parameters. The picker window's end is inclusive; the endpoint's `to` bound is
  * exclusive, hence the one-millisecond shift.
  */
-export const buildEmailLogsSearch = ({ startTime, endTime, recipient, cursor }: WindowInput) => ({
+export const buildEmailLogsSearch = ({
+  startTime,
+  endTime,
+  recipient,
+  page,
+  pageSize,
+}: WindowInput) => ({
   ...conditional(startTime !== undefined && { from: new Date(startTime).toISOString() }),
   ...conditional(endTime !== undefined && { to: new Date(endTime + 1).toISOString() }),
   ...conditional(recipient && { recipient }),
-  ...conditional(cursor && { cursor }),
+  page: String(page),
+  page_size: String(pageSize),
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,7 +105,7 @@
     "zod": "3.24.3"
   },
   "devDependencies": {
-    "@logto/cloud": "0.2.5-cf6987f",
+    "@logto/cloud": "0.2.5-94350d3",
     "@silverhand/eslint-config": "6.0.1",
     "@silverhand/ts-config": "6.0.0",
     "@types/adm-zip": "^0.5.5",

--- a/packages/phrases/src/locales/en/translation/admin-console/connector-details.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/connector-details.ts
@@ -97,8 +97,6 @@ const connector_details = {
     status_failed: 'Failed',
     language_tag: 'Language',
     provider_message_id: 'Provider message ID',
-    previous_page: 'Previous',
-    next_page: 'Next',
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1957,8 +1957,8 @@ importers:
         version: 3.24.3
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-a4e30ff
-        version: 0.2.5-a4e30ff(zod@3.24.3)
+        specifier: 0.2.5-94350d3
+        version: 0.2.5-94350d3(zod@3.24.3)
       '@silverhand/eslint-config':
         specifier: 6.0.1
         version: 6.0.1(eslint@8.57.0)(prettier@3.5.3)(typescript@5.5.3)
@@ -3772,8 +3772,8 @@ importers:
         specifier: ^29.5.0
         version: 29.6.3
       '@logto/cloud':
-        specifier: 0.2.5-cf6987f
-        version: 0.2.5-cf6987f(zod@3.24.3)
+        specifier: 0.2.5-94350d3
+        version: 0.2.5-94350d3(zod@3.24.3)
       '@logto/connector-kit':
         specifier: workspace:^
         version: link:../toolkit/connector-kit
@@ -4304,8 +4304,8 @@ importers:
         version: 3.24.3
     devDependencies:
       '@logto/cloud':
-        specifier: 0.2.5-cf6987f
-        version: 0.2.5-cf6987f(zod@3.24.3)
+        specifier: 0.2.5-94350d3
+        version: 0.2.5-94350d3(zod@3.24.3)
       '@silverhand/eslint-config':
         specifier: 6.0.1
         version: 6.0.1(eslint@8.57.0)(prettier@3.5.3)(typescript@5.5.3)
@@ -6572,12 +6572,8 @@ packages:
   '@logto/client@3.1.8':
     resolution: {integrity: sha512-f6NcPOV/K1IpPm4ccARWeYpQVMeN4mfikGg+5Qw1rcIPYPUpD5BmDsQbVTAnDepCMbC7syzRerZmbwL8S3UL+A==}
 
-  '@logto/cloud@0.2.5-a4e30ff':
-    resolution: {integrity: sha512-jsYbimDtlLdNNHTQNmrMMC1iGL2YT+aqTHHda76OHJnHZnBxnkC+jNNdnjPnktMehMtW2Co8wAA0JM0F4UogFQ==}
-    engines: {node: ^22.14.0}
-
-  '@logto/cloud@0.2.5-cf6987f':
-    resolution: {integrity: sha512-oU8sC5ocUvN5F++yucF/ZjqOypYuOA0O988F2L0YlOimplHwaYH0loc5t5tVS4QdzUSp68urUAqCsRAdEwvrZA==}
+  '@logto/cloud@0.2.5-94350d3':
+    resolution: {integrity: sha512-eBOYGxcQ/E1e2L5IBaSM+2aS5VVoSOZLq4R3Hi/n5IL+J7aHNLBBeB8zqTUDbOWGXEGCwZ+hg09Str0jmo5tAA==}
     engines: {node: ^22.14.0}
 
   '@logto/js@5.1.0':
@@ -7618,157 +7614,131 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.0':
     resolution: {integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.0':
     resolution: {integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.0':
     resolution: {integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.62.0':
     resolution: {integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.0':
     resolution: {integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.62.0':
     resolution: {integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.0':
     resolution: {integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.0':
     resolution: {integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.0':
     resolution: {integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.0':
     resolution: {integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.0':
     resolution: {integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.0':
     resolution: {integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.62.0':
     resolution: {integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -8239,28 +8209,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.3.52':
     resolution: {integrity: sha512-GCxNjTAborAmv4VV1AMZLyejHLGgIzu13tvLUFqybtU4jFxVbE2ZK4ZnPCfDlWN+eBwyRWk1oNFR2hH+66vaUQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.3.52':
     resolution: {integrity: sha512-mrvDBSkLI3Mza2qcu3uzB5JGwMBYDb1++UQ1VB0RXf2AR21/cCper4P44IpfdeqFz9XyXq18Sh3gblICUCGvig==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.3.52':
     resolution: {integrity: sha512-r9RIvKUQv7yBkpXz+QxPAucdoj8ymBlgIm5rLE0b5VmU7dlKBnpAmRBYaITdH6IXhF0pwuG+FHAd5elBcrkIwA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.3.52':
     resolution: {integrity: sha512-YRtEr7tDo0Wes3M2ZhigF4erUjWBXeFP+O+iz6ELBBmPG7B7m/lrA21eiW9/90YGnzi0iNo46shK6PfXuPhP+Q==}
@@ -12485,28 +12451,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.25.1:
     resolution: {integrity: sha512-IhxVFJoTW8wq6yLvxdPvyHv4NjzcpN1B7gjxrY3uaykQNXPHNIpChLB52+wfH+yS58zm1PL4LemUp8u9Cfp6Bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.25.1:
     resolution: {integrity: sha512-RXIaru79KrREPEd6WLXfKfIp4QzoppZvD3x7vuTKkDA64PwTzKJ2jaC43RZHRt8BmyIkRRlmywNhTRMbmkPYpA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.25.1:
     resolution: {integrity: sha512-TdcNqFsAENEEFr8fJWg0Y4fZ/nwuqTRsIr7W7t2wmDUlA8eSXVepeeONYcb+gtTj1RaXn/WgNLB45SFkz+XBZA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-x64-msvc@1.25.1:
     resolution: {integrity: sha512-9KZZkmmy9oGDSrnyHuxP6iMhbsgChUiu/NSgOx+U1I/wTngBStDf2i2aGRCHvFqj19HqqBEI4WuGVQBa2V6e0A==}
@@ -13398,7 +13360,7 @@ packages:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   oidc-provider@https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/513c523c0e68ee6112da8c871cce86204a136163:
-    resolution: {gitHosted: true, integrity: sha512-KaUwCyEEDSZILL2ua2f9SsQ2oSrgq04JAmkQzq2gj7VJyREH3zQS14G7MhfDYxEKjAhO4JZ6bUGzZjW/0Q5pEg==, tarball: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/513c523c0e68ee6112da8c871cce86204a136163}
+    resolution: {integrity: sha512-KaUwCyEEDSZILL2ua2f9SsQ2oSrgq04JAmkQzq2gj7VJyREH3zQS14G7MhfDYxEKjAhO4JZ6bUGzZjW/0Q5pEg==, tarball: https://codeload.github.com/logto-io/node-oidc-provider/tar.gz/513c523c0e68ee6112da8c871cce86204a136163}
     version: 9.11.3
 
   on-finished@2.4.1:
@@ -17868,14 +17830,7 @@ snapshots:
       camelcase-keys: 9.1.3
       jose: 5.9.6
 
-  '@logto/cloud@0.2.5-a4e30ff(zod@3.24.3)':
-    dependencies:
-      '@silverhand/essentials': 2.9.3
-      '@withtyped/server': 0.14.0(zod@3.24.3)
-    transitivePeerDependencies:
-      - zod
-
-  '@logto/cloud@0.2.5-cf6987f(zod@3.24.3)':
+  '@logto/cloud@0.2.5-94350d3(zod@3.24.3)':
     dependencies:
       '@silverhand/essentials': 2.9.3
       '@withtyped/server': 0.14.0(zod@3.24.3)


### PR DESCRIPTION
## Summary

Adopt the audit-logs pagination footer for the (dev-gated) email logs tab, consuming the page-based email-logs endpoint contract that landed in cloud master (logto-io/cloud#2091).

### What changed

- Bumped the `@logto/cloud` pin to `0.2.5-94350d3` in every package that depends on it — `packages/console`, `packages/core`, and `packages/connectors/connector-logto-email` — so all three resolve one version.
- `EmailLogs/use-email-logs.ts` — deleted the cursor stack; the hook now takes `page`/`pageSize`, keys SWR on every fetch input, and returns `totalCount`/`isTotalCountCapped` from the endpoint.
- `EmailLogs/index.tsx` — replaced the hand-rolled Previous/Next footer with the Table's built-in `pagination` prop, wired the same way as `AuditLogTable`: `page` lives in the URL search params, resets on recipient change here and on window changes inside the shared time-window hook. One `pageSize` binding feeds both the request and the footer's math.
- `EmailLogs/utils.ts` — `buildEmailLogsSearch` builds `page`/`page_size` instead of `cursor`.
- `EmailLogs/index.module.scss` — dropped the custom footer block; `.logs` keeps the `unit(6)` bottom gutter the external footer used to carry (matching the sibling `UserLogs`/`MachineLogs` tables).
- Phrases — removed the now-unused `connector_details.email_logs.previous_page`/`next_page` keys from the en source locale; the translation flow prunes the other locales.

### Expected result

The email logs footer is the same numbered footer the audit logs table renders, including the capped-total display ("10,000+" with previous/next-only traversal past the cap). No cursor-era code or phrases remain in console.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
