### PR TITLE
fix(experience): show CAPTCHA for passkey OTP fallback

### DIFF
--- a/.changeset/calm-cats-switch.md
+++ b/.changeset/calm-cats-switch.md
@@ -1,0 +1,5 @@
+---
+"@logto/experience": patch
+---
+
+allow users to complete CAPTCHA when switching from passkey to verification code sign-in

--- a/packages/experience/src/pages/SignInPasskeyVerification/index.test.tsx
+++ b/packages/experience/src/pages/SignInPasskeyVerification/index.test.tsx
@@ -1,0 +1,73 @@
+import { SignInIdentifier, VerificationType } from '@logto/schemas';
+import { renderHook } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+
+import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { mockSignInExperienceSettings } from '@/__mocks__/logto';
+import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
+
+import SignInPasskeyVerification from '.';
+
+jest.mock('@/containers/CaptchaBox', () => () => <div data-testid="captcha-box" />);
+jest.mock('@/utils/webauthn', () => ({ isWebAuthnOptions: () => true }));
+
+describe('SignInPasskeyVerification', () => {
+  const { result } = renderHook(() => useSessionStorage());
+  const { set, remove } = result.current;
+
+  beforeEach(() => {
+    set(StorageKeys.IdentifierInputValue, {
+      type: SignInIdentifier.Email,
+      value: 'foo@logto.io',
+    });
+    set(StorageKeys.verificationIds, { [VerificationType.SignInPasskey]: 'verification-id' });
+  });
+
+  afterEach(() => {
+    remove(StorageKeys.IdentifierInputValue);
+    remove(StorageKeys.verificationIds);
+  });
+
+  it('mounts the CAPTCHA box when verification code sign-in is available', () => {
+    const { queryByTestId } = renderWithPageContext(
+      <SettingsProvider
+        settings={{
+          ...mockSignInExperienceSettings,
+          signIn: {
+            methods: [
+              {
+                identifier: SignInIdentifier.Email,
+                password: false,
+                verificationCode: true,
+                isPasswordPrimary: false,
+              },
+            ],
+          },
+          passkeySignIn: {
+            enabled: true,
+            showPasskeyButton: false,
+            allowAutofill: false,
+          },
+        }}
+      >
+        <UserInteractionContextProvider>
+          <Routes>
+            <Route path="/sign-in/passkey" element={<SignInPasskeyVerification />} />
+          </Routes>
+        </UserInteractionContextProvider>
+      </SettingsProvider>,
+      {
+        initialEntries: [
+          {
+            pathname: '/sign-in/passkey',
+            state: { options: { challenge: 'challenge' } },
+          },
+        ],
+      }
+    );
+
+    expect(queryByTestId('captcha-box')).not.toBeNull();
+  });
+});

--- a/packages/experience/src/pages/SignInPasskeyVerification/index.test.tsx
+++ b/packages/experience/src/pages/SignInPasskeyVerification/index.test.tsx
@@ -17,21 +17,8 @@ describe('SignInPasskeyVerification', () => {
   const { result } = renderHook(() => useSessionStorage());
   const { set, remove } = result.current;
 
-  beforeEach(() => {
-    set(StorageKeys.IdentifierInputValue, {
-      type: SignInIdentifier.Email,
-      value: 'foo@logto.io',
-    });
-    set(StorageKeys.verificationIds, { [VerificationType.SignInPasskey]: 'verification-id' });
-  });
-
-  afterEach(() => {
-    remove(StorageKeys.IdentifierInputValue);
-    remove(StorageKeys.verificationIds);
-  });
-
-  it('mounts the CAPTCHA box when verification code sign-in is available', () => {
-    const { queryByTestId } = renderWithPageContext(
+  const renderPasskeyVerificationPage = (password: boolean) =>
+    renderWithPageContext(
       <SettingsProvider
         settings={{
           ...mockSignInExperienceSettings,
@@ -39,9 +26,9 @@ describe('SignInPasskeyVerification', () => {
             methods: [
               {
                 identifier: SignInIdentifier.Email,
-                password: false,
+                password,
                 verificationCode: true,
-                isPasswordPrimary: false,
+                isPasswordPrimary: password,
               },
             ],
           },
@@ -68,6 +55,28 @@ describe('SignInPasskeyVerification', () => {
       }
     );
 
+  beforeEach(() => {
+    set(StorageKeys.IdentifierInputValue, {
+      type: SignInIdentifier.Email,
+      value: 'foo@logto.io',
+    });
+    set(StorageKeys.verificationIds, { [VerificationType.SignInPasskey]: 'verification-id' });
+  });
+
+  afterEach(() => {
+    remove(StorageKeys.IdentifierInputValue);
+    remove(StorageKeys.verificationIds);
+  });
+
+  it('mounts the CAPTCHA box for direct verification code fallback', () => {
+    const { queryByTestId } = renderPasskeyVerificationPage(false);
+
     expect(queryByTestId('captcha-box')).not.toBeNull();
+  });
+
+  it('does not mount the CAPTCHA box when password fallback takes priority', () => {
+    const { queryByTestId } = renderPasskeyVerificationPage(true);
+
+    expect(queryByTestId('captcha-box')).toBeNull();
   });
 });

--- a/packages/experience/src/pages/SignInPasskeyVerification/index.tsx
+++ b/packages/experience/src/pages/SignInPasskeyVerification/index.tsx
@@ -7,6 +7,7 @@ import { validate } from 'superstruct';
 import SecondaryPageLayout from '@/Layout/SecondaryPageLayout';
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import SwitchToVerificationMethodsLink from '@/components/SwitchToVerificationMethodsLink';
+import CaptchaBox from '@/containers/CaptchaBox';
 import useIdentifierPasskeySignInVerification from '@/hooks/use-identifier-passkey-sign-in-verification';
 import { useSieMethods } from '@/hooks/use-sie';
 import ErrorPage from '@/pages/ErrorPage';
@@ -71,6 +72,7 @@ const SignInPasskeyVerification = () => {
           setIsVerifying(false);
         }}
       />
+      {type !== SignInIdentifier.Username && methodSetting?.verificationCode && <CaptchaBox />}
       <SwitchToVerificationMethodsLink
         className={styles.switchLink}
         identifier={cond(type !== SignInIdentifier.Username && type)}

--- a/packages/experience/src/pages/SignInPasskeyVerification/index.tsx
+++ b/packages/experience/src/pages/SignInPasskeyVerification/index.tsx
@@ -56,6 +56,11 @@ const SignInPasskeyVerification = () => {
 
   // Check if alternative methods are available
   const methodSetting = signInMethods.find((method) => method.identifier === type);
+  const isVerificationCodeIdentifier = type !== SignInIdentifier.Username;
+  const hasPassword = Boolean(methodSetting?.password);
+  const hasVerificationCode =
+    isVerificationCodeIdentifier && Boolean(methodSetting?.verificationCode);
+  const shouldRenderCaptcha = hasVerificationCode && !hasPassword;
 
   return (
     <SecondaryPageLayout
@@ -72,13 +77,13 @@ const SignInPasskeyVerification = () => {
           setIsVerifying(false);
         }}
       />
-      {type !== SignInIdentifier.Username && methodSetting?.verificationCode && <CaptchaBox />}
+      {shouldRenderCaptcha && <CaptchaBox />}
       <SwitchToVerificationMethodsLink
         className={styles.switchLink}
-        identifier={cond(type !== SignInIdentifier.Username && type)}
+        identifier={cond(isVerificationCodeIdentifier && type)}
         value={identifierInputValue.value}
-        hasPassword={methodSetting?.password}
-        hasVerificationCode={type !== SignInIdentifier.Username && methodSetting?.verificationCode}
+        hasPassword={hasPassword}
+        hasVerificationCode={hasVerificationCode}
       />
     </SecondaryPageLayout>
   );

--- a/packages/experience/src/pages/SignInVerificationMethods/index.test.tsx
+++ b/packages/experience/src/pages/SignInVerificationMethods/index.test.tsx
@@ -1,0 +1,63 @@
+import { SignInIdentifier } from '@logto/schemas';
+import { renderHook } from '@testing-library/react';
+import { Route, Routes } from 'react-router-dom';
+
+import UserInteractionContextProvider from '@/Providers/UserInteractionContextProvider';
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import SettingsProvider from '@/__mocks__/RenderWithPageContext/SettingsProvider';
+import { mockSignInExperienceSettings } from '@/__mocks__/logto';
+import useSessionStorage, { StorageKeys } from '@/hooks/use-session-storages';
+
+import SignInVerificationMethods from '.';
+
+jest.mock('@/containers/CaptchaBox', () => () => <div data-testid="captcha-box" />);
+
+describe('SignInVerificationMethods', () => {
+  const { result } = renderHook(() => useSessionStorage());
+  const { set, remove } = result.current;
+
+  beforeEach(() => {
+    set(StorageKeys.IdentifierInputValue, {
+      type: SignInIdentifier.Email,
+      value: 'foo@logto.io',
+    });
+  });
+
+  afterEach(() => {
+    remove(StorageKeys.IdentifierInputValue);
+  });
+
+  it('mounts the CAPTCHA box when verification code sign-in is available', () => {
+    const { queryByTestId } = renderWithPageContext(
+      <SettingsProvider
+        settings={{
+          ...mockSignInExperienceSettings,
+          signIn: {
+            methods: [
+              {
+                identifier: SignInIdentifier.Email,
+                password: true,
+                verificationCode: true,
+                isPasswordPrimary: true,
+              },
+            ],
+          },
+          passkeySignIn: {
+            enabled: true,
+            showPasskeyButton: false,
+            allowAutofill: false,
+          },
+        }}
+      >
+        <UserInteractionContextProvider>
+          <Routes>
+            <Route path="/sign-in/verification-methods" element={<SignInVerificationMethods />} />
+          </Routes>
+        </UserInteractionContextProvider>
+      </SettingsProvider>,
+      { initialEntries: ['/sign-in/verification-methods'] }
+    );
+
+    expect(queryByTestId('captcha-box')).not.toBeNull();
+  });
+});

--- a/packages/experience/src/pages/SignInVerificationMethods/index.test.tsx
+++ b/packages/experience/src/pages/SignInVerificationMethods/index.test.tsx
@@ -58,6 +58,9 @@ describe('SignInVerificationMethods', () => {
       { initialEntries: ['/sign-in/verification-methods'] }
     );
 
-    expect(queryByTestId('captcha-box')).not.toBeNull();
+    const captchaBox = queryByTestId('captcha-box');
+
+    expect(captchaBox).not.toBeNull();
+    expect(captchaBox?.closest('[class*="methodList"]')).toBeNull();
   });
 });

--- a/packages/experience/src/pages/SignInVerificationMethods/index.tsx
+++ b/packages/experience/src/pages/SignInVerificationMethods/index.tsx
@@ -8,6 +8,7 @@ import FactorPhone from '@/assets/icons/factor-phone.svg?react';
 import FactorWebAuthn from '@/assets/icons/factor-webauthn.svg?react';
 import LockIcon from '@/assets/icons/lock.svg?react';
 import useVerificationCodeLink from '@/components/SwitchToVerificationMethodsLink/use-verification-code-link';
+import CaptchaBox from '@/containers/CaptchaBox';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import { useSieMethods } from '@/hooks/use-sie';
 import useStartIdentifierPasskeySignInProcessing from '@/hooks/use-start-identifier-passkey-sign-in-processing';
@@ -77,6 +78,7 @@ const SignInVerificationMethods = () => {
             }}
           />
         )}
+        {hasVerificationCode && type !== SignInIdentifier.Username && <CaptchaBox />}
         {hasVerificationCode && type !== SignInIdentifier.Username && (
           <VerificationMethodCard
             titleKey={`description.verification_method.${type}_verification_code`}

--- a/packages/experience/src/pages/SignInVerificationMethods/index.tsx
+++ b/packages/experience/src/pages/SignInVerificationMethods/index.tsx
@@ -47,7 +47,8 @@ const SignInVerificationMethods = () => {
   const { type, value } = identifierInputValue;
   const methodSetting = signInMethods.find((method) => method.identifier === type);
   const hasPassword = Boolean(methodSetting?.password);
-  const hasVerificationCode = Boolean(methodSetting?.verificationCode);
+  const hasVerificationCode =
+    type !== SignInIdentifier.Username && Boolean(methodSetting?.verificationCode);
 
   return (
     <SecondaryPageLayout
@@ -78,8 +79,7 @@ const SignInVerificationMethods = () => {
             }}
           />
         )}
-        {hasVerificationCode && type !== SignInIdentifier.Username && <CaptchaBox />}
-        {hasVerificationCode && type !== SignInIdentifier.Username && (
+        {hasVerificationCode && (
           <VerificationMethodCard
             titleKey={`description.verification_method.${type}_verification_code`}
             descriptionKey="description.verification_method.verification_code_description"
@@ -91,6 +91,7 @@ const SignInVerificationMethods = () => {
           />
         )}
       </div>
+      {hasVerificationCode && <CaptchaBox />}
     </SecondaryPageLayout>
   );
 };

--- a/packages/integration-tests/src/tests/experience/identifier-first-verification-switching.test.ts
+++ b/packages/integration-tests/src/tests/experience/identifier-first-verification-switching.test.ts
@@ -1,16 +1,19 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { CaptchaType, SignInIdentifier } from '@logto/schemas';
+import { SignInIdentifier } from '@logto/schemas';
 
 import { deleteUser, updateUser } from '#src/api/admin-user.js';
-import { deleteCaptchaProvider, updateCaptchaProvider } from '#src/api/captcha-provider.js';
+import { deleteCaptchaProvider } from '#src/api/captcha-provider.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { demoAppUrl } from '#src/constants.js';
+import { setAlwaysPassCaptcha } from '#src/helpers/captcha.js';
 import {
   clearConnectorsByTypes,
   setEmailConnector,
   setSmsConnector,
 } from '#src/helpers/connector.js';
 import {
+  disableCaptcha,
+  enableCaptcha,
   enableMandatoryMfaWithWebAuthn,
   resetMfaSettings,
 } from '#src/helpers/sign-in-experience.js';
@@ -272,32 +275,31 @@ describe('identifier-first verification method switching', () => {
       await experience.verifyThenEnd(false);
       await updateUser(userId, { primaryEmail: email });
 
-      await updateCaptchaProvider({
-        config: {
-          type: CaptchaType.Turnstile,
-          siteKey: 'site_key',
-          secretKey: 'secret_key',
-        },
-      });
+      await setAlwaysPassCaptcha();
       await setupSignInExperience({
         passkeyEnabled: true,
         passwordEnabled: false,
         verificationCodeEnabled: true,
         isPasswordPrimary: false,
       });
-      await updateSignInExperience({ captchaPolicy: { enabled: true } });
+      await enableCaptcha();
 
-      await experience.startWith(demoAppUrl);
-      await experience.toFillInput('identifier', email, { submit: true });
-      await experience.waitForPathname('sign-in/passkey');
+      try {
+        await experience.startWith(demoAppUrl);
+        await experience.toFillInput('identifier', email, { submit: true });
+        await experience.waitForPathname('sign-in/passkey');
 
-      await expect(experience.page).toMatchElement('div[class*="captchaBox"]');
-
-      await updateSignInExperience({ captchaPolicy: { enabled: false } });
-      await deleteCaptchaProvider();
-      await experience.clearVirtualAuthenticator();
-      await deleteUser(userId);
-      await experience.page.close();
+        await expect(experience.page).toMatchElement('div[class*="captchaBox"]');
+        await experience.page.waitForFunction(() => 'turnstile' in window);
+        await experience.toClick('a', /sign in with verification code/i);
+        await experience.waitForPathname('sign-in/verification-code');
+      } finally {
+        await disableCaptcha();
+        await deleteCaptchaProvider();
+        await experience.clearVirtualAuthenticator();
+        await deleteUser(userId);
+        await experience.page.close();
+      }
     });
 
     it('should show switch link and navigate to password page when switching methods', async () => {

--- a/packages/integration-tests/src/tests/experience/identifier-first-verification-switching.test.ts
+++ b/packages/integration-tests/src/tests/experience/identifier-first-verification-switching.test.ts
@@ -1,7 +1,8 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInIdentifier } from '@logto/schemas';
+import { CaptchaType, SignInIdentifier } from '@logto/schemas';
 
-import { deleteUser } from '#src/api/admin-user.js';
+import { deleteUser, updateUser } from '#src/api/admin-user.js';
+import { deleteCaptchaProvider, updateCaptchaProvider } from '#src/api/captcha-provider.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { demoAppUrl } from '#src/constants.js';
 import {
@@ -246,6 +247,57 @@ describe('identifier-first verification method switching', () => {
       await experience.clearVirtualAuthenticator();
       await experience.verifyThenEnd();
       await deleteUser(userId);
+    });
+
+    it('should render CAPTCHA when switching from passkey to verification code', async () => {
+      await setupSignInExperience({});
+      await enableMandatoryMfaWithWebAuthn();
+
+      const username = generateUsername();
+      const password = 'l0gt0_T3st_P@ssw0rd';
+      const email = `${generateUsername()}@logto.io`;
+
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'register');
+      await experience.toFillInput('identifier', username, { submit: true });
+      experience.toBeAt('register/password');
+      await experience.toFillNewPasswords(password);
+
+      experience.toBeAt('mfa-binding/WebAuthn');
+      await experience.toCreatePasskey();
+
+      const userId = await experience.getUserIdFromDemoAppPage();
+      await experience.verifyThenEnd(false);
+      await updateUser(userId, { primaryEmail: email });
+
+      await updateCaptchaProvider({
+        config: {
+          type: CaptchaType.Turnstile,
+          siteKey: 'site_key',
+          secretKey: 'secret_key',
+        },
+      });
+      await setupSignInExperience({
+        passkeyEnabled: true,
+        passwordEnabled: false,
+        verificationCodeEnabled: true,
+        isPasswordPrimary: false,
+      });
+      await updateSignInExperience({ captchaPolicy: { enabled: true } });
+
+      await experience.startWith(demoAppUrl);
+      await experience.toFillInput('identifier', email, { submit: true });
+      await experience.waitForPathname('sign-in/passkey');
+
+      await expect(experience.page).toMatchElement('div[class*="captchaBox"]');
+
+      await updateSignInExperience({ captchaPolicy: { enabled: false } });
+      await deleteCaptchaProvider();
+      await experience.clearVirtualAuthenticator();
+      await deleteUser(userId);
+      await experience.page.close();
     });
 
     it('should show switch link and navigate to password page when switching methods', async () => {


### PR DESCRIPTION
## Summary

- mount the CAPTCHA widget host on the passkey verification page when verification code sign-in is available
- mount the CAPTCHA widget host on the multi-method chooser for verification code fallback
- add unit and integration coverage for the affected identifier-first flow

Fixes #9482

## Testing

Unit tests

Integration tests