### PR TITLE
feat(experience): support multi-organization consent

### DIFF
--- a/packages/experience/src/apis/consent.ts
+++ b/packages/experience/src/apis/consent.ts
@@ -2,16 +2,14 @@ import { type ConsentInfoResponse } from '@logto/schemas';
 
 import api from './api';
 
-export const consent = async (organizationId?: string) => {
+export const consent = async (organizationIds?: string[]) => {
   type Response = {
     redirectTo: string;
   };
 
   return api
     .post('/api/interaction/consent', {
-      json: {
-        organizationIds: organizationId && [organizationId],
-      },
+      json: { organizationIds },
     })
     .json<Response>();
 };

--- a/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationItem/index.module.scss
+++ b/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationItem/index.module.scss
@@ -29,4 +29,17 @@
       color: var(--color-brand-default);
     }
   }
+
+  &[aria-disabled='true'] {
+    color: var(--color-type-disable);
+    cursor: not-allowed;
+
+    &:hover {
+      background-color: transparent;
+    }
+
+    .icon {
+      color: var(--color-type-disable);
+    }
+  }
 }

--- a/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationItem/index.tsx
+++ b/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationItem/index.tsx
@@ -15,6 +15,7 @@ type OrganizationItemProps = {
   readonly organization: Organization;
   readonly onSelect?: (organization: Organization) => void;
   readonly isSelected?: boolean;
+  readonly isDisabled?: boolean;
   readonly suffixElement?: ReactNode;
 };
 
@@ -22,6 +23,7 @@ const OrganizationItem = ({
   organization,
   onSelect,
   isSelected,
+  isDisabled,
   suffixElement,
   className,
 }: OrganizationItemProps) => {
@@ -32,12 +34,15 @@ const OrganizationItem = ({
       {...(onSelect && {
         role: 'button',
         'aria-pressed': isSelected,
+        'aria-disabled': isDisabled,
         tabIndex: 0,
-        onClick: () => {
-          onSelect(organization);
-        },
-        onKeyDown: onKeyDownHandler(() => {
-          onSelect(organization);
+        ...(!isDisabled && {
+          onClick: () => {
+            onSelect(organization);
+          },
+          onKeyDown: onKeyDownHandler(() => {
+            onSelect(organization);
+          }),
         }),
       })}
     >

--- a/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationItem/index.tsx
+++ b/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationItem/index.tsx
@@ -31,6 +31,7 @@ const OrganizationItem = ({
       data-selected={isSelected}
       {...(onSelect && {
         role: 'button',
+        'aria-pressed': isSelected,
         tabIndex: 0,
         onClick: () => {
           onSelect(organization);

--- a/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationSelectorModal/index.tsx
+++ b/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationSelectorModal/index.tsx
@@ -12,8 +12,9 @@ type Props = {
   readonly isOpen: boolean;
   readonly parentElementRef: React.RefObject<HTMLDivElement>;
   readonly organizations: Organization[];
-  readonly selectedOrganization: Organization;
-  readonly onSelect: (organization: Organization) => void;
+  readonly selectedOrganizations: Organization[];
+  readonly isMultiSelectEnabled: boolean;
+  readonly onToggle: (organization: Organization) => void;
   readonly onClose: () => void;
 };
 
@@ -21,8 +22,9 @@ const OrganizationSelectorModal = ({
   isOpen,
   parentElementRef,
   organizations,
-  selectedOrganization,
-  onSelect,
+  selectedOrganizations,
+  isMultiSelectEnabled,
+  onToggle,
   onClose,
 }: Props) => {
   const { isMobile } = usePlatform();
@@ -83,10 +85,13 @@ const OrganizationSelectorModal = ({
             key={organization.id}
             className={styles.organizationItem}
             organization={organization}
-            isSelected={organization.id === selectedOrganization.id}
+            isSelected={selectedOrganizations.some(({ id }) => id === organization.id)}
             onSelect={() => {
-              onClose();
-              onSelect(organization);
+              onToggle(organization);
+
+              if (!isMultiSelectEnabled) {
+                onClose();
+              }
             }}
           />
         ))}

--- a/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationSelectorModal/index.tsx
+++ b/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationSelectorModal/index.tsx
@@ -64,7 +64,7 @@ const OrganizationSelectorModal = ({
     return () => {
       window.removeEventListener('resize', updatePosition);
     };
-  }, [updatePosition, isOpen]);
+  }, [updatePosition, isOpen, selectedOrganizations.length]);
 
   return (
     <ReactModal

--- a/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationSelectorModal/index.tsx
+++ b/packages/experience/src/pages/Consent/OrganizationSelector/OrganizationSelectorModal/index.tsx
@@ -80,21 +80,26 @@ const OrganizationSelectorModal = ({
       onRequestClose={onClose}
     >
       <div className={styles.container}>
-        {organizations.map((organization) => (
-          <OrganizationItem
-            key={organization.id}
-            className={styles.organizationItem}
-            organization={organization}
-            isSelected={selectedOrganizations.some(({ id }) => id === organization.id)}
-            onSelect={() => {
-              onToggle(organization);
+        {organizations.map((organization) => {
+          const isSelected = selectedOrganizations.some(({ id }) => id === organization.id);
 
-              if (!isMultiSelectEnabled) {
-                onClose();
-              }
-            }}
-          />
-        ))}
+          return (
+            <OrganizationItem
+              key={organization.id}
+              className={styles.organizationItem}
+              organization={organization}
+              isSelected={isSelected}
+              isDisabled={isMultiSelectEnabled && isSelected && selectedOrganizations.length === 1}
+              onSelect={() => {
+                onToggle(organization);
+
+                if (!isMultiSelectEnabled) {
+                  onClose();
+                }
+              }}
+            />
+          );
+        })}
       </div>
     </ReactModal>
   );

--- a/packages/experience/src/pages/Consent/OrganizationSelector/index.tsx
+++ b/packages/experience/src/pages/Consent/OrganizationSelector/index.tsx
@@ -13,33 +13,69 @@ import styles from './index.module.scss';
 
 export { type Organization } from './OrganizationItem';
 
+type ResourceScopes = NonNullable<Organization['missingResourceScopes']>;
+
+const mergeResourceScopes = (
+  resourceScopes: ResourceScopes,
+  scopesToMerge: ResourceScopes
+): ResourceScopes =>
+  scopesToMerge.reduce<ResourceScopes>((mergedResourceScopes, resourceScope) => {
+    const existingResourceScope = mergedResourceScopes.find(
+      ({ resource }) => resource.id === resourceScope.resource.id
+    );
+
+    if (!existingResourceScope) {
+      return [...mergedResourceScopes, resourceScope];
+    }
+
+    return mergedResourceScopes.map((candidate) =>
+      candidate.resource.id === resourceScope.resource.id
+        ? {
+            ...candidate,
+            scopes: [
+              ...candidate.scopes,
+              ...resourceScope.scopes.filter(
+                ({ id }) => !candidate.scopes.some((scope) => scope.id === id)
+              ),
+            ],
+          }
+        : candidate
+    );
+  }, resourceScopes);
+
 type Props = {
   readonly organizations: Organization[];
-  readonly selectedOrganization: Organization | undefined;
-  readonly onSelect: (organization: Organization) => void;
+  readonly selectedOrganizations: Organization[];
+  readonly isMultiSelectEnabled: boolean;
+  readonly onToggle: (organization: Organization) => void;
   readonly className?: string;
 };
 
 const OrganizationSelector = ({
   organizations,
-  selectedOrganization,
-  onSelect,
+  selectedOrganizations,
+  isMultiSelectEnabled,
+  onToggle,
   className,
 }: Props) => {
   const { t } = useTranslation();
   const parentElementRef = useRef<HTMLDivElement>(null);
   const [showDropdown, setShowDropdown] = useState(false);
 
-  if (organizations.length === 0 || !selectedOrganization) {
+  if (organizations.length === 0 || selectedOrganizations.length === 0) {
     return null;
   }
 
-  const { missingResourceScopes: resourceScopes } = selectedOrganization;
+  const resourceScopes = selectedOrganizations.reduce<ResourceScopes>(
+    (resourceScopes, { missingResourceScopes = [] }) =>
+      mergeResourceScopes(resourceScopes, missingResourceScopes),
+    []
+  );
 
   return (
     <div className={className}>
       <div className={styles.title}>{t(`description.authorize_organization_access`)}</div>
-      {resourceScopes && resourceScopes.length > 0 && (
+      {resourceScopes.length > 0 && (
         <div className={styles.scopeListWrapper}>
           {resourceScopes
             .slice()
@@ -68,25 +104,31 @@ const OrganizationSelector = ({
         ref={parentElementRef}
         className={classNames(
           styles.cardWrapper,
-          Boolean(resourceScopes?.length) && styles.withoutTopRadius
+          resourceScopes.length > 0 && styles.withoutTopRadius
         )}
         data-active={showDropdown}
       >
-        <OrganizationItem
-          className={styles.selectedOrganization}
-          organization={selectedOrganization}
-          suffixElement={<ExpandableIcon className={styles.expandButton} />}
-          onSelect={() => {
-            setShowDropdown(true);
-          }}
-        />
+        {selectedOrganizations.map((organization, index) => (
+          <OrganizationItem
+            key={organization.id}
+            className={styles.selectedOrganization}
+            organization={organization}
+            suffixElement={
+              index === 0 ? <ExpandableIcon className={styles.expandButton} /> : undefined
+            }
+            onSelect={() => {
+              setShowDropdown(true);
+            }}
+          />
+        ))}
       </div>
       <OrganizationSelectorModal
         isOpen={showDropdown}
         parentElementRef={parentElementRef}
         organizations={organizations}
-        selectedOrganization={selectedOrganization}
-        onSelect={onSelect}
+        selectedOrganizations={selectedOrganizations}
+        isMultiSelectEnabled={isMultiSelectEnabled}
+        onToggle={onToggle}
         onClose={() => {
           setShowDropdown(false);
         }}

--- a/packages/experience/src/pages/Consent/index.test.tsx
+++ b/packages/experience/src/pages/Consent/index.test.tsx
@@ -295,4 +295,30 @@ describe('Consent', () => {
       expect(mockedConsent).toBeCalledWith(['organization_2']);
     });
   });
+
+  it('disables deselecting the last selected organization', async () => {
+    mockedGetConsentInfo.mockResolvedValueOnce({
+      ...consentInfo,
+      organizations: [
+        { id: 'organization_1', name: 'Organization 1' },
+        { id: 'organization_2', name: 'Organization 2' },
+      ],
+    });
+
+    const { getAllByText, getByText } = renderConsent();
+
+    await waitFor(() => {
+      expect(getByText('Organization 1')).not.toBeNull();
+    });
+
+    fireEvent.click(getByText('Organization 1'));
+
+    const organization1Item = getAllByText('Organization 1').at(-1)?.closest('[role="button"]');
+
+    expect(organization1Item?.getAttribute('aria-disabled')).toBe('true');
+
+    fireEvent.click(getByText('Organization 2'));
+
+    expect(organization1Item?.getAttribute('aria-disabled')).toBe('false');
+  });
 });

--- a/packages/experience/src/pages/Consent/index.test.tsx
+++ b/packages/experience/src/pages/Consent/index.test.tsx
@@ -204,6 +204,31 @@ describe('Consent', () => {
       expect(queryByText(/is self-declared by/)).toBeNull();
       unmount();
     });
+
+    it('only submits one selected organization', async () => {
+      mockedGetConsentInfo.mockResolvedValueOnce({
+        ...cimdConsentInfo('Fancy client'),
+        organizations: [
+          { id: 'organization_1', name: 'Organization 1' },
+          { id: 'organization_2', name: 'Organization 2' },
+        ],
+      });
+      mockedConsent.mockResolvedValueOnce({ redirectTo: '' });
+
+      const { getByText } = renderConsent();
+
+      await waitFor(() => {
+        expect(getByText('Organization 1')).not.toBeNull();
+      });
+
+      fireEvent.click(getByText('Organization 1'));
+      fireEvent.click(getByText('Organization 2'));
+      fireEvent.click(getByText('action.authorize'));
+
+      await waitFor(() => {
+        expect(mockedConsent).toBeCalledWith(['organization_2']);
+      });
+    });
   });
 
   it('signs out from the access denied page', async () => {

--- a/packages/experience/src/pages/Consent/index.test.tsx
+++ b/packages/experience/src/pages/Consent/index.test.tsx
@@ -219,4 +219,55 @@ describe('Consent', () => {
 
     expect(assign).toBeCalledWith('http://localhost/oidc/session/end?client_id=application_id');
   });
+
+  it('submits all selected organizations', async () => {
+    mockedGetConsentInfo.mockResolvedValueOnce({
+      ...consentInfo,
+      organizations: [
+        { id: 'organization_1', name: 'Organization 1' },
+        { id: 'organization_2', name: 'Organization 2' },
+      ],
+    });
+    mockedConsent.mockResolvedValueOnce({ redirectTo: '' });
+
+    const { getByText } = renderConsent();
+
+    await waitFor(() => {
+      expect(getByText('Organization 1')).not.toBeNull();
+    });
+
+    fireEvent.click(getByText('Organization 1'));
+    fireEvent.click(getByText('Organization 2'));
+    fireEvent.click(getByText('action.authorize'));
+
+    await waitFor(() => {
+      expect(mockedConsent).toBeCalledWith(['organization_1', 'organization_2']);
+    });
+  });
+
+  it('allows a selected organization to be removed when another remains', async () => {
+    mockedGetConsentInfo.mockResolvedValueOnce({
+      ...consentInfo,
+      organizations: [
+        { id: 'organization_1', name: 'Organization 1' },
+        { id: 'organization_2', name: 'Organization 2' },
+      ],
+    });
+    mockedConsent.mockResolvedValueOnce({ redirectTo: '' });
+
+    const { getAllByText, getByText } = renderConsent();
+
+    await waitFor(() => {
+      expect(getByText('Organization 1')).not.toBeNull();
+    });
+
+    fireEvent.click(getByText('Organization 1'));
+    fireEvent.click(getByText('Organization 2'));
+    fireEvent.click(getAllByText('Organization 1').at(-1)!);
+    fireEvent.click(getByText('action.authorize'));
+
+    await waitFor(() => {
+      expect(mockedConsent).toBeCalledWith(['organization_2']);
+    });
+  });
 });

--- a/packages/experience/src/pages/Consent/index.tsx
+++ b/packages/experience/src/pages/Consent/index.tsx
@@ -101,25 +101,6 @@ const Consent = () => {
     }
   }, [asyncConsent, handleConsentError, redirectTo, selectedOrganizations]);
 
-  const toggleOrganization = useCallback((organization: Organization) => {
-    setSelectedOrganizations((selectedOrganizations) => {
-      if (!isMultiOrganizationConsentEnabled) {
-        return [organization];
-      }
-
-      const isSelected = selectedOrganizations.some(({ id }) => id === organization.id);
-
-      // Organization access consent always requires at least one selected organization.
-      if (isSelected && selectedOrganizations.length === 1) {
-        return selectedOrganizations;
-      }
-
-      return isSelected
-        ? selectedOrganizations.filter(({ id }) => id !== organization.id)
-        : [...selectedOrganizations, organization];
-    });
-  }, []);
-
   useEffect(() => {
     const getConsentInfoHandler = async () => {
       const [error, result] = await asyncGetConsentInfo();
@@ -166,6 +147,25 @@ const Consent = () => {
   } = consentData;
 
   const { unregisteredClientHost, applicationName } = getClientDisplayData(consentData);
+  const isMultiSelectEnabled = isMultiOrganizationConsentEnabled && !unregisteredClientHost;
+  const toggleOrganization = (organization: Organization) => {
+    setSelectedOrganizations((selectedOrganizations) => {
+      if (!isMultiSelectEnabled) {
+        return [organization];
+      }
+
+      const isSelected = selectedOrganizations.some(({ id }) => id === organization.id);
+
+      // Organization access consent always requires at least one selected organization.
+      if (isSelected && selectedOrganizations.length === 1) {
+        return selectedOrganizations;
+      }
+
+      return isSelected
+        ? selectedOrganizations.filter(({ id }) => id !== organization.id)
+        : [...selectedOrganizations, organization];
+    });
+  };
   const showTerms = Boolean(termsOfUseUrl ?? privacyPolicyUrl);
   const { redirectUri } = consentData;
   const redirectUriOrigin = consentData.redirectUri
@@ -203,7 +203,7 @@ const Consent = () => {
           className={styles.organizationSelector}
           organizations={consentData.organizations}
           selectedOrganizations={selectedOrganizations}
-          isMultiSelectEnabled={isMultiOrganizationConsentEnabled}
+          isMultiSelectEnabled={isMultiSelectEnabled}
           onToggle={toggleOrganization}
         />
       )}

--- a/packages/experience/src/pages/Consent/index.tsx
+++ b/packages/experience/src/pages/Consent/index.tsx
@@ -7,6 +7,7 @@ import LandingPageLayout from '@/Layout/LandingPageLayout';
 import { consent, getConsentInfo } from '@/apis/consent';
 import TermsLinks from '@/components/TermsLinks';
 import TextLink from '@/components/TextLink';
+import { isDevFeaturesEnabled } from '@/constants/env';
 import useApi from '@/hooks/use-api';
 import useErrorHandler, { type ErrorHandlers } from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
@@ -38,6 +39,9 @@ const getClientDisplayData = ({ application: { id, displayName, name } }: Consen
   };
 };
 
+// Multi-organization third-party consent
+const isMultiOrganizationConsentEnabled = isDevFeaturesEnabled;
+
 const Consent = () => {
   const handleError = useErrorHandler();
   const asyncConsent = useApi(consent);
@@ -45,7 +49,7 @@ const Consent = () => {
   const redirectTo = useGlobalRedirectTo();
 
   const [consentData, setConsentData] = useState<ConsentInfoResponse>();
-  const [selectedOrganization, setSelectedOrganization] = useState<Organization>();
+  const [selectedOrganizations, setSelectedOrganizations] = useState<Organization[]>([]);
   const [isAccessDenied, setIsAccessDenied] = useState(false);
 
   const [isConsentLoading, setIsConsentLoading] = useState(false);
@@ -83,7 +87,7 @@ const Consent = () => {
 
   const consentHandler = useCallback(async () => {
     setIsConsentLoading(true);
-    const [error, result] = await asyncConsent(selectedOrganization?.id);
+    const [error, result] = await asyncConsent(selectedOrganizations.map(({ id }) => id));
     setIsConsentLoading(false);
 
     if (error) {
@@ -95,7 +99,26 @@ const Consent = () => {
     if (result?.redirectTo) {
       await redirectTo(result.redirectTo);
     }
-  }, [asyncConsent, handleConsentError, redirectTo, selectedOrganization?.id]);
+  }, [asyncConsent, handleConsentError, redirectTo, selectedOrganizations]);
+
+  const toggleOrganization = useCallback((organization: Organization) => {
+    setSelectedOrganizations((selectedOrganizations) => {
+      if (!isMultiOrganizationConsentEnabled) {
+        return [organization];
+      }
+
+      const isSelected = selectedOrganizations.some(({ id }) => id === organization.id);
+
+      // Organization access consent always requires at least one selected organization.
+      if (isSelected && selectedOrganizations.length === 1) {
+        return selectedOrganizations;
+      }
+
+      return isSelected
+        ? selectedOrganizations.filter(({ id }) => id !== organization.id)
+        : [...selectedOrganizations, organization];
+    });
+  }, []);
 
   useEffect(() => {
     const getConsentInfoHandler = async () => {
@@ -114,7 +137,7 @@ const Consent = () => {
         return;
       }
 
-      setSelectedOrganization(result.organizations[0]);
+      setSelectedOrganizations(result.organizations.slice(0, 1));
     };
 
     void getConsentInfoHandler();
@@ -179,8 +202,9 @@ const Consent = () => {
         <OrganizationSelector
           className={styles.organizationSelector}
           organizations={consentData.organizations}
-          selectedOrganization={selectedOrganization}
-          onSelect={setSelectedOrganization}
+          selectedOrganizations={selectedOrganizations}
+          isMultiSelectEnabled={isMultiOrganizationConsentEnabled}
+          onToggle={toggleOrganization}
         />
       )}
       <div className={styles.footerButton}>


### PR DESCRIPTION
## Summary

- allow users to select multiple organizations when authorizing a third-party application
- keep selected organizations visible in the consent selector
- merge and deduplicate organization permissions shown for the selected organizations
- submit all selected organization IDs in the consent interaction

## Testing

- Tested locally
- Unit tests
