### PR TITLE
ci: allow fork PR checkout for size diff

### DIFF
--- a/.github/workflows/update-pr-metadata.yml
+++ b/.github/workflows/update-pr-metadata.yml
@@ -39,6 +39,7 @@ jobs:
           ref: refs/pull/${{ github.event.number }}/merge
           fetch-depth: 0
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Prepare
         run: |


### PR DESCRIPTION
## Summary
Allow the PR size diff job to explicitly check out fork pull request merge refs after the new `actions/checkout` security default.

## Testing
N/A

## Checklist
- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments