### PR TITLE
fix(account,console,core): remove trusted device pagination

### DIFF
--- a/packages/account/src/apis/trusted-devices.ts
+++ b/packages/account/src/apis/trusted-devices.ts
@@ -10,7 +10,6 @@ export const getTrustedDevices = async (
   return createAuthenticatedKy(accessToken)
     .get('/api/my-account/trusted-devices', {
       headers: { [verificationRecordIdHeader]: verificationRecordId },
-      searchParams: { page_size: '100' },
     })
     .json<AccountTrustedDeviceResponse[]>();
 };

--- a/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.test.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.test.tsx
@@ -34,10 +34,6 @@ jest.mock('@/hooks/use-confirm-modal', () => ({
   useConfirmModal: jest.fn(),
 }));
 
-jest.mock('@/consts', () => ({
-  defaultPageSize: 20,
-}));
-
 jest.mock('@/hooks/use-tenant-pathname', () => ({
   __esModule: true,
   default: () => ({ getTo: (path: string) => path }),
@@ -122,7 +118,7 @@ describe('UserTrustedDevices', () => {
 
   it('renders approved device metadata without exposing the raw IP address', () => {
     mockedUseSWR.mockReturnValue({
-      data: [[trustedDevice], 1],
+      data: [trustedDevice],
       mutate: mockMutate,
     } as unknown as ReturnType<typeof useSWR>);
 
@@ -144,7 +140,7 @@ describe('UserTrustedDevices', () => {
   it('formats the expiry date using the current Console language', async () => {
     await i18next.changeLanguage('ja');
     mockedUseSWR.mockReturnValue({
-      data: [[trustedDevice], 1],
+      data: [trustedDevice],
       mutate: mockMutate,
     } as unknown as ReturnType<typeof useSWR>);
 
@@ -155,7 +151,7 @@ describe('UserTrustedDevices', () => {
 
   it('shows the empty state when the user has no active trusted devices', () => {
     mockedUseSWR.mockReturnValue({
-      data: [[], 0],
+      data: [],
       mutate: mockMutate,
     } as unknown as ReturnType<typeof useSWR>);
 
@@ -179,24 +175,21 @@ describe('UserTrustedDevices', () => {
     expect(mockMutate).toHaveBeenCalledTimes(1);
   });
 
-  it('requests the selected page through the Management API', () => {
+  it('requests all trusted devices without pagination parameters', () => {
     mockedUseSWR.mockReturnValue({
-      data: [[trustedDevice], 21],
+      data: [trustedDevice],
       mutate: mockMutate,
     } as unknown as ReturnType<typeof useSWR>);
 
     renderTrustedDevices();
-    fireEvent.click(screen.getByRole('button', { name: '2' }));
 
-    expect(mockedUseSWR).toHaveBeenLastCalledWith(
-      'api/users/user-id/trusted-devices?page=2&page_size=20'
-    );
+    expect(mockedUseSWR).toHaveBeenLastCalledWith('api/users/user-id/trusted-devices');
   });
 
   it('keeps the device when removal is canceled', async () => {
     mockShowConfirm.mockResolvedValue([false]);
     mockedUseSWR.mockReturnValue({
-      data: [[trustedDevice], 1],
+      data: [trustedDevice],
       mutate: mockMutate,
     } as unknown as ReturnType<typeof useSWR>);
 
@@ -211,7 +204,7 @@ describe('UserTrustedDevices', () => {
 
   it('removes a confirmed device and refreshes the successful state', async () => {
     mockedUseSWR.mockReturnValue({
-      data: [[trustedDevice], 1],
+      data: [trustedDevice],
       mutate: mockMutate,
     } as unknown as ReturnType<typeof useSWR>);
 
@@ -236,7 +229,7 @@ describe('UserTrustedDevices', () => {
   it('keeps the current list when removal fails', async () => {
     mockDelete.mockRejectedValue(new Error('request failed'));
     mockedUseSWR.mockReturnValue({
-      data: [[trustedDevice], 1],
+      data: [trustedDevice],
       mutate: mockMutate,
     } as unknown as ReturnType<typeof useSWR>);
 

--- a/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.tsx
@@ -6,13 +6,11 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import FormCard from '@/components/FormCard';
-import { defaultPageSize } from '@/consts';
 import Button from '@/ds-components/Button';
 import FormField from '@/ds-components/FormField';
 import Table from '@/ds-components/Table';
 import useApi, { type RequestError } from '@/hooks/use-api';
 import { useConfirmModal } from '@/hooks/use-confirm-modal';
-import { buildUrl } from '@/utils/url';
 
 import styles from './index.module.scss';
 
@@ -25,11 +23,8 @@ type TrustedDeviceTableRow = TrustedDeviceResponse & {
   readonly location?: string;
 };
 
-const pageSize = defaultPageSize;
-
 function UserTrustedDevices({ userId }: Props) {
   const { t, i18n } = useTranslation(undefined, { keyPrefix: 'admin_console' });
-  const [page, setPage] = useState(1);
   const [deletingDeviceId, setDeletingDeviceId] = useState<string>();
   const expiryDateFormatter = useMemo(
     () =>
@@ -41,18 +36,14 @@ function UserTrustedDevices({ userId }: Props) {
     [i18n.language]
   );
 
-  const { data, error, mutate } = useSWR<[TrustedDeviceResponse[], number], RequestError>(
-    buildUrl(`api/users/${userId}/trusted-devices`, {
-      page: String(page),
-      page_size: String(pageSize),
-    })
+  const { data, error, mutate } = useSWR<TrustedDeviceResponse[], RequestError>(
+    `api/users/${userId}/trusted-devices`
   );
 
   const isLoading = !data && !error;
-  const [trustedDevices, totalCount] = data ?? [[], 0];
   const rows = useMemo(
     () =>
-      trustedDevices.map<TrustedDeviceTableRow>((trustedDevice) => {
+      (data ?? []).map<TrustedDeviceTableRow>((trustedDevice) => {
         const { userAgent, country, city } = trustedDevice;
 
         return {
@@ -64,7 +55,7 @@ function UserTrustedDevices({ userId }: Props) {
           }),
         };
       }),
-    [trustedDevices]
+    [data]
   );
   const hasRows = rows.length > 0;
 
@@ -89,12 +80,6 @@ function UserTrustedDevices({ userId }: Props) {
       try {
         await api.delete(`api/users/${userId}/trusted-devices/${trustedDevice.id}`);
         toast.success(t('mfa.trusted_device.management_removed'));
-
-        if (rows.length === 1 && page > 1) {
-          setPage(page - 1);
-          return;
-        }
-
         await mutate();
       } catch {
         // Request errors are surfaced by useApi's global error handler.
@@ -102,7 +87,7 @@ function UserTrustedDevices({ userId }: Props) {
         setDeletingDeviceId(undefined);
       }
     },
-    [api, mutate, page, rows.length, showConfirm, t, userId]
+    [api, mutate, showConfirm, t, userId]
   );
 
   return (
@@ -169,12 +154,6 @@ function UserTrustedDevices({ userId }: Props) {
                 ),
               },
             ]}
-            pagination={{
-              page,
-              pageSize,
-              totalCount,
-              onChange: setPage,
-            }}
             onRetry={() => {
               void mutate();
             }}

--- a/packages/core/src/queries/trusted-device.test.ts
+++ b/packages/core/src/queries/trusted-device.test.ts
@@ -87,37 +87,24 @@ describe('trusted device queries', () => {
     ).resolves.toBeNull();
   });
 
-  it('uses the same strict active predicate for paginated list and count', async () => {
+  it('returns all active devices in reverse creation order', async () => {
     const listSql = sql`
       select ${expandFields(TrustedDevices)}
       from ${table}
       where ${fields.userId} = $1
         and ${fields.expiresAt} > now()
       order by ${fields.createdAt} desc
-      limit $2 offset $3
-    `;
-    const countSql = sql`
-      select count(*)
-      from ${table}
-      where ${fields.userId} = $1
-        and ${fields.expiresAt} > now()
     `;
 
-    mockQuery
-      .mockImplementationOnce(async (query, values) => {
-        expectSqlAssert(query, countSql.sql);
-        expect(values).toEqual([trustedDevice.userId]);
-        return createMockQueryResult([{ count: '1' }]);
-      })
-      .mockImplementationOnce(async (query, values) => {
-        expectSqlAssert(query, listSql.sql);
-        expect(values).toEqual([trustedDevice.userId, 20, 40]);
-        return createMockQueryResult([trustedDevice]);
-      });
+    mockQuery.mockImplementationOnce(async (query, values) => {
+      expectSqlAssert(query, listSql.sql);
+      expect(values).toEqual([trustedDevice.userId]);
+      return createMockQueryResult([trustedDevice]);
+    });
 
-    await expect(
-      queries.findActiveByUserId(trustedDevice.userId, { limit: 20, offset: 40 })
-    ).resolves.toEqual([1, [trustedDevice]]);
+    await expect(queries.findActiveByUserId(trustedDevice.userId)).resolves.toEqual([
+      trustedDevice,
+    ]);
   });
 
   it('constrains active point lookup by record and user ownership', async () => {

--- a/packages/core/src/queries/trusted-device.ts
+++ b/packages/core/src/queries/trusted-device.ts
@@ -22,11 +22,6 @@ export type TrustedDeviceMetadata = Readonly<{
 type TrustedDeviceCreation = TrustedDeviceMetadata &
   Readonly<Pick<TrustedDevice, 'id' | 'userId' | 'secretHash' | 'expiresAt'>>;
 
-type Pagination = Readonly<{
-  limit: number;
-  offset: number;
-}>;
-
 export class TrustedDeviceQueries {
   constructor(public readonly pool: CommonQueryMethods) {}
 
@@ -65,23 +60,16 @@ export class TrustedDeviceQueries {
     `);
   }
 
-  public async findActiveByUserId(
-    userId: string,
-    { limit, offset }: Pagination
-  ): Promise<[totalNumber: number, rows: readonly TrustedDevice[]]> {
-    return Promise.all([
-      this.countActiveByUserId(userId),
-      manyRows(
-        this.pool.query<TrustedDevice>(sql`
-          select ${expandFields(TrustedDevices)}
-          from ${table}
-          where ${fields.userId} = ${userId}
-            and ${activePredicate}
-          order by ${fields.createdAt} desc
-          limit ${limit} offset ${offset}
-        `)
-      ),
-    ]);
+  public async findActiveByUserId(userId: string) {
+    return manyRows(
+      this.pool.query<TrustedDevice>(sql`
+        select ${expandFields(TrustedDevices)}
+        from ${table}
+        where ${fields.userId} = ${userId}
+          and ${activePredicate}
+        order by ${fields.createdAt} desc
+      `)
+    );
   }
 
   public async findActiveByIdAndUserId(id: string, userId: string) {
@@ -144,16 +132,5 @@ export class TrustedDeviceQueries {
     `);
 
     return rowCount;
-  }
-
-  private async countActiveByUserId(userId: string) {
-    return Number(
-      await this.pool.oneFirst<string>(sql`
-        select count(*)
-        from ${table}
-        where ${fields.userId} = ${userId}
-          and ${activePredicate}
-      `)
-    );
   }
 }

--- a/packages/core/src/routes/account/index.openapi.json
+++ b/packages/core/src/routes/account/index.openapi.json
@@ -786,10 +786,10 @@
         "tags": ["Dev feature"],
         "operationId": "GetTrustedDevices",
         "summary": "Get trusted devices",
-        "description": "Retrieve a paginated list of active trusted devices for the signed-in user. A logto-verification-id in header and the trusted-devices scope are required. Each entry includes isCurrent, which is true only when the browser's trusted-device cookie passes full credential validation for that record.",
+        "description": "Retrieve all active trusted devices for the signed-in user. A logto-verification-id in header and the trusted-devices scope are required. Each entry includes isCurrent, which is true only when the browser's trusted-device cookie passes full credential validation for that record.",
         "responses": {
           "200": {
-            "description": "A paginated list of the signed-in user's active trusted devices."
+            "description": "A list of the signed-in user's active trusted devices."
           },
           "401": {
             "description": "Permission denied, the verification record is invalid or the access token does not include the trusted-devices scope."

--- a/packages/core/src/routes/account/trusted-device.test.ts
+++ b/packages/core/src/routes/account/trusted-device.test.ts
@@ -40,7 +40,7 @@ const otherTrustedDevice: TrustedDevice = {
 };
 
 const findActiveByUserId = jest.fn(
-  async (): Promise<[number, readonly TrustedDevice[]]> => [2, [trustedDevice, otherTrustedDevice]]
+  async (): Promise<readonly TrustedDevice[]> => [trustedDevice, otherTrustedDevice]
 );
 const validateCredential = jest.fn(async (): Promise<TrustedDevice | undefined> => trustedDevice);
 const deleteByIdAndUserId = jest.fn(async (): Promise<TrustedDevice | undefined> => trustedDevice);
@@ -112,14 +112,14 @@ describe('account trusted device routes', () => {
     setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
   });
 
-  it('returns a paginated, redacted list and marks only the validated credential as current', async () => {
-    const response = await buildRequester({ field: AccountCenterControlValue.ReadOnly })
-      .get('/my-account/trusted-devices')
-      .query({ page: 2, page_size: 1 });
+  it('returns all redacted devices and marks only the validated credential as current', async () => {
+    const response = await buildRequester({ field: AccountCenterControlValue.ReadOnly }).get(
+      '/my-account/trusted-devices'
+    );
 
     expect(response.status).toBe(200);
-    expect(response.headers['total-number']).toBe('2');
-    expect(response.headers.link).toContain('rel="first"');
+    expect(response.headers['total-number']).toBeUndefined();
+    expect(response.headers.link).toBeUndefined();
     expect(response.body).toEqual([
       {
         id: trustedDevice.id,
@@ -145,7 +145,7 @@ describe('account trusted device routes', () => {
     expect(response.text).not.toContain('secretHash');
     expect(response.text).not.toContain(trustedDevice.ip);
     expect(validateCredential).toHaveBeenCalledWith(expect.any(Object), mockUser.id);
-    expect(findActiveByUserId).toHaveBeenCalledWith(mockUser.id, { limit: 1, offset: 1 });
+    expect(findActiveByUserId).toHaveBeenCalledWith(mockUser.id);
   });
 
   it('does not infer the current device from a record ID when credential validation fails', async () => {

--- a/packages/core/src/routes/account/trusted-device.ts
+++ b/packages/core/src/routes/account/trusted-device.ts
@@ -10,7 +10,6 @@ import { z } from 'zod';
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import koaPagination from '#src/middleware/koa-pagination.js';
 import { assertFirstPartyClient } from '#src/utils/assert-first-party-client.js';
 import assertThat from '#src/utils/assert-that.js';
 
@@ -31,7 +30,6 @@ export default function accountTrustedDeviceRoutes<T extends UserRouter>(
 
   router.get(
     `${accountApiPrefix}/trusted-devices`,
-    koaPagination(),
     koaGuard({
       response: accountTrustedDeviceResponseGuard.array(),
       status: [200, 400, 401, 500],
@@ -53,13 +51,11 @@ export default function accountTrustedDeviceRoutes<T extends UserRouter>(
         scopes.has(UserScope.TrustedDevices),
         new RequestError({ code: 'auth.unauthorized', status: 401 })
       );
-      const { limit, offset } = ctx.pagination;
-      const [currentTrustedDevice, [totalNumber, records]] = await Promise.all([
+      const [currentTrustedDevice, records] = await Promise.all([
         trustedDeviceLibrary.validateCredential(ctx, userId),
-        trustedDevices.findActiveByUserId(userId, { limit, offset }),
+        trustedDevices.findActiveByUserId(userId),
       ]);
 
-      ctx.pagination.totalCount = totalNumber;
       ctx.body = records.map(
         (record) =>
           ({

--- a/packages/core/src/routes/admin-user/trusted-device.openapi.json
+++ b/packages/core/src/routes/admin-user/trusted-device.openapi.json
@@ -4,10 +4,10 @@
       "get": {
         "tags": ["Dev feature"],
         "summary": "Get user trusted devices",
-        "description": "Retrieve a paginated list of active trusted devices for the user.",
+        "description": "Retrieve all active trusted devices for the user.",
         "responses": {
           "200": {
-            "description": "A paginated list of the user's active trusted devices."
+            "description": "A list of the user's active trusted devices."
           },
           "404": {
             "description": "The user was not found."

--- a/packages/core/src/routes/admin-user/trusted-device.test.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.test.ts
@@ -33,9 +33,7 @@ const mockedQueries = {
     findUserById: jest.fn(async () => mockUser),
   },
   trustedDevices: {
-    findActiveByUserId: jest.fn(
-      async (): Promise<[number, readonly TrustedDevice[]]> => [1, [trustedDevice]]
-    ),
+    findActiveByUserId: jest.fn(async (): Promise<readonly TrustedDevice[]> => [trustedDevice]),
     deleteByIdAndUserId: jest.fn(async (): Promise<TrustedDevice> => trustedDevice),
   },
 } satisfies Partial2<Queries>;
@@ -75,14 +73,12 @@ describe('admin user trusted device routes', () => {
     setDevFeaturesEnabled(originalIsDevFeaturesEnabled);
   });
 
-  it('returns a paginated and redacted list of active trusted devices', async () => {
-    const response = await createTrustedDeviceRequester()
-      .get(`/users/${userId}/trusted-devices`)
-      .query({ page: 2, page_size: 1 });
+  it('returns all active trusted devices with sensitive fields redacted', async () => {
+    const response = await createTrustedDeviceRequester().get(`/users/${userId}/trusted-devices`);
 
     expect(response.status).toBe(200);
-    expect(response.headers['total-number']).toBe('1');
-    expect(response.headers.link).toContain('rel="first"');
+    expect(response.headers['total-number']).toBeUndefined();
+    expect(response.headers.link).toBeUndefined();
     expect(response.body).toEqual([
       {
         id: trustedDevice.id,
@@ -97,7 +93,7 @@ describe('admin user trusted device routes', () => {
     expect(response.text).not.toContain('secretHash');
     expect(response.text).not.toContain(trustedDevice.ip);
     expect(findUserById).toHaveBeenCalledWith(userId);
-    expect(findActiveByUserId).toHaveBeenCalledWith(userId, { limit: 1, offset: 1 });
+    expect(findActiveByUserId).toHaveBeenCalledWith(userId);
   });
 
   it('returns 404 without querying devices when the user does not exist', async () => {
@@ -106,16 +102,6 @@ describe('admin user trusted device routes', () => {
     const response = await createTrustedDeviceRequester().get(`/users/${userId}/trusted-devices`);
 
     expect(response.status).toBe(404);
-    expect(findActiveByUserId).not.toHaveBeenCalled();
-  });
-
-  it('returns 400 for invalid pagination', async () => {
-    const response = await createTrustedDeviceRequester().get(
-      `/users/${userId}/trusted-devices?page=0`
-    );
-
-    expect(response.status).toBe(400);
-    expect(findUserById).not.toHaveBeenCalled();
     expect(findActiveByUserId).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/routes/admin-user/trusted-device.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.ts
@@ -6,7 +6,6 @@ import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildManagementApiContext } from '#src/libraries/hook/utils.js';
 import koaGuard from '#src/middleware/koa-guard.js';
-import koaPagination from '#src/middleware/koa-pagination.js';
 import assertThat from '#src/utils/assert-that.js';
 
 import type { ManagementApiRouter, RouterInitArgs } from '../types.js';
@@ -29,7 +28,6 @@ export default function adminUserTrustedDeviceRoutes<T extends ManagementApiRout
 
   router.get(
     '/users/:userId/trusted-devices',
-    koaPagination(),
     koaGuard({
       params: z.object({ userId: z.string() }),
       response: trustedDeviceResponseGuard.array(),
@@ -37,15 +35,10 @@ export default function adminUserTrustedDeviceRoutes<T extends ManagementApiRout
     }),
     async (ctx, next) => {
       const { userId } = ctx.guard.params;
-      const { limit, offset } = ctx.pagination;
 
       await findUserById(userId);
-      const [totalNumber, records] = await trustedDevices.findActiveByUserId(userId, {
-        limit,
-        offset,
-      });
+      const records = await trustedDevices.findActiveByUserId(userId);
 
-      ctx.pagination.totalCount = totalNumber;
       ctx.body = records.map(
         (record) =>
           pick(

--- a/packages/integration-tests/src/api/admin-user.ts
+++ b/packages/integration-tests/src/api/admin-user.ts
@@ -219,19 +219,8 @@ export const updatePersonalAccessTokenLegacy = async (
     })
     .json<PersonalAccessToken>();
 
-export const getUserTrustedDevicesResponse = async (
-  userId: string,
-  searchParams?: URLSearchParams
-) =>
-  authedAdminApi.get(`users/${userId}/trusted-devices`, {
-    searchParams,
-  });
-
-export const getUserTrustedDevices = async (userId: string, searchParams?: URLSearchParams) => {
-  const response = await getUserTrustedDevicesResponse(userId, searchParams);
-
-  return response.json<TrustedDeviceResponse[]>();
-};
+export const getUserTrustedDevices = async (userId: string) =>
+  authedAdminApi.get(`users/${userId}/trusted-devices`).json<TrustedDeviceResponse[]>();
 
 export const deleteUserTrustedDevice = async (userId: string, trustedDeviceId: string) =>
   authedAdminApi.delete(`users/${userId}/trusted-devices/${trustedDeviceId}`);

--- a/packages/integration-tests/src/api/my-account.ts
+++ b/packages/integration-tests/src/api/my-account.ts
@@ -260,22 +260,13 @@ export const deleteSession = async (
     headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
-export const getTrustedDevicesResponse = async (
-  api: KyInstance,
-  verificationRecordId: string,
-  searchParams?: URLSearchParams
-) =>
+export const getTrustedDevicesResponse = async (api: KyInstance, verificationRecordId: string) =>
   api.get('api/my-account/trusted-devices', {
-    searchParams,
     headers: { [verificationRecordIdHeader]: verificationRecordId },
   });
 
-export const getTrustedDevices = async (
-  api: KyInstance,
-  verificationRecordId: string,
-  searchParams?: URLSearchParams
-) => {
-  const response = await getTrustedDevicesResponse(api, verificationRecordId, searchParams);
+export const getTrustedDevices = async (api: KyInstance, verificationRecordId: string) => {
+  const response = await getTrustedDevicesResponse(api, verificationRecordId);
 
   return response.json<AccountTrustedDeviceResponse[]>();
 };

--- a/packages/integration-tests/src/tests/api/account/trusted-device.test.ts
+++ b/packages/integration-tests/src/tests/api/account/trusted-device.test.ts
@@ -180,26 +180,38 @@ devFeatureTest.describe('account trusted device management', () => {
     await pool.end();
   });
 
-  it('returns paginated redacted records and marks only a fully validated credential as current', async () => {
+  it('returns more than 100 redacted records and marks only a fully validated credential as current', async () => {
     const api = buildApiWithCredential(
       owner.accessToken,
       owner.user.id,
       currentCredential.id,
       currentCredential.secret
     );
-    const firstPageResponse = await getTrustedDevicesResponse(
-      api,
-      owner.verificationRecordId,
-      new URLSearchParams({ page: '1', page_size: '1' })
-    );
-    const firstPage = await firstPageResponse.json<AccountTrustedDeviceResponse[]>();
-    const [firstDevice] = firstPage;
-    assert(firstDevice, new Error('Expected the first trusted-device page'));
+    const now = Date.now();
+    const additionalCredentials = Array.from({ length: 99 }, (_, index) => ({
+      ...createCredential(generateStandardId()),
+      createdAt: now - 2000 - index,
+    }));
 
-    expect(firstPageResponse.headers.get('total-number')).toBe('2');
-    expect(firstPageResponse.headers.get('link')).toContain('rel="next"');
-    expect(firstPage).toEqual([
+    await Promise.all(
+      additionalCredentials.map(async (credential) =>
+        insertTrustedDevice({
+          ...credential,
+          userId: owner.user.id,
+        })
+      )
+    );
+    const response = await getTrustedDevicesResponse(api, owner.verificationRecordId);
+    const devices = await response.json<AccountTrustedDeviceResponse[]>();
+    const [firstDevice] = devices;
+    assert(firstDevice, new Error('Expected an active trusted device'));
+
+    expect(response.headers.get('total-number')).toBeNull();
+    expect(response.headers.get('link')).toBeNull();
+    expect(devices).toHaveLength(101);
+    expect(devices.slice(0, 2)).toEqual([
       expect.objectContaining({ id: currentCredential.id, isCurrent: true }),
+      expect.objectContaining({ id: remoteCredential.id, isCurrent: false }),
     ]);
     expect(firstDevice).toMatchObject({
       id: currentCredential.id,
@@ -211,17 +223,8 @@ devFeatureTest.describe('account trusted device management', () => {
     expect(typeof firstDevice.createdAt).toBe('number');
     expect(typeof firstDevice.lastUsedAt).toBe('number');
     expect(typeof firstDevice.expiresAt).toBe('number');
-    expect(JSON.stringify(firstPage)).not.toContain('192.0.2.1');
-    expect(JSON.stringify(firstPage)).not.toContain('secretHash');
-
-    const secondPage = await getTrustedDevices(
-      api,
-      owner.verificationRecordId,
-      new URLSearchParams({ page: '2', page_size: '1' })
-    );
-    expect(secondPage).toEqual([
-      expect.objectContaining({ id: remoteCredential.id, isCurrent: false }),
-    ]);
+    expect(JSON.stringify(devices)).not.toContain('192.0.2.1');
+    expect(JSON.stringify(devices)).not.toContain('secretHash');
   });
 
   it('never marks a record current when the cookie ID matches but the secret is invalid', async () => {

--- a/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
+++ b/packages/integration-tests/src/tests/api/admin-user.trusted-devices.test.ts
@@ -1,14 +1,9 @@
-import { defaultTenantId, type TrustedDeviceResponse } from '@logto/schemas';
+import { defaultTenantId } from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { assertEnv } from '@silverhand/essentials';
 import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
 
-import {
-  deleteUser,
-  deleteUserTrustedDevice,
-  getUserTrustedDevices,
-  getUserTrustedDevicesResponse,
-} from '#src/api/admin-user.js';
+import { deleteUser, deleteUserTrustedDevice, getUserTrustedDevices } from '#src/api/admin-user.js';
 import { createUserByAdmin } from '#src/helpers/index.js';
 import { devFeatureTest } from '#src/utils.js';
 
@@ -64,7 +59,7 @@ devFeatureTest.describe('admin user trusted devices', () => {
     await pool.end();
   });
 
-  it('lists only active owned records with pagination and deletes only owned records', async () => {
+  it('lists all active owned records and deletes only owned records', async () => {
     const [user, otherUser] = await Promise.all([createUserByAdmin(), createUserByAdmin()]);
     const now = Date.now();
     const olderDeviceId = generateStandardId();
@@ -100,15 +95,9 @@ devFeatureTest.describe('admin user trusted devices', () => {
         }),
       ]);
 
-      const firstPageResponse = await getUserTrustedDevicesResponse(
-        user.id,
-        new URLSearchParams({ page: '1', page_size: '1' })
-      );
-      const firstPage = await firstPageResponse.json<TrustedDeviceResponse[]>();
+      const trustedDevices = await getUserTrustedDevices(user.id);
 
-      expect(firstPageResponse.headers.get('Total-Number')).toBe('2');
-      expect(firstPageResponse.headers.get('Link')).toContain('rel="next"');
-      expect(firstPage).toEqual([
+      expect(trustedDevices).toEqual([
         {
           id: newerDeviceId,
           userAgent: 'Mozilla/5.0 integration test',
@@ -118,9 +107,18 @@ devFeatureTest.describe('admin user trusted devices', () => {
           lastUsedAt: now - 1000,
           expiresAt: now + 60_000,
         },
+        {
+          id: olderDeviceId,
+          userAgent: 'Mozilla/5.0 integration test',
+          country: 'US',
+          city: 'San Francisco',
+          createdAt: now - 2000,
+          lastUsedAt: now - 2000,
+          expiresAt: now + 60_000,
+        },
       ]);
-      expect(JSON.stringify(firstPage)).not.toContain('192.0.2.1');
-      expect(JSON.stringify(firstPage)).not.toContain('secretHash');
+      expect(JSON.stringify(trustedDevices)).not.toContain('192.0.2.1');
+      expect(JSON.stringify(trustedDevices)).not.toContain('secretHash');
 
       await expect(deleteUserTrustedDevice(user.id, otherUserDeviceId)).rejects.toHaveProperty(
         'response.status',


### PR DESCRIPTION
## Summary
- return all active trusted devices from the Management API and Account API without pagination metadata
- update Console and Hosted Account Center consumers to use the complete list
- cover lists larger than 100 devices while preserving redaction and current-device detection

## Testing
Unit tests
Integration tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments