### PR TITLE
fix(console): hide Bring your UI Pro tag in OSS

### DIFF
--- a/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.tsx
+++ b/packages/console/src/pages/SignInExperience/PageContent/Branding/CustomUiForm/index.tsx
@@ -1,3 +1,4 @@
+import { cond } from '@silverhand/essentials';
 import { useContext } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Trans, useTranslation } from 'react-i18next';
@@ -82,7 +83,7 @@ function CustomUiForm() {
       <Card>
         <FormSectionTitle
           title="custom_ui.bring_your_ui_title"
-          featureTag={{ isVisible: !isBringYourUiEnabled, plan: latestProPlanId }}
+          featureTag={cond(isCloud && { isVisible: !isBringYourUiEnabled, plan: latestProPlanId })}
         />
         {isCloud && (
           <FormField


### PR DESCRIPTION
## Summary

Only render the Bring your UI Pro paywall tag in Logto Cloud. Keep the open-source Console focused on the Cloud tag and its Cloud upsell card.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments