### PR TITLE
fix(console): simplify trusted device empty state

### DIFF
--- a/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.test.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.test.tsx
@@ -69,11 +69,6 @@ jest.mock('@/ds-components/FormField', () => ({
   ),
 }));
 
-jest.mock('@/components/EmptyDataPlaceholder', () => ({
-  __esModule: true,
-  default: ({ title }: { readonly title: React.ReactNode }) => <div>{title}</div>,
-}));
-
 jest.mock('@/ds-components/OverlayScrollbar', () => ({
   __esModule: true,
   default: ({ children }: { readonly children: React.ReactNode }) => <div>{children}</div>,
@@ -137,6 +132,7 @@ describe('UserTrustedDevices', () => {
     expect(screen.getByText('trusted-device-id')).toBeTruthy();
     expect(screen.getByText('Shanghai, China')).toBeTruthy();
     expect(screen.getByText('Jul 26, 2026')).toBeTruthy();
+    expect(screen.getByText('admin_console.mfa.trusted_device.management_hint')).toBeTruthy();
     expect(screen.queryByText('192.0.2.1')).toBeNull();
     expect(screen.getByText('admin_console.user_details.sessions.name_column')).toBeTruthy();
     expect(screen.getByText('admin_console.user_details.sessions.location_column')).toBeTruthy();
@@ -166,6 +162,8 @@ describe('UserTrustedDevices', () => {
     renderTrustedDevices();
 
     expect(screen.getByText('admin_console.mfa.trusted_device.management_empty')).toBeTruthy();
+    expect(screen.queryByText('admin_console.mfa.trusted_device.management_hint')).toBeNull();
+    expect(screen.queryByText('admin_console.user_details.sessions.name_column')).toBeNull();
   });
 
   it('shows an error and retries the request', () => {

--- a/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.tsx
@@ -5,7 +5,6 @@ import { toast } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
-import EmptyDataPlaceholder from '@/components/EmptyDataPlaceholder';
 import FormCard from '@/components/FormCard';
 import { defaultPageSize } from '@/consts';
 import Button from '@/ds-components/Button';
@@ -67,6 +66,7 @@ function UserTrustedDevices({ userId }: Props) {
       }),
     [trustedDevices]
   );
+  const hasRows = rows.length > 0;
 
   const api = useApi();
   const { show: showConfirm } = useConfirmModal();
@@ -111,74 +111,79 @@ function UserTrustedDevices({ userId }: Props) {
       description="mfa.trusted_device.management_description"
     >
       <FormField title="mfa.trusted_device.title">
-        <div className={styles.hint}>{t('mfa.trusted_device.management_hint')}</div>
-        <Table
-          hasBorder
-          isRowHoverEffectDisabled
-          className={styles.table}
-          bodyTableWrapperClassName={styles.tableBody}
-          rowGroups={[{ key: 'trustedDevices', data: rows }]}
-          rowIndexKey="id"
-          isLoading={isLoading}
-          errorMessage={error?.body?.message ?? error?.message}
-          columns={[
-            {
-              title: t('user_details.sessions.name_column'),
-              dataIndex: 'name',
-              colSpan: 7,
-              render: ({ id, name }) => (
-                <div className={styles.name}>
-                  <span>{name ?? '-'}</span>
-                  <span className={styles.id}>{id}</span>
-                </div>
-              ),
-            },
-            {
-              title: t('user_details.sessions.location_column'),
-              dataIndex: 'location',
-              colSpan: 5,
-              render: ({ location }) => location ?? '-',
-            },
-            {
-              title: t('user_details.personal_access_tokens.expires_at'),
-              dataIndex: 'expiresAt',
-              colSpan: 4,
-              render: ({ expiresAt }) => (
-                <span className={styles.expiresAt}>{expiryDateFormatter.format(expiresAt)}</span>
-              ),
-            },
-            {
-              title: null,
-              dataIndex: 'action',
-              colSpan: 2,
-              render: (trustedDevice) => (
-                <div className={styles.action}>
-                  <Button
-                    title="general.remove"
-                    type="text"
-                    size="small"
-                    isLoading={deletingDeviceId === trustedDevice.id}
-                    onClick={() => {
-                      void handleRemove(trustedDevice);
-                    }}
-                  />
-                </div>
-              ),
-            },
-          ]}
-          pagination={{
-            page,
-            pageSize,
-            totalCount,
-            onChange: setPage,
-          }}
-          placeholder={
-            <EmptyDataPlaceholder size="small" title={t('mfa.trusted_device.management_empty')} />
-          }
-          onRetry={() => {
-            void mutate();
-          }}
-        />
+        {!isLoading && !error && (
+          <div className={styles.hint}>
+            {t(
+              hasRows ? 'mfa.trusted_device.management_hint' : 'mfa.trusted_device.management_empty'
+            )}
+          </div>
+        )}
+        {(isLoading || hasRows || error) && (
+          <Table
+            hasBorder
+            isRowHoverEffectDisabled
+            className={styles.table}
+            bodyTableWrapperClassName={styles.tableBody}
+            rowGroups={[{ key: 'trustedDevices', data: rows }]}
+            rowIndexKey="id"
+            isLoading={isLoading}
+            errorMessage={error?.body?.message ?? error?.message}
+            columns={[
+              {
+                title: t('user_details.sessions.name_column'),
+                dataIndex: 'name',
+                colSpan: 7,
+                render: ({ id, name }) => (
+                  <div className={styles.name}>
+                    <span>{name ?? '-'}</span>
+                    <span className={styles.id}>{id}</span>
+                  </div>
+                ),
+              },
+              {
+                title: t('user_details.sessions.location_column'),
+                dataIndex: 'location',
+                colSpan: 5,
+                render: ({ location }) => location ?? '-',
+              },
+              {
+                title: t('user_details.personal_access_tokens.expires_at'),
+                dataIndex: 'expiresAt',
+                colSpan: 4,
+                render: ({ expiresAt }) => (
+                  <span className={styles.expiresAt}>{expiryDateFormatter.format(expiresAt)}</span>
+                ),
+              },
+              {
+                title: null,
+                dataIndex: 'action',
+                colSpan: 2,
+                render: (trustedDevice) => (
+                  <div className={styles.action}>
+                    <Button
+                      title="general.remove"
+                      type="text"
+                      size="small"
+                      isLoading={deletingDeviceId === trustedDevice.id}
+                      onClick={() => {
+                        void handleRemove(trustedDevice);
+                      }}
+                    />
+                  </div>
+                ),
+              },
+            ]}
+            pagination={{
+              page,
+              pageSize,
+              totalCount,
+              onChange: setPage,
+            }}
+            onRetry={() => {
+              void mutate();
+            }}
+          />
+        )}
       </FormField>
     </FormCard>
   );


### PR DESCRIPTION
## Summary

Simplify the trusted-device empty state on the user details page to match the Sessions and Connections sections. Empty results now show a single line of text without rendering the table or illustration, while loading, error, and populated states retain the existing table behavior.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
