### PR TITLE
fix(core): revalidate trusted devices for each request

### DIFF
--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -111,6 +111,23 @@ describe('trusted device library', () => {
     jest.restoreAllMocks();
   });
 
+  it('checks for an unsigned user-specific trusted-device cookie', () => {
+    const queries = createQueries();
+    const { ctx, get } = createCookieContext('credential');
+    const library = createTrustedDeviceLibrary(tenantId, queries, createPolicyLibrary(), {
+      isProduction: false,
+    });
+
+    expect(library.hasCredential(ctx, userId)).toBe(true);
+    expect(get).toHaveBeenCalledWith(getTrustedDeviceCookieName(tenantId, userId, false), {
+      signed: false,
+    });
+
+    const { ctx: emptyContext } = createCookieContext();
+
+    expect(library.hasCredential(emptyContext, userId)).toBe(false);
+  });
+
   it('creates a record with only the secret hash and writes an unsigned host-only cookie', async () => {
     const now = Date.now();
     const durationDays = 7;

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -145,6 +145,9 @@ export const createTrustedDeviceLibrary = (
   const getCookieName = (userId: string) =>
     getTrustedDeviceCookieName(tenantId, userId, isProduction);
 
+  const hasCredential = (ctx: TrustedDeviceCookieContext, userId: string) =>
+    Boolean(ctx.cookies.get(getCookieName(userId), { signed: false }));
+
   const clearCredential = (ctx: TrustedDeviceCookieContext, userId: string) => {
     ctx.cookies.set(getCookieName(userId), '', {
       expires: new Date(0),
@@ -305,6 +308,7 @@ export const createTrustedDeviceLibrary = (
     createCredential,
     deleteByIdAndUserId,
     getCookieName,
+    hasCredential,
     updateMetadata,
     validateCredential,
     writeCredential,

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -217,15 +217,15 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
     expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
 
-  it('caches valid credential fulfillment only within the current request', async () => {
-    validateCredential.mockResolvedValueOnce(trustedDevice);
+  it('revalidates the trusted-device credential every time the guard runs', async () => {
+    validateCredential.mockResolvedValue(trustedDevice);
     const { ctx, experienceInteraction } = createInteraction();
 
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
 
-    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
-    expect(validateCredential).toHaveBeenCalledTimes(1);
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(2);
+    expect(validateCredential).toHaveBeenCalledTimes(2);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
     expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
     expect(experienceInteraction.toSanitizedJson()).not.toHaveProperty('trustedDeviceFulfillment');

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -53,6 +53,7 @@ const adaptiveMfaSignInExperience: SignInExperience = {
 const findDefaultSignInExperience = jest.fn().mockResolvedValue(requiredMfaSignInExperience);
 const findUserById = jest.fn().mockResolvedValue(mockUserWithMfaVerifications);
 const getEffectivePolicy = jest.fn().mockResolvedValue({ enabled: true, durationDays: 30 });
+const hasCredential = jest.fn().mockReturnValue(true);
 const validateCredential = jest.fn();
 
 const tenant = new MockTenant(
@@ -64,7 +65,7 @@ const tenant = new MockTenant(
   undefined,
   {
     trustedDevicePolicy: { getEffectivePolicy },
-    trustedDevices: { validateCredential },
+    trustedDevices: { hasCredential, validateCredential },
   }
 );
 
@@ -127,7 +128,7 @@ const expectConventionalMfaRequired = async (
   );
 };
 
-describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
+describe('ExperienceInteraction trusted-device MFA verification', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle the mocked feature environment per test.
@@ -135,6 +136,7 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
     findDefaultSignInExperience.mockResolvedValue(requiredMfaSignInExperience);
     findUserById.mockResolvedValue(mockUserWithMfaVerifications);
     getEffectivePolicy.mockResolvedValue({ enabled: true, durationDays: 30 });
+    hasCredential.mockReturnValue(true);
   });
 
   afterEach(() => {
@@ -207,7 +209,18 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
     expect(validateCredential).not.toHaveBeenCalled();
   });
 
-  it('falls back to conventional MFA when credential validation does not fulfill the guard', async () => {
+  it('skips policy and credential validation when no trusted-device cookie is present', async () => {
+    hasCredential.mockReturnValueOnce(false);
+    const { ctx, experienceInteraction } = createInteraction();
+
+    await expectConventionalMfaRequired(experienceInteraction);
+
+    expect(hasCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
+    expect(getEffectivePolicy).not.toHaveBeenCalled();
+    expect(validateCredential).not.toHaveBeenCalled();
+  });
+
+  it('falls back to conventional MFA when credential validation does not verify the guard', async () => {
     const { ctx, experienceInteraction } = createInteraction();
 
     await expectConventionalMfaRequired(experienceInteraction);
@@ -231,7 +244,7 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
     expect(experienceInteraction.toSanitizedJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
 
-  it('allows a valid trusted device to fulfill adaptive MFA', async () => {
+  it('allows a valid trusted device to verify adaptive MFA', async () => {
     findDefaultSignInExperience.mockResolvedValueOnce(adaptiveMfaSignInExperience);
     validateCredential.mockResolvedValueOnce(trustedDevice);
     const { ctx, experienceInteraction } = createInteraction({}, { 'x-logto-cf-bot-score': '10' });
@@ -253,7 +266,7 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
     });
   });
 
-  it('does not enable trusted-device fulfillment when dev features are disabled', async () => {
+  it('does not enable trusted-device verification when dev features are disabled', async () => {
     // eslint-disable-next-line @silverhand/fp/no-mutation -- Verify the feature-level runtime guard.
     mockEnvSetValues.isDevFeaturesEnabled = false;
     validateCredential.mockResolvedValueOnce(trustedDevice);

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -169,31 +169,33 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
     expect(validateCredential).not.toHaveBeenCalled();
   });
 
-  it('restores matching interaction fulfillment before resolving effective policy', async () => {
+  it('ignores legacy interaction fulfillment and revalidates the trusted-device credential', async () => {
     findDefaultSignInExperience.mockResolvedValueOnce(adaptiveMfaSignInExperience);
-    const fulfillment = {
-      userId: mockUserWithMfaVerifications.id,
-      trustedDeviceId: trustedDevice.id,
-      fulfilledAt: 1_786_435_200_000,
-    };
+    validateCredential.mockResolvedValueOnce(trustedDevice);
     const { ctx, experienceInteraction } = createInteraction(
-      { trustedDeviceFulfillment: fulfillment },
+      {
+        // A pending interaction created before request-local fulfillment may still contain this field.
+        trustedDeviceFulfillment: {
+          userId: mockUserWithMfaVerifications.id,
+          trustedDeviceId: trustedDevice.id,
+          fulfilledAt: 1_786_435_200_000,
+        },
+      },
       { 'x-logto-cf-bot-score': '10' }
     );
 
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
 
-    expect(experienceInteraction.toJson().trustedDeviceFulfillment).toEqual(fulfillment);
-    expect(getEffectivePolicy).not.toHaveBeenCalled();
-    expect(validateCredential).not.toHaveBeenCalled();
-    expect(ctx.assignReleaseAnywayInteractionHookResult).not.toHaveBeenCalled();
+    expect(getEffectivePolicy).toHaveBeenCalledWith(mockUserWithMfaVerifications.id);
+    expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
+    expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
 
-  it('does not use fulfillment stored for another user', async () => {
+  it('rechecks policy instead of reusing legacy interaction fulfillment', async () => {
     getEffectivePolicy.mockResolvedValueOnce({ enabled: false, durationDays: 30 });
     const { experienceInteraction } = createInteraction({
       trustedDeviceFulfillment: {
-        userId: 'another-user',
+        userId: mockUserWithMfaVerifications.id,
         trustedDeviceId: trustedDevice.id,
         fulfilledAt: 1_786_435_200_000,
       },
@@ -212,23 +214,20 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
 
     expect(getEffectivePolicy).toHaveBeenCalledWith(mockUserWithMfaVerifications.id);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
-    expect(experienceInteraction.toJson().trustedDeviceFulfillment).toBeUndefined();
+    expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
 
-  it('stores valid credential fulfillment internally without exposing it publicly', async () => {
-    const fulfilledAt = 1_786_435_200_000;
-    jest.spyOn(Date, 'now').mockReturnValue(fulfilledAt);
+  it('caches valid credential fulfillment only within the current request', async () => {
     validateCredential.mockResolvedValueOnce(trustedDevice);
     const { ctx, experienceInteraction } = createInteraction();
 
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
+    await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
 
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
+    expect(validateCredential).toHaveBeenCalledTimes(1);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
-    expect(experienceInteraction.toJson().trustedDeviceFulfillment).toEqual({
-      userId: mockUserWithMfaVerifications.id,
-      trustedDeviceId: trustedDevice.id,
-      fulfilledAt,
-    });
+    expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
     expect(experienceInteraction.toSanitizedJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
 
@@ -239,12 +238,7 @@ describe('ExperienceInteraction trusted-device MFA fulfillment', () => {
 
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
 
-    expect(experienceInteraction.toJson().trustedDeviceFulfillment).toEqual(
-      expect.objectContaining({
-        userId: mockUserWithMfaVerifications.id,
-        trustedDeviceId: trustedDevice.id,
-      })
-    );
+    expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
     expect(ctx.assignReleaseAnywayInteractionHookResult).toHaveBeenCalledWith({
       event: InteractionHookEvent.PostSignInAdaptiveMfaTriggered,
       payload: {

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -390,15 +390,11 @@ export default class ExperienceInteraction {
       return;
     }
 
-    const trustedDeviceValidationStatus = await this.trustedDevice.tryFulfillMfa(user.id);
-
-    if (trustedDeviceValidationStatus === 'cached') {
-      return;
-    }
+    const isMfaFulfilledByTrustedDevice = await this.trustedDevice.tryFulfillMfa(user.id);
 
     this.assignAdaptiveMfaHookResult(user.id, adaptiveMfaResult);
 
-    if (trustedDeviceValidationStatus === 'validated') {
+    if (isMfaFulfilledByTrustedDevice) {
       return;
     }
 

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -149,7 +149,6 @@ export default class ExperienceInteraction {
       mfa = {},
       userId,
       trustedDeviceCreation,
-      trustedDeviceFulfillment,
       interactionEvent,
       captcha = {
         verified: false,
@@ -163,7 +162,6 @@ export default class ExperienceInteraction {
     this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.trustedDevice = new TrustedDevice(ctx, tenant, {
       trustedDeviceCreation,
-      trustedDeviceFulfillment,
     });
     this.captcha = captcha;
     for (const record of verificationRecords) {
@@ -392,15 +390,15 @@ export default class ExperienceInteraction {
       return;
     }
 
-    const trustedDeviceFulfillmentStatus = await this.trustedDevice.tryFulfillMfa(user.id);
+    const trustedDeviceValidationStatus = await this.trustedDevice.tryFulfillMfa(user.id);
 
-    if (trustedDeviceFulfillmentStatus === 'stored') {
+    if (trustedDeviceValidationStatus === 'cached') {
       return;
     }
 
     this.assignAdaptiveMfaHookResult(user.id, adaptiveMfaResult);
 
-    if (trustedDeviceFulfillmentStatus === 'validated') {
+    if (trustedDeviceValidationStatus === 'validated') {
       return;
     }
 
@@ -738,12 +736,8 @@ export default class ExperienceInteraction {
   }
 
   public toSanitizedJson(): SanitizedInteractionStorageData {
-    // Trusted-device intent and fulfillment are internal authentication state.
-    const {
-      trustedDeviceCreation: _,
-      trustedDeviceFulfillment: __,
-      ...interactionStorage
-    } = this.toJson();
+    // Trusted-device creation intent is internal authentication state.
+    const { trustedDeviceCreation: _, ...interactionStorage } = this.toJson();
 
     return {
       ...interactionStorage,

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -69,7 +69,7 @@ export default class ExperienceInteraction {
   readonly profile: Profile;
   /** The user linked MFA data in the current interaction that needs to be stored to database. */
   readonly mfa: Mfa;
-  /** Trusted-device intent, fulfillment, and credential lifecycle for the current interaction. */
+  /** Persisted creation intent and request-local trusted-device MFA verification lifecycle. */
   readonly trustedDevice: TrustedDevice;
 
   /** The user verification record list for the current interaction. */
@@ -390,11 +390,11 @@ export default class ExperienceInteraction {
       return;
     }
 
-    const isMfaFulfilledByTrustedDevice = await this.trustedDevice.tryFulfillMfa(user.id);
+    const isMfaVerifiedWithTrustedDevice = await this.trustedDevice.tryVerifyMfa(user.id);
 
     this.assignAdaptiveMfaHookResult(user.id, adaptiveMfaResult);
 
-    if (isMfaFulfilledByTrustedDevice) {
+    if (isMfaVerifiedWithTrustedDevice) {
       return;
     }
 

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -61,16 +61,18 @@ const createSubject = ({
   const createCredential = jest.fn().mockResolvedValue(createResult);
   const updateMetadata = jest.fn().mockResolvedValue(updateResult);
   const validateCredential = jest.fn().mockResolvedValue(validateResult);
+  const hasCredential = jest.fn().mockReturnValue(true);
+  const getEffectivePolicy = jest.fn().mockResolvedValue({ enabled: true, durationDays: 30 });
   const tenant = new MockTenant(undefined, undefined, undefined, {
-    trustedDevicePolicy: {
-      getEffectivePolicy: jest.fn().mockResolvedValue({ enabled: true, durationDays: 30 }),
-    },
-    trustedDevices: { createCredential, updateMetadata, validateCredential },
+    trustedDevicePolicy: { getEffectivePolicy },
+    trustedDevices: { createCredential, hasCredential, updateMetadata, validateCredential },
   });
 
   return {
     ...context,
     createCredential,
+    getEffectivePolicy,
+    hasCredential,
     updateMetadata,
     validateCredential,
     subject: new TrustedDevice(context.ctx, tenant, data),
@@ -151,8 +153,8 @@ describe('Experience trusted-device lifecycle events', () => {
     };
 
     await Promise.all([
-      success.subject.tryFulfillMfa(userId),
-      inactive.subject.tryFulfillMfa(userId),
+      success.subject.tryVerifyMfa(userId),
+      inactive.subject.tryVerifyMfa(userId),
     ]);
     await Promise.all([success.subject.finalize(options), inactive.subject.finalize(options)]);
 
@@ -188,7 +190,7 @@ describe('Experience trusted-device lifecycle events', () => {
       hasEligibleMfaProof: false,
     };
 
-    await Promise.all([earlier.subject.tryFulfillMfa(userId), later.subject.tryFulfillMfa(userId)]);
+    await Promise.all([earlier.subject.tryVerifyMfa(userId), later.subject.tryVerifyMfa(userId)]);
     await later.subject.finalize(options);
     await earlier.subject.finalize(options);
 
@@ -206,8 +208,8 @@ describe('Experience trusted-device lifecycle events', () => {
     });
     usage.validateCredential.mockResolvedValueOnce(trustedDevice).mockResolvedValueOnce(null);
 
-    await expect(usage.subject.tryFulfillMfa(userId)).resolves.toBe(true);
-    await expect(usage.subject.tryFulfillMfa(userId)).resolves.toBe(false);
+    await expect(usage.subject.tryVerifyMfa(userId)).resolves.toBe(true);
+    await expect(usage.subject.tryVerifyMfa(userId)).resolves.toBe(false);
     await usage.subject.finalize({
       interactionEvent: InteractionEvent.SignIn,
       userId,
@@ -216,6 +218,17 @@ describe('Experience trusted-device lifecycle events', () => {
 
     expect(usage.updateMetadata).not.toHaveBeenCalled();
     expect(usage.createLog).not.toHaveBeenCalled();
+  });
+
+  it('skips policy and credential validation when no trusted-device cookie is present', async () => {
+    const usage = createSubject({ data: {} });
+    usage.hasCredential.mockReturnValueOnce(false);
+
+    await expect(usage.subject.tryVerifyMfa(userId)).resolves.toBe(false);
+
+    expect(usage.hasCredential).toHaveBeenCalledWith(usage.ctx, userId);
+    expect(usage.getEffectivePolicy).not.toHaveBeenCalled();
+    expect(usage.validateCredential).not.toHaveBeenCalled();
   });
 
   it('uses one audit-log key across concurrent requests for the same interaction', async () => {
@@ -233,7 +246,7 @@ describe('Experience trusted-device lifecycle events', () => {
     });
 
     await expect(
-      Promise.all([first.subject.tryFulfillMfa(userId), second.subject.tryFulfillMfa(userId)])
+      Promise.all([first.subject.tryVerifyMfa(userId), second.subject.tryVerifyMfa(userId)])
     ).resolves.toEqual([true, true]);
 
     const options = {
@@ -251,7 +264,7 @@ describe('Experience trusted-device lifecycle events', () => {
     expect(secondIdempotencyKey).toBe(firstIdempotencyKey);
   });
 
-  it('reuses one audit-log idempotency key for concurrent or sequential fulfillment retries', async () => {
+  it('reuses one audit-log idempotency key for concurrent or sequential verification retries', async () => {
     const usage = createSubject({
       data: {},
       updateResult: trustedDevice,
@@ -263,7 +276,7 @@ describe('Experience trusted-device lifecycle events', () => {
       hasEligibleMfaProof: false,
     };
 
-    await usage.subject.tryFulfillMfa(userId);
+    await usage.subject.tryVerifyMfa(userId);
     await Promise.all([usage.subject.finalize(options), usage.subject.finalize(options)]);
     await usage.subject.finalize(options);
 
@@ -295,7 +308,7 @@ describe('Experience trusted-device lifecycle events', () => {
         hasEligibleMfaProof: true,
       })
     ).resolves.toBeUndefined();
-    await usage.subject.tryFulfillMfa(userId);
+    await usage.subject.tryVerifyMfa(userId);
     await expect(
       usage.subject.finalize({
         interactionEvent: InteractionEvent.SignIn,

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -199,6 +199,25 @@ describe('Experience trusted-device lifecycle events', () => {
     expect(earlierIdempotencyKey).not.toBe(laterIdempotencyKey);
   });
 
+  it('clears the request-local device when revalidation fails', async () => {
+    const usage = createSubject({
+      data: {},
+      updateResult: trustedDevice,
+    });
+    usage.validateCredential.mockResolvedValueOnce(trustedDevice).mockResolvedValueOnce(null);
+
+    await expect(usage.subject.tryFulfillMfa(userId)).resolves.toBe(true);
+    await expect(usage.subject.tryFulfillMfa(userId)).resolves.toBe(false);
+    await usage.subject.finalize({
+      interactionEvent: InteractionEvent.SignIn,
+      userId,
+      hasEligibleMfaProof: false,
+    });
+
+    expect(usage.updateMetadata).not.toHaveBeenCalled();
+    expect(usage.createLog).not.toHaveBeenCalled();
+  });
+
   it('uses one audit-log key across concurrent requests for the same interaction', async () => {
     const first = createSubject({
       data: {},
@@ -215,7 +234,7 @@ describe('Experience trusted-device lifecycle events', () => {
 
     await expect(
       Promise.all([first.subject.tryFulfillMfa(userId), second.subject.tryFulfillMfa(userId)])
-    ).resolves.toEqual(['validated', 'validated']);
+    ).resolves.toEqual([true, true]);
 
     const options = {
       interactionEvent: InteractionEvent.SignIn,

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -171,18 +171,18 @@ describe('Experience trusted-device lifecycle events', () => {
     expect(inactive.createLog).not.toHaveBeenCalled();
   });
 
-  it('keeps distinct trusted-device uses observable when they finish out of order', async () => {
-    const earlier = createSubject({
+  it('uses distinct audit-log keys for different interactions', async () => {
+    const first = createSubject({
       data: {},
       updateResult: trustedDevice,
       validateResult: trustedDevice,
-      interactionId: 'earlier-interaction-id',
+      interactionId: 'first-interaction-id',
     });
-    const later = createSubject({
+    const second = createSubject({
       data: {},
       updateResult: trustedDevice,
       validateResult: trustedDevice,
-      interactionId: 'later-interaction-id',
+      interactionId: 'second-interaction-id',
     });
     const options = {
       interactionEvent: InteractionEvent.SignIn,
@@ -190,15 +190,14 @@ describe('Experience trusted-device lifecycle events', () => {
       hasEligibleMfaProof: false,
     };
 
-    await Promise.all([earlier.subject.tryVerifyMfa(userId), later.subject.tryVerifyMfa(userId)]);
-    await later.subject.finalize(options);
-    await earlier.subject.finalize(options);
+    await Promise.all([first.subject.tryVerifyMfa(userId), second.subject.tryVerifyMfa(userId)]);
+    await Promise.all([first.subject.finalize(options), second.subject.finalize(options)]);
 
-    const laterIdempotencyKey = later.createLog.mock.calls[0]?.[1]?.idempotencyKey;
-    const earlierIdempotencyKey = earlier.createLog.mock.calls[0]?.[1]?.idempotencyKey;
-    expect(laterIdempotencyKey).toHaveLength(21);
-    expect(earlierIdempotencyKey).toHaveLength(21);
-    expect(earlierIdempotencyKey).not.toBe(laterIdempotencyKey);
+    const firstIdempotencyKey = first.createLog.mock.calls[0]?.[1]?.idempotencyKey;
+    const secondIdempotencyKey = second.createLog.mock.calls[0]?.[1]?.idempotencyKey;
+    expect(firstIdempotencyKey).toHaveLength(21);
+    expect(secondIdempotencyKey).toHaveLength(21);
+    expect(firstIdempotencyKey).not.toBe(secondIdempotencyKey);
   });
 
   it('clears the request-local device when revalidation fails', async () => {

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -136,23 +136,13 @@ describe('Experience trusted-device lifecycle events', () => {
 
   it('writes Used audit only after a successful active-device metadata update', async () => {
     const success = createSubject({
-      data: {
-        trustedDeviceFulfillment: {
-          userId,
-          trustedDeviceId,
-          fulfilledAt: 1,
-        },
-      },
+      data: {},
       updateResult: trustedDevice,
+      validateResult: trustedDevice,
     });
     const inactive = createSubject({
-      data: {
-        trustedDeviceFulfillment: {
-          userId,
-          trustedDeviceId,
-          fulfilledAt: 1,
-        },
-      },
+      data: {},
+      validateResult: trustedDevice,
     });
     const options = {
       interactionEvent: InteractionEvent.SignIn,
@@ -160,6 +150,10 @@ describe('Experience trusted-device lifecycle events', () => {
       hasEligibleMfaProof: false,
     };
 
+    await Promise.all([
+      success.subject.tryFulfillMfa(userId),
+      inactive.subject.tryFulfillMfa(userId),
+    ]);
     await Promise.all([success.subject.finalize(options), inactive.subject.finalize(options)]);
 
     expect(success.updateMetadata).toHaveBeenCalledWith(trustedDeviceId, userId, {});
@@ -175,27 +169,17 @@ describe('Experience trusted-device lifecycle events', () => {
     expect(inactive.createLog).not.toHaveBeenCalled();
   });
 
-  it('keeps distinct same-millisecond fulfillments observable when they finish out of order', async () => {
+  it('keeps distinct trusted-device uses observable when they finish out of order', async () => {
     const earlier = createSubject({
-      data: {
-        trustedDeviceFulfillment: {
-          userId,
-          trustedDeviceId,
-          fulfilledAt: 123_000,
-        },
-      },
+      data: {},
       updateResult: trustedDevice,
+      validateResult: trustedDevice,
       interactionId: 'earlier-interaction-id',
     });
     const later = createSubject({
-      data: {
-        trustedDeviceFulfillment: {
-          userId,
-          trustedDeviceId,
-          fulfilledAt: 123_000,
-        },
-      },
+      data: {},
       updateResult: trustedDevice,
+      validateResult: trustedDevice,
       interactionId: 'later-interaction-id',
     });
     const options = {
@@ -204,6 +188,7 @@ describe('Experience trusted-device lifecycle events', () => {
       hasEligibleMfaProof: false,
     };
 
+    await Promise.all([earlier.subject.tryFulfillMfa(userId), later.subject.tryFulfillMfa(userId)]);
     await later.subject.finalize(options);
     await earlier.subject.finalize(options);
 
@@ -214,7 +199,7 @@ describe('Experience trusted-device lifecycle events', () => {
     expect(earlierIdempotencyKey).not.toBe(laterIdempotencyKey);
   });
 
-  it('uses one audit-log key across requests racing before fulfillment is stored', async () => {
+  it('uses one audit-log key across concurrent requests for the same interaction', async () => {
     const first = createSubject({
       data: {},
       updateResult: trustedDevice,
@@ -248,14 +233,10 @@ describe('Experience trusted-device lifecycle events', () => {
   });
 
   it('reuses one audit-log idempotency key for concurrent or sequential fulfillment retries', async () => {
-    const fulfillment = {
-      userId,
-      trustedDeviceId,
-      fulfilledAt: 123_000,
-    };
     const usage = createSubject({
-      data: { trustedDeviceFulfillment: fulfillment },
+      data: {},
       updateResult: trustedDevice,
+      validateResult: trustedDevice,
     });
     const options = {
       interactionEvent: InteractionEvent.SignIn,
@@ -263,6 +244,7 @@ describe('Experience trusted-device lifecycle events', () => {
       hasEligibleMfaProof: false,
     };
 
+    await usage.subject.tryFulfillMfa(userId);
     await Promise.all([usage.subject.finalize(options), usage.subject.finalize(options)]);
     await usage.subject.finalize(options);
 
@@ -281,13 +263,8 @@ describe('Experience trusted-device lifecycle events', () => {
     const creation = createSubject({ data: {} });
     creation.createCredential.mockRejectedValueOnce(error);
     const usage = createSubject({
-      data: {
-        trustedDeviceFulfillment: {
-          userId,
-          trustedDeviceId,
-          fulfilledAt: 1,
-        },
-      },
+      data: {},
+      validateResult: trustedDevice,
     });
     usage.updateMetadata.mockRejectedValueOnce(error);
 
@@ -299,6 +276,7 @@ describe('Experience trusted-device lifecycle events', () => {
         hasEligibleMfaProof: true,
       })
     ).resolves.toBeUndefined();
+    await usage.subject.tryFulfillMfa(userId);
     await expect(
       usage.subject.finalize({
         interactionEvent: InteractionEvent.SignIn,

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -17,8 +17,6 @@ import { type InteractionStorage, type WithHooksAndLogsContext } from '../types.
 
 type TrustedDeviceData = Pick<InteractionStorage, 'trustedDeviceCreation'>;
 
-type ValidatedTrustedDevice = Pick<TrustedDeviceModel, 'id' | 'userId'>;
-
 const buildTrustedDeviceUsageLogId = (tenantId: string, interactionId: string) =>
   createHash('sha256')
     .update(`TrustedDevice.Used:${tenantId}:${interactionId}`)
@@ -41,11 +39,11 @@ type FinalizeOptions = {
 };
 
 /**
- * Owns trusted-device interaction state and coordinates credential fulfillment and creation.
+ * Coordinates persisted creation intent and the request-local trusted-device credential lifecycle.
  */
 export class TrustedDevice {
   #creation?: InteractionStorage['trustedDeviceCreation'];
-  #validatedDevice?: ValidatedTrustedDevice;
+  #validatedDeviceId?: string;
 
   constructor(
     private readonly ctx: WithHooksAndLogsContext,
@@ -93,17 +91,28 @@ export class TrustedDevice {
     };
   }
 
-  async tryFulfillMfa(userId: string): Promise<boolean> {
-    // Trusted-device MFA fulfillment is under development and must remain isolated from released flows.
+  /**
+   * Tries to verify the current MFA requirement with a trusted-device credential.
+   *
+   * @remarks Clears previously validated request-local state. On success, retains the device ID for
+   * post-submit usage finalization.
+   */
+  async tryVerifyMfa(userId: string): Promise<boolean> {
+    // Trusted-device MFA verification is under development and must remain isolated from released flows.
     if (!EnvSet.values.isDevFeaturesEnabled) {
       return false;
     }
 
-    this.#validatedDevice = undefined;
+    this.#validatedDeviceId = undefined;
 
     const {
       libraries: { trustedDevicePolicy, trustedDevices },
     } = this.tenant;
+
+    if (!trustedDevices.hasCredential(this.ctx, userId)) {
+      return false;
+    }
+
     const { enabled } = await trustedDevicePolicy.getEffectivePolicy(userId);
 
     if (!enabled) {
@@ -116,7 +125,7 @@ export class TrustedDevice {
       return false;
     }
 
-    this.#validatedDevice = { id: trustedDevice.id, userId };
+    this.#validatedDeviceId = trustedDevice.id;
 
     return true;
   }
@@ -144,10 +153,10 @@ export class TrustedDevice {
           ...conditional(city && { city }),
         };
 
-        const validatedDevice = this.#validatedDevice;
+        const validatedDeviceId = this.#validatedDeviceId;
 
-        if (validatedDevice?.userId === userId) {
-          await this.#finalizeUsage(validatedDevice, interactionEvent, userId, metadata);
+        if (validatedDeviceId) {
+          await this.#finalizeUsage(validatedDeviceId, interactionEvent, userId, metadata);
           return;
         }
 
@@ -160,7 +169,7 @@ export class TrustedDevice {
   }
 
   async #finalizeUsage(
-    validatedDevice: ValidatedTrustedDevice,
+    validatedDeviceId: string,
     interactionEvent: InteractionEvent,
     userId: string,
     metadata: TrustedDeviceMetadata
@@ -170,7 +179,7 @@ export class TrustedDevice {
     }
 
     const trustedDevice = await this.tenant.libraries.trustedDevices.updateMetadata(
-      validatedDevice.id,
+      validatedDeviceId,
       userId,
       metadata
     );

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -15,12 +15,6 @@ import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import { type InteractionStorage, type WithHooksAndLogsContext } from '../types.js';
 
-type TrustedDeviceValidationStatus =
-  /** A matching trusted-device credential was already validated during the current request. */
-  | 'cached'
-  /** A trusted-device credential was validated during the current request. */
-  | 'validated';
-
 type TrustedDeviceData = Pick<InteractionStorage, 'trustedDeviceCreation'>;
 
 type ValidatedTrustedDevice = Pick<TrustedDeviceModel, 'id' | 'userId'>;
@@ -99,15 +93,13 @@ export class TrustedDevice {
     };
   }
 
-  async tryFulfillMfa(userId: string): Promise<TrustedDeviceValidationStatus | undefined> {
+  async tryFulfillMfa(userId: string): Promise<boolean> {
     // Trusted-device MFA fulfillment is under development and must remain isolated from released flows.
     if (!EnvSet.values.isDevFeaturesEnabled) {
-      return;
+      return false;
     }
 
-    if (this.#validatedDevice?.userId === userId) {
-      return 'cached';
-    }
+    this.#validatedDevice = undefined;
 
     const {
       libraries: { trustedDevicePolicy, trustedDevices },
@@ -115,18 +107,18 @@ export class TrustedDevice {
     const { enabled } = await trustedDevicePolicy.getEffectivePolicy(userId);
 
     if (!enabled) {
-      return;
+      return false;
     }
 
     const trustedDevice = await trustedDevices.validateCredential(this.ctx, userId);
 
     if (!trustedDevice) {
-      return;
+      return false;
     }
 
     this.#validatedDevice = { id: trustedDevice.id, userId };
 
-    return 'validated';
+    return true;
   }
 
   async finalize({

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -15,18 +15,15 @@ import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import { type InteractionStorage, type WithHooksAndLogsContext } from '../types.js';
 
-type TrustedDeviceFulfillmentStatus =
-  /** A matching trusted-device fulfillment was restored from interaction storage. */
-  | 'stored'
-  /** A trusted-device credential was validated and stored during the current request. */
+type TrustedDeviceValidationStatus =
+  /** A matching trusted-device credential was already validated during the current request. */
+  | 'cached'
+  /** A trusted-device credential was validated during the current request. */
   | 'validated';
 
-type TrustedDeviceData = Pick<
-  InteractionStorage,
-  'trustedDeviceCreation' | 'trustedDeviceFulfillment'
->;
+type TrustedDeviceData = Pick<InteractionStorage, 'trustedDeviceCreation'>;
 
-type TrustedDeviceFulfillment = NonNullable<InteractionStorage['trustedDeviceFulfillment']>;
+type ValidatedTrustedDevice = Pick<TrustedDeviceModel, 'id' | 'userId'>;
 
 const buildTrustedDeviceUsageLogId = (tenantId: string, interactionId: string) =>
   createHash('sha256')
@@ -54,7 +51,7 @@ type FinalizeOptions = {
  */
 export class TrustedDevice {
   #creation?: InteractionStorage['trustedDeviceCreation'];
-  #fulfillment?: TrustedDeviceFulfillment;
+  #validatedDevice?: ValidatedTrustedDevice;
 
   constructor(
     private readonly ctx: WithHooksAndLogsContext,
@@ -62,13 +59,11 @@ export class TrustedDevice {
     data: TrustedDeviceData
   ) {
     this.#creation = data.trustedDeviceCreation;
-    this.#fulfillment = data.trustedDeviceFulfillment;
   }
 
   get data(): TrustedDeviceData {
     return {
       ...conditional(this.#creation && { trustedDeviceCreation: this.#creation }),
-      ...conditional(this.#fulfillment && { trustedDeviceFulfillment: this.#fulfillment }),
     };
   }
 
@@ -104,14 +99,14 @@ export class TrustedDevice {
     };
   }
 
-  async tryFulfillMfa(userId: string): Promise<TrustedDeviceFulfillmentStatus | undefined> {
+  async tryFulfillMfa(userId: string): Promise<TrustedDeviceValidationStatus | undefined> {
     // Trusted-device MFA fulfillment is under development and must remain isolated from released flows.
     if (!EnvSet.values.isDevFeaturesEnabled) {
       return;
     }
 
-    if (this.#fulfillment?.userId === userId) {
-      return 'stored';
+    if (this.#validatedDevice?.userId === userId) {
+      return 'cached';
     }
 
     const {
@@ -129,11 +124,7 @@ export class TrustedDevice {
       return;
     }
 
-    this.#fulfillment = {
-      userId,
-      trustedDeviceId: trustedDevice.id,
-      fulfilledAt: Date.now(),
-    };
+    this.#validatedDevice = { id: trustedDevice.id, userId };
 
     return 'validated';
   }
@@ -161,10 +152,10 @@ export class TrustedDevice {
           ...conditional(city && { city }),
         };
 
-        const fulfillment = this.#fulfillment;
+        const validatedDevice = this.#validatedDevice;
 
-        if (fulfillment?.userId === userId) {
-          await this.#finalizeFulfillment(fulfillment, interactionEvent, userId, metadata);
+        if (validatedDevice?.userId === userId) {
+          await this.#finalizeUsage(validatedDevice, interactionEvent, userId, metadata);
           return;
         }
 
@@ -176,8 +167,8 @@ export class TrustedDevice {
     );
   }
 
-  async #finalizeFulfillment(
-    fulfillment: TrustedDeviceFulfillment,
+  async #finalizeUsage(
+    validatedDevice: ValidatedTrustedDevice,
     interactionEvent: InteractionEvent,
     userId: string,
     metadata: TrustedDeviceMetadata
@@ -187,7 +178,7 @@ export class TrustedDevice {
     }
 
     const trustedDevice = await this.tenant.libraries.trustedDevices.updateMetadata(
-      fulfillment.trustedDeviceId,
+      validatedDevice.id,
       userId,
       metadata
     );

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -8,6 +8,7 @@ import {
   SignInIdentifier,
   VerificationType,
   type Mfa,
+  type TrustedDevice,
   type User,
 } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
@@ -86,6 +87,20 @@ const eligibleTrustedDeviceVerificationCases: Array<{
     },
   },
 ];
+
+const buildTrustedDevice = (userId: string): TrustedDevice => ({
+  tenantId: 'tenant-id',
+  id: 'trusted-device-id',
+  userId,
+  secretHash: Buffer.alloc(32, 1),
+  userAgent: null,
+  ip: null,
+  country: null,
+  city: null,
+  createdAt: 1,
+  lastUsedAt: 1,
+  expiresAt: 2,
+});
 
 const createLogMiddleware = (): {
   middleware: Middleware<unknown, IRouterParamContext>;
@@ -885,23 +900,17 @@ describe('POST /experience/submit', () => {
     setDevFeaturesEnabled(true);
     const metadataError = new Error('trusted-device metadata update failed');
     const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
-    const fulfilledAt = Date.now();
     const user = {
       ...mockUser,
       mfaVerifications: [mockUserTotpMfaVerification],
     };
-    const { requester, createCredential, updateMetadata } = createRequesterWithMocks({
-      user,
-      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
-      interactionResult: {
-        trustedDeviceFulfillment: {
-          userId: user.id,
-          trustedDeviceId: 'trusted-device-id',
-          fulfilledAt,
-        },
-      },
-      trustedDevicePolicy: { enabled: true, durationDays: 30 },
-    });
+    const { requester, createCredential, updateMetadata, validateCredential } =
+      createRequesterWithMocks({
+        user,
+        mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+        trustedDevicePolicy: { enabled: true, durationDays: 30 },
+      });
+    validateCredential.mockResolvedValueOnce(buildTrustedDevice(user.id));
     updateMetadata.mockRejectedValueOnce(metadataError);
 
     const response = await requester.post('/experience/submit').set('x-logto-cf-country', 'US');
@@ -916,49 +925,80 @@ describe('POST /experience/submit', () => {
     expect(trackException).toHaveBeenCalledWith(metadataError, expect.any(Object));
   });
 
-  it('should not update trusted-device metadata from another user fulfillment', async () => {
+  it('should revalidate the trusted-device credential on each Experience request', async () => {
     setDevFeaturesEnabled(true);
-    const { requester, createCredential, updateMetadata } = createRequesterWithMocks({
-      interactionResult: {
-        trustedDeviceFulfillment: {
-          userId: 'another-user-id',
-          trustedDeviceId: 'another-user-trusted-device-id',
-          fulfilledAt: Date.now(),
-        },
-      },
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const trustedDevice = buildTrustedDevice(user.id);
+    const { requester, getEffectivePolicy, validateCredential, updateMetadata } =
+      createRequesterWithMocks({
+        user,
+        mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+        persistInteractionResult: true,
+        trustedDevicePolicy: { enabled: true, durationDays: 30 },
+      });
+    validateCredential.mockResolvedValue(trustedDevice);
+    updateMetadata.mockResolvedValue(trustedDevice);
+
+    const intermediateResponse = await requester.post(
+      '/experience/profile/mfa/mfa-suggestion-skipped'
+    );
+    const submitResponse = await requester.post('/experience/submit');
+
+    expect(intermediateResponse.status).toBe(204);
+    expect(submitResponse.status).toBe(200);
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(2);
+    expect(validateCredential).toHaveBeenCalledTimes(2);
+    expect(updateMetadata).toHaveBeenCalledWith('trusted-device-id', user.id, expect.any(Object));
+  });
+
+  it('should require MFA when the trusted device becomes inactive between requests', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, validateCredential, updateMetadata } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      persistInteractionResult: true,
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
+    validateCredential
+      .mockResolvedValueOnce(buildTrustedDevice(user.id))
+      .mockResolvedValueOnce(null);
 
-    const response = await requester.post('/experience/submit');
+    const intermediateResponse = await requester.post(
+      '/experience/profile/mfa/mfa-suggestion-skipped'
+    );
+    const submitResponse = await requester.post('/experience/submit');
 
-    expect(response.status).toBe(200);
+    expect(intermediateResponse.status).toBe(204);
+    expect(submitResponse.status).toBe(403);
+    expect(validateCredential).toHaveBeenCalledTimes(2);
     expect(updateMetadata).not.toHaveBeenCalled();
-    expect(createCredential).not.toHaveBeenCalled();
   });
 
   it('should omit trusted-device location when the current context has none', async () => {
     setDevFeaturesEnabled(true);
-    const fulfilledAt = Date.now();
-    const { requester, updateMetadata } = createRequesterWithMocks({
-      interactionResult: {
-        trustedDeviceFulfillment: {
-          userId: mockUser.id,
-          trustedDeviceId: 'trusted-device-id',
-          fulfilledAt,
-        },
-      },
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, updateMetadata, validateCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
+    validateCredential.mockResolvedValueOnce(buildTrustedDevice(user.id));
 
     const response = await requester.post('/experience/submit');
     const metadata = updateMetadata.mock.calls[0]?.[2] as Record<string, unknown> | undefined;
 
     expect(response.status).toBe(200);
-    expect(updateMetadata).toHaveBeenCalledWith(
-      'trusted-device-id',
-      mockUser.id,
-      expect.any(Object)
-    );
+    expect(updateMetadata).toHaveBeenCalledWith('trusted-device-id', user.id, expect.any(Object));
     expect(metadata).not.toHaveProperty('country');
     expect(metadata).not.toHaveProperty('city');
   });

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -198,6 +198,7 @@ const createRequesterWithMocks = ({
     }),
   };
   const getEffectivePolicy = jest.fn().mockResolvedValue(trustedDevicePolicy);
+  const hasCredential = jest.fn().mockReturnValue(true);
   const validateCredential = jest.fn();
   const createCredential = jest.fn();
   const updateMetadata = jest.fn();
@@ -215,7 +216,7 @@ const createRequesterWithMocks = ({
       trustedDevicePolicy: {
         getEffectivePolicy,
       },
-      trustedDevices: { validateCredential, createCredential, updateMetadata },
+      trustedDevices: { hasCredential, validateCredential, createCredential, updateMetadata },
     }
   );
 
@@ -896,7 +897,7 @@ describe('POST /experience/submit', () => {
     expect(createCredential).not.toHaveBeenCalled();
   });
 
-  it('should update a fulfilling trusted device best effort without creating a duplicate', async () => {
+  it('should update a verifying trusted device best effort without creating a duplicate', async () => {
     setDevFeaturesEnabled(true);
     const metadataError = new Error('trusted-device metadata update failed');
     const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -201,11 +201,6 @@ export type InteractionStorage = {
   trustedDeviceCreation?: {
     deviceId: string;
   };
-  trustedDeviceFulfillment?: {
-    userId: string;
-    trustedDeviceId: string;
-    fulfilledAt: number;
-  };
   profile?: InteractionProfile;
   mfa?: MfaData;
   verificationRecords?: VerificationRecordData[];
@@ -222,13 +217,6 @@ export const interactionStorageGuard = z.object({
   trustedDeviceCreation: z
     .object({
       deviceId: TrustedDevices.guard.shape.id,
-    })
-    .optional(),
-  trustedDeviceFulfillment: z
-    .object({
-      userId: z.string(),
-      trustedDeviceId: z.string(),
-      fulfilledAt: z.number(),
     })
     .optional(),
   profile: interactionProfileGuard.optional(),


### PR DESCRIPTION
## Summary

Remove persisted trusted-device MFA fulfillment state from Experience interactions.
Revalidate effective policy and trusted-device credentials for each request while retaining the validated device only for current-request finalization.
This makes device revocation and policy changes effective on the next Experience request and keeps internal validation state out of submit logs.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
