### PR TITLE
fix(core): show trusted device audit logs

### DIFF
--- a/packages/core/src/routes/log.test.ts
+++ b/packages/core/src/routes/log.test.ts
@@ -6,6 +6,7 @@ import {
   LogKeyUnknown,
   jwtCustomizer,
   saml,
+  trustedDevice,
 } from '@logto/schemas';
 import type { Log } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
@@ -64,6 +65,7 @@ describe('logRoutes', () => {
             jwtCustomizer.prefix,
             saml.prefix,
             action.prefix,
+            trustedDevice.prefix,
             LogKeyUnknown,
           ],
         },
@@ -82,6 +84,7 @@ describe('logRoutes', () => {
           jwtCustomizer.prefix,
           saml.prefix,
           action.prefix,
+          trustedDevice.prefix,
           LogKeyUnknown,
         ],
       });

--- a/packages/core/src/routes/log.ts
+++ b/packages/core/src/routes/log.ts
@@ -6,6 +6,7 @@ import {
   LogKeyUnknown,
   jwtCustomizer,
   saml,
+  trustedDevice,
   type AuditLogPrefix,
 } from '@logto/schemas';
 import { yes } from '@silverhand/essentials';
@@ -55,6 +56,7 @@ export default function logRoutes<T extends ManagementApiRouter>(
         jwtCustomizer.prefix,
         saml.prefix,
         action.prefix,
+        trustedDevice.prefix,
         LogKeyUnknown,
       ];
 

--- a/packages/integration-tests/src/tests/api/audit-logs/trusted-device.test.ts
+++ b/packages/integration-tests/src/tests/api/audit-logs/trusted-device.test.ts
@@ -1,0 +1,58 @@
+import { LogResult, defaultTenantId, trustedDevice } from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+import { assertEnv } from '@silverhand/essentials';
+import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
+
+import { getAuditLogs } from '#src/api/logs.js';
+
+describe('trusted-device audit logs', () => {
+  const createdLogId = generateStandardId();
+  const usedLogId = generateStandardId();
+  const createdLogKey = `${trustedDevice.prefix}.${trustedDevice.Type.Created}`;
+  const usedLogKey = `${trustedDevice.prefix}.${trustedDevice.Type.Used}`;
+
+  /* eslint-disable @silverhand/fp/no-let -- Jest lifecycle initializes the shared database pool */
+  let pool: DatabasePool;
+  /* eslint-enable @silverhand/fp/no-let */
+
+  beforeAll(async () => {
+    /* eslint-disable @silverhand/fp/no-mutation -- Jest lifecycle initializes the shared database pool */
+    pool = await createPool(assertEnv('DB_URL'), {
+      interceptors: createInterceptorsPreset(),
+    });
+    /* eslint-enable @silverhand/fp/no-mutation */
+
+    await pool.query(sql`
+      insert into logs (tenant_id, id, key, payload)
+      values
+        (
+          ${defaultTenantId},
+          ${createdLogId},
+          ${createdLogKey},
+          ${sql.jsonb({ key: createdLogKey, result: LogResult.Success })}
+        ),
+        (
+          ${defaultTenantId},
+          ${usedLogId},
+          ${usedLogKey},
+          ${sql.jsonb({ key: usedLogKey, result: LogResult.Success })}
+        )
+    `);
+  });
+
+  afterAll(async () => {
+    await pool.query(sql`
+      delete from logs where id in (${createdLogId}, ${usedLogId})
+    `);
+    await pool.end();
+  });
+
+  it.each([
+    [createdLogKey, createdLogId],
+    [usedLogKey, usedLogId],
+  ])('returns %s from the audit log listing endpoint', async (logKey, logId) => {
+    const logs = await getAuditLogs(new URLSearchParams({ logKey }));
+
+    expect(logs.some(({ id }) => id === logId)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Include the trusted-device lifecycle event prefix in audit log listing filters so Created and Used records are returned by the Management API and Console.

Add route-level and API/database regression coverage for both events.

## Testing

Unit tests

Integration tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
