### PR TITLE
fix(console): show trust duration hint after changes

### DIFF
--- a/packages/console/src/pages/Mfa/MfaForm/TrustedDeviceSettings.test.tsx
+++ b/packages/console/src/pages/Mfa/MfaForm/TrustedDeviceSettings.test.tsx
@@ -58,12 +58,17 @@ function TestForm({ isDisabled = false, onSubmit }: Props) {
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, dirtyFields },
   } = useForm<MfaConfigForm>({ defaultValues, mode: 'onChange' });
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <TrustedDeviceSettings isDisabled={isDisabled} register={register} errors={errors} />
+      <TrustedDeviceSettings
+        isDisabled={isDisabled}
+        isDurationDirty={Boolean(dirtyFields.trustedDeviceDurationDays)}
+        register={register}
+        errors={errors}
+      />
       <button type="submit">Save</button>
     </form>
   );
@@ -79,10 +84,6 @@ describe('TrustedDeviceSettings', () => {
 
     expect(enableSwitch.checked).toBe(false);
     expect(durationInput.value).toBe('30');
-    expect(screen.getByRole('note').textContent).toBe(
-      'admin_console.mfa.trusted_device.duration_note'
-    );
-
     fireEvent.click(enableSwitch);
     fireEvent.change(durationInput, { target: { value: '365' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -95,6 +96,28 @@ describe('TrustedDeviceSettings', () => {
         }),
         expect.anything()
       );
+    });
+  });
+
+  it('shows the duration note only while the duration value differs from the saved value', async () => {
+    render(<TestForm onSubmit={jest.fn()} />);
+
+    const durationInput = screen.getByRole('spinbutton');
+
+    expect(screen.queryByRole('note')).toBeNull();
+
+    fireEvent.change(durationInput, { target: { value: '365' } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('note').textContent).toBe(
+        'admin_console.mfa.trusted_device.duration_note'
+      );
+    });
+
+    fireEvent.change(durationInput, { target: { value: '30' } });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('note')).toBeNull();
     });
   });
 

--- a/packages/console/src/pages/Mfa/MfaForm/TrustedDeviceSettings.tsx
+++ b/packages/console/src/pages/Mfa/MfaForm/TrustedDeviceSettings.tsx
@@ -13,13 +13,14 @@ import styles from './index.module.scss';
 
 type Props = {
   readonly isDisabled: boolean;
+  readonly isDurationDirty: boolean;
   readonly register: UseFormRegister<MfaConfigForm>;
   readonly errors: FieldErrors<MfaConfigForm>;
 };
 
 const durationRange = Object.freeze({ min: 1, max: 365 });
 
-function TrustedDeviceSettings({ isDisabled, register, errors }: Props) {
+function TrustedDeviceSettings({ isDisabled, isDurationDirty, register, errors }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
 
   return (
@@ -46,9 +47,11 @@ function TrustedDeviceSettings({ isDisabled, register, errors }: Props) {
           })}
         />
       </FormField>
-      <InlineNotification className={styles.trustedDeviceDurationNote}>
-        {t('mfa.trusted_device.duration_note')}
-      </InlineNotification>
+      {isDurationDirty && (
+        <InlineNotification className={styles.trustedDeviceDurationNote}>
+          {t('mfa.trusted_device.duration_note')}
+        </InlineNotification>
+      )}
     </FormCard>
   );
 }

--- a/packages/console/src/pages/Mfa/MfaForm/index.tsx
+++ b/packages/console/src/pages/Mfa/MfaForm/index.tsx
@@ -79,7 +79,7 @@ function MfaForm({ data, adaptiveMfa, trustedDevice, signInMethods, onMfaUpdated
   const {
     register,
     reset,
-    formState: { isDirty, isSubmitting, errors },
+    formState: { isDirty, isSubmitting, errors, dirtyFields },
     handleSubmit,
     control,
     watch,
@@ -461,6 +461,7 @@ function MfaForm({ data, adaptiveMfa, trustedDevice, signInMethods, onMfaUpdated
             register={register}
             errors={errors}
             isDisabled={isPolicySettingsDisabled}
+            isDurationDirty={Boolean(dirtyFields.trustedDeviceDurationDays)}
           />
         )}
       </DetailsForm>


### PR DESCRIPTION
## Summary
Show the trusted-device duration note only when the duration differs from its saved value. Hide the note again when the value is restored, saved, or discarded.

## Testing
Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments