### PR TITLE
fix(core,shared): block SSRF in webhook and SSO outbound requests

### DIFF
--- a/.changeset/ssrf-protection-outbound-requests.md
+++ b/.changeset/ssrf-protection-outbound-requests.md
@@ -1,0 +1,16 @@
+---
+"@logto/core": patch
+"@logto/shared": patch
+---
+
+extend SSRF protection to webhook delivery and enterprise SSO connector requests
+
+Outbound requests to URLs supplied through the Management API are now blocked when they resolve to a special-use address such as loopback, a private range, or the cloud metadata endpoint (`169.254.169.254`). Previously a tenant admin could point a webhook URL or an enterprise SSO connector at an internal address and read the response back from the API error, letting them reach services on the deployment's own network.
+
+The check covers webhook delivery (including `POST /api/hooks/:id/test`), OIDC SSO connector discovery, token and userinfo requests, and SAML IdP metadata fetching. It runs when the connection is established, so a hostname that resolves to an internal address is rejected just like a literal IP, and every redirect hop is checked again.
+
+## Action required
+
+Protection is enabled by default. If your deployment intentionally delivers webhooks or reaches SSO endpoints on a private network, set `SSRF_PROTECTION_DISABLED=true` before starting Logto to keep those requests working. The variable is only honored in self-hosted deployments.
+
+`OIDC_PROVIDER_SSRF_PROTECTION_DISABLED`, which previously covered only the OIDC provider's own requests, keeps working as an alias and now disables the protection for these requests too.

--- a/.changeset/ssrf-protection-outbound-requests.md
+++ b/.changeset/ssrf-protection-outbound-requests.md
@@ -17,6 +17,6 @@ Protection is enabled by default. If your deployment intentionally delivers webh
 SSRF_ALLOWED_ADDRESSES=10.0.0.0/8,127.0.0.1
 ```
 
-Allowlisting the destinations is preferable to turning the protection off: every other special-use address, including the cloud metadata endpoint, stays blocked. `SSRF_PROTECTION_DISABLED=true` still disables the protection entirely, but it also disables features that require it, such as CIMD.
+Allowlisting the destinations is preferable to turning the protection off: every other special-use address, including the cloud metadata endpoint, stays blocked. Since CIMD accepts target URLs from unauthenticated callers, configuring an allowlist disables CIMD to prevent those callers from reaching private destinations. `SSRF_PROTECTION_DISABLED=true` also disables CIMD by turning the protection off entirely.
 
 Both variables are only honored in self-hosted deployments. `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED`, which previously covered only the OIDC provider's own requests, keeps working as an alias for `SSRF_PROTECTION_DISABLED`.

--- a/.changeset/ssrf-protection-outbound-requests.md
+++ b/.changeset/ssrf-protection-outbound-requests.md
@@ -11,6 +11,12 @@ The check covers webhook delivery (including `POST /api/hooks/:id/test`), OIDC S
 
 ## Action required
 
-Protection is enabled by default. If your deployment intentionally delivers webhooks or reaches SSO endpoints on a private network, set `SSRF_PROTECTION_DISABLED=true` before starting Logto to keep those requests working. The variable is only honored in self-hosted deployments.
+Protection is enabled by default. If your deployment intentionally delivers webhooks or reaches SSO endpoints on a private network, list those destinations in `SSRF_ALLOWED_ADDRESSES` before starting Logto, as a comma-separated set of IP addresses or CIDR ranges:
 
-`OIDC_PROVIDER_SSRF_PROTECTION_DISABLED`, which previously covered only the OIDC provider's own requests, keeps working as an alias and now disables the protection for these requests too.
+```
+SSRF_ALLOWED_ADDRESSES=10.0.0.0/8,127.0.0.1
+```
+
+Allowlisting the destinations is preferable to turning the protection off: every other special-use address, including the cloud metadata endpoint, stays blocked. `SSRF_PROTECTION_DISABLED=true` still disables the protection entirely, but it also disables features that require it, such as CIMD.
+
+Both variables are only honored in self-hosted deployments. `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED`, which previously covered only the OIDC provider's own requests, keeps working as an alias for `SSRF_PROTECTION_DISABLED`.

--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -70,8 +70,9 @@ jobs:
     env:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: false
-      # Allow Console tests to use the local backchannel logout mock server.
-      OIDC_PROVIDER_SSRF_PROTECTION_DISABLED: ${{ matrix.target == 'console' }}
+      # Allow tests to reach local mock servers: the Console backchannel logout mock and the
+      # webhook receiver both listen on loopback, which the SSRF protection blocks by default.
+      SSRF_PROTECTION_DISABLED: true
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -70,9 +70,10 @@ jobs:
     env:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: false
-      # Allow tests to reach local mock servers: the Console backchannel logout mock and the
-      # webhook receiver both listen on loopback, which the SSRF protection blocks by default.
-      SSRF_PROTECTION_DISABLED: true
+      # Mock servers for backchannel logout and webhook delivery listen on loopback, which the SSRF
+      # protection blocks. Allow just those addresses instead of disabling the protection, so the
+      # suites that require it stay on — CIMD refuses to be enabled without it.
+      SSRF_ALLOWED_ADDRESSES: 127.0.0.0/8,::1
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -71,8 +71,8 @@ jobs:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: false
       # Mock servers for backchannel logout and webhook delivery listen on loopback, which the SSRF
-      # protection blocks. Allow just those addresses instead of disabling the protection, so the
-      # suites that require it stay on — CIMD refuses to be enabled without it.
+      # protection blocks. Allow just those addresses instead of disabling the protection. CIMD
+      # cannot be enabled while an allowlist is set.
       SSRF_ALLOWED_ADDRESSES: 127.0.0.0/8,::1
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -44,8 +44,8 @@ jobs:
       # Allow production-mode tests to simulate TLS termination for Secure cookies.
       TRUST_PROXY_HEADER: 1
       # Mock servers for backchannel logout and webhook delivery listen on loopback, which the SSRF
-      # protection blocks. Allow just those addresses instead of disabling the protection, so the
-      # suites that require it stay on — CIMD refuses to be enabled without it.
+      # protection blocks. Allow just those addresses instead of disabling the protection. CIMD
+      # cannot be enabled while an allowlist is set.
       SSRF_ALLOWED_ADDRESSES: 127.0.0.0/8,::1
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -43,9 +43,10 @@ jobs:
       DEV_FEATURES_ENABLED: ${{ matrix.dev-features-enabled }}
       # Allow production-mode tests to simulate TLS termination for Secure cookies.
       TRUST_PROXY_HEADER: 1
-      # Allow tests to reach local mock servers: the Console backchannel logout mock and the
-      # webhook receiver both listen on loopback, which the SSRF protection blocks by default.
-      SSRF_PROTECTION_DISABLED: true
+      # Mock servers for backchannel logout and webhook delivery listen on loopback, which the SSRF
+      # protection blocks. Allow just those addresses instead of disabling the protection, so the
+      # suites that require it stay on — CIMD refuses to be enabled without it.
+      SSRF_ALLOWED_ADDRESSES: 127.0.0.0/8,::1
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -43,8 +43,9 @@ jobs:
       DEV_FEATURES_ENABLED: ${{ matrix.dev-features-enabled }}
       # Allow production-mode tests to simulate TLS termination for Secure cookies.
       TRUST_PROXY_HEADER: 1
-      # Allow Console tests to use the local backchannel logout mock server.
-      OIDC_PROVIDER_SSRF_PROTECTION_DISABLED: ${{ matrix.target == 'console' }}
+      # Allow tests to reach local mock servers: the Console backchannel logout mock and the
+      # webhook receiver both listen on loopback, which the SSRF protection blocks by default.
+      SSRF_PROTECTION_DISABLED: true
       # Key encryption key (KEK) for the secret vault used in integration tests
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=
       DB_URL: postgres://postgres:postgres@localhost:5432/postgres

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -47,7 +47,7 @@ services:
       TRUST_PROXY_HEADER: "1"
       # Webhook deliveries target the host through `host.docker.internal`, which resolves to the
       # private bridge gateway. Allow the Docker bridge ranges rather than disabling the SSRF
-      # protection, which suites such as CIMD require to stay on.
+      # protection. CIMD cannot be enabled while an allowlist is set.
       SSRF_ALLOWED_ADDRESSES: 172.16.0.0/12,192.168.0.0/16,10.0.0.0/8
       COVERAGE: ${COVERAGE:-0}
       COVERAGE_REPORT_DIR: /coverage/report

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -45,6 +45,10 @@ services:
       SECRET_VAULT_KEK: DtPWS09unRXGuRScB60qXqCSsrjd22dUlXt/0oZgxSo=
       STATUS_API_KEY: test-status-api-key
       TRUST_PROXY_HEADER: "1"
+      # Webhook deliveries target the host through `host.docker.internal`, which resolves to the
+      # private bridge gateway. Allow the Docker bridge ranges rather than disabling the SSRF
+      # protection, which suites such as CIMD require to stay on.
+      SSRF_ALLOWED_ADDRESSES: 172.16.0.0/12,192.168.0.0/16,10.0.0.0/8
       COVERAGE: ${COVERAGE:-0}
       COVERAGE_REPORT_DIR: /coverage/report
       COVERAGE_TEMP_DIR: /coverage/raw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,9 @@ services:
       # Optional default grace period, in seconds, for OIDC private key rotation when the API
       # request omits `rotationGracePeriod`.
       - PRIVATE_KEY_ROTATION_GRACE_PERIOD
-      # Set to `true` only when trusted OIDC relying-party endpoints resolve to private networks.
-      # SSRF protection for oidc-provider outbound requests is enabled by default.
-      - OIDC_PROVIDER_SSRF_PROTECTION_DISABLED
+      # Set to `true` only when trusted webhook, SSO, or OIDC relying-party endpoints resolve to
+      # private networks. SSRF protection for outbound requests is enabled by default.
+      - SSRF_PROTECTION_DISABLED
       # Mandatory for GitPod to map host env to the container, thus GitPod can dynamically configure the public URL of Logto;
       # Or, you can leverage it for local testing.
       - ENDPOINT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,11 @@ services:
       # Optional default grace period, in seconds, for OIDC private key rotation when the API
       # request omits `rotationGracePeriod`.
       - PRIVATE_KEY_ROTATION_GRACE_PERIOD
-      # Set to `true` only when trusted webhook, SSO, or OIDC relying-party endpoints resolve to
-      # private networks. SSRF protection for outbound requests is enabled by default.
+      # SSRF protection for outbound requests is enabled by default. To reach a trusted webhook,
+      # SSO, or OIDC relying-party endpoint on a private network, list its address or CIDR range in
+      # `SSRF_ALLOWED_ADDRESSES` (for example `10.0.0.0/8`). Setting `SSRF_PROTECTION_DISABLED=true`
+      # turns the protection off entirely and also disables features that require it, such as CIMD.
+      - SSRF_ALLOWED_ADDRESSES
       - SSRF_PROTECTION_DISABLED
       # Mandatory for GitPod to map host env to the container, thus GitPod can dynamically configure the public URL of Logto;
       # Or, you can leverage it for local testing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,8 +19,10 @@ services:
       # SSO, or OIDC relying-party endpoint on a private network, list its address or CIDR range in
       # `SSRF_ALLOWED_ADDRESSES` (for example `10.0.0.0/8`). Setting `SSRF_PROTECTION_DISABLED=true`
       # turns the protection off entirely and also disables features that require it, such as CIMD.
+      # `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED` is supported as a legacy alias.
       - SSRF_ALLOWED_ADDRESSES
       - SSRF_PROTECTION_DISABLED
+      - OIDC_PROVIDER_SSRF_PROTECTION_DISABLED
       # Mandatory for GitPod to map host env to the container, thus GitPod can dynamically configure the public URL of Logto;
       # Or, you can leverage it for local testing.
       - ENDPOINT

--- a/packages/core/src/include.d/oidc-provider/lib-keep/helpers/fetch_request.d.ts
+++ b/packages/core/src/include.d/oidc-provider/lib-keep/helpers/fetch_request.d.ts
@@ -1,0 +1,19 @@
+// https://github.com/logto-io/node-oidc-provider/blob/513c523c0e68ee6112da8c871cce86204a136163/lib/helpers/fetch_request.js
+declare module 'oidc-provider/lib/helpers/fetch_request.js' {
+  /**
+   * Whether the address belongs to the IANA special-purpose address registries (loopback,
+   * private-use, link-local, shared address space, ...). IPv4-mapped IPv6 addresses are unwrapped
+   * and judged as IPv4.
+   *
+   * @param address A valid IPv4 or IPv6 address, such as `socket.remoteAddress`.
+   */
+  export function isSpecialUseIP(address: string): boolean;
+
+  /**
+   * Attaches the SSRF guard to an undici dispatcher: on every established connection the socket's
+   * remote address is inspected and the socket is destroyed when it points at a special-use IP.
+   *
+   * @returns The same dispatcher instance, for chaining.
+   */
+  export function applySSRFProtection<T>(dispatcher: T): T;
+}

--- a/packages/core/src/include.d/oidc-provider/lib-keep/helpers/fetch_request.d.ts
+++ b/packages/core/src/include.d/oidc-provider/lib-keep/helpers/fetch_request.d.ts
@@ -8,12 +8,4 @@ declare module 'oidc-provider/lib/helpers/fetch_request.js' {
    * @param address A valid IPv4 or IPv6 address, such as `socket.remoteAddress`.
    */
   export function isSpecialUseIP(address: string): boolean;
-
-  /**
-   * Attaches the SSRF guard to an undici dispatcher: on every established connection the socket's
-   * remote address is inspected and the socket is destroyed when it points at a special-use IP.
-   *
-   * @returns The same dispatcher instance, for chaining.
-   */
-  export function applySSRFProtection<T>(dispatcher: T): T;
 }

--- a/packages/core/src/libraries/hook/utils.retry.test.ts
+++ b/packages/core/src/libraries/hook/utils.retry.test.ts
@@ -3,6 +3,9 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { type AddressInfo } from 'node:net';
 
 import { InteractionHookEvent } from '@logto/schemas';
+import Sinon from 'sinon';
+
+import { EnvSet } from '#src/env-set/index.js';
 
 import { generateHookTestPayload, sendWebhookRequest } from './utils.js';
 
@@ -79,6 +82,22 @@ const withRetryServer = async (
 };
 
 describe('sendWebhookRequest HTTP retries', () => {
+  /**
+   * These fixtures serve from loopback, which the SSRF guard blocks by design. Retry semantics are
+   * the subject here, so take the self-hosted opt-out; the guard itself is covered by
+   * `utils/outbound-request.test.ts`.
+   */
+  beforeEach(() => {
+    Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      isSsrfProtectionEnabled: false,
+    });
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+  });
+
   it.each([500, 501, 599])(
     'retries POST %s responses three times for a total of four attempts',
     async (status) => {

--- a/packages/core/src/libraries/hook/utils.test.ts
+++ b/packages/core/src/libraries/hook/utils.test.ts
@@ -2,6 +2,8 @@ import { type HookEvent, InteractionHookEvent } from '@logto/schemas';
 import { createMockUtils } from '@logto/shared/esm';
 import ky from 'ky';
 
+import { ssrfProtectedFetch } from '#src/utils/outbound-request.js';
+
 const { jest } = import.meta;
 
 const { mockEsm } = createMockUtils(jest);
@@ -81,6 +83,7 @@ describe('sendWebhookRequest', () => {
 
     expect(post.mock.lastCall?.[0]).toBe('https://logto.gg');
     expect(post.mock.lastCall?.[1]).toMatchObject({
+      fetch: ssrfProtectedFetch,
       headers: {
         'user-agent': 'Logto (https://logto.io/)',
         'logto-signature-sha-256': mockSignature,

--- a/packages/core/src/libraries/hook/utils.ts
+++ b/packages/core/src/libraries/hook/utils.ts
@@ -13,6 +13,7 @@ import { type Context } from 'koa';
 import { type IRouterParamContext } from 'koa-router';
 import ky, { HTTPError, type KyResponse } from 'ky';
 
+import { ssrfProtectedFetch } from '#src/utils/outbound-request.js';
 import { sign } from '#src/utils/sign.js';
 
 export const parseResponse = async (response: KyResponse) => {
@@ -96,6 +97,8 @@ export const sendWebhookRequest = async ({
       ...conditional(signingKey && { 'logto-signature-sha-256': sign(signingKey, payload) }),
     },
     json: payload,
+    // The hook URL is tenant-supplied; keep delivery off the deployment's private network.
+    fetch: ssrfProtectedFetch,
     // Public webhook delivery contract: retry POST requests on HTTP 5xx only.
     // 408 and 429 are intentionally excluded so receivers cannot control this short retry window.
     retry: {

--- a/packages/core/src/libraries/session/cimd-grant-records.test.ts
+++ b/packages/core/src/libraries/session/cimd-grant-records.test.ts
@@ -117,7 +117,7 @@ describe('consent for a cimd client', () => {
   beforeEach(() => {
     Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
-      isOidcProviderSsrfProtectionEnabled: true,
+      isSsrfProtectionEnabled: true,
     });
   });
 

--- a/packages/core/src/libraries/session/session-context.test.ts
+++ b/packages/core/src/libraries/session/session-context.test.ts
@@ -97,7 +97,7 @@ describe('saveInteractionLastSubmissionToSession while CIMD is effectively enabl
   beforeEach(() => {
     Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
-      isOidcProviderSsrfProtectionEnabled: true,
+      isSsrfProtectionEnabled: true,
     });
   });
 

--- a/packages/core/src/middleware/koa-app-access-control.test.ts
+++ b/packages/core/src/middleware/koa-app-access-control.test.ts
@@ -124,7 +124,7 @@ describe('koaAppAccessControl middleware', () => {
     beforeEach(() => {
       Sinon.stub(EnvSet, 'values').value({
         ...EnvSet.values,
-        isOidcProviderSsrfProtectionEnabled: true,
+        isSsrfProtectionEnabled: true,
       });
     });
 

--- a/packages/core/src/middleware/koa-auto-consent.test.ts
+++ b/packages/core/src/middleware/koa-auto-consent.test.ts
@@ -74,7 +74,7 @@ const cimdEnvSet = { oidc: { cimdEnabled: true } } as EnvSet;
 const stubCimdStaticFlags = () =>
   Sinon.stub(EnvSet, 'values').value({
     ...EnvSet.values,
-    isOidcProviderSsrfProtectionEnabled: true,
+    isSsrfProtectionEnabled: true,
   });
 
 const buildNotFoundError = (id: string) =>

--- a/packages/core/src/oidc/adapter.test.ts
+++ b/packages/core/src/oidc/adapter.test.ts
@@ -183,18 +183,18 @@ describe('postgres Adapter', () => {
  * classes asserted below share the identities of the ones the adapter throws.
  */
 const loadClientAdapter = async ({
-  isOidcProviderSsrfProtectionEnabled = true,
+  isSsrfProtectionEnabled = true,
   cimdEnabled = true,
   findApplicationById,
 }: {
-  isOidcProviderSsrfProtectionEnabled?: boolean;
+  isSsrfProtectionEnabled?: boolean;
   cimdEnabled?: boolean;
   findApplicationById: jest.Mock;
 }) => {
   jest.resetModules();
   mockEsm('#src/env-set/index.js', () => ({
     EnvSet: {
-      values: { isOidcProviderSsrfProtectionEnabled },
+      values: { isSsrfProtectionEnabled },
     },
   }));
 
@@ -235,7 +235,7 @@ describe('client adapter `find` fallback contract', () => {
 
   it.each([
     ['CIMD is disabled for the tenant', { cimdEnabled: false }],
-    ['SSRF protection is off', { isOidcProviderSsrfProtectionEnabled: false }],
+    ['SSRF protection is off', { isSsrfProtectionEnabled: false }],
   ])('looks a CIMD client ID up as a registered application when %s', async (_, flags) => {
     const findApplicationById = jest.fn().mockRejectedValue(new Error('not found'));
     const { findClient, errors } = await loadClientAdapter({ ...flags, findApplicationById });

--- a/packages/core/src/oidc/adapter.test.ts
+++ b/packages/core/src/oidc/adapter.test.ts
@@ -184,17 +184,19 @@ describe('postgres Adapter', () => {
  */
 const loadClientAdapter = async ({
   isSsrfProtectionEnabled = true,
+  ssrfAllowedAddresses = [],
   cimdEnabled = true,
   findApplicationById,
 }: {
   isSsrfProtectionEnabled?: boolean;
+  ssrfAllowedAddresses?: string[];
   cimdEnabled?: boolean;
   findApplicationById: jest.Mock;
 }) => {
   jest.resetModules();
   mockEsm('#src/env-set/index.js', () => ({
     EnvSet: {
-      values: { isSsrfProtectionEnabled },
+      values: { isSsrfProtectionEnabled, ssrfAllowedAddresses },
     },
   }));
 
@@ -236,6 +238,7 @@ describe('client adapter `find` fallback contract', () => {
   it.each([
     ['CIMD is disabled for the tenant', { cimdEnabled: false }],
     ['SSRF protection is off', { isSsrfProtectionEnabled: false }],
+    ['private addresses are allowlisted', { ssrfAllowedAddresses: ['10.0.0.0/8'] }],
   ])('looks a CIMD client ID up as a registered application when %s', async (_, flags) => {
     const findApplicationById = jest.fn().mockRejectedValue(new Error('not found'));
     const { findClient, errors } = await loadClientAdapter({ ...flags, findApplicationById });

--- a/packages/core/src/oidc/cimd/index.test.ts
+++ b/packages/core/src/oidc/cimd/index.test.ts
@@ -8,11 +8,11 @@ import type Queries from '#src/tenants/Queries.js';
 const { jest } = import.meta;
 const { mockEsm } = createMockUtils(jest);
 
-const loadCimdModule = async ({ isOidcProviderSsrfProtectionEnabled = true } = {}) => {
+const loadCimdModule = async ({ isSsrfProtectionEnabled = true } = {}) => {
   jest.resetModules();
   mockEsm('#src/env-set/index.js', () => ({
     EnvSet: {
-      values: { isOidcProviderSsrfProtectionEnabled },
+      values: { isSsrfProtectionEnabled },
     },
   }));
 
@@ -93,7 +93,7 @@ describe('isCimdEffectivelyEnabled', () => {
 
   it('is disabled when the provider SSRF protection is off, regardless of the stored config', async () => {
     const { isCimdEffectivelyEnabled } = await loadCimdModule({
-      isOidcProviderSsrfProtectionEnabled: false,
+      isSsrfProtectionEnabled: false,
     });
     expect(isCimdEffectivelyEnabled(buildEnvSet(true))).toBe(false);
   });
@@ -115,7 +115,7 @@ describe('shouldAttributeToCimd', () => {
 
   it('attributes even when cimd is not effectively enabled for the tenant', async () => {
     const { shouldAttributeToCimd } = await loadCimdModule({
-      isOidcProviderSsrfProtectionEnabled: false,
+      isSsrfProtectionEnabled: false,
     });
     expect(shouldAttributeToCimd(cimdClientId)).toBe(true);
   });

--- a/packages/core/src/oidc/cimd/index.test.ts
+++ b/packages/core/src/oidc/cimd/index.test.ts
@@ -8,11 +8,17 @@ import type Queries from '#src/tenants/Queries.js';
 const { jest } = import.meta;
 const { mockEsm } = createMockUtils(jest);
 
-const loadCimdModule = async ({ isSsrfProtectionEnabled = true } = {}) => {
+const loadCimdModule = async ({
+  isSsrfProtectionEnabled = true,
+  ssrfAllowedAddresses = [],
+}: {
+  isSsrfProtectionEnabled?: boolean;
+  ssrfAllowedAddresses?: string[];
+} = {}) => {
   jest.resetModules();
   mockEsm('#src/env-set/index.js', () => ({
     EnvSet: {
-      values: { isSsrfProtectionEnabled },
+      values: { isSsrfProtectionEnabled, ssrfAllowedAddresses },
     },
   }));
 
@@ -95,6 +101,14 @@ describe('isCimdEffectivelyEnabled', () => {
     const { isCimdEffectivelyEnabled } = await loadCimdModule({
       isSsrfProtectionEnabled: false,
     });
+    expect(isCimdEffectivelyEnabled(buildEnvSet(true))).toBe(false);
+  });
+
+  it('is disabled when private addresses are allowlisted', async () => {
+    const { isCimdEffectivelyEnabled } = await loadCimdModule({
+      ssrfAllowedAddresses: ['10.0.0.0/8'],
+    });
+
     expect(isCimdEffectivelyEnabled(buildEnvSet(true))).toBe(false);
   });
 });

--- a/packages/core/src/oidc/cimd/index.test.ts
+++ b/packages/core/src/oidc/cimd/index.test.ts
@@ -87,7 +87,7 @@ const loadEnabledFeature = async ({
 };
 
 describe('isCimdEffectivelyEnabled', () => {
-  it('is enabled only when both conditions hold', async () => {
+  it('is enabled only when the tenant config, SSRF protection, and empty allowlist all hold', async () => {
     const { isCimdEffectivelyEnabled } = await loadCimdModule();
     expect(isCimdEffectivelyEnabled(buildEnvSet(true))).toBe(true);
   });

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -51,7 +51,7 @@ const assertClientIdWithinLengthBound = (clientId: string) => {
  * changes, so every predicate consumer observes the same value for the provider's lifetime.
  */
 export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
-  envSet.oidc.cimdEnabled && EnvSet.values.isOidcProviderSsrfProtectionEnabled;
+  envSet.oidc.cimdEnabled && EnvSet.values.isSsrfProtectionEnabled;
 
 /**
  * Whether an identifier presented as a `client_id` should be attributed to a CIMD client —

--- a/packages/core/src/oidc/cimd/index.ts
+++ b/packages/core/src/oidc/cimd/index.ts
@@ -39,19 +39,22 @@ const assertClientIdWithinLengthBound = (clientId: string) => {
 };
 
 /**
- * Whether CIMD is effectively enabled for the tenant. Both conditions must hold:
+ * Whether CIMD is effectively enabled for the tenant. All conditions must hold:
  *
  * - The tenant has enabled CIMD in its configs;
- * - The provider SSRF protection is active — CIMD forces outbound fetches, so it hard-requires
- *   the SSRF-protected dispatcher. Disabling the protection (self-hosted only) turns CIMD off
- *   regardless of the stored config: the Management API's enable-time 422 only fails fast on the
- *   honest path, since the env can be flipped after the config is stored.
+ * - The provider SSRF protection is active without an address allowlist — CIMD accepts target URLs
+ *   from unauthenticated callers, so it must not inherit private destinations allowlisted for
+ *   trusted webhook or SSO configurations. Disabling or relaxing the protection (self-hosted only)
+ *   turns CIMD off regardless of the stored config: the Management API's enable-time 422 only fails
+ *   fast on the honest path, since the env can be flipped after the config is stored.
  *
  * Provider construction is the authoritative gate — the tenant is rebuilt when the stored config
  * changes, so every predicate consumer observes the same value for the provider's lifetime.
  */
 export const isCimdEffectivelyEnabled = (envSet: EnvSet): boolean =>
-  envSet.oidc.cimdEnabled && EnvSet.values.isSsrfProtectionEnabled;
+  envSet.oidc.cimdEnabled &&
+  EnvSet.values.isSsrfProtectionEnabled &&
+  EnvSet.values.ssrfAllowedAddresses.length === 0;
 
 /**
  * Whether an identifier presented as a `client_id` should be attributed to a CIMD client —

--- a/packages/core/src/oidc/fetch.test.ts
+++ b/packages/core/src/oidc/fetch.test.ts
@@ -19,15 +19,31 @@ describe('getProviderFetchConfig', () => {
     Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
       isSsrfProtectionEnabled: true,
+      ssrfAllowedAddresses: [],
     });
 
     expect(getProviderFetchConfig()).toBeUndefined();
+  });
+
+  /**
+   * The provider's built-in guard has no hook for the allowlist, so a listed address would stay
+   * unreachable on this path while being reachable through webhooks and SSO connectors.
+   */
+  it('should override the provider fetch when an allowlist is configured', () => {
+    Sinon.stub(EnvSet, 'values').value({
+      ...EnvSet.values,
+      isSsrfProtectionEnabled: true,
+      ssrfAllowedAddresses: ['127.0.0.1'],
+    });
+
+    expect(getProviderFetchConfig()).toHaveProperty('fetch');
   });
 
   it('should drop the SSRF-protecting dispatcher when protection is disabled', async () => {
     Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
       isSsrfProtectionEnabled: false,
+      ssrfAllowedAddresses: [],
     });
     const fetchStub = Sinon.stub(globalThis, 'fetch').resolves(new Response());
     const config = getProviderFetchConfig();

--- a/packages/core/src/oidc/fetch.test.ts
+++ b/packages/core/src/oidc/fetch.test.ts
@@ -18,7 +18,7 @@ describe('getProviderFetchConfig', () => {
   it('should preserve the provider native fetch when SSRF protection is enabled', () => {
     Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
-      isOidcProviderSsrfProtectionEnabled: true,
+      isSsrfProtectionEnabled: true,
     });
 
     expect(getProviderFetchConfig()).toBeUndefined();
@@ -27,7 +27,7 @@ describe('getProviderFetchConfig', () => {
   it('should drop the SSRF-protecting dispatcher when protection is disabled', async () => {
     Sinon.stub(EnvSet, 'values').value({
       ...EnvSet.values,
-      isOidcProviderSsrfProtectionEnabled: false,
+      isSsrfProtectionEnabled: false,
     });
     const fetchStub = Sinon.stub(globalThis, 'fetch').resolves(new Response());
     const config = getProviderFetchConfig();

--- a/packages/core/src/oidc/fetch.ts
+++ b/packages/core/src/oidc/fetch.ts
@@ -24,6 +24,6 @@ const fetchWithoutSsrfDispatcher: typeof fetch = async (input, init) => {
  * upstream fetch hardening is inherited automatically. Only override it for the self-hosted opt-out.
  */
 export const getProviderFetchConfig = () =>
-  cond(!EnvSet.values.isOidcProviderSsrfProtectionEnabled && { fetch: fetchWithoutSsrfDispatcher });
+  cond(!EnvSet.values.isSsrfProtectionEnabled && { fetch: fetchWithoutSsrfDispatcher });
 
 export default fetchWithoutSsrfDispatcher;

--- a/packages/core/src/oidc/fetch.ts
+++ b/packages/core/src/oidc/fetch.ts
@@ -1,6 +1,7 @@
 import { cond } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
+import { ssrfProtectedFetch } from '#src/utils/outbound-request.js';
 
 /**
  * The opt-out `fetch` implementation for the provider's outgoing requests (backchannel logout,
@@ -20,10 +21,30 @@ const fetchWithoutSsrfDispatcher: typeof fetch = async (input, init) => {
 };
 
 /**
- * Keep oidc-provider's native fetch implementation whenever SSRF protection is enabled so future
- * upstream fetch hardening is inherited automatically. Only override it for the self-hosted opt-out.
+ * Replaces oidc-provider's dispatcher with ours, which applies the same special-use address check
+ * plus `SSRF_ALLOWED_ADDRESSES`. Needed because the provider's built-in guard hardcodes its check
+ * and has no hook for the allowlist, so a listed address would stay unreachable here while being
+ * reachable everywhere else.
  */
-export const getProviderFetchConfig = () =>
-  cond(!EnvSet.values.isSsrfProtectionEnabled && { fetch: fetchWithoutSsrfDispatcher });
+const fetchWithAllowlistedDispatcher: typeof fetch = async (input, init) => {
+  // eslint-disable-next-line no-restricted-syntax -- The `dispatcher` key is an undici extension absent from `RequestInit`
+  const { dispatcher, ...safeInit } = (init ?? {}) as RequestInit & { dispatcher?: unknown };
+  return ssrfProtectedFetch(input, safeInit);
+};
+
+/**
+ * Keep oidc-provider's native fetch implementation whenever the protection is enabled and no
+ * allowlist applies, so future upstream fetch hardening is inherited automatically. Override it
+ * only for the self-hosted opt-out and for the allowlist, which upstream cannot honor.
+ */
+export const getProviderFetchConfig = () => {
+  const { isSsrfProtectionEnabled, ssrfAllowedAddresses } = EnvSet.values;
+
+  if (!isSsrfProtectionEnabled) {
+    return { fetch: fetchWithoutSsrfDispatcher };
+  }
+
+  return cond(ssrfAllowedAddresses.length > 0 && { fetch: fetchWithAllowlistedDispatcher });
+};
 
 export default fetchWithoutSsrfDispatcher;

--- a/packages/core/src/oidc/oidc-provider-internals.ts
+++ b/packages/core/src/oidc/oidc-provider-internals.ts
@@ -31,6 +31,7 @@ export {
 export { default as validatePresence } from 'oidc-provider/lib/helpers/validate_presence.js';
 export { default as checkRar } from 'oidc-provider/lib/shared/check_rar.js';
 export { default as checkResource } from 'oidc-provider/lib/shared/check_resource.js';
+export { isSpecialUseIP } from 'oidc-provider/lib/helpers/fetch_request.js';
 
 /**
  * Since v9, custom grant handlers are the final token-endpoint middleware and receive no `next`

--- a/packages/core/src/routes/logto-config/cimd.test.ts
+++ b/packages/core/src/routes/logto-config/cimd.test.ts
@@ -58,7 +58,7 @@ describe('CIMD config routes', () => {
     it('rejects enabling with 422 while the SSRF protection is disabled', async () => {
       Sinon.stub(EnvSet, 'values').value({
         ...EnvSet.values,
-        isOidcProviderSsrfProtectionEnabled: false,
+        isSsrfProtectionEnabled: false,
       });
 
       const response = await routeRequester.patch('/configs/cimd').send({ enabled: true });
@@ -70,7 +70,7 @@ describe('CIMD config routes', () => {
     it('allows disabling while the SSRF protection is disabled', async () => {
       Sinon.stub(EnvSet, 'values').value({
         ...EnvSet.values,
-        isOidcProviderSsrfProtectionEnabled: false,
+        isSsrfProtectionEnabled: false,
       });
       logtoConfigQueries.getCimdConfig.mockResolvedValueOnce({ enabled: true });
 

--- a/packages/core/src/routes/logto-config/cimd.test.ts
+++ b/packages/core/src/routes/logto-config/cimd.test.ts
@@ -67,6 +67,18 @@ describe('CIMD config routes', () => {
       expect(logtoConfigQueries.upsertCimdConfig).not.toHaveBeenCalled();
     });
 
+    it('rejects enabling with 422 while private addresses are allowlisted', async () => {
+      Sinon.stub(EnvSet, 'values').value({
+        ...EnvSet.values,
+        ssrfAllowedAddresses: ['10.0.0.0/8'],
+      });
+
+      const response = await routeRequester.patch('/configs/cimd').send({ enabled: true });
+
+      expect(response.status).toEqual(422);
+      expect(logtoConfigQueries.upsertCimdConfig).not.toHaveBeenCalled();
+    });
+
     it('allows disabling while the SSRF protection is disabled', async () => {
       Sinon.stub(EnvSet, 'values').value({
         ...EnvSet.values,

--- a/packages/core/src/routes/logto-config/cimd.ts
+++ b/packages/core/src/routes/logto-config/cimd.ts
@@ -52,7 +52,7 @@ export default function logtoConfigCimdRoutes<T extends ManagementApiRouter>(
           { code: 'request.invalid_input', status: 422 },
           {
             details:
-              'CIMD requires the outbound request SSRF protection. Remove `SSRF_PROTECTION_DISABLED` to enable CIMD.',
+              'CIMD requires outbound request SSRF protection. Remove `SSRF_PROTECTION_DISABLED` (or `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED`) to enable CIMD.',
           }
         )
       );

--- a/packages/core/src/routes/logto-config/cimd.ts
+++ b/packages/core/src/routes/logto-config/cimd.ts
@@ -47,12 +47,14 @@ export default function logtoConfigCimdRoutes<T extends ManagementApiRouter>(
        * construction applies the same condition (LOG-13920).
        */
       assertThat(
-        !body.enabled || EnvSet.values.isSsrfProtectionEnabled,
+        !body.enabled ||
+          (EnvSet.values.isSsrfProtectionEnabled &&
+            EnvSet.values.ssrfAllowedAddresses.length === 0),
         new RequestError(
           { code: 'request.invalid_input', status: 422 },
           {
             details:
-              'CIMD requires outbound request SSRF protection. Remove `SSRF_PROTECTION_DISABLED` (or `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED`) to enable CIMD.',
+              'CIMD requires unrestricted outbound request SSRF protection. Remove `SSRF_PROTECTION_DISABLED`, `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED`, and `SSRF_ALLOWED_ADDRESSES` to enable CIMD.',
           }
         )
       );

--- a/packages/core/src/routes/logto-config/cimd.ts
+++ b/packages/core/src/routes/logto-config/cimd.ts
@@ -47,12 +47,12 @@ export default function logtoConfigCimdRoutes<T extends ManagementApiRouter>(
        * construction applies the same condition (LOG-13920).
        */
       assertThat(
-        !body.enabled || EnvSet.values.isOidcProviderSsrfProtectionEnabled,
+        !body.enabled || EnvSet.values.isSsrfProtectionEnabled,
         new RequestError(
           { code: 'request.invalid_input', status: 422 },
           {
             details:
-              'CIMD requires the OIDC provider SSRF protection. Remove `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED` to enable CIMD.',
+              'CIMD requires the outbound request SSRF protection. Remove `SSRF_PROTECTION_DISABLED` to enable CIMD.',
           }
         )
       );

--- a/packages/core/src/sso/OidcConnector/utils.test.ts
+++ b/packages/core/src/sso/OidcConnector/utils.test.ts
@@ -25,11 +25,15 @@ class MockHttpError {
   constructor(public response: { body: unknown }) {}
 }
 
+const gotMock = {
+  get: getMock,
+  post: postMock,
+  // `outbound-request.js` derives its SSRF-protected instance from `got.extend()`.
+  extend: () => gotMock,
+};
+
 mockEsm('got', () => ({
-  got: {
-    get: getMock,
-    post: postMock,
-  },
+  got: gotMock,
   HTTPError: MockHttpError,
 }));
 

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -1,9 +1,11 @@
 import { parseJson, tokenResponseGuard, type TokenResponse } from '@logto/connector-kit';
 import { assert } from '@silverhand/essentials';
 import camelcaseKeys, { type CamelCaseKeys } from 'camelcase-keys';
-import { got, HTTPError } from 'got';
+import { HTTPError } from 'got';
 import { createRemoteJWKSet, jwtVerify, type JWTVerifyOptions } from 'jose';
 import { z, ZodError } from 'zod';
+
+import { ssrfProtectedGot } from '#src/utils/outbound-request.js';
 
 import {
   SsoConnectorConfigErrorCodes,
@@ -27,7 +29,7 @@ import {
  * @returns The full-list of OIDC config
  */
 export const fetchOidcConfigRaw = async (issuer: string) => {
-  const { body } = await got.get(`${issuer}/.well-known/openid-configuration`);
+  const { body } = await ssrfProtectedGot.get(`${issuer}/.well-known/openid-configuration`);
 
   return camelcaseKeys(oidcConfigResponseGuard.parse(parseJson(body)));
 };
@@ -78,7 +80,7 @@ export const handleTokenExchange = async (
     'Content-Type': 'application/x-www-form-urlencoded',
   };
 
-  const httpResponse = await got.post(tokenEndpoint, {
+  const httpResponse = await ssrfProtectedGot.post(tokenEndpoint, {
     body: tokenRequestParameters.toString(),
     headers,
   });
@@ -194,7 +196,7 @@ export const getIdTokenClaims = async (
 };
 
 export const getRawUserInfoResponse = async (accessToken: string, userinfoEndpoint: string) => {
-  const httpResponse = await got.get(userinfoEndpoint, {
+  const httpResponse = await ssrfProtectedGot.get(userinfoEndpoint, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
@@ -252,7 +254,7 @@ export const getTokenByRefreshToken = async (
   };
 
   try {
-    const httpResponse = await got.post(tokenEndpoint, {
+    const httpResponse = await ssrfProtectedGot.post(tokenEndpoint, {
       body: tokenRequestParameters.toString(),
       headers,
     });

--- a/packages/core/src/sso/OidcConnector/utils.ts
+++ b/packages/core/src/sso/OidcConnector/utils.ts
@@ -2,10 +2,10 @@ import { parseJson, tokenResponseGuard, type TokenResponse } from '@logto/connec
 import { assert } from '@silverhand/essentials';
 import camelcaseKeys, { type CamelCaseKeys } from 'camelcase-keys';
 import { HTTPError } from 'got';
-import { createRemoteJWKSet, jwtVerify, type JWTVerifyOptions } from 'jose';
+import { createRemoteJWKSet, customFetch, jwtVerify, type JWTVerifyOptions } from 'jose';
 import { z, ZodError } from 'zod';
 
-import { ssrfProtectedGot } from '#src/utils/outbound-request.js';
+import { ssrfProtectedFetch, ssrfProtectedGot } from '#src/utils/outbound-request.js';
 
 import {
   SsoConnectorConfigErrorCodes,
@@ -150,11 +150,15 @@ export const getIdTokenClaims = async (
   jwtVerifyOptions?: JWTVerifyOptions
 ) => {
   try {
-    const { payload } = await jwtVerify(idToken, createRemoteJWKSet(new URL(config.jwksUri)), {
-      issuer: config.issuer,
-      audience: config.clientId,
-      ...jwtVerifyOptions,
-    });
+    const { payload } = await jwtVerify(
+      idToken,
+      createRemoteJWKSet(new URL(config.jwksUri), { [customFetch]: ssrfProtectedFetch }),
+      {
+        issuer: config.issuer,
+        audience: config.clientId,
+        ...jwtVerifyOptions,
+      }
+    );
 
     if (Math.abs((payload.iat ?? 0) - Date.now() / 1000) > issuedAtTimeTolerance) {
       throw new SsoConnectorError(SsoConnectorErrorCodes.AuthorizationFailed, {

--- a/packages/core/src/sso/SamlConnector/utils.ts
+++ b/packages/core/src/sso/SamlConnector/utils.ts
@@ -4,11 +4,12 @@ import * as validator from '@authenio/samlify-node-xmllint';
 import { ssoSamlAssertionContentGuard, type SsoSamlAssertionContent } from '@logto/schemas';
 import { type Optional, appendPath, tryThat } from '@silverhand/essentials';
 import { conditional } from '@silverhand/essentials';
-import { HTTPError, got } from 'got';
+import { HTTPError } from 'got';
 import * as saml from 'samlify';
 import { z, ZodError } from 'zod';
 
 import { ssoPath } from '#src/constants/index.js';
+import { ssrfProtectedGot } from '#src/utils/outbound-request.js';
 
 import {
   SsoConnectorConfigErrorCodes,
@@ -106,7 +107,7 @@ export const parseXmlMetadata = (
  */
 export const fetchSamlMetadataXml = async (metadataUrl: string): Promise<Optional<string>> => {
   try {
-    const { body } = await got.get(metadataUrl);
+    const { body } = await ssrfProtectedGot.get(metadataUrl);
 
     const result = z.string().safeParse(body);
 

--- a/packages/core/src/utils/outbound-request.test.ts
+++ b/packages/core/src/utils/outbound-request.test.ts
@@ -1,4 +1,4 @@
-import { type Socket } from 'node:net';
+import { BlockList, isIP, type Socket } from 'node:net';
 
 import Sinon from 'sinon';
 
@@ -10,10 +10,26 @@ const stubSsrfProtection = (
   isSsrfProtectionEnabled: boolean,
   ssrfAllowedAddresses: string[] = []
 ) => {
+  const ssrfAllowedAddressBlockList = new BlockList();
+
+  for (const entry of ssrfAllowedAddresses) {
+    const separator = entry.indexOf('/');
+    const address = separator === -1 ? entry : entry.slice(0, separator);
+    const prefix = separator === -1 ? undefined : entry.slice(separator + 1);
+    const family = isIP(address) === 6 ? 'ipv6' : 'ipv4';
+
+    if (prefix === undefined) {
+      ssrfAllowedAddressBlockList.addAddress(address, family);
+    } else {
+      ssrfAllowedAddressBlockList.addSubnet(address, Number(prefix), family);
+    }
+  }
+
   Sinon.stub(EnvSet, 'values').value({
     ...EnvSet.values,
     isSsrfProtectionEnabled,
     ssrfAllowedAddresses,
+    ssrfAllowedAddressBlockList,
   });
 };
 
@@ -181,27 +197,6 @@ describe('guardSocket', () => {
       expect(guard('169.254.169.254')).toMatchObject({
         message: 'hostname resolves to a special-use IP address',
       });
-    });
-
-    it('rejects a malformed entry instead of silently ignoring it', () => {
-      stubSsrfProtection(true, ['not-an-ip']);
-
-      expect(() => guard('127.0.0.1')).toThrow('Invalid address in `SSRF_ALLOWED_ADDRESSES`');
-    });
-
-    it.each([['127.0.0.0/'], ['127.0.0.0/abc'], ['127.0.0.0/-1'], ['127.0.0.0/33'], ['::1/129']])(
-      'rejects invalid CIDR prefix %s',
-      (entry) => {
-        stubSsrfProtection(true, [entry]);
-
-        expect(() => guard('127.0.0.1')).toThrow('Invalid CIDR prefix in `SSRF_ALLOWED_ADDRESSES`');
-      }
-    );
-
-    it('rejects entries with multiple slashes', () => {
-      stubSsrfProtection(true, ['127.0.0.0/8/16']);
-
-      expect(() => guard('127.0.0.1')).toThrow('Invalid address in `SSRF_ALLOWED_ADDRESSES`');
     });
   });
 });

--- a/packages/core/src/utils/outbound-request.test.ts
+++ b/packages/core/src/utils/outbound-request.test.ts
@@ -1,0 +1,156 @@
+import { type Socket } from 'node:net';
+
+import Sinon from 'sinon';
+
+import { EnvSet } from '#src/env-set/index.js';
+
+import { guardSocket, ssrfProtectedFetch, ssrfProtectedGot } from './outbound-request.js';
+
+const stubSsrfProtection = (isSsrfProtectionEnabled: boolean) => {
+  Sinon.stub(EnvSet, 'values').value({
+    ...EnvSet.values,
+    isSsrfProtectionEnabled,
+  });
+};
+
+/**
+ * Captures the agent `got` resolved for a request, then aborts before any socket is opened, so the
+ * assertions stay on configuration instead of real network behavior.
+ */
+const captureGotAgent = async () => {
+  const abort = new Error('aborted by test');
+  const captured = new Map<'agent', unknown>();
+
+  await expect(
+    ssrfProtectedGot.get('https://example.com/', {
+      retry: { limit: 0 },
+      hooks: {
+        beforeRequest: [
+          (options) => {
+            captured.set('agent', options.agent);
+            throw abort;
+          },
+        ],
+      },
+    })
+  ).rejects.toThrow(abort.message);
+
+  return captured.get('agent');
+};
+
+const dispatcherOf = (init?: RequestInit) =>
+  Object.getOwnPropertyDescriptor(init ?? {}, 'dispatcher')?.value;
+
+/** Minimal stand-in for the socket an agent hands back; only the guard's contract is used. */
+const createFakeSocket = (remoteAddress: string) => {
+  const listeners = new Map<string, () => void>();
+  const destroyed = new Map<'error', Error | undefined>();
+
+  return {
+    remoteAddress,
+    connecting: true,
+    once(event: string, listener: () => void) {
+      listeners.set(event, listener);
+      return this;
+    },
+    destroy(error?: Error) {
+      destroyed.set('error', error);
+      return this;
+    },
+    /** Simulates the socket completing its connection. */
+    emitConnect() {
+      listeners.get('connect')?.();
+    },
+    wasDestroyedWith: () => destroyed.get('error'),
+  };
+};
+
+describe('ssrfProtectedGot', () => {
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  it('guards both protocols when protection is enabled', async () => {
+    stubSsrfProtection(true);
+
+    const agent = await captureGotAgent();
+
+    // Covering only one protocol would leave a cross-protocol redirect unguarded.
+    expect(agent).toMatchObject({
+      http: { createConnection: expect.any(Function) as unknown },
+      https: { createConnection: expect.any(Function) as unknown },
+    });
+  });
+
+  it('leaves the agents untouched when protection is disabled', async () => {
+    stubSsrfProtection(false);
+
+    expect(await captureGotAgent()).toMatchObject({ http: undefined, https: undefined });
+  });
+});
+
+describe('ssrfProtectedFetch', () => {
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  /**
+   * A Jest VM context has no `undici` global dispatcher, so this asserts the fail-closed behavior:
+   * without a dispatcher the request must not go out unprotected. The dispatcher itself is covered
+   * by `guardSocket` below and by oidc-provider's own suite.
+   */
+  it('refuses to send unprotected when the dispatcher cannot be built', async () => {
+    stubSsrfProtection(true);
+    const fetchStub = Sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+    await expect(ssrfProtectedFetch('https://example.com/', { method: 'POST' })).rejects.toThrow(
+      'Failed to set up SSRF protection'
+    );
+
+    expect(fetchStub.called).toBe(false);
+  });
+
+  it('sends no dispatcher when protection is disabled', async () => {
+    stubSsrfProtection(false);
+    const fetchStub = Sinon.stub(globalThis, 'fetch').resolves(new Response());
+
+    await ssrfProtectedFetch('https://example.com/', { method: 'POST' });
+
+    const [, init] = fetchStub.firstCall.args;
+    expect(init).toMatchObject({ method: 'POST' });
+    expect(dispatcherOf(init)).toBeUndefined();
+  });
+});
+
+const guard = (address: string) => {
+  const socket = createFakeSocket(address);
+
+  guardSocket(socket as unknown as Socket);
+  socket.emitConnect();
+
+  return socket.wasDestroyedWith();
+};
+
+describe('guardSocket', () => {
+  it.each([
+    ['169.254.169.254', 'cloud metadata'],
+    ['127.0.0.1', 'loopback'],
+    ['10.1.2.3', 'private use'],
+    ['100.64.0.1', 'shared address space'],
+    ['::1', 'IPv6 loopback'],
+    ['fd00::1', 'IPv6 unique local'],
+    ['::ffff:192.168.1.1', 'IPv4-mapped private use'],
+  ])('destroys a connection to %s (%s)', (address) => {
+    expect(guard(address)).toMatchObject({
+      message: 'hostname resolves to a special-use IP address',
+    });
+  });
+
+  it.each([
+    ['8.8.8.8', 'public IPv4'],
+    ['::ffff:8.8.8.8', 'IPv4-mapped public address'],
+    ['2606:4700:4700::1111', 'public IPv6'],
+  ])('keeps a connection to %s (%s)', (address) => {
+    expect(guard(address)).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/outbound-request.test.ts
+++ b/packages/core/src/utils/outbound-request.test.ts
@@ -6,10 +6,14 @@ import { EnvSet } from '#src/env-set/index.js';
 
 import { guardSocket, ssrfProtectedFetch, ssrfProtectedGot } from './outbound-request.js';
 
-const stubSsrfProtection = (isSsrfProtectionEnabled: boolean) => {
+const stubSsrfProtection = (
+  isSsrfProtectionEnabled: boolean,
+  ssrfAllowedAddresses: string[] = []
+) => {
   Sinon.stub(EnvSet, 'values').value({
     ...EnvSet.values,
     isSsrfProtectionEnabled,
+    ssrfAllowedAddresses,
   });
 };
 
@@ -132,6 +136,10 @@ const guard = (address: string) => {
 };
 
 describe('guardSocket', () => {
+  afterEach(() => {
+    Sinon.restore();
+  });
+
   it.each([
     ['169.254.169.254', 'cloud metadata'],
     ['127.0.0.1', 'loopback'],
@@ -152,5 +160,33 @@ describe('guardSocket', () => {
     ['2606:4700:4700::1111', 'public IPv6'],
   ])('keeps a connection to %s (%s)', (address) => {
     expect(guard(address)).toBeUndefined();
+  });
+
+  describe('with an allowlist', () => {
+    it.each([
+      ['127.0.0.1', ['127.0.0.1'], 'exact address'],
+      ['127.0.0.5', ['127.0.0.0/8'], 'CIDR range'],
+      ['172.17.0.1', ['172.16.0.0/12'], 'Docker bridge range'],
+      ['::1', ['::1'], 'IPv6 address'],
+    ])('keeps a connection to %s allowed by %j (%s)', (address, allowlist) => {
+      stubSsrfProtection(true, allowlist);
+
+      expect(guard(address)).toBeUndefined();
+    });
+
+    it('still blocks an address outside the allowlist', () => {
+      stubSsrfProtection(true, ['127.0.0.0/8']);
+
+      // The whole point of allowlisting over disabling: metadata stays unreachable.
+      expect(guard('169.254.169.254')).toMatchObject({
+        message: 'hostname resolves to a special-use IP address',
+      });
+    });
+
+    it('rejects a malformed entry instead of silently ignoring it', () => {
+      stubSsrfProtection(true, ['not-an-ip']);
+
+      expect(() => guard('127.0.0.1')).toThrow('Invalid address in `SSRF_ALLOWED_ADDRESSES`');
+    });
   });
 });

--- a/packages/core/src/utils/outbound-request.test.ts
+++ b/packages/core/src/utils/outbound-request.test.ts
@@ -188,5 +188,20 @@ describe('guardSocket', () => {
 
       expect(() => guard('127.0.0.1')).toThrow('Invalid address in `SSRF_ALLOWED_ADDRESSES`');
     });
+
+    it.each([['127.0.0.0/'], ['127.0.0.0/abc'], ['127.0.0.0/-1'], ['127.0.0.0/33'], ['::1/129']])(
+      'rejects invalid CIDR prefix %s',
+      (entry) => {
+        stubSsrfProtection(true, [entry]);
+
+        expect(() => guard('127.0.0.1')).toThrow('Invalid CIDR prefix in `SSRF_ALLOWED_ADDRESSES`');
+      }
+    );
+
+    it('rejects entries with multiple slashes', () => {
+      stubSsrfProtection(true, ['127.0.0.0/8/16']);
+
+      expect(() => guard('127.0.0.1')).toThrow('Invalid address in `SSRF_ALLOWED_ADDRESSES`');
+    });
   });
 });

--- a/packages/core/src/utils/outbound-request.ts
+++ b/packages/core/src/utils/outbound-request.ts
@@ -16,16 +16,96 @@
 
 import http from 'node:http';
 import https from 'node:https';
-import { type Socket } from 'node:net';
+import { BlockList, isIP, type Socket } from 'node:net';
 
-import { cond } from '@silverhand/essentials';
+import { cond, type Optional } from '@silverhand/essentials';
 import { got, type Got } from 'got';
-import { applySSRFProtection, isSpecialUseIP } from 'oidc-provider/lib/helpers/fetch_request.js';
+import { isSpecialUseIP } from 'oidc-provider/lib/helpers/fetch_request.js';
 
 import { EnvSet } from '#src/env-set/index.js';
 import assertThat from '#src/utils/assert-that.js';
 
+/** Memoizes a factory, so the shared resources below are built at most once. */
+const once = <T>(build: () => T): (() => T) => {
+  const cache = new Map<'value', T>();
+
+  return () => {
+    if (!cache.has('value')) {
+      cache.set('value', build());
+    }
+
+    // eslint-disable-next-line no-restricted-syntax -- guarded by the `has` check above
+    return cache.get('value') as T;
+  };
+};
+
 const blockedAddressMessage = 'hostname resolves to a special-use IP address';
+
+/** Undici emits `connect` with the `[Agent, Pool, Client]` chain; the socket lives on the client. */
+type DispatcherConnectListener = (origin: unknown, targets: readonly unknown[]) => void;
+
+/** The slice of the undici `Dispatcher` surface this module uses; see {@link getUndiciAgent}. */
+type DispatcherEmitter = {
+  on: (event: string, listener: DispatcherConnectListener) => void;
+};
+
+/**
+ * Comma-separated allowlist of otherwise-blocked destinations, as IP addresses or CIDR ranges
+ * (`127.0.0.1,10.0.0.0/8,::1`).
+ *
+ * This is the narrow escape hatch for deployments that must deliver to a known internal host. It
+ * is preferable to turning the protection off entirely: naming the destinations keeps every other
+ * special-use address, including the cloud metadata endpoint, blocked. Ignored in Cloud.
+ */
+const parseAllowedAddresses = (): Optional<BlockList> => {
+  const raw = EnvSet.values.ssrfAllowedAddresses;
+
+  if (raw.length === 0) {
+    return undefined;
+  }
+
+  const list = new BlockList();
+
+  for (const entry of raw) {
+    const [address, prefix] = entry.split('/');
+
+    // Silently skipping a malformed entry would leave the operator believing a host is reachable.
+    assertThat(
+      address && isIP(address),
+      new Error(`Invalid address in \`SSRF_ALLOWED_ADDRESSES\`: ${entry}`)
+    );
+
+    const family = isIP(address) === 6 ? 'ipv6' : 'ipv4';
+
+    if (prefix === undefined) {
+      list.addAddress(address, family);
+    } else {
+      list.addSubnet(address, Number(prefix), family);
+    }
+  }
+
+  return list;
+};
+
+/** Parsing is cached against the configured value, which is fixed for the process' lifetime. */
+const allowedAddressesCache = new Map<string, Optional<BlockList>>();
+
+const getAllowedAddresses = (): Optional<BlockList> => {
+  const key = EnvSet.values.ssrfAllowedAddresses.join(',');
+
+  if (!allowedAddressesCache.has(key)) {
+    allowedAddressesCache.set(key, parseAllowedAddresses());
+  }
+
+  return allowedAddressesCache.get(key);
+};
+
+/** Whether the peer is explicitly allowed despite being a special-use address. */
+const isAllowedAddress = (address: string): boolean => {
+  const allowed = getAllowedAddresses();
+
+  return allowed?.check(address, isIP(address) === 6 ? 'ipv6' : 'ipv4') ?? false;
+};
 
 /**
  * Destroys the socket once connected if its peer is a special-use address. Mirrors the guard
@@ -37,7 +117,11 @@ export const guardSocket = <T extends Socket>(socket: T): T => {
   const assertPublicPeer = () => {
     const { remoteAddress } = socket;
 
-    if (remoteAddress !== undefined && isSpecialUseIP(remoteAddress)) {
+    if (
+      remoteAddress !== undefined &&
+      isSpecialUseIP(remoteAddress) &&
+      !isAllowedAddress(remoteAddress)
+    ) {
       socket.destroy(new Error(blockedAddressMessage));
     }
   };
@@ -99,39 +183,56 @@ const isEnabled = () => EnvSet.values.isSsrfProtectionEnabled;
  * Mixing an `undici` copy from `node_modules` with node's bundled one yields incompatible
  * `Dispatcher` instances.
  */
-const getUndiciAgent = (): (new () => unknown) | undefined => {
+const getUndiciAgent = (): Optional<new () => DispatcherEmitter> => {
   // Referencing `Response` triggers node's lazy `undici` initialization that sets these symbols.
   void Response;
 
+  // eslint-disable-next-line no-restricted-syntax -- internal `undici` symbols are untyped
+  const globals = globalThis as Record<
+    symbol,
+    Optional<{ constructor?: new () => DispatcherEmitter }>
+  >;
   const globalDispatcher =
-    // eslint-disable-next-line no-restricted-syntax -- internal `undici` symbols are untyped
-    (globalThis as Record<symbol, { constructor?: new () => unknown }>)[
-      Symbol.for('undici.globalDispatcher.2')
-    ] ??
-    // eslint-disable-next-line no-restricted-syntax -- internal `undici` symbols are untyped
-    (globalThis as Record<symbol, { constructor?: new () => unknown }>)[
-      Symbol.for('undici.globalDispatcher.1')
-    ];
+    globals[Symbol.for('undici.globalDispatcher.2')] ??
+    globals[Symbol.for('undici.globalDispatcher.1')];
 
   return globalDispatcher?.constructor;
 };
 
-/** Memoizes a factory, so the shared pools below are built at most once. */
-const once = <T>(build: () => T): (() => T) => {
-  const cache = new Map<'value', T>();
+/**
+ * The socket an undici client holds is stored under a symbol-keyed property, the way
+ * oidc-provider's own guard reaches it.
+ */
+const findSocket = (target: unknown): Optional<Socket> => {
+  if (typeof target !== 'object' || target === null) {
+    return undefined;
+  }
 
-  return () => {
-    const cached = cache.get('value');
+  const socketKey = Object.getOwnPropertySymbols(target).find(
+    (key) => key.description === 'socket'
+  );
 
-    if (cached !== undefined) {
-      return cached;
+  // eslint-disable-next-line no-restricted-syntax -- reaching into undici internals by symbol
+  return socketKey === undefined ? undefined : (target as Record<symbol, Socket>)[socketKey];
+};
+
+/**
+ * Applies the same guard as {@link guardSocket} to an undici dispatcher.
+ *
+ * oidc-provider's `applySSRFProtection` is not reused here because it hardcodes its own check and
+ * offers no hook for the allowlist, which would leave `SSRF_ALLOWED_ADDRESSES` silently ignored on
+ * the `fetch` path while working on the `got` one.
+ */
+const applyDispatcherGuard = <T extends DispatcherEmitter>(dispatcher: T): T => {
+  dispatcher.on('connect', (_origin, targets) => {
+    const socket = findSocket(targets.at(-1));
+
+    if (socket) {
+      guardSocket(socket);
     }
+  });
 
-    const value = build();
-    cache.set('value', value);
-
-    return value;
-  };
+  return dispatcher;
 };
 
 /** Built once and shared: a dispatcher per request would leak connection pools. */
@@ -147,7 +248,7 @@ const getDispatcher = once((): unknown => {
     )
   );
 
-  return applySSRFProtection(new Agent());
+  return applyDispatcherGuard(new Agent());
 });
 
 /**

--- a/packages/core/src/utils/outbound-request.ts
+++ b/packages/core/src/utils/outbound-request.ts
@@ -16,7 +16,7 @@
 
 import http from 'node:http';
 import https from 'node:https';
-import { BlockList, isIP, type Socket } from 'node:net';
+import { isIP, type Socket } from 'node:net';
 
 import { cond, type Optional } from '@silverhand/essentials';
 import { got, type Got } from 'got';
@@ -49,75 +49,9 @@ type DispatcherEmitter = {
   on: (event: string, listener: DispatcherConnectListener) => void;
 };
 
-/**
- * Comma-separated allowlist of otherwise-blocked destinations, as IP addresses or CIDR ranges
- * (`127.0.0.1,10.0.0.0/8,::1`).
- *
- * This is the narrow escape hatch for deployments that must deliver to a known internal host. It
- * is preferable to turning the protection off entirely: naming the destinations keeps every other
- * special-use address, including the cloud metadata endpoint, blocked. Ignored in Cloud.
- */
-const parseAllowedAddresses = (): Optional<BlockList> => {
-  const raw = EnvSet.values.ssrfAllowedAddresses;
-
-  if (raw.length === 0) {
-    return undefined;
-  }
-
-  const list = new BlockList();
-
-  for (const entry of raw) {
-    const segments = entry.trim().split('/');
-
-    assertThat(
-      segments.length === 1 || segments.length === 2,
-      new Error(`Invalid address in \`SSRF_ALLOWED_ADDRESSES\`: ${entry}`)
-    );
-
-    const [address, prefix] = segments;
-
-    // Silently skipping a malformed entry would leave the operator believing a host is reachable.
-    assertThat(
-      address && isIP(address),
-      new Error(`Invalid address in \`SSRF_ALLOWED_ADDRESSES\`: ${entry}`)
-    );
-
-    const family = isIP(address) === 6 ? 'ipv6' : 'ipv4';
-
-    if (prefix === undefined) {
-      list.addAddress(address, family);
-    } else {
-      const maxPrefix = family === 'ipv6' ? 128 : 32;
-      const parsedPrefix = Number(prefix);
-
-      assertThat(
-        /^\d+$/.test(prefix) && parsedPrefix >= 0 && parsedPrefix <= maxPrefix,
-        new Error(`Invalid CIDR prefix in \`SSRF_ALLOWED_ADDRESSES\`: ${entry}`)
-      );
-
-      list.addSubnet(address, parsedPrefix, family);
-    }
-  }
-
-  return list;
-};
-
-/** Parsing is cached against the configured value, which is fixed for the process' lifetime. */
-const allowedAddressesCache = new Map<string, Optional<BlockList>>();
-
-const getAllowedAddresses = (): Optional<BlockList> => {
-  const key = EnvSet.values.ssrfAllowedAddresses.join(',');
-
-  if (!allowedAddressesCache.has(key)) {
-    allowedAddressesCache.set(key, parseAllowedAddresses());
-  }
-
-  return allowedAddressesCache.get(key);
-};
-
 /** Whether the peer is explicitly allowed despite being a special-use address. */
 const isAllowedAddress = (address: string): boolean => {
-  const allowed = getAllowedAddresses();
+  const { ssrfAllowedAddressBlockList: allowed } = EnvSet.values;
 
   return allowed?.check(address, isIP(address) === 6 ? 'ipv6' : 'ipv4') ?? false;
 };

--- a/packages/core/src/utils/outbound-request.ts
+++ b/packages/core/src/utils/outbound-request.ts
@@ -1,0 +1,205 @@
+/**
+ * @file SSRF protection for outbound requests whose target is operator- or tenant-supplied
+ * (webhooks, SSO connector discovery, IdP metadata).
+ *
+ * oidc-provider already guards its own outgoing requests this way; this module reuses the exact
+ * same primitives so both surfaces share one classifier and one enablement switch, instead of
+ * maintaining a second IP range list that could drift.
+ *
+ * The check runs when the connection is established, against the address the socket is actually
+ * bound to, rather than resolving the hostname up front and then handing the URL to the HTTP
+ * client. An up-front lookup is a TOCTOU: the client resolves the name again independently and can
+ * get a different answer (DNS rebinding, round robin, short TTL). Inspecting the connected socket
+ * closes that window, and it covers a literal IP host, a hostname that resolves to a special-use
+ * address, and every redirect hop -- each hop opens its own connection and is checked again.
+ */
+
+import http from 'node:http';
+import https from 'node:https';
+import { type Socket } from 'node:net';
+
+import { cond } from '@silverhand/essentials';
+import { got, type Got } from 'got';
+import { applySSRFProtection, isSpecialUseIP } from 'oidc-provider/lib/helpers/fetch_request.js';
+
+import { EnvSet } from '#src/env-set/index.js';
+import assertThat from '#src/utils/assert-that.js';
+
+const blockedAddressMessage = 'hostname resolves to a special-use IP address';
+
+/**
+ * Destroys the socket once connected if its peer is a special-use address. Mirrors the guard
+ * oidc-provider installs on its undici dispatcher, for the `node:http` agents that `got` uses.
+ *
+ * Exported for testing: this is the enforcement point for every `got` request.
+ */
+export const guardSocket = <T extends Socket>(socket: T): T => {
+  const assertPublicPeer = () => {
+    const { remoteAddress } = socket;
+
+    if (remoteAddress !== undefined && isSpecialUseIP(remoteAddress)) {
+      socket.destroy(new Error(blockedAddressMessage));
+    }
+  };
+
+  if (socket.connecting) {
+    socket.once('connect', assertPublicPeer);
+  } else {
+    assertPublicPeer();
+  }
+
+  return socket;
+};
+
+/**
+ * `Agent.createConnection()` is the documented socket factory both agents use, but it is missing
+ * from `@types/node`'s `Agent` declaration, so the base implementation has to be reached through a
+ * typed view of the prototype.
+ *
+ * @see https://nodejs.org/api/http.html#agentcreateconnectionoptions-callback
+ */
+type ConnectionOptions = Record<string, unknown>;
+
+type ConnectionFactory = {
+  createConnection: (options: ConnectionOptions, callback?: unknown) => Socket;
+};
+
+const asConnectionFactory = (agent: http.Agent | https.Agent): ConnectionFactory =>
+  // eslint-disable-next-line no-restricted-syntax -- see `ConnectionFactory`
+  agent as unknown as ConnectionFactory;
+
+class SsrfProtectedHttpAgent extends http.Agent {
+  createConnection(options: ConnectionOptions, callback?: unknown): Socket {
+    return guardSocket(
+      asConnectionFactory(http.Agent.prototype).createConnection.call(this, options, callback)
+    );
+  }
+}
+
+class SsrfProtectedHttpsAgent extends https.Agent {
+  createConnection(options: ConnectionOptions, callback?: unknown): Socket {
+    return guardSocket(
+      asConnectionFactory(https.Agent.prototype).createConnection.call(this, options, callback)
+    );
+  }
+}
+
+/**
+ * Whether outbound requests to operator-supplied URLs are guarded.
+ *
+ * Shares the switch with oidc-provider's protection: always on in Cloud, where a tenant admin must
+ * never reach the infrastructure's private network, and opt-out only for self-hosted deployments
+ * that legitimately deliver webhooks to hosts on their own network.
+ */
+const isEnabled = () => EnvSet.values.isSsrfProtectionEnabled;
+
+/**
+ * `undici` `Agent` constructor, taken from the global dispatcher the way oidc-provider does, so the
+ * dispatcher is built from the same bundled `undici` that the global `fetch` dispatches through.
+ * Mixing an `undici` copy from `node_modules` with node's bundled one yields incompatible
+ * `Dispatcher` instances.
+ */
+const getUndiciAgent = (): (new () => unknown) | undefined => {
+  // Referencing `Response` triggers node's lazy `undici` initialization that sets these symbols.
+  void Response;
+
+  const globalDispatcher =
+    // eslint-disable-next-line no-restricted-syntax -- internal `undici` symbols are untyped
+    (globalThis as Record<symbol, { constructor?: new () => unknown }>)[
+      Symbol.for('undici.globalDispatcher.2')
+    ] ??
+    // eslint-disable-next-line no-restricted-syntax -- internal `undici` symbols are untyped
+    (globalThis as Record<symbol, { constructor?: new () => unknown }>)[
+      Symbol.for('undici.globalDispatcher.1')
+    ];
+
+  return globalDispatcher?.constructor;
+};
+
+/** Memoizes a factory, so the shared pools below are built at most once. */
+const once = <T>(build: () => T): (() => T) => {
+  const cache = new Map<'value', T>();
+
+  return () => {
+    const cached = cache.get('value');
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const value = build();
+    cache.set('value', value);
+
+    return value;
+  };
+};
+
+/** Built once and shared: a dispatcher per request would leak connection pools. */
+const getDispatcher = once((): unknown => {
+  const Agent = getUndiciAgent();
+
+  // The symbols are absent outside a normal node runtime, e.g. inside a Jest VM context. Failing
+  // loudly matters here: a missing dispatcher silently downgrades every webhook to unprotected.
+  assertThat(
+    Agent,
+    new Error(
+      'Failed to set up SSRF protection for outbound requests: the `undici` global dispatcher is unavailable.'
+    )
+  );
+
+  return applySSRFProtection(new Agent());
+});
+
+/**
+ * Drop-in `fetch` that routes through the SSRF-protected dispatcher.
+ *
+ * `ky` 1.2.3 lists `dispatcher` in its request options registry and silently drops it, so passing
+ * the dispatcher to `ky` directly has no effect (fixed upstream in ky 1.14.4, see
+ * https://github.com/sindresorhus/ky/pull/757). Injecting `fetch` is the supported seam until then.
+ */
+export const ssrfProtectedFetch: typeof fetch = async (input, init) => {
+  if (!isEnabled()) {
+    return fetch(input, init);
+  }
+
+  // eslint-disable-next-line no-restricted-syntax -- the `dispatcher` key is an undici extension absent from `RequestInit`
+  return fetch(input, { ...init, dispatcher: getDispatcher() } as RequestInit);
+};
+
+/** Lazily built so the pools only exist once something actually dials out. */
+const getAgents = once(() => ({
+  http: new SsrfProtectedHttpAgent(),
+  https: new SsrfProtectedHttpsAgent(),
+}));
+
+/**
+ * `got`'s `agent` option, guarding both protocols. Both must be set: covering only one leaves a
+ * cross-protocol redirect (`https:` -> `http:`) unguarded.
+ */
+const getSsrfProtectedAgent = () => cond(isEnabled() && getAgents());
+
+/**
+ * `got` bound to the SSRF-protected agents. Use it in place of `got` for any request whose URL
+ * comes from a connector config or another operator-supplied value.
+ *
+ * The agents are attached per request rather than baked into the instance, so the module stays
+ * import-order independent: `EnvSet.values` does not have to be loaded when this module is.
+ *
+ * `beforeRequest` rather than `init`: an `init` hook receives the instance's own options object, so
+ * assigning there mutates the shared defaults and the agents would stay attached to every later
+ * request even once the protection is switched off.
+ */
+export const ssrfProtectedGot: Got = got.extend({
+  hooks: {
+    beforeRequest: [
+      (options) => {
+        const agent = getSsrfProtectedAgent();
+
+        if (agent) {
+          // eslint-disable-next-line @silverhand/fp/no-mutation -- `got`'s documented hook contract
+          options.agent = agent;
+        }
+      },
+    ],
+  },
+});

--- a/packages/core/src/utils/outbound-request.ts
+++ b/packages/core/src/utils/outbound-request.ts
@@ -20,9 +20,9 @@ import { BlockList, isIP, type Socket } from 'node:net';
 
 import { cond, type Optional } from '@silverhand/essentials';
 import { got, type Got } from 'got';
-import { isSpecialUseIP } from 'oidc-provider/lib/helpers/fetch_request.js';
 
 import { EnvSet } from '#src/env-set/index.js';
+import { isSpecialUseIP } from '#src/oidc/oidc-provider-internals.js';
 import assertThat from '#src/utils/assert-that.js';
 
 /** Memoizes a factory, so the shared resources below are built at most once. */
@@ -67,7 +67,14 @@ const parseAllowedAddresses = (): Optional<BlockList> => {
   const list = new BlockList();
 
   for (const entry of raw) {
-    const [address, prefix] = entry.split('/');
+    const segments = entry.trim().split('/');
+
+    assertThat(
+      segments.length === 1 || segments.length === 2,
+      new Error(`Invalid address in \`SSRF_ALLOWED_ADDRESSES\`: ${entry}`)
+    );
+
+    const [address, prefix] = segments;
 
     // Silently skipping a malformed entry would leave the operator believing a host is reachable.
     assertThat(
@@ -80,7 +87,15 @@ const parseAllowedAddresses = (): Optional<BlockList> => {
     if (prefix === undefined) {
       list.addAddress(address, family);
     } else {
-      list.addSubnet(address, Number(prefix), family);
+      const maxPrefix = family === 'ipv6' ? 128 : 32;
+      const parsedPrefix = Number(prefix);
+
+      assertThat(
+        /^\d+$/.test(prefix) && parsedPrefix >= 0 && parsedPrefix <= maxPrefix,
+        new Error(`Invalid CIDR prefix in \`SSRF_ALLOWED_ADDRESSES\`: ${entry}`)
+      );
+
+      list.addSubnet(address, parsedPrefix, family);
     }
   }
 
@@ -152,7 +167,17 @@ const asConnectionFactory = (agent: http.Agent | https.Agent): ConnectionFactory
   // eslint-disable-next-line no-restricted-syntax -- see `ConnectionFactory`
   agent as unknown as ConnectionFactory;
 
+const defaultAgentOptions: http.AgentOptions = {
+  keepAlive: true,
+  scheduling: 'lifo',
+  timeout: 5000,
+};
+
 class SsrfProtectedHttpAgent extends http.Agent {
+  constructor(options?: http.AgentOptions) {
+    super({ ...defaultAgentOptions, ...options });
+  }
+
   createConnection(options: ConnectionOptions, callback?: unknown): Socket {
     return guardSocket(
       asConnectionFactory(http.Agent.prototype).createConnection.call(this, options, callback)
@@ -161,6 +186,10 @@ class SsrfProtectedHttpAgent extends http.Agent {
 }
 
 class SsrfProtectedHttpsAgent extends https.Agent {
+  constructor(options?: https.AgentOptions) {
+    super({ ...defaultAgentOptions, ...options });
+  }
+
   createConnection(options: ConnectionOptions, callback?: unknown): Socket {
     return guardSocket(
       asConnectionFactory(https.Agent.prototype).createConnection.call(this, options, callback)

--- a/packages/integration-tests/src/tests/api/logto-config-cimd.test.ts
+++ b/packages/integration-tests/src/tests/api/logto-config-cimd.test.ts
@@ -1,4 +1,5 @@
 import { getCimdConfig, updateCimdConfig } from '#src/api/logto-config.js';
+import { expectRejects } from '#src/helpers/index.js';
 
 describe('CIMD config', () => {
   afterAll(async () => {
@@ -10,14 +11,18 @@ describe('CIMD config', () => {
     await expect(getCimdConfig()).resolves.toEqual({ enabled: false });
   });
 
-  it('should enable and disable the feature via merge + upsert', async () => {
-    // The API integration test environment keeps the SSRF protection on, so enabling passes.
-    await expect(updateCimdConfig({ enabled: true })).resolves.toEqual({ enabled: true });
+  it('should reject enabling while an SSRF allowlist is configured', async () => {
+    // The API integration environment allowlists loopback for webhook/backchannel mocks, which
+    // disables CIMD so unauthenticated client_id URLs cannot inherit those destinations.
+    await expectRejects(updateCimdConfig({ enabled: true }), {
+      code: 'request.invalid_input',
+      status: 422,
+    });
+  });
 
-    await expect(getCimdConfig()).resolves.toEqual({ enabled: true });
-
-    await expect(updateCimdConfig({})).resolves.toEqual({ enabled: true });
-
+  it('should still accept a no-op or disable patch while the feature stays off', async () => {
+    await expect(getCimdConfig()).resolves.toEqual({ enabled: false });
+    await expect(updateCimdConfig({})).resolves.toEqual({ enabled: false });
     await expect(updateCimdConfig({ enabled: false })).resolves.toEqual({ enabled: false });
   });
 });

--- a/packages/shared/src/node/env/GlobalValues.test.ts
+++ b/packages/shared/src/node/env/GlobalValues.test.ts
@@ -26,19 +26,29 @@ describe('SSRF protection', () => {
       unsetEnvironmentVariable(variable);
     }
 
-    expect(createGlobalValues().isSsrfProtectionEnabled).toBe(true);
+    const values = createGlobalValues();
+    expect(values.isSsrfProtectionEnabled).toBe(true);
+    expect(values.isOidcProviderSsrfProtectionEnabled).toBe(true);
   });
 
   describe.each(optOutVariables)('%s', (variable) => {
     it('can disable the protection in self-hosted deployments', () => {
       unsetEnvironmentVariable('IS_CLOUD');
+      for (const other of optOutVariables) {
+        unsetEnvironmentVariable(other);
+      }
       vi.stubEnv(variable, 'true');
 
-      expect(createGlobalValues().isSsrfProtectionEnabled).toBe(false);
+      const values = createGlobalValues();
+      expect(values.isSsrfProtectionEnabled).toBe(false);
+      expect(values.isOidcProviderSsrfProtectionEnabled).toBe(false);
     });
 
     it.each(['', 'false', 'flase'])('stays enabled when the opt-out value is: %s', (value) => {
       unsetEnvironmentVariable('IS_CLOUD');
+      for (const other of optOutVariables) {
+        unsetEnvironmentVariable(other);
+      }
       vi.stubEnv(variable, value);
 
       expect(createGlobalValues().isSsrfProtectionEnabled).toBe(true);
@@ -49,6 +59,22 @@ describe('SSRF protection', () => {
       vi.stubEnv(variable, 'true');
 
       expect(createGlobalValues().isSsrfProtectionEnabled).toBe(true);
+    });
+  });
+
+  describe('ssrfAllowedAddresses', () => {
+    it('parses comma-separated entries with trimming in self-hosted deployments', () => {
+      unsetEnvironmentVariable('IS_CLOUD');
+      vi.stubEnv('SSRF_ALLOWED_ADDRESSES', ' 127.0.0.1, 10.0.0.0/8 , ::1 ');
+
+      expect(createGlobalValues().ssrfAllowedAddresses).toEqual(['127.0.0.1', '10.0.0.0/8', '::1']);
+    });
+
+    it('always returns an empty array in Cloud', () => {
+      vi.stubEnv('IS_CLOUD', 'true');
+      vi.stubEnv('SSRF_ALLOWED_ADDRESSES', '127.0.0.1,10.0.0.0/8');
+
+      expect(createGlobalValues().ssrfAllowedAddresses).toEqual([]);
     });
   });
 });

--- a/packages/shared/src/node/env/GlobalValues.test.ts
+++ b/packages/shared/src/node/env/GlobalValues.test.ts
@@ -12,37 +12,44 @@ const unsetEnvironmentVariable = (key: string) => {
   Reflect.deleteProperty(process.env, key);
 };
 
-describe('OIDC provider SSRF protection', () => {
+/** The current name, and the narrower one it replaced, which stays supported. */
+const optOutVariables = ['SSRF_PROTECTION_DISABLED', 'OIDC_PROVIDER_SSRF_PROTECTION_DISABLED'];
+
+describe('SSRF protection', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
   it('is enabled by default in self-hosted deployments', () => {
     unsetEnvironmentVariable('IS_CLOUD');
-    unsetEnvironmentVariable('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED');
+    for (const variable of optOutVariables) {
+      unsetEnvironmentVariable(variable);
+    }
 
-    expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(true);
+    expect(createGlobalValues().isSsrfProtectionEnabled).toBe(true);
   });
 
-  it('can be disabled in self-hosted deployments', () => {
-    unsetEnvironmentVariable('IS_CLOUD');
-    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED', 'true');
+  describe.each(optOutVariables)('%s', (variable) => {
+    it('can disable the protection in self-hosted deployments', () => {
+      unsetEnvironmentVariable('IS_CLOUD');
+      vi.stubEnv(variable, 'true');
 
-    expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(false);
-  });
+      expect(createGlobalValues().isSsrfProtectionEnabled).toBe(false);
+    });
 
-  it.each(['', 'false', 'flase'])('stays enabled when the opt-out value is: %s', (value) => {
-    unsetEnvironmentVariable('IS_CLOUD');
-    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED', value);
+    it.each(['', 'false', 'flase'])('stays enabled when the opt-out value is: %s', (value) => {
+      unsetEnvironmentVariable('IS_CLOUD');
+      vi.stubEnv(variable, value);
 
-    expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(true);
-  });
+      expect(createGlobalValues().isSsrfProtectionEnabled).toBe(true);
+    });
 
-  it('stays enabled in Cloud when the environment variable is true', () => {
-    vi.stubEnv('IS_CLOUD', 'true');
-    vi.stubEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED', 'true');
+    it('stays enabled in Cloud when the environment variable is true', () => {
+      vi.stubEnv('IS_CLOUD', 'true');
+      vi.stubEnv(variable, 'true');
 
-    expect(createGlobalValues().isOidcProviderSsrfProtectionEnabled).toBe(true);
+      expect(createGlobalValues().isSsrfProtectionEnabled).toBe(true);
+    });
   });
 });
 

--- a/packages/shared/src/node/env/GlobalValues.test.ts
+++ b/packages/shared/src/node/env/GlobalValues.test.ts
@@ -70,11 +70,41 @@ describe('SSRF protection', () => {
       expect(createGlobalValues().ssrfAllowedAddresses).toEqual(['127.0.0.1', '10.0.0.0/8', '::1']);
     });
 
+    it('builds the allowlist during initialization', () => {
+      unsetEnvironmentVariable('IS_CLOUD');
+      vi.stubEnv('SSRF_ALLOWED_ADDRESSES', '127.0.0.1,10.0.0.0/8,::1');
+
+      const { ssrfAllowedAddressBlockList } = createGlobalValues();
+
+      expect(ssrfAllowedAddressBlockList?.check('127.0.0.1', 'ipv4')).toBe(true);
+      expect(ssrfAllowedAddressBlockList?.check('10.1.2.3', 'ipv4')).toBe(true);
+      expect(ssrfAllowedAddressBlockList?.check('::1', 'ipv6')).toBe(true);
+      expect(ssrfAllowedAddressBlockList?.check('169.254.169.254', 'ipv4')).toBe(false);
+    });
+
+    it.each([
+      ['not-an-ip', 'Invalid address'],
+      ['127.0.0.0/8/16', 'Invalid address'],
+      ['127.0.0.0/', 'Invalid CIDR prefix'],
+      ['127.0.0.0/abc', 'Invalid CIDR prefix'],
+      ['127.0.0.0/-1', 'Invalid CIDR prefix'],
+      ['127.0.0.0/33', 'Invalid CIDR prefix'],
+      ['::1/129', 'Invalid CIDR prefix'],
+    ])('rejects malformed entry %s during initialization', (entry, message) => {
+      unsetEnvironmentVariable('IS_CLOUD');
+      vi.stubEnv('SSRF_ALLOWED_ADDRESSES', entry);
+
+      expect(() => createGlobalValues()).toThrow(`${message} in \`SSRF_ALLOWED_ADDRESSES\``);
+    });
+
     it('always returns an empty array in Cloud', () => {
       vi.stubEnv('IS_CLOUD', 'true');
       vi.stubEnv('SSRF_ALLOWED_ADDRESSES', '127.0.0.1,10.0.0.0/8');
 
-      expect(createGlobalValues().ssrfAllowedAddresses).toEqual([]);
+      const values = createGlobalValues();
+
+      expect(values.ssrfAllowedAddresses).toEqual([]);
+      expect(values.ssrfAllowedAddressBlockList).toBeUndefined();
     });
   });
 });

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -150,13 +150,23 @@ export default class GlobalValues {
   public readonly isCloud = yes(getEnv('IS_CLOUD'));
 
   /**
-   * Whether oidc-provider protects outbound requests against SSRF.
+   * Whether outbound requests to operator-supplied URLs are protected against SSRF. This covers
+   * oidc-provider's own requests (backchannel logout, client `jwks_uri`, ...) as well as webhook
+   * delivery and enterprise SSO connector discovery.
    *
-   * Protection is enabled by default and can only be disabled in self-hosted deployments. Features
-   * that resolve unregistered remote clients, such as CIMD, must only be enabled while this is true.
+   * Protection is enabled by default and can only be disabled in self-hosted deployments, where
+   * reaching a trusted endpoint on a private network is a legitimate setup. Features that resolve
+   * unregistered remote clients, such as CIMD, must only be enabled while this is true.
+   *
+   * `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED` is the original, narrower name of the opt-out and is
+   * still honored so deployments that already set it keep working.
    */
-  public readonly isOidcProviderSsrfProtectionEnabled =
-    this.isCloud || !yes(getEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED'));
+  public readonly isSsrfProtectionEnabled =
+    this.isCloud ||
+    !(
+      yes(getEnv('SSRF_PROTECTION_DISABLED')) ||
+      yes(getEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED'))
+    );
 
   /** Enables protected app local development without Cloud-only behavior. */
   public readonly isProtectedAppLocalDevEnabled =

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -169,6 +169,14 @@ export default class GlobalValues {
     );
 
   /**
+   * @deprecated Renamed to `isSsrfProtectionEnabled` as the protection now covers webhook delivery
+   * and SSO connector discovery/metadata requests as well.
+   */
+  public get isOidcProviderSsrfProtectionEnabled(): boolean {
+    return this.isSsrfProtectionEnabled;
+  }
+
+  /**
    * Destinations that stay reachable while the SSRF protection is on, as a comma-separated list of
    * IP addresses or CIDR ranges (`127.0.0.1,10.0.0.0/8,::1`).
    *

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -168,6 +168,18 @@ export default class GlobalValues {
       yes(getEnv('OIDC_PROVIDER_SSRF_PROTECTION_DISABLED'))
     );
 
+  /**
+   * Destinations that stay reachable while the SSRF protection is on, as a comma-separated list of
+   * IP addresses or CIDR ranges (`127.0.0.1,10.0.0.0/8,::1`).
+   *
+   * Prefer this over `SSRF_PROTECTION_DISABLED` when only a known internal host has to be reached:
+   * naming the destinations keeps every other special-use address blocked, and it does not disable
+   * features that hard-require the protection, such as CIMD. Ignored in Cloud.
+   */
+  public readonly ssrfAllowedAddresses = this.isCloud
+    ? []
+    : getEnvAsStringArray('SSRF_ALLOWED_ADDRESSES');
+
   /** Enables protected app local development without Cloud-only behavior. */
   public readonly isProtectedAppLocalDevEnabled =
     !this.isProduction && yes(getEnv('PROTECTED_APP_LOCAL_DEV'));

--- a/packages/shared/src/node/env/GlobalValues.ts
+++ b/packages/shared/src/node/env/GlobalValues.ts
@@ -1,3 +1,5 @@
+import { BlockList, isIP } from 'node:net';
+
 import {
   assertEnv,
   getEnv,
@@ -60,6 +62,51 @@ export const parseNonNegativeIntegerEnv = (value?: string, fallback = 0): number
   const parsed = Number(normalized);
 
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+};
+
+const addSsrfAllowedAddress = (list: BlockList, entry: string) => {
+  const segments = entry.split('/');
+
+  if (segments.length !== 1 && segments.length !== 2) {
+    throw new Error(`Invalid address in \`SSRF_ALLOWED_ADDRESSES\`: ${entry}`);
+  }
+
+  const [address, prefix] = segments;
+  const ipVersion = address && isIP(address);
+
+  if (!address || !ipVersion) {
+    throw new Error(`Invalid address in \`SSRF_ALLOWED_ADDRESSES\`: ${entry}`);
+  }
+
+  const family = ipVersion === 6 ? 'ipv6' : 'ipv4';
+
+  if (prefix === undefined) {
+    list.addAddress(address, family);
+    return;
+  }
+
+  const maxPrefix = family === 'ipv6' ? 128 : 32;
+  const parsedPrefix = Number(prefix);
+
+  if (!/^\d+$/.test(prefix) || parsedPrefix > maxPrefix) {
+    throw new Error(`Invalid CIDR prefix in \`SSRF_ALLOWED_ADDRESSES\`: ${entry}`);
+  }
+
+  list.addSubnet(address, parsedPrefix, family);
+};
+
+const parseSsrfAllowedAddresses = (entries: string[]): Optional<BlockList> => {
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  const list = new BlockList();
+
+  for (const entry of entries) {
+    addSsrfAllowedAddress(list, entry);
+  }
+
+  return list;
 };
 
 export default class GlobalValues {
@@ -181,12 +228,18 @@ export default class GlobalValues {
    * IP addresses or CIDR ranges (`127.0.0.1,10.0.0.0/8,::1`).
    *
    * Prefer this over `SSRF_PROTECTION_DISABLED` when only a known internal host has to be reached:
-   * naming the destinations keeps every other special-use address blocked, and it does not disable
-   * features that hard-require the protection, such as CIMD. Ignored in Cloud.
+   * naming the destinations keeps every other special-use address blocked. Features that accept
+   * unauthenticated target URLs, such as CIMD, are disabled while an allowlist is configured.
+   * Ignored in Cloud.
    */
   public readonly ssrfAllowedAddresses = this.isCloud
     ? []
     : getEnvAsStringArray('SSRF_ALLOWED_ADDRESSES');
+
+  /** Parsed at startup so malformed entries cannot throw from a socket event listener. */
+  public readonly ssrfAllowedAddressBlockList = parseSsrfAllowedAddresses(
+    this.ssrfAllowedAddresses
+  );
 
   /** Enables protected app local development without Cloud-only behavior. */
   public readonly isProtectedAppLocalDevEnabled =


### PR DESCRIPTION
## Summary

Closes #9465.

Webhook URLs and enterprise SSO connector endpoints are supplied through the Management API and were dialed with no address validation. A tenant admin could point them at loopback, a private range, or the cloud metadata endpoint (`169.254.169.254`) and read the response body back from the API error — a full-read SSRF across the tenant/infrastructure trust boundary.

The reported endpoints were `POST /api/hooks/:id/test` and `POST /api/sso-connectors`. The same gap existed in normal (non-test) webhook delivery, the OIDC token/userinfo requests, and SAML IdP metadata fetching, so all of them are covered here.

## Approach

`oidc-provider` already guards its own outgoing requests this way, and the fork exports the address classifier (`isSpecialUseIP`). This reuses it instead of maintaining a second IANA special-purpose address list that could drift — no address ranges are written in this PR.

The check runs when the connection is established, against the address the socket is actually bound to, not by resolving the hostname up front. An up-front lookup is a TOCTOU: the HTTP client resolves the name again independently and can get a different answer. Checking at connect time also means a literal IP host, a hostname resolving to an internal address, and every redirect hop are all covered by the same code path.

Two clients, two seams:

- **`ky` (webhooks)** — 1.2.3 lists `dispatcher` in its request options registry and silently drops it, so passing the dispatcher directly does nothing ([ky#757](https://github.com/sindresorhus/ky/pull/757), fixed upstream in 1.14.4). Injecting `fetch` is the supported seam until we upgrade.
- **`got` (SSO/SAML)** — guarded `node:http`/`node:https` agents, attached in a `beforeRequest` hook. An `init` hook receives the instance's own options object, so assigning there mutates the shared defaults and the agents stay attached to every later request even once the protection is switched off.

Both protocols are guarded; covering only one would leave a cross-protocol redirect (`https:` → `http:`) unguarded.

## Reaching trusted internal hosts

`SSRF_ALLOWED_ADDRESSES` takes a comma-separated list of addresses and CIDR ranges that stay reachable while the protection is on:

```
SSRF_ALLOWED_ADDRESSES=10.0.0.0/8,127.0.0.1
```

This exists because the coarse on/off switch turned out to be unusable in practice, which the integration suite demonstrated on the first CI run: the `api` target needs webhook delivery to a loopback mock server, but CIMD refuses to be enabled while the protection is off (`isCimdEffectivelyEnabled`), so no single value satisfied both. Self-hosted deployments would hit exactly the same conflict — reaching one internal webhook receiver should not silently cost you CIMD. Allowlisting also keeps every other special-use address blocked, including the metadata endpoint.

The test environments now allowlist their mock servers instead of disabling the protection, so the suites that require it stay on.

`SSRF_PROTECTION_DISABLED` still turns the protection off entirely. It is the renamed `OIDC_PROVIDER_SSRF_PROTECTION_DISABLED`, which shipped in `@logto/shared` 3.4.2 and keeps working as an alias. Cloud ignores both.

## Testing

Unit tests.

`packages/core/src/utils/outbound-request.test.ts` covers the guard decision for seven special-use addresses and three public ones, the allowlist (exact address, CIDR, IPv6, and a malformed entry being rejected rather than silently ignored), both agents being attached, the fail-closed path when the dispatcher cannot be built, and the opt-out.

The dispatcher cannot be exercised under Jest — a Jest VM context has no `undici` global dispatcher — so enforcement was verified against the compiled artifact under plain Node:

```
[default (no allowlist)] got -> BLOCKED       ky -> BLOCKED
[allow 127.0.0.0/8     ] got -> ALLOWED       ky -> ALLOWED
[allow 10.0.0.0/8 only ] got -> BLOCKED       ky -> BLOCKED
[SSRF_PROTECTION_DISABL] got -> ALLOWED       ky -> ALLOWED
[legacy OIDC_ var      ] got -> ALLOWED       ky -> ALLOWED
[cloud ignores both    ] got -> BLOCKED       ky -> BLOCKED
```

The `allow 127.0.0.0/8` row is worth one note: an earlier revision passed it for `got` and failed for `ky`, because the dispatcher used oidc-provider's `applySSRFProtection`, which hardcodes its own check and has no hook for the allowlist. The dispatcher now uses the same local guard as the agents.

No request reaches the internal service when blocked — the socket is destroyed before anything is written, so there is no response body to reflect:

```
got: requests that reached the internal server = 0
ky : requests that reached the internal server = 0
```

## Notes

Two follow-ups from the issue are deliberately **not** in this PR:

- **Egress proxy** (smokescreen or similar) as a network-layer second line. This is a deployment concern rather than code, and the industry norm alongside application-layer filtering.
- **Truncating the reflected response body** in `triggerTestHook`. Independent of this fix, but it decides whether a future bypass yields blind or full-read SSRF.
