### PR TITLE
test(test): stabilize flaky MFA page assertions

### DIFF
--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -147,6 +147,21 @@ export default class ExpectExperience extends ExpectPage {
   }
 
   /**
+   * Poll the page URL (query excluded) until it is at the given experience path. Unlike
+   * {@link toBeAt}, this tolerates navigations that only complete after one or more API
+   * round trips, which can exceed any fixed delay under CI load.
+   *
+   * @param pathname The experience path to wait for.
+   */
+  async waitToBeAt(pathname: ExperiencePath) {
+    const expected = this.buildExperienceUrl(pathname).href;
+    await this.waitForUrlToMatch(
+      (current) => stripQuery(current) === expected,
+      `to be ${expected}`
+    );
+  }
+
+  /**
    * Assert the page is at the verification code page and fill the verification code inputs with the
    * code from Logto database.
    *

--- a/packages/integration-tests/src/ui-helpers/expect-mfa-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-mfa-experience.ts
@@ -11,10 +11,10 @@ export default class ExpectMfaExperience extends ExpectExperience {
   }
 
   /**
-   * Expect the page to be at the backup code page and retrieve backup codes.
+   * Wait until the page is at the backup code page and retrieve backup codes.
    */
   async retrieveBackupCodes() {
-    this.toBeAt('mfa-binding/BackupCode');
+    await this.waitToBeAt('mfa-binding/BackupCode');
     const backupCodesDiv = await expect(this.page).toMatchElement(cls('backupCodes'));
     const backupCodesSpanList = await backupCodesDiv.$$('span');
     return Promise.all(

--- a/packages/integration-tests/src/ui-helpers/expect-totp-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-totp-experience.ts
@@ -10,17 +10,14 @@ export default class ExpectTotpExperience extends ExpectMfaExperience {
   }
 
   /**
-   * Assert the page is at the TOTP binding page and fill the TOTP code
+   * Wait until the page is at the TOTP binding page and fill the TOTP code
    * generated from the TOTP secret.
    *
    * @param [signingInAfterBinding=true] Whether the flow will continue to sign in after the binding.
    * @returns The binding TOTP secret.
    */
   async toBindTotp(signingInAfterBinding = true) {
-    // Wait for the page to load
-    await waitFor(500);
-
-    this.toBeAt('mfa-binding/Totp');
+    await this.waitToBeAt('mfa-binding/Totp');
     // Expect the QR code rendered
     await expect(this.page).toMatchElement(`${dcls('qrCode')} img[src*="data:image"]`);
 
@@ -46,17 +43,14 @@ export default class ExpectTotpExperience extends ExpectMfaExperience {
   }
 
   /**
-   * Assert the page is at the TOTP verification page and fill the TOTP code
+   * Wait until the page is at the TOTP verification page and fill the TOTP code
    * generated from the TOTP secret.
    *
    * @param secret The TOTP secret.
    * @param [signingInAfterVerification=true] Whether the flow will continue to sign in after the verification.
    */
   async toVerifyTotp(secret: string, signingInAfterVerification = true) {
-    // Wait for the page to load
-    await waitFor(500);
-
-    this.toBeAt('mfa-verification/Totp');
+    await this.waitToBeAt('mfa-verification/Totp');
 
     const code = authenticator.generate(secret);
 

--- a/packages/integration-tests/src/ui-helpers/expect-webauthn-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-webauthn-experience.ts
@@ -50,12 +50,12 @@ export default class ExpectWebAuthnExperience extends ExpectMfaExperience {
   }
 
   async toCreatePasskey() {
-    this.toBeAt('mfa-binding/WebAuthn');
+    await this.waitToBeAt('mfa-binding/WebAuthn');
     await this.toClickCeremonyButton('Create a passkey');
   }
 
   async toVerifyViaPasskey() {
-    this.toBeAt('mfa-verification/WebAuthn');
+    await this.waitToBeAt('mfa-verification/WebAuthn');
     await this.toClickCeremonyButton('Verify via passkey');
   }
 


### PR DESCRIPTION
## Summary

Replace the fixed 500 ms sleep + one-shot URL assertion in the MFA experience helpers with URL polling, so the assertions tolerate navigations that only complete after several API round trips under CI load.

- New `ExpectExperience.waitToBeAt(pathname)` polls the page URL (query excluded) on top of the `waitForUrlToMatch` primitive from #9454, and throws with the actual URL on timeout.
- Applied to `toBindTotp`, `toVerifyTotp`, `retrieveBackupCodes`, `toCreatePasskey`, and `toVerifyViaPasskey` — all of them run right after an action that triggers a cross-page navigation.

### Evidence

[Run 32823978203 attempt 1](https://github.com/logto-io/logto/actions/runs/32823978203/attempts/1) (`run-logto (experience, true)`) failed with:

```
● MFA - TOTP › should add missing phone number before binding missing TOTP factor
    Expected: "http://localhost:3001/mfa-binding/Totp"
    Received: "http://localhost:3001/continue/verification-code"
```

After the last verification-code digit is filled, the client performs three sequential requests before it can leave the page (verify the code → PATCH the profile → submit the interaction, which returns 422 `user.missing_mfa` and triggers the client-side redirect to `/mfa-binding/Totp`), while `toBindTotp` waited a fixed 500 ms and then asserted the URL exactly once. The sibling matrix job in the same attempt ran the identical suite in 27.5 s and passed, so the failure is the 500 ms race, not a functional difference.

## Testing

Integration tests; verified by the CI runs on this PR (the affected suites run in both `run-logto (experience, *)` matrix jobs).

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
