### PR TITLE
test(test): fix flaky password rejection message assertion

### DIFF
--- a/packages/integration-tests/src/tests/experience/password-policy.test.ts
+++ b/packages/integration-tests/src/tests/experience/password-policy.test.ts
@@ -50,7 +50,12 @@ describe('password policy', () => {
     await experience.waitForPathname('register/password');
     await experience.toFillNewPasswords(
       ...invalidPasswords,
-      [username + 'A', /product context .* personal information/],
+      /**
+       * No literal spaces around the wildcard: when the random part of the username happens to
+       * contain a sequential or repeated character run (e.g. "567"), the alert gains a third
+       * reason and reads "product context, your personal information, and sequential characters".
+       */
+      [username + 'A', /product context.*personal information/],
       username + 'ABCD_ok'
     );
 


### PR DESCRIPTION
## Summary

Drop the two literal spaces in the password-rejection regex (`/product context .* personal information/` → `/product context.*personal information/`) so the assertion tolerates a legitimately-present third rejection reason. This removes the long-standing dominant flake of the `run-logto (experience, *)` jobs.

### Evidence

The on-timeout diagnostic introduced in #9455 has since fired on `master` three times (attempt-1 failures masked by the auto-rerun), always with the same shape:

```
Expected the alert to match /product context .* personal information/ for password "test_f567ab1cbade22b3A",
but the alert reads "Avoid overusing product context, your personal information, and sequential characters."
(submission in flight: false)
```

Every sampled failure has a sequential run inside the random part of the password:

- [Job 97703070293](https://github.com/logto-io/logto/actions/runs/32815311304/job/97703070293): `test_f567ab1cbade22b3A` — contains `567`
- [Job 97712721246](https://github.com/logto-io/logto/actions/runs/32818595090/job/97712721246): `test_3abc74a25b6e970bA` — contains `abc`
- [Job 97410146301](https://github.com/logto-io/logto/actions/runs/32719988309/job/97410146301): `test_5475ec21b9c91defA` — contains `def`

### Root cause

- The test's username is `'test_' + randomString()`, where `randomString()` returns 16 random hex chars, and the rejected password under assertion is `username + 'A'`.
- The policy checker flags sequential/repeated runs of length ≥ 3 (`PasswordPolicyChecker.repetitionAndSequenceThreshold`; `0123456789` and the alphabet, both directions), so whenever the hex happens to contain a run such as `567`, `abc`, or `aaa`, `check()` reports `restricted.sequence`/`restricted.repetition` on top of `restricted.words` + `restricted.user_info`.
- The alert then renders as a three-item list — "product context, **your personal information, and sequential characters**" — and the comma directly after "context" fails the old regex, which required a literal space there. With two reasons the alert reads "product context and your personal information", which is why the test passes most of the time.
- The chance of such a run in 16 random hex chars is ≈ 13% per execution, ≈ 24% per CI run across the two matrix jobs — matching the observed failure rate, which stayed flat across the cache fixes (#9428–#9436) and the wait hardening (#9455): the flake is a test-data collision, not timing or staleness.

The fixed regex still requires both phrases in order (`restricted.words` always registers before `restricted.user_info` since both match from the first character of the password); only the tolerance for extra reasons changes.

## Testing

Integration tests; verified by the CI runs on this PR.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
