### PR TITLE
chore(core): document why token exchange stays first-party only

### DIFF
--- a/packages/core/src/oidc/grants/token-exchange/index.ts
+++ b/packages/core/src/oidc/grants/token-exchange/index.ts
@@ -8,6 +8,17 @@
  * no upstream counterpart to stay in sync with. It still consumes the shared token-endpoint
  * helpers from v9's `grant_common.js` through the `oidc-provider-internals.js` seam module, so
  * the sender-constraining (mTLS and DPoP) behavior stays aligned with the forked grants.
+ *
+ * This grant is deliberately a first-party-only capability: subject tokens are minted through
+ * the Management API by the tenant's own trusted backends, and the exchange involves no user
+ * consent, while third-party access is governed by the consent model — the two are mutually
+ * exclusive, so third-party applications can never enable this grant type (enforced when
+ * configuring applications, see `assertThirdPartyApplicationTokenExchangeDisabled`). That is
+ * also why no per-client scope filtering happens here: every client that can reach this grant
+ * is first-party and carries no scope allowlist, so issued scopes are capped only by what the
+ * user owns and by the global OIDC scope set. A third party that needs an exchanged token
+ * should obtain it from the tenant's own machine-to-machine backend instead of performing the
+ * exchange itself.
  */
 
 import { buildOrganizationUrn } from '@logto/core-kit';

--- a/packages/core/src/routes/applications/application.ts
+++ b/packages/core/src/routes/applications/application.ts
@@ -50,7 +50,13 @@ const parseIsThirdPartQueryParam = (isThirdPartyQuery: 'true' | 'false' | undefi
   return isThirdPartyQuery === 'true';
 };
 
-/** Third-party applications are not allowed to enable token exchange. */
+/**
+ * Third-party applications are not allowed to enable token exchange — by design, not as a
+ * temporary limitation: token exchange is consent-free impersonation reserved for the tenant's
+ * own services, while third-party access is governed by user consent, and the token exchange
+ * grant performs no per-client scope filtering on that premise. A third party that needs an
+ * exchanged token should obtain it through the tenant's own machine-to-machine backend.
+ */
 const assertThirdPartyApplicationTokenExchangeDisabled = (
   isThirdParty: boolean,
   allowTokenExchange?: boolean


### PR DESCRIPTION
## Summary

Document that token exchange is a first-party-only capability by design — consent-free impersonation for the tenant's own trusted backends, mutually exclusive with the consent model that governs third-party access. This is why third-party applications can never enable the grant, and why the grant performs no per-client scope filtering. A third party that needs an exchanged token goes through the tenant's own machine-to-machine backend. Comment-only change.

## Testing

N/A

## Checklist

- [x] `.changeset` (not needed — comment-only)
- [x] unit tests (N/A)
- [x] integration tests (N/A)
- [x] necessary TSDoc comments