### PR TITLE
test(core): reuse trusted device fixture

### DIFF
--- a/packages/core/src/__mocks__/index.ts
+++ b/packages/core/src/__mocks__/index.ts
@@ -31,6 +31,7 @@ export * from './domain.js';
 export * from './protected-app.js';
 export * from './sign-in-experience.js';
 export * from './sso.js';
+export * from './trusted-device.js';
 export * from './user.js';
 export * from './captcha.js';
 export * from './custom-profile-fields.js';

--- a/packages/core/src/__mocks__/trusted-device.ts
+++ b/packages/core/src/__mocks__/trusted-device.ts
@@ -1,0 +1,16 @@
+import { type TrustedDevice, defaultTenantId } from '@logto/schemas';
+
+export const createMockTrustedDevice = (overrides: Partial<TrustedDevice> = {}): TrustedDevice => ({
+  tenantId: defaultTenantId,
+  id: 'trusted-device-id',
+  userId: 'user-id',
+  secretHash: Buffer.alloc(32, 1),
+  userAgent: null,
+  ip: null,
+  country: null,
+  city: null,
+  createdAt: 1,
+  lastUsedAt: 1,
+  expiresAt: 2,
+  ...overrides,
+});

--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 
 import type { TrustedDevice } from '@logto/schemas';
 
+import { createMockTrustedDevice } from '#src/__mocks__/trusted-device.js';
 import type { TrustedDeviceQueries } from '#src/queries/trusted-device.js';
 
 import type { createTrustedDevicePolicyLibrary } from './trusted-device-policy.js';
@@ -49,19 +50,14 @@ const createPolicyLibrary = ({ enabled = true, durationDays = 30 } = {}) =>
     getEffectivePolicy: jest.fn(async () => ({ enabled, durationDays })),
   }) as unknown as TrustedDevicePolicyLibrary;
 
-const buildTrustedDevice = (secretHash: Uint8Array): TrustedDevice => ({
-  tenantId,
-  id: trustedDeviceId,
-  userId,
-  secretHash: Buffer.from(secretHash),
-  userAgent: null,
-  ip: null,
-  country: null,
-  city: null,
-  createdAt: 1,
-  lastUsedAt: 1,
-  expiresAt: Date.now() + 60_000,
-});
+const buildTrustedDevice = (secretHash: Uint8Array): TrustedDevice =>
+  createMockTrustedDevice({
+    tenantId,
+    id: trustedDeviceId,
+    userId,
+    secretHash: Buffer.from(secretHash),
+    expiresAt: Date.now() + 60_000,
+  });
 
 describe('trusted device credential helpers', () => {
   it('builds deterministic non-identifying per-user cookie names', () => {

--- a/packages/core/src/queries/trusted-device.test.ts
+++ b/packages/core/src/queries/trusted-device.test.ts
@@ -1,6 +1,7 @@
 import { TrustedDevices, type TrustedDevice } from '@logto/schemas';
 import { createMockPool, createMockQueryResult, sql } from '@silverhand/slonik';
 
+import { createMockTrustedDevice } from '#src/__mocks__/trusted-device.js';
 import { expandFields } from '#src/database/utils.js';
 import { convertToIdentifiers } from '#src/utils/sql.js';
 import type { QueryType } from '#src/utils/test-utils.js';
@@ -18,11 +19,10 @@ const queries = new TrustedDeviceQueries(pool);
 
 const { table, fields } = convertToIdentifiers(TrustedDevices);
 
-const trustedDevice: TrustedDevice = {
+const trustedDevice: TrustedDevice = createMockTrustedDevice({
   tenantId: 'tenant-id',
   id: 'trusted-device-id',
   userId: 'user-id',
-  secretHash: Buffer.alloc(32, 1),
   userAgent: 'user-agent',
   ip: '127.0.0.1',
   country: 'US',
@@ -30,7 +30,7 @@ const trustedDevice: TrustedDevice = {
   createdAt: 1,
   lastUsedAt: 1,
   expiresAt: 2,
-};
+});
 
 describe('trusted device queries', () => {
   beforeEach(() => {

--- a/packages/core/src/routes/account/trusted-device.test.ts
+++ b/packages/core/src/routes/account/trusted-device.test.ts
@@ -1,8 +1,8 @@
 import { UserScope } from '@logto/core-kit';
-import { AccountCenterControlValue, type TrustedDevice, defaultTenantId } from '@logto/schemas';
+import { AccountCenterControlValue, type TrustedDevice } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 
-import { mockUser } from '#src/__mocks__/index.js';
+import { createMockTrustedDevice, mockUser } from '#src/__mocks__/index.js';
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaErrorHandler from '#src/middleware/koa-error-handler.js';
@@ -21,11 +21,9 @@ jest.unstable_mockModule('#src/utils/assert-first-party-client.js', () => ({
 
 const trustedDeviceId = 'trusteddeviceid';
 const otherTrustedDeviceId = 'othertrusteddeviceid';
-const trustedDevice: TrustedDevice = {
-  tenantId: defaultTenantId,
+const trustedDevice: TrustedDevice = createMockTrustedDevice({
   id: trustedDeviceId,
   userId: mockUser.id,
-  secretHash: Buffer.alloc(32, 1),
   userAgent: 'Mozilla/5.0 test browser',
   ip: '192.0.2.1',
   country: 'US',
@@ -33,7 +31,7 @@ const trustedDevice: TrustedDevice = {
   createdAt: 1000,
   lastUsedAt: 2000,
   expiresAt: 3000,
-};
+});
 const otherTrustedDevice: TrustedDevice = {
   ...trustedDevice,
   id: otherTrustedDeviceId,

--- a/packages/core/src/routes/admin-user/trusted-device.test.ts
+++ b/packages/core/src/routes/admin-user/trusted-device.test.ts
@@ -1,7 +1,7 @@
-import { type TrustedDevice, defaultTenantId } from '@logto/schemas';
+import { type TrustedDevice } from '@logto/schemas';
 import { pickDefault } from '@logto/shared/esm';
 
-import { mockUser } from '#src/__mocks__/index.js';
+import { createMockTrustedDevice, mockUser } from '#src/__mocks__/index.js';
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { koaManagementApiHooks } from '#src/middleware/koa-management-api-hooks.js';
@@ -14,11 +14,9 @@ const { jest } = import.meta;
 
 const userId = mockUser.id;
 const trustedDeviceId = 'device-id';
-const trustedDevice: TrustedDevice = {
-  tenantId: defaultTenantId,
+const trustedDevice: TrustedDevice = createMockTrustedDevice({
   id: trustedDeviceId,
   userId,
-  secretHash: Buffer.alloc(32, 1),
   userAgent: 'Mozilla/5.0 test browser',
   ip: '192.0.2.1',
   country: 'US',
@@ -26,7 +24,7 @@ const trustedDevice: TrustedDevice = {
   createdAt: 1000,
   lastUsedAt: 2000,
   expiresAt: 3000,
-};
+});
 
 const mockedQueries = {
   users: {

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -10,6 +10,7 @@ import {
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
+import { createMockTrustedDevice } from '#src/__mocks__/trusted-device.js';
 import { mockUser, mockUserWithMfaVerifications } from '#src/__mocks__/user.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
@@ -69,19 +70,11 @@ const tenant = new MockTenant(
   }
 );
 
-const trustedDevice: TrustedDevice = {
+const trustedDevice: TrustedDevice = createMockTrustedDevice({
   tenantId: tenant.id,
   id: 'trusteddeviceid',
   userId: mockUserWithMfaVerifications.id,
-  secretHash: Buffer.alloc(32, 1),
-  userAgent: null,
-  ip: null,
-  country: null,
-  city: null,
-  createdAt: 1,
-  lastUsedAt: 1,
-  expiresAt: 2,
-};
+});
 
 const ExperienceInteraction = await pickDefault(import('./experience-interaction.js'));
 

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -1,6 +1,7 @@
 import { appInsights } from '@logto/app-insights/node';
 import { InteractionEvent, type TrustedDevice as TrustedDeviceModel } from '@logto/schemas';
 
+import { createMockTrustedDevice } from '#src/__mocks__/trusted-device.js';
 import { EnvSet } from '#src/env-set/index.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
@@ -14,19 +15,15 @@ const { jest } = import.meta;
 
 const userId = 'user-id';
 const trustedDeviceId = 'trusteddeviceid';
-const trustedDevice: TrustedDeviceModel = {
+const trustedDevice: TrustedDeviceModel = createMockTrustedDevice({
   tenantId: 'tenant-id',
   id: trustedDeviceId,
   userId,
-  secretHash: Buffer.alloc(32, 1),
   userAgent: 'private user agent',
   ip: '192.0.2.1',
   country: 'US',
   city: 'Portland',
-  createdAt: 1,
-  lastUsedAt: 1,
-  expiresAt: 2,
-};
+});
 
 const createContext = (interactionId = 'interaction-id') => {
   const { mockAppend, ...logContext } = createMockLogContext();

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -16,6 +16,7 @@ import type { Middleware } from 'koa';
 import type { IRouterParamContext } from 'koa-router';
 
 import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
+import { createMockTrustedDevice } from '#src/__mocks__/trusted-device.js';
 import {
   mockUser,
   mockUserBackupCodeMfaVerification,
@@ -88,19 +89,8 @@ const eligibleTrustedDeviceVerificationCases: Array<{
   },
 ];
 
-const buildTrustedDevice = (userId: string): TrustedDevice => ({
-  tenantId: 'tenant-id',
-  id: 'trusted-device-id',
-  userId,
-  secretHash: Buffer.alloc(32, 1),
-  userAgent: null,
-  ip: null,
-  country: null,
-  city: null,
-  createdAt: 1,
-  lastUsedAt: 1,
-  expiresAt: 2,
-});
+const buildTrustedDevice = (userId: string): TrustedDevice =>
+  createMockTrustedDevice({ tenantId: 'tenant-id', userId });
 
 const createLogMiddleware = (): {
   middleware: Middleware<unknown, IRouterParamContext>;


### PR DESCRIPTION
## Summary

- add a shared `createMockTrustedDevice` factory that returns schema-complete records
- reuse the factory across trusted-device library, query, API, and Experience tests while keeping scenario-specific values local

Stacked on #9496.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments