### PR TITLE
fix(console): hide hosted email quotas from plan downgrade diff

### DIFF
--- a/packages/console/src/consts/plan-quotas.ts
+++ b/packages/console/src/consts/plan-quotas.ts
@@ -52,6 +52,9 @@ export const hiddenQuotaDiffUsageKeys: Array<keyof LogtoSkuQuota> = [
   'tokenLimit',
   // Keep Actions hidden from the plan quota UI until the feature is ready after further testing.
   'actionsEnabled',
+  // Hosted-email caps are surfaced in Connector details, not the plan quota UI.
+  'hostedEmailLimit',
+  'hostedEmailDailyLimit',
   'scopesPerResourceLimit',
   'userRolesLimit',
   'machineToMachineRolesLimit',


### PR DESCRIPTION
## Summary

The plan downgrade confirmation modal rendered two blank rows at the end of both quota cards (an empty bullet on the current-plan card and a descend arrow with no text on the target-plan card).

<img width="771" height="253" alt="2026-08-26_10-47-13" src="https://github.com/user-attachments/assets/be4641fd-057d-4468-8d64-bf02170218b7" />


- `hostedEmailLimit` and `hostedEmailDailyLimit` are excluded from the quota item phrase maps by design since hosted-email caps are surfaced in Connector details, but they were not added to `hiddenQuotaDiffUsageKeys`, so the downgrade quota diff still iterated them and rendered phrase-less items.
- Add both keys to `hiddenQuotaDiffUsageKeys`, matching the existing `actionsEnabled` handling.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)