### PR TITLE
feat(console): add cancellation feedback modal

### DIFF
--- a/packages/console/src/pages/TenantSettings/Subscription/CancelFeedbackModal/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/CancelFeedbackModal/index.tsx
@@ -1,0 +1,90 @@
+import { conditional } from '@silverhand/essentials';
+import { usePostHog } from 'posthog-js/react';
+import { useState } from 'react';
+import ReactModal from 'react-modal';
+
+import Button from '@/ds-components/Button';
+import FormField from '@/ds-components/FormField';
+import ModalLayout from '@/ds-components/ModalLayout';
+import Textarea from '@/ds-components/Textarea';
+import modalStyles from '@/scss/modal.module.scss';
+
+type Props = {
+  readonly isOpen: boolean;
+  /** The SKU the tenant was subscribed to before the cancellation. */
+  readonly fromSkuId: string;
+  readonly onClose: () => void;
+};
+
+function CancelFeedbackModal({ isOpen, fromSkuId, onClose }: Props) {
+  const postHog = usePostHog();
+  const [whatMadeYouCancel, setWhatMadeYouCancel] = useState('');
+  const [howToReconsider, setHowToReconsider] = useState('');
+
+  const cancelReason = whatMadeYouCancel.trim();
+  const reconsiderSuggestion = howToReconsider.trim();
+
+  const captureAndClose = (properties: Record<string, unknown>) => {
+    postHog.capture('console:subscription_cancel_feedback', {
+      from_sku_id: fromSkuId,
+      ...properties,
+    });
+    onClose();
+  };
+
+  const skip = () => {
+    captureAndClose({ skipped: true });
+  };
+
+  const submit = () => {
+    captureAndClose({
+      ...conditional(cancelReason && { cancel_reason: cancelReason }),
+      ...conditional(reconsiderSuggestion && { reconsider_suggestion: reconsiderSuggestion }),
+    });
+  };
+
+  return (
+    <ReactModal
+      isOpen={isOpen}
+      className={modalStyles.content}
+      overlayClassName={modalStyles.overlay}
+      onRequestClose={skip}
+    >
+      <ModalLayout
+        title="subscription.cancel_feedback_modal.title"
+        subtitle="subscription.cancel_feedback_modal.description"
+        footer={
+          <Button
+            size="large"
+            type="primary"
+            title="general.submit"
+            disabled={!cancelReason && !reconsiderSuggestion}
+            onClick={submit}
+          />
+        }
+        onClose={skip}
+      >
+        <FormField title="subscription.cancel_feedback_modal.what_made_you_cancel">
+          <Textarea
+            rows={4}
+            value={whatMadeYouCancel}
+            onChange={({ currentTarget: { value } }) => {
+              setWhatMadeYouCancel(value);
+            }}
+          />
+        </FormField>
+        <FormField title="subscription.cancel_feedback_modal.how_to_reconsider">
+          <Textarea
+            rows={4}
+            value={howToReconsider}
+            onChange={({ currentTarget: { value } }) => {
+              setHowToReconsider(value);
+            }}
+          />
+        </FormField>
+      </ModalLayout>
+    </ReactModal>
+  );
+}
+
+export default CancelFeedbackModal;

--- a/packages/console/src/pages/TenantSettings/Subscription/SwitchPlanActionBar/index.tsx
+++ b/packages/console/src/pages/TenantSettings/Subscription/SwitchPlanActionBar/index.tsx
@@ -20,6 +20,7 @@ import {
   parseExceededSkuQuotaLimitError,
 } from '@/utils/subscription';
 
+import CancelFeedbackModal from '../CancelFeedbackModal';
 import DowngradeConfirmModalContent from '../DowngradeConfirmModalContent';
 
 import styles from './index.module.scss';
@@ -89,6 +90,7 @@ function SwitchPlanActionBar({ onSubscriptionUpdated, currentSkuId, logtoSkus }:
   const { subscribe, cancelSubscription } = useSubscribe();
   const { show } = useConfirmModal();
   const [currentLoadingSkuId, setCurrentLoadingSkuId] = useState<string>();
+  const [canceledSkuId, setCanceledSkuId] = useState<string>();
 
   const handleSubscribe = async (targetSkuId: string, isDowngrade: boolean) => {
     if (currentLoadingSkuId) {
@@ -126,6 +128,7 @@ function SwitchPlanActionBar({ onSubscriptionUpdated, currentSkuId, logtoSkus }:
             {t('downgrade_success')}
           </Trans>
         );
+        setCanceledSkuId(currentSku.id);
 
         return;
       }
@@ -168,32 +171,43 @@ function SwitchPlanActionBar({ onSubscriptionUpdated, currentSkuId, logtoSkus }:
   };
 
   return (
-    <div className={styles.container}>
-      <div className={styles.buttonPlaceholder} />
-      {/** Public reserved plan buttons */}
-      {logtoSkus.map(({ id: skuId }) => {
-        return (
-          <SkuButton
-            key={skuId}
-            targetSkuId={skuId}
-            currentSkuId={currentSkuId}
-            isCurrentEnterprisePlan={isEnterprisePlan}
-            loadingSkuId={currentLoadingSkuId}
-            onClick={handleSubscribe}
-          />
-        );
-      })}
-      {/** Enterprise plan button */}
-      <div>
-        <a href={contactEmailLink} className={styles.buttonLink} rel="noopener">
-          <Button
-            title={isEnterprisePlan ? 'subscription.current' : 'general.contact_us_action'}
-            type="primary"
-            disabled={isEnterprisePlan}
-          />
-        </a>
+    <>
+      <div className={styles.container}>
+        <div className={styles.buttonPlaceholder} />
+        {/** Public reserved plan buttons */}
+        {logtoSkus.map(({ id: skuId }) => {
+          return (
+            <SkuButton
+              key={skuId}
+              targetSkuId={skuId}
+              currentSkuId={currentSkuId}
+              isCurrentEnterprisePlan={isEnterprisePlan}
+              loadingSkuId={currentLoadingSkuId}
+              onClick={handleSubscribe}
+            />
+          );
+        })}
+        {/** Enterprise plan button */}
+        <div>
+          <a href={contactEmailLink} className={styles.buttonLink} rel="noopener">
+            <Button
+              title={isEnterprisePlan ? 'subscription.current' : 'general.contact_us_action'}
+              type="primary"
+              disabled={isEnterprisePlan}
+            />
+          </a>
+        </div>
       </div>
-    </div>
+      {canceledSkuId && (
+        <CancelFeedbackModal
+          isOpen
+          fromSkuId={canceledSkuId}
+          onClose={() => {
+            setCanceledSkuId(undefined);
+          }}
+        />
+      )}
+    </>
   );
 }
 

--- a/packages/phrases/src/locales/ar/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/subscription/index.ts
@@ -43,6 +43,12 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'نأسف لرحيلك',
+    description: 'تم إلغاء اشتراكك. ملاحظاتك تساعدنا في جعل Logto أفضل. نقرأ كل رد.',
+    what_made_you_cancel: 'ما الذي دفعك إلى الإلغاء؟',
+    how_to_reconsider: 'ما الذي يمكننا فعله لتعيد النظر؟',
+  },
   downgrade_modal: {
     title: 'هل أنت متأكد أنك تريد التخفيض؟',
     description:

--- a/packages/phrases/src/locales/de/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/subscription/index.ts
@@ -45,6 +45,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Schade, dass Sie gehen',
+    description:
+      'Ihr Abonnement wurde gekündigt. Ihr Feedback hilft uns, Logto besser zu machen. Wir lesen jede Antwort.',
+    what_made_you_cancel: 'Was hat Sie zur Kündigung bewogen?',
+    how_to_reconsider: 'Was könnten wir tun, damit Sie es sich noch einmal überlegen?',
+  },
   downgrade_modal: {
     title: 'Sind Sie sicher, dass Sie herabstufen möchten?',
     description:

--- a/packages/phrases/src/locales/en/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/subscription/index.ts
@@ -44,6 +44,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Sorry to see you go',
+    description:
+      'Your subscription has been canceled. Your feedback helps us make Logto better. We read every response.',
+    what_made_you_cancel: 'What made you cancel?',
+    how_to_reconsider: 'What could we do to make you reconsider?',
+  },
   downgrade_modal: {
     title: 'Are you sure you want to downgrade?',
     description:

--- a/packages/phrases/src/locales/es/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/subscription/index.ts
@@ -45,6 +45,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Lamentamos que se vaya',
+    description:
+      'Su suscripción ha sido cancelada. Sus comentarios nos ayudan a mejorar Logto. Leemos todas las respuestas.',
+    what_made_you_cancel: '¿Qué le llevó a cancelar?',
+    how_to_reconsider: '¿Qué podríamos hacer para que lo reconsidere?',
+  },
   downgrade_modal: {
     title: '¿Está seguro de que desea degradar?',
     description:

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/subscription/index.ts
@@ -44,6 +44,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'از رفتن شما متأسفیم',
+    description:
+      'اشتراک شما لغو شد. بازخورد شما به ما کمک می‌کند Logto را بهتر کنیم. همه پاسخ‌ها را می‌خوانیم.',
+    what_made_you_cancel: 'چه چیزی باعث شد لغو کنید؟',
+    how_to_reconsider: 'چه کاری می‌توانیم انجام دهیم تا تجدیدنظر کنید؟',
+  },
   downgrade_modal: {
     title: 'آیا مطمئن هستید که می‌خواهید پلن را کاهش دهید؟',
     description:

--- a/packages/phrases/src/locales/fr/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/subscription/index.ts
@@ -46,6 +46,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Désolé de vous voir partir',
+    description:
+      'Votre abonnement a été annulé. Vos retours nous aident à améliorer Logto. Nous lisons chaque réponse.',
+    what_made_you_cancel: "Qu'est-ce qui vous a poussé à annuler?",
+    how_to_reconsider: "Que pourrions-nous faire pour vous faire changer d'avis?",
+  },
   downgrade_modal: {
     title: 'Êtes-vous sûr de vouloir passer à un Plan Inférieur?',
     description:

--- a/packages/phrases/src/locales/it/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/subscription/index.ts
@@ -45,6 +45,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Ci dispiace vederti andare via',
+    description:
+      'Il tuo abbonamento è stato annullato. Il tuo feedback ci aiuta a migliorare Logto. Leggiamo ogni risposta.',
+    what_made_you_cancel: 'Cosa ti ha spinto ad annullare?',
+    how_to_reconsider: 'Cosa potremmo fare per farti riconsiderare?',
+  },
   downgrade_modal: {
     title: 'Sei sicuro di voler effettuare il degrado?',
     description:

--- a/packages/phrases/src/locales/ja/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/subscription/index.ts
@@ -45,6 +45,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'ご利用ありがとうございました',
+    description:
+      'サブスクリプションはキャンセルされました。いただいたフィードバックは Logto の改善に役立てます。すべての回答に目を通しています。',
+    what_made_you_cancel: 'キャンセルの理由は何でしたか？',
+    how_to_reconsider: '再検討いただくために、私たちに何ができますか？',
+  },
   downgrade_modal: {
     title: 'ダウングレードしますか？',
     description:

--- a/packages/phrases/src/locales/ko/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/subscription/index.ts
@@ -44,6 +44,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: '떠나신다니 아쉽습니다',
+    description:
+      '구독이 취소되었습니다. 보내주신 의견은 Logto를 개선하는 데 도움이 됩니다. 모든 답변을 빠짐없이 읽고 있습니다.',
+    what_made_you_cancel: '취소하신 이유는 무엇인가요?',
+    how_to_reconsider: '다시 고려하시려면 저희가 무엇을 해야 할까요?',
+  },
   downgrade_modal: {
     title: '다운그레이드하시겠습니까?',
     description:

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/index.ts
@@ -45,6 +45,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Szkoda, że odchodzisz',
+    description:
+      'Twoja subskrypcja została anulowana. Twoja opinia pomaga nam ulepszać Logto. Czytamy każdą odpowiedź.',
+    what_made_you_cancel: 'Co skłoniło Cię do anulowania?',
+    how_to_reconsider: 'Co moglibyśmy zrobić, abyś ponownie rozważył(a) decyzję?',
+  },
   downgrade_modal: {
     title: 'Czy na pewno chcesz zdegradować?',
     description:

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/index.ts
@@ -45,6 +45,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Que pena ver você partir',
+    description:
+      'Sua assinatura foi cancelada. Seu feedback nos ajuda a melhorar o Logto. Lemos todas as respostas.',
+    what_made_you_cancel: 'O que fez você cancelar?',
+    how_to_reconsider: 'O que poderíamos fazer para você reconsiderar?',
+  },
   downgrade_modal: {
     title: 'Tem certeza de que deseja fazer downgrade?',
     description:

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/index.ts
@@ -45,6 +45,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Lamentamos vê-lo partir',
+    description:
+      'A sua subscrição foi cancelada. O seu feedback ajuda-nos a melhorar o Logto. Lemos todas as respostas.',
+    what_made_you_cancel: 'O que o levou a cancelar?',
+    how_to_reconsider: 'O que poderíamos fazer para que reconsidere?',
+  },
   downgrade_modal: {
     title: 'Tem certeza de que deseja fazer o downgrade?',
     description:

--- a/packages/phrases/src/locales/ru/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/subscription/index.ts
@@ -44,6 +44,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Жаль, что вы уходите',
+    description:
+      'Ваша подписка отменена. Ваши отзывы помогают нам делать Logto лучше. Мы читаем каждый ответ.',
+    what_made_you_cancel: 'Что побудило вас отменить подписку?',
+    how_to_reconsider: 'Что мы могли бы сделать, чтобы вы передумали?',
+  },
   downgrade_modal: {
     title: 'Вы действительно хотите понизить уровень?',
     description:

--- a/packages/phrases/src/locales/th/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/subscription/index.ts
@@ -43,6 +43,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'เสียดายที่คุณต้องไป',
+    description:
+      'การสมัครสมาชิกของคุณถูกยกเลิกแล้ว ความคิดเห็นของคุณช่วยให้เราพัฒนา Logto ให้ดียิ่งขึ้น เราอ่านทุกคำตอบ',
+    what_made_you_cancel: 'อะไรทำให้คุณยกเลิก?',
+    how_to_reconsider: 'เราจะทำอะไรได้บ้างเพื่อให้คุณเปลี่ยนใจ?',
+  },
   downgrade_modal: {
     title: 'คุณแน่ใจหรือว่าต้องการลดระดับ?',
     description:

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/index.ts
@@ -45,6 +45,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: 'Gittiğinizi görmek üzücü',
+    description:
+      "Aboneliğiniz iptal edildi. Geri bildiriminiz Logto'yu daha iyi hale getirmemize yardımcı oluyor. Her yanıtı okuyoruz.",
+    what_made_you_cancel: 'İptal etmenize ne sebep oldu?',
+    how_to_reconsider: 'Yeniden düşünmeniz için ne yapabiliriz?',
+  },
   downgrade_modal: {
     title: 'Emin misiniz, düşürmek istediğinize?',
     description:

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/index.ts
@@ -43,6 +43,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: '很遗憾您要离开',
+    description:
+      '您的订阅已取消。您的反馈将帮助我们把 Logto 做得更好。每一条反馈我们都会认真阅读。',
+    what_made_you_cancel: '是什么让您决定取消？',
+    how_to_reconsider: '我们做些什么能让您重新考虑？',
+  },
   downgrade_modal: {
     title: '确认要降级吗？',
     description:

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/index.ts
@@ -43,6 +43,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: '很遺憾你要離開',
+    description:
+      '你的訂閱已取消。你的意見將幫助我們把 Logto 做得更好。每一條回應我們都會認真閱讀。',
+    what_made_you_cancel: '是什麼讓你決定取消？',
+    how_to_reconsider: '我們做些什麼能讓你重新考慮？',
+  },
   downgrade_modal: {
     title: '確定要降級嗎？',
     description:

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/index.ts
@@ -43,6 +43,13 @@ const subscription = {
     },
   },
   quota_item,
+  cancel_feedback_modal: {
+    title: '很遺憾你要離開',
+    description:
+      '你的訂閱已取消。你的回饋將幫助我們把 Logto 做得更好。每一則回覆我們都會認真閱讀。',
+    what_made_you_cancel: '是什麼讓你決定取消？',
+    how_to_reconsider: '我們做些什麼能讓你重新考慮？',
+  },
   downgrade_modal: {
     title: '你確定要降級嗎？',
     description:


### PR DESCRIPTION
## Summary

Show a feedback modal after a tenant cancels its paid subscription (downgrades to the Free plan) in Console.

- Asks two optional open questions: "What made you cancel?" and "What could we do to make you reconsider?"; no placeholder hints, so answers are not led.
- Captures a client-side PostHog event `console:subscription_cancel_feedback` with `cancel_reason` / `reconsider_suggestion`; skipping or dismissing reports `skipped: true`, and every event carries `from_sku_id` so the response rate is measurable.
- The modal appears only after the cancellation has succeeded and never blocks the flow.
- Adds the new phrases to all locales.

## Testing

Tested locally.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
