### PR TITLE
feat(console): add email logs for the logto email service

### DIFF
--- a/packages/console/src/pages/ConnectorDetails/index.tsx
+++ b/packages/console/src/pages/ConnectorDetails/index.tsx
@@ -22,7 +22,7 @@ import Drawer from '@/components/Drawer';
 import Markdown from '@/components/Markdown';
 import PageMeta from '@/components/PageMeta';
 import UnnamedTrans from '@/components/UnnamedTrans';
-import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
+import { isCloud } from '@/consts/env';
 import { ConnectorsTabs } from '@/consts/page-tabs';
 import TabNav, { TabNavItem } from '@/ds-components/TabNav';
 import type { RequestError } from '@/hooks/use-api';
@@ -47,10 +47,7 @@ const emailLogsTab = 'email-logs';
 
 /** The hosted-email log only exists for the cloud built-in email service connector. */
 const isEmailLogsAvailable = (data?: ConnectorResponse) =>
-  isCloud &&
-  isDevFeaturesEnabled &&
-  data?.type === ConnectorType.Email &&
-  data.connectorId === ServiceConnector.Email;
+  isCloud && data?.type === ConnectorType.Email && data.connectorId === ServiceConnector.Email;
 
 function ConnectorDetails() {
   const { pathname } = useLocation();


### PR DESCRIPTION
## Summary

Enable the "Email logs" tab on the Logto email service connector for all cloud tenants: remove the dev-features clause from `isEmailLogsAvailable` (the `isCloud` + built-in email connector conditions stay). No changeset — the tab is cloud-only and never renders in the OSS console.

> **Note**: hold merging until the backing cloud email-logs endpoint is released — the tab would call an endpoint that is not yet live.

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
