### PR TITLE
feat(console): attribute general OSS upsell surfaces

### DIFF
--- a/packages/console/src/consts/external-links.test.ts
+++ b/packages/console/src/consts/external-links.test.ts
@@ -1,4 +1,8 @@
-import { logtoCloudConsoleUrl, selfHostedPlansLink } from './external-links';
+import {
+  buildOfficialWebsiteContactPageUrl,
+  logtoCloudConsoleUrl,
+  selfHostedPlansLink,
+} from './external-links';
 
 describe('external links', () => {
   it('uses the cloud console URL for OSS members upsell entry', () => {
@@ -7,5 +11,13 @@ describe('external links', () => {
 
   it('points self-hosted plans upsell at the public landing page', () => {
     expect(selfHostedPlansLink).toBe('https://logto.io/self-hosted-plans');
+  });
+
+  it('attributes official website contact links', () => {
+    const url = new URL(buildOfficialWebsiteContactPageUrl('private-cloud'));
+
+    expect(url.origin).toBe('https://logto.io');
+    expect(url.pathname).toBe('/contact');
+    expect(url.searchParams.get('src')).toBe('private-cloud');
   });
 });

--- a/packages/console/src/consts/external-links.ts
+++ b/packages/console/src/consts/external-links.ts
@@ -12,6 +12,13 @@ export const pricingLink = `${officialWebsiteLink}/pricing`;
 export const selfHostedPlansLink = `${officialWebsiteLink}/self-hosted-plans`;
 export const logtoCloudConsoleLink = 'https://cloud.logto.io';
 export const officialWebsiteContactPageLink = `${officialWebsiteLink}/contact`;
+export const buildOfficialWebsiteContactPageUrl = (source: string) => {
+  const url = new URL(officialWebsiteContactPageLink);
+
+  url.searchParams.set('src', source);
+
+  return url.toString();
+};
 export const entityPolicyLink = 'https://docs.logto.io/logto-cloud/system-limit';
 export const logtoOssFeatureSupportLink =
   'https://docs.logto.io/logto-oss#feature-supported-by-logto-oss';

--- a/packages/console/src/containers/ConsoleContent/Sidebar/OssCloudCard.tsx
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/OssCloudCard.tsx
@@ -12,7 +12,7 @@ import { isCloud, isDevFeaturesEnabled } from '@/consts/env';
 import IconButton from '@/ds-components/IconButton';
 import TextLink from '@/ds-components/TextLink';
 import useTheme from '@/hooks/use-theme';
-import { buildCloudUpsellUrl, ossUpsellEntries } from '@/utils/oss-upsell';
+import { buildCloudUpsellUrl, buildSelfHostedPlansUrl, ossUpsellEntries } from '@/utils/oss-upsell';
 
 import {
   ossCloudSidebarCardDismissDuration,
@@ -31,6 +31,7 @@ function OssCloudCard() {
     keyPrefix: 'admin_console.get_started.oss_cloud.sidebar',
   });
   const { t: tGeneral } = useTranslation(undefined, { keyPrefix: 'admin_console.general' });
+  const { t: tUpsell } = useTranslation(undefined, { keyPrefix: 'admin_console.upsell' });
   const theme = useTheme();
   const CloudBannerIcon = icons[theme];
   const now = Date.now();
@@ -39,7 +40,8 @@ function OssCloudCard() {
       localStorage.getItem(storageKeys.ossSidebarCloudUpsellDismissedUntil)
     )
   );
-  const cloudUpsellUrl = buildCloudUpsellUrl(ossUpsellEntries.ossSidebarCloudCard);
+  const entry = ossUpsellEntries.ossSidebarCloudCard;
+  const cloudUpsellUrl = buildCloudUpsellUrl(entry);
 
   if (
     !shouldShowOssCloudSidebarCard({
@@ -90,6 +92,18 @@ function OssCloudCard() {
         >
           {tSidebar('action')}
         </TextLink>
+        {/* Self-hosted plans upsell routing. */}
+        {isDevFeaturesEnabled && (
+          <TextLink
+            isTrailingIcon
+            className={classNames(styles.link, styles.secondaryLink)}
+            href={buildSelfHostedPlansUrl(entry)}
+            icon={<ExternalLinkIcon className={styles.linkIcon} />}
+            targetBlank="noopener"
+          >
+            {tUpsell('explore_self_hosted_plans')}
+          </TextLink>
+        )}
       </div>
     </div>
   );

--- a/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
+++ b/packages/console/src/containers/ConsoleContent/Sidebar/oss-cloud-card.module.scss
@@ -69,6 +69,10 @@
   color: var(--color-text-link);
 }
 
+.secondaryLink {
+  color: var(--color-text-secondary);
+}
+
 .linkIcon {
   width: _.unit(4);
   height: _.unit(4);

--- a/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
+++ b/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
@@ -76,10 +76,8 @@ function OssCloudUpsell({ isBannerVisible, onDismissBanner }: Props) {
               {/* Self-hosted plans upsell routing. */}
               {isDevFeaturesEnabled && (
                 <TextLink
-                  isTrailingIcon
                   className={styles.selfHostedPlansLink}
                   href={buildSelfHostedPlansUrl(entry)}
-                  icon={<ExternalLinkIcon className={styles.selfHostedPlansLinkIcon} />}
                   targetBlank="noopener"
                 >
                   {t('upsell.explore_self_hosted_plans')}

--- a/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
+++ b/packages/console/src/pages/GetStarted/OssCloudUpsell.tsx
@@ -8,14 +8,16 @@ import CloudIcon from '@/assets/icons/cloud-icon.svg?react';
 import ExternalLinkIcon from '@/assets/icons/external-link.svg?react';
 import LighteningIcon from '@/assets/icons/lightening.svg?react';
 import PrivateCloudIcon from '@/assets/icons/private-cloud.svg?react';
-import { officialWebsiteContactPageLink } from '@/consts';
+import { buildOfficialWebsiteContactPageUrl, officialWebsiteContactPageLink } from '@/consts';
+import { isDevFeaturesEnabled } from '@/consts/env';
 import Button, { LinkButton } from '@/ds-components/Button';
 import Card from '@/ds-components/Card';
 import IconButton from '@/ds-components/IconButton';
 import Spacer from '@/ds-components/Spacer';
 import Tag from '@/ds-components/Tag';
+import TextLink from '@/ds-components/TextLink';
 import useTheme from '@/hooks/use-theme';
-import { openCloudUpsell, ossUpsellEntries } from '@/utils/oss-upsell';
+import { buildSelfHostedPlansUrl, openCloudUpsell, ossUpsellEntries } from '@/utils/oss-upsell';
 
 import styles from './index.module.scss';
 
@@ -33,6 +35,11 @@ function OssCloudUpsell({ isBannerVisible, onDismissBanner }: Props) {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console' });
   const theme = useTheme();
   const CloudBannerIcon = icons[theme];
+  const entry = ossUpsellEntries.getStartedOssCloudBanner;
+  // Self-hosted plans upsell routing attribution.
+  const privateCloudContactHref = isDevFeaturesEnabled
+    ? buildOfficialWebsiteContactPageUrl('private-cloud')
+    : officialWebsiteContactPageLink;
 
   return (
     <>
@@ -63,11 +70,21 @@ function OssCloudUpsell({ isBannerVisible, onDismissBanner }: Props) {
                 title="get_started.oss_cloud.try.action"
                 trailingIcon={<ExternalLinkIcon className={styles.bannerActionIcon} />}
                 onClick={() => {
-                  openCloudUpsell({
-                    entry: ossUpsellEntries.getStartedOssCloudBanner,
-                  });
+                  openCloudUpsell({ entry });
                 }}
               />
+              {/* Self-hosted plans upsell routing. */}
+              {isDevFeaturesEnabled && (
+                <TextLink
+                  isTrailingIcon
+                  className={styles.selfHostedPlansLink}
+                  href={buildSelfHostedPlansUrl(entry)}
+                  icon={<ExternalLinkIcon className={styles.selfHostedPlansLinkIcon} />}
+                  targetBlank="noopener"
+                >
+                  {t('upsell.explore_self_hosted_plans')}
+                </TextLink>
+              )}
             </div>
           </div>
           <IconButton
@@ -100,7 +117,7 @@ function OssCloudUpsell({ isBannerVisible, onDismissBanner }: Props) {
           <Spacer />
           <LinkButton
             title="general.contact_us_action"
-            href={officialWebsiteContactPageLink}
+            href={privateCloudContactHref}
             type="outline"
             targetBlank="noopener"
           />

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -154,7 +154,8 @@
 
 .ossCloudBannerActions {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   gap: _.unit(4);
   margin-left: auto;
   margin-right: _.unit(4.5);
@@ -286,8 +287,6 @@
   }
 
   .ossCloudBannerActions {
-    flex-direction: column;
-    align-items: flex-start;
     margin-left: 0;
     margin-right: 0;
     width: 100%;

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -155,6 +155,7 @@
 .ossCloudBannerActions {
   display: flex;
   align-items: center;
+  gap: _.unit(4);
   margin-left: auto;
   margin-right: _.unit(4.5);
   flex-shrink: 0;
@@ -164,6 +165,16 @@
   width: 20px;
   height: 20px;
   opacity: 70%;
+}
+
+.selfHostedPlansLink {
+  white-space: nowrap;
+  color: var(--color-text-secondary);
+}
+
+.selfHostedPlansLinkIcon {
+  width: 16px;
+  height: 16px;
 }
 
 .dismissButton {
@@ -275,6 +286,8 @@
   }
 
   .ossCloudBannerActions {
+    flex-direction: column;
+    align-items: flex-start;
     margin-left: 0;
     margin-right: 0;
     width: 100%;

--- a/packages/console/src/pages/GetStarted/index.module.scss
+++ b/packages/console/src/pages/GetStarted/index.module.scss
@@ -156,7 +156,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: _.unit(4);
+  gap: _.unit(2);
   margin-left: auto;
   margin-right: _.unit(4.5);
   flex-shrink: 0;
@@ -171,11 +171,6 @@
 .selfHostedPlansLink {
   white-space: nowrap;
   color: var(--color-text-secondary);
-}
-
-.selfHostedPlansLinkIcon {
-  width: 16px;
-  height: 16px;
 }
 
 .dismissButton {

--- a/packages/console/src/utils/oss-upsell.test.ts
+++ b/packages/console/src/utils/oss-upsell.test.ts
@@ -37,6 +37,16 @@ describe('oss upsell helpers', () => {
     expect(url.searchParams.get('utm_content')).toBe('tenant_settings_members_oss_upsell');
   });
 
+  it.each([
+    [ossUpsellEntries.ossSidebarCloudCard, 'oss_sidebar_cloud_card'],
+    [ossUpsellEntries.getStartedOssCloudBanner, 'get_started_oss_cloud_banner'],
+  ])('attributes the %s general upsell surface to self-hosted plans', (entry, content) => {
+    const url = new URL(buildSelfHostedPlansUrl(entry));
+
+    expect(url.searchParams.get('utm_campaign')).toBe('self_hosted_plans');
+    expect(url.searchParams.get('utm_content')).toBe(content);
+  });
+
   it('opens the UTM-tagged Cloud URL in a new tab', () => {
     const targetUrl = openCloudUpsell({
       entry: ossUpsellEntries.ossSidebarCloudCard,


### PR DESCRIPTION
## Summary

Closes [LOG-14069](https://linear.app/silverhand/issue/LOG-14069/featconsole-attribute-sidebar-and-get-started-upsell-surfaces).

Stacked on #9511. General OSS upsell surfaces keep Logto Cloud as the primary path while adding attributable self-hosted plan discovery.

- Add secondary self-hosted plans links to the sidebar Cloud card and Get started Cloud banner.
- Keep the primary Cloud actions unchanged; the secondary self-hosted plans link stacks below the primary action, and the banner content stacks on narrow screens.
- Attribute Private Cloud contact leads with `src=private-cloud`.
- Reuse existing localized self-hosted plans copy across all locales.

## Testing

Unit tests

<img width="216" height="218" alt="image" src="https://github.com/user-attachments/assets/6ec15d41-6411-44b2-b334-1014788b641c" />

<img width="1440" height="1000" alt="image" src="https://github.com/user-attachments/assets/4f30e98a-ed6f-4ffe-b084-068790230263" />


## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
