### PR TITLE
feat(experience): pass trusted device availability through MFA errors

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,8 +41,6 @@ jobs:
     env:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: ${{ matrix.dev-features-enabled }}
-      # Allow production-mode tests to simulate TLS termination for Secure cookies.
-      TRUST_PROXY_HEADER: 1
       # Allow Console tests to use the local backchannel logout mock server.
       OIDC_PROVIDER_SSRF_PROTECTION_DISABLED: ${{ matrix.target == 'console' }}
       # Key encryption key (KEK) for the secret vault used in integration tests

--- a/packages/core/src/libraries/trusted-device-policy.test.ts
+++ b/packages/core/src/libraries/trusted-device-policy.test.ts
@@ -82,4 +82,23 @@ describe('trusted device policy library', () => {
       expectSqlString('"organizations"."is_trusted_device_allowed" = false')
     );
   });
+
+  it('derives organization eligibility from already loaded rows', async () => {
+    const pool = {
+      exists: jest.fn(async () => false),
+    };
+    const signInExperience = {
+      ...mockSignInExperience,
+      trustedDevice: { enabled: true, durationDays: 30 },
+    };
+    const library = createTrustedDevicePolicyLibrary(createQueries(pool, signInExperience));
+
+    await expect(
+      library.getEffectivePolicy('user-id', [{ isTrustedDeviceAllowed: false }] as never)
+    ).resolves.toEqual({
+      enabled: false,
+      durationDays: 30,
+    });
+    expect(pool.exists).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/libraries/trusted-device-policy.ts
+++ b/packages/core/src/libraries/trusted-device-policy.ts
@@ -1,9 +1,13 @@
-import { defaultTrustedDevicePolicy, type TrustedDevicePolicy } from '@logto/schemas';
+import {
+  defaultTrustedDevicePolicy,
+  type OrganizationWithRoles,
+  type TrustedDevicePolicy,
+} from '@logto/schemas';
 
 import { UserRelationQueries } from '#src/queries/organization/user-relations.js';
 import type Queries from '#src/tenants/Queries.js';
 
-type EffectiveTrustedDevicePolicy = Readonly<Required<TrustedDevicePolicy>>;
+export type EffectiveTrustedDevicePolicy = Readonly<Required<TrustedDevicePolicy>>;
 
 export const resolveEffectiveTrustedDevicePolicy = (
   policy: TrustedDevicePolicy,
@@ -14,10 +18,15 @@ export const resolveEffectiveTrustedDevicePolicy = (
 });
 
 export const createTrustedDevicePolicyLibrary = (queries: Queries) => {
-  const getEffectivePolicy = async (userId: string) => {
+  const getEffectivePolicy = async (
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) => {
     const [signInExperience, hasDisallowedOrganization] = await Promise.all([
       queries.signInExperiences.findDefaultSignInExperience(),
-      new UserRelationQueries(queries.pool).hasUserDisallowedTrustedDeviceOrganization(userId),
+      organizations
+        ? organizations.some(({ isTrustedDeviceAllowed }) => !isTrustedDeviceAllowed)
+        : new UserRelationQueries(queries.pool).hasUserDisallowedTrustedDeviceOrganization(userId),
     ]);
 
     return resolveEffectiveTrustedDevicePolicy(

--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -202,6 +202,28 @@ describe('trusted device library', () => {
     expect(set).not.toHaveBeenCalled();
   });
 
+  it('enforces a request-resolved disabled policy without querying it again', async () => {
+    const queries = createQueries();
+    const policyLibrary = createPolicyLibrary({ enabled: true });
+    const { ctx, set } = createCookieContext();
+    const library = createTrustedDeviceLibrary(tenantId, queries, policyLibrary, {
+      isProduction: false,
+    });
+
+    await expect(
+      library.createCredential({
+        ctx,
+        deviceId: trustedDeviceId,
+        effectivePolicy: { enabled: false, durationDays: 30 },
+        userId,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(policyLibrary.getEffectivePolicy).not.toHaveBeenCalled();
+    expect(queries.insertIfNotExists).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
+  });
+
   it('rechecks the effective policy before each creation attempt', async () => {
     const queries = createQueries();
     const getEffectivePolicy = jest

--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto';
 import type { TrustedDevice } from '@logto/schemas';
 
 import { createMockTrustedDevice } from '#src/__mocks__/trusted-device.js';
+import { EnvSet } from '#src/env-set/index.js';
 import type { TrustedDeviceQueries } from '#src/queries/trusted-device.js';
 
 import type { createTrustedDevicePolicyLibrary } from './trusted-device-policy.js';
@@ -302,6 +303,36 @@ describe('trusted device library', () => {
       serializeTrustedDeviceCredential(credential),
       expect.objectContaining({ secure: true, signed: false, path: '/' })
     );
+  });
+
+  it('uses an HTTP-compatible cookie in the integration test harness', () => {
+    const originalEnv = {
+      isProduction: EnvSet.values.isProduction,
+      isIntegrationTest: EnvSet.values.isIntegrationTest,
+    };
+    const setEnvFlag = (key: 'isProduction' | 'isIntegrationTest', value: boolean) => {
+      Reflect.set(EnvSet.values, key, value);
+    };
+    setEnvFlag('isProduction', true);
+    setEnvFlag('isIntegrationTest', true);
+
+    try {
+      const queries = createQueries();
+      const { ctx, set } = createCookieContext();
+      const library = createTrustedDeviceLibrary(tenantId, queries, createPolicyLibrary());
+      const credential = { id: trustedDeviceId, secret: generateTrustedDeviceSecret() };
+
+      library.writeCredential(ctx, userId, credential, Date.now() + 60_000);
+
+      expect(set).toHaveBeenCalledWith(
+        getTrustedDeviceCookieName(tenantId, userId, false),
+        serializeTrustedDeviceCredential(credential),
+        expect.objectContaining({ secure: false, signed: false, path: '/' })
+      );
+    } finally {
+      setEnvFlag('isProduction', originalEnv.isProduction);
+      setEnvFlag('isIntegrationTest', originalEnv.isIntegrationTest);
+    }
   });
 
   it('queues a redacted deletion webhook only after deleting an existing record', async () => {

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -139,7 +139,9 @@ export const createTrustedDeviceLibrary = (
   queries: TrustedDeviceQueries,
   policyLibrary: TrustedDevicePolicyLibrary,
   {
-    isProduction = EnvSet.values.isProduction,
+    // Integration tests run the production build over HTTP. Production cookie attributes are
+    // covered by unit tests, while browser-level tests need a credential the HTTP harness can use.
+    isProduction = EnvSet.values.isProduction && !EnvSet.values.isIntegrationTest,
     cleanupCooldown = trustedDeviceCleanupCooldown,
   }: TrustedDeviceLibraryOptions = {}
 ) => {

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -13,7 +13,10 @@ import { EnvSet } from '#src/env-set/index.js';
 import type { TrustedDeviceMetadata, TrustedDeviceQueries } from '#src/queries/trusted-device.js';
 
 import type { HookContextManager } from './hook/context-manager.js';
-import type { createTrustedDevicePolicyLibrary } from './trusted-device-policy.js';
+import type {
+  createTrustedDevicePolicyLibrary,
+  EffectiveTrustedDevicePolicy,
+} from './trusted-device-policy.js';
 
 const trustedDeviceSecretByteLength = 32;
 const trustedDeviceSecretHashAlgorithm = 'sha256';
@@ -40,6 +43,7 @@ type CreateTrustedDeviceCredential = TrustedDeviceMetadata &
   Readonly<{
     ctx: TrustedDeviceCookieContext;
     deviceId: string;
+    effectivePolicy?: EffectiveTrustedDevicePolicy;
     userId: string;
   }>;
 
@@ -201,10 +205,11 @@ export const createTrustedDeviceLibrary = (
   const createCredential = async ({
     ctx,
     deviceId,
+    effectivePolicy,
     userId,
     ...metadata
   }: CreateTrustedDeviceCredential) => {
-    const policy = await policyLibrary.getEffectivePolicy(userId);
+    const policy = effectivePolicy ?? (await policyLibrary.getEffectivePolicy(userId));
 
     if (!policy.enabled) {
       return;

--- a/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
@@ -204,6 +204,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         {
           availableFactors: [MfaFactor.TOTP],
           maskedIdentifiers: {},
+          trustedDevice: { canCreate: false },
         }
       )
     );
@@ -298,6 +299,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         {
           availableFactors: [MfaFactor.TOTP],
           maskedIdentifiers: {},
+          trustedDevice: { canCreate: false },
         }
       )
     );
@@ -963,6 +965,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         {
           availableFactors: [MfaFactor.TOTP],
           maskedIdentifiers: {},
+          trustedDevice: { canCreate: false },
         }
       )
     );

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -108,14 +108,25 @@ const createInteraction = (
 };
 
 const expectConventionalMfaRequired = async (
-  experienceInteraction: InstanceType<typeof ExperienceInteraction>
+  experienceInteraction: InstanceType<typeof ExperienceInteraction>,
+  options?: {
+    trustedDeviceAvailability?: { canCreate: boolean; durationDays?: number };
+    includeTrustedDevice?: boolean;
+  }
 ) => {
+  const trustedDeviceAvailability = options?.trustedDeviceAvailability ?? {
+    canCreate: true,
+    durationDays: 30,
+  };
   await expect(experienceInteraction.guardMfaVerificationStatus()).rejects.toMatchError(
     new RequestError(
       { code: 'session.mfa.require_mfa_verification', status: 403 },
       {
         availableFactors: [MfaFactor.TOTP],
         maskedIdentifiers: {},
+        ...(options?.includeTrustedDevice === false
+          ? {}
+          : { trustedDevice: trustedDeviceAvailability }),
       }
     )
   );
@@ -196,20 +207,22 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
       },
     });
 
-    await expectConventionalMfaRequired(experienceInteraction);
+    await expectConventionalMfaRequired(experienceInteraction, {
+      trustedDeviceAvailability: { canCreate: false },
+    });
 
     expect(getEffectivePolicy).toHaveBeenCalledWith(mockUserWithMfaVerifications.id);
     expect(validateCredential).not.toHaveBeenCalled();
   });
 
-  it('skips policy and credential validation when no trusted-device cookie is present', async () => {
+  it('resolves advisory availability but skips credential validation when no cookie is present', async () => {
     hasCredential.mockReturnValueOnce(false);
     const { ctx, experienceInteraction } = createInteraction();
 
     await expectConventionalMfaRequired(experienceInteraction);
 
     expect(hasCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
-    expect(getEffectivePolicy).not.toHaveBeenCalled();
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).not.toHaveBeenCalled();
   });
 
@@ -230,7 +243,7 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
 
-    expect(getEffectivePolicy).toHaveBeenCalledTimes(2);
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).toHaveBeenCalledTimes(2);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
     expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
@@ -265,7 +278,7 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
     validateCredential.mockResolvedValueOnce(trustedDevice);
     const { experienceInteraction } = createInteraction();
 
-    await expectConventionalMfaRequired(experienceInteraction);
+    await expectConventionalMfaRequired(experienceInteraction, { includeTrustedDevice: false });
 
     expect(getEffectivePolicy).not.toHaveBeenCalled();
     expect(validateCredential).not.toHaveBeenCalled();

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -118,6 +118,8 @@ export default class ExperienceInteraction {
         this.getVerificationRecordByTypeAndId(type, verificationId),
       getVerificationRecordById: (verificationId) => this.getVerificationRecordById(verificationId),
       getCurrentProfile: () => this.profile.data,
+      getTrustedDeviceCreationAvailability: async (userId, organizations) =>
+        this.trustedDevice.getCreationAvailability(userId, organizations),
     };
 
     this.adaptiveMfaValidator = new AdaptiveMfaValidator({
@@ -130,8 +132,8 @@ export default class ExperienceInteraction {
     if (typeof interactionData === 'string') {
       this.#interactionEvent = interactionData;
       this.profile = new Profile(libraries, queries, {}, interactionContext);
-      this.mfa = new Mfa(libraries, queries, {}, interactionContext);
       this.trustedDevice = new TrustedDevice(ctx, tenant, {});
+      this.mfa = new Mfa(libraries, queries, {}, interactionContext);
       return;
     }
 
@@ -159,10 +161,10 @@ export default class ExperienceInteraction {
     this.#interactionEvent = interactionEvent;
     this.userId = userId;
     this.profile = new Profile(libraries, queries, profile, interactionContext);
-    this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.trustedDevice = new TrustedDevice(ctx, tenant, {
       trustedDeviceCreation,
     });
+    this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.captcha = captcha;
     for (const record of verificationRecords) {
       const instance = buildVerificationRecord(libraries, queries, record);
@@ -399,6 +401,7 @@ export default class ExperienceInteraction {
     }
 
     const { primaryEmail, primaryPhone } = user;
+    const trustedDevice = await this.trustedDevice.getCreationAvailability(user.id);
     const maskedIdentifiers: Record<string, string> = {
       ...(mfaValidator.availableUserMfaVerificationTypes.includes(
         MfaFactor.EmailVerificationCode
@@ -419,6 +422,7 @@ export default class ExperienceInteraction {
         {
           availableFactors: mfaValidator.availableUserMfaVerificationTypes,
           maskedIdentifiers,
+          ...conditional(trustedDevice && { trustedDevice }),
         }
       )
     );
@@ -436,7 +440,10 @@ export default class ExperienceInteraction {
   /** Record an explicit trusted-device opt-in after validating eligible MFA proof. */
   public async requestTrustedDeviceCreation() {
     const user = await this.getIdentifiedUser();
-    this.trustedDevice.requestCreation(await this.hasEligibleTrustedDeviceProof(user));
+    await this.trustedDevice.requestCreation(
+      user.id,
+      await this.hasEligibleTrustedDeviceProof(user)
+    );
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/mfa.test.ts
@@ -3,6 +3,7 @@ import {
   MfaFactor,
   type Mfa as MfaSettings,
   MfaPolicy,
+  type OrganizationWithRoles,
   OrganizationRequiredMfaPolicy,
   userMfaDataKey,
   type User,
@@ -31,11 +32,15 @@ const createMfa = ({
     mfaVerifications: [],
   },
   currentProfile = {},
+  organizations = [],
+  trustedDeviceAvailability = { canCreate: true, durationDays: 30 },
 }: {
   mfaSettings?: MfaSettings;
   interactionEvent?: InteractionEvent;
   user?: Partial<User>;
   currentProfile?: Record<string, unknown>;
+  organizations?: Readonly<OrganizationWithRoles[]>;
+  trustedDeviceAvailability?: { canCreate: boolean; durationDays?: number };
 } = {}) => {
   const getIdentifiedUser = jest.fn(async () => user as User);
   const interactionContext: InteractionContext = {
@@ -48,9 +53,17 @@ const createMfa = ({
       throw new Error('should not be called');
     },
     getCurrentProfile: () => currentProfile,
+    getTrustedDeviceCreationAvailability: jest.fn(async () => trustedDeviceAvailability),
   };
 
-  const mfa = new Mfa({} as Libraries, {} as Queries, {}, interactionContext);
+  const getOrganizationsByUserId = jest.fn(async () => organizations);
+  const getTrustedDeviceCreationAvailability = jest.mocked(
+    interactionContext.getTrustedDeviceCreationAvailability
+  );
+  const queries = {
+    organizations: { relations: { users: { getOrganizationsByUserId } } },
+  } as unknown as Queries;
+  const mfa = new Mfa({} as Libraries, queries, {}, interactionContext);
   const { signInExperienceValidator } = mfa as unknown as {
     signInExperienceValidator: SignInExperienceValidator;
   };
@@ -66,6 +79,8 @@ const createMfa = ({
     getIdentifiedUser,
     getMfaSettings,
     getConfiguredMfaFactors,
+    getOrganizationsByUserId,
+    getTrustedDeviceCreationAvailability,
   };
 };
 
@@ -167,8 +182,56 @@ describe('Mfa.assertMfaFulfilled', () => {
       status: 422,
       data: {
         availableFactors: [MfaFactor.TOTP],
+        trustedDevice: { canCreate: true, durationDays: 30 },
       },
     });
+  });
+
+  it('adds trusted-device availability to the optional MFA suggestion', async () => {
+    const { mfa } = createMfa({
+      mfaSettings: {
+        policy: MfaPolicy.PromptOnlyAtSignIn,
+        factors: [MfaFactor.TOTP],
+        organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.NoPrompt,
+      },
+      user: {
+        id: 'user-id',
+        logtoConfig: { [userMfaDataKey]: { enabled: false } },
+        mfaVerifications: [],
+      },
+    });
+
+    await expect(mfa.assertMfaFulfilled()).rejects.toMatchObject({
+      code: 'user.suggest_mfa',
+      status: 422,
+      data: {
+        trustedDevice: { canCreate: true, durationDays: 30 },
+      },
+    });
+  });
+
+  it('reuses loaded organization rows for MFA and trusted-device eligibility', async () => {
+    const organizations = [
+      { isMfaRequired: true, isTrustedDeviceAllowed: false },
+    ] as unknown as Readonly<OrganizationWithRoles[]>;
+    const { mfa, getOrganizationsByUserId, getTrustedDeviceCreationAvailability } = createMfa({
+      mfaSettings: {
+        policy: MfaPolicy.NoPrompt,
+        factors: [MfaFactor.TOTP],
+        organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
+      },
+      organizations,
+      trustedDeviceAvailability: { canCreate: false },
+    });
+
+    await expect(mfa.assertMfaFulfilled()).rejects.toMatchObject({
+      code: 'user.missing_mfa',
+      data: {
+        trustedDevice: { canCreate: false },
+      },
+    });
+    expect(getOrganizationsByUserId).toHaveBeenCalledTimes(1);
+    expect(getTrustedDeviceCreationAvailability).toHaveBeenCalledWith('user-id', organizations);
   });
 
   it('skips additional MFA suggestion when user has persisted skipped flag', async () => {

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -11,6 +11,7 @@ import {
   InteractionEvent,
   type JsonObject,
   MfaPolicy,
+  type OrganizationWithRoles,
   type User,
   VerificationType,
   type Mfa as MfaSettings,
@@ -23,7 +24,7 @@ import {
   SignInIdentifier,
 } from '@logto/schemas';
 import { generateStandardId, maskEmail, maskPhone } from '@logto/shared';
-import { cond, condObject, deduplicate, pick } from '@silverhand/essentials';
+import { cond, conditional, condObject, deduplicate, pick } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -119,6 +120,7 @@ const isPasskeySkipped = (logtoConfig: JsonObject): boolean => {
 
 type SubmitMfaValidationContext = {
   mfaSettings: MfaSettings;
+  organizations?: Readonly<OrganizationWithRoles[]>;
   user: User;
   userFactors: MfaFactor[];
 };
@@ -407,7 +409,12 @@ export class Mfa {
   private async assertOptionalMfaEnablement(
     submitMfaValidationContext: SubmitMfaValidationContext
   ) {
-    const { mfaSettings, user: identifiedUser, userFactors } = submitMfaValidationContext;
+    const {
+      mfaSettings,
+      organizations,
+      user: identifiedUser,
+      userFactors,
+    } = submitMfaValidationContext;
     const { policy, factors } = mfaSettings;
 
     // If there are no factors, bypass the check.
@@ -440,26 +447,11 @@ export class Mfa {
     }
 
     // If MFA is required by organizations, bypass.
-    if (await this.isMfaRequiredByUserOrganizations(mfaSettings, userId)) {
+    if (await this.isMfaRequiredByUserOrganizations(mfaSettings, userId, organizations)) {
       return;
     }
 
-    // Since MFA `enabled` flag is introduced later, legacy users who don't have the `enabled` flag in their config should
-    // be checked if they have any MFA factors bound, in order to determine whether MFA is effectively enabled for them.
-    if (hasEnabledMfa === undefined) {
-      assertThat(
-        userFactors.length > 0,
-        new RequestError({ code: 'user.suggest_mfa', status: 422 })
-      );
-
-      // Backfill the `enabled` flag for legacy users to avoid repeated suggestions in future interactions.
-      this.markMfaEnabled();
-      return;
-    }
-
-    // Suggest MFA binding if the user has not completed MFA binding, even if the policy is not mandatory,
-    // to encourage better account security.
-    assertThat(hasEnabledMfa, new RequestError({ code: 'user.suggest_mfa', status: 422 }));
+    await this.assertOptionalMfaEnabled(hasEnabledMfa, userFactors, userId, organizations);
   }
 
   /**
@@ -471,7 +463,7 @@ export class Mfa {
   private async assertUserMandatoryMfaFulfilled(
     submitMfaValidationContext: SubmitMfaValidationContext
   ) {
-    const { mfaSettings } = submitMfaValidationContext;
+    const { mfaSettings, organizations } = submitMfaValidationContext;
     const { policy, factors } = mfaSettings;
 
     // If there are no factors, then there is nothing to check
@@ -492,7 +484,8 @@ export class Mfa {
 
     const isMfaRequiredByUserOrganizations = await this.isMfaRequiredByUserOrganizations(
       mfaSettings,
-      userId
+      userId,
+      organizations
     );
 
     // If the policy is no prompt, and mfa is not required by the user organizations, then there is nothing to check
@@ -518,15 +511,20 @@ export class Mfa {
     const linkedFactors = deduplicate([...factorsInUser, ...factorsInBind]);
 
     // Assert that the user has at least one of the required factors bound
-    assertThat(
-      configuredFactors.some((factor) => linkedFactors.includes(factor)),
-      new RequestError(
+    if (!configuredFactors.some((factor) => linkedFactors.includes(factor))) {
+      const trustedDevice = await this.getTrustedDeviceCreationAvailability(userId, organizations);
+
+      throw new RequestError(
         { code: 'user.missing_mfa', status: 422 },
-        isNoSkipMfaPolicy(policy) || isMfaRequiredByUserOrganizations
-          ? { availableFactors: configuredFactors }
-          : { availableFactors: configuredFactors, skippable: true }
-      )
-    );
+        {
+          availableFactors: configuredFactors,
+          ...conditional(
+            !isNoSkipMfaPolicy(policy) && !isMfaRequiredByUserOrganizations && { skippable: true }
+          ),
+          ...conditional(trustedDevice && { trustedDevice }),
+        }
+      );
+    }
 
     // Optional suggestion: Let Mfa decide whether to suggest additional binding during registration
     await this.guardAdditionalBindingSuggestion(factorsInUser, configuredFactors, identifiedUser);
@@ -648,15 +646,20 @@ export class Mfa {
     assertThat(isFactorsEnabled, new RequestError({ code: 'session.mfa.mfa_factor_not_enabled' }));
   }
 
-  private async isMfaRequiredByUserOrganizations(mfaSettings: MfaSettings, userId: string) {
+  private async isMfaRequiredByUserOrganizations(
+    mfaSettings: MfaSettings,
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) {
     if (mfaSettings.organizationRequiredMfaPolicy !== OrganizationRequiredMfaPolicy.Mandatory) {
       return false;
     }
 
-    const organizations =
-      await this.queries.organizations.relations.users.getOrganizationsByUserId(userId);
+    const resolvedOrganizations =
+      organizations ??
+      (await this.queries.organizations.relations.users.getOrganizationsByUserId(userId));
 
-    return organizations.some(({ isMfaRequired }) => isMfaRequired);
+    return resolvedOrganizations.some(({ isMfaRequired }) => isMfaRequired);
   }
 
   /**
@@ -675,13 +678,66 @@ export class Mfa {
       this.signInExperienceValidator.getMfaSettings(),
       this.interactionContext.getIdentifiedUser(),
     ]);
-    const userFactors = await this.getUserMfaFactors({ mfaSettings, user });
+    const [userFactors, organizations] = await Promise.all([
+      this.getUserMfaFactors({ mfaSettings, user }),
+      mfaSettings.factors.length > 0 &&
+      mfaSettings.organizationRequiredMfaPolicy === OrganizationRequiredMfaPolicy.Mandatory
+        ? this.queries.organizations.relations.users.getOrganizationsByUserId(user.id)
+        : undefined,
+    ]);
 
     return {
       mfaSettings,
+      organizations,
       user,
       userFactors,
     };
+  }
+
+  private async throwMfaSuggestion(
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ): Promise<never> {
+    const trustedDevice = await this.getTrustedDeviceCreationAvailability(userId, organizations);
+
+    throw new RequestError(
+      { code: 'user.suggest_mfa', status: 422 },
+      {
+        ...conditional(trustedDevice && { trustedDevice }),
+      }
+    );
+  }
+
+  private async assertOptionalMfaEnabled(
+    hasEnabledMfa: boolean | undefined,
+    userFactors: MfaFactor[],
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) {
+    // Since MFA `enabled` flag is introduced later, legacy users who don't have the `enabled` flag in their config should
+    // be checked if they have any MFA factors bound, in order to determine whether MFA is effectively enabled for them.
+    if (hasEnabledMfa === undefined) {
+      if (userFactors.length === 0) {
+        await this.throwMfaSuggestion(userId, organizations);
+      }
+
+      // Backfill the `enabled` flag for legacy users to avoid repeated suggestions in future interactions.
+      this.markMfaEnabled();
+      return;
+    }
+
+    // Suggest MFA binding if the user has not completed MFA binding, even if the policy is not mandatory,
+    // to encourage better account security.
+    if (!hasEnabledMfa) {
+      await this.throwMfaSuggestion(userId, organizations);
+    }
+  }
+
+  private async getTrustedDeviceCreationAvailability(
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) {
+    return this.interactionContext.getTrustedDeviceCreationAvailability?.(userId, organizations);
   }
 
   private async getUserMfaFactors({

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -92,6 +92,40 @@ describe('Experience trusted-device lifecycle events', () => {
     jest.restoreAllMocks();
   });
 
+  it('memoizes effective policy across availability and creation finalization', async () => {
+    const creation = createSubject({ data: {}, createResult: trustedDevice });
+
+    await expect(creation.subject.getCreationAvailability(userId)).resolves.toEqual({
+      canCreate: true,
+      durationDays: 30,
+    });
+    await creation.subject.finalize({
+      creation: { deviceId: trustedDeviceId },
+      interactionEvent: InteractionEvent.SignIn,
+      userId,
+      hasEligibleMfaProof: true,
+    });
+
+    expect(creation.getEffectivePolicy).toHaveBeenCalledTimes(1);
+    expect(creation.createCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: { enabled: true, durationDays: 30 },
+      })
+    );
+  });
+
+  it('rejects creation intent when the current server policy disallows it', async () => {
+    const creation = createSubject({ data: {} });
+    creation.getEffectivePolicy.mockResolvedValueOnce({ enabled: false, durationDays: 30 });
+
+    await expect(creation.subject.requestCreation(userId, true)).rejects.toMatchObject({
+      code: 'session.mfa.require_mfa_verification',
+      status: 403,
+    });
+
+    expect(creation.subject.data).toEqual({});
+  });
+
   it('emits Created audit and webhook events only for the successful insert winner', async () => {
     const winner = createSubject({
       data: {},

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -1,19 +1,28 @@
 import { createHash } from 'node:crypto';
 
 import { appInsights } from '@logto/app-insights/node';
-import { InteractionEvent, type TrustedDevice as TrustedDeviceModel } from '@logto/schemas';
+import {
+  InteractionEvent,
+  type OrganizationWithRoles,
+  type TrustedDevice as TrustedDeviceModel,
+} from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { type EffectiveTrustedDevicePolicy } from '#src/libraries/trusted-device-policy.js';
 import { getTrustedDeviceEventData } from '#src/libraries/trusted-device.js';
 import { type TrustedDeviceMetadata } from '#src/queries/trusted-device.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
-import { type InteractionStorage, type WithHooksAndLogsContext } from '../types.js';
+import {
+  type InteractionStorage,
+  type TrustedDeviceAvailability,
+  type WithHooksAndLogsContext,
+} from '../types.js';
 
 type TrustedDeviceData = Pick<InteractionStorage, 'trustedDeviceCreation'>;
 
@@ -44,6 +53,7 @@ type FinalizeOptions = {
 export class TrustedDevice {
   #creation?: InteractionStorage['trustedDeviceCreation'];
   #validatedDeviceId?: string;
+  #effectivePolicy?: Promise<EffectiveTrustedDevicePolicy>;
 
   constructor(
     private readonly ctx: WithHooksAndLogsContext,
@@ -59,9 +69,16 @@ export class TrustedDevice {
     };
   }
 
-  requestCreation(hasEligibleMfaProof: boolean) {
+  async requestCreation(userId: string, hasEligibleMfaProof: boolean) {
     assertThat(
       hasEligibleMfaProof,
+      new RequestError({ code: 'session.mfa.require_mfa_verification', status: 403 })
+    );
+
+    const { enabled } = await this.#getEffectivePolicy(userId);
+
+    assertThat(
+      enabled,
       new RequestError({ code: 'session.mfa.require_mfa_verification', status: 403 })
     );
 
@@ -76,19 +93,28 @@ export class TrustedDevice {
     return creation;
   }
 
-  async getCreationAvailability(userId?: string) {
+  async getCreationAvailability(
+    userId?: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ): Promise<TrustedDeviceAvailability | undefined> {
     // Trusted-device opt-in is under development and must remain isolated from released flows.
     if (!EnvSet.values.isDevFeaturesEnabled || !userId) {
       return;
     }
 
-    const { enabled, durationDays } =
-      await this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(userId);
+    return trySafe(
+      async () => {
+        const { enabled, durationDays } = await this.#getEffectivePolicy(userId, organizations);
 
-    return {
-      canCreate: enabled,
-      ...conditional(enabled && { durationDays }),
-    };
+        return {
+          canCreate: enabled,
+          ...conditional(enabled && { durationDays }),
+        };
+      },
+      (error) => {
+        void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
+      }
+    );
   }
 
   /**
@@ -105,15 +131,13 @@ export class TrustedDevice {
 
     this.#validatedDeviceId = undefined;
 
-    const {
-      libraries: { trustedDevicePolicy, trustedDevices },
-    } = this.tenant;
+    const { trustedDevices } = this.tenant.libraries;
 
     if (!trustedDevices.hasCredential(this.ctx, userId)) {
       return false;
     }
 
-    const { enabled } = await trustedDevicePolicy.getEffectivePolicy(userId);
+    const { enabled } = await this.#getEffectivePolicy(userId);
 
     if (!enabled) {
       return false;
@@ -206,6 +230,7 @@ export class TrustedDevice {
     const trustedDevice = await this.tenant.libraries.trustedDevices.createCredential({
       ctx: this.ctx,
       deviceId: creation.deviceId,
+      effectivePolicy: await this.#getEffectivePolicy(userId),
       userId,
       ...metadata,
     });
@@ -236,5 +261,13 @@ export class TrustedDevice {
     });
 
     log.append({ userId: data.userId, data });
+  }
+
+  async #getEffectivePolicy(userId: string, organizations?: Readonly<OrganizationWithRoles[]>) {
+    this.#effectivePolicy ??= organizations
+      ? this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(userId, organizations)
+      : this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(userId);
+
+    return this.#effectivePolicy;
   }
 }

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -1187,7 +1187,7 @@ describe('POST /experience/submit', () => {
     }
   );
 
-  it('should expose only trusted-device creation availability for an identified user', async () => {
+  it('should keep the interaction read free of trusted-device policy queries', async () => {
     setDevFeaturesEnabled(true);
     const { requester, getEffectivePolicy } = createRequesterWithMocks({
       interactionResult: {
@@ -1198,46 +1198,15 @@ describe('POST /experience/submit', () => {
           fulfilledAt: Date.now(),
         },
       },
-      trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
-
-    const response = await requester.get('/experience/interaction');
-
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject({
-      trustedDevice: { canCreate: true, durationDays: 30 },
-    });
-    expect(response.body).not.toHaveProperty('trustedDeviceFulfillment');
-    expect(response.body).not.toHaveProperty('trustedDeviceCreation');
-    expect(getEffectivePolicy).toHaveBeenCalledWith(mockUser.id);
-  });
-
-  it('should expose disabled creation without a duration when effective policy disallows it', async () => {
-    setDevFeaturesEnabled(true);
-    const { requester } = createRequesterWithMocks({
-      trustedDevicePolicy: { enabled: false, durationDays: 30 },
-    });
-
-    const response = await requester.get('/experience/interaction');
-
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject({ trustedDevice: { canCreate: false } });
-    expect(response.body.trustedDevice).not.toHaveProperty('durationDays');
-  });
-
-  it('should omit trusted-device availability when the policy lookup fails', async () => {
-    setDevFeaturesEnabled(true);
-    const policyError = new Error('trusted-device policy lookup failed');
-    const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
-    const { requester, getEffectivePolicy } = createRequesterWithMocks();
-    getEffectivePolicy.mockRejectedValueOnce(policyError);
 
     const response = await requester.get('/experience/interaction');
 
     expect(response.status).toBe(200);
     expect(response.body).not.toHaveProperty('trustedDevice');
-    expect(trackException).toHaveBeenCalledWith(policyError, expect.any(Object));
-    trackException.mockRestore();
+    expect(response.body).not.toHaveProperty('trustedDeviceFulfillment');
+    expect(response.body).not.toHaveProperty('trustedDeviceCreation');
+    expect(getEffectivePolicy).not.toHaveBeenCalled();
   });
 
   it('should omit trusted-device interaction data and behavior when dev features are disabled', async () => {

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -10,9 +10,7 @@
  * The experience APIs can be used by developers to build custom user interaction experiences.
  */
 
-import { appInsights } from '@logto/app-insights/node';
 import { identificationApiPayloadGuard, InteractionEvent } from '@logto/schemas';
-import { conditional, trySafe } from '@silverhand/essentials';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
@@ -20,7 +18,6 @@ import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaInteractionDetails from '#src/middleware/koa-interaction-details.js';
 import assertThat from '#src/utils/assert-that.js';
-import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import { type AnonymousRouter, type RouterInitArgs } from '../types.js';
 
@@ -204,20 +201,7 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
     }),
     async (ctx, next) => {
       const { experienceInteraction } = ctx;
-      const trustedDevice = await trySafe(
-        async () =>
-          experienceInteraction.trustedDevice.getCreationAvailability(
-            experienceInteraction.identifiedUserId
-          ),
-        (error) => {
-          void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));
-        }
-      );
-
-      ctx.body = {
-        ...experienceInteraction.toSanitizedJson(),
-        ...conditional(trustedDevice && { trustedDevice }),
-      };
+      ctx.body = experienceInteraction.toSanitizedJson();
       ctx.status = 200;
       return next();
     }

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -3,6 +3,7 @@ import {
   type CreateUser,
   encryptedTokenSetGuard,
   InteractionEvent,
+  type OrganizationWithRoles,
   secretEnterpriseSsoConnectorRelationPayloadGuard,
   secretSocialConnectorRelationPayloadGuard,
   type User,
@@ -176,6 +177,15 @@ export type InteractionContext = {
     verificationId: string
   ) => VerificationRecordMap[K];
   getCurrentProfile: () => InteractionProfile;
+  getTrustedDeviceCreationAvailability?: (
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) => Promise<TrustedDeviceAvailability | undefined>;
+};
+
+export type TrustedDeviceAvailability = {
+  canCreate: boolean;
+  durationDays?: number;
 };
 
 export type ExperienceInteractionRouterContext<ContextT extends WithLogContext = WithLogContext> =
@@ -234,10 +244,6 @@ export const interactionStorageGuard = z.object({
 export type SanitizedInteractionStorageData = {
   interactionEvent: InteractionEvent;
   userId?: string;
-  trustedDevice?: {
-    canCreate: boolean;
-    durationDays?: number;
-  };
   profile?: SanitizedInteractionProfile;
   verificationRecords?: SanitizedVerificationRecordData[];
   mfa?: SanitizedMfaData;
@@ -255,12 +261,6 @@ export type SanitizedInteractionStorageData = {
 export const sanitizedInteractionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
-  trustedDevice: z
-    .object({
-      canCreate: z.boolean(),
-      durationDays: z.number().optional(),
-    })
-    .optional(),
   profile: sanitizedInteractionProfileGuard,
   verificationRecords: publicVerificationRecordDataGuard.array().optional(),
   mfa: sanitizedMfaDataGuard.optional(),

--- a/packages/experience/src/apis/experience/index.test.ts
+++ b/packages/experience/src/apis/experience/index.test.ts
@@ -1,0 +1,70 @@
+import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
+
+import api from '../api';
+
+import { updateProfileWithVerificationCode, verifyAndUpdateProfileWithVerificationCode } from '.';
+import { experienceApiRoutes } from './const';
+import { identifyUser, submitInteraction, updateProfile } from './interaction';
+
+jest.mock('../api', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('./interaction', () => ({
+  identifyAndSubmitInteraction: jest.fn(),
+  identifyUser: jest.fn(),
+  initInteraction: jest.fn(),
+  submitInteraction: jest.fn(),
+  updateInteractionEvent: jest.fn(),
+  updateProfile: jest.fn(),
+}));
+
+const mockedApiPost = api.post as jest.MockedFunction<typeof api.post>;
+const mockedSubmitInteraction = submitInteraction as jest.MockedFunction<typeof submitInteraction>;
+
+const verificationCodePayload = {
+  identifier: { type: SignInIdentifier.Email, value: 'foo@logto.io' },
+  code: '123456',
+  verificationId: 'verification-id',
+} as const;
+
+describe('verification code profile APIs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApiPost.mockReturnValue({
+      json: jest.fn().mockResolvedValue({ verificationId: 'verified-id' }),
+    } as unknown as ReturnType<typeof api.post>);
+  });
+
+  it('verifies and updates the profile without submitting the interaction', async () => {
+    await verifyAndUpdateProfileWithVerificationCode(
+      verificationCodePayload,
+      InteractionEvent.Register
+    );
+
+    expect(mockedApiPost).toBeCalledWith(
+      `${experienceApiRoutes.verification}/verification-code/verify`,
+      { json: verificationCodePayload }
+    );
+    expect(updateProfile).toBeCalledWith({
+      type: SignInIdentifier.Email,
+      verificationId: 'verified-id',
+    });
+    expect(identifyUser).toBeCalledTimes(1);
+    expect(mockedSubmitInteraction).not.toBeCalled();
+  });
+
+  it('submits once after verifying and updating the profile in a regular continue flow', async () => {
+    mockedSubmitInteraction.mockResolvedValue({ redirectTo: '/callback' });
+
+    await expect(
+      updateProfileWithVerificationCode(verificationCodePayload, InteractionEvent.SignIn)
+    ).resolves.toEqual({ redirectTo: '/callback' });
+
+    expect(identifyUser).not.toBeCalled();
+    expect(mockedSubmitInteraction).toBeCalledTimes(1);
+  });
+});

--- a/packages/experience/src/apis/experience/index.ts
+++ b/packages/experience/src/apis/experience/index.ts
@@ -126,7 +126,7 @@ export const identifyWithVerificationCode = async (json: VerificationCodePayload
 
 // Profile APIs
 
-export const updateProfileWithVerificationCode = async (
+export const verifyAndUpdateProfileWithVerificationCode = async (
   json: VerificationCodePayload,
   interactionEvent?: ContinueFlowInteractionEvent
 ) => {
@@ -144,6 +144,13 @@ export const updateProfileWithVerificationCode = async (
   if (interactionEvent === InteractionEvent.Register) {
     await identifyUser();
   }
+};
+
+export const updateProfileWithVerificationCode = async (
+  json: VerificationCodePayload,
+  interactionEvent?: ContinueFlowInteractionEvent
+) => {
+  await verifyAndUpdateProfileWithVerificationCode(json, interactionEvent);
 
   return submitInteraction();
 };

--- a/packages/experience/src/apis/experience/index.ts
+++ b/packages/experience/src/apis/experience/index.ts
@@ -21,12 +21,10 @@ import {
 
 export {
   initInteraction,
-  getInteraction,
   submitInteraction,
   identifyUser,
   identifyAndSubmitInteraction,
 } from './interaction';
-export type { TrustedDeviceAvailability, TrustedDeviceInteractionData } from './interaction';
 
 export * from './avatar';
 export * from './mfa';

--- a/packages/experience/src/apis/experience/interaction.test.ts
+++ b/packages/experience/src/apis/experience/interaction.test.ts
@@ -1,33 +1,20 @@
 import api from '../api';
 
 import { experienceApiRoutes } from './const';
-import { getInteraction, submitInteraction } from './interaction';
+import { submitInteraction } from './interaction';
 
 jest.mock('../api', () => ({
   __esModule: true,
   default: {
-    get: jest.fn(),
     post: jest.fn(),
   },
 }));
 
-const mockedApiGet = api.get as jest.MockedFunction<typeof api.get>;
 const mockedApiPost = api.post as jest.MockedFunction<typeof api.post>;
 
 describe('interaction experience APIs', () => {
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('gets trusted-device creation availability from public interaction data', async () => {
-    const response = { trustedDevice: { canCreate: true, durationDays: 30 } };
-    const json = jest.fn().mockResolvedValue(response);
-    mockedApiGet.mockReturnValueOnce({ json } as unknown as ReturnType<typeof api.get>);
-
-    await expect(getInteraction()).resolves.toEqual(response);
-
-    expect(mockedApiGet).toBeCalledWith(experienceApiRoutes.interaction, { signal: undefined });
-    expect(json).toBeCalled();
   });
 
   it('records selected trusted-device intent before submitting the interaction', async () => {

--- a/packages/experience/src/apis/experience/interaction.ts
+++ b/packages/experience/src/apis/experience/interaction.ts
@@ -13,15 +13,6 @@ type SubmitInteractionResponse = {
   redirectTo: string;
 };
 
-export type TrustedDeviceAvailability = {
-  canCreate: boolean;
-  durationDays?: number;
-};
-
-export type TrustedDeviceInteractionData = {
-  trustedDevice?: TrustedDeviceAvailability;
-};
-
 type SubmitInteractionOptions = {
   createTrustedDevice?: boolean;
 };
@@ -36,9 +27,6 @@ export const initInteraction = async (interactionEvent: InteractionEvent, captch
 
 export const identifyUser = async (payload: IdentificationApiPayload = {}) =>
   api.post(experienceApiRoutes.identification, { json: payload });
-
-export const getInteraction = async (signal?: AbortSignal) =>
-  api.get(experienceApiRoutes.interaction, { signal }).json<TrustedDeviceInteractionData>();
 
 const requestTrustedDeviceCreation = async () =>
   api.post(`${experienceApiRoutes.mfa}/trusted-device`);

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
@@ -20,7 +20,11 @@ const TestOptIn = ({ isEnabled = true }: { readonly isEnabled?: boolean }) => {
   );
 };
 
-const renderOptIn = (trustedDevice?: TrustedDeviceAvailability, isEnabled = true) =>
+const renderOptIn = (
+  trustedDevice?: TrustedDeviceAvailability,
+  isEnabled = true,
+  additionalState: Record<string, unknown> = {}
+) =>
   render(
     <MemoryRouter
       initialEntries={[
@@ -29,6 +33,7 @@ const renderOptIn = (trustedDevice?: TrustedDeviceAvailability, isEnabled = true
           state: {
             availableFactors: [MfaFactor.TOTP],
             trustedDevice,
+            ...additionalState,
           },
         },
       ]}
@@ -52,6 +57,14 @@ describe('<TrustedDeviceOptIn />', () => {
     });
 
     expect(checkbox?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('shows the checkbox when WebAuthn options are included in route state', () => {
+    const { container } = renderOptIn({ canCreate: true, durationDays: 365 }, true, {
+      options: { challenge: 'challenge' },
+    });
+
+    expect(container.querySelector('[role="checkbox"]')).not.toBeNull();
   });
 
   it('stays hidden when MFA flow state disallows creation', () => {

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
@@ -1,15 +1,11 @@
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { MfaFactor } from '@logto/schemas';
+import { act, fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
-import { getInteraction } from '@/apis/experience';
 import useTrustedDeviceOptIn from '@/hooks/use-trusted-device-opt-in';
+import { type TrustedDeviceAvailability } from '@/types/guard';
 
 import TrustedDeviceOptIn from '.';
-
-jest.mock('@/apis/experience', () => ({
-  getInteraction: jest.fn(),
-}));
-
-const mockedGetInteraction = getInteraction as jest.MockedFunction<typeof getInteraction>;
 
 const TestOptIn = ({ isEnabled = true }: { readonly isEnabled?: boolean }) => {
   const { availability, isLoading, isChecked, setIsChecked } = useTrustedDeviceOptIn(isEnabled);
@@ -24,23 +20,29 @@ const TestOptIn = ({ isEnabled = true }: { readonly isEnabled?: boolean }) => {
   );
 };
 
+const renderOptIn = (trustedDevice?: TrustedDeviceAvailability, isEnabled = true) =>
+  render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/',
+          state: {
+            availableFactors: [MfaFactor.TOTP],
+            trustedDevice,
+          },
+        },
+      ]}
+    >
+      <TestOptIn isEnabled={isEnabled} />
+    </MemoryRouter>
+  );
+
 describe('<TrustedDeviceOptIn />', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('shows a default-unchecked checkbox when effective policy allows creation', async () => {
-    mockedGetInteraction.mockResolvedValue({
-      trustedDevice: { canCreate: true, durationDays: 30 },
-    });
-    const { container } = render(<TestOptIn />);
-
-    await waitFor(() => {
-      expect(container.querySelector('[role="checkbox"]')).not.toBeNull();
-    });
-    expect(mockedGetInteraction).toBeCalledWith(expect.any(AbortSignal));
-
+  it('shows a default-unchecked checkbox when MFA flow state allows creation', () => {
+    const { container } = renderOptIn({ canCreate: true, durationDays: 30 });
     const checkbox = container.querySelector('[role="checkbox"]');
+
+    expect(checkbox).not.toBeNull();
     expect(checkbox?.getAttribute('aria-checked')).toBe('false');
 
     act(() => {
@@ -52,50 +54,27 @@ describe('<TrustedDeviceOptIn />', () => {
     expect(checkbox?.getAttribute('aria-checked')).toBe('true');
   });
 
-  it('stays hidden when effective policy disallows creation', async () => {
-    mockedGetInteraction.mockResolvedValue({ trustedDevice: { canCreate: false } });
-    const { container } = render(<TestOptIn />);
-
-    await waitFor(() => {
-      expect(mockedGetInteraction).toBeCalled();
-    });
+  it('stays hidden when MFA flow state disallows creation', () => {
+    const { container } = renderOptIn({ canCreate: false });
 
     expect(container.querySelector('[role="checkbox"]')).toBeNull();
   });
 
-  it('stays hidden when availability cannot be loaded', async () => {
-    mockedGetInteraction.mockRejectedValue(new Error('Request failed'));
-    const { container } = render(<TestOptIn />);
+  it('stays hidden when MFA flow state has no availability', () => {
+    const { container } = renderOptIn();
 
-    await waitFor(() => {
-      expect(container.firstElementChild).toBeNull();
-    });
+    expect(container.firstElementChild).toBeNull();
   });
 
-  it('stays hidden when an available policy does not include a duration', async () => {
-    mockedGetInteraction.mockResolvedValue({ trustedDevice: { canCreate: true } });
-    const { container } = render(<TestOptIn />);
+  it('stays hidden when an available policy does not include a duration', () => {
+    const { container } = renderOptIn({ canCreate: true });
 
-    await waitFor(() => {
-      expect(container.firstElementChild).toBeNull();
-    });
+    expect(container.firstElementChild).toBeNull();
   });
 
-  it('reserves the checkbox space while availability is loading', () => {
-    mockedGetInteraction.mockReturnValue(
-      new Promise(() => {
-        // Keep the request pending to verify the loading placeholder.
-      })
-    );
-    const { container } = render(<TestOptIn />);
+  it('stays hidden when the calling page is invalid', () => {
+    const { container } = renderOptIn({ canCreate: true, durationDays: 30 }, false);
 
-    expect(container.firstElementChild).not.toBeNull();
-    expect(container.querySelector('[role="checkbox"]')).toBeNull();
-  });
-
-  it('does not query availability when the calling page is invalid', () => {
-    render(<TestOptIn isEnabled={false} />);
-
-    expect(mockedGetInteraction).not.toBeCalled();
+    expect(container.firstElementChild).toBeNull();
   });
 });

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.tsx
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import { type TrustedDeviceAvailability } from '@/apis/experience';
 import CheckboxField from '@/components/InputFields/CheckboxField';
+import { type TrustedDeviceAvailability } from '@/types/guard';
 
 import styles from './index.module.scss';
 

--- a/packages/experience/src/containers/VerificationCode/index.module.scss
+++ b/packages/experience/src/containers/VerificationCode/index.module.scss
@@ -28,6 +28,7 @@
   }
 
   .switch,
+  .optIn,
   .continueButton {
     margin-top: _.unit(6);
   }

--- a/packages/experience/src/containers/VerificationCode/index.tsx
+++ b/packages/experience/src/containers/VerificationCode/index.tsx
@@ -5,6 +5,8 @@ import { useTranslation, Trans } from 'react-i18next';
 
 import SwitchToVerificationMethodsLink from '@/components/SwitchToVerificationMethodsLink';
 import TextLink from '@/components/TextLink';
+import TrustedDeviceOptIn from '@/containers/TrustedDeviceOptIn';
+import useTrustedDeviceOptIn from '@/hooks/use-trusted-device-opt-in';
 import Button from '@/shared/components/Button';
 import VerificationCodeInput, { defaultLength } from '@/shared/components/VerificationCode';
 import { UserFlow } from '@/types';
@@ -32,6 +34,9 @@ const VerificationCode = ({
   const [inputErrorMessage, setInputErrorMessage] = useState<string>();
 
   const { t } = useTranslation();
+  const { availability, isLoading, isVisible, isChecked, setIsChecked } = useTrustedDeviceOptIn(
+    flow === UserFlow.Continue
+  );
 
   const isCodeInputReady = useMemo(
     () => codeInput.length === defaultLength && codeInput.every(Boolean),
@@ -49,7 +54,7 @@ const VerificationCode = ({
     errorMessage: submitErrorMessage,
     clearErrorMessage,
     onSubmit,
-  } = useVerificationCode(identifier, verificationId, errorCallback);
+  } = useVerificationCode(identifier, verificationId, errorCallback, isChecked);
 
   const errorMessage = inputErrorMessage ?? submitErrorMessage;
 
@@ -91,10 +96,10 @@ const VerificationCode = ({
   handleSubmitRef.current = handleSubmit;
 
   useEffect(() => {
-    if (isCodeInputReady) {
+    if (isCodeInputReady && !isVisible) {
       void handleSubmitRef.current(codeInput);
     }
-  }, [codeInput, isCodeInputReady]);
+  }, [codeInput, isCodeInputReady, isVisible]);
 
   return (
     <form className={classNames(styles.form, className)}>
@@ -137,6 +142,13 @@ const VerificationCode = ({
           className={styles.switch}
         />
       )}
+      <TrustedDeviceOptIn
+        availability={availability}
+        isLoading={isLoading}
+        isChecked={isChecked}
+        className={styles.optIn}
+        onChange={setIsChecked}
+      />
       <Button
         title="action.continue"
         type="primary"

--- a/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
@@ -2,7 +2,6 @@ import type { VerificationCodeIdentifier } from '@logto/schemas';
 import { InteractionEvent, MfaFactor, VerificationType } from '@logto/schemas';
 import { useCallback, useContext, useMemo } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
-import { validate } from 'superstruct';
 
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import { updateProfileWithVerificationCode } from '@/apis/experience';
@@ -12,11 +11,11 @@ import useApi from '@/hooks/use-api';
 import type { ErrorHandlers } from '@/hooks/use-error-handler';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
+import useMfaFlowState from '@/hooks/use-mfa-factors-state';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import { useSieMethods } from '@/hooks/use-sie';
 import useSubmitInteractionErrorHandler from '@/hooks/use-submit-interaction-error-handler';
 import { SearchParameters } from '@/types';
-import { mfaFlowStateGuard } from '@/types/guard';
 
 import useGeneralVerificationCodeErrorHandler from './use-general-verification-code-error-handler';
 import useIdentifierErrorAlert, { IdentifierErrorType } from './use-identifier-error-alert';
@@ -26,13 +25,15 @@ import useSignInWithExistIdentifierConfirmModal from './use-sign-in-with-exist-i
 const useContinueFlowCodeVerification = (
   identifier: VerificationCodeIdentifier,
   verificationId: string,
-  errorCallback?: () => void
+  errorCallback?: () => void,
+  createTrustedDevice = false
 ) => {
   const [searchParameters] = useSearchParams();
   const redirectTo = useGlobalRedirectTo();
   const navigate = useNavigateWithPreservedSearchParams();
 
   const { state } = useLocation();
+  const mfaFlowState = useMfaFlowState();
   const { verificationIdsMap } = useContext(UserInteractionContext);
   const { isVerificationCodeEnabledForSignIn } = useSieMethods();
 
@@ -118,12 +119,12 @@ const useContinueFlowCodeVerification = (
 
   const onSubmit = useCallback(
     async (code: string) => {
-      const [, mfaFlowState] = validate(state, mfaFlowStateGuard);
-      // Check if this is an email MFA binding flow
-      if (
-        mfaFlowState?.availableFactors.includes(MfaFactor.EmailVerificationCode) &&
+      const factor =
         identifier.type === 'email'
-      ) {
+          ? MfaFactor.EmailVerificationCode
+          : MfaFactor.PhoneVerificationCode;
+
+      if (mfaFlowState?.availableFactors.includes(factor)) {
         const [verifyError] = await verifyVerificationCode(
           {
             code,
@@ -140,8 +141,10 @@ const useContinueFlowCodeVerification = (
         }
 
         const [bindError, bindResult] = await asyncBindMfa(
-          MfaFactor.EmailVerificationCode,
-          verificationId
+          factor,
+          verificationId,
+          undefined,
+          createTrustedDevice
         );
 
         if (bindError) {
@@ -180,12 +183,13 @@ const useContinueFlowCodeVerification = (
     },
     [
       asyncBindMfa,
+      createTrustedDevice,
       errorCallback,
       handleError,
       identifier,
       interactionEvent,
+      mfaFlowState,
       redirectTo,
-      state,
       verificationId,
       verifyVerificationCode,
       verifyVerificationCodeErrorHandlers,

--- a/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
@@ -4,7 +4,10 @@ import { useCallback, useContext, useMemo } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
-import { updateProfileWithVerificationCode } from '@/apis/experience';
+import {
+  updateProfileWithVerificationCode,
+  verifyAndUpdateProfileWithVerificationCode,
+} from '@/apis/experience';
 import { bindMfa } from '@/apis/experience/mfa';
 import { getInteractionEventFromState } from '@/apis/utils';
 import useApi from '@/hooks/use-api';
@@ -45,6 +48,7 @@ const useContinueFlowCodeVerification = (
   const handleError = useErrorHandler();
 
   const verifyVerificationCode = useApi(updateProfileWithVerificationCode);
+  const verifyAndUpdateProfile = useApi(verifyAndUpdateProfileWithVerificationCode);
   const asyncBindMfa = useApi(bindMfa);
 
   const { generalVerificationCodeErrorHandlers, errorMessage, clearErrorMessage } =
@@ -125,7 +129,7 @@ const useContinueFlowCodeVerification = (
           : MfaFactor.PhoneVerificationCode;
 
       if (mfaFlowState?.availableFactors.includes(factor)) {
-        const [verifyError] = await verifyVerificationCode(
+        const [verifyError] = await verifyAndUpdateProfile(
           {
             code,
             identifier,
@@ -193,6 +197,7 @@ const useContinueFlowCodeVerification = (
       verificationId,
       verifyVerificationCode,
       verifyVerificationCodeErrorHandlers,
+      verifyAndUpdateProfile,
     ]
   );
 

--- a/packages/experience/src/containers/VerificationCode/utils.ts
+++ b/packages/experience/src/containers/VerificationCode/utils.ts
@@ -1,3 +1,5 @@
+import type { VerificationCodeIdentifier } from '@logto/schemas';
+
 import { UserFlow } from '@/types';
 
 import useContinueFlowCodeVerification from './use-continue-flow-code-verification';
@@ -5,11 +7,23 @@ import useForgotPasswordFlowCodeVerification from './use-forgot-password-flow-co
 import useRegisterFlowCodeVerification from './use-register-flow-code-verification';
 import useSignInFlowCodeVerification from './use-sign-in-flow-code-verification';
 
-export const codeVerificationHooks = Object.freeze({
-  [UserFlow.SignIn]: useSignInFlowCodeVerification,
-  [UserFlow.Register]: useRegisterFlowCodeVerification,
-  [UserFlow.ForgotPassword]: useForgotPasswordFlowCodeVerification,
-  [UserFlow.Continue]: useContinueFlowCodeVerification,
-});
+type VerificationCodeHook = (
+  identifier: VerificationCodeIdentifier,
+  verificationId: string,
+  errorCallback?: () => void,
+  createTrustedDevice?: boolean
+) => {
+  errorMessage: string | undefined;
+  clearErrorMessage: () => void;
+  onSubmit: (code: string) => Promise<void>;
+};
+
+export const codeVerificationHooks: Readonly<Record<UserFlow, VerificationCodeHook>> =
+  Object.freeze({
+    [UserFlow.SignIn]: useSignInFlowCodeVerification,
+    [UserFlow.Register]: useRegisterFlowCodeVerification,
+    [UserFlow.ForgotPassword]: useForgotPasswordFlowCodeVerification,
+    [UserFlow.Continue]: useContinueFlowCodeVerification,
+  });
 
 export const getCodeVerificationHookByFlow = (flow: UserFlow) => codeVerificationHooks[flow];

--- a/packages/experience/src/hooks/use-mfa-error-handler.test.tsx
+++ b/packages/experience/src/hooks/use-mfa-error-handler.test.tsx
@@ -1,0 +1,67 @@
+import { type RequestErrorBody } from '@logto/schemas';
+import { act, renderHook } from '@testing-library/react';
+
+import useMfaErrorHandler from './use-mfa-error-handler';
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('./use-navigate-with-preserved-search-params', () => ({
+  __esModule: true,
+  default: () => mockedNavigate,
+}));
+
+jest.mock('./use-send-mfa-verification-code', () => ({
+  __esModule: true,
+  default: () => ({ onSubmit: jest.fn() }),
+}));
+
+jest.mock('./use-start-backup-code-binding', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+jest.mock('./use-start-totp-binding', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+jest.mock('./use-start-webauthn-processing', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+jest.mock('./use-toast', () => ({
+  __esModule: true,
+  default: () => ({ setToast: jest.fn() }),
+}));
+
+describe('useMfaErrorHandler', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('carries trusted-device availability through the suggest-MFA onboarding redirect', async () => {
+    const { result } = renderHook(() => useMfaErrorHandler());
+    const error: RequestErrorBody = {
+      code: 'user.suggest_mfa',
+      message: 'MFA suggested',
+      data: { trustedDevice: { canCreate: true, durationDays: 30 } },
+    };
+
+    await act(async () => {
+      await result.current['user.suggest_mfa']?.(error);
+    });
+
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      { pathname: '/mfa-onboarding' },
+      {
+        replace: undefined,
+        state: { trustedDevice: { canCreate: true, durationDays: 30 } },
+      }
+    );
+  });
+});

--- a/packages/experience/src/hooks/use-mfa-error-handler.ts
+++ b/packages/experience/src/hooks/use-mfa-error-handler.ts
@@ -113,17 +113,19 @@ const useMfaErrorHandler = ({ replace }: Options = {}) => {
   const handleMfaError = useCallback(
     (flow: UserMfaFlow) => {
       return async (error: RequestErrorBody) => {
+        const [_, data] = validate(error.data, mfaErrorDataGuard);
+
         if (error.code === 'user.suggest_mfa') {
-          navigate({ pathname: `/mfa-onboarding` }, { replace });
+          navigate({ pathname: `/mfa-onboarding` }, { replace, state: data });
           return;
         }
 
-        const [_, data] = validate(error.data, mfaErrorDataGuard);
         const factors = data?.availableFactors ?? [];
         const skippable = data?.skippable;
         const maskedIdentifiers = data?.maskedIdentifiers;
         const suggestion = data?.suggestion;
         const isWebAuthnUsedAsSignInPasskey = data?.isWebAuthnUsedAsSignInPasskey;
+        const trustedDevice = data?.trustedDevice;
 
         if (factors.length === 0) {
           setToast(error.message);
@@ -142,6 +144,7 @@ const useMfaErrorHandler = ({ replace }: Options = {}) => {
           maskedIdentifiers,
           suggestion,
           isWebAuthnUsedAsSignInPasskey,
+          trustedDevice,
         });
       };
     },

--- a/packages/experience/src/hooks/use-mfa-factors-state.test.tsx
+++ b/packages/experience/src/hooks/use-mfa-factors-state.test.tsx
@@ -1,0 +1,33 @@
+import { MfaFactor } from '@logto/schemas';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { UserMfaFlow } from '@/types';
+
+import useMfaFlowState from './use-mfa-factors-state';
+
+const TestHook = () => {
+  const flowState = useMfaFlowState();
+  return <span>{JSON.stringify(flowState)}</span>;
+};
+
+it('reads MFA flow state nested by the verification-code binding route', () => {
+  const mfaFlowState = {
+    availableFactors: [MfaFactor.EmailVerificationCode],
+    trustedDevice: { canCreate: true, durationDays: 365 },
+  };
+  const { container } = render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/continue/verification-code',
+          state: { flow: UserMfaFlow.MfaBinding, mfaFlowState },
+        },
+      ]}
+    >
+      <TestHook />
+    </MemoryRouter>
+  );
+
+  expect(container.textContent).toBe(JSON.stringify(mfaFlowState));
+});

--- a/packages/experience/src/hooks/use-mfa-factors-state.ts
+++ b/packages/experience/src/hooks/use-mfa-factors-state.ts
@@ -1,13 +1,14 @@
 import { useLocation } from 'react-router-dom';
 import { validate } from 'superstruct';
 
-import { mfaFlowStateGuard } from '@/types/guard';
+import { mfaBindingVerificationCodeStateGuard, mfaFlowStateGuard } from '@/types/guard';
 
 const useMfaFlowState = () => {
   const { state } = useLocation();
   const [, mfaFlowState] = validate(state, mfaFlowStateGuard);
+  const [, verificationCodeState] = validate(state, mfaBindingVerificationCodeStateGuard);
 
-  return mfaFlowState;
+  return mfaFlowState ?? verificationCodeState?.mfaFlowState;
 };
 
 export default useMfaFlowState;

--- a/packages/experience/src/hooks/use-trusted-device-opt-in.test.tsx
+++ b/packages/experience/src/hooks/use-trusted-device-opt-in.test.tsx
@@ -1,24 +1,34 @@
+import { MfaFactor } from '@logto/schemas';
 import { render } from '@testing-library/react';
-
-import { getInteraction } from '@/apis/experience';
+import { MemoryRouter } from 'react-router-dom';
 
 import useTrustedDeviceOptIn from './use-trusted-device-opt-in';
-
-jest.mock('@/apis/experience', () => ({
-  getInteraction: jest.fn(),
-}));
 
 jest.mock('@/constants/env', () => ({
   isDevFeaturesEnabled: false,
 }));
 
 const TestHook = () => {
-  useTrustedDeviceOptIn();
-  return null;
+  const { availability } = useTrustedDeviceOptIn();
+  return <span>{JSON.stringify(availability)}</span>;
 };
 
-it('does not query trusted-device availability when dev features are disabled', () => {
-  render(<TestHook />);
+it('ignores router-state availability when dev features are disabled', () => {
+  const { container } = render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/',
+          state: {
+            availableFactors: [MfaFactor.TOTP],
+            trustedDevice: { canCreate: true, durationDays: 30 },
+          },
+        },
+      ]}
+    >
+      <TestHook />
+    </MemoryRouter>
+  );
 
-  expect(getInteraction).not.toBeCalled();
+  expect(container.textContent).toBe('');
 });

--- a/packages/experience/src/hooks/use-trusted-device-opt-in.ts
+++ b/packages/experience/src/hooks/use-trusted-device-opt-in.ts
@@ -1,47 +1,22 @@
 import { useEffect, useState } from 'react';
 
-import { getInteraction, type TrustedDeviceAvailability } from '@/apis/experience';
 import { isDevFeaturesEnabled } from '@/constants/env';
-import useApi from '@/hooks/use-api';
+import useMfaFlowState from '@/hooks/use-mfa-factors-state';
 
-const useTrustedDeviceOptIn = (shouldFetch = true) => {
-  const canFetch = isDevFeaturesEnabled && shouldFetch;
-  const [availability, setAvailability] = useState<TrustedDeviceAvailability>();
-  const [isLoading, setIsLoading] = useState(canFetch);
+const useTrustedDeviceOptIn = (isEnabled = true) => {
+  const flowState = useMfaFlowState();
+  const availability = isDevFeaturesEnabled && isEnabled ? flowState?.trustedDevice : undefined;
   const [isChecked, setIsChecked] = useState(false);
-  const request = useApi(getInteraction, { silent: true });
 
   useEffect(() => {
-    setAvailability(undefined);
-    setIsLoading(canFetch);
     setIsChecked(false);
-
-    // Trusted-device opt-in stays isolated from released Experience flows until launch.
-    if (!canFetch) {
-      return;
-    }
-
-    const controller = new AbortController();
-
-    void (async () => {
-      const [, result] = await request(controller.signal);
-
-      if (!controller.signal.aborted) {
-        setAvailability(result?.trustedDevice);
-        setIsLoading(false);
-      }
-    })();
-
-    return () => {
-      controller.abort();
-    };
-  }, [canFetch, request]);
+  }, [availability?.canCreate, availability?.durationDays]);
 
   const isVisible = Boolean(availability?.canCreate && availability.durationDays);
 
   return {
     availability,
-    isLoading,
+    isLoading: false,
     isVisible,
     isChecked,
     setIsChecked,

--- a/packages/experience/src/pages/MfaBinding/TotpBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/TotpBinding/index.tsx
@@ -12,7 +12,7 @@ import useSkipMfa from '@/hooks/use-skip-mfa';
 import useSkipOptionalMfa from '@/hooks/use-skip-optional-mfa';
 import ErrorPage from '@/pages/ErrorPage';
 import { UserMfaFlow } from '@/types';
-import { type MfaFlowState, totpBindingStateGuard } from '@/types/guard';
+import { totpBindingStateGuard } from '@/types/guard';
 
 import SecretSection from './SecretSection';
 import VerificationSection from './VerificationSection';
@@ -31,20 +31,8 @@ const TotpBinding = () => {
     return <ErrorPage title="error.invalid_session" />;
   }
 
-  const {
-    availableFactors,
-    skippable,
-    suggestion,
-    maskedIdentifiers,
-    isWebAuthnUsedAsSignInPasskey,
-  } = totpBindingState;
-  const mfaFlowState: MfaFlowState = {
-    availableFactors,
-    skippable,
-    suggestion,
-    maskedIdentifiers,
-    isWebAuthnUsedAsSignInPasskey,
-  };
+  const { secret: _secret, secretQrCode: _secretQrCode, ...mfaFlowState } = totpBindingState;
+  const { availableFactors, skippable, suggestion } = mfaFlowState;
 
   return (
     <SecondaryPageLayout

--- a/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
@@ -15,7 +15,7 @@ import useWebAuthnOperation from '@/hooks/use-webauthn-operation';
 import ErrorPage from '@/pages/ErrorPage';
 import Button from '@/shared/components/Button';
 import { UserMfaFlow } from '@/types';
-import { type MfaFlowState, webAuthnStateGuard } from '@/types/guard';
+import { webAuthnStateGuard } from '@/types/guard';
 import { isWebAuthnOptions } from '@/utils/webauthn';
 
 import styles from './index.module.scss';
@@ -40,21 +40,8 @@ const WebAuthnBinding = () => {
     return <ErrorPage title="error.invalid_session" />;
   }
 
-  const {
-    options,
-    availableFactors,
-    skippable,
-    suggestion,
-    maskedIdentifiers,
-    isWebAuthnUsedAsSignInPasskey,
-  } = webAuthnState;
-  const mfaFlowState: MfaFlowState = {
-    availableFactors,
-    skippable,
-    suggestion,
-    maskedIdentifiers,
-    isWebAuthnUsedAsSignInPasskey,
-  };
+  const { options, ...mfaFlowState } = webAuthnState;
+  const { availableFactors, skippable, suggestion } = mfaFlowState;
 
   if (!isWebAuthnOptions(options)) {
     return <ErrorPage title="error.invalid_session" />;

--- a/packages/experience/src/pages/MfaVerification/WebAuthnVerification/index.tsx
+++ b/packages/experience/src/pages/MfaVerification/WebAuthnVerification/index.tsx
@@ -36,7 +36,7 @@ const WebAuthnVerification = () => {
     return <ErrorPage title="error.invalid_session" />;
   }
 
-  const { options, availableFactors, skippable } = webAuthnState;
+  const { options, ...flowState } = webAuthnState;
 
   if (!isWebAuthnOptions(options)) {
     return <ErrorPage title="error.invalid_session" />;
@@ -66,10 +66,7 @@ const WebAuthnVerification = () => {
           }}
         />
       </SectionLayout>
-      <SwitchMfaFactorsLink
-        flow={UserMfaFlow.MfaVerification}
-        flowState={{ availableFactors, skippable }}
-      />
+      <SwitchMfaFactorsLink flow={UserMfaFlow.MfaVerification} flowState={flowState} />
     </SecondaryPageLayout>
   );
 };

--- a/packages/experience/src/types/guard.test.ts
+++ b/packages/experience/src/types/guard.test.ts
@@ -1,7 +1,7 @@
 import { MfaFactor, VerificationType } from '@logto/schemas';
 import * as s from 'superstruct';
 
-import { mfaErrorDataGuard, verificationIdsMapGuard } from './guard';
+import { mfaErrorDataGuard, mfaFlowStateGuard, verificationIdsMapGuard } from './guard';
 
 describe('guard', () => {
   it.each(Object.values(VerificationType))('verificationIdsMapGuard: %s', (type) => {
@@ -41,6 +41,19 @@ describe('guard', () => {
         },
         mfaErrorDataGuard
       );
+    }).not.toThrow();
+  });
+
+  it('mfaFlowStateGuard should accept page-specific route state', () => {
+    const state = {
+      availableFactors: [MfaFactor.WebAuthn, MfaFactor.BackupCode],
+      maskedIdentifiers: {},
+      trustedDevice: { canCreate: true, durationDays: 365 },
+      options: { challenge: 'challenge' },
+    };
+
+    expect(() => {
+      s.assert(state, mfaFlowStateGuard);
     }).not.toThrow();
   });
 });

--- a/packages/experience/src/types/guard.test.ts
+++ b/packages/experience/src/types/guard.test.ts
@@ -37,6 +37,7 @@ describe('guard', () => {
           skippable: true,
           suggestion: true,
           isWebAuthnUsedAsSignInPasskey: true,
+          trustedDevice: { canCreate: true, durationDays: 30 },
         },
         mfaErrorDataGuard
       );

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -12,7 +12,7 @@ import * as s from 'superstruct';
 
 import { type IdentifierInputValue } from '@/shared/components/InputFields/SmartInputField';
 
-import { UserFlow } from '.';
+import { UserFlow, UserMfaFlow } from '.';
 
 export const userFlowGuard = s.enums([
   UserFlow.SignIn,
@@ -100,6 +100,11 @@ export const mfaFlowStateGuard = s.type({
 
 export type MfaFlowState = s.Infer<typeof mfaFlowStateGuard>;
 export type TrustedDeviceAvailability = s.Infer<typeof trustedDeviceAvailabilityGuard>;
+
+export const mfaBindingVerificationCodeStateGuard = s.type({
+  flow: s.literal(UserMfaFlow.MfaBinding),
+  mfaFlowState: mfaFlowStateGuard,
+});
 
 export const totpBindingStateGuard = s.assign(
   s.object({

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -74,19 +74,29 @@ const mfaFactorEnumValues = [
   MfaFactor.PhoneVerificationCode,
 ] as const;
 
+const trustedDeviceAvailabilityGuard = s.object({
+  canCreate: s.boolean(),
+  durationDays: s.optional(s.number()),
+});
+
 export const mfaErrorDataGuard = s.object({
-  availableFactors: mfaFactorsGuard,
+  availableFactors: s.optional(mfaFactorsGuard),
   skippable: s.optional(s.boolean()),
   maskedIdentifiers: s.optional(s.record(s.enums(mfaFactorEnumValues), s.string())),
   // Whether this MFA flow is an optional suggestion (e.g., add another factor after sign-up)
   suggestion: s.optional(s.boolean()),
   // Whether the current WebAuthn factor is used as a sign-in passkey.
   isWebAuthnUsedAsSignInPasskey: s.optional(s.boolean()),
+  trustedDevice: s.optional(trustedDeviceAvailabilityGuard),
 });
 
-export const mfaFlowStateGuard = mfaErrorDataGuard;
+export const mfaFlowStateGuard = s.assign(
+  mfaErrorDataGuard,
+  s.object({ availableFactors: mfaFactorsGuard })
+);
 
 export type MfaFlowState = s.Infer<typeof mfaFlowStateGuard>;
+export type TrustedDeviceAvailability = s.Infer<typeof trustedDeviceAvailabilityGuard>;
 
 export const totpBindingStateGuard = s.assign(
   s.object({

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -79,7 +79,7 @@ const trustedDeviceAvailabilityGuard = s.object({
   durationDays: s.optional(s.number()),
 });
 
-export const mfaErrorDataGuard = s.object({
+const mfaErrorDataShape = {
   availableFactors: s.optional(mfaFactorsGuard),
   skippable: s.optional(s.boolean()),
   maskedIdentifiers: s.optional(s.record(s.enums(mfaFactorEnumValues), s.string())),
@@ -88,12 +88,15 @@ export const mfaErrorDataGuard = s.object({
   // Whether the current WebAuthn factor is used as a sign-in passkey.
   isWebAuthnUsedAsSignInPasskey: s.optional(s.boolean()),
   trustedDevice: s.optional(trustedDeviceAvailabilityGuard),
-});
+};
 
-export const mfaFlowStateGuard = s.assign(
-  mfaErrorDataGuard,
-  s.object({ availableFactors: mfaFactorsGuard })
-);
+export const mfaErrorDataGuard = s.object(mfaErrorDataShape);
+
+// MFA route state can include page-specific fields such as WebAuthn options or TOTP secrets.
+export const mfaFlowStateGuard = s.type({
+  ...mfaErrorDataShape,
+  availableFactors: mfaFactorsGuard,
+});
 
 export type MfaFlowState = s.Infer<typeof mfaFlowStateGuard>;
 export type TrustedDeviceAvailability = s.Infer<typeof trustedDeviceAvailabilityGuard>;

--- a/packages/integration-tests/src/tests/api/account/trusted-device.test.ts
+++ b/packages/integration-tests/src/tests/api/account/trusted-device.test.ts
@@ -43,7 +43,7 @@ const getTrustedDeviceCookieName = (userId: string) => {
     .update(`${defaultTenantId}:${userId}`)
     .digest('base64url');
 
-  return `__Host-logto-trusted-device-${subjectHash}`;
+  return `logto-trusted-device-${subjectHash}`;
 };
 
 const createCredential = (id: string) => {
@@ -58,7 +58,6 @@ const buildApiWithCredential = (accessToken: string, userId: string, id: string,
     headers: {
       Authorization: `Bearer ${accessToken}`,
       Cookie: `${getTrustedDeviceCookieName(userId)}=${id}.${secret}`,
-      'X-Forwarded-Proto': 'https',
     },
   });
 

--- a/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
@@ -1,5 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInIdentifier } from '@logto/schemas';
+import { MfaFactor, SignInIdentifier } from '@logto/schemas';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -8,7 +8,13 @@ import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connecto
 import { enableMandatoryMfaWithEmail, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
-import { generateEmail, generatePassword, generateUsername, waitFor } from '#src/utils.js';
+import {
+  devFeatureTest,
+  generateEmail,
+  generatePassword,
+  generateUsername,
+  waitFor,
+} from '#src/utils.js';
 
 describe('email MFA binding', () => {
   beforeAll(async () => {
@@ -79,5 +85,69 @@ describe('email MFA binding', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('creates a trusted device from email MFA binding and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.EmailVerificationCode}`);
+      await experience.toFillInput('identifier', generateEmail(), { submit: true });
+      await experience.toOptInTrustedDevice();
+      await experience.toCompleteVerification('continue', ConnectorType.Email);
+      await experience.toClickButton('Continue');
+      await experience.verifyThenEnd(false);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('creates a trusted device from email MFA verification and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({
+        username: true,
+        password: true,
+        primaryEmail: true,
+      });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.EmailVerificationCode}`);
+      await experience.toOptInTrustedDevice();
+      await experience.toCompleteMfaVerification(ConnectorType.Email, true);
+      await experience.verifyThenEnd(false);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
   });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
@@ -111,13 +111,16 @@ describe('email MFA binding', () => {
       await experience.toCompleteVerification('continue', ConnectorType.Email);
       await experience.toClickButton('Continue');
       await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
 
-      await experience.startWith(demoAppUrl, 'sign-in');
-      await experience.toFillForm(
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
         { identifier: userProfile.username, password: userProfile.password },
         { submit: true }
       );
-      await experience.verifyThenEnd();
+      await trustedDeviceExperience.verifyThenEnd();
 
       await deleteUser(user.id);
     });
@@ -139,13 +142,16 @@ describe('email MFA binding', () => {
       await experience.toOptInTrustedDevice();
       await experience.toCompleteMfaVerification(ConnectorType.Email, true);
       await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
 
-      await experience.startWith(demoAppUrl, 'sign-in');
-      await experience.toFillForm(
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
         { identifier: userProfile.username, password: userProfile.password },
         { submit: true }
       );
-      await experience.verifyThenEnd();
+      await trustedDeviceExperience.verifyThenEnd();
 
       await deleteUser(user.id);
     });

--- a/packages/integration-tests/src/tests/experience/mfa/multi-factors.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/multi-factors.test.ts
@@ -8,7 +8,7 @@ import { clearConnectorsByTypes, setSocialConnector } from '#src/helpers/connect
 import { resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectWebAuthnExperience from '#src/ui-helpers/expect-webauthn-experience.js';
-import { waitFor } from '#src/utils.js';
+import { devFeatureTest, waitFor } from '#src/utils.js';
 
 describe('MFA - Multi factors', () => {
   beforeAll(async () => {
@@ -108,5 +108,68 @@ describe('MFA - Multi factors', () => {
     await experience.clearVirtualAuthenticator();
     await experience.verifyThenEnd();
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in after switching factors', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('keeps trusted-device availability across binding and verification factor switches', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt('mfa-binding');
+
+      await experience.toClick('button div[class$=name]', 'Authenticator app OTP');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.TOTP}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toClickSwitchFactorsLink({ isBinding: true });
+
+      await experience.toClick('button div[class$=name]', 'Passkey');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.WebAuthn}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toClickSwitchFactorsLink({ isBinding: true });
+
+      await experience.toClick('button div[class$=name]', 'Authenticator app OTP');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.TOTP}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toClickSwitchFactorsLink({ isBinding: true });
+
+      await experience.toClick('button div[class$=name]', 'Passkey');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.WebAuthn}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toCreatePasskey();
+      await experience.toClickButton('Continue');
+      await experience.verifyThenEnd(false);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.WebAuthn}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toClickSwitchFactorsLink({ isBinding: false });
+
+      await experience.toClick('button div[class$=name]', 'Passkey');
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.WebAuthn}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toVerifyViaPasskey();
+
+      await experience.clearVirtualAuthenticator();
+      await experience.verifyThenEnd();
+      await deleteUser(user.id);
+    });
   });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
@@ -1,5 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInIdentifier } from '@logto/schemas';
+import { MfaFactor, SignInIdentifier } from '@logto/schemas';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -8,7 +8,13 @@ import { clearConnectorsByTypes, setSmsConnector } from '#src/helpers/connector.
 import { enableMandatoryMfaWithPhone, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
-import { generatePhone, generatePassword, generateUsername, waitFor } from '#src/utils.js';
+import {
+  devFeatureTest,
+  generatePhone,
+  generatePassword,
+  generateUsername,
+  waitFor,
+} from '#src/utils.js';
 
 describe('phone MFA binding', () => {
   beforeAll(async () => {
@@ -79,5 +85,69 @@ describe('phone MFA binding', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('creates a trusted device from phone MFA binding and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.PhoneVerificationCode}`);
+      await experience.toFillInput('identifier', generatePhone(), { submit: true });
+      await experience.toOptInTrustedDevice();
+      await experience.toCompleteVerification('continue', ConnectorType.Sms);
+      await experience.toClickButton('Continue');
+      await experience.verifyThenEnd(false);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('creates a trusted device from phone MFA verification and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({
+        username: true,
+        password: true,
+        primaryPhone: true,
+      });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.PhoneVerificationCode}`);
+      await experience.toOptInTrustedDevice();
+      await experience.toCompleteMfaVerification(ConnectorType.Sms, true);
+      await experience.verifyThenEnd(false);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
   });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
@@ -111,13 +111,16 @@ describe('phone MFA binding', () => {
       await experience.toCompleteVerification('continue', ConnectorType.Sms);
       await experience.toClickButton('Continue');
       await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
 
-      await experience.startWith(demoAppUrl, 'sign-in');
-      await experience.toFillForm(
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
         { identifier: userProfile.username, password: userProfile.password },
         { submit: true }
       );
-      await experience.verifyThenEnd();
+      await trustedDeviceExperience.verifyThenEnd();
 
       await deleteUser(user.id);
     });
@@ -139,13 +142,16 @@ describe('phone MFA binding', () => {
       await experience.toOptInTrustedDevice();
       await experience.toCompleteMfaVerification(ConnectorType.Sms, true);
       await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
 
-      await experience.startWith(demoAppUrl, 'sign-in');
-      await experience.toFillForm(
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
         { identifier: userProfile.username, password: userProfile.password },
         { submit: true }
       );
-      await experience.verifyThenEnd();
+      await trustedDeviceExperience.verifyThenEnd();
 
       await deleteUser(user.id);
     });

--- a/packages/integration-tests/src/tests/experience/mfa/totp/password-identifier-flow.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/totp/password-identifier-flow.test.ts
@@ -1,6 +1,6 @@
-import { ConnectorType, SignInIdentifier } from '@logto/schemas';
+import { ConnectorType, MfaFactor, SignInIdentifier } from '@logto/schemas';
 
-import { deleteUser } from '#src/api/admin-user.js';
+import { createUserMfaVerification, deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { demoAppUrl } from '#src/constants.js';
 import { clearConnectorsByTypes } from '#src/helpers/connector.js';
@@ -11,7 +11,7 @@ import {
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectTotpExperience from '#src/ui-helpers/expect-totp-experience.js';
-import { generateUsername } from '#src/utils.js';
+import { devFeatureTest, generateUsername } from '#src/utils.js';
 
 import TotpTestingContext from './totp-testing-context.js';
 
@@ -108,6 +108,69 @@ describe('MFA - TOTP', () => {
 
       // Clean up
       await deleteUser(user.id);
+    });
+
+    devFeatureTest.describe('trusted device opt-in', () => {
+      beforeAll(async () => {
+        await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+      });
+
+      afterAll(async () => {
+        await updateSignInExperience({ trustedDevice: { enabled: false } });
+      });
+
+      it('creates a trusted device from TOTP binding and skips MFA on the next sign-in', async () => {
+        const { userProfile, user } = await generateNewUser({ username: true, password: true });
+        const experience = new ExpectTotpExperience(await browser.newPage());
+
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.waitToBeAt(`mfa-binding/${MfaFactor.TOTP}`);
+        await experience.toOptInTrustedDevice();
+        await experience.toBindTotp(true, true);
+        await experience.verifyThenEnd(false);
+
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.verifyThenEnd();
+
+        await deleteUser(user.id);
+      });
+
+      it('creates a trusted device from TOTP verification and skips MFA on the next sign-in', async () => {
+        const { userProfile, user } = await generateNewUser({ username: true, password: true });
+        const verification = await createUserMfaVerification(user.id, MfaFactor.TOTP);
+
+        if (verification.type !== MfaFactor.TOTP) {
+          throw new Error('unexpected MFA verification type');
+        }
+
+        const experience = new ExpectTotpExperience(await browser.newPage());
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.waitToBeAt(`mfa-verification/${MfaFactor.TOTP}`);
+        await experience.toOptInTrustedDevice();
+        await experience.toVerifyTotp(verification.secret, true, true);
+        await experience.verifyThenEnd(false);
+
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.verifyThenEnd();
+
+        await deleteUser(user.id);
+      });
     });
   });
 

--- a/packages/integration-tests/src/tests/experience/mfa/totp/password-identifier-flow.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/totp/password-identifier-flow.test.ts
@@ -132,13 +132,16 @@ describe('MFA - TOTP', () => {
         await experience.toOptInTrustedDevice();
         await experience.toBindTotp(true, true);
         await experience.verifyThenEnd(false);
+        await experience.clearDemoAppSession();
+        await experience.page.close();
+        const trustedDeviceExperience = new ExpectTotpExperience(await browser.newPage());
 
-        await experience.startWith(demoAppUrl, 'sign-in');
-        await experience.toFillForm(
+        await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+        await trustedDeviceExperience.toFillForm(
           { identifier: userProfile.username, password: userProfile.password },
           { submit: true }
         );
-        await experience.verifyThenEnd();
+        await trustedDeviceExperience.verifyThenEnd();
 
         await deleteUser(user.id);
       });
@@ -161,13 +164,16 @@ describe('MFA - TOTP', () => {
         await experience.toOptInTrustedDevice();
         await experience.toVerifyTotp(verification.secret, true, true);
         await experience.verifyThenEnd(false);
+        await experience.clearDemoAppSession();
+        await experience.page.close();
+        const trustedDeviceExperience = new ExpectTotpExperience(await browser.newPage());
 
-        await experience.startWith(demoAppUrl, 'sign-in');
-        await experience.toFillForm(
+        await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+        await trustedDeviceExperience.toFillForm(
           { identifier: userProfile.username, password: userProfile.password },
           { submit: true }
         );
-        await experience.verifyThenEnd();
+        await trustedDeviceExperience.verifyThenEnd();
 
         await deleteUser(user.id);
       });

--- a/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
@@ -128,14 +128,17 @@ describe('MFA - WebAuthn', () => {
       await experience.toOptInTrustedDevice();
       await experience.toCreatePasskey();
       await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
       await experience.clearVirtualAuthenticator();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectWebAuthnExperience(await browser.newPage());
 
-      await experience.startWith(demoAppUrl, 'sign-in');
-      await experience.toFillForm(
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
         { identifier: userProfile.username, password: userProfile.password },
         { submit: true }
       );
-      await experience.verifyThenEnd();
+      await trustedDeviceExperience.verifyThenEnd();
 
       await deleteUser(user.id);
     });
@@ -162,17 +165,20 @@ describe('MFA - WebAuthn', () => {
       await experience.toOptInTrustedDevice();
       await experience.toVerifyViaPasskey();
       await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
       await experience.clearVirtualAuthenticator();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectWebAuthnExperience(await browser.newPage());
 
-      await experience.startWith(demoAppUrl, 'sign-in');
-      await experience.toFillForm(
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
         { identifier: userProfile.username, password: userProfile.password },
         { submit: true }
       );
-      await experience.verifyThenEnd();
+      await trustedDeviceExperience.verifyThenEnd();
 
       await deleteUser(user.id);
-    });
+    }, 90_000);
   });
 });
 

--- a/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
@@ -10,7 +10,7 @@ import {
 } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { SsoConnectorApi } from '#src/api/sso-connector.js';
-import { demoAppUrl, isDevFeaturesEnabled } from '#src/constants.js';
+import { demoAppUrl } from '#src/constants.js';
 import { clearConnectorsByTypes } from '#src/helpers/connector.js';
 import { signInWithEnterpriseSso } from '#src/helpers/experience/index.js';
 import {
@@ -20,7 +20,7 @@ import {
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectWebAuthnExperience from '#src/ui-helpers/expect-webauthn-experience.js';
-import { generateUsername, waitFor } from '#src/utils.js';
+import { devFeatureTest, generateUsername, waitFor } from '#src/utils.js';
 
 describe('MFA - WebAuthn', () => {
   beforeAll(async () => {
@@ -44,22 +44,10 @@ describe('MFA - WebAuthn', () => {
       },
       forgotPasswordMethods: [],
     });
-
-    if (isDevFeaturesEnabled) {
-      await updateSignInExperience({
-        trustedDevice: { enabled: true, durationDays: 365 },
-      });
-    }
   });
 
   afterAll(async () => {
     await resetMfaSettings();
-
-    if (isDevFeaturesEnabled) {
-      await updateSignInExperience({
-        trustedDevice: { enabled: false },
-      });
-    }
   });
 
   it('should bind WebAuthn when registering and verify WebAuthn when signing in', async () => {
@@ -85,12 +73,6 @@ describe('MFA - WebAuthn', () => {
     );
     // Wait for the page to process submitting request.
     await waitFor(500);
-
-    if (isDevFeaturesEnabled) {
-      await experience.toMatchElement('div[role=checkbox][aria-checked=false]', {
-        text: 'Trust this device for 365 days',
-      });
-    }
 
     await experience.toVerifyViaPasskey();
 
@@ -121,6 +103,76 @@ describe('MFA - WebAuthn', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('creates a trusted device from WebAuthn binding and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.WebAuthn}`);
+      await experience.toOptInTrustedDevice();
+      await experience.toCreatePasskey();
+      await experience.verifyThenEnd(false);
+      await experience.clearVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('creates a trusted device from WebAuthn verification and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.toCreatePasskey();
+      await experience.verifyThenEnd(false);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.WebAuthn}`);
+      await experience.toOptInTrustedDevice();
+      await experience.toVerifyViaPasskey();
+      await experience.verifyThenEnd(false);
+      await experience.clearVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
   });
 });
 

--- a/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
@@ -10,7 +10,7 @@ import {
 } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { SsoConnectorApi } from '#src/api/sso-connector.js';
-import { demoAppUrl } from '#src/constants.js';
+import { demoAppUrl, isDevFeaturesEnabled } from '#src/constants.js';
 import { clearConnectorsByTypes } from '#src/helpers/connector.js';
 import { signInWithEnterpriseSso } from '#src/helpers/experience/index.js';
 import {
@@ -44,10 +44,22 @@ describe('MFA - WebAuthn', () => {
       },
       forgotPasswordMethods: [],
     });
+
+    if (isDevFeaturesEnabled) {
+      await updateSignInExperience({
+        trustedDevice: { enabled: true, durationDays: 365 },
+      });
+    }
   });
 
   afterAll(async () => {
     await resetMfaSettings();
+
+    if (isDevFeaturesEnabled) {
+      await updateSignInExperience({
+        trustedDevice: { enabled: false },
+      });
+    }
   });
 
   it('should bind WebAuthn when registering and verify WebAuthn when signing in', async () => {
@@ -73,6 +85,13 @@ describe('MFA - WebAuthn', () => {
     );
     // Wait for the page to process submitting request.
     await waitFor(500);
+
+    if (isDevFeaturesEnabled) {
+      await experience.toMatchElement('div[role=checkbox][aria-checked=false]', {
+        text: 'Trust this device for 365 days',
+      });
+    }
+
     await experience.toVerifyViaPasskey();
 
     await experience.clearVirtualAuthenticator();

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -188,6 +188,22 @@ export default class ExpectExperience extends ExpectPage {
     }
   }
 
+  async toCompleteMfaVerification(
+    connectorType: Parameters<typeof readConnectorMessage>['0'],
+    submitManually = false
+  ) {
+    const { code } = await readConnectorMessage(connectorType);
+
+    for (const [index, char] of code.split('').entries()) {
+      // eslint-disable-next-line no-await-in-loop -- verification inputs must be filled in order
+      await this.toFillInput(`mfaCode_${index}`, char);
+    }
+
+    if (submitManually) {
+      await this.toClickButton('Continue');
+    }
+  }
+
   /**
    * Fill the password form inputs with the given passwords. If forgot password flow is enabled,
    * only the `newPassword` input will be filled; otherwise, both `newPassword` and `confirmPassword`
@@ -261,6 +277,13 @@ export default class ExpectExperience extends ExpectPage {
    */
   async waitForToast(text: string | RegExp) {
     return this.toMatchAndRemove('div[role=toast]', text);
+  }
+
+  async toOptInTrustedDevice(durationDays = 365) {
+    const text = `Trust this device for ${durationDays} days`;
+    await this.toMatchElement('div[role=checkbox][aria-checked=false]', { text });
+    await this.toClick('div[role=checkbox]', text, false);
+    await this.toMatchElement('div[role=checkbox][aria-checked=true]', { text });
   }
 
   /**

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -279,9 +279,14 @@ export default class ExpectExperience extends ExpectPage {
     return this.toMatchAndRemove('div[role=toast]', text);
   }
 
-  async toOptInTrustedDevice(durationDays = 365) {
+  async toSeeTrustedDeviceOptIn(durationDays = 365) {
     const text = `Trust this device for ${durationDays} days`;
     await this.toMatchElement('div[role=checkbox][aria-checked=false]', { text });
+  }
+
+  async toOptInTrustedDevice(durationDays = 365) {
+    const text = `Trust this device for ${durationDays} days`;
+    await this.toSeeTrustedDeviceOptIn(durationDays);
     await this.toClick('div[role=checkbox]', text, false);
     await this.toMatchElement('div[role=checkbox][aria-checked=true]', { text });
   }

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -1,6 +1,5 @@
 import { demoAppApplicationId, type MfaFactor } from '@logto/schemas';
 import { appendPath } from '@silverhand/essentials';
-import { type CDPSession, type Protocol } from 'puppeteer';
 
 import { logtoUrl, mockSocialAuthPageUrl } from '#src/constants.js';
 import { readConnectorMessage } from '#src/helpers/index.js';
@@ -68,7 +67,6 @@ export default class ExpectExperience extends ExpectPage {
   }
 
   #ongoing?: OngoingExperience;
-  #tlsTerminationClient?: CDPSession;
 
   constructor(thePage = global.page, options: ExpectExperienceOptions = {}) {
     super(thePage);
@@ -130,8 +128,6 @@ export default class ExpectExperience extends ExpectPage {
     }
 
     await this.waitForUrl(this.#ongoing.initialUrl);
-
-    await this.#stopTlsTerminationSimulation();
 
     await this.toClick('div[role=button]', /sign out/i);
 
@@ -308,11 +304,6 @@ export default class ExpectExperience extends ExpectPage {
   async toOptInTrustedDevice(durationDays = 365) {
     const text = `Trust this device for ${durationDays} days`;
     await this.toSeeTrustedDeviceOptIn(durationDays);
-    // Integration tests run the production build over HTTP while Logto trusts proxy headers.
-    // Simulate TLS termination only for the interaction submit request so Koa can emit the
-    // production-only Secure credential cookie without affecting WebAuthn ceremonies, document
-    // navigation, or the demo app's authorization-code exchange.
-    await this.#startTlsTerminationSimulation();
     await this.toClick('div[role=checkbox]', text, false);
     await this.toMatchElement('div[role=checkbox][aria-checked=true]', { text });
   }
@@ -449,43 +440,5 @@ export default class ExpectExperience extends ExpectPage {
     return this.throwError(
       'The experience has not started yet. Use `startWith` to start the experience.'
     );
-  }
-
-  async #startTlsTerminationSimulation() {
-    if (this.#tlsTerminationClient) {
-      return;
-    }
-
-    const client = await this.page.target().createCDPSession();
-    const handler = async ({ requestId, request }: Protocol.Fetch.RequestPausedEvent) => {
-      const headers = Object.entries(request.headers)
-        .filter(([name]) => name.toLowerCase() !== 'x-forwarded-proto')
-        .map(([name, value]) => ({ name, value: String(value) }));
-
-      await client.send('Fetch.continueRequest', {
-        requestId,
-        headers: [...headers, { name: 'X-Forwarded-Proto', value: 'https' }],
-      });
-    };
-
-    this.#tlsTerminationClient = client;
-    client.on('Fetch.requestPaused', handler);
-    await client.send('Fetch.enable', {
-      patterns: [{ urlPattern: `${logtoUrl}/api/experience/submit*`, requestStage: 'Request' }],
-    });
-  }
-
-  async #stopTlsTerminationSimulation() {
-    const client = this.#tlsTerminationClient;
-
-    if (!client) {
-      return;
-    }
-
-    await client.send('Fetch.disable');
-    client.removeAllListeners('Fetch.requestPaused');
-    // Leave this page-scoped session attached until the page closes. Detaching it also tears down
-    // the virtual authenticator environment enabled by WebAuthn integration tests on this target.
-    this.#tlsTerminationClient = undefined;
   }
 }

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -1,5 +1,6 @@
 import { demoAppApplicationId, type MfaFactor } from '@logto/schemas';
 import { appendPath } from '@silverhand/essentials';
+import { type HTTPRequest } from 'puppeteer';
 
 import { logtoUrl, mockSocialAuthPageUrl } from '#src/constants.js';
 import { readConnectorMessage } from '#src/helpers/index.js';
@@ -14,6 +15,16 @@ const defaultUrlWaitTimeout = 30_000;
 
 /** Remove the query string together with the `?` from a URL string. */
 const stripQuery = (url: string) => url.split('?')[0];
+
+const tlsTerminationRequestHandler = async (request: HTTPRequest) => {
+  const isApiRequest = request.resourceType() === 'fetch' || request.resourceType() === 'xhr';
+  await request.continue({
+    headers: {
+      ...request.headers(),
+      ...(isApiRequest && { 'X-Forwarded-Proto': 'https' }),
+    },
+  });
+};
 
 export type ExperienceType = 'sign-in' | 'register' | 'continue' | 'forgot-password';
 
@@ -67,7 +78,7 @@ export default class ExpectExperience extends ExpectPage {
   }
 
   #ongoing?: OngoingExperience;
-  #isTlsTerminationSimulated = false;
+  #tlsTerminationRequestHandler?: (request: HTTPRequest) => Promise<void>;
 
   constructor(thePage = global.page, options: ExpectExperienceOptions = {}) {
     super(thePage);
@@ -130,10 +141,7 @@ export default class ExpectExperience extends ExpectPage {
 
     await this.waitForUrl(this.#ongoing.initialUrl);
 
-    if (this.#isTlsTerminationSimulated) {
-      await this.page.setExtraHTTPHeaders({});
-      this.#isTlsTerminationSimulated = false;
-    }
+    await this.#stopTlsTerminationSimulation();
 
     await this.toClick('div[role=button]', /sign out/i);
 
@@ -310,9 +318,9 @@ export default class ExpectExperience extends ExpectPage {
     const text = `Trust this device for ${durationDays} days`;
     await this.toSeeTrustedDeviceOptIn(durationDays);
     // Integration tests run the production build over HTTP while Logto trusts proxy headers.
-    // Simulate TLS termination so Koa can emit the production-only Secure credential cookie.
-    await this.page.setExtraHTTPHeaders({ 'X-Forwarded-Proto': 'https' });
-    this.#isTlsTerminationSimulated = true;
+    // Simulate TLS termination only for API calls so Koa can emit the production-only Secure
+    // credential cookie without turning the following HTTP document navigation into HTTPS.
+    await this.#startTlsTerminationSimulation();
     await this.toClick('div[role=checkbox]', text, false);
     await this.toMatchElement('div[role=checkbox][aria-checked=true]', { text });
   }
@@ -449,5 +457,28 @@ export default class ExpectExperience extends ExpectPage {
     return this.throwError(
       'The experience has not started yet. Use `startWith` to start the experience.'
     );
+  }
+
+  async #startTlsTerminationSimulation() {
+    if (this.#tlsTerminationRequestHandler) {
+      return;
+    }
+
+    await this.page.setRequestInterception(true);
+    const handler = tlsTerminationRequestHandler;
+    this.#tlsTerminationRequestHandler = handler;
+    this.page.on('request', handler);
+  }
+
+  async #stopTlsTerminationSimulation() {
+    const handler = this.#tlsTerminationRequestHandler;
+
+    if (!handler) {
+      return;
+    }
+
+    await this.page.setRequestInterception(false);
+    this.page.off('request', handler);
+    this.#tlsTerminationRequestHandler = undefined;
   }
 }

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -1,6 +1,6 @@
 import { demoAppApplicationId, type MfaFactor } from '@logto/schemas';
 import { appendPath } from '@silverhand/essentials';
-import { type HTTPRequest } from 'puppeteer';
+import { type CDPSession, type Protocol } from 'puppeteer';
 
 import { logtoUrl, mockSocialAuthPageUrl } from '#src/constants.js';
 import { readConnectorMessage } from '#src/helpers/index.js';
@@ -15,16 +15,6 @@ const defaultUrlWaitTimeout = 30_000;
 
 /** Remove the query string together with the `?` from a URL string. */
 const stripQuery = (url: string) => url.split('?')[0];
-
-const tlsTerminationRequestHandler = async (request: HTTPRequest) => {
-  const isApiRequest = request.resourceType() === 'fetch' || request.resourceType() === 'xhr';
-  await request.continue({
-    headers: {
-      ...request.headers(),
-      ...(isApiRequest && { 'X-Forwarded-Proto': 'https' }),
-    },
-  });
-};
 
 export type ExperienceType = 'sign-in' | 'register' | 'continue' | 'forgot-password';
 
@@ -78,7 +68,7 @@ export default class ExpectExperience extends ExpectPage {
   }
 
   #ongoing?: OngoingExperience;
-  #tlsTerminationRequestHandler?: (request: HTTPRequest) => Promise<void>;
+  #tlsTerminationClient?: CDPSession;
 
   constructor(thePage = global.page, options: ExpectExperienceOptions = {}) {
     super(thePage);
@@ -160,7 +150,8 @@ export default class ExpectExperience extends ExpectPage {
       localStorage.clear();
       sessionStorage.clear();
     });
-    const cookies = await this.page.cookies();
+    const cookies = await this.page.cookies(logtoUrl);
+    expect(cookies.some(({ name }) => name.includes('logto-trusted-device-'))).toBe(true);
     const sessionCookies = cookies.filter(({ name }) => !name.includes('logto-trusted-device-'));
     await this.page.deleteCookie(...sessionCookies);
     await this.page.goto('about:blank');
@@ -318,8 +309,9 @@ export default class ExpectExperience extends ExpectPage {
     const text = `Trust this device for ${durationDays} days`;
     await this.toSeeTrustedDeviceOptIn(durationDays);
     // Integration tests run the production build over HTTP while Logto trusts proxy headers.
-    // Simulate TLS termination only for API calls so Koa can emit the production-only Secure
-    // credential cookie without turning the following HTTP document navigation into HTTPS.
+    // Simulate TLS termination only for the interaction submit request so Koa can emit the
+    // production-only Secure credential cookie without affecting WebAuthn ceremonies, document
+    // navigation, or the demo app's authorization-code exchange.
     await this.#startTlsTerminationSimulation();
     await this.toClick('div[role=checkbox]', text, false);
     await this.toMatchElement('div[role=checkbox][aria-checked=true]', { text });
@@ -460,25 +452,40 @@ export default class ExpectExperience extends ExpectPage {
   }
 
   async #startTlsTerminationSimulation() {
-    if (this.#tlsTerminationRequestHandler) {
+    if (this.#tlsTerminationClient) {
       return;
     }
 
-    await this.page.setRequestInterception(true);
-    const handler = tlsTerminationRequestHandler;
-    this.#tlsTerminationRequestHandler = handler;
-    this.page.on('request', handler);
+    const client = await this.page.target().createCDPSession();
+    const handler = async ({ requestId, request }: Protocol.Fetch.RequestPausedEvent) => {
+      const headers = Object.entries(request.headers)
+        .filter(([name]) => name.toLowerCase() !== 'x-forwarded-proto')
+        .map(([name, value]) => ({ name, value: String(value) }));
+
+      await client.send('Fetch.continueRequest', {
+        requestId,
+        headers: [...headers, { name: 'X-Forwarded-Proto', value: 'https' }],
+      });
+    };
+
+    this.#tlsTerminationClient = client;
+    client.on('Fetch.requestPaused', handler);
+    await client.send('Fetch.enable', {
+      patterns: [{ urlPattern: `${logtoUrl}/api/experience/submit*`, requestStage: 'Request' }],
+    });
   }
 
   async #stopTlsTerminationSimulation() {
-    const handler = this.#tlsTerminationRequestHandler;
+    const client = this.#tlsTerminationClient;
 
-    if (!handler) {
+    if (!client) {
       return;
     }
 
-    await this.page.setRequestInterception(false);
-    this.page.off('request', handler);
-    this.#tlsTerminationRequestHandler = undefined;
+    await client.send('Fetch.disable');
+    client.removeAllListeners('Fetch.requestPaused');
+    // Leave this page-scoped session attached until the page closes. Detaching it also tears down
+    // the virtual authenticator environment enabled by WebAuthn integration tests on this target.
+    this.#tlsTerminationClient = undefined;
   }
 }

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -67,6 +67,7 @@ export default class ExpectExperience extends ExpectPage {
   }
 
   #ongoing?: OngoingExperience;
+  #isTlsTerminationSimulated = false;
 
   constructor(thePage = global.page, options: ExpectExperienceOptions = {}) {
     super(thePage);
@@ -89,7 +90,7 @@ export default class ExpectExperience extends ExpectPage {
    */
   async startWith(initialUrl = demoAppUrl, type: ExperienceType = 'sign-in') {
     await this.toStart(initialUrl);
-    this.toBeAt('sign-in');
+    await this.waitToBeAt('sign-in');
 
     if (type === 'register') {
       await this.toClick('a', 'Create account');
@@ -128,12 +129,33 @@ export default class ExpectExperience extends ExpectPage {
     }
 
     await this.waitForUrl(this.#ongoing.initialUrl);
+
+    if (this.#isTlsTerminationSimulated) {
+      await this.page.setExtraHTTPHeaders({});
+      this.#isTlsTerminationSimulated = false;
+    }
+
     await this.toClick('div[role=button]', /sign out/i);
 
     this.#ongoing = undefined;
     if (closePage) {
       await this.page.close();
     }
+  }
+
+  /**
+   * Clear the demo app browser storage and session cookies while preserving the trusted-device
+   * credential under test. This guarantees the next visit starts a new sign-in interaction.
+   */
+  async clearDemoAppSession() {
+    await this.page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    const cookies = await this.page.cookies();
+    const sessionCookies = cookies.filter(({ name }) => !name.includes('logto-trusted-device-'));
+    await this.page.deleteCookie(...sessionCookies);
+    await this.page.goto('about:blank');
   }
 
   /**
@@ -287,6 +309,10 @@ export default class ExpectExperience extends ExpectPage {
   async toOptInTrustedDevice(durationDays = 365) {
     const text = `Trust this device for ${durationDays} days`;
     await this.toSeeTrustedDeviceOptIn(durationDays);
+    // Integration tests run the production build over HTTP while Logto trusts proxy headers.
+    // Simulate TLS termination so Koa can emit the production-only Secure credential cookie.
+    await this.page.setExtraHTTPHeaders({ 'X-Forwarded-Proto': 'https' });
+    this.#isTlsTerminationSimulated = true;
     await this.toClick('div[role=checkbox]', text, false);
     await this.toMatchElement('div[role=checkbox][aria-checked=true]', { text });
   }

--- a/packages/integration-tests/src/ui-helpers/expect-totp-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-totp-experience.ts
@@ -14,9 +14,10 @@ export default class ExpectTotpExperience extends ExpectMfaExperience {
    * generated from the TOTP secret.
    *
    * @param [signingInAfterBinding=true] Whether the flow will continue to sign in after the binding.
+   * @param [submitManually=false] Whether to click Continue after entering the code.
    * @returns The binding TOTP secret.
    */
-  async toBindTotp(signingInAfterBinding = true) {
+  async toBindTotp(signingInAfterBinding = true, submitManually = false) {
     await this.waitToBeAt('mfa-binding/Totp');
     // Expect the QR code rendered
     await expect(this.page).toMatchElement(`${dcls('qrCode')} img[src*="data:image"]`);
@@ -33,6 +34,10 @@ export default class ExpectTotpExperience extends ExpectMfaExperience {
 
     await this.fillTotpCode(code);
 
+    if (submitManually) {
+      await this.toClickButton('Continue', false);
+    }
+
     // Wait for the form to commit automatically
     await waitFor(500);
     if (signingInAfterBinding) {
@@ -48,13 +53,18 @@ export default class ExpectTotpExperience extends ExpectMfaExperience {
    *
    * @param secret The TOTP secret.
    * @param [signingInAfterVerification=true] Whether the flow will continue to sign in after the verification.
+   * @param [submitManually=false] Whether to click Continue after entering the code.
    */
-  async toVerifyTotp(secret: string, signingInAfterVerification = true) {
+  async toVerifyTotp(secret: string, signingInAfterVerification = true, submitManually = false) {
     await this.waitToBeAt('mfa-verification/Totp');
 
     const code = authenticator.generate(secret);
 
     await this.fillTotpCode(code);
+
+    if (submitManually) {
+      await this.toClickButton('Continue', false);
+    }
 
     // Wait for the form to commit automatically
     await waitFor(500);


### PR DESCRIPTION
## Summary

Pass trusted-device creation availability through the existing MFA error data for verification, missing-MFA, and suggested-MFA flows.

Reuse request-scoped policy and organization results on the server, and seed the built-in Experience opt-in UI from MFA router state instead of reading the interaction separately.

Keep trusted-device creation protected by server-side policy and MFA-proof validation.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments