### PR TITLE
fix(core,phrases): interpolate the rejected scope into OIDC scope error messages

### DIFF
--- a/.changeset/oidc-scope-error-message-interpolation.md
+++ b/.changeset/oidc-scope-error-message-interpolation.md
@@ -1,0 +1,8 @@
+---
+"@logto/core": patch
+"@logto/phrases": patch
+---
+
+fix OIDC scope error messages showing a raw placeholder instead of the rejected scope
+
+The `invalid_scope` and `insufficient_scope` messages rendered the literal `{{error_description}}` and `{{scope}}` text because the error handler never passed the values in. They now name the scope that was rejected, so an end user who hits a stale scope on the consent page no longer sees a placeholder in the error toast.

--- a/packages/core/src/middleware/koa-oidc-error-handler.test.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.test.ts
@@ -53,7 +53,17 @@ describe('koaOidcErrorHandler middleware', () => {
     const ctx = createContextWithRouteParameters();
     const error_description = 'Mock scope is invalid';
     const mockScope = 'read:foo';
-    await expectErrorResponse(ctx, new errors.InvalidScope(error_description, mockScope));
+    await expectErrorResponse(ctx, new errors.InvalidScope(error_description, mockScope), {
+      message: 'Invalid scope: read:foo.',
+    });
+  });
+
+  it('should not escape the interpolated scope', async () => {
+    const ctx = createContextWithRouteParameters();
+
+    await expectErrorResponse(ctx, new errors.InvalidScope('Mock scope is invalid', 'read:a&b'), {
+      message: 'Invalid scope: read:a&b.',
+    });
   });
 
   it('should transform session not found error code', async () => {
@@ -71,6 +81,7 @@ describe('koaOidcErrorHandler middleware', () => {
 
     await expectErrorResponse(ctx, new errors.InsufficientScope(error_description, scope), {
       scope,
+      message: 'Token missing scope `read:foo`.',
     });
   });
 

--- a/packages/core/src/middleware/koa-oidc-error-handler.ts
+++ b/packages/core/src/middleware/koa-oidc-error-handler.ts
@@ -124,6 +124,7 @@ export default function koaOidcErrorHandler<StateT, ContextT extends WithI18nCon
         .object({
           error: z.string(),
           error_description: z.string().optional(),
+          scope: z.string().optional(),
         })
         .safeParse(ctx.body);
 
@@ -140,6 +141,11 @@ export default function koaOidcErrorHandler<StateT, ContextT extends WithI18nCon
           code,
           message: ctx.i18n.t(['errors:' + code, 'errors:oidc.provider_error_fallback'], {
             code,
+            scope: data.scope,
+            interpolation: {
+              // Disable i18next escape value since it's for API response, we can show HTML tags.
+              escapeValue: false,
+            },
           }),
           error_uri: uri,
           ...ctx.body,

--- a/packages/phrases/src/locales/ar/errors/oidc.ts
+++ b/packages/phrases/src/locales/ar/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'أنهى المستخدم التفاعل.',
-  invalid_scope: 'نطاق غير صالح: {{error_description}}.',
+  invalid_scope: 'نطاق غير صالح: {{scope}}.',
   invalid_token: 'الرمز غير صالح.',
   invalid_client_metadata: 'بيانات العميل غير صالحة.',
   insufficient_scope: 'الرمز ناقص في النطاق `{{scope}}`.',

--- a/packages/phrases/src/locales/de/errors/oidc.ts
+++ b/packages/phrases/src/locales/de/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'Der Endnutzer hat die Interaktion abgebrochen.',
-  invalid_scope: 'Ungültiger Anwendungsbereich: {{error_description}}.',
+  invalid_scope: 'Ungültiger Anwendungsbereich: {{scope}}.',
   invalid_token: 'Ungültiger Token übermittelt.',
   invalid_client_metadata: 'Ungültige Client Metadaten übermittelt.',
   insufficient_scope: 'Token fehlt den Anwendungsbereich `{{scope}}`.',

--- a/packages/phrases/src/locales/en/errors/oidc.ts
+++ b/packages/phrases/src/locales/en/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'The end-user aborted interaction.',
-  invalid_scope: 'Invalid scope: {{error_description}}.',
+  invalid_scope: 'Invalid scope: {{scope}}.',
   invalid_token: 'Invalid token provided.',
   invalid_client_metadata: 'Invalid client metadata provided.',
   insufficient_scope: 'Token missing scope `{{scope}}`.',

--- a/packages/phrases/src/locales/es/errors/oidc.ts
+++ b/packages/phrases/src/locales/es/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'El usuario final abortó la interacción.',
-  invalid_scope: 'Ámbito no válido: {{error_description}}.',
+  invalid_scope: 'Ámbito no válido: {{scope}}.',
   invalid_token: 'Se proporcionó un token no válido.',
   invalid_client_metadata: 'Se proporcionaron metadatos de cliente no válidos.',
   insufficient_scope: 'Falta el ámbito del token `{{scope}}`.',

--- a/packages/phrases/src/locales/fa-ir/errors/oidc.ts
+++ b/packages/phrases/src/locales/fa-ir/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'کاربر نهایی تعامل را لغو کرد.',
-  invalid_scope: 'scope نامعتبر: {{error_description}}.',
+  invalid_scope: 'scope نامعتبر: {{scope}}.',
   invalid_token: 'توکن ارائه‌شده نامعتبر است.',
   invalid_client_metadata: 'متادیتای کلاینت ارائه‌شده نامعتبر است.',
   insufficient_scope: 'توکن فاقد scope `{{scope}}` است.',

--- a/packages/phrases/src/locales/fr/errors/oidc.ts
+++ b/packages/phrases/src/locales/fr/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: "L'utilisateur a abandonné l'interaction.",
-  invalid_scope: 'Scope invalide : {{error_description}}.',
+  invalid_scope: 'Scope invalide : {{scope}}.',
   invalid_token: 'Jeton fourni invalide.',
   invalid_client_metadata: 'Les métadonnées du client fournies sont invalides.',
   insufficient_scope: 'Manque de champ `{{scope}}` dans le jeton.',

--- a/packages/phrases/src/locales/it/errors/oidc.ts
+++ b/packages/phrases/src/locales/it/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: "L'utente finale ha annullato l'interazione.",
-  invalid_scope: 'Ambito non valido: {{error_description}}.',
+  invalid_scope: 'Ambito non valido: {{scope}}.',
   invalid_token: 'Token non valido fornito.',
   invalid_client_metadata: 'Metadata client non valide fornite.',
   insufficient_scope: "Token mancante dell'ambito `{{scope}}`.",

--- a/packages/phrases/src/locales/ja/errors/oidc.ts
+++ b/packages/phrases/src/locales/ja/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'エンドユーザが操作を中止しました。',
-  invalid_scope: 'スコープが無効です: {{error_description}}。',
+  invalid_scope: 'スコープが無効です: {{scope}}。',
   invalid_token: '提供されたトークンが無効です。',
   invalid_client_metadata: '提供されたクライアントメタデータが無効です。',
   insufficient_scope: 'トークンにスコープ `{{scope}}` が含まれていません。',

--- a/packages/phrases/src/locales/ko/errors/oidc.ts
+++ b/packages/phrases/src/locales/ko/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'End 사용자가 상호 작용을 중단했어요.',
-  invalid_scope: '허용되지 않은 범위: {{error_description}}.',
+  invalid_scope: '허용되지 않은 범위: {{scope}}.',
   invalid_token: '유효하지 않은 토큰이 제공되었어요.',
   invalid_client_metadata: '유효하지 않은 클라이언트 메타데이터가 제공되었어요.',
   insufficient_scope: '토큰에 `{{scope}}` 범위가 누락되었어요.',

--- a/packages/phrases/src/locales/pl-pl/errors/oidc.ts
+++ b/packages/phrases/src/locales/pl-pl/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'Koniec interakcji z użytkownikiem.',
-  invalid_scope: 'Nieprawidłowy zakres: {{error_description}}.',
+  invalid_scope: 'Nieprawidłowy zakres: {{scope}}.',
   invalid_token: 'Podano nieprawidłowy token.',
   invalid_client_metadata: 'Podano nieprawidłowe metadane klienta.',
   insufficient_scope: 'Token nie zawiera zakresu `{{scope}}`.',

--- a/packages/phrases/src/locales/pt-br/errors/oidc.ts
+++ b/packages/phrases/src/locales/pt-br/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'A interação foi abortada pelo usuário final',
-  invalid_scope: 'Escopo inválido: {{error_description}}.',
+  invalid_scope: 'Escopo inválido: {{scope}}.',
   invalid_token: 'Token inválido.',
   invalid_client_metadata: 'Metadados do cliente inválidos.',
   insufficient_scope: 'Token sem escopo `{{scope}}`.',

--- a/packages/phrases/src/locales/pt-pt/errors/oidc.ts
+++ b/packages/phrases/src/locales/pt-pt/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'O utilizador final abortou a interação.',
-  invalid_scope: 'Âmbito inválido: {{error_description}}.',
+  invalid_scope: 'Âmbito inválido: {{scope}}.',
   invalid_token: 'O Token fornecido é inválido.',
   invalid_client_metadata: 'Metadados de cliente inválidos fornecidos.',
   insufficient_scope: 'Token em falta com âmbito `{{scope}}`.',

--- a/packages/phrases/src/locales/ru/errors/oidc.ts
+++ b/packages/phrases/src/locales/ru/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'Конечный пользователь прервал взаимодействие.',
-  invalid_scope: 'Недопустимая область: {{error_description}}.',
+  invalid_scope: 'Недопустимая область: {{scope}}.',
   invalid_token: 'Недействительный токен.',
   invalid_client_metadata: 'Недопустимые метаданные клиента.',
   insufficient_scope: 'Отсутствует область токена `{{scope}}`.',

--- a/packages/phrases/src/locales/th/errors/oidc.ts
+++ b/packages/phrases/src/locales/th/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'ผู้ใช้ยกเลิกการโต้ตอบแล้ว',
-  invalid_scope: 'ขอบเขตไม่ถูกต้อง: {{error_description}}',
+  invalid_scope: 'ขอบเขตไม่ถูกต้อง: {{scope}}',
   invalid_token: 'โทเค็นไม่ถูกต้อง',
   invalid_client_metadata: 'ข้อมูลเมทาดาท่าของไคลเอนต์ไม่ถูกต้อง',
   insufficient_scope: 'โทเค็นไม่มีขอบเขต `{{scope}}`',

--- a/packages/phrases/src/locales/tr-tr/errors/oidc.ts
+++ b/packages/phrases/src/locales/tr-tr/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: 'Son kullanıcı etkileşimi iptal etti.',
-  invalid_scope: 'Kapsam geçersiz: {{error_description}}.',
+  invalid_scope: 'Kapsam geçersiz: {{scope}}.',
   invalid_token: 'Sağlanan belirteç geçersiz.',
   invalid_client_metadata: 'Sağlanan istemci meta verisi geçersiz.',
   insufficient_scope: "Token'ın `{{scope}}` kapsamı eksik.",

--- a/packages/phrases/src/locales/zh-cn/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-cn/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: '用户终止了交互。',
-  invalid_scope: '无效的范围: {{error_description}}。',
+  invalid_scope: '无效的范围: {{scope}}。',
   invalid_token: 'Token 无效',
   invalid_client_metadata: '无效的客户端元数据',
   insufficient_scope: 'Token 缺少范围 `{{scope}}`.',

--- a/packages/phrases/src/locales/zh-hk/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-hk/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: '用戶終止了交互。',
-  invalid_scope: '無效範圍: {{error_description}}.',
+  invalid_scope: '無效範圍: {{scope}}.',
   invalid_token: 'Token 無效',
   invalid_client_metadata: '無效的客戶端元數據',
   insufficient_scope: '缺少權限範圍 `{{scope}}`。',

--- a/packages/phrases/src/locales/zh-tw/errors/oidc.ts
+++ b/packages/phrases/src/locales/zh-tw/errors/oidc.ts
@@ -1,6 +1,6 @@
 const oidc = {
   aborted: '使用者終止了互動。',
-  invalid_scope: '無效的範圍: {{error_description}}。',
+  invalid_scope: '無效的範圍: {{scope}}。',
   invalid_token: 'Token 無效',
   invalid_client_metadata: '無效的用戶端元數據',
   insufficient_scope: 'Token 缺少範圍 `{{scope}}`。',


### PR DESCRIPTION
## Summary

Fix OIDC scope error messages rendering their i18n placeholder literally instead of the scope that was rejected.

- The error handler passed only `code` into the interpolation, so `oidc.invalid_scope` and `oidc.insufficient_scope` returned `{{error_description}}` and `{{scope}}` verbatim. `invalid_scope` reaches end users as a consent-page toast.
- `invalid_scope` now interpolates `scope` instead of `error_description`, since the provider description is developer-facing English that should not sit inside a localized sentence. `error_description` is unchanged in the response body.
- Disable i18next escaping on the message, matching the other interpolation sites in core. Scope names are client-controlled, so `read:a&b` would otherwise render as `read:a&amp;b`.

Audited the rest of `errors/oidc.ts`: `provider_error_fallback` was already fed, `custom_claims_script_error` is resolved before its error is thrown, `key_not_found` is a `RequestError` that passes its own data, and `provider_error` is deprecated with no consumers.

## Testing

<img width="612" height="784" alt="image" src="https://github.com/user-attachments/assets/4c134bb3-60cd-4502-938f-61c2bc91db89" />

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
