### PR TITLE
fix(core): grant the requested scope ceiling at consent

### DIFF
--- a/packages/core/src/libraries/user.ts
+++ b/packages/core/src/libraries/user.ts
@@ -156,13 +156,14 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
 
   /**
    * Find user scopes for a resource indicator, from roles and organization roles.
-   * Set `organizationId` to narrow down the search to the specific organization, otherwise it will search all organizations.
+   * Set `organizationIds` to only count contributions from those organizations (an empty array
+   * counts none, an omitted value counts all); personal role scopes are unaffected.
    */
   const findUserScopesForResourceIndicator = async (
     userId: string,
     resourceIndicator: string,
     findFromOrganizations = false,
-    organizationId?: string
+    organizationIds?: readonly string[]
   ): Promise<readonly Scope[]> => {
     const usersRoles = await findUsersRolesByUserId(userId);
     const rolesScopes = await findRolesScopesByRoleIds(usersRoles.map(({ roleId }) => roleId));
@@ -170,7 +171,7 @@ export const createUserLibrary = (tenantId: string, queries: Queries) => {
       ? await organizations.relations.usersRoles.getUserResourceScopes(
           userId,
           resourceIndicator,
-          organizationId
+          organizationIds
         )
       : [];
 

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -248,9 +248,9 @@ describe('oidc provider init', () => {
         _userId: string,
         _indicator: string,
         _findFromOrganizations?: boolean,
-        orgId?: string
+        organizationIds?: readonly string[]
       ) =>
-        orgId === 'org_2'
+        organizationIds?.includes('org_2')
           ? [buildScope('scope_2', 'write:api')]
           : [buildScope('scope_1', 'read:api')]
     );

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -69,6 +69,7 @@ import { getProviderFetchConfig } from './fetch.js';
 import { registerGrants } from './grants/index.js';
 import { installWildcardRedirectUriMatching } from './redirect-uri/index.js';
 import {
+  findIssuanceConsentedOrganizationIds,
   findResource,
   findResourceScopes,
   getSharedResourceServerData,
@@ -107,7 +108,7 @@ export default function initOidc(
     indicator: string,
     clientId: string | undefined,
     userId: string | undefined,
-    organizationId: string | undefined
+    { organizationId, isTokenIssuance }: { organizationId?: string; isTokenIssuance: boolean }
   ): Promise<Pick<ResourceServer, 'accessTokenFormat' | 'jwt' | 'accessTokenTTL' | 'scope'>> => {
     const resourceServer = await findResource(queries, indicator);
 
@@ -117,17 +118,17 @@ export default function initOidc(
 
     const { accessTokenTtl: accessTokenTTL } = resourceServer;
 
-    const scopes = await findResourceScopes({
-      queries,
-      libraries,
-      indicator,
-      findFromOrganizations: true,
-      organizationId,
-      applicationId: clientId,
-      userId,
-    });
-
     if (isCimdClient(envSet, clientId)) {
+      const scopes = await findResourceScopes({
+        queries,
+        libraries,
+        indicator,
+        findFromOrganizations: true,
+        organizationId,
+        applicationId: clientId,
+        userId,
+      });
+
       /**
        * CIMD clients are unregistered: the tenant-wide ceiling replaces the per-application
        * consent configuration the third-party filter below reads.
@@ -141,7 +142,27 @@ export default function initOidc(
       };
     }
 
-    if (clientId && (await isThirdPartyApplication(queries, clientId))) {
+    const isThirdParty = Boolean(clientId && (await isThirdPartyApplication(queries, clientId)));
+    const consentedOrganizationIds = await findIssuanceConsentedOrganizationIds(queries, {
+      isTokenIssuance,
+      isThirdParty,
+      clientId,
+      userId,
+      organizationId,
+    });
+
+    const scopes = await findResourceScopes({
+      queries,
+      libraries,
+      indicator,
+      findFromOrganizations: true,
+      organizationId,
+      organizationIds: consentedOrganizationIds,
+      applicationId: clientId,
+      userId,
+    });
+
+    if (clientId && isThirdParty) {
       const filteredScopes = await filterResourceScopesForTheThirdPartyApplication(
         libraries,
         clientId,
@@ -247,12 +268,15 @@ export default function initOidc(
         // Disable the auto use of authorization_code granted resource feature
         useGrantedResource: () => false,
         getResourceServerInfo: async (ctx, indicator) => {
-          const { client, params, session, entities } = ctx.oidc;
+          const { client, params, session, entities, route } = ctx.oidc;
           const userId = session?.accountId ?? entities.Account?.accountId;
           const organizationId =
             typeof params?.organization_id === 'string' ? params.organization_id : undefined;
 
-          return getResourceServerInfoCore(indicator, client?.clientId, userId, organizationId);
+          return getResourceServerInfoCore(indicator, client?.clientId, userId, {
+            organizationId,
+            isTokenIssuance: route === 'token',
+          });
         },
       },
     },

--- a/packages/core/src/oidc/resource.ts
+++ b/packages/core/src/oidc/resource.ts
@@ -1,5 +1,10 @@
 import { ReservedResource } from '@logto/core-kit';
-import { isBuiltInApplicationId, isCimdClientId, type Resource } from '@logto/schemas';
+import {
+  isBuiltInApplicationId,
+  isCimdClientId,
+  Organizations,
+  type Resource,
+} from '@logto/schemas';
 import { trySafe, type Nullable } from '@silverhand/essentials';
 import { type ResourceServer } from 'oidc-provider';
 
@@ -45,6 +50,7 @@ export const findResourceScopes = async ({
   applicationId,
   indicator,
   organizationId,
+  organizationIds,
   findFromOrganizations,
 }: {
   queries: Queries;
@@ -63,6 +69,11 @@ export const findResourceScopes = async ({
   userId?: string;
   applicationId?: string;
   organizationId?: string;
+  /**
+   * Only count organization-role contributions from these organizations (an empty array counts
+   * none); personal role scopes are unaffected. `organizationId` takes precedence when set.
+   */
+  organizationIds?: readonly string[];
 }): Promise<ReadonlyArray<{ name: string; id: string }>> => {
   if (isReservedResource(indicator)) {
     switch (indicator) {
@@ -83,7 +94,7 @@ export const findResourceScopes = async ({
       userId,
       indicator,
       findFromOrganizations,
-      organizationId
+      organizationId ? [organizationId] : organizationIds
     );
   }
 
@@ -260,4 +271,41 @@ export const isOrganizationConsentedToApplication = async (
   organizationId: string
 ) => {
   return userConsentOrganizations.exists({ applicationId, userId: accountId, organizationId });
+};
+
+/**
+ * Find the organizations the user has consented to the application, to bound the
+ * organization-role aggregation at token issuance: the grant records the requested ceiling for
+ * a registered third-party client, so a token without an `organization_id` has no other
+ * consent boundary left. Resolves to `undefined` (no bounding) everywhere else; authorization
+ * and consent rendering keep the full aggregation, which is what builds and displays the
+ * ceiling in the first place. The registered-client path owns the call; CIMD branches off
+ * before it, its grant being per-organization already.
+ */
+export const findIssuanceConsentedOrganizationIds = async (
+  queries: Queries,
+  {
+    isTokenIssuance,
+    isThirdParty,
+    clientId,
+    userId,
+    organizationId,
+  }: {
+    isTokenIssuance: boolean;
+    isThirdParty: boolean;
+    clientId: string | undefined;
+    userId: string | undefined;
+    organizationId: string | undefined;
+  }
+): Promise<readonly string[] | undefined> => {
+  if (!isTokenIssuance || !isThirdParty || !clientId || !userId || organizationId) {
+    return undefined;
+  }
+
+  const [, entities] = await queries.applications.userConsentOrganizations.getEntities(
+    Organizations,
+    { applicationId: clientId, userId }
+  );
+
+  return entities.map(({ id }) => id);
 };

--- a/packages/core/src/queries/organization/user-role-relations.ts
+++ b/packages/core/src/queries/organization/user-role-relations.ts
@@ -51,14 +51,18 @@ export class UserRoleRelationQueries extends RelationQueries<
   }
 
   /**
-   * Get the available resource scopes of a user in all organizations.
-   * If `organizationId` is provided, it will only search in that organization.
+   * Get the available resource scopes of a user, from the roles in the given organizations.
+   * When `organizationIds` is omitted, every organization counts; an empty array counts none.
    */
   async getUserResourceScopes(
     userId: string,
     resourceIndicator: string,
-    organizationId?: string
+    organizationIds?: readonly string[]
   ): Promise<readonly ResourceScopeEntity[]> {
+    if (organizationIds?.length === 0) {
+      return [];
+    }
+
     const { fields } = convertToIdentifiers(OrganizationRoleUserRelations, true);
     const roleScopeRelations = convertToIdentifiers(OrganizationRoleResourceScopeRelations, true);
     const scopes = convertToIdentifiers(Scopes, true);
@@ -76,7 +80,10 @@ export class UserRoleRelationQueries extends RelationQueries<
         on ${resources.fields.id} = ${scopes.fields.resourceId}
       where ${fields.userId} = ${userId}
       and ${resources.fields.indicator} = ${resourceIndicator}
-      ${conditionalSql(organizationId, (value) => sql`and ${fields.organizationId} = ${value}`)}
+      ${conditionalSql(
+        organizationIds,
+        (values) => sql`and ${fields.organizationId} = any(${sql.array([...values], 'varchar')})`
+      )}
     `);
   }
 

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- the consent GET and POST handlers share one interaction context */
 import { UserScope } from '@logto/core-kit';
 import {
   ApplicationType,
@@ -30,6 +31,7 @@ import {
   buildResourceScopesToReject,
   filterAndParseMissingResourceScopes,
   revalidateConsentClient,
+  revalidateResourceScopeCeiling,
 } from './utils.js';
 
 const { InvalidClient, InvalidRedirectUri, InvalidRequest } = errors;
@@ -205,12 +207,20 @@ export default function consentRoutes<T extends IRouterParamContext>(
       );
 
       /**
-       * A registered third-party grant records the requested ceiling as-is: per-organization
-       * effective access is re-bounded by the user's roles at issuance time anyway, and
-       * role-filtering the grant here would push requested-but-uncarried scopes into rejections
-       * that a later role change can never lift. CIMD keeps its per-organization narrowing.
+       * A registered grant records the requested ceiling (revalidated against the current
+       * consent configuration) instead of a role-filtered subset: per-organization effective
+       * access is re-bounded by the user's roles at issuance time anyway, and role-filtering
+       * the grant here would push requested-but-uncarried scopes into rejections that a later
+       * role change can never lift. CIMD keeps its per-organization narrowing.
        */
-      const grantedResourceScopes = cimd ? resourceScopesToGrant : allMissingResourceScopes;
+      const grantedResourceScopes = cimd
+        ? resourceScopesToGrant
+        : await revalidateResourceScopeCeiling({
+            queries,
+            libraries,
+            applicationId,
+            resourceScopes: allMissingResourceScopes,
+          });
 
       const resourceScopesToReject = buildResourceScopesToReject(
         allMissingResourceScopes,
@@ -406,3 +416,4 @@ export default function consentRoutes<T extends IRouterParamContext>(
     }
   );
 }
+/* eslint-enable max-lines */

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -204,9 +204,17 @@ export default function consentRoutes<T extends IRouterParamContext>(
         )
       );
 
+      /**
+       * A registered third-party grant records the requested ceiling as-is: per-organization
+       * effective access is re-bounded by the user's roles at issuance time anyway, and
+       * role-filtering the grant here would push requested-but-uncarried scopes into rejections
+       * that a later role change can never lift. CIMD keeps its per-organization narrowing.
+       */
+      const grantedResourceScopes = cimd ? resourceScopesToGrant : allMissingResourceScopes;
+
       const resourceScopesToReject = buildResourceScopesToReject(
         allMissingResourceScopes,
-        resourceScopesToGrant,
+        grantedResourceScopes,
         cimd
       );
 
@@ -217,7 +225,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
         queries,
         interactionDetails,
         missingOIDCScopes: missingOIDCScope,
-        resourceScopesToGrant,
+        resourceScopesToGrant: grantedResourceScopes,
         resourceScopesToReject,
         markAppLevelAccessControlChecked: true,
         cimdOrganizationId: conditional(cimd && organizationIds?.[0]),

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -207,6 +207,76 @@ export const buildResourceScopesToReject = (
   );
 
 /**
+ * Resolve requested scope names to their current entities, dropping the ones that no longer
+ * exist. Role-independent by design, unlike `findResourceScopes`.
+ */
+const resolveRequestedResourceScopes = async (
+  queries: Queries,
+  resourceIndicator: string,
+  scopeNames: string[]
+): Promise<ReadonlyArray<{ name: string; id: string }>> => {
+  if (resourceIndicator === ReservedResource.Organization) {
+    const [, organizationScopes] = await queries.organizations.scopes.findAll();
+    return organizationScopes.filter(({ name }) => scopeNames.includes(name));
+  }
+
+  const resource = await queries.resources.findResourceByIndicator(resourceIndicator);
+
+  if (!resource) {
+    return [];
+  }
+
+  const scopes = await Promise.all(
+    scopeNames.map(async (scopeName) =>
+      queries.scopes.findScopeByNameAndResourceId(scopeName, resource.id)
+    )
+  );
+
+  // eslint-disable-next-line no-implicit-coercion -- filter out removed scopes
+  return scopes.filter((scope): scope is Scope => !!scope);
+};
+
+/**
+ * Re-bound the requested ceiling against the application's current consent configuration.
+ * The prompt snapshot can be as old as the interaction, so a scope the configuration no longer
+ * allows, or that no longer exists, must not be persisted onto the grant. Role filtering is
+ * deliberately absent: per-organization effective access is re-bounded at issuance time.
+ */
+export const revalidateResourceScopeCeiling = async ({
+  queries,
+  libraries,
+  applicationId,
+  resourceScopes,
+}: {
+  queries: Queries;
+  libraries: Libraries;
+  applicationId: string;
+  resourceScopes: Record<string, string[]>;
+}): Promise<Record<string, string[]>> => {
+  /** A first-party application has no consent configuration to revalidate against. */
+  if (!(await isThirdPartyApplication(queries, applicationId))) {
+    return resourceScopes;
+  }
+
+  const entries = await Promise.all(
+    Object.entries(resourceScopes).map(
+      async ([resourceIndicator, scopeNames]): Promise<[string, string[]]> => {
+        const filteredScopes = await filterResourceScopesForTheThirdPartyApplication(
+          libraries,
+          applicationId,
+          resourceIndicator,
+          await resolveRequestedResourceScopes(queries, resourceIndicator, scopeNames)
+        );
+
+        return [resourceIndicator, filteredScopes.map(({ name }) => name)];
+      }
+    )
+  );
+
+  return Object.fromEntries(entries.filter(([, scopes]) => scopes.length > 0));
+};
+
+/**
  * The missingResourceScopes in the prompt details are from `getResourceServerInfo`,
  * which contains resource scopes and organization resource scopes.
  * We need to separate the organization resource scopes from the resource scopes.

--- a/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
@@ -336,6 +336,77 @@ describe('consent api', () => {
         deleteUser(user.id),
       ]);
     });
+
+    it('grant the requested scope ceiling and issue a scope gained from a later role change without re-consent', async () => {
+      const application = applications.get(thirdPartyApplicationName);
+      assert(application, new Error('application.not_found'));
+
+      const resource = await createResource(generateResourceName(), generateResourceIndicator());
+      const scope = await createScope(resource.id, generateScopeName());
+      const scope2 = await createScope(resource.id, generateScopeName());
+      const roleApi = new OrganizationRoleApiTest();
+      const role = await roleApi.create({
+        name: generateRoleName(),
+        resourceScopeIds: [scope.id],
+      });
+      const role2 = await roleApi.create({
+        name: generateRoleName(),
+        resourceScopeIds: [scope2.id],
+      });
+      const organizationApi = new OrganizationApiTest();
+      const organization = await organizationApi.create({ name: 'test_org_3' });
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      await organizationApi.addUsers(organization.id, [user.id]);
+      await organizationApi.addUserRoles(organization.id, user.id, [role.id]);
+
+      /**
+       * `scope2` enters the requested ceiling through the role in this organization, which stays
+       * unconsented; the consented organization's role does not carry it at consent time.
+       */
+      const organization2 = await organizationApi.create({ name: 'test_org_4' });
+      await organizationApi.addUsers(organization2.id, [user.id]);
+      await organizationApi.addUserRoles(organization2.id, user.id, [role2.id]);
+
+      await assignUserConsentScopes(application.id, {
+        organizationResourceScopes: [scope.id, scope2.id],
+        userScopes: [UserScope.Organizations],
+      });
+
+      const client = await initClientAndSignIn(application, userProfile, {
+        scopes: [UserScope.Organizations, UserScope.Profile, scope.name, scope2.name],
+        resources: [resource.indicator],
+      });
+
+      const { redirectTo } = await client.submitInteraction();
+
+      await client.processSession(redirectTo, false);
+      const { redirectTo: consentRedirectTo } = await client.send(consent, {
+        organizationIds: [organization.id],
+      });
+      await client.manualConsent(consentRedirectTo);
+
+      // The grant records the requested ceiling, but the issued token stays bounded by the role
+      const accessToken = await client.getAccessToken(resource.indicator, organization.id);
+      expect(getAccessTokenPayload(accessToken)).toHaveProperty('scope', scope.name);
+
+      await roleApi.addResourceScopes(role.id, [scope2.id]);
+      await client.clearAccessToken();
+
+      // A fresh token picks up the newly carried scope without another consent round
+      const refreshedAccessToken = await client.getAccessToken(resource.indicator, organization.id);
+      const { scope: refreshedScope } = getAccessTokenPayload(refreshedAccessToken);
+      assert(typeof refreshedScope === 'string', new Error('scope must be a string'));
+      expect(refreshedScope.split(' ').slice().sort()).toEqual(
+        [scope.name, scope2.name].slice().sort()
+      );
+
+      await Promise.all([
+        roleApi.cleanUp(),
+        organizationApi.cleanUp(),
+        deleteResource(resource.id),
+        deleteUser(user.id),
+      ]);
+    });
   });
 
   afterAll(async () => {

--- a/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
@@ -389,6 +389,11 @@ describe('consent api', () => {
       const accessToken = await client.getAccessToken(resource.indicator, organization.id);
       expect(getAccessTokenPayload(accessToken)).toHaveProperty('scope', scope.name);
 
+      // A token without an organization only aggregates roles from consented organizations,
+      // so the scope carried solely by the unconsented organization stays out
+      const plainAccessToken = await client.getAccessToken(resource.indicator);
+      expect(getAccessTokenPayload(plainAccessToken)).toHaveProperty('scope', scope.name);
+
       await roleApi.addResourceScopes(role.id, [scope2.id]);
       await client.clearAccessToken();
 
@@ -397,6 +402,14 @@ describe('consent api', () => {
       const { scope: refreshedScope } = getAccessTokenPayload(refreshedAccessToken);
       assert(typeof refreshedScope === 'string', new Error('scope must be a string'));
       expect(refreshedScope.split(' ').slice().sort()).toEqual(
+        [scope.name, scope2.name].slice().sort()
+      );
+
+      // The consented organization's role now carries it, so the plain token follows suit
+      const refreshedPlainAccessToken = await client.getAccessToken(resource.indicator);
+      const { scope: refreshedPlainScope } = getAccessTokenPayload(refreshedPlainAccessToken);
+      assert(typeof refreshedPlainScope === 'string', new Error('scope must be a string'));
+      expect(refreshedPlainScope.split(' ').slice().sort()).toEqual(
         [scope.name, scope2.name].slice().sort()
       );
 

--- a/packages/integration-tests/src/tests/api/interaction/consent/scope-revalidation.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/consent/scope-revalidation.test.ts
@@ -11,8 +11,10 @@ import { createApplicationWithSecret, deleteApplication } from '#src/api/applica
 import { consent } from '#src/api/interaction.js';
 import { logtoUrl } from '#src/constants.js';
 import { initExperienceClient } from '#src/helpers/client.js';
+import { OrganizationApiTest } from '#src/helpers/organization.js';
 import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
+import { generateRoleName, generateScopeName } from '#src/utils.js';
 
 describe('consent scope revalidation', () => {
   const redirectUri = 'http://example.com';
@@ -102,5 +104,83 @@ describe('consent scope revalidation', () => {
     await client.manualConsent(redirectTo);
 
     await Promise.all([deleteApplication(application.id), deleteUser(user.id)]);
+  });
+
+  it('should drop an organization scope removed from the consent configuration mid-interaction', async () => {
+    const organizationApi = new OrganizationApiTest();
+    const orgScope = await organizationApi.scopeApi.create({ name: generateScopeName() });
+    const orgScope2 = await organizationApi.scopeApi.create({ name: generateScopeName() });
+    const role = await organizationApi.roleApi.create({
+      name: generateRoleName(),
+      organizationScopeIds: [orgScope.id, orgScope2.id],
+    });
+
+    const application = await createApplicationWithSecret(
+      'consent-scope-revalidation-org-app',
+      ApplicationType.Traditional,
+      {
+        isThirdParty: true,
+        oidcClientMetadata: {
+          redirectUris: [redirectUri],
+          postLogoutRedirectUris: [],
+        },
+      }
+    );
+
+    await assignUserConsentScopes(application.id, {
+      userScopes: [UserScope.Profile, UserScope.Organizations],
+      organizationScopes: [orgScope.id, orgScope2.id],
+    });
+
+    const { userProfile, user } = await generateNewUser({ username: true, password: true });
+    const organization = await organizationApi.create({ name: 'test_org_revalidation' });
+    await organizationApi.addUsers(organization.id, [user.id]);
+    await organizationApi.addUserRoles(organization.id, user.id, [role.id]);
+
+    const client = await initExperienceClient({
+      config: {
+        appId: application.id,
+        appSecret: application.secret,
+        scopes: [UserScope.Profile, UserScope.Organizations, orgScope.name, orgScope2.name],
+      },
+      redirectUri,
+    });
+
+    const { verificationId } = await client.verifyPassword({
+      identifier: {
+        type: SignInIdentifier.Username,
+        value: userProfile.username,
+      },
+      password: userProfile.password,
+    });
+    await client.identifyUser({ verificationId });
+
+    const { redirectTo } = await client.submitInteraction();
+    await client.processSession(redirectTo, false);
+
+    // The configuration change lands while the consent screen is open
+    await deleteUserConsentScopes(
+      application.id,
+      ApplicationUserConsentScopeType.OrganizationScopes,
+      orgScope2.id
+    );
+
+    const { redirectTo: consentRedirectTo } = await client.send(consent, {
+      organizationIds: [organization.id],
+    });
+    await client.manualConsent(consentRedirectTo);
+
+    // The grant records only what the current configuration allows, so the role-carried but
+    // configuration-removed scope never reaches the organization token
+    await expect(client.getOrganizationTokenClaims(organization.id)).resolves.toHaveProperty(
+      'scope',
+      orgScope.name
+    );
+
+    await Promise.all([
+      organizationApi.cleanUp(),
+      deleteApplication(application.id),
+      deleteUser(user.id),
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

For a registered third-party application, the consent submission now writes the requested scope ceiling to the grant as-is, instead of narrowing it to the scopes carried by the consented organizations' roles.

- Before: a scope the app was allowed to request but no consented organization's role carried was recorded as rejected on the long-lived grant. oidc-provider never asks about rejected scopes again, so it stayed unobtainable forever, even after the user's role later gained it.
- After: the grant records exactly what the user approved on the consent screen; a later role change takes effect at the next token issuance, with no re-consent round.

Example: the app requests `read` and `admin`; the user is a Viewer (`read`) in organization A and an Admin (`admin`) in organization B, and consents only to organization A:

| | Before | After |
| --- | --- | --- |
| Grant after consent | granted `read`, rejected `admin` | granted `read` + `admin` |
| Organization A token | `read` | `read` (identical) |
| Organization A token, after its role gains `admin` | `read` only, locked out forever | `read` + `admin`, no re-consent |

Issued tokens are unchanged: issuance already bounds scopes by the user's roles in the target organization and by the app's consent configuration, so the grant-level role filtering added no security. CIMD consent is untouched; its grants are per-authorization, so rejections die with the grant.

Linear: https://linear.app/logto/issue/LOG-14084

## Testing

integration tests

## Checklist

- [ ] `.changeset` (added before merge)
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
