### PR TITLE
feat(core): include trusted device availability in MFA errors

### DIFF
--- a/packages/core/src/libraries/trusted-device-policy.test.ts
+++ b/packages/core/src/libraries/trusted-device-policy.test.ts
@@ -82,4 +82,23 @@ describe('trusted device policy library', () => {
       expectSqlString('"organizations"."is_trusted_device_allowed" = false')
     );
   });
+
+  it('derives organization eligibility from already loaded rows', async () => {
+    const pool = {
+      exists: jest.fn(async () => false),
+    };
+    const signInExperience = {
+      ...mockSignInExperience,
+      trustedDevice: { enabled: true, durationDays: 30 },
+    };
+    const library = createTrustedDevicePolicyLibrary(createQueries(pool, signInExperience));
+
+    await expect(
+      library.getEffectivePolicy('user-id', [{ isTrustedDeviceAllowed: false }] as never)
+    ).resolves.toEqual({
+      enabled: false,
+      durationDays: 30,
+    });
+    expect(pool.exists).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/libraries/trusted-device-policy.ts
+++ b/packages/core/src/libraries/trusted-device-policy.ts
@@ -1,9 +1,13 @@
-import { defaultTrustedDevicePolicy, type TrustedDevicePolicy } from '@logto/schemas';
+import {
+  defaultTrustedDevicePolicy,
+  type OrganizationWithRoles,
+  type TrustedDevicePolicy,
+} from '@logto/schemas';
 
 import { UserRelationQueries } from '#src/queries/organization/user-relations.js';
 import type Queries from '#src/tenants/Queries.js';
 
-type EffectiveTrustedDevicePolicy = Readonly<Required<TrustedDevicePolicy>>;
+export type EffectiveTrustedDevicePolicy = Readonly<Required<TrustedDevicePolicy>>;
 
 export const resolveEffectiveTrustedDevicePolicy = (
   policy: TrustedDevicePolicy,
@@ -14,10 +18,15 @@ export const resolveEffectiveTrustedDevicePolicy = (
 });
 
 export const createTrustedDevicePolicyLibrary = (queries: Queries) => {
-  const getEffectivePolicy = async (userId: string) => {
+  const getEffectivePolicy = async (
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) => {
     const [signInExperience, hasDisallowedOrganization] = await Promise.all([
       queries.signInExperiences.findDefaultSignInExperience(),
-      new UserRelationQueries(queries.pool).hasUserDisallowedTrustedDeviceOrganization(userId),
+      organizations
+        ? organizations.some(({ isTrustedDeviceAllowed }) => !isTrustedDeviceAllowed)
+        : new UserRelationQueries(queries.pool).hasUserDisallowedTrustedDeviceOrganization(userId),
     ]);
 
     return resolveEffectiveTrustedDevicePolicy(

--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -202,6 +202,28 @@ describe('trusted device library', () => {
     expect(set).not.toHaveBeenCalled();
   });
 
+  it('enforces a request-resolved disabled policy without querying it again', async () => {
+    const queries = createQueries();
+    const policyLibrary = createPolicyLibrary({ enabled: true });
+    const { ctx, set } = createCookieContext();
+    const library = createTrustedDeviceLibrary(tenantId, queries, policyLibrary, {
+      isProduction: false,
+    });
+
+    await expect(
+      library.createCredential({
+        ctx,
+        deviceId: trustedDeviceId,
+        effectivePolicy: { enabled: false, durationDays: 30 },
+        userId,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(policyLibrary.getEffectivePolicy).not.toHaveBeenCalled();
+    expect(queries.insertIfNotExists).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
+  });
+
   it('rechecks the effective policy before each creation attempt', async () => {
     const queries = createQueries();
     const getEffectivePolicy = jest

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -13,7 +13,10 @@ import { EnvSet } from '#src/env-set/index.js';
 import type { TrustedDeviceMetadata, TrustedDeviceQueries } from '#src/queries/trusted-device.js';
 
 import type { HookContextManager } from './hook/context-manager.js';
-import type { createTrustedDevicePolicyLibrary } from './trusted-device-policy.js';
+import type {
+  createTrustedDevicePolicyLibrary,
+  EffectiveTrustedDevicePolicy,
+} from './trusted-device-policy.js';
 
 const trustedDeviceSecretByteLength = 32;
 const trustedDeviceSecretHashAlgorithm = 'sha256';
@@ -40,6 +43,7 @@ type CreateTrustedDeviceCredential = TrustedDeviceMetadata &
   Readonly<{
     ctx: TrustedDeviceCookieContext;
     deviceId: string;
+    effectivePolicy?: EffectiveTrustedDevicePolicy;
     userId: string;
   }>;
 
@@ -201,10 +205,11 @@ export const createTrustedDeviceLibrary = (
   const createCredential = async ({
     ctx,
     deviceId,
+    effectivePolicy,
     userId,
     ...metadata
   }: CreateTrustedDeviceCredential) => {
-    const policy = await policyLibrary.getEffectivePolicy(userId);
+    const policy = effectivePolicy ?? (await policyLibrary.getEffectivePolicy(userId));
 
     if (!policy.enabled) {
       return;

--- a/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
@@ -204,6 +204,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         {
           availableFactors: [MfaFactor.TOTP],
           maskedIdentifiers: {},
+          trustedDevice: { canCreate: false },
         }
       )
     );
@@ -298,6 +299,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         {
           availableFactors: [MfaFactor.TOTP],
           maskedIdentifiers: {},
+          trustedDevice: { canCreate: false },
         }
       )
     );
@@ -963,6 +965,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         {
           availableFactors: [MfaFactor.TOTP],
           maskedIdentifiers: {},
+          trustedDevice: { canCreate: false },
         }
       )
     );

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -18,7 +18,11 @@ import { createMockProvider } from '#src/test-utils/oidc-provider.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 import { createContextWithRouteParameters } from '#src/utils/test-utils.js';
 
-import { type Interaction, type WithHooksAndLogsContext } from '../types.js';
+import {
+  type Interaction,
+  type TrustedDeviceAvailability,
+  type WithHooksAndLogsContext,
+} from '../types.js';
 
 const { jest } = import.meta;
 const { mockEsmWithActual } = createMockUtils(jest);
@@ -110,23 +114,20 @@ const createInteraction = (
 const expectConventionalMfaRequired = async (
   experienceInteraction: InstanceType<typeof ExperienceInteraction>,
   options?: {
-    trustedDeviceAvailability?: { canCreate: boolean; durationDays?: number };
-    includeTrustedDevice?: boolean;
+    trustedDevice?: TrustedDeviceAvailability | false;
   }
 ) => {
-  const trustedDeviceAvailability = options?.trustedDeviceAvailability ?? {
-    canCreate: true,
-    durationDays: 30,
-  };
+  const trustedDevice =
+    options?.trustedDevice === undefined
+      ? { canCreate: true, durationDays: 30 }
+      : options.trustedDevice;
   await expect(experienceInteraction.guardMfaVerificationStatus()).rejects.toMatchError(
     new RequestError(
       { code: 'session.mfa.require_mfa_verification', status: 403 },
       {
         availableFactors: [MfaFactor.TOTP],
         maskedIdentifiers: {},
-        ...(options?.includeTrustedDevice === false
-          ? {}
-          : { trustedDevice: trustedDeviceAvailability }),
+        ...(trustedDevice ? { trustedDevice } : {}),
       }
     )
   );
@@ -192,7 +193,7 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
 
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
 
-    expect(getEffectivePolicy).toHaveBeenCalledWith(mockUserWithMfaVerifications.id);
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
     expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
@@ -208,10 +209,10 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
     });
 
     await expectConventionalMfaRequired(experienceInteraction, {
-      trustedDeviceAvailability: { canCreate: false },
+      trustedDevice: { canCreate: false },
     });
 
-    expect(getEffectivePolicy).toHaveBeenCalledWith(mockUserWithMfaVerifications.id);
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).not.toHaveBeenCalled();
   });
 
@@ -231,7 +232,7 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
 
     await expectConventionalMfaRequired(experienceInteraction);
 
-    expect(getEffectivePolicy).toHaveBeenCalledWith(mockUserWithMfaVerifications.id);
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
     expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
@@ -278,7 +279,7 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
     validateCredential.mockResolvedValueOnce(trustedDevice);
     const { experienceInteraction } = createInteraction();
 
-    await expectConventionalMfaRequired(experienceInteraction, { includeTrustedDevice: false });
+    await expectConventionalMfaRequired(experienceInteraction, { trustedDevice: false });
 
     expect(getEffectivePolicy).not.toHaveBeenCalled();
     expect(validateCredential).not.toHaveBeenCalled();

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -108,14 +108,25 @@ const createInteraction = (
 };
 
 const expectConventionalMfaRequired = async (
-  experienceInteraction: InstanceType<typeof ExperienceInteraction>
+  experienceInteraction: InstanceType<typeof ExperienceInteraction>,
+  options?: {
+    trustedDeviceAvailability?: { canCreate: boolean; durationDays?: number };
+    includeTrustedDevice?: boolean;
+  }
 ) => {
+  const trustedDeviceAvailability = options?.trustedDeviceAvailability ?? {
+    canCreate: true,
+    durationDays: 30,
+  };
   await expect(experienceInteraction.guardMfaVerificationStatus()).rejects.toMatchError(
     new RequestError(
       { code: 'session.mfa.require_mfa_verification', status: 403 },
       {
         availableFactors: [MfaFactor.TOTP],
         maskedIdentifiers: {},
+        ...(options?.includeTrustedDevice === false
+          ? {}
+          : { trustedDevice: trustedDeviceAvailability }),
       }
     )
   );
@@ -196,20 +207,22 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
       },
     });
 
-    await expectConventionalMfaRequired(experienceInteraction);
+    await expectConventionalMfaRequired(experienceInteraction, {
+      trustedDeviceAvailability: { canCreate: false },
+    });
 
     expect(getEffectivePolicy).toHaveBeenCalledWith(mockUserWithMfaVerifications.id);
     expect(validateCredential).not.toHaveBeenCalled();
   });
 
-  it('skips policy and credential validation when no trusted-device cookie is present', async () => {
+  it('resolves advisory availability but skips credential validation when no cookie is present', async () => {
     hasCredential.mockReturnValueOnce(false);
     const { ctx, experienceInteraction } = createInteraction();
 
     await expectConventionalMfaRequired(experienceInteraction);
 
     expect(hasCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
-    expect(getEffectivePolicy).not.toHaveBeenCalled();
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).not.toHaveBeenCalled();
   });
 
@@ -230,7 +243,7 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
 
-    expect(getEffectivePolicy).toHaveBeenCalledTimes(2);
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).toHaveBeenCalledTimes(2);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
     expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
@@ -265,7 +278,7 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
     validateCredential.mockResolvedValueOnce(trustedDevice);
     const { experienceInteraction } = createInteraction();
 
-    await expectConventionalMfaRequired(experienceInteraction);
+    await expectConventionalMfaRequired(experienceInteraction, { includeTrustedDevice: false });
 
     expect(getEffectivePolicy).not.toHaveBeenCalled();
     expect(validateCredential).not.toHaveBeenCalled();

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -132,8 +132,8 @@ export default class ExperienceInteraction {
     if (typeof interactionData === 'string') {
       this.#interactionEvent = interactionData;
       this.profile = new Profile(libraries, queries, {}, interactionContext);
-      this.trustedDevice = new TrustedDevice(ctx, tenant, {});
       this.mfa = new Mfa(libraries, queries, {}, interactionContext);
+      this.trustedDevice = new TrustedDevice(ctx, tenant, {});
       return;
     }
 
@@ -161,10 +161,10 @@ export default class ExperienceInteraction {
     this.#interactionEvent = interactionEvent;
     this.userId = userId;
     this.profile = new Profile(libraries, queries, profile, interactionContext);
+    this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.trustedDevice = new TrustedDevice(ctx, tenant, {
       trustedDeviceCreation,
     });
-    this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.captcha = captcha;
     for (const record of verificationRecords) {
       const instance = buildVerificationRecord(libraries, queries, record);
@@ -392,6 +392,7 @@ export default class ExperienceInteraction {
       return;
     }
 
+    const trustedDeviceAvailabilityPromise = this.trustedDevice.getCreationAvailability(user.id);
     const isMfaVerifiedWithTrustedDevice = await this.trustedDevice.tryVerifyMfa(user.id);
 
     this.assignAdaptiveMfaHookResult(user.id, adaptiveMfaResult);
@@ -401,7 +402,7 @@ export default class ExperienceInteraction {
     }
 
     const { primaryEmail, primaryPhone } = user;
-    const trustedDevice = await this.trustedDevice.getCreationAvailability(user.id);
+    const trustedDevice = await trustedDeviceAvailabilityPromise;
     const maskedIdentifiers: Record<string, string> = {
       ...(mfaValidator.availableUserMfaVerificationTypes.includes(
         MfaFactor.EmailVerificationCode

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -118,6 +118,8 @@ export default class ExperienceInteraction {
         this.getVerificationRecordByTypeAndId(type, verificationId),
       getVerificationRecordById: (verificationId) => this.getVerificationRecordById(verificationId),
       getCurrentProfile: () => this.profile.data,
+      getTrustedDeviceCreationAvailability: async (userId, organizations) =>
+        this.trustedDevice.getCreationAvailability(userId, organizations),
     };
 
     this.adaptiveMfaValidator = new AdaptiveMfaValidator({
@@ -130,8 +132,8 @@ export default class ExperienceInteraction {
     if (typeof interactionData === 'string') {
       this.#interactionEvent = interactionData;
       this.profile = new Profile(libraries, queries, {}, interactionContext);
-      this.mfa = new Mfa(libraries, queries, {}, interactionContext);
       this.trustedDevice = new TrustedDevice(ctx, tenant, {});
+      this.mfa = new Mfa(libraries, queries, {}, interactionContext);
       return;
     }
 
@@ -159,10 +161,10 @@ export default class ExperienceInteraction {
     this.#interactionEvent = interactionEvent;
     this.userId = userId;
     this.profile = new Profile(libraries, queries, profile, interactionContext);
-    this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.trustedDevice = new TrustedDevice(ctx, tenant, {
       trustedDeviceCreation,
     });
+    this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.captcha = captcha;
     for (const record of verificationRecords) {
       const instance = buildVerificationRecord(libraries, queries, record);
@@ -399,6 +401,7 @@ export default class ExperienceInteraction {
     }
 
     const { primaryEmail, primaryPhone } = user;
+    const trustedDevice = await this.trustedDevice.getCreationAvailability(user.id);
     const maskedIdentifiers: Record<string, string> = {
       ...(mfaValidator.availableUserMfaVerificationTypes.includes(
         MfaFactor.EmailVerificationCode
@@ -419,6 +422,7 @@ export default class ExperienceInteraction {
         {
           availableFactors: mfaValidator.availableUserMfaVerificationTypes,
           maskedIdentifiers,
+          ...conditional(trustedDevice && { trustedDevice }),
         }
       )
     );
@@ -436,7 +440,10 @@ export default class ExperienceInteraction {
   /** Record an explicit trusted-device opt-in after validating eligible MFA proof. */
   public async requestTrustedDeviceCreation() {
     const user = await this.getIdentifiedUser();
-    this.trustedDevice.requestCreation(await this.hasEligibleTrustedDeviceProof(user));
+    await this.trustedDevice.requestCreation(
+      user.id,
+      await this.hasEligibleTrustedDeviceProof(user)
+    );
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/mfa.test.ts
@@ -5,6 +5,7 @@ import {
   MfaPolicy,
   type OrganizationWithRoles,
   OrganizationRequiredMfaPolicy,
+  SignInIdentifier,
   userMfaDataKey,
   type User,
 } from '@logto/schemas';
@@ -255,6 +256,44 @@ describe('Mfa.assertMfaFulfilled', () => {
       },
     });
     expect(getOrganizationsByUserId).toHaveBeenCalledTimes(1);
+    expect(getTrustedDeviceCreationAvailability).toHaveBeenCalledWith('user-id', organizations);
+  });
+
+  it('adds trusted-device availability to an additional-factor binding suggestion', async () => {
+    const organizations = [
+      { isMfaRequired: false, isTrustedDeviceAllowed: true },
+    ] as unknown as Readonly<OrganizationWithRoles[]>;
+    const { mfa, getTrustedDeviceCreationAvailability } = createMfa({
+      interactionEvent: InteractionEvent.Register,
+      mfaSettings: {
+        policy: MfaPolicy.Mandatory,
+        factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
+        organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
+      },
+      organizations,
+      user: {
+        id: 'user-id',
+        logtoConfig: {},
+        primaryEmail: 'foo@example.com',
+        mfaVerifications: [],
+      },
+    });
+    const { signInExperienceValidator } = mfa as unknown as {
+      signInExperienceValidator: SignInExperienceValidator;
+    };
+    jest.spyOn(signInExperienceValidator, 'getSignInExperienceData').mockResolvedValue({
+      signUp: { identifiers: [SignInIdentifier.Email] },
+      passkeySignIn: { enabled: false },
+    } as never);
+
+    await expect(mfa.assertMfaFulfilled()).rejects.toMatchObject({
+      code: 'session.mfa.suggest_additional_mfa',
+      status: 422,
+      data: {
+        availableFactors: [MfaFactor.TOTP, MfaFactor.EmailVerificationCode],
+        trustedDevice: { canCreate: true, durationDays: 30 },
+      },
+    });
     expect(getTrustedDeviceCreationAvailability).toHaveBeenCalledWith('user-id', organizations);
   });
 

--- a/packages/core/src/routes/experience/classes/mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/mfa.test.ts
@@ -3,6 +3,7 @@ import {
   MfaFactor,
   type Mfa as MfaSettings,
   MfaPolicy,
+  type OrganizationWithRoles,
   OrganizationRequiredMfaPolicy,
   userMfaDataKey,
   type User,
@@ -31,11 +32,15 @@ const createMfa = ({
     mfaVerifications: [],
   },
   currentProfile = {},
+  organizations = [],
+  trustedDeviceAvailability = { canCreate: true, durationDays: 30 },
 }: {
   mfaSettings?: MfaSettings;
   interactionEvent?: InteractionEvent;
   user?: Partial<User>;
   currentProfile?: Record<string, unknown>;
+  organizations?: Readonly<OrganizationWithRoles[]>;
+  trustedDeviceAvailability?: { canCreate: boolean; durationDays?: number };
 } = {}) => {
   const getIdentifiedUser = jest.fn(async () => user as User);
   const interactionContext: InteractionContext = {
@@ -48,9 +53,17 @@ const createMfa = ({
       throw new Error('should not be called');
     },
     getCurrentProfile: () => currentProfile,
+    getTrustedDeviceCreationAvailability: jest.fn(async () => trustedDeviceAvailability),
   };
 
-  const mfa = new Mfa({} as Libraries, {} as Queries, {}, interactionContext);
+  const getOrganizationsByUserId = jest.fn(async () => organizations);
+  const getTrustedDeviceCreationAvailability = jest.mocked(
+    interactionContext.getTrustedDeviceCreationAvailability
+  );
+  const queries = {
+    organizations: { relations: { users: { getOrganizationsByUserId } } },
+  } as unknown as Queries;
+  const mfa = new Mfa({} as Libraries, queries, {}, interactionContext);
   const { signInExperienceValidator } = mfa as unknown as {
     signInExperienceValidator: SignInExperienceValidator;
   };
@@ -66,6 +79,8 @@ const createMfa = ({
     getIdentifiedUser,
     getMfaSettings,
     getConfiguredMfaFactors,
+    getOrganizationsByUserId,
+    getTrustedDeviceCreationAvailability,
   };
 };
 
@@ -167,8 +182,56 @@ describe('Mfa.assertMfaFulfilled', () => {
       status: 422,
       data: {
         availableFactors: [MfaFactor.TOTP],
+        trustedDevice: { canCreate: true, durationDays: 30 },
       },
     });
+  });
+
+  it('adds trusted-device availability to the optional MFA suggestion', async () => {
+    const { mfa } = createMfa({
+      mfaSettings: {
+        policy: MfaPolicy.PromptOnlyAtSignIn,
+        factors: [MfaFactor.TOTP],
+        organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.NoPrompt,
+      },
+      user: {
+        id: 'user-id',
+        logtoConfig: { [userMfaDataKey]: { enabled: false } },
+        mfaVerifications: [],
+      },
+    });
+
+    await expect(mfa.assertMfaFulfilled()).rejects.toMatchObject({
+      code: 'user.suggest_mfa',
+      status: 422,
+      data: {
+        trustedDevice: { canCreate: true, durationDays: 30 },
+      },
+    });
+  });
+
+  it('reuses loaded organization rows for MFA and trusted-device eligibility', async () => {
+    const organizations = [
+      { isMfaRequired: true, isTrustedDeviceAllowed: false },
+    ] as unknown as Readonly<OrganizationWithRoles[]>;
+    const { mfa, getOrganizationsByUserId, getTrustedDeviceCreationAvailability } = createMfa({
+      mfaSettings: {
+        policy: MfaPolicy.NoPrompt,
+        factors: [MfaFactor.TOTP],
+        organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
+      },
+      organizations,
+      trustedDeviceAvailability: { canCreate: false },
+    });
+
+    await expect(mfa.assertMfaFulfilled()).rejects.toMatchObject({
+      code: 'user.missing_mfa',
+      data: {
+        trustedDevice: { canCreate: false },
+      },
+    });
+    expect(getOrganizationsByUserId).toHaveBeenCalledTimes(1);
+    expect(getTrustedDeviceCreationAvailability).toHaveBeenCalledWith('user-id', organizations);
   });
 
   it('skips additional MFA suggestion when user has persisted skipped flag', async () => {

--- a/packages/core/src/routes/experience/classes/mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/mfa.test.ts
@@ -12,7 +12,7 @@ import {
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
-import { type InteractionContext } from '../types.js';
+import { type InteractionContext, type TrustedDeviceAvailability } from '../types.js';
 
 import { type SignInExperienceValidator } from './libraries/sign-in-experience-validator.js';
 import { Mfa } from './mfa.js';
@@ -40,7 +40,7 @@ const createMfa = ({
   user?: Partial<User>;
   currentProfile?: Record<string, unknown>;
   organizations?: Readonly<OrganizationWithRoles[]>;
-  trustedDeviceAvailability?: { canCreate: boolean; durationDays?: number };
+  trustedDeviceAvailability?: TrustedDeviceAvailability | false;
 } = {}) => {
   const getIdentifiedUser = jest.fn(async () => user as User);
   const interactionContext: InteractionContext = {
@@ -53,7 +53,9 @@ const createMfa = ({
       throw new Error('should not be called');
     },
     getCurrentProfile: () => currentProfile,
-    getTrustedDeviceCreationAvailability: jest.fn(async () => trustedDeviceAvailability),
+    getTrustedDeviceCreationAvailability: jest.fn(
+      async () => trustedDeviceAvailability || undefined
+    ),
   };
 
   const getOrganizationsByUserId = jest.fn(async () => organizations);
@@ -207,6 +209,28 @@ describe('Mfa.assertMfaFulfilled', () => {
       data: {
         trustedDevice: { canCreate: true, durationDays: 30 },
       },
+    });
+  });
+
+  it('keeps optional MFA suggestion data absent without trusted-device availability', async () => {
+    const { mfa } = createMfa({
+      mfaSettings: {
+        policy: MfaPolicy.PromptOnlyAtSignIn,
+        factors: [MfaFactor.TOTP],
+        organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.NoPrompt,
+      },
+      user: {
+        id: 'user-id',
+        logtoConfig: { [userMfaDataKey]: { enabled: false } },
+        mfaVerifications: [],
+      },
+      trustedDeviceAvailability: false,
+    });
+
+    await expect(mfa.assertMfaFulfilled()).rejects.toMatchObject({
+      code: 'user.suggest_mfa',
+      status: 422,
+      data: undefined,
     });
   });
 

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -527,7 +527,12 @@ export class Mfa {
     }
 
     // Optional suggestion: Let Mfa decide whether to suggest additional binding during registration
-    await this.guardAdditionalBindingSuggestion(factorsInUser, configuredFactors, identifiedUser);
+    await this.guardAdditionalBindingSuggestion(
+      factorsInUser,
+      configuredFactors,
+      identifiedUser,
+      organizations
+    );
 
     // Assert backup code
     assertThat(
@@ -550,7 +555,8 @@ export class Mfa {
   private async guardAdditionalBindingSuggestion(
     factorsInUser: MfaFactor[],
     availableFactors: MfaFactor[],
-    identifiedUser: User
+    identifiedUser: User,
+    organizations?: Readonly<OrganizationWithRoles[]>
   ) {
     // Respect user's choice to skip suggestion for this interaction.
     if (this.additionalBindingSuggestionSkipped) {
@@ -618,6 +624,10 @@ export class Mfa {
         primaryPhone &&
         maskPhone(primaryPhone),
     });
+    const trustedDevice = await this.getTrustedDeviceCreationAvailability(
+      identifiedUser.id,
+      organizations
+    );
 
     throw new RequestError(
       { code: 'session.mfa.suggest_additional_mfa', status: 422 },
@@ -628,6 +638,7 @@ export class Mfa {
           passkeySignIn.enabled && factorsInUser.includes(MfaFactor.WebAuthn),
         skippable: true,
         suggestion: true,
+        ...conditional(trustedDevice && { trustedDevice }),
       }
     );
   }

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -11,6 +11,7 @@ import {
   InteractionEvent,
   type JsonObject,
   MfaPolicy,
+  type OrganizationWithRoles,
   type User,
   VerificationType,
   type Mfa as MfaSettings,
@@ -23,7 +24,7 @@ import {
   SignInIdentifier,
 } from '@logto/schemas';
 import { generateStandardId, maskEmail, maskPhone } from '@logto/shared';
-import { cond, condObject, deduplicate, pick } from '@silverhand/essentials';
+import { cond, conditional, condObject, deduplicate, pick } from '@silverhand/essentials';
 import { z } from 'zod';
 
 import RequestError from '#src/errors/RequestError/index.js';
@@ -119,6 +120,7 @@ const isPasskeySkipped = (logtoConfig: JsonObject): boolean => {
 
 type SubmitMfaValidationContext = {
   mfaSettings: MfaSettings;
+  organizations?: Readonly<OrganizationWithRoles[]>;
   user: User;
   userFactors: MfaFactor[];
 };
@@ -407,7 +409,12 @@ export class Mfa {
   private async assertOptionalMfaEnablement(
     submitMfaValidationContext: SubmitMfaValidationContext
   ) {
-    const { mfaSettings, user: identifiedUser, userFactors } = submitMfaValidationContext;
+    const {
+      mfaSettings,
+      organizations,
+      user: identifiedUser,
+      userFactors,
+    } = submitMfaValidationContext;
     const { policy, factors } = mfaSettings;
 
     // If there are no factors, bypass the check.
@@ -440,26 +447,11 @@ export class Mfa {
     }
 
     // If MFA is required by organizations, bypass.
-    if (await this.isMfaRequiredByUserOrganizations(mfaSettings, userId)) {
+    if (await this.isMfaRequiredByUserOrganizations(mfaSettings, userId, organizations)) {
       return;
     }
 
-    // Since MFA `enabled` flag is introduced later, legacy users who don't have the `enabled` flag in their config should
-    // be checked if they have any MFA factors bound, in order to determine whether MFA is effectively enabled for them.
-    if (hasEnabledMfa === undefined) {
-      assertThat(
-        userFactors.length > 0,
-        new RequestError({ code: 'user.suggest_mfa', status: 422 })
-      );
-
-      // Backfill the `enabled` flag for legacy users to avoid repeated suggestions in future interactions.
-      this.markMfaEnabled();
-      return;
-    }
-
-    // Suggest MFA binding if the user has not completed MFA binding, even if the policy is not mandatory,
-    // to encourage better account security.
-    assertThat(hasEnabledMfa, new RequestError({ code: 'user.suggest_mfa', status: 422 }));
+    await this.assertOptionalMfaEnabled(hasEnabledMfa, userFactors, userId, organizations);
   }
 
   /**
@@ -471,7 +463,7 @@ export class Mfa {
   private async assertUserMandatoryMfaFulfilled(
     submitMfaValidationContext: SubmitMfaValidationContext
   ) {
-    const { mfaSettings } = submitMfaValidationContext;
+    const { mfaSettings, organizations } = submitMfaValidationContext;
     const { policy, factors } = mfaSettings;
 
     // If there are no factors, then there is nothing to check
@@ -492,7 +484,8 @@ export class Mfa {
 
     const isMfaRequiredByUserOrganizations = await this.isMfaRequiredByUserOrganizations(
       mfaSettings,
-      userId
+      userId,
+      organizations
     );
 
     // If the policy is no prompt, and mfa is not required by the user organizations, then there is nothing to check
@@ -518,15 +511,20 @@ export class Mfa {
     const linkedFactors = deduplicate([...factorsInUser, ...factorsInBind]);
 
     // Assert that the user has at least one of the required factors bound
-    assertThat(
-      configuredFactors.some((factor) => linkedFactors.includes(factor)),
-      new RequestError(
+    if (!configuredFactors.some((factor) => linkedFactors.includes(factor))) {
+      const trustedDevice = await this.getTrustedDeviceCreationAvailability(userId, organizations);
+
+      throw new RequestError(
         { code: 'user.missing_mfa', status: 422 },
-        isNoSkipMfaPolicy(policy) || isMfaRequiredByUserOrganizations
-          ? { availableFactors: configuredFactors }
-          : { availableFactors: configuredFactors, skippable: true }
-      )
-    );
+        {
+          availableFactors: configuredFactors,
+          ...conditional(
+            !isNoSkipMfaPolicy(policy) && !isMfaRequiredByUserOrganizations && { skippable: true }
+          ),
+          ...conditional(trustedDevice && { trustedDevice }),
+        }
+      );
+    }
 
     // Optional suggestion: Let Mfa decide whether to suggest additional binding during registration
     await this.guardAdditionalBindingSuggestion(factorsInUser, configuredFactors, identifiedUser);
@@ -648,15 +646,20 @@ export class Mfa {
     assertThat(isFactorsEnabled, new RequestError({ code: 'session.mfa.mfa_factor_not_enabled' }));
   }
 
-  private async isMfaRequiredByUserOrganizations(mfaSettings: MfaSettings, userId: string) {
+  private async isMfaRequiredByUserOrganizations(
+    mfaSettings: MfaSettings,
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) {
     if (mfaSettings.organizationRequiredMfaPolicy !== OrganizationRequiredMfaPolicy.Mandatory) {
       return false;
     }
 
-    const organizations =
-      await this.queries.organizations.relations.users.getOrganizationsByUserId(userId);
+    const resolvedOrganizations =
+      organizations ??
+      (await this.queries.organizations.relations.users.getOrganizationsByUserId(userId));
 
-    return organizations.some(({ isMfaRequired }) => isMfaRequired);
+    return resolvedOrganizations.some(({ isMfaRequired }) => isMfaRequired);
   }
 
   /**
@@ -675,13 +678,66 @@ export class Mfa {
       this.signInExperienceValidator.getMfaSettings(),
       this.interactionContext.getIdentifiedUser(),
     ]);
-    const userFactors = await this.getUserMfaFactors({ mfaSettings, user });
+    const [userFactors, organizations] = await Promise.all([
+      this.getUserMfaFactors({ mfaSettings, user }),
+      mfaSettings.factors.length > 0 &&
+      mfaSettings.organizationRequiredMfaPolicy === OrganizationRequiredMfaPolicy.Mandatory
+        ? this.queries.organizations.relations.users.getOrganizationsByUserId(user.id)
+        : undefined,
+    ]);
 
     return {
       mfaSettings,
+      organizations,
       user,
       userFactors,
     };
+  }
+
+  private async throwMfaSuggestion(
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ): Promise<never> {
+    const trustedDevice = await this.getTrustedDeviceCreationAvailability(userId, organizations);
+
+    throw new RequestError(
+      { code: 'user.suggest_mfa', status: 422 },
+      {
+        ...conditional(trustedDevice && { trustedDevice }),
+      }
+    );
+  }
+
+  private async assertOptionalMfaEnabled(
+    hasEnabledMfa: boolean | undefined,
+    userFactors: MfaFactor[],
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) {
+    // Since MFA `enabled` flag is introduced later, legacy users who don't have the `enabled` flag in their config should
+    // be checked if they have any MFA factors bound, in order to determine whether MFA is effectively enabled for them.
+    if (hasEnabledMfa === undefined) {
+      if (userFactors.length === 0) {
+        await this.throwMfaSuggestion(userId, organizations);
+      }
+
+      // Backfill the `enabled` flag for legacy users to avoid repeated suggestions in future interactions.
+      this.markMfaEnabled();
+      return;
+    }
+
+    // Suggest MFA binding if the user has not completed MFA binding, even if the policy is not mandatory,
+    // to encourage better account security.
+    if (!hasEnabledMfa) {
+      await this.throwMfaSuggestion(userId, organizations);
+    }
+  }
+
+  private async getTrustedDeviceCreationAvailability(
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) {
+    return this.interactionContext.getTrustedDeviceCreationAvailability?.(userId, organizations);
   }
 
   private async getUserMfaFactors({

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -451,7 +451,7 @@ export class Mfa {
       return;
     }
 
-    await this.assertOptionalMfaEnabled(hasEnabledMfa, userFactors, userId, organizations);
+    await this.assertMfaEnabledOrSuggest(hasEnabledMfa, userFactors, userId, organizations);
   }
 
   /**
@@ -694,21 +694,19 @@ export class Mfa {
     };
   }
 
-  private async throwMfaSuggestion(
+  private async buildMfaSuggestionError(
     userId: string,
     organizations?: Readonly<OrganizationWithRoles[]>
-  ): Promise<never> {
+  ) {
     const trustedDevice = await this.getTrustedDeviceCreationAvailability(userId, organizations);
 
-    throw new RequestError(
+    return new RequestError(
       { code: 'user.suggest_mfa', status: 422 },
-      {
-        ...conditional(trustedDevice && { trustedDevice }),
-      }
+      conditional(trustedDevice && { trustedDevice })
     );
   }
 
-  private async assertOptionalMfaEnabled(
+  private async assertMfaEnabledOrSuggest(
     hasEnabledMfa: boolean | undefined,
     userFactors: MfaFactor[],
     userId: string,
@@ -718,7 +716,7 @@ export class Mfa {
     // be checked if they have any MFA factors bound, in order to determine whether MFA is effectively enabled for them.
     if (hasEnabledMfa === undefined) {
       if (userFactors.length === 0) {
-        await this.throwMfaSuggestion(userId, organizations);
+        throw await this.buildMfaSuggestionError(userId, organizations);
       }
 
       // Backfill the `enabled` flag for legacy users to avoid repeated suggestions in future interactions.
@@ -729,7 +727,7 @@ export class Mfa {
     // Suggest MFA binding if the user has not completed MFA binding, even if the policy is not mandatory,
     // to encourage better account security.
     if (!hasEnabledMfa) {
-      await this.throwMfaSuggestion(userId, organizations);
+      throw await this.buildMfaSuggestionError(userId, organizations);
     }
   }
 
@@ -737,7 +735,7 @@ export class Mfa {
     userId: string,
     organizations?: Readonly<OrganizationWithRoles[]>
   ) {
-    return this.interactionContext.getTrustedDeviceCreationAvailability?.(userId, organizations);
+    return this.interactionContext.getTrustedDeviceCreationAvailability(userId, organizations);
   }
 
   private async getUserMfaFactors({

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -92,6 +92,40 @@ describe('Experience trusted-device lifecycle events', () => {
     jest.restoreAllMocks();
   });
 
+  it('memoizes effective policy across availability and creation finalization', async () => {
+    const creation = createSubject({ data: {}, createResult: trustedDevice });
+
+    await expect(creation.subject.getCreationAvailability(userId)).resolves.toEqual({
+      canCreate: true,
+      durationDays: 30,
+    });
+    await creation.subject.finalize({
+      creation: { deviceId: trustedDeviceId },
+      interactionEvent: InteractionEvent.SignIn,
+      userId,
+      hasEligibleMfaProof: true,
+    });
+
+    expect(creation.getEffectivePolicy).toHaveBeenCalledTimes(1);
+    expect(creation.createCredential).toHaveBeenCalledWith(
+      expect.objectContaining({
+        effectivePolicy: { enabled: true, durationDays: 30 },
+      })
+    );
+  });
+
+  it('rejects creation intent when the current server policy disallows it', async () => {
+    const creation = createSubject({ data: {} });
+    creation.getEffectivePolicy.mockResolvedValueOnce({ enabled: false, durationDays: 30 });
+
+    await expect(creation.subject.requestCreation(userId, true)).rejects.toMatchObject({
+      code: 'session.mfa.require_mfa_verification',
+      status: 403,
+    });
+
+    expect(creation.subject.data).toEqual({});
+  });
+
   it('emits Created audit and webhook events only for the successful insert winner', async () => {
     const winner = createSubject({
       data: {},

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -1,5 +1,9 @@
 import { appInsights } from '@logto/app-insights/node';
-import { InteractionEvent, type TrustedDevice as TrustedDeviceModel } from '@logto/schemas';
+import {
+  InteractionEvent,
+  type OrganizationWithRoles,
+  type TrustedDevice as TrustedDeviceModel,
+} from '@logto/schemas';
 
 import { createMockTrustedDevice } from '#src/__mocks__/trusted-device.js';
 import { EnvSet } from '#src/env-set/index.js';
@@ -114,16 +118,42 @@ describe('Experience trusted-device lifecycle events', () => {
     );
   });
 
-  it('rejects creation intent when the current server policy disallows it', async () => {
+  it('ignores creation intent when the current server policy disallows it', async () => {
     const creation = createSubject({ data: {} });
     creation.getEffectivePolicy.mockResolvedValueOnce({ enabled: false, durationDays: 30 });
 
-    await expect(creation.subject.requestCreation(userId, true)).rejects.toMatchObject({
-      code: 'session.mfa.require_mfa_verification',
-      status: 403,
-    });
+    await expect(creation.subject.requestCreation(userId, true)).resolves.toBeUndefined();
 
     expect(creation.subject.data).toEqual({});
+  });
+
+  it('retries effective policy resolution after a failed availability lookup', async () => {
+    const error = new Error('policy lookup failed');
+    const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
+    const creation = createSubject({ data: {} });
+    creation.getEffectivePolicy
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce({ enabled: true, durationDays: 30 });
+
+    await expect(creation.subject.getCreationAvailability(userId)).resolves.toBeUndefined();
+    await expect(creation.subject.requestCreation(userId, true)).resolves.toBeUndefined();
+
+    expect(creation.getEffectivePolicy).toHaveBeenCalledTimes(2);
+    expect(creation.subject.data.trustedDeviceCreation?.deviceId).toEqual(expect.any(String));
+    expect(trackException).toHaveBeenCalledWith(error, expect.any(Object));
+  });
+
+  it('refreshes an unscoped policy memo when loaded organizations are supplied', async () => {
+    const organizations = [{ isTrustedDeviceAllowed: true }] as unknown as Readonly<
+      OrganizationWithRoles[]
+    >;
+    const creation = createSubject({ data: {} });
+
+    await creation.subject.getCreationAvailability(userId);
+    await creation.subject.getCreationAvailability(userId, organizations);
+
+    expect(creation.getEffectivePolicy).toHaveBeenCalledTimes(2);
+    expect(creation.getEffectivePolicy).toHaveBeenNthCalledWith(2, userId, organizations);
   });
 
   it('emits Created audit and webhook events only for the successful insert winner', async () => {

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -1,19 +1,28 @@
 import { createHash } from 'node:crypto';
 
 import { appInsights } from '@logto/app-insights/node';
-import { InteractionEvent, type TrustedDevice as TrustedDeviceModel } from '@logto/schemas';
+import {
+  InteractionEvent,
+  type OrganizationWithRoles,
+  type TrustedDevice as TrustedDeviceModel,
+} from '@logto/schemas';
 import { generateStandardId } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { type EffectiveTrustedDevicePolicy } from '#src/libraries/trusted-device-policy.js';
 import { getTrustedDeviceEventData } from '#src/libraries/trusted-device.js';
 import { type TrustedDeviceMetadata } from '#src/queries/trusted-device.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
-import { type InteractionStorage, type WithHooksAndLogsContext } from '../types.js';
+import {
+  type InteractionStorage,
+  type TrustedDeviceAvailability,
+  type WithHooksAndLogsContext,
+} from '../types.js';
 
 type TrustedDeviceData = Pick<InteractionStorage, 'trustedDeviceCreation'>;
 
@@ -44,6 +53,7 @@ type FinalizeOptions = {
 export class TrustedDevice {
   #creation?: InteractionStorage['trustedDeviceCreation'];
   #validatedDeviceId?: string;
+  #effectivePolicy?: Promise<EffectiveTrustedDevicePolicy>;
 
   constructor(
     private readonly ctx: WithHooksAndLogsContext,
@@ -59,9 +69,16 @@ export class TrustedDevice {
     };
   }
 
-  requestCreation(hasEligibleMfaProof: boolean) {
+  async requestCreation(userId: string, hasEligibleMfaProof: boolean) {
     assertThat(
       hasEligibleMfaProof,
+      new RequestError({ code: 'session.mfa.require_mfa_verification', status: 403 })
+    );
+
+    const { enabled } = await this.#getEffectivePolicy(userId);
+
+    assertThat(
+      enabled,
       new RequestError({ code: 'session.mfa.require_mfa_verification', status: 403 })
     );
 
@@ -76,19 +93,28 @@ export class TrustedDevice {
     return creation;
   }
 
-  async getCreationAvailability(userId?: string) {
+  async getCreationAvailability(
+    userId?: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ): Promise<TrustedDeviceAvailability | undefined> {
     // Trusted-device opt-in is under development and must remain isolated from released flows.
     if (!EnvSet.values.isDevFeaturesEnabled || !userId) {
       return;
     }
 
-    const { enabled, durationDays } =
-      await this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(userId);
+    return trySafe(
+      async () => {
+        const { enabled, durationDays } = await this.#getEffectivePolicy(userId, organizations);
 
-    return {
-      canCreate: enabled,
-      ...conditional(enabled && { durationDays }),
-    };
+        return {
+          canCreate: enabled,
+          ...conditional(enabled && { durationDays }),
+        };
+      },
+      (error) => {
+        void appInsights.trackException(error, buildAppInsightsTelemetry(this.ctx));
+      }
+    );
   }
 
   /**
@@ -105,15 +131,13 @@ export class TrustedDevice {
 
     this.#validatedDeviceId = undefined;
 
-    const {
-      libraries: { trustedDevicePolicy, trustedDevices },
-    } = this.tenant;
+    const { trustedDevices } = this.tenant.libraries;
 
     if (!trustedDevices.hasCredential(this.ctx, userId)) {
       return false;
     }
 
-    const { enabled } = await trustedDevicePolicy.getEffectivePolicy(userId);
+    const { enabled } = await this.#getEffectivePolicy(userId);
 
     if (!enabled) {
       return false;
@@ -206,6 +230,7 @@ export class TrustedDevice {
     const trustedDevice = await this.tenant.libraries.trustedDevices.createCredential({
       ctx: this.ctx,
       deviceId: creation.deviceId,
+      effectivePolicy: await this.#getEffectivePolicy(userId),
       userId,
       ...metadata,
     });
@@ -236,5 +261,13 @@ export class TrustedDevice {
     });
 
     log.append({ userId: data.userId, data });
+  }
+
+  async #getEffectivePolicy(userId: string, organizations?: Readonly<OrganizationWithRoles[]>) {
+    this.#effectivePolicy ??= organizations
+      ? this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(userId, organizations)
+      : this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(userId);
+
+    return this.#effectivePolicy;
   }
 }

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -53,7 +53,11 @@ type FinalizeOptions = {
 export class TrustedDevice {
   #creation?: InteractionStorage['trustedDeviceCreation'];
   #validatedDeviceId?: string;
-  #effectivePolicy?: Promise<EffectiveTrustedDevicePolicy>;
+  #effectivePolicy?: {
+    userId: string;
+    includesOrganizations: boolean;
+    promise: Promise<EffectiveTrustedDevicePolicy>;
+  };
 
   constructor(
     private readonly ctx: WithHooksAndLogsContext,
@@ -77,10 +81,9 @@ export class TrustedDevice {
 
     const { enabled } = await this.#getEffectivePolicy(userId);
 
-    assertThat(
-      enabled,
-      new RequestError({ code: 'session.mfa.require_mfa_verification', status: 403 })
-    );
+    if (!enabled) {
+      return;
+    }
 
     this.#creation ||= { deviceId: generateStandardId() };
   }
@@ -264,10 +267,34 @@ export class TrustedDevice {
   }
 
   async #getEffectivePolicy(userId: string, organizations?: Readonly<OrganizationWithRoles[]>) {
-    this.#effectivePolicy ??= organizations
-      ? this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(userId, organizations)
-      : this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(userId);
+    const cachedPolicy = this.#effectivePolicy;
 
-    return this.#effectivePolicy;
+    if (
+      cachedPolicy?.userId === userId &&
+      (cachedPolicy.includesOrganizations || organizations === undefined)
+    ) {
+      return cachedPolicy.promise;
+    }
+
+    const promise = this.tenant.libraries.trustedDevicePolicy.getEffectivePolicy(
+      userId,
+      organizations
+    );
+    const policyEntry = {
+      userId,
+      includesOrganizations: organizations !== undefined,
+      promise,
+    };
+    this.#effectivePolicy = policyEntry;
+
+    try {
+      return await promise;
+    } catch (error: unknown) {
+      if (this.#effectivePolicy === policyEntry) {
+        this.#effectivePolicy = undefined;
+      }
+
+      throw error;
+    }
   }
 }

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -1209,7 +1209,7 @@ describe('POST /experience/submit', () => {
     });
     expect(response.body).not.toHaveProperty('trustedDeviceFulfillment');
     expect(response.body).not.toHaveProperty('trustedDeviceCreation');
-    expect(getEffectivePolicy).toHaveBeenCalledWith(mockUser.id);
+    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
   });
 
   it('should expose disabled creation without a duration when effective policy disallows it', async () => {

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -10,9 +10,8 @@
  * The experience APIs can be used by developers to build custom user interaction experiences.
  */
 
-import { appInsights } from '@logto/app-insights/node';
 import { identificationApiPayloadGuard, InteractionEvent } from '@logto/schemas';
-import { conditional, trySafe } from '@silverhand/essentials';
+import { conditional } from '@silverhand/essentials';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
@@ -20,7 +19,6 @@ import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaInteractionDetails from '#src/middleware/koa-interaction-details.js';
 import assertThat from '#src/utils/assert-that.js';
-import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import { type AnonymousRouter, type RouterInitArgs } from '../types.js';
 
@@ -204,14 +202,8 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
     }),
     async (ctx, next) => {
       const { experienceInteraction } = ctx;
-      const trustedDevice = await trySafe(
-        async () =>
-          experienceInteraction.trustedDevice.getCreationAvailability(
-            experienceInteraction.identifiedUserId
-          ),
-        (error) => {
-          void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));
-        }
+      const trustedDevice = await experienceInteraction.trustedDevice.getCreationAvailability(
+        experienceInteraction.identifiedUserId
       );
 
       ctx.body = {

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -177,7 +177,7 @@ export type InteractionContext = {
     verificationId: string
   ) => VerificationRecordMap[K];
   getCurrentProfile: () => InteractionProfile;
-  getTrustedDeviceCreationAvailability?: (
+  getTrustedDeviceCreationAvailability: (
     userId: string,
     organizations?: Readonly<OrganizationWithRoles[]>
   ) => Promise<TrustedDeviceAvailability | undefined>;

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -3,6 +3,7 @@ import {
   type CreateUser,
   encryptedTokenSetGuard,
   InteractionEvent,
+  type OrganizationWithRoles,
   secretEnterpriseSsoConnectorRelationPayloadGuard,
   secretSocialConnectorRelationPayloadGuard,
   type User,
@@ -176,6 +177,15 @@ export type InteractionContext = {
     verificationId: string
   ) => VerificationRecordMap[K];
   getCurrentProfile: () => InteractionProfile;
+  getTrustedDeviceCreationAvailability?: (
+    userId: string,
+    organizations?: Readonly<OrganizationWithRoles[]>
+  ) => Promise<TrustedDeviceAvailability | undefined>;
+};
+
+export type TrustedDeviceAvailability = {
+  canCreate: boolean;
+  durationDays?: number;
 };
 
 export type ExperienceInteractionRouterContext<ContextT extends WithLogContext = WithLogContext> =
@@ -234,10 +244,7 @@ export const interactionStorageGuard = z.object({
 export type SanitizedInteractionStorageData = {
   interactionEvent: InteractionEvent;
   userId?: string;
-  trustedDevice?: {
-    canCreate: boolean;
-    durationDays?: number;
-  };
+  trustedDevice?: TrustedDeviceAvailability;
   profile?: SanitizedInteractionProfile;
   verificationRecords?: SanitizedVerificationRecordData[];
   mfa?: SanitizedMfaData;

--- a/packages/experience/src/types/guard.test.ts
+++ b/packages/experience/src/types/guard.test.ts
@@ -29,7 +29,7 @@ describe('guard', () => {
     expect(value).toEqual(record);
   });
 
-  it('mfaErrorDataGuard should accept passkey suggestion metadata', () => {
+  it('mfaErrorDataGuard should accept passkey suggestion and trusted-device metadata', () => {
     expect(() => {
       s.assert(
         {
@@ -37,6 +37,7 @@ describe('guard', () => {
           skippable: true,
           suggestion: true,
           isWebAuthnUsedAsSignInPasskey: true,
+          trustedDevice: { canCreate: true, durationDays: 30 },
         },
         mfaErrorDataGuard
       );

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -78,6 +78,12 @@ export const mfaErrorDataGuard = s.object({
   availableFactors: mfaFactorsGuard,
   skippable: s.optional(s.boolean()),
   maskedIdentifiers: s.optional(s.record(s.enums(mfaFactorEnumValues), s.string())),
+  trustedDevice: s.optional(
+    s.object({
+      canCreate: s.boolean(),
+      durationDays: s.optional(s.number()),
+    })
+  ),
   // Whether this MFA flow is an optional suggestion (e.g., add another factor after sign-up)
   suggestion: s.optional(s.boolean()),
   // Whether the current WebAuthn factor is used as a sign-in passkey.


### PR DESCRIPTION
## Summary

Add trusted-device creation availability to MFA verification, missing-MFA, and suggested-MFA error details.

Reuse request-scoped policy and organization results while keeping the existing interaction API response unchanged for compatibility with the next stacked change.

Stack: 1/4

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
