### PR TITLE
feat(experience): use MFA error details for trusted device opt-in

### DIFF
--- a/packages/experience/src/apis/experience/index.test.ts
+++ b/packages/experience/src/apis/experience/index.test.ts
@@ -1,0 +1,70 @@
+import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
+
+import api from '../api';
+
+import { updateProfileWithVerificationCode, verifyAndUpdateProfileWithVerificationCode } from '.';
+import { experienceApiRoutes } from './const';
+import { identifyUser, submitInteraction, updateProfile } from './interaction';
+
+jest.mock('../api', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+jest.mock('./interaction', () => ({
+  identifyAndSubmitInteraction: jest.fn(),
+  identifyUser: jest.fn(),
+  initInteraction: jest.fn(),
+  submitInteraction: jest.fn(),
+  updateInteractionEvent: jest.fn(),
+  updateProfile: jest.fn(),
+}));
+
+const mockedApiPost = api.post as jest.MockedFunction<typeof api.post>;
+const mockedSubmitInteraction = submitInteraction as jest.MockedFunction<typeof submitInteraction>;
+
+const verificationCodePayload = {
+  identifier: { type: SignInIdentifier.Email, value: 'foo@logto.io' },
+  code: '123456',
+  verificationId: 'verification-id',
+} as const;
+
+describe('verification code profile APIs', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApiPost.mockReturnValue({
+      json: jest.fn().mockResolvedValue({ verificationId: 'verified-id' }),
+    } as unknown as ReturnType<typeof api.post>);
+  });
+
+  it('verifies and updates the profile without submitting the interaction', async () => {
+    await verifyAndUpdateProfileWithVerificationCode(
+      verificationCodePayload,
+      InteractionEvent.Register
+    );
+
+    expect(mockedApiPost).toBeCalledWith(
+      `${experienceApiRoutes.verification}/verification-code/verify`,
+      { json: verificationCodePayload }
+    );
+    expect(updateProfile).toBeCalledWith({
+      type: SignInIdentifier.Email,
+      verificationId: 'verified-id',
+    });
+    expect(identifyUser).toBeCalledTimes(1);
+    expect(mockedSubmitInteraction).not.toBeCalled();
+  });
+
+  it('submits once after verifying and updating the profile in a regular continue flow', async () => {
+    mockedSubmitInteraction.mockResolvedValue({ redirectTo: '/callback' });
+
+    await expect(
+      updateProfileWithVerificationCode(verificationCodePayload, InteractionEvent.SignIn)
+    ).resolves.toEqual({ redirectTo: '/callback' });
+
+    expect(identifyUser).not.toBeCalled();
+    expect(mockedSubmitInteraction).toBeCalledTimes(1);
+  });
+});

--- a/packages/experience/src/apis/experience/index.ts
+++ b/packages/experience/src/apis/experience/index.ts
@@ -128,7 +128,7 @@ export const identifyWithVerificationCode = async (json: VerificationCodePayload
 
 // Profile APIs
 
-export const updateProfileWithVerificationCode = async (
+export const verifyAndUpdateProfileWithVerificationCode = async (
   json: VerificationCodePayload,
   interactionEvent?: ContinueFlowInteractionEvent
 ) => {
@@ -146,6 +146,13 @@ export const updateProfileWithVerificationCode = async (
   if (interactionEvent === InteractionEvent.Register) {
     await identifyUser();
   }
+};
+
+export const updateProfileWithVerificationCode = async (
+  json: VerificationCodePayload,
+  interactionEvent?: ContinueFlowInteractionEvent
+) => {
+  await verifyAndUpdateProfileWithVerificationCode(json, interactionEvent);
 
   return submitInteraction();
 };

--- a/packages/experience/src/containers/MfaCodeVerification/index.test.tsx
+++ b/packages/experience/src/containers/MfaCodeVerification/index.test.tsx
@@ -36,9 +36,7 @@ const mockedUseResendMfaVerificationCode = jest.mocked(useResendMfaVerificationC
 const renderVerification = (isVisible: boolean) => {
   const onSubmit = jest.fn().mockResolvedValue(undefined);
   mockedUseTrustedDeviceOptIn.mockReturnValue({
-    availability: isVisible ? { canCreate: true, durationDays: 30 } : undefined,
-    isLoading: false,
-    isVisible,
+    durationDays: isVisible ? 30 : undefined,
     isChecked: false,
     setIsChecked: jest.fn(),
   });

--- a/packages/experience/src/containers/MfaCodeVerification/index.tsx
+++ b/packages/experience/src/containers/MfaCodeVerification/index.tsx
@@ -29,6 +29,7 @@ const MfaCodeVerification = ({ identifierType, verificationId }: Props) => {
   const [inputErrorMessage, setInputErrorMessage] = useState<string>();
   const [currentVerificationId, setCurrentVerificationId] = useState(verificationId);
   const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn();
+  const isTrustedDeviceOptInVisible = Boolean(durationDays);
 
   useEffect(() => {
     setCurrentVerificationId(verificationId);
@@ -77,7 +78,7 @@ const MfaCodeVerification = ({ identifierType, verificationId }: Props) => {
         error={errorMessage}
         onChange={(code) => {
           setCodeInput(code);
-          if (isCodeReady(code) && !durationDays) {
+          if (isCodeReady(code) && !isTrustedDeviceOptInVisible) {
             void handleSubmit(code);
           }
         }}

--- a/packages/experience/src/containers/MfaCodeVerification/index.tsx
+++ b/packages/experience/src/containers/MfaCodeVerification/index.tsx
@@ -28,7 +28,7 @@ const MfaCodeVerification = ({ identifierType, verificationId }: Props) => {
   const [codeInput, setCodeInput] = useState<string[]>([]);
   const [inputErrorMessage, setInputErrorMessage] = useState<string>();
   const [currentVerificationId, setCurrentVerificationId] = useState(verificationId);
-  const { availability, isLoading, isVisible, isChecked, setIsChecked } = useTrustedDeviceOptIn();
+  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn();
 
   useEffect(() => {
     setCurrentVerificationId(verificationId);
@@ -77,7 +77,7 @@ const MfaCodeVerification = ({ identifierType, verificationId }: Props) => {
         error={errorMessage}
         onChange={(code) => {
           setCodeInput(code);
-          if (isCodeReady(code) && !isVisible) {
+          if (isCodeReady(code) && !durationDays) {
             void handleSubmit(code);
           }
         }}
@@ -110,8 +110,7 @@ const MfaCodeVerification = ({ identifierType, verificationId }: Props) => {
         )}
       </div>
       <TrustedDeviceOptIn
-        availability={availability}
-        isLoading={isLoading}
+        durationDays={durationDays}
         isChecked={isChecked}
         className={styles.optIn}
         onChange={setIsChecked}

--- a/packages/experience/src/containers/TotpCodeVerification/index.test.tsx
+++ b/packages/experience/src/containers/TotpCodeVerification/index.test.tsx
@@ -33,9 +33,7 @@ const mockedUseTotpCodeVerification = jest.mocked(useTotpCodeVerification);
 const renderVerification = (isVisible: boolean) => {
   const onSubmit = jest.fn().mockResolvedValue(undefined);
   mockedUseTrustedDeviceOptIn.mockReturnValue({
-    availability: isVisible ? { canCreate: true, durationDays: 30 } : undefined,
-    isLoading: false,
-    isVisible,
+    durationDays: isVisible ? 30 : undefined,
     isChecked: false,
     setIsChecked: jest.fn(),
   });

--- a/packages/experience/src/containers/TotpCodeVerification/index.tsx
+++ b/packages/experience/src/containers/TotpCodeVerification/index.tsx
@@ -37,7 +37,7 @@ const TotpCodeVerification = <T extends UserMfaFlow>(props: Props<T>) => {
   }, []);
 
   const { errorMessage: submitErrorMessage, onSubmit } = useTotpCodeVerification(errorCallback);
-  const { availability, isLoading, isVisible, isChecked, setIsChecked } = useTrustedDeviceOptIn();
+  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -67,14 +67,13 @@ const TotpCodeVerification = <T extends UserMfaFlow>(props: Props<T>) => {
         error={errorMessage}
         onChange={(code) => {
           setCodeInput(code);
-          if (isCodeReady(code) && !isVisible) {
+          if (isCodeReady(code) && !durationDays) {
             void handleSubmit(code);
           }
         }}
       />
       <TrustedDeviceOptIn
-        availability={availability}
-        isLoading={isLoading}
+        durationDays={durationDays}
         isChecked={isChecked}
         className={styles.optIn}
         onChange={setIsChecked}

--- a/packages/experience/src/containers/TotpCodeVerification/index.tsx
+++ b/packages/experience/src/containers/TotpCodeVerification/index.tsx
@@ -38,6 +38,7 @@ const TotpCodeVerification = <T extends UserMfaFlow>(props: Props<T>) => {
 
   const { errorMessage: submitErrorMessage, onSubmit } = useTotpCodeVerification(errorCallback);
   const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn();
+  const isTrustedDeviceOptInVisible = Boolean(durationDays);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -67,7 +68,7 @@ const TotpCodeVerification = <T extends UserMfaFlow>(props: Props<T>) => {
         error={errorMessage}
         onChange={(code) => {
           setCodeInput(code);
-          if (isCodeReady(code) && !durationDays) {
+          if (isCodeReady(code) && !isTrustedDeviceOptInVisible) {
             void handleSubmit(code);
           }
         }}

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.module.scss
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.module.scss
@@ -10,10 +10,6 @@
   }
 }
 
-.placeholder {
-  min-height: _.unit(6);
-}
-
 :global(body.mobile) {
   .optIn {
     padding: _.unit(1) 0;

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
@@ -8,15 +8,10 @@ import { type TrustedDeviceAvailability } from '@/types/guard';
 import TrustedDeviceOptIn from '.';
 
 const TestOptIn = ({ isEnabled = true }: { readonly isEnabled?: boolean }) => {
-  const { availability, isLoading, isChecked, setIsChecked } = useTrustedDeviceOptIn(isEnabled);
+  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn(isEnabled);
 
   return (
-    <TrustedDeviceOptIn
-      availability={availability}
-      isLoading={isLoading}
-      isChecked={isChecked}
-      onChange={setIsChecked}
-    />
+    <TrustedDeviceOptIn durationDays={durationDays} isChecked={isChecked} onChange={setIsChecked} />
   );
 };
 

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
@@ -1,15 +1,11 @@
-import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { MfaFactor } from '@logto/schemas';
+import { act, fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
-import { getInteraction } from '@/apis/experience';
 import useTrustedDeviceOptIn from '@/hooks/use-trusted-device-opt-in';
+import { type TrustedDeviceAvailability } from '@/types/guard';
 
 import TrustedDeviceOptIn from '.';
-
-jest.mock('@/apis/experience', () => ({
-  getInteraction: jest.fn(),
-}));
-
-const mockedGetInteraction = getInteraction as jest.MockedFunction<typeof getInteraction>;
 
 const TestOptIn = ({ isEnabled = true }: { readonly isEnabled?: boolean }) => {
   const { availability, isLoading, isChecked, setIsChecked } = useTrustedDeviceOptIn(isEnabled);
@@ -24,23 +20,34 @@ const TestOptIn = ({ isEnabled = true }: { readonly isEnabled?: boolean }) => {
   );
 };
 
+const renderOptIn = (
+  trustedDevice?: TrustedDeviceAvailability,
+  isEnabled = true,
+  additionalState: Record<string, unknown> = {}
+) =>
+  render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/',
+          state: {
+            availableFactors: [MfaFactor.TOTP],
+            trustedDevice,
+            ...additionalState,
+          },
+        },
+      ]}
+    >
+      <TestOptIn isEnabled={isEnabled} />
+    </MemoryRouter>
+  );
+
 describe('<TrustedDeviceOptIn />', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('shows a default-unchecked checkbox when effective policy allows creation', async () => {
-    mockedGetInteraction.mockResolvedValue({
-      trustedDevice: { canCreate: true, durationDays: 30 },
-    });
-    const { container } = render(<TestOptIn />);
-
-    await waitFor(() => {
-      expect(container.querySelector('[role="checkbox"]')).not.toBeNull();
-    });
-    expect(mockedGetInteraction).toBeCalledWith(expect.any(AbortSignal));
-
+  it('shows a default-unchecked checkbox when MFA flow state allows creation', () => {
+    const { container } = renderOptIn({ canCreate: true, durationDays: 30 });
     const checkbox = container.querySelector('[role="checkbox"]');
+
+    expect(checkbox).not.toBeNull();
     expect(checkbox?.getAttribute('aria-checked')).toBe('false');
 
     act(() => {
@@ -52,50 +59,35 @@ describe('<TrustedDeviceOptIn />', () => {
     expect(checkbox?.getAttribute('aria-checked')).toBe('true');
   });
 
-  it('stays hidden when effective policy disallows creation', async () => {
-    mockedGetInteraction.mockResolvedValue({ trustedDevice: { canCreate: false } });
-    const { container } = render(<TestOptIn />);
-
-    await waitFor(() => {
-      expect(mockedGetInteraction).toBeCalled();
+  it('shows the checkbox when WebAuthn options are included in route state', () => {
+    const { container } = renderOptIn({ canCreate: true, durationDays: 365 }, true, {
+      options: { challenge: 'challenge' },
     });
+
+    expect(container.querySelector('[role="checkbox"]')).not.toBeNull();
+  });
+
+  it('stays hidden when MFA flow state disallows creation', () => {
+    const { container } = renderOptIn({ canCreate: false });
 
     expect(container.querySelector('[role="checkbox"]')).toBeNull();
   });
 
-  it('stays hidden when availability cannot be loaded', async () => {
-    mockedGetInteraction.mockRejectedValue(new Error('Request failed'));
-    const { container } = render(<TestOptIn />);
+  it('stays hidden when MFA flow state has no availability', () => {
+    const { container } = renderOptIn();
 
-    await waitFor(() => {
-      expect(container.firstElementChild).toBeNull();
-    });
+    expect(container.firstElementChild).toBeNull();
   });
 
-  it('stays hidden when an available policy does not include a duration', async () => {
-    mockedGetInteraction.mockResolvedValue({ trustedDevice: { canCreate: true } });
-    const { container } = render(<TestOptIn />);
+  it('stays hidden when an available policy does not include a duration', () => {
+    const { container } = renderOptIn({ canCreate: true });
 
-    await waitFor(() => {
-      expect(container.firstElementChild).toBeNull();
-    });
+    expect(container.firstElementChild).toBeNull();
   });
 
-  it('reserves the checkbox space while availability is loading', () => {
-    mockedGetInteraction.mockReturnValue(
-      new Promise(() => {
-        // Keep the request pending to verify the loading placeholder.
-      })
-    );
-    const { container } = render(<TestOptIn />);
+  it('stays hidden when the calling page is invalid', () => {
+    const { container } = renderOptIn({ canCreate: true, durationDays: 30 }, false);
 
-    expect(container.firstElementChild).not.toBeNull();
-    expect(container.querySelector('[role="checkbox"]')).toBeNull();
-  });
-
-  it('does not query availability when the calling page is invalid', () => {
-    render(<TestOptIn isEnabled={false} />);
-
-    expect(mockedGetInteraction).not.toBeCalled();
+    expect(container.firstElementChild).toBeNull();
   });
 });

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.tsx
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.tsx
@@ -2,30 +2,22 @@ import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import CheckboxField from '@/components/InputFields/CheckboxField';
-import { type TrustedDeviceAvailability } from '@/types/guard';
 
 import styles from './index.module.scss';
 
 type Props = {
-  readonly availability?: TrustedDeviceAvailability;
-  readonly isLoading: boolean;
+  readonly durationDays?: number;
   readonly isChecked: boolean;
   readonly className?: string;
   readonly onChange: (checked: boolean) => void;
 };
 
-const TrustedDeviceOptIn = ({ availability, isLoading, isChecked, className, onChange }: Props) => {
+const TrustedDeviceOptIn = ({ durationDays, isChecked, className, onChange }: Props) => {
   const { t } = useTranslation();
 
-  if (isLoading) {
-    return <div aria-hidden className={classNames(styles.placeholder, className)} />;
-  }
-
-  if (!availability?.canCreate || !availability.durationDays) {
+  if (!durationDays) {
     return null;
   }
-
-  const { durationDays } = availability;
 
   return (
     <CheckboxField

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.tsx
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.tsx
@@ -1,8 +1,8 @@
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import { type TrustedDeviceAvailability } from '@/apis/experience';
 import CheckboxField from '@/components/InputFields/CheckboxField';
+import { type TrustedDeviceAvailability } from '@/types/guard';
 
 import styles from './index.module.scss';
 

--- a/packages/experience/src/containers/VerificationCode/index.module.scss
+++ b/packages/experience/src/containers/VerificationCode/index.module.scss
@@ -28,6 +28,7 @@
   }
 
   .switch,
+  .optIn,
   .continueButton {
     margin-top: _.unit(6);
   }

--- a/packages/experience/src/containers/VerificationCode/index.tsx
+++ b/packages/experience/src/containers/VerificationCode/index.tsx
@@ -5,6 +5,8 @@ import { useTranslation, Trans } from 'react-i18next';
 
 import SwitchToVerificationMethodsLink from '@/components/SwitchToVerificationMethodsLink';
 import TextLink from '@/components/TextLink';
+import TrustedDeviceOptIn from '@/containers/TrustedDeviceOptIn';
+import useTrustedDeviceOptIn from '@/hooks/use-trusted-device-opt-in';
 import Button from '@/shared/components/Button';
 import VerificationCodeInput, { defaultLength } from '@/shared/components/VerificationCode';
 import { UserFlow } from '@/types';
@@ -32,6 +34,9 @@ const VerificationCode = ({
   const [inputErrorMessage, setInputErrorMessage] = useState<string>();
 
   const { t } = useTranslation();
+  const { availability, isLoading, isVisible, isChecked, setIsChecked } = useTrustedDeviceOptIn(
+    flow === UserFlow.Continue
+  );
 
   const isCodeInputReady = useMemo(
     () => codeInput.length === defaultLength && codeInput.every(Boolean),
@@ -49,7 +54,7 @@ const VerificationCode = ({
     errorMessage: submitErrorMessage,
     clearErrorMessage,
     onSubmit,
-  } = useVerificationCode(identifier, verificationId, errorCallback);
+  } = useVerificationCode(identifier, verificationId, errorCallback, isChecked);
 
   const errorMessage = inputErrorMessage ?? submitErrorMessage;
 
@@ -91,10 +96,10 @@ const VerificationCode = ({
   handleSubmitRef.current = handleSubmit;
 
   useEffect(() => {
-    if (isCodeInputReady) {
+    if (isCodeInputReady && !isVisible) {
       void handleSubmitRef.current(codeInput);
     }
-  }, [codeInput, isCodeInputReady]);
+  }, [codeInput, isCodeInputReady, isVisible]);
 
   return (
     <form className={classNames(styles.form, className)}>
@@ -137,6 +142,13 @@ const VerificationCode = ({
           className={styles.switch}
         />
       )}
+      <TrustedDeviceOptIn
+        availability={availability}
+        isLoading={isLoading}
+        isChecked={isChecked}
+        className={styles.optIn}
+        onChange={setIsChecked}
+      />
       <Button
         title="action.continue"
         type="primary"

--- a/packages/experience/src/containers/VerificationCode/index.tsx
+++ b/packages/experience/src/containers/VerificationCode/index.tsx
@@ -37,6 +37,7 @@ const VerificationCode = ({
   const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn(
     flow === UserFlow.Continue
   );
+  const isTrustedDeviceOptInVisible = Boolean(durationDays);
 
   const isCodeInputReady = useMemo(
     () => codeInput.length === defaultLength && codeInput.every(Boolean),
@@ -96,10 +97,10 @@ const VerificationCode = ({
   handleSubmitRef.current = handleSubmit;
 
   useEffect(() => {
-    if (isCodeInputReady && !durationDays) {
+    if (isCodeInputReady && !isTrustedDeviceOptInVisible) {
       void handleSubmitRef.current(codeInput);
     }
-  }, [codeInput, durationDays, isCodeInputReady]);
+  }, [codeInput, isCodeInputReady, isTrustedDeviceOptInVisible]);
 
   return (
     <form className={classNames(styles.form, className)}>

--- a/packages/experience/src/containers/VerificationCode/index.tsx
+++ b/packages/experience/src/containers/VerificationCode/index.tsx
@@ -34,7 +34,7 @@ const VerificationCode = ({
   const [inputErrorMessage, setInputErrorMessage] = useState<string>();
 
   const { t } = useTranslation();
-  const { availability, isLoading, isVisible, isChecked, setIsChecked } = useTrustedDeviceOptIn(
+  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn(
     flow === UserFlow.Continue
   );
 
@@ -96,10 +96,10 @@ const VerificationCode = ({
   handleSubmitRef.current = handleSubmit;
 
   useEffect(() => {
-    if (isCodeInputReady && !isVisible) {
+    if (isCodeInputReady && !durationDays) {
       void handleSubmitRef.current(codeInput);
     }
-  }, [codeInput, isCodeInputReady, isVisible]);
+  }, [codeInput, durationDays, isCodeInputReady]);
 
   return (
     <form className={classNames(styles.form, className)}>
@@ -143,8 +143,7 @@ const VerificationCode = ({
         />
       )}
       <TrustedDeviceOptIn
-        availability={availability}
-        isLoading={isLoading}
+        durationDays={durationDays}
         isChecked={isChecked}
         className={styles.optIn}
         onChange={setIsChecked}

--- a/packages/experience/src/containers/VerificationCode/mfa-binding.test.tsx
+++ b/packages/experience/src/containers/VerificationCode/mfa-binding.test.tsx
@@ -1,0 +1,133 @@
+import {
+  InteractionEvent,
+  MfaFactor,
+  SignInIdentifier,
+  type VerificationCodeIdentifier,
+} from '@logto/schemas';
+import { act, fireEvent, waitFor } from '@testing-library/react';
+import { HTTPError } from 'ky';
+
+import renderWithPageContext from '@/__mocks__/RenderWithPageContext';
+import { verifyAndUpdateProfileWithVerificationCode } from '@/apis/experience';
+import { bindMfa } from '@/apis/experience/mfa';
+import { UserFlow } from '@/types';
+
+import VerificationCode from '.';
+
+const mockedStartBackupCodeBinding = jest.fn();
+const mockedStartTotpBinding = jest.fn();
+
+jest.mock('@/apis/experience', () => ({
+  ...jest.requireActual('@/apis/experience'),
+  verifyAndUpdateProfileWithVerificationCode: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/apis/experience/mfa', () => ({
+  bindMfa: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-start-backup-code-binding', () => ({
+  __esModule: true,
+  default: () => mockedStartBackupCodeBinding,
+}));
+
+jest.mock('@/hooks/use-start-totp-binding', () => ({
+  __esModule: true,
+  default: () => mockedStartTotpBinding,
+}));
+
+const createRequestError = (code: string, data?: unknown) => {
+  const response = {
+    status: 422,
+    statusText: 'Unprocessable Entity',
+    json: async () => ({ code, message: code, data }),
+  } as unknown as Response;
+
+  return new HTTPError(response, {} as Request, {} as never);
+};
+
+const fillVerificationCode = (container: HTMLElement) => {
+  for (const input of container.querySelectorAll('input')) {
+    act(() => {
+      fireEvent.input(input, { target: { value: '1' } });
+    });
+  }
+};
+
+const renderMfaBindingVerification = (
+  identifier: VerificationCodeIdentifier,
+  factor: MfaFactor.EmailVerificationCode | MfaFactor.PhoneVerificationCode
+) =>
+  renderWithPageContext(
+    <VerificationCode
+      flow={UserFlow.Continue}
+      identifier={identifier}
+      verificationId="verification-id"
+    />,
+    {
+      initialEntries: [
+        {
+          pathname: '/continue/verification-code',
+          state: {
+            interactionEvent: InteractionEvent.SignIn,
+            availableFactors: [factor],
+          },
+        },
+      ],
+    }
+  );
+
+describe('Email and Phone MFA binding submit errors', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('starts backup-code binding when Email MFA binding submit requires it', async () => {
+    jest
+      .mocked(bindMfa)
+      .mockRejectedValueOnce(createRequestError('session.mfa.backup_code_required'));
+
+    const { container } = renderMfaBindingVerification(
+      { type: SignInIdentifier.Email, value: 'foo@logto.io' },
+      MfaFactor.EmailVerificationCode
+    );
+
+    fillVerificationCode(container);
+
+    await waitFor(() => {
+      expect(verifyAndUpdateProfileWithVerificationCode).toHaveBeenCalled();
+      expect(bindMfa).toHaveBeenCalled();
+      expect(mockedStartBackupCodeBinding).toHaveBeenCalledWith(true);
+    });
+  });
+
+  it('starts additional-factor binding when Phone MFA binding submit suggests it', async () => {
+    jest.mocked(bindMfa).mockRejectedValueOnce(
+      createRequestError('session.mfa.suggest_additional_mfa', {
+        availableFactors: [MfaFactor.TOTP],
+        skippable: true,
+        suggestion: true,
+      })
+    );
+
+    const { container } = renderMfaBindingVerification(
+      { type: SignInIdentifier.Phone, value: '18573333333' },
+      MfaFactor.PhoneVerificationCode
+    );
+
+    fillVerificationCode(container);
+
+    await waitFor(() => {
+      expect(verifyAndUpdateProfileWithVerificationCode).toHaveBeenCalled();
+      expect(bindMfa).toHaveBeenCalled();
+      expect(mockedStartTotpBinding).toHaveBeenCalledWith(
+        expect.objectContaining({
+          availableFactors: [MfaFactor.TOTP],
+          skippable: true,
+          suggestion: true,
+        }),
+        true
+      );
+    });
+  });
+});

--- a/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
@@ -2,21 +2,23 @@ import type { VerificationCodeIdentifier } from '@logto/schemas';
 import { InteractionEvent, MfaFactor, VerificationType } from '@logto/schemas';
 import { useCallback, useContext, useMemo } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
-import { validate } from 'superstruct';
 
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
-import { updateProfileWithVerificationCode } from '@/apis/experience';
+import {
+  updateProfileWithVerificationCode,
+  verifyAndUpdateProfileWithVerificationCode,
+} from '@/apis/experience';
 import { bindMfa } from '@/apis/experience/mfa';
 import { getInteractionEventFromState } from '@/apis/utils';
 import useApi from '@/hooks/use-api';
 import type { ErrorHandlers } from '@/hooks/use-error-handler';
 import useErrorHandler from '@/hooks/use-error-handler';
 import useGlobalRedirectTo from '@/hooks/use-global-redirect-to';
+import useMfaFlowState from '@/hooks/use-mfa-factors-state';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import { useSieMethods } from '@/hooks/use-sie';
 import useSubmitInteractionErrorHandler from '@/hooks/use-submit-interaction-error-handler';
 import { SearchParameters } from '@/types';
-import { mfaFlowStateGuard } from '@/types/guard';
 
 import useGeneralVerificationCodeErrorHandler from './use-general-verification-code-error-handler';
 import useIdentifierErrorAlert, { IdentifierErrorType } from './use-identifier-error-alert';
@@ -26,13 +28,15 @@ import useSignInWithExistIdentifierConfirmModal from './use-sign-in-with-exist-i
 const useContinueFlowCodeVerification = (
   identifier: VerificationCodeIdentifier,
   verificationId: string,
-  errorCallback?: () => void
+  errorCallback?: () => void,
+  createTrustedDevice = false
 ) => {
   const [searchParameters] = useSearchParams();
   const redirectTo = useGlobalRedirectTo();
   const navigate = useNavigateWithPreservedSearchParams();
 
   const { state } = useLocation();
+  const mfaFlowState = useMfaFlowState();
   const { verificationIdsMap } = useContext(UserInteractionContext);
   const { isVerificationCodeEnabledForSignIn } = useSieMethods();
 
@@ -44,6 +48,7 @@ const useContinueFlowCodeVerification = (
   const handleError = useErrorHandler();
 
   const verifyVerificationCode = useApi(updateProfileWithVerificationCode);
+  const verifyAndUpdateProfile = useApi(verifyAndUpdateProfileWithVerificationCode);
   const asyncBindMfa = useApi(bindMfa);
 
   const { generalVerificationCodeErrorHandlers, errorMessage, clearErrorMessage } =
@@ -118,13 +123,13 @@ const useContinueFlowCodeVerification = (
 
   const onSubmit = useCallback(
     async (code: string) => {
-      const [, mfaFlowState] = validate(state, mfaFlowStateGuard);
-      // Check if this is an email MFA binding flow
-      if (
-        mfaFlowState?.availableFactors.includes(MfaFactor.EmailVerificationCode) &&
+      const factor =
         identifier.type === 'email'
-      ) {
-        const [verifyError] = await verifyVerificationCode(
+          ? MfaFactor.EmailVerificationCode
+          : MfaFactor.PhoneVerificationCode;
+
+      if (mfaFlowState?.availableFactors.includes(factor)) {
+        const [verifyError] = await verifyAndUpdateProfile(
           {
             code,
             identifier,
@@ -140,8 +145,10 @@ const useContinueFlowCodeVerification = (
         }
 
         const [bindError, bindResult] = await asyncBindMfa(
-          MfaFactor.EmailVerificationCode,
-          verificationId
+          factor,
+          verificationId,
+          undefined,
+          createTrustedDevice
         );
 
         if (bindError) {
@@ -180,15 +187,17 @@ const useContinueFlowCodeVerification = (
     },
     [
       asyncBindMfa,
+      createTrustedDevice,
       errorCallback,
       handleError,
       identifier,
       interactionEvent,
+      mfaFlowState,
       redirectTo,
-      state,
       verificationId,
       verifyVerificationCode,
       verifyVerificationCodeErrorHandlers,
+      verifyAndUpdateProfile,
     ]
   );
 

--- a/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
@@ -152,7 +152,7 @@ const useContinueFlowCodeVerification = (
         );
 
         if (bindError) {
-          await handleError(bindError);
+          await handleError(bindError, submitInteractionErrorHandler);
           errorCallback?.();
           return;
         }
@@ -194,6 +194,7 @@ const useContinueFlowCodeVerification = (
       interactionEvent,
       mfaFlowState,
       redirectTo,
+      submitInteractionErrorHandler,
       verificationId,
       verifyVerificationCode,
       verifyVerificationCodeErrorHandlers,

--- a/packages/experience/src/containers/VerificationCode/utils.ts
+++ b/packages/experience/src/containers/VerificationCode/utils.ts
@@ -1,3 +1,5 @@
+import type { VerificationCodeIdentifier } from '@logto/schemas';
+
 import { UserFlow } from '@/types';
 
 import useContinueFlowCodeVerification from './use-continue-flow-code-verification';
@@ -5,11 +7,23 @@ import useForgotPasswordFlowCodeVerification from './use-forgot-password-flow-co
 import useRegisterFlowCodeVerification from './use-register-flow-code-verification';
 import useSignInFlowCodeVerification from './use-sign-in-flow-code-verification';
 
-export const codeVerificationHooks = Object.freeze({
-  [UserFlow.SignIn]: useSignInFlowCodeVerification,
-  [UserFlow.Register]: useRegisterFlowCodeVerification,
-  [UserFlow.ForgotPassword]: useForgotPasswordFlowCodeVerification,
-  [UserFlow.Continue]: useContinueFlowCodeVerification,
-});
+type VerificationCodeHook = (
+  identifier: VerificationCodeIdentifier,
+  verificationId: string,
+  errorCallback?: () => void,
+  createTrustedDevice?: boolean
+) => {
+  errorMessage: string | undefined;
+  clearErrorMessage: () => void;
+  onSubmit: (code: string) => Promise<void>;
+};
+
+export const codeVerificationHooks: Readonly<Record<UserFlow, VerificationCodeHook>> =
+  Object.freeze({
+    [UserFlow.SignIn]: useSignInFlowCodeVerification,
+    [UserFlow.Register]: useRegisterFlowCodeVerification,
+    [UserFlow.ForgotPassword]: useForgotPasswordFlowCodeVerification,
+    [UserFlow.Continue]: useContinueFlowCodeVerification,
+  });
 
 export const getCodeVerificationHookByFlow = (flow: UserFlow) => codeVerificationHooks[flow];

--- a/packages/experience/src/hooks/use-mfa-error-handler.test.tsx
+++ b/packages/experience/src/hooks/use-mfa-error-handler.test.tsx
@@ -1,4 +1,4 @@
-import { type RequestErrorBody } from '@logto/schemas';
+import { MfaFactor, type RequestErrorBody } from '@logto/schemas';
 import { act, renderHook } from '@testing-library/react';
 
 import useMfaErrorHandler from './use-mfa-error-handler';
@@ -44,7 +44,7 @@ describe('useMfaErrorHandler', () => {
     jest.clearAllMocks();
   });
 
-  it('carries trusted-device availability through the suggest-MFA onboarding redirect', async () => {
+  it('does not carry unused error data through the suggest-MFA onboarding redirect', async () => {
     const { result } = renderHook(() => useMfaErrorHandler());
     const error: RequestErrorBody = {
       code: 'user.suggest_mfa',
@@ -58,9 +58,34 @@ describe('useMfaErrorHandler', () => {
 
     expect(mockedNavigate).toHaveBeenCalledWith(
       { pathname: '/mfa-onboarding' },
+      { replace: undefined }
+    );
+  });
+
+  it('masks unknown error data before forwarding MFA flow state', async () => {
+    const { result } = renderHook(() => useMfaErrorHandler());
+    const error: RequestErrorBody = {
+      code: 'user.missing_mfa',
+      message: 'MFA is missing',
+      data: {
+        availableFactors: [MfaFactor.TOTP, MfaFactor.WebAuthn],
+        trustedDevice: { canCreate: true, durationDays: 30 },
+        futureField: 'ignored',
+      },
+    };
+
+    await act(async () => {
+      await result.current['user.missing_mfa']?.(error);
+    });
+
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      { pathname: '/mfa-binding' },
       {
         replace: undefined,
-        state: { trustedDevice: { canCreate: true, durationDays: 30 } },
+        state: {
+          availableFactors: [MfaFactor.TOTP, MfaFactor.WebAuthn],
+          trustedDevice: { canCreate: true, durationDays: 30 },
+        },
       }
     );
   });

--- a/packages/experience/src/hooks/use-mfa-error-handler.test.tsx
+++ b/packages/experience/src/hooks/use-mfa-error-handler.test.tsx
@@ -1,0 +1,67 @@
+import { type RequestErrorBody } from '@logto/schemas';
+import { act, renderHook } from '@testing-library/react';
+
+import useMfaErrorHandler from './use-mfa-error-handler';
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('./use-navigate-with-preserved-search-params', () => ({
+  __esModule: true,
+  default: () => mockedNavigate,
+}));
+
+jest.mock('./use-send-mfa-verification-code', () => ({
+  __esModule: true,
+  default: () => ({ onSubmit: jest.fn() }),
+}));
+
+jest.mock('./use-start-backup-code-binding', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+jest.mock('./use-start-totp-binding', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+jest.mock('./use-start-webauthn-processing', () => ({
+  __esModule: true,
+  default: () => jest.fn(),
+}));
+
+jest.mock('./use-toast', () => ({
+  __esModule: true,
+  default: () => ({ setToast: jest.fn() }),
+}));
+
+describe('useMfaErrorHandler', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('carries trusted-device availability through the suggest-MFA onboarding redirect', async () => {
+    const { result } = renderHook(() => useMfaErrorHandler());
+    const error: RequestErrorBody = {
+      code: 'user.suggest_mfa',
+      message: 'MFA suggested',
+      data: { trustedDevice: { canCreate: true, durationDays: 30 } },
+    };
+
+    await act(async () => {
+      await result.current['user.suggest_mfa']?.(error);
+    });
+
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      { pathname: '/mfa-onboarding' },
+      {
+        replace: undefined,
+        state: { trustedDevice: { canCreate: true, durationDays: 30 } },
+      }
+    );
+  });
+});

--- a/packages/experience/src/hooks/use-mfa-error-handler.ts
+++ b/packages/experience/src/hooks/use-mfa-error-handler.ts
@@ -113,17 +113,19 @@ const useMfaErrorHandler = ({ replace }: Options = {}) => {
   const handleMfaError = useCallback(
     (flow: UserMfaFlow) => {
       return async (error: RequestErrorBody) => {
+        const [_, data] = validate(error.data, mfaErrorDataGuard);
+
         if (error.code === 'user.suggest_mfa') {
-          navigate({ pathname: `/mfa-onboarding` }, { replace });
+          navigate({ pathname: `/mfa-onboarding` }, { replace, state: data });
           return;
         }
 
-        const [_, data] = validate(error.data, mfaErrorDataGuard);
         const factors = data?.availableFactors ?? [];
         const skippable = data?.skippable;
         const maskedIdentifiers = data?.maskedIdentifiers;
         const suggestion = data?.suggestion;
         const isWebAuthnUsedAsSignInPasskey = data?.isWebAuthnUsedAsSignInPasskey;
+        const trustedDevice = data?.trustedDevice;
 
         if (factors.length === 0) {
           setToast(error.message);
@@ -142,6 +144,7 @@ const useMfaErrorHandler = ({ replace }: Options = {}) => {
           maskedIdentifiers,
           suggestion,
           isWebAuthnUsedAsSignInPasskey,
+          trustedDevice,
         });
       };
     },

--- a/packages/experience/src/hooks/use-mfa-error-handler.ts
+++ b/packages/experience/src/hooks/use-mfa-error-handler.ts
@@ -1,11 +1,10 @@
 import { MfaFactor, SignInIdentifier, type RequestErrorBody } from '@logto/schemas';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { validate } from 'superstruct';
 
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import { UserMfaFlow } from '@/types';
-import { type MfaFlowState, mfaErrorDataGuard } from '@/types/guard';
+import { type MfaFlowState, mfaErrorDataGuard, parseGuard } from '@/types/guard';
 import { isNativeWebview } from '@/utils/native-sdk';
 
 import type { ErrorHandlers } from './use-error-handler';
@@ -113,13 +112,12 @@ const useMfaErrorHandler = ({ replace }: Options = {}) => {
   const handleMfaError = useCallback(
     (flow: UserMfaFlow) => {
       return async (error: RequestErrorBody) => {
-        const [_, data] = validate(error.data, mfaErrorDataGuard);
-
         if (error.code === 'user.suggest_mfa') {
-          navigate({ pathname: `/mfa-onboarding` }, { replace, state: data });
+          navigate({ pathname: `/mfa-onboarding` }, { replace });
           return;
         }
 
+        const data = parseGuard(error.data, mfaErrorDataGuard);
         const factors = data?.availableFactors ?? [];
         const skippable = data?.skippable;
         const maskedIdentifiers = data?.maskedIdentifiers;

--- a/packages/experience/src/hooks/use-mfa-factors-state.test.tsx
+++ b/packages/experience/src/hooks/use-mfa-factors-state.test.tsx
@@ -1,0 +1,33 @@
+import { MfaFactor } from '@logto/schemas';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { UserMfaFlow } from '@/types';
+
+import useMfaFlowState from './use-mfa-factors-state';
+
+const TestHook = () => {
+  const flowState = useMfaFlowState();
+  return <span>{JSON.stringify(flowState)}</span>;
+};
+
+it('reads MFA flow state nested by the verification-code binding route', () => {
+  const mfaFlowState = {
+    availableFactors: [MfaFactor.EmailVerificationCode],
+    trustedDevice: { canCreate: true, durationDays: 365 },
+  };
+  const { container } = render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/continue/verification-code',
+          state: { flow: UserMfaFlow.MfaBinding, mfaFlowState },
+        },
+      ]}
+    >
+      <TestHook />
+    </MemoryRouter>
+  );
+
+  expect(container.textContent).toBe(JSON.stringify(mfaFlowState));
+});

--- a/packages/experience/src/hooks/use-mfa-factors-state.test.tsx
+++ b/packages/experience/src/hooks/use-mfa-factors-state.test.tsx
@@ -11,7 +11,7 @@ const TestHook = () => {
   return <span>{JSON.stringify(flowState)}</span>;
 };
 
-it('reads MFA flow state nested by the verification-code binding route', () => {
+it('reads and masks MFA flow state nested by the verification-code binding route', () => {
   const mfaFlowState = {
     availableFactors: [MfaFactor.EmailVerificationCode],
     trustedDevice: { canCreate: true, durationDays: 365 },
@@ -21,7 +21,35 @@ it('reads MFA flow state nested by the verification-code binding route', () => {
       initialEntries={[
         {
           pathname: '/continue/verification-code',
-          state: { flow: UserMfaFlow.MfaBinding, mfaFlowState },
+          state: {
+            flow: UserMfaFlow.MfaBinding,
+            mfaFlowState: { ...mfaFlowState, futureField: 'ignored' },
+          },
+        },
+      ]}
+    >
+      <TestHook />
+    </MemoryRouter>
+  );
+
+  expect(container.textContent).toBe(JSON.stringify(mfaFlowState));
+});
+
+it('masks page-specific fields from direct MFA flow state', () => {
+  const mfaFlowState = {
+    availableFactors: [MfaFactor.TOTP, MfaFactor.WebAuthn],
+    trustedDevice: { canCreate: true, durationDays: 30 },
+  };
+  const { container } = render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/mfa-binding/totp',
+          state: {
+            ...mfaFlowState,
+            secret: 'secret',
+            secretQrCode: 'data:image/png;base64,qr-code',
+          },
         },
       ]}
     >

--- a/packages/experience/src/hooks/use-mfa-factors-state.ts
+++ b/packages/experience/src/hooks/use-mfa-factors-state.ts
@@ -1,13 +1,14 @@
 import { useLocation } from 'react-router-dom';
 import { validate } from 'superstruct';
 
-import { mfaFlowStateGuard } from '@/types/guard';
+import { mfaBindingVerificationCodeStateGuard, mfaFlowStateGuard } from '@/types/guard';
 
 const useMfaFlowState = () => {
   const { state } = useLocation();
   const [, mfaFlowState] = validate(state, mfaFlowStateGuard);
+  const [, verificationCodeState] = validate(state, mfaBindingVerificationCodeStateGuard);
 
-  return mfaFlowState;
+  return mfaFlowState ?? verificationCodeState?.mfaFlowState;
 };
 
 export default useMfaFlowState;

--- a/packages/experience/src/hooks/use-mfa-factors-state.ts
+++ b/packages/experience/src/hooks/use-mfa-factors-state.ts
@@ -1,14 +1,17 @@
+import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
-import { validate } from 'superstruct';
 
-import { mfaBindingVerificationCodeStateGuard, mfaFlowStateGuard } from '@/types/guard';
+import { mfaBindingVerificationCodeStateGuard, mfaFlowStateGuard, parseGuard } from '@/types/guard';
 
 const useMfaFlowState = () => {
   const { state } = useLocation();
-  const [, mfaFlowState] = validate(state, mfaFlowStateGuard);
-  const [, verificationCodeState] = validate(state, mfaBindingVerificationCodeStateGuard);
 
-  return mfaFlowState ?? verificationCodeState?.mfaFlowState;
+  return useMemo(
+    () =>
+      parseGuard(state, mfaFlowStateGuard) ??
+      parseGuard(state, mfaBindingVerificationCodeStateGuard)?.mfaFlowState,
+    [state]
+  );
 };
 
 export default useMfaFlowState;

--- a/packages/experience/src/hooks/use-trusted-device-opt-in.test.tsx
+++ b/packages/experience/src/hooks/use-trusted-device-opt-in.test.tsx
@@ -9,8 +9,8 @@ jest.mock('@/constants/env', () => ({
 }));
 
 const TestHook = () => {
-  const { availability } = useTrustedDeviceOptIn();
-  return <span>{JSON.stringify(availability)}</span>;
+  const { durationDays } = useTrustedDeviceOptIn();
+  return <span>{durationDays}</span>;
 };
 
 it('ignores router-state availability when dev features are disabled', () => {

--- a/packages/experience/src/hooks/use-trusted-device-opt-in.test.tsx
+++ b/packages/experience/src/hooks/use-trusted-device-opt-in.test.tsx
@@ -1,24 +1,34 @@
+import { MfaFactor } from '@logto/schemas';
 import { render } from '@testing-library/react';
-
-import { getInteraction } from '@/apis/experience';
+import { MemoryRouter } from 'react-router-dom';
 
 import useTrustedDeviceOptIn from './use-trusted-device-opt-in';
-
-jest.mock('@/apis/experience', () => ({
-  getInteraction: jest.fn(),
-}));
 
 jest.mock('@/constants/env', () => ({
   isDevFeaturesEnabled: false,
 }));
 
 const TestHook = () => {
-  useTrustedDeviceOptIn();
-  return null;
+  const { availability } = useTrustedDeviceOptIn();
+  return <span>{JSON.stringify(availability)}</span>;
 };
 
-it('does not query trusted-device availability when dev features are disabled', () => {
-  render(<TestHook />);
+it('ignores router-state availability when dev features are disabled', () => {
+  const { container } = render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: '/',
+          state: {
+            availableFactors: [MfaFactor.TOTP],
+            trustedDevice: { canCreate: true, durationDays: 30 },
+          },
+        },
+      ]}
+    >
+      <TestHook />
+    </MemoryRouter>
+  );
 
-  expect(getInteraction).not.toBeCalled();
+  expect(container.textContent).toBe('');
 });

--- a/packages/experience/src/hooks/use-trusted-device-opt-in.ts
+++ b/packages/experience/src/hooks/use-trusted-device-opt-in.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { isDevFeaturesEnabled } from '@/constants/env';
 import useMfaFlowState from '@/hooks/use-mfa-factors-state';
@@ -6,18 +6,11 @@ import useMfaFlowState from '@/hooks/use-mfa-factors-state';
 const useTrustedDeviceOptIn = (isEnabled = true) => {
   const flowState = useMfaFlowState();
   const availability = isDevFeaturesEnabled && isEnabled ? flowState?.trustedDevice : undefined;
+  const durationDays = availability?.canCreate ? availability.durationDays : undefined;
   const [isChecked, setIsChecked] = useState(false);
 
-  useEffect(() => {
-    setIsChecked(false);
-  }, [availability?.canCreate, availability?.durationDays]);
-
-  const isVisible = Boolean(availability?.canCreate && availability.durationDays);
-
   return {
-    availability,
-    isLoading: false,
-    isVisible,
+    durationDays,
     isChecked,
     setIsChecked,
   };

--- a/packages/experience/src/hooks/use-trusted-device-opt-in.ts
+++ b/packages/experience/src/hooks/use-trusted-device-opt-in.ts
@@ -1,47 +1,22 @@
 import { useEffect, useState } from 'react';
 
-import { getInteraction, type TrustedDeviceAvailability } from '@/apis/experience';
 import { isDevFeaturesEnabled } from '@/constants/env';
-import useApi from '@/hooks/use-api';
+import useMfaFlowState from '@/hooks/use-mfa-factors-state';
 
-const useTrustedDeviceOptIn = (shouldFetch = true) => {
-  const canFetch = isDevFeaturesEnabled && shouldFetch;
-  const [availability, setAvailability] = useState<TrustedDeviceAvailability>();
-  const [isLoading, setIsLoading] = useState(canFetch);
+const useTrustedDeviceOptIn = (isEnabled = true) => {
+  const flowState = useMfaFlowState();
+  const availability = isDevFeaturesEnabled && isEnabled ? flowState?.trustedDevice : undefined;
   const [isChecked, setIsChecked] = useState(false);
-  const request = useApi(getInteraction, { silent: true });
 
   useEffect(() => {
-    setAvailability(undefined);
-    setIsLoading(canFetch);
     setIsChecked(false);
-
-    // Trusted-device opt-in stays isolated from released Experience flows until launch.
-    if (!canFetch) {
-      return;
-    }
-
-    const controller = new AbortController();
-
-    void (async () => {
-      const [, result] = await request(controller.signal);
-
-      if (!controller.signal.aborted) {
-        setAvailability(result?.trustedDevice);
-        setIsLoading(false);
-      }
-    })();
-
-    return () => {
-      controller.abort();
-    };
-  }, [canFetch, request]);
+  }, [availability?.canCreate, availability?.durationDays]);
 
   const isVisible = Boolean(availability?.canCreate && availability.durationDays);
 
   return {
     availability,
-    isLoading,
+    isLoading: false,
     isVisible,
     isChecked,
     setIsChecked,

--- a/packages/experience/src/pages/MfaBinding/TotpBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/TotpBinding/index.tsx
@@ -12,7 +12,7 @@ import useSkipMfa from '@/hooks/use-skip-mfa';
 import useSkipOptionalMfa from '@/hooks/use-skip-optional-mfa';
 import ErrorPage from '@/pages/ErrorPage';
 import { UserMfaFlow } from '@/types';
-import { type MfaFlowState, totpBindingStateGuard } from '@/types/guard';
+import { totpBindingStateGuard } from '@/types/guard';
 
 import SecretSection from './SecretSection';
 import VerificationSection from './VerificationSection';
@@ -31,20 +31,8 @@ const TotpBinding = () => {
     return <ErrorPage title="error.invalid_session" />;
   }
 
-  const {
-    availableFactors,
-    skippable,
-    suggestion,
-    maskedIdentifiers,
-    isWebAuthnUsedAsSignInPasskey,
-  } = totpBindingState;
-  const mfaFlowState: MfaFlowState = {
-    availableFactors,
-    skippable,
-    suggestion,
-    maskedIdentifiers,
-    isWebAuthnUsedAsSignInPasskey,
-  };
+  const { secret: _secret, secretQrCode: _secretQrCode, ...mfaFlowState } = totpBindingState;
+  const { availableFactors, skippable, suggestion } = mfaFlowState;
 
   return (
     <SecondaryPageLayout

--- a/packages/experience/src/pages/MfaBinding/VerificationCodeMfaBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/VerificationCodeMfaBinding/index.tsx
@@ -2,21 +2,19 @@ import { InteractionEvent, type SignInIdentifier } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 import { type TFuncKey } from 'i18next';
 import { useCallback, useContext, useState } from 'react';
-import { useLocation } from 'react-router-dom';
-import { validate } from 'superstruct';
 
 import SecondaryPageLayout from '@/Layout/SecondaryPageLayout';
 import UserInteractionContext from '@/Providers/UserInteractionContextProvider/UserInteractionContext';
 import { sendVerificationCode } from '@/apis/experience';
 import SwitchMfaFactorsLink from '@/components/SwitchMfaFactorsLink';
 import useErrorHandler from '@/hooks/use-error-handler';
+import useMfaFlowState from '@/hooks/use-mfa-factors-state';
 import useNavigateWithPreservedSearchParams from '@/hooks/use-navigate-with-preserved-search-params';
 import useSkipMfa from '@/hooks/use-skip-mfa';
 import useSkipOptionalMfa from '@/hooks/use-skip-optional-mfa';
 import IdentifierProfileForm from '@/pages/Continue/IdentifierProfileForm';
 import ErrorPage from '@/pages/ErrorPage';
 import { UserMfaFlow } from '@/types';
-import { mfaFlowStateGuard } from '@/types/guard';
 import { codeVerificationTypeMap } from '@/utils/sign-in-experience';
 
 import styles from './index.module.scss';
@@ -34,8 +32,7 @@ const VerificationCodeMfaBinding = ({
   descriptionKey,
   invalidInputErrorKey,
 }: Props) => {
-  const { state } = useLocation();
-  const [, mfaFlowState] = validate(state, mfaFlowStateGuard);
+  const mfaFlowState = useMfaFlowState();
   const { setVerificationId, setIdentifierInputValue } = useContext(UserInteractionContext);
   const navigate = useNavigateWithPreservedSearchParams();
   const [errorMessage, setErrorMessage] = useState<string>();

--- a/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
@@ -30,8 +30,7 @@ const WebAuthnBinding = () => {
   );
 
   const handleWebAuthn = useWebAuthnOperation();
-  const { availability, isLoading, isChecked, setIsChecked } =
-    useTrustedDeviceOptIn(isSessionValid);
+  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn(isSessionValid);
   const skipMfa = useSkipMfa();
   const skipOptionalMfa = useSkipOptionalMfa();
   const [isCreatingPasskey, setIsCreatingPasskey] = useState(false);
@@ -54,8 +53,7 @@ const WebAuthnBinding = () => {
       onSkip={conditional(skippable && (suggestion ? skipOptionalMfa : skipMfa))}
     >
       <TrustedDeviceOptIn
-        availability={availability}
-        isLoading={isLoading}
+        durationDays={durationDays}
         isChecked={isChecked}
         className={styles.optIn}
         onChange={setIsChecked}

--- a/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
@@ -40,7 +40,7 @@ const WebAuthnBinding = () => {
   }
 
   const { options, ...mfaFlowState } = webAuthnState;
-  const { availableFactors, skippable, suggestion } = mfaFlowState;
+  const { skippable, suggestion } = mfaFlowState;
 
   if (!isWebAuthnOptions(options)) {
     return <ErrorPage title="error.invalid_session" />;

--- a/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
@@ -15,7 +15,7 @@ import useWebAuthnOperation from '@/hooks/use-webauthn-operation';
 import ErrorPage from '@/pages/ErrorPage';
 import Button from '@/shared/components/Button';
 import { UserMfaFlow } from '@/types';
-import { type MfaFlowState, webAuthnStateGuard } from '@/types/guard';
+import { webAuthnStateGuard } from '@/types/guard';
 import { isWebAuthnOptions } from '@/utils/webauthn';
 
 import styles from './index.module.scss';
@@ -40,21 +40,8 @@ const WebAuthnBinding = () => {
     return <ErrorPage title="error.invalid_session" />;
   }
 
-  const {
-    options,
-    availableFactors,
-    skippable,
-    suggestion,
-    maskedIdentifiers,
-    isWebAuthnUsedAsSignInPasskey,
-  } = webAuthnState;
-  const mfaFlowState: MfaFlowState = {
-    availableFactors,
-    skippable,
-    suggestion,
-    maskedIdentifiers,
-    isWebAuthnUsedAsSignInPasskey,
-  };
+  const { options, ...mfaFlowState } = webAuthnState;
+  const { availableFactors, skippable, suggestion } = mfaFlowState;
 
   if (!isWebAuthnOptions(options)) {
     return <ErrorPage title="error.invalid_session" />;

--- a/packages/experience/src/pages/MfaVerification/WebAuthnVerification/index.tsx
+++ b/packages/experience/src/pages/MfaVerification/WebAuthnVerification/index.tsx
@@ -36,7 +36,7 @@ const WebAuthnVerification = () => {
     return <ErrorPage title="error.invalid_session" />;
   }
 
-  const { options, availableFactors, skippable } = webAuthnState;
+  const { options, ...flowState } = webAuthnState;
 
   if (!isWebAuthnOptions(options)) {
     return <ErrorPage title="error.invalid_session" />;
@@ -66,10 +66,7 @@ const WebAuthnVerification = () => {
           }}
         />
       </SectionLayout>
-      <SwitchMfaFactorsLink
-        flow={UserMfaFlow.MfaVerification}
-        flowState={{ availableFactors, skippable }}
-      />
+      <SwitchMfaFactorsLink flow={UserMfaFlow.MfaVerification} flowState={flowState} />
     </SecondaryPageLayout>
   );
 };

--- a/packages/experience/src/pages/MfaVerification/WebAuthnVerification/index.tsx
+++ b/packages/experience/src/pages/MfaVerification/WebAuthnVerification/index.tsx
@@ -28,8 +28,7 @@ const WebAuthnVerification = () => {
   );
 
   const handleWebAuthn = useWebAuthnOperation();
-  const { availability, isLoading, isChecked, setIsChecked } =
-    useTrustedDeviceOptIn(isSessionValid);
+  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn(isSessionValid);
   const [isVerifying, setIsVerifying] = useState(false);
 
   if (!webAuthnState || !verificationId) {
@@ -49,8 +48,7 @@ const WebAuthnVerification = () => {
         description="mfa.verify_via_passkey_description"
       >
         <TrustedDeviceOptIn
-          availability={availability}
-          isLoading={isLoading}
+          durationDays={durationDays}
           isChecked={isChecked}
           className={styles.optIn}
           onChange={setIsChecked}

--- a/packages/experience/src/types/guard.test.ts
+++ b/packages/experience/src/types/guard.test.ts
@@ -1,7 +1,7 @@
 import { MfaFactor, VerificationType } from '@logto/schemas';
 import * as s from 'superstruct';
 
-import { mfaErrorDataGuard, mfaFlowStateGuard, verificationIdsMapGuard } from './guard';
+import { mfaErrorDataGuard, verificationIdsMapGuard } from './guard';
 
 describe('guard', () => {
   it.each(Object.values(VerificationType))('verificationIdsMapGuard: %s', (type) => {
@@ -41,19 +41,6 @@ describe('guard', () => {
         },
         mfaErrorDataGuard
       );
-    }).not.toThrow();
-  });
-
-  it('mfaFlowStateGuard should accept page-specific route state', () => {
-    const state = {
-      availableFactors: [MfaFactor.WebAuthn, MfaFactor.BackupCode],
-      maskedIdentifiers: {},
-      trustedDevice: { canCreate: true, durationDays: 365 },
-      options: { challenge: 'challenge' },
-    };
-
-    expect(() => {
-      s.assert(state, mfaFlowStateGuard);
     }).not.toThrow();
   });
 });

--- a/packages/experience/src/types/guard.test.ts
+++ b/packages/experience/src/types/guard.test.ts
@@ -1,7 +1,7 @@
 import { MfaFactor, VerificationType } from '@logto/schemas';
 import * as s from 'superstruct';
 
-import { mfaErrorDataGuard, verificationIdsMapGuard } from './guard';
+import { mfaErrorDataGuard, mfaFlowStateGuard, verificationIdsMapGuard } from './guard';
 
 describe('guard', () => {
   it.each(Object.values(VerificationType))('verificationIdsMapGuard: %s', (type) => {
@@ -41,6 +41,19 @@ describe('guard', () => {
         },
         mfaErrorDataGuard
       );
+    }).not.toThrow();
+  });
+
+  it('mfaFlowStateGuard should accept page-specific route state', () => {
+    const state = {
+      availableFactors: [MfaFactor.WebAuthn, MfaFactor.BackupCode],
+      maskedIdentifiers: {},
+      trustedDevice: { canCreate: true, durationDays: 365 },
+      options: { challenge: 'challenge' },
+    };
+
+    expect(() => {
+      s.assert(state, mfaFlowStateGuard);
     }).not.toThrow();
   });
 });

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -12,7 +12,7 @@ import * as s from 'superstruct';
 
 import { type IdentifierInputValue } from '@/shared/components/InputFields/SmartInputField';
 
-import { UserFlow } from '.';
+import { UserFlow, UserMfaFlow } from '.';
 
 export const userFlowGuard = s.enums([
   UserFlow.SignIn,
@@ -74,25 +74,37 @@ const mfaFactorEnumValues = [
   MfaFactor.PhoneVerificationCode,
 ] as const;
 
-export const mfaErrorDataGuard = s.object({
-  availableFactors: mfaFactorsGuard,
+const trustedDeviceAvailabilityGuard = s.object({
+  canCreate: s.boolean(),
+  durationDays: s.optional(s.number()),
+});
+
+const mfaErrorDataShape = {
+  availableFactors: s.optional(mfaFactorsGuard),
   skippable: s.optional(s.boolean()),
   maskedIdentifiers: s.optional(s.record(s.enums(mfaFactorEnumValues), s.string())),
-  trustedDevice: s.optional(
-    s.object({
-      canCreate: s.boolean(),
-      durationDays: s.optional(s.number()),
-    })
-  ),
   // Whether this MFA flow is an optional suggestion (e.g., add another factor after sign-up)
   suggestion: s.optional(s.boolean()),
   // Whether the current WebAuthn factor is used as a sign-in passkey.
   isWebAuthnUsedAsSignInPasskey: s.optional(s.boolean()),
+  trustedDevice: s.optional(trustedDeviceAvailabilityGuard),
+};
+
+export const mfaErrorDataGuard = s.object(mfaErrorDataShape);
+
+// MFA route state can include page-specific fields such as WebAuthn options or TOTP secrets.
+export const mfaFlowStateGuard = s.type({
+  ...mfaErrorDataShape,
+  availableFactors: mfaFactorsGuard,
 });
 
-export const mfaFlowStateGuard = mfaErrorDataGuard;
-
 export type MfaFlowState = s.Infer<typeof mfaFlowStateGuard>;
+export type TrustedDeviceAvailability = s.Infer<typeof trustedDeviceAvailabilityGuard>;
+
+export const mfaBindingVerificationCodeStateGuard = s.type({
+  flow: s.literal(UserMfaFlow.MfaBinding),
+  mfaFlowState: mfaFlowStateGuard,
+});
 
 export const totpBindingStateGuard = s.assign(
   s.object({

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -80,7 +80,7 @@ const trustedDeviceAvailabilityGuard = s.object({
 });
 
 const mfaErrorDataShape = {
-  availableFactors: s.optional(mfaFactorsGuard),
+  availableFactors: mfaFactorsGuard,
   skippable: s.optional(s.boolean()),
   maskedIdentifiers: s.optional(s.record(s.enums(mfaFactorEnumValues), s.string())),
   // Whether this MFA flow is an optional suggestion (e.g., add another factor after sign-up)
@@ -92,11 +92,10 @@ const mfaErrorDataShape = {
 
 export const mfaErrorDataGuard = s.object(mfaErrorDataShape);
 
-// MFA route state can include page-specific fields such as WebAuthn options or TOTP secrets.
-export const mfaFlowStateGuard = s.type({
-  ...mfaErrorDataShape,
-  availableFactors: mfaFactorsGuard,
-});
+export const mfaFlowStateGuard = s.object(mfaErrorDataShape);
+
+export const parseGuard = <T, S>(value: unknown, struct: s.Struct<T, S>) =>
+  s.validate(value, struct, { coerce: true, mask: true })[1];
 
 export type MfaFlowState = s.Infer<typeof mfaFlowStateGuard>;
 export type TrustedDeviceAvailability = s.Infer<typeof trustedDeviceAvailabilityGuard>;


### PR DESCRIPTION
## Summary

Read trusted-device opt-in availability from MFA error details and carry it through MFA route state for binding and verification flows.

Preserve shared state when switching factors, accept page-specific route state, and keep email and phone MFA binding to a single final interaction submission.

Keep the existing interaction client API available for removal in the next stacked change.

Stack: 2/4. Depends on #9518.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
