### PR TITLE
refactor(experience): remove trusted device interaction data

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -195,7 +195,6 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
 
     expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
-    expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
 
   it('rechecks policy instead of reusing legacy interaction fulfillment', async () => {
@@ -234,7 +233,6 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
 
     expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
-    expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
 
   it('revalidates the trusted-device credential every time the guard runs', async () => {
@@ -247,8 +245,6 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
     expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
     expect(validateCredential).toHaveBeenCalledTimes(2);
     expect(validateCredential).toHaveBeenCalledWith(ctx, mockUserWithMfaVerifications.id);
-    expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
-    expect(experienceInteraction.toSanitizedJson()).not.toHaveProperty('trustedDeviceFulfillment');
   });
 
   it('allows a valid trusted device to verify adaptive MFA', async () => {
@@ -258,7 +254,6 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
 
     await expect(experienceInteraction.guardMfaVerificationStatus()).resolves.toBeUndefined();
 
-    expect(experienceInteraction.toJson()).not.toHaveProperty('trustedDeviceFulfillment');
     expect(ctx.assignReleaseAnywayInteractionHookResult).toHaveBeenCalledWith({
       event: InteractionHookEvent.PostSignInAdaptiveMfaTriggered,
       payload: {

--- a/packages/core/src/routes/experience/experience.openapi.json
+++ b/packages/core/src/routes/experience/experience.openapi.json
@@ -126,19 +126,7 @@
         "description": "Get the public interaction data.",
         "responses": {
           "200": {
-            "description": "The public interaction data has been successfully retrieved.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "trustedDevice": {
-                      "description": "Dev feature. Trusted-device creation availability for the identified user and current effective policy.",
-                      "x-logto-dev-feature": true
-                    }
-                  }
-                }
-              }
-            }
+            "description": "The public interaction data has been successfully retrieved."
           }
         }
       }

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -1187,60 +1187,7 @@ describe('POST /experience/submit', () => {
     }
   );
 
-  it('should expose only trusted-device creation availability for an identified user', async () => {
-    setDevFeaturesEnabled(true);
-    const { requester, getEffectivePolicy } = createRequesterWithMocks({
-      interactionResult: {
-        trustedDeviceCreation: { deviceId: 'internal-device-id' },
-        trustedDeviceFulfillment: {
-          userId: mockUser.id,
-          trustedDeviceId: 'internal-device-id',
-          fulfilledAt: Date.now(),
-        },
-      },
-      trustedDevicePolicy: { enabled: true, durationDays: 30 },
-    });
-
-    const response = await requester.get('/experience/interaction');
-
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject({
-      trustedDevice: { canCreate: true, durationDays: 30 },
-    });
-    expect(response.body).not.toHaveProperty('trustedDeviceFulfillment');
-    expect(response.body).not.toHaveProperty('trustedDeviceCreation');
-    expect(getEffectivePolicy).toHaveBeenCalledTimes(1);
-  });
-
-  it('should expose disabled creation without a duration when effective policy disallows it', async () => {
-    setDevFeaturesEnabled(true);
-    const { requester } = createRequesterWithMocks({
-      trustedDevicePolicy: { enabled: false, durationDays: 30 },
-    });
-
-    const response = await requester.get('/experience/interaction');
-
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject({ trustedDevice: { canCreate: false } });
-    expect(response.body.trustedDevice).not.toHaveProperty('durationDays');
-  });
-
-  it('should omit trusted-device availability when the policy lookup fails', async () => {
-    setDevFeaturesEnabled(true);
-    const policyError = new Error('trusted-device policy lookup failed');
-    const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
-    const { requester, getEffectivePolicy } = createRequesterWithMocks();
-    getEffectivePolicy.mockRejectedValueOnce(policyError);
-
-    const response = await requester.get('/experience/interaction');
-
-    expect(response.status).toBe(200);
-    expect(response.body).not.toHaveProperty('trustedDevice');
-    expect(trackException).toHaveBeenCalledWith(policyError, expect.any(Object));
-    trackException.mockRestore();
-  });
-
-  it('should omit trusted-device interaction data and behavior when dev features are disabled', async () => {
+  it('should disable trusted-device behavior when dev features are disabled', async () => {
     setDevFeaturesEnabled(false);
     const user = {
       ...mockUser,
@@ -1262,15 +1209,12 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const interactionResponse = await requester.get('/experience/interaction');
     const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
     const submitResponse = await requester
       .post('/experience/submit')
       .set('Content-Type', 'text/plain')
       .send('released submit payload');
 
-    expect(interactionResponse.status).toBe(200);
-    expect(interactionResponse.body).not.toHaveProperty('trustedDevice');
     expect(optInResponse.status).toBe(404);
     expect(submitResponse.status).toBe(200);
     expect(getEffectivePolicy).not.toHaveBeenCalled();

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -11,7 +11,6 @@
  */
 
 import { identificationApiPayloadGuard, InteractionEvent } from '@logto/schemas';
-import { conditional } from '@silverhand/essentials';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
@@ -202,14 +201,7 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
     }),
     async (ctx, next) => {
       const { experienceInteraction } = ctx;
-      const trustedDevice = await experienceInteraction.trustedDevice.getCreationAvailability(
-        experienceInteraction.identifiedUserId
-      );
-
-      ctx.body = {
-        ...experienceInteraction.toSanitizedJson(),
-        ...conditional(trustedDevice && { trustedDevice }),
-      };
+      ctx.body = experienceInteraction.toSanitizedJson();
       ctx.status = 200;
       return next();
     }

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -244,7 +244,6 @@ export const interactionStorageGuard = z.object({
 export type SanitizedInteractionStorageData = {
   interactionEvent: InteractionEvent;
   userId?: string;
-  trustedDevice?: TrustedDeviceAvailability;
   profile?: SanitizedInteractionProfile;
   verificationRecords?: SanitizedVerificationRecordData[];
   mfa?: SanitizedMfaData;
@@ -262,12 +261,6 @@ export type SanitizedInteractionStorageData = {
 export const sanitizedInteractionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
-  trustedDevice: z
-    .object({
-      canCreate: z.boolean(),
-      durationDays: z.number().optional(),
-    })
-    .optional(),
   profile: sanitizedInteractionProfileGuard,
   verificationRecords: publicVerificationRecordDataGuard.array().optional(),
   mfa: sanitizedMfaDataGuard.optional(),

--- a/packages/experience/src/apis/experience/index.ts
+++ b/packages/experience/src/apis/experience/index.ts
@@ -21,12 +21,10 @@ import {
 
 export {
   initInteraction,
-  getInteraction,
   submitInteraction,
   identifyUser,
   identifyAndSubmitInteraction,
 } from './interaction';
-export type { TrustedDeviceAvailability, TrustedDeviceInteractionData } from './interaction';
 
 export * from './avatar';
 export * from './mfa';

--- a/packages/experience/src/apis/experience/interaction.test.ts
+++ b/packages/experience/src/apis/experience/interaction.test.ts
@@ -1,33 +1,20 @@
 import api from '../api';
 
 import { experienceApiRoutes } from './const';
-import { getInteraction, submitInteraction } from './interaction';
+import { submitInteraction } from './interaction';
 
 jest.mock('../api', () => ({
   __esModule: true,
   default: {
-    get: jest.fn(),
     post: jest.fn(),
   },
 }));
 
-const mockedApiGet = api.get as jest.MockedFunction<typeof api.get>;
 const mockedApiPost = api.post as jest.MockedFunction<typeof api.post>;
 
 describe('interaction experience APIs', () => {
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('gets trusted-device creation availability from public interaction data', async () => {
-    const response = { trustedDevice: { canCreate: true, durationDays: 30 } };
-    const json = jest.fn().mockResolvedValue(response);
-    mockedApiGet.mockReturnValueOnce({ json } as unknown as ReturnType<typeof api.get>);
-
-    await expect(getInteraction()).resolves.toEqual(response);
-
-    expect(mockedApiGet).toBeCalledWith(experienceApiRoutes.interaction, { signal: undefined });
-    expect(json).toBeCalled();
   });
 
   it('records selected trusted-device intent before submitting the interaction', async () => {

--- a/packages/experience/src/apis/experience/interaction.ts
+++ b/packages/experience/src/apis/experience/interaction.ts
@@ -13,15 +13,6 @@ type SubmitInteractionResponse = {
   redirectTo: string;
 };
 
-export type TrustedDeviceAvailability = {
-  canCreate: boolean;
-  durationDays?: number;
-};
-
-export type TrustedDeviceInteractionData = {
-  trustedDevice?: TrustedDeviceAvailability;
-};
-
 type SubmitInteractionOptions = {
   createTrustedDevice?: boolean;
 };
@@ -36,9 +27,6 @@ export const initInteraction = async (interactionEvent: InteractionEvent, captch
 
 export const identifyUser = async (payload: IdentificationApiPayload = {}) =>
   api.post(experienceApiRoutes.identification, { json: payload });
-
-export const getInteraction = async (signal?: AbortSignal) =>
-  api.get(experienceApiRoutes.interaction, { signal }).json<TrustedDeviceInteractionData>();
 
 const requestTrustedDeviceCreation = async () =>
   api.post(`${experienceApiRoutes.mfa}/trusted-device`);


### PR DESCRIPTION
## Summary

Remove trusted-device availability from the interaction API response after Experience has switched to MFA error details.

Delete the now-unused Experience interaction client method, exported types, and obsolete tests so the opt-in UI no longer reads interaction state separately.

Stack: 3/4. Depends on #9519.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
