### PR TITLE
test(experience): cover trusted device MFA flows

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,8 +41,6 @@ jobs:
     env:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: ${{ matrix.dev-features-enabled }}
-      # Allow production-mode tests to simulate TLS termination for Secure cookies.
-      TRUST_PROXY_HEADER: 1
       # Mock servers for backchannel logout and webhook delivery listen on loopback, which the SSRF
       # protection blocks. Allow just those addresses instead of disabling the protection. CIMD
       # cannot be enabled while an allowlist is set.

--- a/packages/core/src/libraries/trusted-device.test.ts
+++ b/packages/core/src/libraries/trusted-device.test.ts
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto';
 import type { TrustedDevice } from '@logto/schemas';
 
 import { createMockTrustedDevice } from '#src/__mocks__/trusted-device.js';
+import { EnvSet } from '#src/env-set/index.js';
 import type { TrustedDeviceQueries } from '#src/queries/trusted-device.js';
 
 import type { createTrustedDevicePolicyLibrary } from './trusted-device-policy.js';
@@ -302,6 +303,36 @@ describe('trusted device library', () => {
       serializeTrustedDeviceCredential(credential),
       expect.objectContaining({ secure: true, signed: false, path: '/' })
     );
+  });
+
+  it('uses an HTTP-compatible cookie in the integration test harness', () => {
+    const originalEnv = {
+      isProduction: EnvSet.values.isProduction,
+      isIntegrationTest: EnvSet.values.isIntegrationTest,
+    };
+    const setEnvFlag = (key: 'isProduction' | 'isIntegrationTest', value: boolean) => {
+      Reflect.set(EnvSet.values, key, value);
+    };
+    setEnvFlag('isProduction', true);
+    setEnvFlag('isIntegrationTest', true);
+
+    try {
+      const queries = createQueries();
+      const { ctx, set } = createCookieContext();
+      const library = createTrustedDeviceLibrary(tenantId, queries, createPolicyLibrary());
+      const credential = { id: trustedDeviceId, secret: generateTrustedDeviceSecret() };
+
+      library.writeCredential(ctx, userId, credential, Date.now() + 60_000);
+
+      expect(set).toHaveBeenCalledWith(
+        getTrustedDeviceCookieName(tenantId, userId, false),
+        serializeTrustedDeviceCredential(credential),
+        expect.objectContaining({ secure: false, signed: false, path: '/' })
+      );
+    } finally {
+      setEnvFlag('isProduction', originalEnv.isProduction);
+      setEnvFlag('isIntegrationTest', originalEnv.isIntegrationTest);
+    }
   });
 
   it('queues a redacted deletion webhook only after deleting an existing record', async () => {

--- a/packages/core/src/libraries/trusted-device.ts
+++ b/packages/core/src/libraries/trusted-device.ts
@@ -139,7 +139,9 @@ export const createTrustedDeviceLibrary = (
   queries: TrustedDeviceQueries,
   policyLibrary: TrustedDevicePolicyLibrary,
   {
-    isProduction = EnvSet.values.isProduction,
+    // Integration tests run the production build over HTTP. Production cookie attributes are
+    // covered by unit tests, while browser-level tests need a credential the HTTP harness can use.
+    isProduction = EnvSet.values.isProduction && !EnvSet.values.isIntegrationTest,
     cleanupCooldown = trustedDeviceCleanupCooldown,
   }: TrustedDeviceLibraryOptions = {}
 ) => {

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -27,13 +27,9 @@ import {
 const { jest } = import.meta;
 const { mockEsmWithActual } = createMockUtils(jest);
 
-const mockEnvSetValues = {
-  isDevFeaturesEnabled: true,
-};
-
 await mockEsmWithActual('#src/env-set/index.js', () => ({
   EnvSet: {
-    values: mockEnvSetValues,
+    values: { isDevFeaturesEnabled: true },
   },
 }));
 
@@ -136,8 +132,6 @@ const expectConventionalMfaRequired = async (
 describe('ExperienceInteraction trusted-device MFA verification', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Toggle the mocked feature environment per test.
-    mockEnvSetValues.isDevFeaturesEnabled = true;
     findDefaultSignInExperience.mockResolvedValue(requiredMfaSignInExperience);
     findUserById.mockResolvedValue(mockUserWithMfaVerifications);
     getEffectivePolicy.mockResolvedValue({ enabled: true, durationDays: 30 });
@@ -266,17 +260,5 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
       },
       userId: mockUserWithMfaVerifications.id,
     });
-  });
-
-  it('does not enable trusted-device verification when dev features are disabled', async () => {
-    // eslint-disable-next-line @silverhand/fp/no-mutation -- Verify the feature-level runtime guard.
-    mockEnvSetValues.isDevFeaturesEnabled = false;
-    validateCredential.mockResolvedValueOnce(trustedDevice);
-    const { experienceInteraction } = createInteraction();
-
-    await expectConventionalMfaRequired(experienceInteraction, { trustedDevice: false });
-
-    expect(getEffectivePolicy).not.toHaveBeenCalled();
-    expect(validateCredential).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -1186,39 +1186,5 @@ describe('POST /experience/submit', () => {
       expect(createCredential).toHaveBeenCalledWith(expect.objectContaining({ userId: user.id }));
     }
   );
-
-  it('should disable trusted-device behavior when dev features are disabled', async () => {
-    setDevFeaturesEnabled(false);
-    const user = {
-      ...mockUser,
-      mfaVerifications: [mockUserTotpMfaVerification],
-    };
-    const { requester, createCredential, getEffectivePolicy } = createRequesterWithMocks({
-      user,
-      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
-      interactionResult: {
-        verificationRecords: [
-          {
-            id: 'totp-verification-id',
-            type: VerificationType.TOTP,
-            userId: user.id,
-            verified: true,
-          },
-        ],
-      },
-      trustedDevicePolicy: { enabled: true, durationDays: 30 },
-    });
-
-    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
-    const submitResponse = await requester
-      .post('/experience/submit')
-      .set('Content-Type', 'text/plain')
-      .send('released submit payload');
-
-    expect(optInResponse.status).toBe(404);
-    expect(submitResponse.status).toBe(200);
-    expect(getEffectivePolicy).not.toHaveBeenCalled();
-    expect(createCredential).not.toHaveBeenCalled();
-  });
 });
 /* eslint-enable max-lines */

--- a/packages/integration-tests/src/tests/api/account/trusted-device.test.ts
+++ b/packages/integration-tests/src/tests/api/account/trusted-device.test.ts
@@ -43,7 +43,7 @@ const getTrustedDeviceCookieName = (userId: string) => {
     .update(`${defaultTenantId}:${userId}`)
     .digest('base64url');
 
-  return `__Host-logto-trusted-device-${subjectHash}`;
+  return `logto-trusted-device-${subjectHash}`;
 };
 
 const createCredential = (id: string) => {
@@ -58,7 +58,6 @@ const buildApiWithCredential = (accessToken: string, userId: string, id: string,
     headers: {
       Authorization: `Bearer ${accessToken}`,
       Cookie: `${getTrustedDeviceCookieName(userId)}=${id}.${secret}`,
-      'X-Forwarded-Proto': 'https',
     },
   });
 

--- a/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
@@ -1,5 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInIdentifier } from '@logto/schemas';
+import { MfaFactor, SignInIdentifier } from '@logto/schemas';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -8,7 +8,13 @@ import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connecto
 import { enableMandatoryMfaWithEmail, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
-import { generateEmail, generatePassword, generateUsername, waitFor } from '#src/utils.js';
+import {
+  devFeatureTest,
+  generateEmail,
+  generatePassword,
+  generateUsername,
+  waitFor,
+} from '#src/utils.js';
 
 describe('email MFA binding', () => {
   beforeAll(async () => {
@@ -79,5 +85,75 @@ describe('email MFA binding', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('creates a trusted device from email MFA binding and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.EmailVerificationCode}`);
+      await experience.toFillInput('identifier', generateEmail(), { submit: true });
+      await experience.toOptInTrustedDevice();
+      await experience.toCompleteVerification('continue', ConnectorType.Email);
+      await experience.toClickButton('Continue');
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('creates a trusted device from email MFA verification and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({
+        username: true,
+        password: true,
+        primaryEmail: true,
+      });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.EmailVerificationCode}`);
+      await experience.toOptInTrustedDevice();
+      await experience.toCompleteMfaVerification(ConnectorType.Email, true);
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
   });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/multi-factors.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/multi-factors.test.ts
@@ -8,7 +8,7 @@ import { clearConnectorsByTypes, setSocialConnector } from '#src/helpers/connect
 import { resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectWebAuthnExperience from '#src/ui-helpers/expect-webauthn-experience.js';
-import { waitFor } from '#src/utils.js';
+import { devFeatureTest, waitFor } from '#src/utils.js';
 
 describe('MFA - Multi factors', () => {
   beforeAll(async () => {
@@ -108,5 +108,68 @@ describe('MFA - Multi factors', () => {
     await experience.clearVirtualAuthenticator();
     await experience.verifyThenEnd();
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in after switching factors', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('keeps trusted-device availability across binding and verification factor switches', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt('mfa-binding');
+
+      await experience.toClick('button div[class$=name]', 'Authenticator app OTP');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.TOTP}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toClickSwitchFactorsLink({ isBinding: true });
+
+      await experience.toClick('button div[class$=name]', 'Passkey');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.WebAuthn}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toClickSwitchFactorsLink({ isBinding: true });
+
+      await experience.toClick('button div[class$=name]', 'Authenticator app OTP');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.TOTP}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toClickSwitchFactorsLink({ isBinding: true });
+
+      await experience.toClick('button div[class$=name]', 'Passkey');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.WebAuthn}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toCreatePasskey();
+      await experience.toClickButton('Continue');
+      await experience.verifyThenEnd(false);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.WebAuthn}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toClickSwitchFactorsLink({ isBinding: false });
+
+      await experience.toClick('button div[class$=name]', 'Passkey');
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.WebAuthn}`);
+      await experience.toSeeTrustedDeviceOptIn();
+      await experience.toVerifyViaPasskey();
+
+      await experience.clearVirtualAuthenticator();
+      await experience.verifyThenEnd();
+      await deleteUser(user.id);
+    });
   });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
@@ -1,5 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInIdentifier } from '@logto/schemas';
+import { MfaFactor, SignInIdentifier } from '@logto/schemas';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -8,7 +8,13 @@ import { clearConnectorsByTypes, setSmsConnector } from '#src/helpers/connector.
 import { enableMandatoryMfaWithPhone, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
-import { generatePhone, generatePassword, generateUsername, waitFor } from '#src/utils.js';
+import {
+  devFeatureTest,
+  generatePhone,
+  generatePassword,
+  generateUsername,
+  waitFor,
+} from '#src/utils.js';
 
 describe('phone MFA binding', () => {
   beforeAll(async () => {
@@ -79,5 +85,75 @@ describe('phone MFA binding', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('creates a trusted device from phone MFA binding and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.PhoneVerificationCode}`);
+      await experience.toFillInput('identifier', generatePhone(), { submit: true });
+      await experience.toOptInTrustedDevice();
+      await experience.toCompleteVerification('continue', ConnectorType.Sms);
+      await experience.toClickButton('Continue');
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('creates a trusted device from phone MFA verification and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({
+        username: true,
+        password: true,
+        primaryPhone: true,
+      });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.PhoneVerificationCode}`);
+      await experience.toOptInTrustedDevice();
+      await experience.toCompleteMfaVerification(ConnectorType.Sms, true);
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
   });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/totp/password-identifier-flow.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/totp/password-identifier-flow.test.ts
@@ -1,6 +1,6 @@
-import { ConnectorType, SignInIdentifier } from '@logto/schemas';
+import { ConnectorType, MfaFactor, SignInIdentifier } from '@logto/schemas';
 
-import { deleteUser } from '#src/api/admin-user.js';
+import { createUserMfaVerification, deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { demoAppUrl } from '#src/constants.js';
 import { clearConnectorsByTypes } from '#src/helpers/connector.js';
@@ -11,7 +11,7 @@ import {
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectTotpExperience from '#src/ui-helpers/expect-totp-experience.js';
-import { generateUsername } from '#src/utils.js';
+import { devFeatureTest, generateUsername } from '#src/utils.js';
 
 import TotpTestingContext from './totp-testing-context.js';
 
@@ -108,6 +108,75 @@ describe('MFA - TOTP', () => {
 
       // Clean up
       await deleteUser(user.id);
+    });
+
+    devFeatureTest.describe('trusted device opt-in', () => {
+      beforeAll(async () => {
+        await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+      });
+
+      afterAll(async () => {
+        await updateSignInExperience({ trustedDevice: { enabled: false } });
+      });
+
+      it('creates a trusted device from TOTP binding and skips MFA on the next sign-in', async () => {
+        const { userProfile, user } = await generateNewUser({ username: true, password: true });
+        const experience = new ExpectTotpExperience(await browser.newPage());
+
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.waitToBeAt(`mfa-binding/${MfaFactor.TOTP}`);
+        await experience.toOptInTrustedDevice();
+        await experience.toBindTotp(true, true);
+        await experience.verifyThenEnd(false);
+        await experience.clearDemoAppSession();
+        await experience.page.close();
+        const trustedDeviceExperience = new ExpectTotpExperience(await browser.newPage());
+
+        await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+        await trustedDeviceExperience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await trustedDeviceExperience.verifyThenEnd();
+
+        await deleteUser(user.id);
+      });
+
+      it('creates a trusted device from TOTP verification and skips MFA on the next sign-in', async () => {
+        const { userProfile, user } = await generateNewUser({ username: true, password: true });
+        const verification = await createUserMfaVerification(user.id, MfaFactor.TOTP);
+
+        if (verification.type !== MfaFactor.TOTP) {
+          throw new Error('unexpected MFA verification type');
+        }
+
+        const experience = new ExpectTotpExperience(await browser.newPage());
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.waitToBeAt(`mfa-verification/${MfaFactor.TOTP}`);
+        await experience.toOptInTrustedDevice();
+        await experience.toVerifyTotp(verification.secret, true, true);
+        await experience.verifyThenEnd(false);
+        await experience.clearDemoAppSession();
+        await experience.page.close();
+        const trustedDeviceExperience = new ExpectTotpExperience(await browser.newPage());
+
+        await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+        await trustedDeviceExperience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await trustedDeviceExperience.verifyThenEnd();
+
+        await deleteUser(user.id);
+      });
     });
   });
 

--- a/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
@@ -20,7 +20,7 @@ import {
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectWebAuthnExperience from '#src/ui-helpers/expect-webauthn-experience.js';
-import { generateUsername, waitFor } from '#src/utils.js';
+import { devFeatureTest, generateUsername, waitFor } from '#src/utils.js';
 
 describe('MFA - WebAuthn', () => {
   beforeAll(async () => {
@@ -73,6 +73,7 @@ describe('MFA - WebAuthn', () => {
     );
     // Wait for the page to process submitting request.
     await waitFor(500);
+
     await experience.toVerifyViaPasskey();
 
     await experience.clearVirtualAuthenticator();
@@ -102,6 +103,82 @@ describe('MFA - WebAuthn', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('creates a trusted device from WebAuthn binding and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.WebAuthn}`);
+      await experience.toOptInTrustedDevice();
+      await experience.toCreatePasskey();
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.clearVirtualAuthenticator();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectWebAuthnExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('creates a trusted device from WebAuthn verification and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.toCreatePasskey();
+      await experience.verifyThenEnd(false);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.WebAuthn}`);
+      await experience.toOptInTrustedDevice();
+      await experience.toVerifyViaPasskey();
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.clearVirtualAuthenticator();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectWebAuthnExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    }, 90_000);
   });
 });
 

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -89,7 +89,7 @@ export default class ExpectExperience extends ExpectPage {
    */
   async startWith(initialUrl = demoAppUrl, type: ExperienceType = 'sign-in') {
     await this.toStart(initialUrl);
-    this.toBeAt('sign-in');
+    await this.waitToBeAt('sign-in');
 
     if (type === 'register') {
       await this.toClick('a', 'Create account');
@@ -128,12 +128,29 @@ export default class ExpectExperience extends ExpectPage {
     }
 
     await this.waitForUrl(this.#ongoing.initialUrl);
+
     await this.toClick('div[role=button]', /sign out/i);
 
     this.#ongoing = undefined;
     if (closePage) {
       await this.page.close();
     }
+  }
+
+  /**
+   * Clear the demo app browser storage and session cookies while preserving the trusted-device
+   * credential under test. This guarantees the next visit starts a new sign-in interaction.
+   */
+  async clearDemoAppSession() {
+    await this.page.evaluate(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+    });
+    const cookies = await this.page.cookies(logtoUrl);
+    expect(cookies.some(({ name }) => name.includes('logto-trusted-device-'))).toBe(true);
+    const sessionCookies = cookies.filter(({ name }) => !name.includes('logto-trusted-device-'));
+    await this.page.deleteCookie(...sessionCookies);
+    await this.page.goto('about:blank');
   }
 
   /**
@@ -185,6 +202,22 @@ export default class ExpectExperience extends ExpectPage {
     for (const [index, char] of code.split('').entries()) {
       // eslint-disable-next-line no-await-in-loop
       await this.toFillInput(`passcode_${index}`, char);
+    }
+  }
+
+  async toCompleteMfaVerification(
+    connectorType: Parameters<typeof readConnectorMessage>['0'],
+    submitManually = false
+  ) {
+    const { code } = await readConnectorMessage(connectorType);
+
+    for (const [index, char] of code.split('').entries()) {
+      // eslint-disable-next-line no-await-in-loop -- verification inputs must be filled in order
+      await this.toFillInput(`mfaCode_${index}`, char);
+    }
+
+    if (submitManually) {
+      await this.toClickButton('Continue');
     }
   }
 
@@ -261,6 +294,18 @@ export default class ExpectExperience extends ExpectPage {
    */
   async waitForToast(text: string | RegExp) {
     return this.toMatchAndRemove('div[role=toast]', text);
+  }
+
+  async toSeeTrustedDeviceOptIn(durationDays = 365) {
+    const text = `Trust this device for ${durationDays} days`;
+    await this.toMatchElement('div[role=checkbox][aria-checked=false]', { text });
+  }
+
+  async toOptInTrustedDevice(durationDays = 365) {
+    const text = `Trust this device for ${durationDays} days`;
+    await this.toSeeTrustedDeviceOptIn(durationDays);
+    await this.toClick('div[role=checkbox]', text, false);
+    await this.toMatchElement('div[role=checkbox][aria-checked=true]', { text });
   }
 
   /**

--- a/packages/integration-tests/src/ui-helpers/expect-totp-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-totp-experience.ts
@@ -14,9 +14,10 @@ export default class ExpectTotpExperience extends ExpectMfaExperience {
    * generated from the TOTP secret.
    *
    * @param [signingInAfterBinding=true] Whether the flow will continue to sign in after the binding.
+   * @param [submitManually=false] Whether to click Continue after entering the code.
    * @returns The binding TOTP secret.
    */
-  async toBindTotp(signingInAfterBinding = true) {
+  async toBindTotp(signingInAfterBinding = true, submitManually = false) {
     await this.waitToBeAt('mfa-binding/Totp');
     // Expect the QR code rendered
     await expect(this.page).toMatchElement(`${dcls('qrCode')} img[src*="data:image"]`);
@@ -33,6 +34,10 @@ export default class ExpectTotpExperience extends ExpectMfaExperience {
 
     await this.fillTotpCode(code);
 
+    if (submitManually) {
+      await this.toClickButton('Continue', false);
+    }
+
     // Wait for the form to commit automatically
     await waitFor(500);
     if (signingInAfterBinding) {
@@ -48,13 +53,18 @@ export default class ExpectTotpExperience extends ExpectMfaExperience {
    *
    * @param secret The TOTP secret.
    * @param [signingInAfterVerification=true] Whether the flow will continue to sign in after the verification.
+   * @param [submitManually=false] Whether to click Continue after entering the code.
    */
-  async toVerifyTotp(secret: string, signingInAfterVerification = true) {
+  async toVerifyTotp(secret: string, signingInAfterVerification = true, submitManually = false) {
     await this.waitToBeAt('mfa-verification/Totp');
 
     const code = authenticator.generate(secret);
 
     await this.fillTotpCode(code);
+
+    if (submitManually) {
+      await this.toClickButton('Continue', false);
+    }
 
     // Wait for the form to commit automatically
     await waitFor(500);


### PR DESCRIPTION
## Summary

Add end-to-end trusted-device opt-in coverage for TOTP, WebAuthn, email OTP, and SMS OTP across MFA binding and verification flows.

Verify that opting in creates a browser credential and that the next sign-in for the same account skips MFA. Keep backup-code flows excluded.

Use an HTTP-compatible cookie in the integration harness and remove the previous TLS simulation configuration.

Stack: 4/4. Depends on #9520.

## Testing

Unit tests

Integration tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
