### PR TITLE
docs: fix typo protocal -> protocol

### DIFF
--- a/packages/console/src/assets/docs/guides/web-wordpress/README.mdx
+++ b/packages/console/src/assets/docs/guides/web-wordpress/README.mdx
@@ -17,7 +17,7 @@ Follow the official [Wordpress installation guide](https://wordpress.org/support
 
 <Step title="Install the plugin">
 
-We will use the [OpenID Connect Generic](https://wordpress.org/plugins/generic-openid-connect/) plugin to integrate Logto via OIDC protocal into your Wordpress website.
+We will use the [OpenID Connect Generic](https://wordpress.org/plugins/generic-openid-connect/) plugin to integrate Logto via OIDC protocol into your Wordpress website.
 
 1. Log in to your WordPress site.
 2. Navigate to "Plugins" and click "Add New".


### PR DESCRIPTION
One-word typo fix in `packages/console/src/assets/docs/guides/web-wordpress/README.mdx:20`: "We will use the [OpenID Co..." → `protocol`.
