### PR TITLE
feat(core,schemas): support incremental organization consent

### DIFF
--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -1,4 +1,3 @@
-import { UserScope } from '@logto/core-kit';
 import {
   ApplicationType,
   applicationSignInExperienceGuard,
@@ -26,6 +25,7 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { interactionPrefix } from '../const.js';
 
+import { buildConsentOrganizations } from './organizations.js';
 import {
   buildResourceScopesToReject,
   filterAndParseMissingResourceScopes,
@@ -252,7 +252,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
 
       const {
         session,
-        params: { client_id: clientId, redirect_uri: redirectUri },
+        params: { client_id: clientId, redirect_uri: redirectUri, scope: requestedScope },
         prompt,
       } = interactionDetails;
 
@@ -368,31 +368,24 @@ export default function consentRoutes<T extends IRouterParamContext>(
         applicationId: clientId,
       });
 
-      // Find the organizations if the application is requesting the organizations scope.
-      const organizations = missingOIDCScope?.includes(UserScope.Organizations)
-        ? await queries.organizations.relations.users.getOrganizationsByUserId(accountId)
-        : [];
-
-      const organizationsWithMissingResourceScopes = await Promise.all(
-        organizations.map(async ({ name, id }) => {
-          const missingResourceScopes = await filterAndParseMissingResourceScopes({
-            resourceScopes: allMissingResourceScopes,
-            envSet,
-            queries,
-            libraries,
-            userId: accountId,
-            organizationId: id,
-            applicationId: clientId,
-          });
-
-          return { name, id, missingResourceScopes };
-        })
-      );
+      const { organizations, organizationResourceScopes } = await buildConsentOrganizations({
+        envSet,
+        queries,
+        libraries,
+        cimd,
+        userId: accountId,
+        applicationId: clientId,
+        requestedScope,
+        missingOIDCScope,
+        allMissingResourceScopes,
+        userMissingResourceScopes: missingResourceScopes,
+      });
 
       ctx.body = {
         application,
         user: publicUserInfoGuard.parse(userInfo),
-        organizations: organizationsWithMissingResourceScopes,
+        organizations,
+        organizationResourceScopes,
         // Filter out the OIDC scopes that are not needed for the consent page.
         missingOIDCScope: missingOIDCScope?.filter(
           (scope) => scope !== 'openid' && scope !== 'offline_access'

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -380,18 +380,13 @@ export default function consentRoutes<T extends IRouterParamContext>(
         allMissingResourceScopes,
       });
 
-      /**
-       * The ceiling card renders once above the roster, so it only exists when a registered
-       * third-party roster does; CIMD organizations carry their own scope breakdown instead.
-       */
-      const organizationResourceScopes =
-        cimd || organizations.length === 0
-          ? undefined
-          : await getOrganizationResourceScopes(
-              queries,
-              allMissingResourceScopes,
-              missingResourceScopes
-            );
+      const organizationResourceScopes = await getOrganizationResourceScopes({
+        queries,
+        cimd,
+        organizations,
+        allMissingResourceScopes,
+        userMissingResourceScopes: missingResourceScopes,
+      });
 
       ctx.body = {
         application,

--- a/packages/core/src/routes/interaction/consent/index.ts
+++ b/packages/core/src/routes/interaction/consent/index.ts
@@ -25,7 +25,7 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { interactionPrefix } from '../const.js';
 
-import { buildConsentOrganizations } from './organizations.js';
+import { getConsentOrganizations, getOrganizationResourceScopes } from './organizations.js';
 import {
   buildResourceScopesToReject,
   filterAndParseMissingResourceScopes,
@@ -368,7 +368,7 @@ export default function consentRoutes<T extends IRouterParamContext>(
         applicationId: clientId,
       });
 
-      const { organizations, organizationResourceScopes } = await buildConsentOrganizations({
+      const organizations = await getConsentOrganizations({
         envSet,
         queries,
         libraries,
@@ -378,8 +378,20 @@ export default function consentRoutes<T extends IRouterParamContext>(
         requestedScope,
         missingOIDCScope,
         allMissingResourceScopes,
-        userMissingResourceScopes: missingResourceScopes,
       });
+
+      /**
+       * The ceiling card renders once above the roster, so it only exists when a registered
+       * third-party roster does; CIMD organizations carry their own scope breakdown instead.
+       */
+      const organizationResourceScopes =
+        cimd || organizations.length === 0
+          ? undefined
+          : await getOrganizationResourceScopes(
+              queries,
+              allMissingResourceScopes,
+              missingResourceScopes
+            );
 
       ctx.body = {
         application,

--- a/packages/core/src/routes/interaction/consent/organizations.ts
+++ b/packages/core/src/routes/interaction/consent/organizations.ts
@@ -111,19 +111,39 @@ export const getConsentOrganizations = async ({
   }));
 };
 
+type GetOrganizationResourceScopesOptions = {
+  queries: Queries;
+  cimd: boolean;
+  /** The roster the consent page will render. */
+  organizations: PublicOrganization[];
+  /** The requested scope ceiling from the prompt details. */
+  allMissingResourceScopes: Record<string, string[]>;
+  /** The user-level scope card of the consent page, which the organization-facing part excludes. */
+  userMissingResourceScopes: MissingResourceScopes[];
+};
+
 /**
- * The organization-facing part of the requested scope ceiling, shown once above the roster.
+ * The organization-facing part of the requested scope ceiling, or `undefined` when this consent
+ * response carries none: the card renders once above the organization roster, so it only
+ * accompanies a non-empty registered third-party roster — CIMD organizations carry their own
+ * scope breakdown instead.
  *
  * The reserved organization resource always belongs here, as the user-level card filters it out
  * of its own display. API resource scopes can be reachable both directly and through
  * organization roles, so they are deduplicated against what the user-level card already lists,
  * and groups left with no scopes are dropped.
  */
-export const getOrganizationResourceScopes = async (
-  queries: Queries,
-  allMissingResourceScopes: Record<string, string[]>,
-  userMissingResourceScopes: MissingResourceScopes[]
-): Promise<MissingResourceScopes[]> => {
+export const getOrganizationResourceScopes = async ({
+  queries,
+  cimd,
+  organizations,
+  allMissingResourceScopes,
+  userMissingResourceScopes,
+}: GetOrganizationResourceScopesOptions): Promise<MissingResourceScopes[] | undefined> => {
+  if (cimd || organizations.length === 0) {
+    return;
+  }
+
   const requestedResourceScopes = await parseMissingResourceScopesInfo(
     queries,
     allMissingResourceScopes

--- a/packages/core/src/routes/interaction/consent/organizations.ts
+++ b/packages/core/src/routes/interaction/consent/organizations.ts
@@ -14,16 +14,60 @@ type BuildConsentOrganizationsOptions = {
   cimd: boolean;
   userId: string;
   applicationId: string;
-  /** The `scope` parameter of the authorization request. */
+  /**
+   * The `scope` parameter of the authorization request. Provider-owned interaction params are
+   * untyped, so the value arrives as `unknown`; a non-string reads as "requested nothing",
+   * matching how `revalidateConsentClient` treats the same parameter.
+   */
   requestedScope: unknown;
   missingOIDCScope?: string[];
   /**
-   * The requested scope ceiling from the prompt details, already bounded at authorization time by
-   * the user's roles across all of their organizations.
+   * The requested scope ceiling from the prompt details, already bounded at authorization time
+   * by the user's roles across all of their organizations.
    */
   allMissingResourceScopes: Record<string, string[]>;
   /** The user-level scope card of the consent page, which the organization-facing part excludes. */
   userMissingResourceScopes: MissingResourceScopes[];
+};
+
+type ConsentOrganizationsInfo = {
+  organizations: PublicOrganization[];
+  organizationResourceScopes?: MissingResourceScopes[];
+};
+
+/**
+ * The organization-facing part of the requested scope ceiling, shown once above the roster.
+ *
+ * The reserved organization resource always belongs here, as the user-level card filters it out
+ * of its own display. API resource scopes can be reachable both directly and through
+ * organization roles, so they are deduplicated against what the user-level card already lists,
+ * and groups left with no scopes are dropped.
+ */
+const buildOrganizationResourceScopes = async (
+  queries: Queries,
+  allMissingResourceScopes: Record<string, string[]>,
+  userMissingResourceScopes: MissingResourceScopes[]
+): Promise<MissingResourceScopes[]> => {
+  const requestedResourceScopes = await parseMissingResourceScopesInfo(
+    queries,
+    allMissingResourceScopes
+  );
+
+  return requestedResourceScopes
+    .map(({ resource, scopes }) => {
+      if (resource.id === ReservedResource.Organization) {
+        return { resource, scopes };
+      }
+
+      const userCardScopes =
+        userMissingResourceScopes.find(({ resource: { id } }) => id === resource.id)?.scopes ?? [];
+
+      return {
+        resource,
+        scopes: scopes.filter((scope) => !userCardScopes.some(({ id }) => id === scope.id)),
+      };
+    })
+    .filter(({ scopes }) => scopes.length > 0);
 };
 
 /**
@@ -32,8 +76,7 @@ type BuildConsentOrganizationsOptions = {
  *
  * A registered third-party consent records an application-wide ceiling plus a roster, so the
  * roster carries no per-organization scope detail: the effective access of each organization is
- * re-bounded by the user's role there at token issuance. CIMD consent is grant-scoped per
- * authorization, and keeps the per-organization breakdown its model displays.
+ * re-bounded by the user's role there at token issuance.
  */
 export const buildConsentOrganizations = async ({
   envSet,
@@ -46,29 +89,20 @@ export const buildConsentOrganizations = async ({
   missingOIDCScope,
   allMissingResourceScopes,
   userMissingResourceScopes,
-}: BuildConsentOrganizationsOptions): Promise<{
-  organizations: PublicOrganization[];
-  organizationResourceScopes?: MissingResourceScopes[];
-}> => {
+}: BuildConsentOrganizationsOptions): Promise<ConsentOrganizationsInfo> => {
   /**
-   * The roster is gated on the requested `organizations` scope rather than on its missing state
-   * alone: after the first grant the scope is never missing again, yet a later consent round
-   * (e.g. a `prompt=consent` re-authorization) must still offer the organizations that are not
-   * consented yet, so the selection stays amendable. The consent prompt trigger itself is
-   * untouched, which keeps the resume flow single-pass. A CIMD authorization consents exactly
-   * one organization to its own grant, so it keeps the missing-scope gate.
+   * CIMD consent is grant-scoped per authorization (one grant carries one organization), so no
+   * cross-grant roster or ceiling concept applies. It keeps the pre-roster behavior verbatim:
+   * the missing-scope gate and a per-organization scope breakdown.
    */
-  const wantsOrganizations =
-    Boolean(missingOIDCScope?.includes(UserScope.Organizations)) ||
-    (!cimd &&
-      typeof requestedScope === 'string' &&
-      requestedScope.split(' ').includes(UserScope.Organizations));
-
-  const organizations = wantsOrganizations
-    ? await queries.organizations.relations.users.getOrganizationsByUserId(userId)
-    : [];
-
   if (cimd) {
+    if (!missingOIDCScope?.includes(UserScope.Organizations)) {
+      return { organizations: [] };
+    }
+
+    const organizations =
+      await queries.organizations.relations.users.getOrganizationsByUserId(userId);
+
     return {
       organizations: await Promise.all(
         organizations.map(async ({ name, id }) => ({
@@ -88,6 +122,23 @@ export const buildConsentOrganizations = async ({
     };
   }
 
+  /**
+   * The roster is gated on the requested `organizations` scope, not on its missing state: after
+   * the first grant the scope is never missing again, yet a later consent round (e.g. a
+   * `prompt=consent` re-authorization) must still offer the organizations that are not consented
+   * yet. Missing scopes are computed from the requested set, so this check subsumes the legacy
+   * missing-state gate. The consent prompt trigger itself is untouched, which keeps the resume
+   * flow single-pass.
+   */
+  const requestedScopes = typeof requestedScope === 'string' ? requestedScope.split(' ') : [];
+
+  if (!requestedScopes.includes(UserScope.Organizations)) {
+    return { organizations: [] };
+  }
+
+  const organizations =
+    await queries.organizations.relations.users.getOrganizationsByUserId(userId);
+
   if (organizations.length === 0) {
     return { organizations: [] };
   }
@@ -99,37 +150,16 @@ export const buildConsentOrganizations = async ({
     });
   const consentedOrganizationIds = new Set(consentedOrganizations.map(({ id }) => id));
 
-  /**
-   * The reserved organization resource always belongs to the organization-facing part; API
-   * resource scopes may be carried by an organization role as well as directly by the user, so
-   * they are deduplicated against what the user-level card already lists.
-   */
-  const requestedResourceScopes = await parseMissingResourceScopesInfo(
-    queries,
-    allMissingResourceScopes
-  );
-  const organizationResourceScopes = requestedResourceScopes
-    .map(({ resource, scopes }) => ({
-      resource,
-      scopes:
-        resource.id === ReservedResource.Organization
-          ? scopes
-          : scopes.filter(
-              (scope) =>
-                !userMissingResourceScopes.some(
-                  ({ resource: userResource, scopes: userScopes }) =>
-                    userResource.id === resource.id && userScopes.some(({ id }) => id === scope.id)
-                )
-            ),
-    }))
-    .filter(({ scopes }) => scopes.length > 0);
-
   return {
     organizations: organizations.map(({ name, id }) => ({
       name,
       id,
       isConsented: consentedOrganizationIds.has(id),
     })),
-    organizationResourceScopes,
+    organizationResourceScopes: await buildOrganizationResourceScopes(
+      queries,
+      allMissingResourceScopes,
+      userMissingResourceScopes
+    ),
   };
 };

--- a/packages/core/src/routes/interaction/consent/organizations.ts
+++ b/packages/core/src/routes/interaction/consent/organizations.ts
@@ -1,0 +1,135 @@
+import { ReservedResource, UserScope } from '@logto/core-kit';
+import { type MissingResourceScopes, Organizations, type PublicOrganization } from '@logto/schemas';
+
+import { type EnvSet } from '#src/env-set/index.js';
+import type Libraries from '#src/tenants/Libraries.js';
+import type Queries from '#src/tenants/Queries.js';
+
+import { filterAndParseMissingResourceScopes, parseMissingResourceScopesInfo } from './utils.js';
+
+type BuildConsentOrganizationsOptions = {
+  envSet: EnvSet;
+  queries: Queries;
+  libraries: Libraries;
+  cimd: boolean;
+  userId: string;
+  applicationId: string;
+  /** The `scope` parameter of the authorization request. */
+  requestedScope: unknown;
+  missingOIDCScope?: string[];
+  /**
+   * The requested scope ceiling from the prompt details, already bounded at authorization time by
+   * the user's roles across all of their organizations.
+   */
+  allMissingResourceScopes: Record<string, string[]>;
+  /** The user-level scope card of the consent page, which the organization-facing part excludes. */
+  userMissingResourceScopes: MissingResourceScopes[];
+};
+
+/**
+ * Build the organization roster of the consent page, along with the organization-facing part of
+ * the requested scope ceiling.
+ *
+ * A registered third-party consent records an application-wide ceiling plus a roster, so the
+ * roster carries no per-organization scope detail: the effective access of each organization is
+ * re-bounded by the user's role there at token issuance. CIMD consent is grant-scoped per
+ * authorization, and keeps the per-organization breakdown its model displays.
+ */
+export const buildConsentOrganizations = async ({
+  envSet,
+  queries,
+  libraries,
+  cimd,
+  userId,
+  applicationId,
+  requestedScope,
+  missingOIDCScope,
+  allMissingResourceScopes,
+  userMissingResourceScopes,
+}: BuildConsentOrganizationsOptions): Promise<{
+  organizations: PublicOrganization[];
+  organizationResourceScopes?: MissingResourceScopes[];
+}> => {
+  /**
+   * The roster is gated on the requested `organizations` scope rather than on its missing state
+   * alone: after the first grant the scope is never missing again, yet a later consent round
+   * (e.g. a `prompt=consent` re-authorization) must still offer the organizations that are not
+   * consented yet, so the selection stays amendable. The consent prompt trigger itself is
+   * untouched, which keeps the resume flow single-pass. A CIMD authorization consents exactly
+   * one organization to its own grant, so it keeps the missing-scope gate.
+   */
+  const wantsOrganizations =
+    Boolean(missingOIDCScope?.includes(UserScope.Organizations)) ||
+    (!cimd &&
+      typeof requestedScope === 'string' &&
+      requestedScope.split(' ').includes(UserScope.Organizations));
+
+  const organizations = wantsOrganizations
+    ? await queries.organizations.relations.users.getOrganizationsByUserId(userId)
+    : [];
+
+  if (cimd) {
+    return {
+      organizations: await Promise.all(
+        organizations.map(async ({ name, id }) => ({
+          name,
+          id,
+          missingResourceScopes: await filterAndParseMissingResourceScopes({
+            resourceScopes: allMissingResourceScopes,
+            envSet,
+            queries,
+            libraries,
+            userId,
+            organizationId: id,
+            applicationId,
+          }),
+        }))
+      ),
+    };
+  }
+
+  if (organizations.length === 0) {
+    return { organizations: [] };
+  }
+
+  const [, consentedOrganizations] =
+    await queries.applications.userConsentOrganizations.getEntities(Organizations, {
+      applicationId,
+      userId,
+    });
+  const consentedOrganizationIds = new Set(consentedOrganizations.map(({ id }) => id));
+
+  /**
+   * The reserved organization resource always belongs to the organization-facing part; API
+   * resource scopes may be carried by an organization role as well as directly by the user, so
+   * they are deduplicated against what the user-level card already lists.
+   */
+  const requestedResourceScopes = await parseMissingResourceScopesInfo(
+    queries,
+    allMissingResourceScopes
+  );
+  const organizationResourceScopes = requestedResourceScopes
+    .map(({ resource, scopes }) => ({
+      resource,
+      scopes:
+        resource.id === ReservedResource.Organization
+          ? scopes
+          : scopes.filter(
+              (scope) =>
+                !userMissingResourceScopes.some(
+                  ({ resource: userResource, scopes: userScopes }) =>
+                    userResource.id === resource.id && userScopes.some(({ id }) => id === scope.id)
+                )
+            ),
+    }))
+    .filter(({ scopes }) => scopes.length > 0);
+
+  return {
+    organizations: organizations.map(({ name, id }) => ({
+      name,
+      id,
+      isConsented: consentedOrganizationIds.has(id),
+    })),
+    organizationResourceScopes,
+  };
+};

--- a/packages/core/src/routes/interaction/consent/organizations.ts
+++ b/packages/core/src/routes/interaction/consent/organizations.ts
@@ -7,7 +7,7 @@ import type Queries from '#src/tenants/Queries.js';
 
 import { filterAndParseMissingResourceScopes, parseMissingResourceScopesInfo } from './utils.js';
 
-type BuildConsentOrganizationsOptions = {
+type GetConsentOrganizationsOptions = {
   envSet: EnvSet;
   queries: Queries;
   libraries: Libraries;
@@ -26,13 +26,89 @@ type BuildConsentOrganizationsOptions = {
    * by the user's roles across all of their organizations.
    */
   allMissingResourceScopes: Record<string, string[]>;
-  /** The user-level scope card of the consent page, which the organization-facing part excludes. */
-  userMissingResourceScopes: MissingResourceScopes[];
 };
 
-type ConsentOrganizationsInfo = {
-  organizations: PublicOrganization[];
-  organizationResourceScopes?: MissingResourceScopes[];
+/**
+ * Build the organization roster of the consent page.
+ *
+ * A registered third-party consent records an application-wide ceiling plus a roster, so the
+ * roster carries no per-organization scope detail: the effective access of each organization is
+ * re-bounded by the user's role there at token issuance.
+ */
+export const getConsentOrganizations = async ({
+  envSet,
+  queries,
+  libraries,
+  cimd,
+  userId,
+  applicationId,
+  requestedScope,
+  missingOIDCScope,
+  allMissingResourceScopes,
+}: GetConsentOrganizationsOptions): Promise<PublicOrganization[]> => {
+  /**
+   * CIMD consent is grant-scoped per authorization (one grant carries one organization), so no
+   * cross-grant roster applies. It keeps the pre-roster behavior verbatim: the missing-scope
+   * gate and a per-organization scope breakdown.
+   */
+  if (cimd) {
+    if (!missingOIDCScope?.includes(UserScope.Organizations)) {
+      return [];
+    }
+
+    const organizations =
+      await queries.organizations.relations.users.getOrganizationsByUserId(userId);
+
+    return Promise.all(
+      organizations.map(async ({ name, id }) => ({
+        name,
+        id,
+        missingResourceScopes: await filterAndParseMissingResourceScopes({
+          resourceScopes: allMissingResourceScopes,
+          envSet,
+          queries,
+          libraries,
+          userId,
+          organizationId: id,
+          applicationId,
+        }),
+      }))
+    );
+  }
+
+  /**
+   * The roster is gated on the requested `organizations` scope, not on its missing state: after
+   * the first grant the scope is never missing again, yet a later consent round (e.g. a
+   * `prompt=consent` re-authorization) must still offer the organizations that are not consented
+   * yet. Missing scopes are computed from the requested set, so this check subsumes the legacy
+   * missing-state gate. The consent prompt trigger itself is untouched, which keeps the resume
+   * flow single-pass.
+   */
+  const requestedScopes = typeof requestedScope === 'string' ? requestedScope.split(' ') : [];
+
+  if (!requestedScopes.includes(UserScope.Organizations)) {
+    return [];
+  }
+
+  const organizations =
+    await queries.organizations.relations.users.getOrganizationsByUserId(userId);
+
+  if (organizations.length === 0) {
+    return [];
+  }
+
+  const [, consentedOrganizations] =
+    await queries.applications.userConsentOrganizations.getEntities(Organizations, {
+      applicationId,
+      userId,
+    });
+  const consentedOrganizationIds = new Set(consentedOrganizations.map(({ id }) => id));
+
+  return organizations.map(({ name, id }) => ({
+    name,
+    id,
+    isConsented: consentedOrganizationIds.has(id),
+  }));
 };
 
 /**
@@ -43,7 +119,7 @@ type ConsentOrganizationsInfo = {
  * organization roles, so they are deduplicated against what the user-level card already lists,
  * and groups left with no scopes are dropped.
  */
-const buildOrganizationResourceScopes = async (
+export const getOrganizationResourceScopes = async (
   queries: Queries,
   allMissingResourceScopes: Record<string, string[]>,
   userMissingResourceScopes: MissingResourceScopes[]
@@ -68,98 +144,4 @@ const buildOrganizationResourceScopes = async (
       };
     })
     .filter(({ scopes }) => scopes.length > 0);
-};
-
-/**
- * Build the organization roster of the consent page, along with the organization-facing part of
- * the requested scope ceiling.
- *
- * A registered third-party consent records an application-wide ceiling plus a roster, so the
- * roster carries no per-organization scope detail: the effective access of each organization is
- * re-bounded by the user's role there at token issuance.
- */
-export const buildConsentOrganizations = async ({
-  envSet,
-  queries,
-  libraries,
-  cimd,
-  userId,
-  applicationId,
-  requestedScope,
-  missingOIDCScope,
-  allMissingResourceScopes,
-  userMissingResourceScopes,
-}: BuildConsentOrganizationsOptions): Promise<ConsentOrganizationsInfo> => {
-  /**
-   * CIMD consent is grant-scoped per authorization (one grant carries one organization), so no
-   * cross-grant roster or ceiling concept applies. It keeps the pre-roster behavior verbatim:
-   * the missing-scope gate and a per-organization scope breakdown.
-   */
-  if (cimd) {
-    if (!missingOIDCScope?.includes(UserScope.Organizations)) {
-      return { organizations: [] };
-    }
-
-    const organizations =
-      await queries.organizations.relations.users.getOrganizationsByUserId(userId);
-
-    return {
-      organizations: await Promise.all(
-        organizations.map(async ({ name, id }) => ({
-          name,
-          id,
-          missingResourceScopes: await filterAndParseMissingResourceScopes({
-            resourceScopes: allMissingResourceScopes,
-            envSet,
-            queries,
-            libraries,
-            userId,
-            organizationId: id,
-            applicationId,
-          }),
-        }))
-      ),
-    };
-  }
-
-  /**
-   * The roster is gated on the requested `organizations` scope, not on its missing state: after
-   * the first grant the scope is never missing again, yet a later consent round (e.g. a
-   * `prompt=consent` re-authorization) must still offer the organizations that are not consented
-   * yet. Missing scopes are computed from the requested set, so this check subsumes the legacy
-   * missing-state gate. The consent prompt trigger itself is untouched, which keeps the resume
-   * flow single-pass.
-   */
-  const requestedScopes = typeof requestedScope === 'string' ? requestedScope.split(' ') : [];
-
-  if (!requestedScopes.includes(UserScope.Organizations)) {
-    return { organizations: [] };
-  }
-
-  const organizations =
-    await queries.organizations.relations.users.getOrganizationsByUserId(userId);
-
-  if (organizations.length === 0) {
-    return { organizations: [] };
-  }
-
-  const [, consentedOrganizations] =
-    await queries.applications.userConsentOrganizations.getEntities(Organizations, {
-      applicationId,
-      userId,
-    });
-  const consentedOrganizationIds = new Set(consentedOrganizations.map(({ id }) => id));
-
-  return {
-    organizations: organizations.map(({ name, id }) => ({
-      name,
-      id,
-      isConsented: consentedOrganizationIds.has(id),
-    })),
-    organizationResourceScopes: await buildOrganizationResourceScopes(
-      queries,
-      allMissingResourceScopes,
-      userMissingResourceScopes
-    ),
-  };
 };

--- a/packages/core/src/routes/interaction/consent/utils.ts
+++ b/packages/core/src/routes/interaction/consent/utils.ts
@@ -20,7 +20,7 @@ const { InvalidClient, InvalidRedirectUri, InvalidScope, InvalidTarget } = error
 /**
  * Parse the missing resource scopes info with details. We need to display the resource name and scope details on the consent page.
  */
-const parseMissingResourceScopesInfo = async (
+export const parseMissingResourceScopesInfo = async (
   queries: Queries,
   missingResourceScopes?: Record<string, string[]>
 ): Promise<MissingResourceScopes[]> => {

--- a/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
+++ b/packages/integration-tests/src/tests/api/interaction/consent/happy-path.test.ts
@@ -1,4 +1,5 @@
 import { ReservedResource, UserScope } from '@logto/core-kit';
+import { Prompt } from '@logto/node';
 import { type Application, ApplicationType, SignInIdentifier } from '@logto/schemas';
 import { assert } from '@silverhand/essentials';
 
@@ -191,8 +192,18 @@ describe('consent api', () => {
       const result = await client.send(getConsentInfo);
 
       expect(result.missingResourceScopes).toHaveLength(0);
-      // Only scope1, scope2 is removed
-      expect(result.organizations?.[0]?.missingResourceScopes).toHaveLength(1);
+      /**
+       * The roster of a registered third-party application carries no per-organization scope
+       * detail; the requested ceiling is shown once above it instead.
+       */
+      expect(result.organizations?.[0]?.missingResourceScopes).toBeUndefined();
+      expect(result.organizations?.[0]?.isConsented).toBe(false);
+      // Only scope1, scope2 is not in the application's consent configuration
+      expect(result.organizationResourceScopes).toHaveLength(1);
+      expect(result.organizationResourceScopes?.[0]?.resource.indicator).toBe(resource.indicator);
+      expect(result.organizationResourceScopes?.[0]?.scopes.map(({ name }) => name)).toEqual([
+        scope.name,
+      ]);
 
       await deleteResource(resource.id);
       await deleteUser(user.id);
@@ -231,8 +242,17 @@ describe('consent api', () => {
       const result = await client.send(getConsentInfo);
 
       expect(result.missingResourceScopes).toHaveLength(0);
-      // No missing resource scopes, because the scope is only assigned to resourceScopes
-      expect(result.organizations?.[0]?.missingResourceScopes).toHaveLength(0);
+      expect(result.organizations?.[0]?.missingResourceScopes).toBeUndefined();
+      /**
+       * The user reaches the scope through an organization role only, so it lands in the
+       * organization-facing part of the ceiling: the user-level card lists nothing to deduplicate
+       * it against.
+       */
+      expect(result.organizationResourceScopes).toHaveLength(1);
+      expect(result.organizationResourceScopes?.[0]?.resource.indicator).toBe(resource.indicator);
+      expect(result.organizationResourceScopes?.[0]?.scopes.map(({ name }) => name)).toEqual([
+        scope.name,
+      ]);
 
       await deleteResource(resource.id);
       await deleteUser(user.id);
@@ -406,6 +426,57 @@ describe('consent api', () => {
         deleteResource(resource.id),
         deleteUser(user.id),
       ]);
+    });
+
+    it('offer the organizations that are not consented yet on a later consent round', async () => {
+      const application = applications.get(thirdPartyApplicationName);
+      assert(application, new Error('application.not_found'));
+
+      const organizationApi = new OrganizationApiTest();
+      const organization = await organizationApi.create({ name: 'test_org_5' });
+      const organization2 = await organizationApi.create({ name: 'test_org_6' });
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      await organizationApi.addUsers(organization.id, [user.id]);
+      await organizationApi.addUsers(organization2.id, [user.id]);
+
+      await assignUserConsentScopes(application.id, {
+        userScopes: [UserScope.Organizations],
+      });
+
+      const client = await initClientAndSignIn(application, userProfile, {
+        scopes: [UserScope.Organizations, UserScope.Profile],
+      });
+
+      const { redirectTo } = await client.submitInteraction();
+
+      await client.processSession(redirectTo, false);
+      const { redirectTo: consentRedirectTo } = await client.send(consent, {
+        organizationIds: [organization.id],
+      });
+      await client.manualConsent(consentRedirectTo);
+
+      const reconsentResponse = await client.startAuthorization(
+        redirectUri,
+        { prompt: Prompt.Consent },
+        client.interactionCookie
+      );
+
+      expect(reconsentResponse.status).toBe(303);
+      expect(reconsentResponse.headers.get('location')).toBe(`/consent?app_id=${application.id}`);
+      client.mergeRawCookies(reconsentResponse.headers.getSetCookie());
+
+      const result = await client.send(getConsentInfo);
+
+      // The scope is granted by now, yet the roster still offers what is left to consent
+      expect(result.missingOIDCScope ?? []).not.toContain(UserScope.Organizations);
+      expect(result.organizations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: organization.id, isConsented: true }),
+          expect.objectContaining({ id: organization2.id, isConsented: false }),
+        ])
+      );
+
+      await Promise.all([organizationApi.cleanUp(), deleteUser(user.id)]);
     });
   });
 

--- a/packages/schemas/src/types/consent.ts
+++ b/packages/schemas/src/types/consent.ts
@@ -68,6 +68,11 @@ export const publicOrganizationGuard = Organizations.guard
   })
   .extend({
     missingResourceScopes: missingResourceScopesGuard.array().optional(),
+    /**
+     * Whether the user has already consented this organization to the application. Consented
+     * organizations render pre-selected and locked, so a later consent round can only add.
+     */
+    isConsented: z.boolean().optional(),
   });
 
 export type PublicOrganization = z.infer<typeof publicOrganizationGuard>;
@@ -76,6 +81,12 @@ export const consentInfoResponseGuard = z.object({
   application: publicApplicationGuard.merge(applicationSignInExperienceGuard.partial()),
   user: publicUserInfoGuard,
   organizations: publicOrganizationGuard.array().optional(),
+  /**
+   * The organization-facing part of the requested scope ceiling, shown once above the
+   * organization roster. Effective access per organization is still bounded by the user's role
+   * there at token issuance.
+   */
+  organizationResourceScopes: missingResourceScopesGuard.array().optional(),
   missingOIDCScope: z.string().array().optional(),
   missingResourceScopes: missingResourceScopesGuard.array().optional(),
   // Device flow consent does not require a redirect_uri.


### PR DESCRIPTION
## Summary

Teach the consent info API which organizations the user has already consented to, and replace the per-organization scope breakdown of registered third-party applications with a single requested-ceiling card.

- The organization selector is gated on the requested `organizations` scope instead of its missing state, so a later consent round (e.g. a `prompt=consent` re-authorization) still offers the organizations that are not consented yet. The consent prompt trigger is untouched, so the resume flow stays single-pass.
- `organizations[].isConsented` marks the organizations already consented to the application, for the UI to render pre-selected and locked.
- `organizationResourceScopes` carries the organization-facing part of the requested ceiling, deduplicated against the user-level scope card. Effective access per organization is still bounded by the user's role there at token issuance.
- CIMD consent is grant-scoped per authorization, so it keeps the missing-scope gate and its per-organization breakdown.

The experience-package UI is a follow-up PR.

## Testing

integration tests

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
