### PR TITLE
feat(experience): rework organization selector for incremental consent

### DIFF
--- a/packages/experience/src/apis/consent.ts
+++ b/packages/experience/src/apis/consent.ts
@@ -2,16 +2,14 @@ import { type ConsentInfoResponse } from '@logto/schemas';
 
 import api from './api';
 
-export const consent = async (organizationId?: string) => {
+export const consent = async (organizationIds?: string[]) => {
   type Response = {
     redirectTo: string;
   };
 
   return api
     .post('/api/interaction/consent', {
-      json: {
-        organizationIds: organizationId && [organizationId],
-      },
+      json: { organizationIds },
     })
     .json<Response>();
 };

--- a/packages/experience/src/components/Checkbox/index.module.scss
+++ b/packages/experience/src/components/Checkbox/index.module.scss
@@ -43,6 +43,18 @@
   input:checked:not(:disabled) ~ .icon > *:nth-child(3) {
     display: block;
   }
+
+  /* A disabled input matches none of the sprite rules above and used to render an empty box; keep the glyph visible, dimmed to the disabled text color. */
+  input:not(:checked):disabled ~ .icon > *:nth-child(1),
+  input:checked:disabled ~ .icon > *:nth-child(2),
+  input:checked:disabled ~ .icon > *:nth-child(3) {
+    display: block;
+  }
+
+  input:disabled ~ .icon > *:nth-child(1),
+  input:disabled ~ .icon > *:nth-child(2) {
+    color: var(--color-type-disable);
+  }
 }
 
 :global(body.mobile) {

--- a/packages/experience/src/pages/Consent/OrganizationRoster/index.module.scss
+++ b/packages/experience/src/pages/Consent/OrganizationRoster/index.module.scss
@@ -1,0 +1,57 @@
+@use '@/shared/scss/underscore' as _;
+
+.title {
+  font: var(--font-label-2);
+  margin-bottom: _.unit(2);
+}
+
+.scopeListWrapper {
+  border: _.border(var(--color-line-divider));
+  border-bottom: unset;
+  border-radius: 8px 8px 0 0;
+  padding: _.unit(2) 0;
+}
+
+.roster {
+  border: _.border(var(--color-line-divider));
+  border-radius: 8px;
+  overflow: hidden;
+
+  &.withoutTopRadius {
+    border-radius: 0 0 8px 8px;
+  }
+}
+
+.row {
+  @include _.flex-row;
+  padding: _.unit(2.5) _.unit(4);
+  cursor: pointer;
+
+  &:not(:last-child) {
+    border-bottom: _.border(var(--color-line-divider));
+  }
+
+  &:hover {
+    background: var(--color-overlay-neutral-hover);
+  }
+
+  &[aria-disabled='true'] {
+    cursor: default;
+
+    &:hover {
+      background: transparent;
+    }
+  }
+
+  .icon {
+    width: 20px;
+    height: 20px;
+    color: var(--color-type-secondary);
+    margin-inline-end: _.unit(2);
+  }
+
+  .name {
+    font: var(--font-body-2);
+    flex: 1;
+  }
+}

--- a/packages/experience/src/pages/Consent/OrganizationRoster/index.tsx
+++ b/packages/experience/src/pages/Consent/OrganizationRoster/index.tsx
@@ -1,0 +1,108 @@
+import { ReservedResource } from '@logto/core-kit';
+import { type MissingResourceScopes } from '@logto/schemas';
+import classNames from 'classnames';
+import { useTranslation } from 'react-i18next';
+
+import OrganizationIcon from '@/assets/icons/organization-icon.svg?react';
+import Checkbox from '@/components/Checkbox';
+import { onKeyDownHandler } from '@/shared/utils/a11y';
+
+import { type Organization } from '../OrganizationSelector';
+import ScopeGroup from '../ScopeGroup';
+
+import styles from './index.module.scss';
+
+type Props = {
+  readonly organizations: Organization[];
+  readonly selectedOrganizations: Organization[];
+  /**
+   * The organization-facing part of the requested scope ceiling. It applies to every organization
+   * alike, so it renders once above the roster instead of per organization.
+   */
+  readonly resourceScopes?: MissingResourceScopes[];
+  readonly onToggle: (organization: Organization) => void;
+  readonly className?: string;
+};
+
+/**
+ * The multi-select organization roster for registered third-party applications. Organizations the
+ * user has already consented to render pre-checked and locked: a later consent round can only add
+ * organizations, never withdraw one.
+ */
+const OrganizationRoster = ({
+  organizations,
+  selectedOrganizations,
+  resourceScopes = [],
+  onToggle,
+  className,
+}: Props) => {
+  const { t } = useTranslation();
+
+  if (organizations.length === 0) {
+    return null;
+  }
+
+  const hasScopes = resourceScopes.length > 0;
+
+  return (
+    <div className={className}>
+      <div className={styles.title}>{t('description.authorize_organizations_access')}</div>
+      {hasScopes && (
+        <div className={styles.scopeListWrapper}>
+          {resourceScopes
+            .slice()
+            // Sort the scopes to make sure the organization scope is always on top
+            .sort(({ resource: resourceA }, { resource: resourceB }) => {
+              if (resourceA.id === ReservedResource.Organization) {
+                return -1;
+              }
+              return resourceB.id === ReservedResource.Organization ? 1 : 0;
+            })
+            .map(({ resource, scopes }) => (
+              <ScopeGroup
+                key={resource.id}
+                groupName={
+                  resource.id === ReservedResource.Organization
+                    ? t('description.organization_scopes')
+                    : resource.name
+                }
+                scopes={scopes}
+                isAutoExpand={resourceScopes.length === 1}
+              />
+            ))}
+        </div>
+      )}
+      <div className={classNames(styles.roster, hasScopes && styles.withoutTopRadius)}>
+        {organizations.map((organization) => {
+          const isSelected = selectedOrganizations.some(({ id }) => id === organization.id);
+          const isLocked = Boolean(organization.isConsented);
+
+          return (
+            <div
+              key={organization.id}
+              className={styles.row}
+              role="checkbox"
+              aria-checked={isSelected}
+              aria-disabled={isLocked}
+              tabIndex={isLocked ? -1 : 0}
+              {...(!isLocked && {
+                onClick: () => {
+                  onToggle(organization);
+                },
+                onKeyDown: onKeyDownHandler(() => {
+                  onToggle(organization);
+                }),
+              })}
+            >
+              <Checkbox checked={isSelected} disabled={isLocked} tabIndex={-1} />
+              <OrganizationIcon className={styles.icon} />
+              <div className={styles.name}>{organization.name}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default OrganizationRoster;

--- a/packages/experience/src/pages/Consent/index.test.tsx
+++ b/packages/experience/src/pages/Consent/index.test.tsx
@@ -206,6 +206,145 @@ describe('Consent', () => {
     });
   });
 
+  describe('organization consent', () => {
+    const organizations = [
+      { id: 'organization_1', name: 'Organization 1' },
+      { id: 'organization_2', name: 'Organization 2' },
+    ];
+
+    it('submits the organizations selected on the roster', async () => {
+      mockedGetConsentInfo.mockResolvedValueOnce({ ...consentInfo, organizations });
+      mockedConsent.mockResolvedValueOnce({ redirectTo: '' });
+
+      const { getByText } = renderConsent();
+
+      await waitFor(() => {
+        expect(getByText('Organization 1')).not.toBeNull();
+      });
+
+      fireEvent.click(getByText('Organization 1'));
+      fireEvent.click(getByText('Organization 2'));
+      fireEvent.click(getByText('action.authorize'));
+
+      await waitFor(() => {
+        expect(mockedConsent).toBeCalledWith(['organization_1', 'organization_2']);
+      });
+    });
+
+    it('deselects a toggled organization on a second click', async () => {
+      mockedGetConsentInfo.mockResolvedValueOnce({ ...consentInfo, organizations });
+      mockedConsent.mockResolvedValueOnce({ redirectTo: '' });
+
+      const { getByText } = renderConsent();
+
+      await waitFor(() => {
+        expect(getByText('Organization 1')).not.toBeNull();
+      });
+
+      fireEvent.click(getByText('Organization 1'));
+      fireEvent.click(getByText('Organization 2'));
+      fireEvent.click(getByText('Organization 1'));
+      fireEvent.click(getByText('action.authorize'));
+
+      await waitFor(() => {
+        expect(mockedConsent).toBeCalledWith(['organization_2']);
+      });
+    });
+
+    it('locks consented organizations while additional ones can be added', async () => {
+      mockedGetConsentInfo.mockResolvedValueOnce({
+        ...consentInfo,
+        organizations: [
+          { id: 'organization_1', name: 'Organization 1', isConsented: true },
+          { id: 'organization_2', name: 'Organization 2' },
+        ],
+      });
+      mockedConsent.mockResolvedValueOnce({ redirectTo: '' });
+
+      const { getByText } = renderConsent();
+
+      await waitFor(() => {
+        expect(getByText('Organization 1')).not.toBeNull();
+      });
+
+      const lockedRow = getByText('Organization 1').closest('[role="checkbox"]');
+      expect(lockedRow?.getAttribute('aria-checked')).toBe('true');
+      expect(lockedRow?.getAttribute('aria-disabled')).toBe('true');
+
+      // A locked organization cannot be deselected
+      fireEvent.click(getByText('Organization 1'));
+      fireEvent.click(getByText('Organization 2'));
+      fireEvent.click(getByText('action.authorize'));
+
+      await waitFor(() => {
+        expect(mockedConsent).toBeCalledWith(['organization_1', 'organization_2']);
+      });
+    });
+
+    it('renders the organization resource scopes once above the roster', async () => {
+      mockedGetConsentInfo.mockResolvedValueOnce({
+        ...consentInfo,
+        organizations,
+        organizationResourceScopes: [
+          {
+            resource: { id: 'resource_1', name: 'Resource 1', indicator: 'https://resource-1.io' },
+            scopes: [{ id: 'scope_1', name: 'read:data', description: 'Read data' }],
+          },
+        ],
+      });
+
+      const { getAllByText, getByText } = renderConsent();
+
+      await waitFor(() => {
+        expect(getByText('Organization 1')).not.toBeNull();
+      });
+
+      expect(getAllByText('Resource 1')).toHaveLength(1);
+      expect(getByText('Read data')).not.toBeNull();
+    });
+
+    it('keeps the single-organization selection with per-organization scopes for a CIMD client', async () => {
+      mockedGetConsentInfo.mockResolvedValueOnce({
+        ...cimdConsentInfo('Fancy client'),
+        organizations: [
+          {
+            id: 'organization_1',
+            name: 'Organization 1',
+            missingResourceScopes: [
+              {
+                resource: {
+                  id: 'resource_1',
+                  name: 'Resource 1',
+                  indicator: 'https://resource-1.io',
+                },
+                scopes: [{ id: 'scope_1', name: 'read:data', description: 'Read data' }],
+              },
+            ],
+          },
+          { id: 'organization_2', name: 'Organization 2' },
+        ],
+      });
+      mockedConsent.mockResolvedValueOnce({ redirectTo: '' });
+
+      const { getByText, queryByText } = renderConsent();
+
+      await waitFor(() => {
+        expect(getByText('Organization 1')).not.toBeNull();
+      });
+
+      // The per-organization scope breakdown of the selected organization stays
+      expect(getByText('Resource 1')).not.toBeNull();
+      // Other organizations stay behind the dropdown
+      expect(queryByText('Organization 2')).toBeNull();
+
+      fireEvent.click(getByText('action.authorize'));
+
+      await waitFor(() => {
+        expect(mockedConsent).toBeCalledWith(['organization_1']);
+      });
+    });
+  });
+
   it('signs out from the access denied page', async () => {
     mockedGetConsentInfo.mockRejectedValueOnce(accessDeniedError());
 

--- a/packages/experience/src/pages/Consent/index.tsx
+++ b/packages/experience/src/pages/Consent/index.tsx
@@ -14,6 +14,7 @@ import ErrorPage from '@/pages/ErrorPage';
 import Button from '@/shared/components/Button';
 import { searchKeys } from '@/shared/utils/search-parameters';
 
+import OrganizationRoster from './OrganizationRoster';
 import OrganizationSelector, { type Organization } from './OrganizationSelector';
 import ScopesListCard from './ScopesListCard';
 import UnregisteredClientNotice from './UnregisteredClientNotice';
@@ -45,7 +46,7 @@ const Consent = () => {
   const redirectTo = useGlobalRedirectTo();
 
   const [consentData, setConsentData] = useState<ConsentInfoResponse>();
-  const [selectedOrganization, setSelectedOrganization] = useState<Organization>();
+  const [selectedOrganizations, setSelectedOrganizations] = useState<Organization[]>([]);
   const [isAccessDenied, setIsAccessDenied] = useState(false);
 
   const [isConsentLoading, setIsConsentLoading] = useState(false);
@@ -83,7 +84,7 @@ const Consent = () => {
 
   const consentHandler = useCallback(async () => {
     setIsConsentLoading(true);
-    const [error, result] = await asyncConsent(selectedOrganization?.id);
+    const [error, result] = await asyncConsent(selectedOrganizations.map(({ id }) => id));
     setIsConsentLoading(false);
 
     if (error) {
@@ -95,7 +96,7 @@ const Consent = () => {
     if (result?.redirectTo) {
       await redirectTo(result.redirectTo);
     }
-  }, [asyncConsent, handleConsentError, redirectTo, selectedOrganization?.id]);
+  }, [asyncConsent, handleConsentError, redirectTo, selectedOrganizations]);
 
   useEffect(() => {
     const getConsentInfoHandler = async () => {
@@ -114,7 +115,25 @@ const Consent = () => {
         return;
       }
 
-      setSelectedOrganization(result.organizations[0]);
+      /**
+       * A CIMD authorization consents exactly one organization, so the first stays preselected.
+       * A registered application starts from its consented organizations, which are locked into
+       * the selection; beyond that, a sole organization offers no real choice and stays
+       * preselected, while a roster of several starts empty for the user to pick from.
+       */
+      if (isCimdClientId(result.application.id)) {
+        setSelectedOrganizations(result.organizations.slice(0, 1));
+
+        return;
+      }
+
+      const consentedOrganizations = result.organizations.filter(({ isConsented }) => isConsented);
+
+      setSelectedOrganizations(
+        consentedOrganizations.length > 0 || result.organizations.length > 1
+          ? consentedOrganizations
+          : result.organizations.slice(0, 1)
+      );
     };
 
     void getConsentInfoHandler();
@@ -143,6 +162,24 @@ const Consent = () => {
   } = consentData;
 
   const { unregisteredClientHost, applicationName } = getClientDisplayData(consentData);
+
+  const toggleOrganization = (organization: Organization) => {
+    /**
+     * Consented organizations are locked: a later consent round can only add organizations.
+     * They stay in the submitted selection, which is safe since the consent insert is
+     * idempotent.
+     */
+    if (organization.isConsented) {
+      return;
+    }
+
+    setSelectedOrganizations((selectedOrganizations) =>
+      selectedOrganizations.some(({ id }) => id === organization.id)
+        ? selectedOrganizations.filter(({ id }) => id !== organization.id)
+        : [...selectedOrganizations, organization]
+    );
+  };
+
   const showTerms = Boolean(termsOfUseUrl ?? privacyPolicyUrl);
   const { redirectUri } = consentData;
   const redirectUriOrigin = consentData.redirectUri
@@ -175,14 +212,26 @@ const Consent = () => {
         appName={applicationName}
         className={styles.scopesCard}
       />
-      {consentData.organizations && (
-        <OrganizationSelector
-          className={styles.organizationSelector}
-          organizations={consentData.organizations}
-          selectedOrganization={selectedOrganization}
-          onSelect={setSelectedOrganization}
-        />
-      )}
+      {/* An unregistered (CIMD) client consents a single organization per authorization and keeps its per-organization scope breakdown; a registered client consents an amendable multi-select roster. */}
+      {consentData.organizations &&
+        (unregisteredClientHost ? (
+          <OrganizationSelector
+            className={styles.organizationSelector}
+            organizations={consentData.organizations}
+            selectedOrganization={selectedOrganizations[0]}
+            onSelect={(organization) => {
+              setSelectedOrganizations([organization]);
+            }}
+          />
+        ) : (
+          <OrganizationRoster
+            className={styles.organizationSelector}
+            organizations={consentData.organizations}
+            selectedOrganizations={selectedOrganizations}
+            resourceScopes={consentData.organizationResourceScopes}
+            onToggle={toggleOrganization}
+          />
+        ))}
       <div className={styles.footerButton}>
         {redirectUri && (
           <Button

--- a/packages/phrases-experience/src/locales/ar/description.ts
+++ b/packages/phrases-experience/src/locales/ar/description.ts
@@ -107,6 +107,7 @@ const description = {
   grant_organization_access: 'منح الوصول إلى المؤسسة:',
   authorize_personal_data_usage: 'السماح باستخدام البيانات الشخصية الخاصة بك:',
   authorize_organization_access: 'السماح بالوصول إلى المؤسسة المحددة:',
+  authorize_organizations_access: 'السماح بالوصول إلى مؤسساتك:',
   user_scopes: 'بيانات المستخدم الشخصية',
   organization_scopes: 'الوصول إلى المؤسسة',
   authorize_agreement: `بالسماح بالوصول، فإنك توافق على <link></link> لـ {{name}}.`,

--- a/packages/phrases-experience/src/locales/cs/description.ts
+++ b/packages/phrases-experience/src/locales/cs/description.ts
@@ -110,6 +110,7 @@ const description = {
   grant_organization_access: 'Udělit organizaci přístup:',
   authorize_personal_data_usage: 'Povolit použití tvých osobních údajů:',
   authorize_organization_access: 'Povolit přístup konkrétní organizaci:',
+  authorize_organizations_access: 'Povolit přístup k vašim organizacím:',
   user_scopes: 'Osobní údaje uživatele',
   organization_scopes: 'Přístup organizace',
   authorize_agreement: `Povolením přístupu souhlasíš s {{name}} <link></link>.`,

--- a/packages/phrases-experience/src/locales/de/description.ts
+++ b/packages/phrases-experience/src/locales/de/description.ts
@@ -113,6 +113,7 @@ const description = {
   grant_organization_access: 'Gewähren Sie der Organisation Zugriff:',
   authorize_personal_data_usage: 'Erlauben Sie die Nutzung Ihrer persönlichen Daten:',
   authorize_organization_access: 'Erlauben Sie Zugriff auf die spezifische Organisation:',
+  authorize_organizations_access: 'Erlauben Sie Zugriff auf Ihre Organisationen:',
   user_scopes: 'Persönliche Benutzerdaten',
   organization_scopes: 'Zugriff auf die Organisation',
   authorize_agreement: `Indem Sie den Zugriff autorisieren, stimmen Sie den <link></link> von {{name}} zu.`,

--- a/packages/phrases-experience/src/locales/en/description.ts
+++ b/packages/phrases-experience/src/locales/en/description.ts
@@ -110,6 +110,7 @@ const description = {
   grant_organization_access: 'Grant the organization access:',
   authorize_personal_data_usage: 'Authorize the use of your personal data:',
   authorize_organization_access: 'Authorize access to the specific organization:',
+  authorize_organizations_access: 'Authorize access to your organizations:',
   user_scopes: 'Personal user data',
   organization_scopes: 'Organization access',
   authorize_agreement: `By authorizing the access, you agree to the {{name}}'s <link></link>.`,

--- a/packages/phrases-experience/src/locales/es/description.ts
+++ b/packages/phrases-experience/src/locales/es/description.ts
@@ -114,6 +114,7 @@ const description = {
   grant_organization_access: 'Otorgar acceso a la organización:',
   authorize_personal_data_usage: 'Autorizar el uso de tus datos personales:',
   authorize_organization_access: 'Autorizar acceso a la organización específica:',
+  authorize_organizations_access: 'Autorizar acceso a tus organizaciones:',
   user_scopes: 'Datos personales del usuario',
   organization_scopes: 'Acceso a la organización',
   authorize_agreement: `Al autorizar el acceso, aceptas los <link></link> de {{name}}.`,

--- a/packages/phrases-experience/src/locales/fa-ir/description.ts
+++ b/packages/phrases-experience/src/locales/fa-ir/description.ts
@@ -109,6 +109,7 @@ const description = {
   grant_organization_access: 'اعطای دسترسی به سازمان:',
   authorize_personal_data_usage: 'مجوز استفاده از اطلاعات شخصی شما:',
   authorize_organization_access: 'مجوز دسترسی به سازمان خاص:',
+  authorize_organizations_access: 'مجوز دسترسی به سازمان‌های شما:',
   user_scopes: 'اطلاعات شخصی کاربر',
   organization_scopes: 'دسترسی سازمان',
   authorize_agreement: `با مجوز دادن به دسترسی، با <link></link> {{name}} موافقت می‌کنید.`,

--- a/packages/phrases-experience/src/locales/fr/description.ts
+++ b/packages/phrases-experience/src/locales/fr/description.ts
@@ -113,6 +113,7 @@ const description = {
   grant_organization_access: "Accorder l'accès à l'organisation :",
   authorize_personal_data_usage: "Autoriser l'utilisation de vos données personnelles :",
   authorize_organization_access: "Autoriser l'accès à l'organisation spécifique :",
+  authorize_organizations_access: "Autoriser l'accès à vos organisations :",
   user_scopes: 'Données utilisateur personnelles',
   organization_scopes: "Accès à l'organisation",
   authorize_agreement: `En autorisant l'accès, vous acceptez les termes de {{name}} <link></link>.`,

--- a/packages/phrases-experience/src/locales/it/description.ts
+++ b/packages/phrases-experience/src/locales/it/description.ts
@@ -110,6 +110,7 @@ const description = {
   grant_organization_access: "Concedi accesso all'organizzazione:",
   authorize_personal_data_usage: "Autorizza l'utilizzo dei tuoi dati personali:",
   authorize_organization_access: "Autorizza l'accesso all'organizzazione specifica:",
+  authorize_organizations_access: "Autorizza l'accesso alle tue organizzazioni:",
   user_scopes: 'Dati utente personali',
   organization_scopes: "Accesso all'organizzazione",
   authorize_agreement: "Autorizzando l'accesso, accetti i <link></link> di {{name}}.",

--- a/packages/phrases-experience/src/locales/ja/description.ts
+++ b/packages/phrases-experience/src/locales/ja/description.ts
@@ -107,6 +107,7 @@ const description = {
   grant_organization_access: '組織へのアクセスを許可する：',
   authorize_personal_data_usage: '個人データの使用を承認する：',
   authorize_organization_access: '特定の組織へのアクセスを承認する：',
+  authorize_organizations_access: '組織へのアクセスを承認する：',
   user_scopes: '個人ユーザーデータ',
   organization_scopes: '組織へのアクセス',
   authorize_agreement: `アクセスを承認することで、{{name}} の<link></link>に同意したことになります。`,

--- a/packages/phrases-experience/src/locales/ko/description.ts
+++ b/packages/phrases-experience/src/locales/ko/description.ts
@@ -101,6 +101,7 @@ const description = {
   grant_organization_access: '조직 접근 권한 부여:',
   authorize_personal_data_usage: '개인 데이터 사용 권한 부여:',
   authorize_organization_access: '특정 조직에 대한 접근 권한 부여:',
+  authorize_organizations_access: '조직에 대한 접근 권한 부여:',
   user_scopes: '개인 사용자 데이터',
   organization_scopes: '조직 액세스',
   authorize_agreement: `접근을 허용함으로써, {{name}} 의 <link></link>에 동의하게 됩니다.`,

--- a/packages/phrases-experience/src/locales/pl-pl/description.ts
+++ b/packages/phrases-experience/src/locales/pl-pl/description.ts
@@ -112,6 +112,7 @@ const description = {
   grant_organization_access: 'Przyznaj dostęp do organizacji:',
   authorize_personal_data_usage: 'Autoryzuj użycie twoich danych osobowych:',
   authorize_organization_access: 'Autoryzuj dostęp do określonej organizacji:',
+  authorize_organizations_access: 'Autoryzuj dostęp do swoich organizacji:',
   user_scopes: 'Dane osobowe użytkownika',
   organization_scopes: 'Dostęp do organizacji',
   authorize_agreement: `Autoryzując dostęp, zgadzasz się na <link></link> {{name}}.`,

--- a/packages/phrases-experience/src/locales/pt-br/description.ts
+++ b/packages/phrases-experience/src/locales/pt-br/description.ts
@@ -109,6 +109,7 @@ const description = {
   grant_organization_access: 'Conceder acesso à organização:',
   authorize_personal_data_usage: 'Autorizar o uso dos seus dados pessoais:',
   authorize_organization_access: 'Autorizar acesso à organização específica:',
+  authorize_organizations_access: 'Autorizar acesso às suas organizações:',
   user_scopes: 'Dados pessoais do usuário',
   organization_scopes: 'Acesso à organização',
   authorize_agreement: `Ao autorizar o acesso, você concorda com os <link></link> de {{name}}.`,

--- a/packages/phrases-experience/src/locales/pt-pt/description.ts
+++ b/packages/phrases-experience/src/locales/pt-pt/description.ts
@@ -110,6 +110,7 @@ const description = {
   grant_organization_access: 'Conceder acesso à organização:',
   authorize_personal_data_usage: 'Autorizar o uso dos seus dados pessoais:',
   authorize_organization_access: 'Autorizar o acesso à organização específica:',
+  authorize_organizations_access: 'Autorizar o acesso às suas organizações:',
   user_scopes: 'Dados pessoais do usuário',
   organization_scopes: 'Acesso à organização',
   authorize_agreement: `Ao autorizar o acesso, você concorda com o {{name}}'s <link></link>.`,

--- a/packages/phrases-experience/src/locales/ru/description.ts
+++ b/packages/phrases-experience/src/locales/ru/description.ts
@@ -113,6 +113,7 @@ const description = {
   grant_organization_access: 'Предоставить доступ организации:',
   authorize_personal_data_usage: 'Авторизовать использование ваших личных данных:',
   authorize_organization_access: 'Авторизовать доступ к конкретной организации:',
+  authorize_organizations_access: 'Авторизовать доступ к вашим организациям:',
   user_scopes: 'Личные данные пользователя',
   organization_scopes: 'Доступ к организации',
   authorize_agreement: `Авторизуя доступ, вы соглашаетесь с <link></link> {{name}}.`,

--- a/packages/phrases-experience/src/locales/th/description.ts
+++ b/packages/phrases-experience/src/locales/th/description.ts
@@ -109,6 +109,7 @@ const description = {
   grant_organization_access: 'ให้สิทธิ์เข้าถึงองค์กร:',
   authorize_personal_data_usage: 'อนุญาตให้ใช้ข้อมูลส่วนตัวของคุณ:',
   authorize_organization_access: 'อนุญาตให้เข้าถึงองค์กรที่ระบุ:',
+  authorize_organizations_access: 'อนุญาตให้เข้าถึงองค์กรของคุณ:',
   user_scopes: 'ข้อมูลผู้ใช้ส่วนตัว',
   organization_scopes: 'การเข้าถึงองค์กร',
   authorize_agreement: `เมื่ออนุมัติการเข้าถึง ถือว่าคุณยอมรับ <link></link> ของ {{name}}`,

--- a/packages/phrases-experience/src/locales/tr-tr/description.ts
+++ b/packages/phrases-experience/src/locales/tr-tr/description.ts
@@ -107,6 +107,7 @@ const description = {
   grant_organization_access: 'Organizasyon erişimi ver:',
   authorize_personal_data_usage: 'Kişisel verilerinizin kullanımını yetkilendirin:',
   authorize_organization_access: 'Belirli organizasyonlara erişim yetkisi verin:',
+  authorize_organizations_access: 'Organizasyonlarınıza erişim yetkisi verin:',
   user_scopes: 'Kişisel kullanıcı verileri',
   organization_scopes: 'Organizasyon erişimi',
   authorize_agreement: `Erişim yetkisi vererek, {{name}}'nin <link></link> şartlarını kabul etmiş olursunuz.`,

--- a/packages/phrases-experience/src/locales/uk-ua/description.ts
+++ b/packages/phrases-experience/src/locales/uk-ua/description.ts
@@ -112,6 +112,7 @@ const description = {
   grant_organization_access: 'Надати доступ організації:',
   authorize_personal_data_usage: 'Дозволити використання ваших персональних даних:',
   authorize_organization_access: 'Дозволити доступ до конкретної організації:',
+  authorize_organizations_access: 'Дозволити доступ до ваших організацій:',
   user_scopes: 'Персональні дані користувача',
   organization_scopes: 'Доступ до організації',
   authorize_agreement: 'Авторизуючи доступ, ви погоджуєтесь з <link></link> {{name}}.',

--- a/packages/phrases-experience/src/locales/zh-cn/description.ts
+++ b/packages/phrases-experience/src/locales/zh-cn/description.ts
@@ -96,6 +96,7 @@ const description = {
   grant_organization_access: '授予组织访问权限：',
   authorize_personal_data_usage: '你将授权该应用使用你的以下个人数据：',
   authorize_organization_access: '授权访问特定组织：',
+  authorize_organizations_access: '授权访问你的组织：',
   user_scopes: '用户个人信息',
   organization_scopes: '组织权限',
   authorize_agreement: `你将同意授权给 {{name}} <link></link>.`,

--- a/packages/phrases-experience/src/locales/zh-hk/description.ts
+++ b/packages/phrases-experience/src/locales/zh-hk/description.ts
@@ -96,6 +96,7 @@ const description = {
   grant_organization_access: '授予組織訪問權限：',
   authorize_personal_data_usage: '授權使用你的個人數據：',
   authorize_organization_access: '授權訪問指定的組織：',
+  authorize_organizations_access: '授權訪問你的組織：',
   user_scopes: '個人用戶數據',
   organization_scopes: '組織訪問',
   authorize_agreement: `通過授權訪問，您同意 {{name}} 的 <link></link>。`,

--- a/packages/phrases-experience/src/locales/zh-tw/description.ts
+++ b/packages/phrases-experience/src/locales/zh-tw/description.ts
@@ -96,6 +96,7 @@ const description = {
   grant_organization_access: '授予組織訪問權限：',
   authorize_personal_data_usage: '授權使用你的個人數據：',
   authorize_organization_access: '授權訪問指定組織：',
+  authorize_organizations_access: '授權訪問你的組織：',
   user_scopes: '個人用戶數據',
   organization_scopes: '組織訪問',
   authorize_agreement: `通過授權訪問，你同意{{name}}的<link></link>。`,


### PR DESCRIPTION
## Summary

Rework the consent-page organization selector for incremental organization consent (UI half of the contract shipped in #9523).

- For registered third-party clients, the dropdown selector becomes a multi-select checkbox roster; already-consented organizations render pre-checked and locked, so a later consent round can only add organizations.
- The organization-facing part of the requested scope ceiling (`organizationResourceScopes`) renders once above the roster, replacing the per-organization scope breakdown.
- CIMD (unregistered client) consent keeps its existing single-organization selection with the per-organization scope breakdown.
- The shared `Checkbox` now renders a dimmed glyph when disabled instead of an empty box.
- New `authorize_organizations_access` phrase in all locales for the roster title.

## Testing

Unit tests.

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
