### PR TITLE
fix(core): key identifier lockout on the normalized identifier

### DIFF
--- a/.changeset/great-donuts-notice.md
+++ b/.changeset/great-donuts-notice.md
@@ -1,0 +1,13 @@
+---
+"@logto/core": patch
+---
+
+key identifier lockout on the normalized identifier
+
+The identifier lockout counter is now keyed on the same form of the identifier that the user lookup matches on, so a single account maps to a single lockout bucket however the identifier was spelled in the request. Previously the counter keyed on the value exactly as submitted while the lookup normalized before matching, which let the two disagree and weakened the configured `maxAttempts` policy.
+
+Emails are lower-cased and phone numbers canonicalized, matching their lookups. Usernames fold case only when the tenant's username policy is case-insensitive: under the default case-sensitive policy `Alice` and `alice` are different accounts and keep separate buckets, so attempts against one cannot lock out the other.
+
+Manual unlock (`POST /sentinel-activities/delete`) also clears the other spellings of the submitted identifier, so unblocking works when an admin types an address in a different case. Case is only folded where both spellings must be the same account — always for an email address, and otherwise only when the tenant's username policy is case-insensitive — so an unlock can never reach a different account. Identifiers that are keyed verbatim still have to be submitted as they were typed.
+
+Note for operators upgrading: lockouts are re-keyed by this change, so an active lockout recorded under a non-canonical spelling stops applying once deployed. Affected users are unblocked early, at most one `lockoutDuration` ahead of schedule; no user becomes more locked out than before, and failure counters older than an hour are already outside the counting window.

--- a/packages/core/src/routes/experience/classes/libraries/sentinel-guard.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sentinel-guard.test.ts
@@ -1,0 +1,373 @@
+import {
+  AdditionalIdentifier,
+  Sentinel,
+  SentinelActionResult,
+  SentinelActivityAction,
+  SentinelDecision,
+  SignInIdentifier,
+  type ActivityReport,
+  type VerificationIdentifier,
+} from '@logto/schemas';
+import { sha256 } from 'hash-wasm';
+
+import { type WithI18nContext } from '#src/middleware/koa-i18next.js';
+import { type WithHookContext } from '#src/middleware/koa-management-api-hooks.js';
+import type Queries from '#src/tenants/Queries.js';
+
+import {
+  canFoldLockoutTargetCase,
+  getLockoutTargetCandidates,
+  withSentinel,
+} from './sentinel-guard.js';
+
+const { jest } = import.meta;
+
+class CapturingSentinel extends Sentinel {
+  activities: readonly ActivityReport[] = [];
+
+  constructor(private readonly decision: SentinelDecision = SentinelDecision.Allowed) {
+    super();
+  }
+
+  get lastActivity() {
+    return this.activities.at(-1);
+  }
+
+  override async reportActivity(activity: ActivityReport) {
+    this.activities = [...this.activities, activity];
+
+    return [this.decision, Date.now() + 60_000] as const;
+  }
+}
+
+const buildContext = () =>
+  ({
+    appendExceptionHookContext: jest.fn(),
+    i18n: { languages: ['en'] },
+  }) as unknown as WithI18nContext & WithHookContext;
+
+const buildQueries = (isUsernameCaseSensitive: boolean, getUsernameCaseSensitive?: () => never) =>
+  ({
+    signInExperiences: {
+      getUsernameCaseSensitive: getUsernameCaseSensitive ?? (async () => isUsernameCaseSensitive),
+    },
+  }) as unknown as Queries;
+
+/** Runs the guard on a successful verification and returns the lockout bucket key it reported. */
+const getBucketKey = async (
+  identifier: VerificationIdentifier,
+  isUsernameCaseSensitive = true
+): Promise<string> => {
+  const sentinel = new CapturingSentinel();
+
+  await withSentinel(
+    {
+      ctx: buildContext(),
+      sentinel,
+      queries: buildQueries(isUsernameCaseSensitive),
+      action: SentinelActivityAction.Password,
+      identifier,
+      payload: {},
+    },
+    Promise.resolve('verified')
+  );
+
+  // `reportActivity` always runs, so the hash is always captured.
+  return sentinel.lastActivity!.targetHash;
+};
+
+const emailKey = async (value: string) => getBucketKey({ type: SignInIdentifier.Email, value });
+const phoneKey = async (value: string) => getBucketKey({ type: SignInIdentifier.Phone, value });
+const usernameKey = async (value: string, isCaseSensitive: boolean) =>
+  getBucketKey({ type: SignInIdentifier.Username, value }, isCaseSensitive);
+
+describe('withSentinel lockout bucket keying', () => {
+  describe('email', () => {
+    it('shares one bucket across casing variants', async () => {
+      const [mixed, lower, upper] = await Promise.all([
+        emailKey('Victim@Example.com'),
+        emailKey('victim@example.com'),
+        emailKey('VICTIM@EXAMPLE.COM'),
+      ]);
+
+      expect(mixed).toBe(lower);
+      expect(upper).toBe(lower);
+    });
+
+    it('keys on the lower-cased address, matching `findUserByEmail`', async () => {
+      await expect(emailKey('Victim@Example.com')).resolves.toBe(
+        await sha256('victim@example.com')
+      );
+    });
+
+    it('keeps separate buckets for near-miss addresses the lookup treats as distinct', async () => {
+      // Neither sub-address tags nor surrounding whitespace are folded by `findUserByEmail`, so
+      // folding either here would merge accounts it keeps apart.
+      await expect(emailKey('victim+tag@example.com')).resolves.not.toBe(
+        await emailKey('victim@example.com')
+      );
+      await expect(emailKey(' victim@example.com')).resolves.not.toBe(
+        await emailKey('victim@example.com')
+      );
+    });
+  });
+
+  describe('phone', () => {
+    it('shares one bucket across equivalent formats', async () => {
+      // All three resolve to the same user through `findUserByNormalizedPhone`.
+      const [spaced, parenthesized, leadingZero] = await Promise.all([
+        phoneKey('61 412 345 678'),
+        phoneKey('+61 (0) 412 345 678'),
+        phoneKey('610412345678'),
+      ]);
+
+      expect(parenthesized).toBe(spaced);
+      expect(leadingZero).toBe(spaced);
+    });
+
+    it('keys on the canonical international number', async () => {
+      await expect(phoneKey('+61 (0) 412 345 678')).resolves.toBe(await sha256('61412345678'));
+    });
+
+    it('falls back to an exact key when the number cannot be parsed', async () => {
+      // Mirrors `findUserByNormalizedPhone` deferring to `findUserByPhone` on an invalid number.
+      await expect(phoneKey('0123')).resolves.toBe(await sha256('0123'));
+      await expect(phoneKey('0123')).resolves.not.toBe(await phoneKey('0124'));
+    });
+  });
+
+  describe('username', () => {
+    it('keeps separate buckets for case variants under the default case-sensitive policy', async () => {
+      // `Alice` and `alice` are different accounts here; merging their buckets would let attempts
+      // against one lock out the other.
+      await expect(usernameKey('Alice', true)).resolves.not.toBe(await usernameKey('alice', true));
+    });
+
+    it('shares one bucket for case variants when the policy is case-insensitive', async () => {
+      await expect(usernameKey('Alice', false)).resolves.toBe(await usernameKey('alice', false));
+    });
+
+    it('keys on the raw username under the case-sensitive policy', async () => {
+      await expect(usernameKey('Alice', true)).resolves.toBe(await sha256('Alice'));
+    });
+  });
+
+  describe('user id', () => {
+    it('keys exactly, without folding case', async () => {
+      const identifier = { type: AdditionalIdentifier.UserId, value: 'Abc123' } as const;
+
+      await expect(getBucketKey(identifier)).resolves.toBe(await sha256('Abc123'));
+      await expect(getBucketKey(identifier)).resolves.not.toBe(
+        await getBucketKey({ type: AdditionalIdentifier.UserId, value: 'abc123' })
+      );
+    });
+  });
+});
+
+describe('withSentinel reporting and blocking', () => {
+  const identifier = { type: SignInIdentifier.Email, value: 'victim@example.com' } as const;
+
+  const run = async (
+    sentinel: CapturingSentinel,
+    verification: Promise<string>,
+    ctx = buildContext()
+  ) =>
+    withSentinel(
+      {
+        ctx,
+        sentinel,
+        queries: buildQueries(true),
+        action: SentinelActivityAction.Password,
+        identifier,
+        payload: {},
+      },
+      verification
+    );
+
+  it('reports a failed result when the verification rejects', async () => {
+    const sentinel = new CapturingSentinel();
+
+    await expect(run(sentinel, Promise.reject(new Error('wrong password')))).rejects.toThrow(
+      'wrong password'
+    );
+    expect(sentinel.lastActivity?.actionResult).toBe(SentinelActionResult.Failed);
+  });
+
+  it('reports a successful result when the verification resolves', async () => {
+    const sentinel = new CapturingSentinel();
+
+    await expect(run(sentinel, Promise.resolve('verified'))).resolves.toBe('verified');
+    expect(sentinel.lastActivity?.actionResult).toBe(SentinelActionResult.Success);
+  });
+
+  it('throws the lockout error and reports the identifier as typed when blocked', async () => {
+    const sentinel = new CapturingSentinel(SentinelDecision.Blocked);
+    const ctx = buildContext();
+    const mixedCase = { type: SignInIdentifier.Email, value: 'Victim@Example.com' } as const;
+
+    await expect(
+      withSentinel(
+        {
+          ctx,
+          sentinel,
+          queries: buildQueries(true),
+          action: SentinelActivityAction.Password,
+          identifier: mixedCase,
+          payload: {},
+        },
+        Promise.resolve('verified')
+      )
+    ).rejects.toMatchObject({ code: 'session.verification_blocked_too_many_attempts' });
+
+    // Keyed on the normalized value, but surfaced to admins as the caller spelled it.
+    expect(ctx.appendExceptionHookContext).toHaveBeenCalledWith('Identifier.Lockout', mixedCase);
+    expect(sentinel.lastActivity?.targetHash).toBe(await sha256('victim@example.com'));
+  });
+
+  it('still reports the attempt when the lockout target cannot be resolved', async () => {
+    // A database fault on the sign-in-experience read must not cost us the record — an unreported
+    // attempt is an uncounted one.
+    const sentinel = new CapturingSentinel();
+    const rejectingQueries = buildQueries(true, () => {
+      throw new Error('database unavailable');
+    });
+
+    await expect(
+      withSentinel(
+        {
+          ctx: buildContext(),
+          sentinel,
+          queries: rejectingQueries,
+          action: SentinelActivityAction.Password,
+          identifier: { type: SignInIdentifier.Username, value: 'Alice' },
+          payload: {},
+        },
+        Promise.reject(new Error('wrong password'))
+      )
+    ).rejects.toThrow('wrong password');
+
+    expect(sentinel.activities).toHaveLength(1);
+    expect(sentinel.lastActivity?.actionResult).toBe(SentinelActionResult.Failed);
+    expect(sentinel.lastActivity?.targetHash).toBe(await sha256('Alice'));
+  });
+});
+
+describe('getLockoutTargetCandidates', () => {
+  /**
+   * Manual unlock has to cover the key the guard records for the same value, or it silently stops
+   * clearing that bucket. This catches a normalization added to one side and not the other; it does
+   * not cover an admin submitting a different spelling than the one that tripped the lockout.
+   */
+  it.each([
+    ['a mixed-case email', { type: SignInIdentifier.Email, value: 'Victim@Example.com' }, true],
+    ['a formatted phone', { type: SignInIdentifier.Phone, value: '+61 (0) 412 345 678' }, true],
+    ['an unparseable phone', { type: SignInIdentifier.Phone, value: '0123' }, true],
+    ['a case-sensitive username', { type: SignInIdentifier.Username, value: 'Alice' }, true],
+    ['a case-insensitive username', { type: SignInIdentifier.Username, value: 'Alice' }, false],
+    ['a user id', { type: AdditionalIdentifier.UserId, value: 'Abc123' }, true],
+  ] as const)('covers the bucket key recorded for %s', async (_, identifier, isCaseSensitive) => {
+    const bucketKey = await getBucketKey(identifier, isCaseSensitive);
+    const foldCase = await canFoldLockoutTargetCase(
+      buildQueries(isCaseSensitive),
+      identifier.value
+    );
+    const candidateKeys = await Promise.all(
+      getLockoutTargetCandidates(identifier.value, foldCase).map(async (candidate) =>
+        sha256(candidate)
+      )
+    );
+
+    expect(candidateKeys).toContain(bucketKey);
+  });
+
+  it('does not repeat a candidate when the spellings coincide', () => {
+    expect(getLockoutTargetCandidates('alice', true)).toStrictEqual(['alice']);
+  });
+
+  it('drops the lower-cased candidate when folding could reach another account', () => {
+    // `Alice` and `alice` are separate accounts under a case-sensitive policy, so unblocking one
+    // must not clear the other.
+    expect(getLockoutTargetCandidates('Alice', false)).toStrictEqual(['Alice']);
+    expect(getLockoutTargetCandidates('Alice', true)).toStrictEqual(['Alice', 'alice']);
+  });
+
+  it('still folds a formatted phone when case folding is withheld', () => {
+    expect(getLockoutTargetCandidates('+61 (0) 412 345 678', false)).toStrictEqual([
+      '+61 (0) 412 345 678',
+      '61412345678',
+    ]);
+  });
+
+  /**
+   * The per-type table above only pins the normalizations that exist today. This drives the same
+   * invariant from values a *future* normalization would plausibly touch, across every type and
+   * both username policies, so adding one to `resolveLockoutTarget` without adding it here fails.
+   */
+  const adversarialValues = [
+    'Victim@Example.com',
+    '  Victim@Example.com  ',
+    'victim+tag@Example.com',
+    'VICTIM@EXAMPLE.COM',
+    'Alice',
+    'ALICE',
+    '+61 (0) 412 345 678',
+    '610412345678',
+    '61 412 345 678',
+    '2250707123456',
+    '225707123456',
+    '0123',
+    'İstanbul',
+    'Abc123',
+  ];
+  const identifierTypes = [
+    SignInIdentifier.Email,
+    SignInIdentifier.Phone,
+    SignInIdentifier.Username,
+    AdditionalIdentifier.UserId,
+  ] as const;
+
+  it.each(adversarialValues)('covers every type-and-policy bucket key for %p', async (value) => {
+    const bucketKeys = await Promise.all(
+      identifierTypes.flatMap((type) =>
+        [true, false].map(async (isCaseSensitive) => getBucketKey({ type, value }, isCaseSensitive))
+      )
+    );
+    // Asserted against the permissive form: it is the superset every restricted form is drawn from,
+    // so a normalization added to `resolveLockoutTarget` and not here still fails.
+    const candidateKeys = await Promise.all(
+      getLockoutTargetCandidates(value, true).map(async (candidate) => sha256(candidate))
+    );
+
+    expect(candidateKeys).toEqual(expect.arrayContaining(bucketKeys));
+  });
+
+  it.each(adversarialValues)(
+    'always keeps the value as typed among the candidates for %p',
+    (value) => {
+      // Dropping it would break manual unlock for every verbatim-keyed identifier at once.
+      expect(getLockoutTargetCandidates(value, true)).toContain(value);
+      expect(getLockoutTargetCandidates(value, false)).toContain(value);
+    }
+  );
+});
+
+describe('canFoldLockoutTargetCase', () => {
+  it.each([true, false])(
+    'folds an email whether or not usernames are case-sensitive (%p)',
+    async (isCaseSensitive) => {
+      // `usernameRegEx` admits no `@`, so a value containing one cannot collide with a username.
+      await expect(
+        canFoldLockoutTargetCase(buildQueries(isCaseSensitive), 'Victim@Example.com')
+      ).resolves.toBe(true);
+    }
+  );
+
+  it('does not fold a non-email under the default case-sensitive policy', async () => {
+    await expect(canFoldLockoutTargetCase(buildQueries(true), 'Alice')).resolves.toBe(false);
+  });
+
+  it('folds a non-email when the policy is case-insensitive', async () => {
+    // `Alice` and `alice` are the same account there, so folding cannot reach a second one.
+    await expect(canFoldLockoutTargetCase(buildQueries(false), 'Alice')).resolves.toBe(true);
+  });
+});

--- a/packages/core/src/routes/experience/classes/libraries/sentinel-guard.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sentinel-guard.ts
@@ -1,16 +1,131 @@
 import {
+  AdditionalIdentifier,
   SentinelActionResult,
   SentinelActivityTargetType,
   SentinelDecision,
+  SignInIdentifier,
   type VerificationIdentifier,
   type Sentinel,
   type SentinelActivityAction,
 } from '@logto/schemas';
+import { PhoneNumberParser } from '@logto/shared';
+import { deduplicate } from '@silverhand/essentials';
 import { sha256 } from 'hash-wasm';
 
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithI18nContext } from '#src/middleware/koa-i18next.js';
 import { type WithHookContext } from '#src/middleware/koa-management-api-hooks.js';
+import type Queries from '#src/tenants/Queries.js';
+import { getConsoleLogFromContext } from '#src/utils/console.js';
+
+/**
+ * Resolves the identifier to the form the user lookup matches on, so that every spelling of one
+ * account shares a single lockout bucket.
+ *
+ * @remarks
+ * Each branch mirrors its counterpart in `findUserByIdentifier`
+ * (`routes/experience/classes/utils.ts`), because the mirroring is what makes the bucket
+ * per-account: normalizing less than the lookup lets an attacker mint a fresh bucket per spelling,
+ * and normalizing more merges accounts the lookup keeps apart, so failed attempts against one lock
+ * out another.
+ *
+ * The phone branch knowingly errs toward merging. `findUserByNormalizedPhone` matches both the
+ * international and the leading-zero form but then disambiguates on the raw input, so a tenant
+ * holding legacy rows for both forms has two accounts that share one bucket here. Creating such a
+ * pair is already blocked by `hasUserWithNormalizedPhone`, and the alternative — keying on the raw
+ * value — reopens the bypass for every phone identifier.
+ */
+const resolveLockoutTarget = async (
+  queries: Queries,
+  { type, value }: VerificationIdentifier
+): Promise<string> => {
+  switch (type) {
+    case SignInIdentifier.Email: {
+      // `findUserByEmail` compares `lower(primary_email)` to `lower(input)`.
+      return value.toLowerCase();
+    }
+    case SignInIdentifier.Phone: {
+      // `internationalNumber` is undefined unless the value parses, mirroring where
+      // `findUserByNormalizedPhone` falls back to the exact-match `findUserByPhone`.
+      return new PhoneNumberParser(value).internationalNumber ?? value;
+    }
+    case SignInIdentifier.Username: {
+      // Deliberately the same `getUsernameCaseSensitive()` call the lookup makes before passing the
+      // flag to `findUserByUsername`, rather than a second copy of the rule — the two cannot drift.
+      // It resolves the tenant policy AND-combined with the legacy `CASE_SENSITIVE_USERNAME` env
+      // var, so an env-forced case-insensitive deployment folds here too. Under the default
+      // case-sensitive policy `Alice` and `alice` are different accounts and keep separate buckets.
+      // The sentinel already loads the sign-in experience for its own policy on this path, so this
+      // reads through a warm cache.
+      return (await queries.signInExperiences.getUsernameCaseSensitive())
+        ? value
+        : value.toLowerCase();
+    }
+    case AdditionalIdentifier.UserId: {
+      return value;
+    }
+  }
+};
+
+/**
+ * {@link resolveLockoutTarget}, degraded to the raw identifier value when it fails.
+ *
+ * @remarks
+ * The username branch reads the sign-in experience, so resolution can reject on a database fault.
+ * Letting that propagate would abort {@link withSentinel} after the credential has already been
+ * checked, and an unreported attempt is an uncounted one — a free guess. Keying on the raw value
+ * instead reproduces the pre-normalization bucketing for the duration of the fault, which is
+ * degraded but still counts the attempt.
+ */
+const resolveLockoutTargetOrRaw = async (
+  ctx: WithI18nContext & WithHookContext,
+  queries: Queries,
+  identifier: VerificationIdentifier
+): Promise<string> => {
+  try {
+    return await resolveLockoutTarget(queries, identifier);
+  } catch (error: unknown) {
+    getConsoleLogFromContext(ctx).error(
+      'Failed to resolve the sentinel lockout target, falling back to the raw identifier:',
+      error
+    );
+
+    return identifier.value;
+  }
+};
+
+/**
+ * The lockout keys a bare identifier value could have been recorded under: the value as typed, its
+ * canonical phone form, and — only where case folding cannot span two accounts — its lower-cased
+ * form.
+ *
+ * @remarks
+ * The management API unblocks by identifier value alone, without knowing the identifier type, so it
+ * cannot call {@link resolveLockoutTarget} directly.
+ *
+ * Case is folded only when both spellings are guaranteed to be the same account, so an unblock can
+ * never reach across to another one:
+ *
+ * - An email always folds, because the lookup matches it case-insensitively. `usernameRegEx`
+ *   (`^[A-Z_a-z]\w*$`) admits no `@`, so a value containing one cannot be a username.
+ * - Anything else folds only when the tenant's username policy is case-insensitive, where `Alice`
+ *   and `alice` are one account. Under the default case-sensitive policy they are two, and the
+ *   admin has to submit the spelling that tripped the lockout.
+ *
+ * Phone numbers and user IDs are unaffected either way: their alphabets have no uppercase, so the
+ * lower-cased candidate collapses into the value as typed.
+ */
+export const getLockoutTargetCandidates = (value: string, foldCase: boolean): string[] => {
+  // `internationalNumber` is undefined unless the value parses as a phone number, in which case that
+  // candidate collapses into the first.
+  const { internationalNumber } = new PhoneNumberParser(value);
+
+  return deduplicate([value, foldCase ? value.toLowerCase() : value, internationalNumber ?? value]);
+};
+
+/** Whether folding this value's case can only ever reach the account it was submitted for. */
+export const canFoldLockoutTargetCase = async (queries: Queries, value: string): Promise<boolean> =>
+  value.includes('@') || !(await queries.signInExperiences.getUsernameCaseSensitive());
 
 /**
  * Applies a sentinel guard to a verification promise.
@@ -29,12 +144,14 @@ export async function withSentinel<T>(
   {
     ctx,
     sentinel,
+    queries,
     action,
     identifier,
     payload,
   }: {
     ctx: WithI18nContext & WithHookContext;
     sentinel: Sentinel;
+    queries: Queries;
     action: SentinelActivityAction;
     identifier: VerificationIdentifier;
     payload: Record<string, unknown>;
@@ -50,16 +167,20 @@ export async function withSentinel<T>(
   })();
 
   const actionResult = error ? SentinelActionResult.Failed : SentinelActionResult.Success;
+  // Resolved into its own statement rather than inline below: an exception while building
+  // `reportActivity`'s argument would skip the call entirely, leaving this attempt uncounted.
+  const targetHash = await sha256(await resolveLockoutTargetOrRaw(ctx, queries, identifier));
 
   const [decision, decisionExpiresAt] = await sentinel.reportActivity({
     targetType: SentinelActivityTargetType.User,
-    targetHash: await sha256(identifier.value),
+    targetHash,
     action,
     actionResult,
     payload,
   });
 
   if (decision === SentinelDecision.Blocked) {
+    // Reported as typed, not as keyed — admins need to see the spelling that tripped the lockout.
     ctx.appendExceptionHookContext('Identifier.Lockout', {
       ...identifier,
     });

--- a/packages/core/src/routes/experience/classes/libraries/sentinel-guard.ts
+++ b/packages/core/src/routes/experience/classes/libraries/sentinel-guard.ts
@@ -29,11 +29,13 @@ import { getConsoleLogFromContext } from '#src/utils/console.js';
  * and normalizing more merges accounts the lookup keeps apart, so failed attempts against one lock
  * out another.
  *
- * The phone branch knowingly errs toward merging. `findUserByNormalizedPhone` matches both the
- * international and the leading-zero form but then disambiguates on the raw input, so a tenant
- * holding legacy rows for both forms has two accounts that share one bucket here. Creating such a
- * pair is already blocked by `hasUserWithNormalizedPhone`, and the alternative — keying on the raw
- * value — reopens the bypass for every phone identifier.
+ * The phone branch looks like it could merge two accounts, because `findUserByNormalizedPhone`
+ * matches both the international and the leading-zero form but then disambiguates on the raw input.
+ * It cannot: sharing a bucket needs both rows to canonicalize identically, which needs both to
+ * parse, and a leading-zero form that parses is normalized to its canonical spelling on write, so
+ * it never becomes a second row. One that does not parse falls through to the raw value here and
+ * keeps its own bucket. The two conditions are mutually exclusive, so canonicalizing costs nothing
+ * here, while keying on the raw value would reopen the bypass for every phone identifier.
  */
 const resolveLockoutTarget = async (
   queries: Queries,

--- a/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
@@ -108,6 +108,7 @@ export default function backupCodeVerificationRoutes<T extends ExperienceInterac
         {
           ctx,
           sentinel,
+          queries,
           action: SentinelActivityAction.MfaBackupCode,
           identifier: {
             type: AdditionalIdentifier.UserId,

--- a/packages/core/src/routes/experience/verification-routes/one-time-token.ts
+++ b/packages/core/src/routes/experience/verification-routes/one-time-token.ts
@@ -52,6 +52,7 @@ export default function oneTimeTokenVerificationRoutes<
         {
           ctx,
           sentinel,
+          queries,
           action: SentinelActivityAction.OneTimeToken,
           identifier,
           payload: {

--- a/packages/core/src/routes/experience/verification-routes/password-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/password-verification.ts
@@ -86,6 +86,7 @@ export default function passwordVerificationRoutes<T extends ExperienceInteracti
         {
           ctx,
           sentinel,
+          queries,
           action: SentinelActivityAction.Password,
           identifier,
           payload: {

--- a/packages/core/src/routes/experience/verification-routes/totp-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/totp-verification.ts
@@ -140,6 +140,7 @@ export default function totpVerificationRoutes<T extends ExperienceInteractionRo
         {
           ctx,
           sentinel,
+          queries,
           action: SentinelActivityAction.MfaTotp,
           identifier: {
             type: AdditionalIdentifier.UserId,

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -208,6 +208,7 @@ type VerifyCodeParams = {
     | VerificationType.MfaEmailVerificationCode
     | VerificationType.MfaPhoneVerificationCode;
   sentinel: Sentinel;
+  queries: Queries;
   ctx: ExperienceInteractionRouterContext;
 };
 
@@ -221,6 +222,7 @@ export const verifyCode = async ({
   identifier,
   verificationType,
   sentinel,
+  queries,
   ctx,
 }: VerifyCodeParams): Promise<{ verificationId: string }> => {
   const { experienceInteraction } = ctx;
@@ -250,6 +252,7 @@ export const verifyCode = async ({
     {
       ctx,
       sentinel,
+      queries,
       action: SentinelActivityAction.VerificationCode,
       identifier,
       payload: {

--- a/packages/core/src/routes/experience/verification-routes/verification-code.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code.ts
@@ -107,6 +107,7 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
         identifier,
         verificationType: codeVerificationIdentifierRecordTypeMap[identifier.type],
         sentinel,
+        queries,
         ctx,
       });
 
@@ -185,6 +186,7 @@ export default function verificationCodeRoutes<T extends ExperienceInteractionRo
         identifier,
         verificationType: mfaVerificationType,
         sentinel,
+        queries,
         ctx,
       });
 

--- a/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
@@ -250,6 +250,7 @@ export default function webAuthnVerificationRoute<T extends ExperienceInteractio
         {
           ctx,
           sentinel,
+          queries,
           action: SentinelActivityAction.WebAuthn,
           identifier: {
             type: AdditionalIdentifier.UserId,

--- a/packages/core/src/routes/sentinel-activities.ts
+++ b/packages/core/src/routes/sentinel-activities.ts
@@ -4,6 +4,10 @@ import { z } from 'zod';
 
 import koaGuard from '../middleware/koa-guard.js';
 
+import {
+  canFoldLockoutTargetCase,
+  getLockoutTargetCandidates,
+} from './experience/classes/libraries/sentinel-guard.js';
 import { type RouterInitArgs, type ManagementApiRouter } from './types.js';
 
 export default function sentinelActivitiesRoutes<T extends ManagementApiRouter>(
@@ -30,7 +34,16 @@ export default function sentinelActivitiesRoutes<T extends ManagementApiRouter>(
 
       const { sentinelActivities } = queries;
 
-      const targetHashes = await Promise.all(targets.map(async (target) => sha256(target)));
+      // Admins type identifiers by hand, so also clear the other spellings of what they entered
+      // rather than that spelling alone — but only those that cannot belong to another account.
+      const candidates = await Promise.all(
+        targets.map(async (target) =>
+          getLockoutTargetCandidates(target, await canFoldLockoutTargetCase(queries, target))
+        )
+      );
+      const targetHashes = await Promise.all(
+        candidates.flat().map(async (candidate) => sha256(candidate))
+      );
       await sentinelActivities.deleteActivities(targetType, targetHashes);
 
       ctx.status = 204;

--- a/packages/core/src/routes/verification/index.ts
+++ b/packages/core/src/routes/verification/index.ts
@@ -59,6 +59,7 @@ export default function verificationRoutes<T extends UserRouter>(
         {
           ctx,
           sentinel,
+          queries,
           action: SentinelActivityAction.Password,
           identifier: {
             type: AdditionalIdentifier.UserId,
@@ -198,6 +199,7 @@ export default function verificationRoutes<T extends UserRouter>(
         {
           ctx,
           sentinel,
+          queries,
           action: SentinelActivityAction.VerificationCode,
           identifier,
           payload: {

--- a/packages/integration-tests/src/tests/api/experience-api/basic-sentinel.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/basic-sentinel.test.ts
@@ -1,7 +1,8 @@
-import { SignInIdentifier } from '@logto/schemas';
+import { SignInIdentifier, type SignInExperience } from '@logto/schemas';
+import { type Optional } from '@silverhand/essentials';
 
 import { authedAdminApi } from '#src/api/api.js';
-import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { getSignInExperience, updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { initExperienceClient } from '#src/helpers/client.js';
 import { signInWithPassword } from '#src/helpers/experience/index.js';
 import { expectRejects } from '#src/helpers/index.js';
@@ -10,8 +11,16 @@ import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
 import { generateUsername } from '#src/utils.js';
 
 describe('basic sentinel', () => {
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let originalSentinelPolicy: Optional<SignInExperience['sentinelPolicy']>;
+
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
+
+    const signInExperience = await getSignInExperience();
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    originalSentinelPolicy = signInExperience.sentinelPolicy;
+
     /**
      * The default policy settings is way too big for the test.
      * We need to override it to make the test.
@@ -26,6 +35,12 @@ describe('basic sentinel', () => {
         lockoutDuration: 10,
       },
     });
+  });
+
+  afterAll(async () => {
+    // `sentinelPolicy` is tenant-wide, so leaving it tightened makes unrelated suites fail with
+    // spurious lockouts on a reused database.
+    await updateSignInExperience({ sentinelPolicy: originalSentinelPolicy ?? {} });
   });
 
   describe('sign-in with non-existing username and password', () => {

--- a/packages/integration-tests/src/tests/api/experience-api/sentinel-identifier-normalization.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/sentinel-identifier-normalization.test.ts
@@ -1,0 +1,160 @@
+import {
+  SentinelActivityTargetType,
+  SignInIdentifier,
+  type SignInExperience,
+} from '@logto/schemas';
+import { type Optional } from '@silverhand/essentials';
+
+import { authedAdminApi } from '#src/api/api.js';
+import { getSignInExperience, updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { initExperienceClient } from '#src/helpers/client.js';
+import { expectRejects } from '#src/helpers/index.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+
+const invalidCredentials = { code: 'session.invalid_credentials', status: 422 };
+const lockedOut = { code: 'session.verification_blocked_too_many_attempts', status: 400 };
+
+/** A third spelling: the generated local part is a lower-cased UUID, so only the domain differs. */
+const upperCaseDomain = (email: string) => {
+  const [local = '', domain = ''] = email.split('@');
+
+  return `${local}@${domain.toUpperCase()}`;
+};
+
+/** `1310XXXXXXX` spaced as a human would type it. */
+const spacedPhone = (phone: string) => `+${phone.slice(0, 1)} ${phone.slice(1)}`;
+
+/** `1310XXXXXXX` punctuated as a human would type it. */
+const punctuatedPhone = (phone: string) =>
+  `+${phone.slice(0, 1)} (${phone.slice(1, 4)}) ${phone.slice(4, 7)}-${phone.slice(7)}`;
+
+const attemptWrongPassword = async (type: SignInIdentifier, value: string) => {
+  const client = await initExperienceClient();
+
+  return client.verifyPassword({ identifier: { type, value }, password: 'not-the-password' });
+};
+
+describe('sentinel lockout identifier normalization', () => {
+  const userApi = new UserApiTest();
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let originalSentinelPolicy: Optional<SignInExperience['sentinelPolicy']>;
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+
+    const signInExperience = await getSignInExperience();
+    // eslint-disable-next-line @silverhand/fp/no-mutation
+    originalSentinelPolicy = signInExperience.sentinelPolicy;
+
+    // Two recorded failures are allowed; the third attempt is blocked.
+    await updateSignInExperience({ sentinelPolicy: { maxAttempts: 3, lockoutDuration: 10 } });
+  });
+
+  afterAll(async () => {
+    await userApi.cleanUp();
+    await updateSignInExperience({ sentinelPolicy: originalSentinelPolicy ?? {} });
+  });
+
+  it('counts email casing variants against a single lockout bucket', async () => {
+    const { primaryEmail, password } = generateNewUserProfile({
+      primaryEmail: true,
+      password: true,
+    });
+    await userApi.create({ primaryEmail, password });
+
+    // Every spelling authenticates against the same account, so every spelling must share a bucket.
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Email, primaryEmail),
+      invalidCredentials
+    );
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Email, primaryEmail.toUpperCase()),
+      invalidCredentials
+    );
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Email, upperCaseDomain(primaryEmail)),
+      lockedOut
+    );
+
+    // The lockout covers the canonical spelling too, not only the one that tripped it.
+    await expectRejects(attemptWrongPassword(SignInIdentifier.Email, primaryEmail), lockedOut);
+  });
+
+  it('counts equivalent phone formats against a single lockout bucket', async () => {
+    const { primaryPhone, password } = generateNewUserProfile({
+      primaryPhone: true,
+      password: true,
+    });
+    await userApi.create({ primaryPhone, password });
+
+    // The guard keys on `internationalNumber` while `findUserByNormalizedPhone` matches on both the
+    // international and leading-zero forms — this pins the two together end-to-end.
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Phone, primaryPhone),
+      invalidCredentials
+    );
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Phone, spacedPhone(primaryPhone)),
+      invalidCredentials
+    );
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Phone, punctuatedPhone(primaryPhone)),
+      lockedOut
+    );
+  });
+
+  it('keeps username case variants in separate buckets under a case-sensitive policy', async () => {
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    await userApi.create({ username, password });
+
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Username, username),
+      invalidCredentials
+    );
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Username, username),
+      invalidCredentials
+    );
+    await expectRejects(attemptWrongPassword(SignInIdentifier.Username, username), lockedOut);
+
+    // Usernames are case-sensitive by default, so the upper-cased spelling is a different account
+    // and must not inherit the lockout — otherwise an attacker could lock out a lookalike.
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Username, username.toUpperCase()),
+      invalidCredentials
+    );
+  });
+
+  it('unblocks a locked-out identifier regardless of the spelling the admin submits', async () => {
+    const { primaryEmail, password } = generateNewUserProfile({
+      primaryEmail: true,
+      password: true,
+    });
+    await userApi.create({ primaryEmail, password });
+
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Email, primaryEmail),
+      invalidCredentials
+    );
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Email, primaryEmail),
+      invalidCredentials
+    );
+    await expectRejects(attemptWrongPassword(SignInIdentifier.Email, primaryEmail), lockedOut);
+
+    // The console unblock form takes whatever the admin types, which need not be the spelling the
+    // bucket was keyed under.
+    await authedAdminApi.post('sentinel-activities/delete', {
+      json: {
+        targetType: SentinelActivityTargetType.User,
+        targets: [primaryEmail.toUpperCase()],
+      },
+    });
+
+    await expectRejects(
+      attemptWrongPassword(SignInIdentifier.Email, primaryEmail),
+      invalidCredentials
+    );
+  });
+});

--- a/packages/integration-tests/src/tests/api/hook/hook.trigger.experience.test.ts
+++ b/packages/integration-tests/src/tests/api/hook/hook.trigger.experience.test.ts
@@ -453,6 +453,9 @@ describe('should trigger `Identifier.Lockout` event when user repeatedly fails t
 
   afterAll(async () => {
     await deleteUser(userId);
+    // `sentinelPolicy` is tenant-wide, so leaving it tightened makes unrelated suites fail with
+    // spurious lockouts on a reused database. `{}` is the suite baseline.
+    await updateSignInExperience({ sentinelPolicy: {} });
   });
 
   it('should log lockout hook after max failed attempts', async () => {


### PR DESCRIPTION
## Summary

### Context
The identifier lockout counter keyed on the identifier exactly as submitted, while the user lookup normalizes before matching. The two could therefore disagree about which account a request referred to, so a single account did not reliably map to a single lockout bucket and the configured `maxAttempts` policy was weaker than it appeared.

### What changed
- **`sentinel-guard.ts`** — added `resolveLockoutTarget`, which derives the lockout key the same way the corresponding lookup derives its match: `toLowerCase()` for emails (mirroring `lower(primary_email) = lower($1)`), `PhoneNumberParser.internationalNumber` for phones (mirroring `findUserByNormalizedPhone`, falling back to the submitted value when the number does not parse, as that lookup does), and the raw value for user IDs.
- The username branch calls the **same** `queries.signInExperiences.getUsernameCaseSensitive()` that the lookup passes to `findUserByUsername`, rather than reimplementing the rule. That resolver AND-combines the tenant `usernamePolicy.caseSensitive` with the legacy `CASE_SENSITIVE_USERNAME` env var, so an env-forced case-insensitive deployment folds case here too. Since there is only one implementation, the lockout and lookup policies cannot drift apart.
- Normalization happens inside `withSentinel` rather than at each of its 8 call sites, so a future call site cannot forget it. Those call sites gain a `queries` argument and are otherwise unchanged.
- The key is resolved into its own statement and degrades to the submitted value if resolution throws. Building it inline would let a fault skip `reportActivity` after the credential had already been checked, leaving the attempt uncounted.
- **`sentinel-activities.ts`** — manual unlock now clears the lower-cased and canonical-phone spellings of the submitted identifier, not only that spelling. Console feeds this endpoint free text typed by an admin, so keying the guard on the derived value would otherwise make unblocking a silent no-op whenever the admin typed a different case. The submitted value is always retained as a candidate, so every unblock that worked before still works.

### Expected result
- One account maps to one lockout bucket however the identifier was spelled in the request, so the configured `maxAttempts` policy holds.
- Under the default case-sensitive username policy, `Alice` and `alice` remain different accounts and keep separate buckets — attempts against one cannot lock out the other. Deriving more aggressively than the lookup would have introduced that as a new problem.
- No request or response contract changes: no `koaGuard` body, status, or OpenAPI spec is touched, and `POST /sentinel-activities/delete` keeps its exact body shape and 204. No schema change and no alteration.
- Operators upgrading: lockouts are re-keyed, so an active lockout recorded under a non-canonical spelling stops applying once deployed. Affected users are unblocked at most one `lockoutDuration` early. The re-key is forward-only — no existing row moves into a bucket it was not already in, so no user becomes more locked out than before.

### Reviewer notes
- `resolveLockoutTarget` must keep mirroring `findUserByIdentifier` (`routes/experience/classes/utils.ts`) exactly in both directions. Deriving *less* than the lookup splits one account across buckets; deriving *more* merges accounts the lookup keeps apart, so failed attempts against one would lock out another. Both directions have unit coverage.
- `getLockoutTargetCandidates` is the untyped counterpart used by the management API, which unblocks by value alone and so cannot know the identifier type. A parameterized test asserts it stays a superset of every key `resolveLockoutTarget` can produce for the same value; if the two ever diverge, manual unlock silently stops clearing that bucket.

## Testing
Unit tests, integration tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
