### PR TITLE
feat(connector): make azure ad email sync configurable

### DIFF
--- a/.changeset/azuread-disable-email-sync.md
+++ b/.changeset/azuread-disable-email-sync.md
@@ -1,0 +1,7 @@
+---
+"@logto/connector-azuread": minor
+---
+
+add a `disableEmailSync` switch to the Microsoft Azure AD connector
+
+The connector always synced the `mail` attribute returned by Microsoft Graph to the user profile. This switch makes that configurable, matching the control the Azure OIDC SSO connector already offers. It is off by default, so existing connectors keep their current behavior.

--- a/packages/connectors/connector-azuread/README.md
+++ b/packages/connectors/connector-azuread/README.md
@@ -13,6 +13,7 @@ The Microsoft Azure AD connector provides a succinct way for your application to
     - [Tenant ID](#tenant-id)
     - [Prompts](#prompts)
     - [Scopes](#scopes)
+    - [Disable Email Sync](#disable-email-sync)
   - [References](#references)
 
 ## Set up Microsoft Azure AD in the Azure Portal
@@ -25,14 +26,15 @@ The Microsoft Azure AD connector provides a succinct way for your application to
 
 ## Fill in the configuration in Logto
 
-| Name          | Type     |
-| ------------- | -------- |
-| clientId      | string   |
-| clientSecret  | string   |
-| tenantId      | string   |
-| cloudInstance | string   |
-| prompts       | string[] |
-| scopes        | string?  |
+| Name             | Type     |
+| ---------------- | -------- |
+| clientId         | string   |
+| clientSecret     | string   |
+| tenantId         | string   |
+| cloudInstance    | string   |
+| prompts          | string[] |
+| scopes           | string?  |
+| disableEmailSync | boolean? |
 
 ### Client ID
 
@@ -73,6 +75,14 @@ Logto will concatenate the prompts with a space as the value of `prompt` in the 
 The `scopes` field is a space-separated list of scopes the application needs. The list of scopes can be found in the [Microsoft Graph permissions reference](https://learn.microsoft.com/en-us/graph/permissions-reference).
 
 The default scopes are `User.Read`, leave this field empty unless you need other scopes.
+
+### Disable Email Sync
+
+Microsoft Graph returns the user's email address in the `mail` attribute, but reports no verification state for it. `mail` is a directory attribute that an administrator can set to any value, so it is only as trustworthy as the directory it comes from.
+
+Logto syncs that address to the user profile, where it serves as a user identifier. This switch stops it from doing so. It is off by default. Turn it on to leave the raw value in `rawData` only and source the email elsewhere.
+
+Consider turning it on if the connector accepts sign-ins from directories you do not control. This is the case when the app registration's **access type** is anything other than **Accounts in this organizational directory only**, or when **Tenant ID** is set to `organizations`, `common` or `consumers`.
 
 ## References
 

--- a/packages/connectors/connector-azuread/src/constant.ts
+++ b/packages/connectors/connector-azuread/src/constant.ts
@@ -69,6 +69,17 @@ export const defaultMetadata: ConnectorMetadata = {
       label: 'Scopes',
       placeholder: '<scope1> <scope2>',
     },
+    {
+      key: 'disableEmailSync',
+      type: ConnectorConfigFormItemType.Switch,
+      required: false,
+      label: 'Disable Email Sync',
+      description:
+        'Stop syncing the `mail` attribute returned by Microsoft Graph to the user profile. Turn this on if you do not want Microsoft to supply the email address.',
+      tooltip:
+        'Microsoft Graph reports no verification state for `mail`, and a directory administrator can set it to any value. Turning this on leaves the address in `rawData` only.',
+      defaultValue: false,
+    },
   ],
 };
 

--- a/packages/connectors/connector-azuread/src/index.test.ts
+++ b/packages/connectors/connector-azuread/src/index.test.ts
@@ -17,12 +17,14 @@ vi.mock('@azure/msal-node', async () => ({
   },
 }));
 
-const getConnectorConfig = vi.fn().mockResolvedValue({
+const mockedConfig = {
   clientId: 'clientId',
   clientSecret: 'clientSecret',
   cloudInstance: 'https://login.microsoftonline.com',
   tenantId: 'tenantId',
-});
+};
+
+const getConnectorConfig = vi.fn().mockResolvedValue(mockedConfig);
 
 describe('Azure AD connector', () => {
   it('init without exploding', () => {
@@ -51,6 +53,39 @@ describe('getUserInfo', () => {
       id: 'id',
       name: 'displayName',
       email: 'mail',
+      rawData: {
+        id: 'id',
+        displayName: 'displayName',
+        mail: 'mail',
+        userPrincipalName: 'userPrincipalName',
+      },
+    });
+  });
+
+  it('should not return the email when email sync is disabled', async () => {
+    const graphMeUrl = new URL(graphAPIEndpoint);
+    nock(graphMeUrl.origin).get(graphMeUrl.pathname).reply(200, {
+      id: 'id',
+      displayName: 'displayName',
+      mail: 'mail',
+      userPrincipalName: 'userPrincipalName',
+    });
+
+    const connector = await createConnector({
+      getConfig: vi.fn().mockResolvedValue({
+        ...mockedConfig,
+        disableEmailSync: true,
+      }),
+    });
+    const userInfo = await connector.getUserInfo(
+      { code: 'code', redirectUri: 'redirectUri' },
+      vi.fn()
+    );
+
+    expect(userInfo.email).toBeUndefined();
+    expect(userInfo).toEqual({
+      id: 'id',
+      name: 'displayName',
       rawData: {
         id: 'id',
         displayName: 'displayName',

--- a/packages/connectors/connector-azuread/src/index.ts
+++ b/packages/connectors/connector-azuread/src/index.ts
@@ -131,7 +131,7 @@ const getUserInfo =
 
       return {
         id,
-        email: conditional(mail),
+        email: conditional(!config.disableEmailSync && mail),
         name: conditional(displayName),
         rawData,
       };

--- a/packages/connectors/connector-azuread/src/types.ts
+++ b/packages/connectors/connector-azuread/src/types.ts
@@ -9,6 +9,7 @@ export const azureADConfigGuard = z.object({
   tenantId: z.string(),
   prompts: oidcPromptsGuard,
   scopes: z.string().optional(),
+  disableEmailSync: z.boolean().optional(),
 });
 
 export type AzureADConfig = z.infer<typeof azureADConfigGuard>;


### PR DESCRIPTION
## Summary

The Azure OIDC SSO connector lets developers configure how the email returned by the identity provider is handled. The Microsoft Azure AD social connector has no equivalent: it always syncs the `mail` attribute from Microsoft Graph to the user profile.

This adds a `disableEmailSync` switch so developers can opt out of that. It is off by default, so existing connectors are unaffected.

### What changed

- `src/types.ts`: added `disableEmailSync: z.boolean().optional()` to `azureADConfigGuard`.
- `src/constant.ts`: added a matching `Switch` form item, `defaultValue: false`.
- `src/index.ts:134`: `email` is omitted when the switch is on. `mail` stays in `rawData` either way.
- `src/index.test.ts`: added a case asserting the email is absent when the switch is on; the existing case covers the default.
- `README.md`: documented the setting and when to turn it on.

### Expected result

- Default behavior is unchanged. With the switch unset or off, the connector returns `email` exactly as before.
- With the switch on, the connector returns no `email`, so the address is not synced to the profile and is not used as a user identifier. The raw value remains in `rawData`.

### Reviewer notes

- The switch is named for the disabling action so that its default can be `false`. The Console does not apply a form item's `defaultValue` when a connector already has a config (`initFormData` in `packages/console/src/utils/connector-form.ts`), so a key the stored config does not carry renders as off. A `defaultValue: true` switch would therefore have displayed as off on every connector installed before this change, while the email was still being synced.
- The SSO connector also surfaces `unverifiedEmail` alongside. That is not replicated here: `socialUserInfoGuard` declares no such key and does not use `.catchall`, so core would strip it. Adding it means changing the shared social user-info contract, which is out of scope for this PR.

## Testing

Unit tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
