### PR TITLE
fix(experience): validate url schemes for social redirect and callback links

### DIFF
--- a/.changeset/swift-pans-wave.md
+++ b/.changeset/swift-pans-wave.md
@@ -1,0 +1,9 @@
+---
+"@logto/experience": patch
+---
+
+validate the URL scheme of the social sign-in redirect target and native callback link
+
+The social landing page now requires `redirect_to` to be an `http(s)` URL, and accepts a native
+callback link only when it is a custom app scheme. The callback page re-checks the stored link
+before handing control back to the native app, and falls back to the web flow otherwise.

--- a/packages/experience/src/pages/Callback/use-social-callback-handler.test.ts
+++ b/packages/experience/src/pages/Callback/use-social-callback-handler.test.ts
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react';
+
+import { getCallbackLinkFromStorage, storeCallbackLink } from '@/utils/social-connectors';
+
+import useSocialCallbackHandler from './use-social-callback-handler';
+
+const navigate = jest.fn();
+
+jest.mock('@/hooks/use-navigate-with-preserved-search-params', () => ({
+  __esModule: true,
+  default: () => navigate,
+}));
+
+describe('useSocialCallbackHandler', () => {
+  const replace = jest.fn();
+  const originalLocation = window.location;
+  const connectorId = 'github';
+  const search = '?code=auth-code&state=state-value';
+
+  const invoke = () => {
+    const { result } = renderHook(() => useSocialCallbackHandler());
+    result.current.socialCallbackHandler(connectorId);
+  };
+
+  beforeEach(() => {
+    replace.mockClear();
+    navigate.mockClear();
+    sessionStorage.clear();
+
+    /* eslint-disable @silverhand/fp/no-mutating-methods */
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { origin: 'http://localhost', search, hash: '', replace },
+    });
+    /* eslint-enable @silverhand/fp/no-mutating-methods */
+  });
+
+  afterAll(() => {
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods
+    Object.defineProperty(window, 'location', { value: originalLocation });
+  });
+
+  it('forwards the callback parameters to a native deep link', () => {
+    storeCallbackLink(connectorId, 'logto://callback');
+    invoke();
+
+    expect(replace).toBeCalledWith(new URL(`logto://callback${search}`));
+    expect(navigate).not.toBeCalled();
+  });
+
+  it.each([
+    'https://attacker.example',
+    // eslint-disable-next-line no-script-url -- payload under test
+    'javascript:alert(1)',
+    'not a url',
+  ])('takes the web flow rather than forwarding to %p', (poisoned) => {
+    storeCallbackLink(connectorId, poisoned);
+    invoke();
+
+    expect(replace).not.toBeCalled();
+    expect(navigate).toBeCalledWith(
+      { pathname: `/callback/social/${connectorId}`, search },
+      { replace: true }
+    );
+  });
+
+  it('clears the stored callback link once read', () => {
+    storeCallbackLink(connectorId, 'logto://callback');
+    invoke();
+
+    expect(getCallbackLinkFromStorage(connectorId)).toBeNull();
+  });
+});

--- a/packages/experience/src/pages/Callback/use-social-callback-handler.ts
+++ b/packages/experience/src/pages/Callback/use-social-callback-handler.ts
@@ -5,6 +5,7 @@ import {
   getCallbackLinkFromStorage,
   removeCallbackLinkFromStorage,
 } from '@/utils/social-connectors';
+import { isValidNativeCallbackLink } from '@/utils/url-scheme';
 
 const useSocialCallbackHandler = () => {
   const navigate = useNavigateWithPreservedSearchParams();
@@ -24,7 +25,9 @@ const useSocialCallbackHandler = () => {
       const callbackLink = getCallbackLinkFromStorage(connectorId);
       removeCallbackLinkFromStorage(connectorId);
 
-      if (callbackLink) {
+      // Re-check at the navigation sink: `search` carries the authorization code, so a stored value
+      // that is not a native deep link must fall through to the web flow instead.
+      if (callbackLink && isValidNativeCallbackLink(callbackLink)) {
         window.location.replace(new URL(`${callbackLink}${search}`));
 
         return;

--- a/packages/experience/src/pages/SocialLanding/index.test.tsx
+++ b/packages/experience/src/pages/SocialLanding/index.test.tsx
@@ -9,26 +9,47 @@ import { getCallbackLinkFromStorage } from '@/utils/social-connectors';
 
 import SocialLanding from '.';
 
+const setToast = jest.fn();
+
+jest.mock('@/hooks/use-toast', () => ({
+  __esModule: true,
+  default: () => ({ setToast }),
+}));
+
 describe(`SocialLanding Page`, () => {
   const replace = jest.fn();
   const callbackLink = 'logto:logto.android.com';
   const redirectUri = 'http://www.github.com';
   const originalLocation = window.location;
 
-  beforeAll(() => {
+  const mockLocation = (search: Record<string, string>) => {
     /* eslint-disable @silverhand/fp/no-mutating-methods */
     Object.defineProperty(window, 'location', {
+      writable: true,
       value: {
         origin: 'http://localhost',
         href: `/social/landing?`,
-        search: queryStringify({
-          [SearchParameters.RedirectTo]: redirectUri,
-          [SearchParameters.NativeCallbackLink]: callbackLink,
-        }),
+        search: queryStringify(search),
         replace,
       },
     });
     /* eslint-enable @silverhand/fp/no-mutating-methods */
+  };
+
+  const renderPage = () =>
+    renderWithPageContext(
+      <SettingsProvider>
+        <Routes>
+          <Route path="/social/landing/:connectorId" element={<SocialLanding />} />
+        </Routes>
+      </SettingsProvider>,
+      { initialEntries: ['/social/landing/github'] }
+    );
+
+  beforeEach(() => {
+    replace.mockClear();
+    setToast.mockClear();
+    sessionStorage.clear();
   });
 
   afterAll(() => {
@@ -39,19 +60,49 @@ describe(`SocialLanding Page`, () => {
   });
 
   it('Should set session storage and redirect', async () => {
-    renderWithPageContext(
-      <SettingsProvider>
-        <Routes>
-          <Route path="/social/landing/:connectorId" element={<SocialLanding />} />
-        </Routes>
-      </SettingsProvider>,
-      { initialEntries: ['/social/landing/github'] }
-    );
+    mockLocation({
+      [SearchParameters.RedirectTo]: redirectUri,
+      [SearchParameters.NativeCallbackLink]: callbackLink,
+    });
+
+    renderPage();
 
     await waitFor(() => {
       expect(replace).toBeCalledWith(new URL(redirectUri));
     });
 
     expect(getCallbackLinkFromStorage('github')).toBe(callbackLink);
+  });
+
+  it('does not store a web-scheme callback link but still redirects', async () => {
+    mockLocation({
+      [SearchParameters.RedirectTo]: redirectUri,
+      [SearchParameters.NativeCallbackLink]: 'https://attacker.example',
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(replace).toBeCalledWith(new URL(redirectUri));
+    });
+
+    expect(getCallbackLinkFromStorage('github')).toBeNull();
+  });
+
+  it('does not redirect to a script-capable scheme', async () => {
+    mockLocation({
+      // eslint-disable-next-line no-script-url -- payload under test
+      [SearchParameters.RedirectTo]: 'javascript:alert(1)',
+      [SearchParameters.NativeCallbackLink]: callbackLink,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(setToast).toBeCalledWith('error.invalid_connector_request');
+    });
+
+    expect(replace).not.toBeCalled();
+    expect(getCallbackLinkFromStorage('github')).toBeNull();
   });
 });

--- a/packages/experience/src/pages/SocialLanding/use-social-landing-handler.ts
+++ b/packages/experience/src/pages/SocialLanding/use-social-landing-handler.ts
@@ -5,6 +5,7 @@ import useToast from '@/hooks/use-toast';
 import { SearchParameters } from '@/types';
 import { getSearchParameters } from '@/utils';
 import { storeCallbackLink } from '@/utils/social-connectors';
+import { isValidNativeCallbackLink, isValidWebRedirectUri } from '@/utils/url-scheme';
 
 const useSocialLandingHandler = () => {
   const [loading, setLoading] = useState(true);
@@ -16,7 +17,7 @@ const useSocialLandingHandler = () => {
     (connectorId: string) => {
       const redirectUri = getSearchParameters(search, SearchParameters.RedirectTo);
 
-      if (!redirectUri) {
+      if (!redirectUri || !isValidWebRedirectUri(redirectUri)) {
         setLoading(false);
         setToast(t('error.invalid_connector_request'));
 
@@ -25,7 +26,8 @@ const useSocialLandingHandler = () => {
 
       const nativeCallbackLink = getSearchParameters(search, SearchParameters.NativeCallbackLink);
 
-      if (nativeCallbackLink) {
+      // Drop an invalid link rather than aborting: the web flow below still completes without it.
+      if (nativeCallbackLink && isValidNativeCallbackLink(nativeCallbackLink)) {
         storeCallbackLink(connectorId, nativeCallbackLink);
       }
 

--- a/packages/experience/src/utils/url-scheme.test.ts
+++ b/packages/experience/src/utils/url-scheme.test.ts
@@ -1,0 +1,75 @@
+import { isValidNativeCallbackLink, isValidWebRedirectUri } from './url-scheme';
+
+describe('isValidNativeCallbackLink', () => {
+  it.each([
+    'logto://callback',
+    'logto:logto.android.com',
+    'io.logto.app://callback',
+    'my-app://cb',
+  ])('accepts the custom app scheme %p', (link) => {
+    expect(isValidNativeCallbackLink(link)).toBe(true);
+  });
+
+  it.each(['https://attacker.example', 'http://attacker.example'])(
+    'rejects the web scheme %p',
+    (link) => {
+      expect(isValidNativeCallbackLink(link)).toBe(false);
+    }
+  );
+
+  it.each([
+    // eslint-disable-next-line no-script-url -- payload under test
+    'javascript:alert(1)',
+    'vbscript:msgbox(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'blob:https://logto.dev/uuid',
+    'filesystem:https://logto.dev/temporary/x',
+    'view-source:https://logto.dev',
+    'file:///etc/passwd',
+    'about:blank',
+  ])('rejects the script-capable scheme %p', (link) => {
+    expect(isValidNativeCallbackLink(link)).toBe(false);
+  });
+
+  it.each([
+    // eslint-disable-next-line no-script-url -- payload under test
+    'JavaScript:alert(1)',
+    'java\nscript:alert(1)',
+    ' javascript:alert(1)',
+  ])('rejects the obfuscated script scheme %p', (link) => {
+    expect(isValidNativeCallbackLink(link)).toBe(false);
+  });
+
+  it.each(['', '//attacker.example', 'not a url', '/callback'])(
+    'rejects the unparseable value %p',
+    (link) => {
+      expect(isValidNativeCallbackLink(link)).toBe(false);
+    }
+  );
+});
+
+describe('isValidWebRedirectUri', () => {
+  it.each(['https://accounts.google.com/o/oauth2/auth', 'http://www.github.com'])(
+    'accepts %p',
+    (uri) => {
+      expect(isValidWebRedirectUri(uri)).toBe(true);
+    }
+  );
+
+  it.each([
+    // eslint-disable-next-line no-script-url -- payload under test
+    'javascript:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'about:blank',
+  ])('rejects the script-capable scheme %p', (uri) => {
+    expect(isValidWebRedirectUri(uri)).toBe(false);
+  });
+
+  it('rejects a native deep link', () => {
+    expect(isValidWebRedirectUri('logto://callback')).toBe(false);
+  });
+
+  it.each(['', 'not a url'])('rejects the unparseable value %p', (uri) => {
+    expect(isValidWebRedirectUri(uri)).toBe(false);
+  });
+});

--- a/packages/experience/src/utils/url-scheme.ts
+++ b/packages/experience/src/utils/url-scheme.ts
@@ -1,0 +1,46 @@
+import { trySafe } from '@silverhand/essentials';
+
+/** Schemes that execute script or read local resources when navigated to. */
+const dangerousSchemes = new Set([
+  // eslint-disable-next-line no-script-url -- naming the scheme is what lets this set block it
+  'javascript:',
+  'vbscript:',
+  'data:',
+  'blob:',
+  'filesystem:',
+  'view-source:',
+  'file:',
+  'about:',
+]);
+
+const webSchemes = new Set(['http:', 'https:']);
+
+// The URL parser lowercases the scheme and strips whitespace, tabs, and newlines.
+const getProtocol = (value: string) => trySafe(() => new URL(value).protocol);
+
+/**
+ * Whether the value is a native app deep link, e.g. `logto://callback` or the host-less
+ * `logto:logto.android.com` form.
+ *
+ * `http(s):` is rejected. This link is navigated to with the identity provider's query string
+ * appended, so it has to address the app itself rather than any web origin. It is not the
+ * application's OAuth redirect URI, which is supplied separately as `callbackUri` and is expected
+ * to be `http(s):`.
+ */
+export const isValidNativeCallbackLink = (link: string): boolean => {
+  const protocol = getProtocol(link);
+
+  return Boolean(protocol && !dangerousSchemes.has(protocol) && !webSchemes.has(protocol));
+};
+
+/**
+ * Whether the value is safe to navigate to as a web redirect target.
+ *
+ * Only `http:` and `https:` are accepted. This bounds the scheme, not the destination — the
+ * target is an identity provider's authorization URL and is legitimately cross-origin.
+ */
+export const isValidWebRedirectUri = (uri: string): boolean => {
+  const protocol = getProtocol(uri);
+
+  return Boolean(protocol && webSchemes.has(protocol));
+};


### PR DESCRIPTION
## Summary

### Context
`/social/landing/:connectorId` takes two values straight from the query string: `redirect_to`, which it navigates to, and `native_callback`, which it stores for the callback page to later hand control back to a native app. Neither value's scheme was checked before use, so both sinks accepted any scheme the URL parser would accept.

### What changed
- **`utils/url-scheme.ts`** (new) — two predicates over `new URL(value).protocol`:
  - `isValidWebRedirectUri` accepts only `http:`/`https:`.
  - `isValidNativeCallbackLink` accepts custom app schemes only, rejecting both `http(s):` and a denylist of schemes that execute script or read local resources (`javascript:`, `vbscript:`, `data:`, `blob:`, `filesystem:`, `view-source:`, `file:`, `about:`).

  Parsing rather than string-prefix matching matters here: the URL parser lower-cases the scheme and strips whitespace, tabs and newlines, so `JavaScript:`, `java\nscript:` and a leading-space variant all normalize to the same protocol and are caught by one check. It also handles the host-less `logto:logto.android.com` callback form, which a `//`-based check would reject.
- **`use-social-landing-handler.ts`** — `redirect_to` must now satisfy `isValidWebRedirectUri`, otherwise the page toasts `error.invalid_connector_request` and stops. An invalid `native_callback` is dropped rather than aborting, since the web flow completes without it.
- **`use-social-callback-handler.ts`** — re-checks the stored link before forwarding, falling back to the web flow when it does not pass. The check at the write site would be enough on its own; this is defence in depth at the navigation sink.

### Expected result
- The legitimate native flow is unchanged: `logto://callback`, `logto:logto.android.com`, `io.logto.app://callback` and similar all still round-trip, and the web flow is untouched when no callback link is stored.
- A `native_callback` carrying a web or script-capable scheme is now ignored, and the user completes sign-in through the web flow instead of being navigated to it.
- `redirect_to` is constrained to `http(s):`. This bounds the scheme only — the target is legitimately an external identity provider's authorization URL, so it is not and cannot be origin-restricted here.

### Reviewer notes
- `isValidNativeCallbackLink` is a denylist for dangerous schemes plus a positive rejection of `http(s):`, not an allowlist of known app schemes. An allowlist would need the set of registered schemes, which the experience app does not have. Worth a look if you disagree with that trade-off.
- `redirect_to` remains an open redirect to an arbitrary `https:` origin by design; closing that needs the server to hand back an opaque handle instead of a raw URL, which is out of scope here.

## Testing
Unit tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [ ] integration tests
- [x] necessary TSDoc comments
