### PR TITLE
fix(core,experience): expose trusted-device creation request

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.adaptive-mfa.test.ts
@@ -204,7 +204,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         {
           availableFactors: [MfaFactor.TOTP],
           maskedIdentifiers: {},
-          trustedDevice: { canCreate: false },
+          trustedDevice: { canCreate: false, creationRequested: false },
         }
       )
     );
@@ -299,7 +299,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         {
           availableFactors: [MfaFactor.TOTP],
           maskedIdentifiers: {},
-          trustedDevice: { canCreate: false },
+          trustedDevice: { canCreate: false, creationRequested: false },
         }
       )
     );
@@ -965,7 +965,7 @@ describe('ExperienceInteraction adaptive MFA', () => {
         {
           availableFactors: [MfaFactor.TOTP],
           maskedIdentifiers: {},
-          trustedDevice: { canCreate: false },
+          trustedDevice: { canCreate: false, creationRequested: false },
         }
       )
     );

--- a/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.trusted-device.test.ts
@@ -115,7 +115,7 @@ const expectConventionalMfaRequired = async (
 ) => {
   const trustedDevice =
     options?.trustedDevice === undefined
-      ? { canCreate: true, durationDays: 30 }
+      ? { canCreate: true, durationDays: 30, creationRequested: false }
       : options.trustedDevice;
   await expect(experienceInteraction.guardMfaVerificationStatus()).rejects.toMatchError(
     new RequestError(
@@ -202,7 +202,7 @@ describe('ExperienceInteraction trusted-device MFA verification', () => {
     });
 
     await expectConventionalMfaRequired(experienceInteraction, {
-      trustedDevice: { canCreate: false },
+      trustedDevice: { canCreate: false, creationRequested: false },
     });
 
     expect(getEffectivePolicy).toHaveBeenCalledTimes(1);

--- a/packages/core/src/routes/experience/classes/mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/mfa.test.ts
@@ -34,7 +34,7 @@ const createMfa = ({
   },
   currentProfile = {},
   organizations = [],
-  trustedDeviceAvailability = { canCreate: true, durationDays: 30 },
+  trustedDeviceAvailability = { canCreate: true, durationDays: 30, creationRequested: false },
 }: {
   mfaSettings?: MfaSettings;
   interactionEvent?: InteractionEvent;
@@ -185,7 +185,7 @@ describe('Mfa.assertMfaFulfilled', () => {
       status: 422,
       data: {
         availableFactors: [MfaFactor.TOTP],
-        trustedDevice: { canCreate: true, durationDays: 30 },
+        trustedDevice: { canCreate: true, durationDays: 30, creationRequested: false },
       },
     });
   });
@@ -208,7 +208,7 @@ describe('Mfa.assertMfaFulfilled', () => {
       code: 'user.suggest_mfa',
       status: 422,
       data: {
-        trustedDevice: { canCreate: true, durationDays: 30 },
+        trustedDevice: { canCreate: true, durationDays: 30, creationRequested: false },
       },
     });
   });
@@ -246,13 +246,13 @@ describe('Mfa.assertMfaFulfilled', () => {
         organizationRequiredMfaPolicy: OrganizationRequiredMfaPolicy.Mandatory,
       },
       organizations,
-      trustedDeviceAvailability: { canCreate: false },
+      trustedDeviceAvailability: { canCreate: false, creationRequested: false },
     });
 
     await expect(mfa.assertMfaFulfilled()).rejects.toMatchObject({
       code: 'user.missing_mfa',
       data: {
-        trustedDevice: { canCreate: false },
+        trustedDevice: { canCreate: false, creationRequested: false },
       },
     });
     expect(getOrganizationsByUserId).toHaveBeenCalledTimes(1);
@@ -277,6 +277,11 @@ describe('Mfa.assertMfaFulfilled', () => {
         primaryEmail: 'foo@example.com',
         mfaVerifications: [],
       },
+      trustedDeviceAvailability: {
+        canCreate: true,
+        durationDays: 30,
+        creationRequested: true,
+      },
     });
     const { signInExperienceValidator } = mfa as unknown as {
       signInExperienceValidator: SignInExperienceValidator;
@@ -291,7 +296,7 @@ describe('Mfa.assertMfaFulfilled', () => {
       status: 422,
       data: {
         availableFactors: [MfaFactor.TOTP, MfaFactor.EmailVerificationCode],
-        trustedDevice: { canCreate: true, durationDays: 30 },
+        trustedDevice: { canCreate: true, durationDays: 30, creationRequested: true },
       },
     });
     expect(getTrustedDeviceCreationAvailability).toHaveBeenCalledWith('user-id', organizations);

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -102,6 +102,7 @@ describe('Experience trusted-device lifecycle events', () => {
     await expect(creation.subject.getCreationAvailability(userId)).resolves.toEqual({
       canCreate: true,
       durationDays: 30,
+      creationRequested: false,
     });
     await creation.subject.finalize({
       creation: { deviceId: trustedDeviceId },
@@ -125,6 +126,21 @@ describe('Experience trusted-device lifecycle events', () => {
     await expect(creation.subject.requestCreation(userId, true)).resolves.toBeUndefined();
 
     expect(creation.subject.data).toEqual({});
+  });
+
+  it('reports and reuses the interaction creation request', async () => {
+    const creation = createSubject({ data: {} });
+
+    await creation.subject.requestCreation(userId, true);
+    const requestedCreation = creation.subject.data.trustedDeviceCreation;
+    await creation.subject.requestCreation(userId, true);
+
+    expect(creation.subject.data.trustedDeviceCreation).toEqual(requestedCreation);
+    await expect(creation.subject.getCreationAvailability(userId)).resolves.toEqual({
+      canCreate: true,
+      durationDays: 30,
+      creationRequested: true,
+    });
   });
 
   it('retries effective policy resolution after a failed availability lookup', async () => {

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -112,6 +112,7 @@ export class TrustedDevice {
         return {
           canCreate: enabled,
           ...conditional(enabled && { durationDays }),
+          creationRequested: Boolean(this.#creation),
         };
       },
       (error) => {

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -186,6 +186,7 @@ export type InteractionContext = {
 export type TrustedDeviceAvailability = {
   canCreate: boolean;
   durationDays?: number;
+  creationRequested: boolean;
 };
 
 export type ExperienceInteractionRouterContext<ContextT extends WithLogContext = WithLogContext> =

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
@@ -39,7 +39,11 @@ const renderOptIn = (
 
 describe('<TrustedDeviceOptIn />', () => {
   it('shows a default-unchecked checkbox when MFA flow state allows creation', () => {
-    const { container } = renderOptIn({ canCreate: true, durationDays: 30 });
+    const { container } = renderOptIn({
+      canCreate: true,
+      durationDays: 30,
+      creationRequested: false,
+    });
     const checkbox = container.querySelector('[role="checkbox"]');
 
     expect(checkbox).not.toBeNull();
@@ -55,15 +59,19 @@ describe('<TrustedDeviceOptIn />', () => {
   });
 
   it('shows the checkbox when WebAuthn options are included in route state', () => {
-    const { container } = renderOptIn({ canCreate: true, durationDays: 365 }, true, {
-      options: { challenge: 'challenge' },
-    });
+    const { container } = renderOptIn(
+      { canCreate: true, durationDays: 365, creationRequested: false },
+      true,
+      {
+        options: { challenge: 'challenge' },
+      }
+    );
 
     expect(container.querySelector('[role="checkbox"]')).not.toBeNull();
   });
 
   it('stays hidden when MFA flow state disallows creation', () => {
-    const { container } = renderOptIn({ canCreate: false });
+    const { container } = renderOptIn({ canCreate: false, creationRequested: false });
 
     expect(container.querySelector('[role="checkbox"]')).toBeNull();
   });
@@ -75,13 +83,16 @@ describe('<TrustedDeviceOptIn />', () => {
   });
 
   it('stays hidden when an available policy does not include a duration', () => {
-    const { container } = renderOptIn({ canCreate: true });
+    const { container } = renderOptIn({ canCreate: true, creationRequested: false });
 
     expect(container.firstElementChild).toBeNull();
   });
 
   it('stays hidden when the calling page is invalid', () => {
-    const { container } = renderOptIn({ canCreate: true, durationDays: 30 }, false);
+    const { container } = renderOptIn(
+      { canCreate: true, durationDays: 30, creationRequested: false },
+      false
+    );
 
     expect(container.firstElementChild).toBeNull();
   });

--- a/packages/experience/src/hooks/use-mfa-error-handler.test.tsx
+++ b/packages/experience/src/hooks/use-mfa-error-handler.test.tsx
@@ -49,7 +49,9 @@ describe('useMfaErrorHandler', () => {
     const error: RequestErrorBody = {
       code: 'user.suggest_mfa',
       message: 'MFA suggested',
-      data: { trustedDevice: { canCreate: true, durationDays: 30 } },
+      data: {
+        trustedDevice: { canCreate: true, durationDays: 30, creationRequested: false },
+      },
     };
 
     await act(async () => {
@@ -69,7 +71,7 @@ describe('useMfaErrorHandler', () => {
       message: 'MFA is missing',
       data: {
         availableFactors: [MfaFactor.TOTP, MfaFactor.WebAuthn],
-        trustedDevice: { canCreate: true, durationDays: 30 },
+        trustedDevice: { canCreate: true, durationDays: 30, creationRequested: false },
         futureField: 'ignored',
       },
     };
@@ -84,7 +86,7 @@ describe('useMfaErrorHandler', () => {
         replace: undefined,
         state: {
           availableFactors: [MfaFactor.TOTP, MfaFactor.WebAuthn],
-          trustedDevice: { canCreate: true, durationDays: 30 },
+          trustedDevice: { canCreate: true, durationDays: 30, creationRequested: false },
         },
       }
     );

--- a/packages/experience/src/hooks/use-mfa-factors-state.test.tsx
+++ b/packages/experience/src/hooks/use-mfa-factors-state.test.tsx
@@ -14,7 +14,7 @@ const TestHook = () => {
 it('reads and masks MFA flow state nested by the verification-code binding route', () => {
   const mfaFlowState = {
     availableFactors: [MfaFactor.EmailVerificationCode],
-    trustedDevice: { canCreate: true, durationDays: 365 },
+    trustedDevice: { canCreate: true, durationDays: 365, creationRequested: false },
   };
   const { container } = render(
     <MemoryRouter
@@ -38,7 +38,7 @@ it('reads and masks MFA flow state nested by the verification-code binding route
 it('masks page-specific fields from direct MFA flow state', () => {
   const mfaFlowState = {
     availableFactors: [MfaFactor.TOTP, MfaFactor.WebAuthn],
-    trustedDevice: { canCreate: true, durationDays: 30 },
+    trustedDevice: { canCreate: true, durationDays: 30, creationRequested: false },
   };
   const { container } = render(
     <MemoryRouter

--- a/packages/experience/src/hooks/use-trusted-device-opt-in.test.tsx
+++ b/packages/experience/src/hooks/use-trusted-device-opt-in.test.tsx
@@ -21,7 +21,7 @@ it('ignores router-state availability when dev features are disabled', () => {
           pathname: '/',
           state: {
             availableFactors: [MfaFactor.TOTP],
-            trustedDevice: { canCreate: true, durationDays: 30 },
+            trustedDevice: { canCreate: true, durationDays: 30, creationRequested: false },
           },
         },
       ]}

--- a/packages/experience/src/types/guard.test.ts
+++ b/packages/experience/src/types/guard.test.ts
@@ -37,7 +37,7 @@ describe('guard', () => {
           skippable: true,
           suggestion: true,
           isWebAuthnUsedAsSignInPasskey: true,
-          trustedDevice: { canCreate: true, durationDays: 30 },
+          trustedDevice: { canCreate: true, durationDays: 30, creationRequested: false },
         },
         mfaErrorDataGuard
       );

--- a/packages/experience/src/types/guard.ts
+++ b/packages/experience/src/types/guard.ts
@@ -77,6 +77,7 @@ const mfaFactorEnumValues = [
 const trustedDeviceAvailabilityGuard = s.object({
   canCreate: s.boolean(),
   durationDays: s.optional(s.number()),
+  creationRequested: s.boolean(),
 });
 
 const mfaErrorDataShape = {


### PR DESCRIPTION
## Summary

Expose whether trusted-device creation has already been requested through MFA error details.

Add the required `creationRequested` field to the trusted-device availability contract, default it to `false`, and synchronize the built-in Experience type guard and fixtures.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
