### PR TITLE
fix(core,experience): support optional trusted-device submit intent

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -438,9 +438,15 @@ export default class ExperienceInteraction {
     await this.getIdentifiedUser();
   }
 
-  /** Record an explicit trusted-device opt-in after validating eligible MFA proof. */
-  public async requestTrustedDeviceCreation() {
+  /** Update the trusted-device opt-in after validating eligible MFA proof when requested. */
+  public async updateTrustedDeviceCreationRequest(createTrustedDevice: boolean) {
     const user = await this.getIdentifiedUser();
+
+    if (!createTrustedDevice) {
+      this.trustedDevice.cancelCreationRequest();
+      return;
+    }
+
     await this.trustedDevice.requestCreation(
       user.id,
       await this.hasEligibleTrustedDeviceProof(user)
@@ -481,6 +487,9 @@ export default class ExperienceInteraction {
     const { provider } = this.tenant;
     const details = await provider.interactionDetails(this.ctx.req, this.ctx.res);
     const interactionData = this.toJson();
+    const previousResult = Object.fromEntries(
+      Object.entries(details.result ?? {}).filter(([key]) => key !== 'trustedDeviceCreation')
+    );
 
     // `mergeWithLastSubmission` will only merge current request's interaction results.
     // Manually merge with previous interaction results here.
@@ -488,7 +497,7 @@ export default class ExperienceInteraction {
     await provider.interactionResult(
       this.ctx.req,
       this.ctx.res,
-      { ...details.result, ...interactionData },
+      { ...previousResult, ...interactionData },
       { mergeWithLastSubmission: true }
     );
 

--- a/packages/core/src/routes/experience/classes/trusted-device.test.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.test.ts
@@ -143,6 +143,20 @@ describe('Experience trusted-device lifecycle events', () => {
     });
   });
 
+  it('clears the interaction creation request', async () => {
+    const creation = createSubject({ data: {} });
+
+    await creation.subject.requestCreation(userId, true);
+    creation.subject.cancelCreationRequest();
+
+    expect(creation.subject.data).toEqual({});
+    await expect(creation.subject.getCreationAvailability(userId)).resolves.toEqual({
+      canCreate: true,
+      durationDays: 30,
+      creationRequested: false,
+    });
+  });
+
   it('retries effective policy resolution after a failed availability lookup', async () => {
     const error = new Error('policy lookup failed');
     const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();

--- a/packages/core/src/routes/experience/classes/trusted-device.ts
+++ b/packages/core/src/routes/experience/classes/trusted-device.ts
@@ -88,6 +88,10 @@ export class TrustedDevice {
     this.#creation ||= { deviceId: generateStandardId() };
   }
 
+  cancelCreationRequest() {
+    this.#creation = undefined;
+  }
+
   consumeCreationRequest() {
     const creation = this.#creation;
 

--- a/packages/core/src/routes/experience/experience.openapi.json
+++ b/packages/core/src/routes/experience/experience.openapi.json
@@ -103,6 +103,22 @@
         "operationId": "SubmitInteraction",
         "summary": "Submit interaction",
         "description": "Submit the current interaction. <br/>- Submit the verified user identity to the OIDC provider for further authentication (SignIn and Register). <br/>- Update the user's profile data if any (SignIn and Register). <br/>- Reset the password and clear all the interaction records (ForgotPassword).",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "createTrustedDevice": {
+                    "type": "boolean",
+                    "description": "Whether to trust the current device after the interaction succeeds.",
+                    "x-logto-dev-feature": true
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "The interaction has been successfully submitted."

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -581,14 +581,13 @@ describe('POST /experience/submit', () => {
         trustedDevicePolicy: { enabled: true, durationDays: 30 },
       });
 
-      const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
       const response = await requester
         .post('/experience/submit')
+        .send({ createTrustedDevice: true })
         .set('User-Agent', 'Trusted device test browser')
         .set('x-logto-cf-country', 'us')
         .set('x-logto-cf-city', 'Portland');
 
-      expect(optInResponse.status).toBe(204);
       expect(response.status).toBe(200);
       const payload = createCredential.mock.calls[0]?.[0] as
         | {
@@ -636,24 +635,20 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
-    const repeatedOptInResponse = await requester.post('/experience/profile/mfa/trusted-device');
-    const firstSubmitResponse = await requester.post('/experience/submit');
+    const firstSubmitResponse = await requester
+      .post('/experience/submit')
+      .send({ createTrustedDevice: true });
     const retrySubmitResponse = await requester.post('/experience/submit');
 
-    expect(optInResponse.status).toBe(204);
-    expect(repeatedOptInResponse.status).toBe(204);
     expect(firstSubmitResponse.status).toBe(200);
     expect(retrySubmitResponse.status).toBe(200);
     const interactionResultCalls = (provider.interactionResult as jest.Mock).mock.calls;
-    const firstOptInResult = interactionResultCalls[0]?.[2] as Record<string, unknown> | undefined;
-    const repeatedOptInResult = interactionResultCalls[1]?.[2] as
-      | Record<string, unknown>
+    const savedOptInResult = interactionResultCalls[0]?.[2] as Record<string, unknown> | undefined;
+    const firstSubmitResult = interactionResultCalls[1]?.[2] as Record<string, unknown> | undefined;
+    const savedCreation = savedOptInResult?.trustedDeviceCreation as
+      | { deviceId?: unknown }
       | undefined;
-    const firstSubmitResult = interactionResultCalls[2]?.[2] as Record<string, unknown> | undefined;
-    expect(firstOptInResult?.trustedDeviceCreation).toEqual(
-      repeatedOptInResult?.trustedDeviceCreation
-    );
+    expect(typeof savedCreation?.deviceId).toBe('string');
     expect(firstSubmitResult).not.toHaveProperty('trustedDeviceCreation');
     expect(createCredential).toHaveBeenCalledTimes(1);
     expect(createCredential).toHaveBeenCalledWith(expect.objectContaining({ userId: user.id }));
@@ -661,6 +656,41 @@ describe('POST /experience/submit', () => {
       | { deviceId?: unknown }
       | undefined;
     expect(typeof creationPayload?.deviceId).toBe('string');
+  });
+
+  it('should clear a pending trusted-device creation intent from the latest checkbox value', async () => {
+    setDevFeaturesEnabled(true);
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, provider, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        trustedDeviceCreation: { deviceId: 'trusted-device-id' },
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      persistInteractionResult: true,
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+
+    const response = await requester
+      .post('/experience/submit')
+      .send({ createTrustedDevice: false });
+
+    expect(response.status).toBe(200);
+    expect(createCredential).not.toHaveBeenCalled();
+    expect((provider.interactionResult as jest.Mock).mock.calls[0]?.[2]).not.toHaveProperty(
+      'trustedDeviceCreation'
+    );
   });
 
   it('should use one idempotency key for concurrent submits restored from the same interaction', async () => {
@@ -739,7 +769,7 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const response = await requester.post('/experience/profile/mfa/trusted-device');
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
 
     expect(response.status).toBe(403);
     expect(response.body).toMatchObject({ code: 'session.mfa.require_mfa_verification' });
@@ -785,10 +815,10 @@ describe('POST /experience/submit', () => {
         trustedDevicePolicy: { enabled: true, durationDays: 30 },
       });
 
-      const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
-      const response = await requester.post('/experience/submit');
+      const response = await requester
+        .post('/experience/submit')
+        .send({ createTrustedDevice: true });
 
-      expect(optInResponse.status).toBe(204);
       expect(response.status).toBe(200);
       expect(createCredential).toHaveBeenCalledWith(
         expect.objectContaining({ userId: mockUser.id })
@@ -821,7 +851,7 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const response = await requester.post('/experience/profile/mfa/trusted-device');
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
 
     expect(response.status).toBe(403);
     expect(createCredential).not.toHaveBeenCalled();
@@ -849,7 +879,7 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const response = await requester.post('/experience/profile/mfa/trusted-device');
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
 
     expect(response.status).toBe(403);
     expect(createCredential).not.toHaveBeenCalled();
@@ -881,7 +911,7 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const response = await requester.post('/experience/profile/mfa/trusted-device');
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
 
     expect(response.status).toBe(403);
     expect(createCredential).not.toHaveBeenCalled();
@@ -1020,10 +1050,8 @@ describe('POST /experience/submit', () => {
     });
     createCredential.mockRejectedValueOnce(creationError);
 
-    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
-    const response = await requester.post('/experience/submit');
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
 
-    expect(optInResponse.status).toBe(204);
     expect(response.status).toBe(200);
     expect(createCredential).toHaveBeenCalledTimes(1);
     expect(trackException).toHaveBeenCalledWith(creationError, expect.any(Object));
@@ -1060,10 +1088,10 @@ describe('POST /experience/submit', () => {
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
 
-    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
-    const submitResponse = await requester.post('/experience/submit');
+    const submitResponse = await requester
+      .post('/experience/submit')
+      .send({ createTrustedDevice: true });
 
-    expect(optInResponse.status).toBe(204);
     expect(submitResponse.status).toBe(200);
     expect(hasEligibleTrustedDeviceVerification).toHaveBeenCalledTimes(2);
     expect(createCredential).not.toHaveBeenCalled();
@@ -1092,14 +1120,12 @@ describe('POST /experience/submit', () => {
       persistInteractionResult: true,
       trustedDevicePolicy: { enabled: true, durationDays: 30 },
     });
-    const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
-    (provider.interactionResult as jest.Mock).mockRejectedValueOnce(
-      new Error('interaction submission failed')
-    );
+    (provider.interactionResult as jest.Mock)
+      .mockResolvedValueOnce('redirectTo')
+      .mockRejectedValueOnce(new Error('interaction submission failed'));
 
-    const response = await requester.post('/experience/submit');
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
 
-    expect(optInResponse.status).toBe(204);
     expect(response.status).toBe(500);
     expect(createCredential).not.toHaveBeenCalled();
   });
@@ -1165,11 +1191,10 @@ describe('POST /experience/submit', () => {
       });
       expect(bindResponse.status).toBe(204);
 
-      const optInResponse = await requester.post('/experience/profile/mfa/trusted-device');
       const submitResponse = await requester
         .post('/experience/submit')
+        .send({ createTrustedDevice: true })
         .set('x-logto-cf-bot-score', '10');
-      expect(optInResponse.status).toBe(204);
       expect(submitResponse.status).toBe(200);
 
       expect(users.updateUserById).toHaveBeenCalledWith(

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -1057,6 +1057,39 @@ describe('POST /experience/submit', () => {
     expect(trackException).toHaveBeenCalledWith(creationError, expect.any(Object));
   });
 
+  it('should keep submit successful when trusted-device creation intent update fails', async () => {
+    setDevFeaturesEnabled(true);
+    const intentUpdateError = new Error('trusted-device creation intent update failed');
+    const trackException = jest.spyOn(appInsights, 'trackException').mockResolvedValue();
+    const user = {
+      ...mockUser,
+      mfaVerifications: [mockUserTotpMfaVerification],
+    };
+    const { requester, getEffectivePolicy, createCredential } = createRequesterWithMocks({
+      user,
+      mfa: { policy: MfaPolicy.Mandatory, factors: [MfaFactor.TOTP] },
+      interactionResult: {
+        verificationRecords: [
+          {
+            id: 'totp-verification-id',
+            type: VerificationType.TOTP,
+            userId: user.id,
+            verified: true,
+          },
+        ],
+      },
+      persistInteractionResult: true,
+      trustedDevicePolicy: { enabled: true, durationDays: 30 },
+    });
+    getEffectivePolicy.mockRejectedValueOnce(intentUpdateError);
+
+    const response = await requester.post('/experience/submit').send({ createTrustedDevice: true });
+
+    expect(response.status).toBe(200);
+    expect(createCredential).not.toHaveBeenCalled();
+    expect(trackException).toHaveBeenCalledWith(intentUpdateError, expect.any(Object));
+  });
+
   it('should keep submit successful when trusted-device proof eligibility fails', async () => {
     setDevFeaturesEnabled(true);
     const eligibilityError = new Error('trusted-device proof eligibility failed');

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -10,7 +10,9 @@
  * The experience APIs can be used by developers to build custom user interaction experiences.
  */
 
+import { appInsights } from '@logto/app-insights/node';
 import { identificationApiPayloadGuard, InteractionEvent } from '@logto/schemas';
+import { trySafe } from '@silverhand/essentials';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
@@ -19,6 +21,7 @@ import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaInteractionDetails from '#src/middleware/koa-interaction-details.js';
 import assertThat from '#src/utils/assert-that.js';
+import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import { type AnonymousRouter, type RouterInitArgs } from '../types.js';
 
@@ -187,8 +190,19 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
       const log = createLog(`Interaction.${experienceInteraction.interactionEvent}.Submit`);
 
       if (EnvSet.values.isDevFeaturesEnabled && createTrustedDevice !== undefined) {
-        await experienceInteraction.updateTrustedDeviceCreationRequest(createTrustedDevice);
-        await experienceInteraction.save();
+        await trySafe(
+          async () => {
+            await experienceInteraction.updateTrustedDeviceCreationRequest(createTrustedDevice);
+            await experienceInteraction.save();
+          },
+          (error) => {
+            if (error instanceof RequestError) {
+              throw error;
+            }
+
+            void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));
+          }
+        );
       }
 
       await ctx.experienceInteraction.submit(log);

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -14,6 +14,7 @@ import { identificationApiPayloadGuard, InteractionEvent } from '@logto/schemas'
 import type Router from 'koa-router';
 import { z } from 'zod';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import koaInteractionDetails from '#src/middleware/koa-interaction-details.js';
@@ -169,6 +170,9 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
   experienceRouter.post(
     `${experienceRoutes.prefix}/submit`,
     koaGuard({
+      body: z.object({
+        createTrustedDevice: z.boolean().optional(),
+      }),
       status: [200, 400, 403, 404, 422],
       response: z
         .object({
@@ -178,8 +182,14 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
     }),
     async (ctx, next) => {
       const { createLog, experienceInteraction } = ctx;
+      const { createTrustedDevice } = ctx.guard.body;
 
       const log = createLog(`Interaction.${experienceInteraction.interactionEvent}.Submit`);
+
+      if (EnvSet.values.isDevFeaturesEnabled && createTrustedDevice !== undefined) {
+        await experienceInteraction.updateTrustedDeviceCreationRequest(createTrustedDevice);
+        await experienceInteraction.save();
+      }
 
       await ctx.experienceInteraction.submit(log);
 

--- a/packages/core/src/routes/experience/profile-routes.openapi.json
+++ b/packages/core/src/routes/experience/profile-routes.openapi.json
@@ -162,28 +162,6 @@
         }
       }
     },
-    "/api/experience/profile/mfa/trusted-device": {
-      "post": {
-        "operationId": "RequestTrustedDeviceCreation",
-        "summary": "Request trusted device creation",
-        "description": "Record the user's explicit opt-in to trust the current device after eligible MFA verification or binding. The trusted-device credential is created only after the interaction is successfully submitted.",
-        "tags": ["Dev feature"],
-        "responses": {
-          "204": {
-            "description": "The trusted-device creation request has been recorded for the current interaction."
-          },
-          "400": {
-            "description": "Trusted-device creation is not supported for the current interaction event."
-          },
-          "403": {
-            "description": "An eligible MFA verification or binding is required before requesting trusted-device creation."
-          },
-          "404": {
-            "description": "The user has not been identified yet."
-          }
-        }
-      }
-    },
     "/api/experience/profile/mfa/mfa-suggestion-skipped": {
       "post": {
         "operationId": "SkipMfaSuggestion",

--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -12,7 +12,6 @@ import { type MiddlewareType } from 'koa';
 import type Router from 'koa-router';
 import { object, z } from 'zod';
 
-import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { type WithLogContext } from '#src/middleware/koa-audit-log.js';
 import koaGuard from '#src/middleware/koa-guard.js';
@@ -271,25 +270,6 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
       return next();
     }
   );
-
-  // Trusted-device opt-in is under development. Keep the route out of released API surfaces.
-  if (EnvSet.values.isDevFeaturesEnabled) {
-    router.post(
-      `${experienceRoutes.mfa}/trusted-device`,
-      koaGuard({ status: [204, 400, 403, 404] }),
-      verifiedInteractionGuard(),
-      async (ctx, next) => {
-        const { experienceInteraction } = ctx;
-
-        await experienceInteraction.requestTrustedDeviceCreation();
-        await experienceInteraction.save();
-
-        ctx.status = 204;
-
-        return next();
-      }
-    );
-  }
 
   // Mark optional additional MFA binding suggestion as skipped.
   router.post(

--- a/packages/experience/src/apis/experience/interaction.test.ts
+++ b/packages/experience/src/apis/experience/interaction.test.ts
@@ -17,33 +17,31 @@ describe('interaction experience APIs', () => {
     jest.clearAllMocks();
   });
 
-  it('records selected trusted-device intent before submitting the interaction', async () => {
+  it('submits selected trusted-device intent with the interaction', async () => {
     const response = { redirectTo: '/callback' };
     const json = jest.fn().mockResolvedValue(response);
-    mockedApiPost
-      .mockReturnValueOnce({} as ReturnType<typeof api.post>)
-      .mockReturnValueOnce({ json } as unknown as ReturnType<typeof api.post>);
+    mockedApiPost.mockReturnValueOnce({ json } as unknown as ReturnType<typeof api.post>);
 
     await expect(submitInteraction({ createTrustedDevice: true })).resolves.toEqual(response);
 
-    expect(mockedApiPost).toHaveBeenNthCalledWith(1, `${experienceApiRoutes.mfa}/trusted-device`);
-    expect(mockedApiPost).toHaveBeenNthCalledWith(2, experienceApiRoutes.submit);
+    expect(mockedApiPost).toHaveBeenCalledWith(experienceApiRoutes.submit, {
+      json: { createTrustedDevice: true },
+    });
   });
 
-  it('still submits when recording trusted-device intent fails', async () => {
+  it('submits a cleared trusted-device intent with the interaction', async () => {
     const response = { redirectTo: '/callback' };
     const json = jest.fn().mockResolvedValue(response);
-    mockedApiPost
-      .mockRejectedValueOnce(new Error('Failed to record trusted-device intent'))
-      .mockReturnValueOnce({ json } as unknown as ReturnType<typeof api.post>);
+    mockedApiPost.mockReturnValueOnce({ json } as unknown as ReturnType<typeof api.post>);
 
-    await expect(submitInteraction({ createTrustedDevice: true })).resolves.toEqual(response);
+    await expect(submitInteraction({ createTrustedDevice: false })).resolves.toEqual(response);
 
-    expect(mockedApiPost).toHaveBeenNthCalledWith(1, `${experienceApiRoutes.mfa}/trusted-device`);
-    expect(mockedApiPost).toHaveBeenNthCalledWith(2, experienceApiRoutes.submit);
+    expect(mockedApiPost).toHaveBeenCalledWith(experienceApiRoutes.submit, {
+      json: { createTrustedDevice: false },
+    });
   });
 
-  it('submits directly when trusted-device opt-in is not selected', async () => {
+  it('omits trusted-device intent when the current page has no opt-in', async () => {
     const json = jest.fn().mockResolvedValue({ redirectTo: '/callback' });
     mockedApiPost.mockReturnValueOnce({ json } as unknown as ReturnType<typeof api.post>);
 

--- a/packages/experience/src/apis/experience/interaction.ts
+++ b/packages/experience/src/apis/experience/interaction.ts
@@ -3,7 +3,6 @@ import {
   type IdentificationApiPayload,
   type UpdateProfileApiPayload,
 } from '@logto/schemas';
-import { trySafe } from '@silverhand/essentials';
 
 import api from '../api';
 
@@ -28,17 +27,13 @@ export const initInteraction = async (interactionEvent: InteractionEvent, captch
 export const identifyUser = async (payload: IdentificationApiPayload = {}) =>
   api.post(experienceApiRoutes.identification, { json: payload });
 
-const requestTrustedDeviceCreation = async () =>
-  api.post(`${experienceApiRoutes.mfa}/trusted-device`);
+export const submitInteraction = async ({ createTrustedDevice }: SubmitInteractionOptions = {}) => {
+  const request =
+    createTrustedDevice === undefined
+      ? api.post(experienceApiRoutes.submit)
+      : api.post(experienceApiRoutes.submit, { json: { createTrustedDevice } });
 
-export const submitInteraction = async ({
-  createTrustedDevice = false,
-}: SubmitInteractionOptions = {}) => {
-  if (createTrustedDevice) {
-    await trySafe(requestTrustedDeviceCreation);
-  }
-
-  return api.post(experienceApiRoutes.submit).json<SubmitInteractionResponse>();
+  return request.json<SubmitInteractionResponse>();
 };
 
 export const updateProfile = async (payload: UpdateProfileApiPayload) =>

--- a/packages/experience/src/apis/experience/mfa.ts
+++ b/packages/experience/src/apis/experience/mfa.ts
@@ -75,7 +75,7 @@ export const bindMfa = async (
   type: MfaFactor,
   verificationId: string,
   payload?: BindMfaPayload,
-  createTrustedDevice = false
+  createTrustedDevice?: boolean
 ) => {
   if (payload) {
     switch (payload.type) {
@@ -112,7 +112,7 @@ export const bindMfa = async (
 export const verifyMfa = async (
   payload: VerifyMfaPayload,
   verificationId?: string,
-  createTrustedDevice = false
+  createTrustedDevice?: boolean
 ) => {
   switch (payload.type) {
     case MfaFactor.TOTP: {
@@ -161,7 +161,7 @@ export const verifyMfaByVerificationCode = async (
   verificationId: string,
   code: string,
   identifierType: SignInIdentifier.Email | SignInIdentifier.Phone,
-  createTrustedDevice = false
+  createTrustedDevice?: boolean
 ) => {
   await api.post(`${experienceApiRoutes.verification}/mfa-verification-code/verify`, {
     json: { verificationId, code, identifierType },


### PR DESCRIPTION
## Summary

Support optional trusted-device intent directly in interaction submission.

Treat an omitted `createTrustedDevice` value as no state change, `true` as an opt-in request, and `false` as an explicit cancellation. Remove the standalone opt-in endpoint, preserve `undefined` in the Experience API helpers, and update the OpenAPI contract.

## Testing

Unit tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
