### PR TITLE
fix(experience): preserve trusted-device opt-in state

### DIFF
--- a/packages/experience/src/containers/MfaCodeVerification/index.test.tsx
+++ b/packages/experience/src/containers/MfaCodeVerification/index.test.tsx
@@ -39,6 +39,7 @@ const renderVerification = (isVisible: boolean) => {
     durationDays: isVisible ? 30 : undefined,
     isChecked: false,
     setIsChecked: jest.fn(),
+    createTrustedDevice: isVisible ? false : undefined,
   });
   mockedUseMfaCodeVerification.mockReturnValue({ errorMessage: undefined, onSubmit });
   mockedUseResendMfaVerificationCode.mockReturnValue({

--- a/packages/experience/src/containers/MfaCodeVerification/index.tsx
+++ b/packages/experience/src/containers/MfaCodeVerification/index.tsx
@@ -28,7 +28,7 @@ const MfaCodeVerification = ({ identifierType, verificationId }: Props) => {
   const [codeInput, setCodeInput] = useState<string[]>([]);
   const [inputErrorMessage, setInputErrorMessage] = useState<string>();
   const [currentVerificationId, setCurrentVerificationId] = useState(verificationId);
-  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn();
+  const { durationDays, isChecked, setIsChecked, createTrustedDevice } = useTrustedDeviceOptIn();
   const isTrustedDeviceOptInVisible = Boolean(durationDays);
 
   useEffect(() => {
@@ -43,7 +43,7 @@ const MfaCodeVerification = ({ identifierType, verificationId }: Props) => {
   const { errorMessage: submitErrorMessage, onSubmit } = useMfaCodeVerification(
     identifierType,
     currentVerificationId,
-    isChecked,
+    createTrustedDevice,
     errorCallback
   );
 

--- a/packages/experience/src/containers/MfaCodeVerification/use-mfa-code-verification.ts
+++ b/packages/experience/src/containers/MfaCodeVerification/use-mfa-code-verification.ts
@@ -13,7 +13,7 @@ import useGeneralVerificationCodeErrorHandler from '../VerificationCode/use-gene
 const useMfaCodeVerification = (
   identifierType: SignInIdentifier.Email | SignInIdentifier.Phone,
   verificationId: string,
-  createTrustedDevice: boolean,
+  createTrustedDevice: boolean | undefined,
   errorCallback?: () => void
 ) => {
   const [errorMessage, setErrorMessage] = useState<string>();

--- a/packages/experience/src/containers/TotpCodeVerification/index.test.tsx
+++ b/packages/experience/src/containers/TotpCodeVerification/index.test.tsx
@@ -36,6 +36,7 @@ const renderVerification = (isVisible: boolean) => {
     durationDays: isVisible ? 30 : undefined,
     isChecked: false,
     setIsChecked: jest.fn(),
+    createTrustedDevice: isVisible ? false : undefined,
   });
   mockedUseTotpCodeVerification.mockReturnValue({ errorMessage: undefined, onSubmit });
 
@@ -63,7 +64,7 @@ describe('<TotpCodeVerification />', () => {
     fireEvent.click(getByRole('button', { name: 'Fill code' }));
 
     await waitFor(() => {
-      expect(onSubmit).toBeCalledWith('123456', { flow: UserMfaFlow.MfaVerification }, false);
+      expect(onSubmit).toBeCalledWith('123456', { flow: UserMfaFlow.MfaVerification }, undefined);
     });
   });
 });

--- a/packages/experience/src/containers/TotpCodeVerification/index.tsx
+++ b/packages/experience/src/containers/TotpCodeVerification/index.tsx
@@ -37,7 +37,7 @@ const TotpCodeVerification = <T extends UserMfaFlow>(props: Props<T>) => {
   }, []);
 
   const { errorMessage: submitErrorMessage, onSubmit } = useTotpCodeVerification(errorCallback);
-  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn();
+  const { durationDays, isChecked, setIsChecked, createTrustedDevice } = useTrustedDeviceOptIn();
   const isTrustedDeviceOptInVisible = Boolean(durationDays);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -53,10 +53,10 @@ const TotpCodeVerification = <T extends UserMfaFlow>(props: Props<T>) => {
       setInputErrorMessage(undefined);
       setIsSubmitting(true);
 
-      await onSubmit(code.join(''), props, isChecked);
+      await onSubmit(code.join(''), props, createTrustedDevice);
       setIsSubmitting(false);
     },
-    [isChecked, isSubmitting, onSubmit, props]
+    [createTrustedDevice, isSubmitting, onSubmit, props]
   );
 
   return (

--- a/packages/experience/src/containers/TotpCodeVerification/use-totp-code-verification.ts
+++ b/packages/experience/src/containers/TotpCodeVerification/use-totp-code-verification.ts
@@ -24,7 +24,7 @@ const useTotpCodeVerification = (errorCallback?: () => void) => {
       payload:
         | { flow: UserMfaFlow.MfaBinding; verificationId: string }
         | { flow: UserMfaFlow.MfaVerification },
-      createTrustedDevice: boolean
+      createTrustedDevice: boolean | undefined
     ) => {
       await sendMfaPayload(
         { payload: { type: MfaFactor.TOTP, code }, createTrustedDevice, ...payload },

--- a/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
+++ b/packages/experience/src/containers/TrustedDeviceOptIn/index.test.tsx
@@ -58,6 +58,25 @@ describe('<TrustedDeviceOptIn />', () => {
     expect(checkbox?.getAttribute('aria-checked')).toBe('true');
   });
 
+  it('shows a checked checkbox when creation was requested earlier in the interaction', () => {
+    const { container } = renderOptIn({
+      canCreate: true,
+      durationDays: 30,
+      creationRequested: true,
+    });
+    const checkbox = container.querySelector('[role="checkbox"]');
+
+    expect(checkbox?.getAttribute('aria-checked')).toBe('true');
+
+    act(() => {
+      if (checkbox) {
+        fireEvent.click(checkbox);
+      }
+    });
+
+    expect(checkbox?.getAttribute('aria-checked')).toBe('false');
+  });
+
   it('shows the checkbox when WebAuthn options are included in route state', () => {
     const { container } = renderOptIn(
       { canCreate: true, durationDays: 365, creationRequested: false },

--- a/packages/experience/src/containers/VerificationCode/index.tsx
+++ b/packages/experience/src/containers/VerificationCode/index.tsx
@@ -34,7 +34,7 @@ const VerificationCode = ({
   const [inputErrorMessage, setInputErrorMessage] = useState<string>();
 
   const { t } = useTranslation();
-  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn(
+  const { durationDays, isChecked, setIsChecked, createTrustedDevice } = useTrustedDeviceOptIn(
     flow === UserFlow.Continue
   );
   const isTrustedDeviceOptInVisible = Boolean(durationDays);
@@ -55,7 +55,7 @@ const VerificationCode = ({
     errorMessage: submitErrorMessage,
     clearErrorMessage,
     onSubmit,
-  } = useVerificationCode(identifier, verificationId, errorCallback, isChecked);
+  } = useVerificationCode(identifier, verificationId, errorCallback, createTrustedDevice);
 
   const errorMessage = inputErrorMessage ?? submitErrorMessage;
 

--- a/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
+++ b/packages/experience/src/containers/VerificationCode/use-continue-flow-code-verification.ts
@@ -29,7 +29,7 @@ const useContinueFlowCodeVerification = (
   identifier: VerificationCodeIdentifier,
   verificationId: string,
   errorCallback?: () => void,
-  createTrustedDevice = false
+  createTrustedDevice?: boolean
 ) => {
   const [searchParameters] = useSearchParams();
   const redirectTo = useGlobalRedirectTo();

--- a/packages/experience/src/hooks/use-trusted-device-opt-in.ts
+++ b/packages/experience/src/hooks/use-trusted-device-opt-in.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { isDevFeaturesEnabled } from '@/constants/env';
 import useMfaFlowState from '@/hooks/use-mfa-factors-state';
@@ -7,12 +7,17 @@ const useTrustedDeviceOptIn = (isEnabled = true) => {
   const flowState = useMfaFlowState();
   const availability = isDevFeaturesEnabled && isEnabled ? flowState?.trustedDevice : undefined;
   const durationDays = availability?.canCreate ? availability.durationDays : undefined;
-  const [isChecked, setIsChecked] = useState(false);
+  const [isChecked, setIsChecked] = useState(availability?.creationRequested ?? false);
+
+  useEffect(() => {
+    setIsChecked(availability?.creationRequested ?? false);
+  }, [availability?.creationRequested]);
 
   return {
     durationDays,
     isChecked,
     setIsChecked,
+    createTrustedDevice: durationDays ? isChecked : undefined,
   };
 };
 

--- a/packages/experience/src/hooks/use-webauthn-operation.ts
+++ b/packages/experience/src/hooks/use-webauthn-operation.ts
@@ -39,7 +39,7 @@ const useWebAuthnOperation = () => {
      * Therefore, we should avoid asynchronous operations before invoking the WebAuthn API or the os may consider the WebAuthn authorization is not initiated by the user.
      * So, we need to prepare the necessary WebAuthn options before calling the WebAuthn API, this is why we don't generate the options in this function.
      */
-    async (options: WebAuthnOptions, verificationId: string, createTrustedDevice = false) => {
+    async (options: WebAuthnOptions, verificationId: string, createTrustedDevice?: boolean) => {
       if (!browserSupportsWebAuthn()) {
         setToast(t('mfa.webauthn_not_supported'));
         return;

--- a/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
+++ b/packages/experience/src/pages/MfaBinding/WebAuthnBinding/index.tsx
@@ -30,7 +30,8 @@ const WebAuthnBinding = () => {
   );
 
   const handleWebAuthn = useWebAuthnOperation();
-  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn(isSessionValid);
+  const { durationDays, isChecked, setIsChecked, createTrustedDevice } =
+    useTrustedDeviceOptIn(isSessionValid);
   const skipMfa = useSkipMfa();
   const skipOptionalMfa = useSkipOptionalMfa();
   const [isCreatingPasskey, setIsCreatingPasskey] = useState(false);
@@ -63,7 +64,7 @@ const WebAuthnBinding = () => {
         isLoading={isCreatingPasskey}
         onClick={async () => {
           setIsCreatingPasskey(true);
-          await handleWebAuthn(options, verificationId, isChecked);
+          await handleWebAuthn(options, verificationId, createTrustedDevice);
           setIsCreatingPasskey(false);
         }}
       />

--- a/packages/experience/src/pages/MfaVerification/WebAuthnVerification/index.tsx
+++ b/packages/experience/src/pages/MfaVerification/WebAuthnVerification/index.tsx
@@ -28,7 +28,8 @@ const WebAuthnVerification = () => {
   );
 
   const handleWebAuthn = useWebAuthnOperation();
-  const { durationDays, isChecked, setIsChecked } = useTrustedDeviceOptIn(isSessionValid);
+  const { durationDays, isChecked, setIsChecked, createTrustedDevice } =
+    useTrustedDeviceOptIn(isSessionValid);
   const [isVerifying, setIsVerifying] = useState(false);
 
   if (!webAuthnState || !verificationId) {
@@ -59,7 +60,7 @@ const WebAuthnVerification = () => {
           isLoading={isVerifying}
           onClick={async () => {
             setIsVerifying(true);
-            await handleWebAuthn(options, verificationId, isChecked);
+            await handleWebAuthn(options, verificationId, createTrustedDevice);
             setIsVerifying(false);
           }}
         />

--- a/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
@@ -134,29 +134,34 @@ describe('Experience - suggest additional MFA after email registration', () => {
         },
         trustedDevice: { enabled: true, durationDays: 365 },
       });
-      const { user, userProfile } = await generateNewUser({
-        primaryEmail: true,
-        password: true,
-      });
-      const experience = new ExpectTotpExperience(await browser.newPage());
 
-      await experience.startWith(demoAppUrl, 'sign-in');
-      await experience.toFillForm(
-        { identifier: userProfile.primaryEmail, password: userProfile.password },
-        { submit: true }
-      );
-      await experience.waitForPathname(`mfa-verification/${MfaFactor.EmailVerificationCode}`);
-      await experience.toOptInTrustedDevice();
-      await experience.toCompleteMfaVerification(ConnectorType.Email, true);
+      try {
+        const { user, userProfile } = await generateNewUser({
+          primaryEmail: true,
+          password: true,
+        });
+        const experience = new ExpectTotpExperience(await browser.newPage());
 
-      await experience.waitForPathname('mfa-binding');
-      await experience.toClick('button', 'Authenticator app OTP');
-      await experience.waitForPathname(`mfa-binding/${MfaFactor.TOTP}`);
-      await experience.toSeeTrustedDeviceOptedIn();
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.primaryEmail, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.waitForPathname(`mfa-verification/${MfaFactor.EmailVerificationCode}`);
+        await experience.toOptInTrustedDevice();
+        await experience.toCompleteMfaVerification(ConnectorType.Email, true);
 
-      await experience.toBindTotp();
-      await experience.verifyThenEnd();
-      await deleteUser(user.id);
+        await experience.waitForPathname('mfa-binding');
+        await experience.toClick('button', 'Authenticator app OTP');
+        await experience.waitForPathname(`mfa-binding/${MfaFactor.TOTP}`);
+        await experience.toSeeTrustedDeviceOptedIn();
+
+        await experience.toBindTotp(true, true);
+        await experience.verifyThenEnd();
+        await deleteUser(user.id);
+      } finally {
+        await updateSignInExperience({ trustedDevice: { enabled: false } });
+      }
     }
   );
 

--- a/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/suggest-binding-additional-factor.test.ts
@@ -6,10 +6,11 @@ import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { demoAppUrl } from '#src/constants.js';
 import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connector.js';
 import { resetMfaSettings } from '#src/helpers/sign-in-experience.js';
+import { generateNewUser } from '#src/helpers/user.js';
 import ExpectMfaExperience from '#src/ui-helpers/expect-mfa-experience.js';
 import ExpectTotpExperience from '#src/ui-helpers/expect-totp-experience.js';
 import ExpectWebAuthnExperience from '#src/ui-helpers/expect-webauthn-experience.js';
-import { generateEmail, generateUsername } from '#src/utils.js';
+import { devFeatureTest, generateEmail, generateUsername } from '#src/utils.js';
 
 describe('Experience - suggest additional MFA after email registration', () => {
   beforeAll(async () => {
@@ -122,6 +123,42 @@ describe('Experience - suggest additional MFA after email registration', () => {
     await experience.verifyThenEnd();
     await deleteUser(userId);
   });
+
+  devFeatureTest.it(
+    'keeps trusted-device opt-in selected when suggesting another factor',
+    async () => {
+      await updateSignInExperience({
+        mfa: {
+          factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
+          policy: MfaPolicy.Mandatory,
+        },
+        trustedDevice: { enabled: true, durationDays: 365 },
+      });
+      const { user, userProfile } = await generateNewUser({
+        primaryEmail: true,
+        password: true,
+      });
+      const experience = new ExpectTotpExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.primaryEmail, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitForPathname(`mfa-verification/${MfaFactor.EmailVerificationCode}`);
+      await experience.toOptInTrustedDevice();
+      await experience.toCompleteMfaVerification(ConnectorType.Email, true);
+
+      await experience.waitForPathname('mfa-binding');
+      await experience.toClick('button', 'Authenticator app OTP');
+      await experience.waitForPathname(`mfa-binding/${MfaFactor.TOTP}`);
+      await experience.toSeeTrustedDeviceOptedIn();
+
+      await experience.toBindTotp();
+      await experience.verifyThenEnd();
+      await deleteUser(user.id);
+    }
+  );
 
   it('when Email, TOTP and Backup Code are available: skipping TOTP suggestion requires Backup Code', async () => {
     await updateSignInExperience({

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -308,6 +308,11 @@ export default class ExpectExperience extends ExpectPage {
     await this.toMatchElement('div[role=checkbox][aria-checked=true]', { text });
   }
 
+  async toSeeTrustedDeviceOptedIn(durationDays = 365) {
+    const text = `Trust this device for ${durationDays} days`;
+    await this.toMatchElement('div[role=checkbox][aria-checked=true]', { text });
+  }
+
   /**
    * Optionally click the "Continue with [social name]" button on the page, then process the social
    * sign-in flow with the given user social data.


### PR DESCRIPTION
## Summary

Keep the trusted-device opt-in value synchronized across multi-step MFA flows.

Initialize eligible checkboxes from the interaction's existing creation request, submit the latest visible checkbox value from Email, SMS, TOTP, and WebAuthn flows, and omit the value from pages without an opt-in. Add component and browser regression coverage for an additional-factor flow.

## Testing

Unit tests
Integration tests

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
