### PR TITLE
fix(connector): clarify apple connector services id configuration

### DIFF
--- a/.changeset/apple-services-id-clarity.md
+++ b/.changeset/apple-services-id-clarity.md
@@ -1,0 +1,9 @@
+---
+"@logto/connector-apple": patch
+---
+
+clarify that the Apple connector's identifier is a Services ID
+
+The connector's identifier field is now labeled "Services ID" and states that an App ID (bundle ID) is not a valid value, which Apple rejects with an `invalid_client` error.
+
+Setup instructions cover the Apple Developer portal, so enabling Sign in with Apple no longer appears to require Xcode. Troubleshooting guidance explains `invalid_client` and `invalid_request`, including Apple's caching of identifier configuration, which has been observed to take up to 24 hours to refresh and can make a correct configuration look broken.

--- a/packages/connectors/connector-apple/README.md
+++ b/packages/connectors/connector-apple/README.md
@@ -11,13 +11,17 @@ The official Logto connector for Apple social sign-in.
 - [Configure scope](#configure-scope)
   - [Pitfalls of configuring scope](#pitfalls-of-configuring-scope)
 - [Test Apple connector](#test-apple-connector)
+- [Troubleshooting](#troubleshooting)
+  - [Apple caches your App ID and Services ID configuration](#apple-caches-your-app-id-and-services-id-configuration)
+  - [`invalid_client`](#invalid_client)
+  - [`invalid_request` with "Invalid web redirect url"](#invalid_request-with-invalid-web-redirect-url)
 
 ## Get started
 
 If you don't know the concept of the connector or don't know how to add this connector to your Sign-in experience, please see [Logto tutorial](https://docs.logto.io/docs/tutorials/get-started/enable-social-sign-in).
 
 > ℹ️ **Note**
-> 
+>
 > Apple sign-in is required for AppStore if you have other social sign-in methods in your app.
 > Having Apple sign-in on Android devices is great if you also provide an Android app.
 
@@ -26,10 +30,21 @@ You need to enroll [Apple Developer Program](https://developer.apple.com/program
 ### Enable Sign in with Apple for your app
 
 > ⚠️ **Caution**
-> 
+>
 > Even if you want to implement Sign in with Apple on a web app only, you still need to have an existing app that embraces the AppStore ecosystem (i.e., have a valid App ID).
 
-You can do it via Xcode -> Project settings -> Signing & Capabilities, or visit [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list/bundleId).
+You do not need Xcode for this, or for any other step in this guide. Everything can be done from the Apple Developer portal.
+
+**Option A: Apple Developer portal (no Xcode needed)**
+
+1. Visit [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list/bundleId) and make sure the filter dropdown on the top right is set to "App IDs".
+2. Click the App ID you want to use, or click the "+" button next to "Identifiers" to register a new one.
+3. On the "Capabilities" tab, check "Sign In with Apple". It is enabled as a primary App ID by default, which is what a Services ID groups under. Use the "Edit" button next to the capability to check or change this.
+4. Click "Save" on the top right.
+
+**Option B: Xcode**
+
+Project settings -> Signing & Capabilities.
 
 ![Enable Sign in with Apple](/packages/connectors/connector-apple/docs/enable-sign-in-with-apple-in-xcode.png)
 
@@ -57,17 +72,19 @@ Enter the domain of your Logto instance without protocol and port, e.g., `your.l
 Click "Next" then "Done" to close the modal. Click "Continue" on the top-right corner, then click "Save" to save your configuration.
 
 > ⚠️ **Caution**
-> 
+>
 > Apple does NOT allow Return URLs with HTTP protocol and `localhost` domain.
-> 
+>
 > If you want to test locally, you need to edit `/etc/hosts` file to map localhost to a custom domain and set up a local HTTPS environment. [mkcert](https://github.com/FiloSottile/mkcert) can help you for setting up local HTTPS.
+
+Finally, go back to the Apple connector in Logto Console and paste this identifier into the "Services ID" field, e.g., `io.logto.test`. This must be the Services ID you just configured, not your App ID (bundle ID).
 
 ## Configure scope
 
 To get user's email from Apple, you need to configure the scope to include `email`. For both email and name, you can use `name email` as the scope. See [Apple official docs](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/incorporating_sign_in_with_apple_into_other_platforms#3332113) for more info.
 
 > ℹ️ **Note**
-> 
+>
 > The user may choose to hide their email address from your app. In this case, you will not be able to retrieve the real email address. An email address like `random@privaterelay.appleid.com` will be returned instead.
 
 ### Pitfalls of configuring scope
@@ -83,3 +100,38 @@ See developer discussion [here](https://forums.developer.apple.com/forums/thread
 ## Test Apple connector
 
 That's it. The Apple connector should be available in both web and native apps. Don't forget to [Enable connector in sign-in experience](https://docs.logto.io/docs/recipes/configure-connectors/social-connector/enable-social-sign-in/).
+
+## Troubleshooting
+
+### Apple caches your App ID and Services ID configuration
+
+> ⚠️ **Caution**
+>
+> Apple caches the Sign in with Apple configuration of your identifiers on their side. Changes to an App ID or a Services ID are not always picked up immediately, and have been observed to take up to 24 hours to take effect.
+
+This is a common reason why a configuration that looks entirely correct still fails. If you have checked everything below and it still does not work, wait and try again before changing anything else. Repeatedly editing the configuration does not speed up the refresh.
+
+If it is still failing well after 24 hours, [contact Apple Developer Support](https://developer.apple.com/contact/) and ask them to refresh the cached configuration of your identifier. They can clear the stale entry on their side.
+
+### `invalid_client`
+
+Apple shows this when it cannot resolve your `client_id` into a usable Sign in with Apple web client. An unregistered or mismatched Return URL surfaces as a different error (see below), so `invalid_client` points at the identifier rather than at the redirect URI.
+
+Check the following, in order:
+
+1. **Wait for Apple's cache to refresh.** See the section above.
+2. **Check the "Services ID" field in Logto.** It must hold the Services ID identifier, not your App ID (bundle ID). The App ID is not a valid `client_id` for the web flow.
+3. **Make sure the Services ID configuration was saved.** Reopen the Services ID in the Apple Developer portal and confirm your domain and Return URL are still listed. If they are gone, the "Done" -> "Continue" -> "Save" sequence was not completed and nothing was persisted.
+
+### `invalid_request` with "Invalid web redirect url"
+
+Your Return URL is not registered on the Services ID, or it does not match exactly.
+
+Logto builds the redirect URI from the domain that serves your sign-in experience, so if you use a custom domain, register both your default Logto domain and your custom domain, as "Domains and Subdomains" and again as "Return URLs":
+
+| Domains and Subdomains  | Return URLs                                             |
+| ----------------------- | ------------------------------------------------------- |
+| `your-tenant.logto.app` | `https://your-tenant.logto.app/callback/<connector-id>` |
+| `auth.your-domain.com`  | `https://auth.your-domain.com/callback/<connector-id>`  |
+
+Copy the redirect URIs from the connector page in Logto Console instead of typing them by hand. The connector ID is a randomly generated string, and a single wrong character produces the same error.

--- a/packages/connectors/connector-apple/src/constant.ts
+++ b/packages/connectors/connector-apple/src/constant.ts
@@ -31,8 +31,10 @@ export const defaultMetadata: ConnectorMetadata = {
       key: 'clientId',
       type: ConnectorConfigFormItemType.Text,
       required: true,
-      label: 'Identifier',
-      placeholder: '<your-registered-identifier>',
+      label: 'Services ID',
+      placeholder: 'com.your-company.your-service',
+      tooltip:
+        "The Services ID identifier registered in your Apple Developer account. This is not your app's App ID (bundle ID); using the App ID here makes Apple reject the sign-in request with an `invalid_client` error.",
     },
     {
       key: 'scope',


### PR DESCRIPTION
## Summary

The Apple connector's `Identifier` field gave no indication that it must be an Apple **Services ID**, and the setup guide illustrated the App ID step with an Xcode screenshot, which is not actionable for web-only developers. Both came out of a community report where the identifier was correct and Apple still returned `invalid_client`.

### What changed

- `src/constant.ts` — renamed the `clientId` form item's label from `Identifier` to `Services ID`, replaced the placeholder with a concrete reverse-DNS example, and added a tooltip stating that an App ID (bundle ID) is not a valid value. The config key is unchanged, so existing connector configs are unaffected.
- `README.md` — the App ID step now leads with a four-step Apple Developer portal walkthrough and demotes Xcode to a second option, so the setup no longer reads as if Xcode were required. Added a closing line pointing at where the Services ID goes in Console.
- `README.md` — new Troubleshooting section covering `invalid_client` and `invalid_request`, plus the domain/return-URL pairs to register when a custom domain is in use.

### Expected result

The connector form now names the value Apple calls it, and the tooltip rules out the most common wrong value at the point of entry rather than after a failed sign-in.

### Reviewer notes

- "Services ID" is correct for every flow this connector supports. `clientId` is used both as `client_id` in the authorize URL and as the expected `audience` when verifying the ID token, and there is no native bundle-ID path in core — so there is exactly one valid value.
- The Troubleshooting section leads with Apple caching the Sign in with Apple configuration of an identifier, which has been observed to take up to 24 hours to refresh and makes a correct configuration look broken. This was the actual cause in the reported case, resolved by Apple Support clearing the stale entry. Apple does not document a TTL, so it is worded as observed behavior rather than a guarantee.
- Existing headings are unchanged so external documentation anchors keep resolving.
- The diff includes ~5 whitespace-only lines where Prettier stripped pre-existing trailing spaces from blockquotes in this file.

## Testing

N/A

## Checklist

- [x] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
