### PR TITLE
test: cover trusted device opt-in flow

### DIFF
--- a/end-user-flows/sign-in-flow.md
+++ b/end-user-flows/sign-in-flow.md
@@ -187,8 +187,19 @@ flowchart TD
     backup_gate -->|yes| backup[Generate and save backup codes]
   end
 
-  mfa_on2 -->|no| submit[Submit interaction]
-  backup_gate -->|no| submit
-  backup --> submit
+  subgraph TrustedDeviceOptIn["Trusted device opt-in"]
+    trusted_device_gate{Trusted-device policy enabled<br/>and eligible MFA proof present?}
+    trusted_device_gate -->|yes| trusted_device_page[Trust this device page]
+    trusted_device_page --> trusted_device_decision{Trust this device?}
+    trusted_device_decision -->|yes| trusted_device_accept[Record opt-in]
+    trusted_device_decision -->|skip| trusted_device_skip[Record skip]
+  end
+
+  mfa_on2 -->|no| trusted_device_gate
+  backup_gate -->|no| trusted_device_gate
+  backup --> trusted_device_gate
+  trusted_device_gate -->|no| submit[Submit interaction]
+  trusted_device_accept --> submit
+  trusted_device_skip --> submit
   submit --> done([OIDC redirect])
 ```

--- a/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/email/index.test.ts
@@ -1,5 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInIdentifier } from '@logto/schemas';
+import { MfaFactor, MfaPolicy, SignInIdentifier } from '@logto/schemas';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -8,7 +8,14 @@ import { clearConnectorsByTypes, setEmailConnector } from '#src/helpers/connecto
 import { enableMandatoryMfaWithEmail, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
-import { generateEmail, generatePassword, generateUsername, waitFor } from '#src/utils.js';
+import ExpectTotpExperience from '#src/ui-helpers/expect-totp-experience.js';
+import {
+  devFeatureTest,
+  generateEmail,
+  generatePassword,
+  generateUsername,
+  waitFor,
+} from '#src/utils.js';
 
 describe('email MFA binding', () => {
   beforeAll(async () => {
@@ -79,5 +86,125 @@ describe('email MFA binding', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('creates a trusted device from email MFA binding and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.EmailVerificationCode}`);
+      await experience.toFillInput('identifier', generateEmail(), { submit: true });
+      await experience.toCompleteVerification('continue', ConnectorType.Email);
+      await experience.toClickButton('Continue');
+      await experience.toOptInTrustedDevice();
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('creates a trusted device from email MFA verification and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({
+        username: true,
+        password: true,
+        primaryEmail: true,
+      });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.EmailVerificationCode}`);
+      await experience.toCompleteMfaVerification(ConnectorType.Email);
+      await experience.toOptInTrustedDevice();
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('shows trusted-device opt-in after email verification and additional TOTP binding', async () => {
+      await updateSignInExperience({
+        signUp: {
+          identifiers: [SignInIdentifier.Email],
+          password: true,
+          verify: true,
+        },
+        mfa: {
+          factors: [MfaFactor.EmailVerificationCode, MfaFactor.TOTP],
+          policy: MfaPolicy.Mandatory,
+        },
+      });
+
+      const { userProfile, user } = await generateNewUser({
+        username: true,
+        password: true,
+        primaryEmail: true,
+      });
+      const experience = new ExpectTotpExperience(await browser.newPage());
+
+      try {
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.waitToBeAt(`mfa-verification/${MfaFactor.EmailVerificationCode}`);
+        await experience.toCompleteMfaVerification(ConnectorType.Email);
+
+        await experience.waitToBeAt('mfa-binding');
+        await experience.toClick('button div[class$=name]', 'Authenticator app OTP');
+        await experience.toBindTotp(false);
+
+        await experience.toOptInTrustedDevice();
+        await experience.verifyThenEnd(false);
+        await experience.clearDemoAppSession();
+      } finally {
+        await experience.page.close();
+        await deleteUser(user.id);
+        await enableMandatoryMfaWithEmail();
+        await updateSignInExperience({
+          signUp: {
+            identifiers: [SignInIdentifier.Username],
+            password: true,
+            verify: false,
+          },
+        });
+      }
+    });
   });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/multi-factors.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/multi-factors.test.ts
@@ -8,7 +8,7 @@ import { clearConnectorsByTypes, setSocialConnector } from '#src/helpers/connect
 import { resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectWebAuthnExperience from '#src/ui-helpers/expect-webauthn-experience.js';
-import { waitFor } from '#src/utils.js';
+import { devFeatureTest, waitFor } from '#src/utils.js';
 
 describe('MFA - Multi factors', () => {
   beforeAll(async () => {
@@ -108,5 +108,63 @@ describe('MFA - Multi factors', () => {
     await experience.clearVirtualAuthenticator();
     await experience.verifyThenEnd();
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in after switching factors', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('shows one trusted-device step and honors a persisted skip on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt('mfa-binding');
+
+      await experience.toClick('button div[class$=name]', 'Authenticator app OTP');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.TOTP}`);
+      await experience.toClickSwitchFactorsLink({ isBinding: true });
+
+      await experience.toClick('button div[class$=name]', 'Passkey');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.WebAuthn}`);
+      await experience.toClickSwitchFactorsLink({ isBinding: true });
+
+      await experience.toClick('button div[class$=name]', 'Authenticator app OTP');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.TOTP}`);
+      await experience.toClickSwitchFactorsLink({ isBinding: true });
+
+      await experience.toClick('button div[class$=name]', 'Passkey');
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.WebAuthn}`);
+      await experience.toCreatePasskey();
+      await experience.toClickButton('Continue');
+      await experience.toSkipTrustedDevice();
+      await experience.verifyThenEnd(false);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.WebAuthn}`);
+      await experience.toClickSwitchFactorsLink({ isBinding: false });
+
+      await experience.toClick('button div[class$=name]', 'Passkey');
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.WebAuthn}`);
+      await experience.toVerifyViaPasskey();
+
+      await experience.clearVirtualAuthenticator();
+      await experience.verifyThenEnd();
+      await deleteUser(user.id);
+    });
   });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/phone/index.test.ts
@@ -1,5 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { SignInIdentifier } from '@logto/schemas';
+import { MfaFactor, SignInIdentifier } from '@logto/schemas';
 
 import { deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
@@ -8,7 +8,13 @@ import { clearConnectorsByTypes, setSmsConnector } from '#src/helpers/connector.
 import { enableMandatoryMfaWithPhone, resetMfaSettings } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectExperience from '#src/ui-helpers/expect-experience.js';
-import { generatePassword, generatePhone, generateUsername, waitFor } from '#src/utils.js';
+import {
+  devFeatureTest,
+  generatePhone,
+  generatePassword,
+  generateUsername,
+  waitFor,
+} from '#src/utils.js';
 
 describe('phone MFA binding', () => {
   beforeAll(async () => {
@@ -79,5 +85,75 @@ describe('phone MFA binding', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('creates a trusted device from phone MFA binding and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.PhoneVerificationCode}`);
+      await experience.toFillInput('identifier', generatePhone(), { submit: true });
+      await experience.toCompleteVerification('continue', ConnectorType.Sms);
+      await experience.toClickButton('Continue');
+      await experience.toOptInTrustedDevice();
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('creates a trusted device from phone MFA verification and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({
+        username: true,
+        password: true,
+        primaryPhone: true,
+      });
+      const experience = new ExpectExperience(await browser.newPage());
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.PhoneVerificationCode}`);
+      await experience.toCompleteMfaVerification(ConnectorType.Sms);
+      await experience.toOptInTrustedDevice();
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
   });
 });

--- a/packages/integration-tests/src/tests/experience/mfa/totp/password-identifier-flow.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/totp/password-identifier-flow.test.ts
@@ -1,6 +1,6 @@
-import { ConnectorType, SignInIdentifier } from '@logto/schemas';
+import { ConnectorType, MfaFactor, SignInIdentifier } from '@logto/schemas';
 
-import { deleteUser } from '#src/api/admin-user.js';
+import { createUserMfaVerification, deleteUser } from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { demoAppUrl } from '#src/constants.js';
 import { clearConnectorsByTypes } from '#src/helpers/connector.js';
@@ -11,7 +11,7 @@ import {
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectTotpExperience from '#src/ui-helpers/expect-totp-experience.js';
-import { generateUsername } from '#src/utils.js';
+import { devFeatureTest, generateUsername } from '#src/utils.js';
 
 import TotpTestingContext from './totp-testing-context.js';
 
@@ -108,6 +108,75 @@ describe('MFA - TOTP', () => {
 
       // Clean up
       await deleteUser(user.id);
+    });
+
+    devFeatureTest.describe('trusted device opt-in', () => {
+      beforeAll(async () => {
+        await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+      });
+
+      afterAll(async () => {
+        await updateSignInExperience({ trustedDevice: { enabled: false } });
+      });
+
+      it('creates a trusted device from TOTP binding and skips MFA on the next sign-in', async () => {
+        const { userProfile, user } = await generateNewUser({ username: true, password: true });
+        const experience = new ExpectTotpExperience(await browser.newPage());
+
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.waitToBeAt(`mfa-binding/${MfaFactor.TOTP}`);
+        await experience.toBindTotp(false);
+        await experience.toOptInTrustedDevice();
+        await experience.verifyThenEnd(false);
+        await experience.clearDemoAppSession();
+        await experience.page.close();
+        const trustedDeviceExperience = new ExpectTotpExperience(await browser.newPage());
+
+        await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+        await trustedDeviceExperience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await trustedDeviceExperience.verifyThenEnd();
+
+        await deleteUser(user.id);
+      });
+
+      it('creates a trusted device from TOTP verification and skips MFA on the next sign-in', async () => {
+        const { userProfile, user } = await generateNewUser({ username: true, password: true });
+        const verification = await createUserMfaVerification(user.id, MfaFactor.TOTP);
+
+        if (verification.type !== MfaFactor.TOTP) {
+          throw new Error('unexpected MFA verification type');
+        }
+
+        const experience = new ExpectTotpExperience(await browser.newPage());
+        await experience.startWith(demoAppUrl, 'sign-in');
+        await experience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await experience.waitToBeAt(`mfa-verification/${MfaFactor.TOTP}`);
+        await experience.toVerifyTotp(verification.secret, false);
+        await experience.toOptInTrustedDevice();
+        await experience.verifyThenEnd(false);
+        await experience.clearDemoAppSession();
+        await experience.page.close();
+        const trustedDeviceExperience = new ExpectTotpExperience(await browser.newPage());
+
+        await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+        await trustedDeviceExperience.toFillForm(
+          { identifier: userProfile.username, password: userProfile.password },
+          { submit: true }
+        );
+        await trustedDeviceExperience.verifyThenEnd();
+
+        await deleteUser(user.id);
+      });
     });
   });
 

--- a/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
+++ b/packages/integration-tests/src/tests/experience/mfa/webauthn/index.test.ts
@@ -20,7 +20,7 @@ import {
 } from '#src/helpers/sign-in-experience.js';
 import { generateNewUser } from '#src/helpers/user.js';
 import ExpectWebAuthnExperience from '#src/ui-helpers/expect-webauthn-experience.js';
-import { generateUsername, waitFor } from '#src/utils.js';
+import { devFeatureTest, generateUsername, waitFor } from '#src/utils.js';
 
 describe('MFA - WebAuthn', () => {
   beforeAll(async () => {
@@ -103,6 +103,84 @@ describe('MFA - WebAuthn', () => {
     await experience.verifyThenEnd();
 
     await deleteUser(user.id);
+  });
+
+  devFeatureTest.describe('trusted device opt-in', () => {
+    beforeAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: true, durationDays: 365 } });
+    });
+
+    afterAll(async () => {
+      await updateSignInExperience({ trustedDevice: { enabled: false } });
+    });
+
+    it('creates a trusted device from WebAuthn binding and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-binding/${MfaFactor.WebAuthn}`);
+      await experience.toCreatePasskey();
+      await experience.toOptInTrustedDevice();
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.clearVirtualAuthenticator();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectWebAuthnExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    });
+
+    it('creates a trusted device from WebAuthn verification and skips MFA on the next sign-in', async () => {
+      const { userProfile, user } = await generateNewUser({ username: true, password: true });
+      const experience = new ExpectWebAuthnExperience(await browser.newPage());
+      await experience.setupVirtualAuthenticator();
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.toCreatePasskey();
+      await experience.toSkipTrustedDevice();
+      await experience.verifyThenEnd(false);
+      await experience.clearTrustedDeviceOptOut(user.id);
+
+      await experience.startWith(demoAppUrl, 'sign-in');
+      await experience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await experience.waitToBeAt(`mfa-verification/${MfaFactor.WebAuthn}`);
+      await experience.toVerifyViaPasskey();
+      await experience.toOptInTrustedDevice();
+      await experience.verifyThenEnd(false);
+      await experience.clearDemoAppSession();
+      await experience.clearVirtualAuthenticator();
+      await experience.page.close();
+      const trustedDeviceExperience = new ExpectWebAuthnExperience(await browser.newPage());
+
+      await trustedDeviceExperience.startWith(demoAppUrl, 'sign-in');
+      await trustedDeviceExperience.toFillForm(
+        { identifier: userProfile.username, password: userProfile.password },
+        { submit: true }
+      );
+      await trustedDeviceExperience.verifyThenEnd();
+
+      await deleteUser(user.id);
+    }, 90_000);
   });
 });
 

--- a/packages/integration-tests/src/ui-helpers/expect-experience.ts
+++ b/packages/integration-tests/src/ui-helpers/expect-experience.ts
@@ -1,4 +1,6 @@
-import { demoAppApplicationId, type MfaFactor } from '@logto/schemas';
+import { createHash } from 'node:crypto';
+
+import { defaultTenantId, demoAppApplicationId, type MfaFactor } from '@logto/schemas';
 import { appendPath } from '@silverhand/essentials';
 
 import { logtoUrl, mockSocialAuthPageUrl } from '#src/constants.js';
@@ -11,6 +13,11 @@ const demoAppUrl = appendPath(new URL(logtoUrl), 'demo-app');
 
 /** Aligned with puppeteer's default navigation timeout. */
 const defaultUrlWaitTimeout = 30_000;
+const trustedDeviceCookiePrefix = 'logto-trusted-device-';
+const trustedDeviceOptOutCookiePrefix = 'logto-device-trust-opt-out-';
+
+const isTrustedDeviceCredentialCookie = (name: string) =>
+  name.includes(trustedDeviceCookiePrefix) && !name.includes(trustedDeviceOptOutCookiePrefix);
 
 /** Remove the query string together with the `?` from a URL string. */
 const stripQuery = (url: string) => url.split('?')[0];
@@ -31,6 +38,7 @@ export type ExperiencePath =
   | 'identifier-register'
   | 'single-sign-on'
   | 'reset-password'
+  | 'trusted-device'
   | 'sign-in/passkey'
   | 'sign-in/verification-methods';
 
@@ -147,10 +155,22 @@ export default class ExpectExperience extends ExpectPage {
       sessionStorage.clear();
     });
     const cookies = await this.page.cookies(logtoUrl);
-    expect(cookies.some(({ name }) => name.includes('logto-trusted-device-'))).toBe(true);
-    const sessionCookies = cookies.filter(({ name }) => !name.includes('logto-trusted-device-'));
+    expect(cookies.some(({ name }) => isTrustedDeviceCredentialCookie(name))).toBe(true);
+    const sessionCookies = cookies.filter(({ name }) => !isTrustedDeviceCredentialCookie(name));
     await this.page.deleteCookie(...sessionCookies);
     await this.page.goto('about:blank');
+  }
+
+  /** Clear the persisted trusted-device opt-out preference for the given user. */
+  async clearTrustedDeviceOptOut(userId: string) {
+    const subjectHash = createHash('sha256')
+      .update(`${defaultTenantId}:${userId}`)
+      .digest('base64url');
+    const expectedCookieName = `${trustedDeviceOptOutCookiePrefix}${subjectHash}`;
+    const cookies = await this.page.cookies(logtoUrl);
+    const optOutCookies = cookies.filter(({ name }) => name.endsWith(expectedCookieName));
+    expect(optOutCookies).toHaveLength(1);
+    await this.page.deleteCookie(...optOutCookies);
   }
 
   /**
@@ -287,6 +307,27 @@ export default class ExpectExperience extends ExpectPage {
    */
   async waitForToast(text: string | RegExp) {
     return this.toMatchAndRemove('div[role=toast]', text);
+  }
+
+  async toSeeTrustedDeviceOptIn(durationDays = 365) {
+    const text = `Trust this device for ${durationDays} days`;
+    await this.waitToBeAt('trusted-device');
+    await this.toMatchElement('div[class$=title]', { text: 'Trust this device' });
+    await this.toMatchElement('div[class$=description]', {
+      text: 'You can skip MFA verification on this device during future sign-ins.',
+    });
+    await this.toMatchElement('button', { text });
+  }
+
+  async toOptInTrustedDevice(durationDays = 365) {
+    const text = `Trust this device for ${durationDays} days`;
+    await this.toSeeTrustedDeviceOptIn(durationDays);
+    await this.toClickButton(text, false);
+  }
+
+  async toSkipTrustedDevice(durationDays = 365) {
+    await this.toSeeTrustedDeviceOptIn(durationDays);
+    await this.toClick('div[role=button][class$=skipButton]', undefined, false);
   }
 
   /**


### PR DESCRIPTION
## Summary

Moving trusted-device opt-in out of MFA pages removes the duplicated UI and state synchronization, but it also changes where the decision appears in the end-to-end sign-in sequence. The important regression boundary is no longer an individual factor component: it is the full continuation chain from existing-factor verification, through optional profile/passkey/additional-factor fulfillment, to one trusted-device decision and the final redirect.

This final PR in the stack exercises that boundary in the browser. It verifies that the dedicated step introduced by #9538 and #9539 appears after all required MFA work, is shown only once, remembers an explicit skip on the same browser, and produces a trusted-device credential cookie only when the user opts in.

### What changed

- Added coverage for the opt-in step after existing email, phone, TOTP, and WebAuthn MFA verification.
- Added a multi-factor journey that verifies an existing factor, fulfills the additional-factor requirement, and confirms that trusted-device opt-in appears once after binding is complete rather than on either MFA page.
- Covered both decisions: accepting completes sign-in and creates the trusted-device credential cookie, while skipping completes sign-in without creating a credential and suppresses the suggestion after MFA on the next sign-in.
- Added shared Experience assertions for the standalone page title, description, policy-duration button text, and single-step presentation.
- Updated the sign-in flow reference to place the trusted-device gate after the additional-MFA branch and before final interaction submission.

### Expected result

The supported MFA journeys all converge on the same dedicated trusted-device step after their own verification and binding requirements are satisfied. The tests protect the intended separation: MFA screens handle MFA, the trusted-device page handles the opt-in decision, an explicit skip is remembered for later sign-ins on the same browser, and the credential cookie is created only after an accepted interaction completes successfully.

### Reviewer notes

- The factor-specific cases protect placement after existing-factor verification; the multi-factor case protects placement after the later additional-factor branch that originally exposed the duplicate-checkbox problem.
- The multi-factor case performs another sign-in after Skip and verifies that completing MFA proceeds directly to the application instead of showing the opt-in page again.
- The flow document models opt-in as a single gate before `/experience/submit`, with accept and skip both returning to normal submission.
- These tests cover the complete browser and credential-cookie behavior that the Core and Experience unit tests in the preceding PRs cannot establish independently.

## Testing

Integration tests

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments
