### PR TITLE
fix(core): prune consumed refresh tokens on rotation

### DIFF
--- a/.changeset/prune-consumed-refresh-tokens.md
+++ b/.changeset/prune-consumed-refresh-tokens.md
@@ -1,0 +1,9 @@
+---
+"@logto/core": patch
+---
+
+prune a grant's consumed refresh tokens on rotation
+
+Refresh token rotation kept every consumed token until it expired so a replay could be detected and the grant revoked. A client that refreshes constantly could accumulate enough rows on one grant for revoking it to hit the database statement timeout on `/oidc/token` and `/oidc/token/revocation`.
+
+Each rotation now also deletes a bounded batch of the grant's consumed refresh tokens older than 7 days, detached from the token response. A consumed token replayed after that is still rejected with `invalid_grant`, but revoking the grant is no longer guaranteed: the reuse-detection window shrinks from the token's own lifetime to 7 days, and pruning is driven by rotations of the same grant, whoever performs them.

--- a/packages/core/src/oidc/grants/refresh-token.test.ts
+++ b/packages/core/src/oidc/grants/refresh-token.test.ts
@@ -154,6 +154,16 @@ class StubIdToken {
 const stubIdToken = (ctx: KoaContextWithOIDC) =>
   Sinon.stub(ctx.oidc.provider, 'IdToken').value(StubIdToken);
 
+const mockPrune = (implementation: () => Promise<number>) => {
+  const pruneConsumedRefreshTokensByGrantId = jest
+    .fn<Promise<number>, [string]>()
+    .mockImplementation(implementation);
+  const tenant = new MockTenant(undefined, {
+    oidcModelInstances: { pruneConsumedRefreshTokensByGrantId },
+  });
+  return { tenant, pruneConsumedRefreshTokensByGrantId };
+};
+
 const createAccessDeniedError = (message: string, statusCode: number) => {
   const error = new errors.AccessDenied(message);
   // eslint-disable-next-line @silverhand/fp/no-mutation
@@ -166,6 +176,29 @@ const createPreparedContext = () => {
   stubRefreshToken(ctx);
   stubGrant(ctx);
   stubAccount(ctx);
+  return ctx;
+};
+
+/** A plain refresh (no `organization_id`) that reaches token rotation and ID token issuance. */
+const createRotationContext = (client = validClient) => {
+  const ctx = createOidcContext({
+    ...validOidcContext,
+    client,
+    entities: { ...validOidcContext.entities, Client: client },
+    requestParamScopes: new Set(['openid', ...requestScopes]),
+    params: {
+      refresh_token: 'some_refresh_token',
+      scope: ['openid', ...requestScopes].join(' '),
+    },
+    account: { accountId, claims: jest.fn().mockResolvedValue({ sub: accountId }) },
+  });
+  stubRefreshToken(ctx, {
+    scope: ['openid', ...requestScopes].join(' '),
+    scopes: new Set(['openid', ...requestScopes]),
+  });
+  stubGrant(ctx, { getRejectedOIDCClaims: jest.fn().mockReturnValue([]) });
+  stubAccount(ctx);
+  stubIdToken(ctx);
   return ctx;
 };
 
@@ -416,6 +449,40 @@ describe('refresh token grant', () => {
     expect(claims).toHaveBeenCalledTimes(1);
     expect(claims.mock.calls[0][0]).toBe('id_token');
     expect(claims.mock.calls[0][1]).toBe(requestScope);
+  });
+
+  describe('consumed refresh token pruning', () => {
+    it('should prune the grant on rotation', async () => {
+      const ctx = createRotationContext();
+      const { tenant, pruneConsumedRefreshTokensByGrantId } = mockPrune(async () => 0);
+
+      await expect(mockHandler(tenant)(ctx)).resolves.toBeUndefined();
+      expect(pruneConsumedRefreshTokensByGrantId).toHaveBeenCalledTimes(1);
+      expect(pruneConsumedRefreshTokensByGrantId).toHaveBeenCalledWith(grantId);
+    });
+
+    it('should not prune when the refresh token is not rotated', async () => {
+      // A confidential client early in the token lifetime does not rotate under the default policy.
+      const ctx = createRotationContext({
+        ...validClient,
+        clientAuthMethod: 'client_secret_basic',
+      } as unknown as Client);
+      const { tenant, pruneConsumedRefreshTokensByGrantId } = mockPrune(async () => 0);
+
+      await expect(mockHandler(tenant)(ctx)).resolves.toBeUndefined();
+      expect(pruneConsumedRefreshTokensByGrantId).not.toHaveBeenCalled();
+    });
+
+    it('should still issue tokens when pruning fails', async () => {
+      const ctx = createRotationContext();
+      const { tenant, pruneConsumedRefreshTokensByGrantId } = mockPrune(async () => {
+        throw new Error('statement timeout');
+      });
+
+      await expect(mockHandler(tenant)(ctx)).resolves.toBeUndefined();
+      expect(pruneConsumedRefreshTokensByGrantId).toHaveBeenCalledTimes(1);
+      expect(ctx.body).toHaveProperty('access_token');
+    });
   });
 
   it('should stop issuing a user scope the client is no longer configured for', async () => {

--- a/packages/core/src/oidc/grants/refresh-token.ts
+++ b/packages/core/src/oidc/grants/refresh-token.ts
@@ -28,10 +28,13 @@
  *   grant module, which would pull in the whole grant for one string literal.
  * - The explicit `grantId not found` guard before grant validation is a Logto addition kept
  *   from the v8 fork; upstream relies on the grant lookup failing instead.
+ * - Each rotation kicks off a detached prune of the grant's aged consumed refresh tokens
+ *   (`pruneConsumedRefreshTokensByGrantId`) once the response is built.
  */
 
+import { appInsights } from '@logto/app-insights/node';
 import { ReservedResource, UserScope } from '@logto/core-kit';
-import { noop } from '@silverhand/essentials';
+import { noop, trySafe } from '@silverhand/essentials';
 import { errors, type Provider } from 'oidc-provider';
 
 import { type EnvSet } from '#src/env-set/index.js';
@@ -63,6 +66,8 @@ import {
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
+import { getConsoleLogFromContext } from '#src/utils/console.js';
+import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import { handleOrganizationToken, checkOrganizationAccess } from './utils.js';
 
@@ -257,10 +262,12 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
   }
   /* === End RFC 0001 === */
 
-  if (
+  const { grantId } = refreshToken;
+  const shouldRotate =
     rotateRefreshToken === true ||
-    (typeof rotateRefreshToken === 'function' && (await rotateRefreshToken(ctx)))
-  ) {
+    (typeof rotateRefreshToken === 'function' && (await rotateRefreshToken(ctx)));
+
+  if (shouldRotate) {
     await refreshToken.consume();
     ctx.oidc.entity('RotatedRefreshToken', refreshToken);
 
@@ -421,5 +428,20 @@ export const buildHandler: Handler = (envSet, queries, appAccess) => async (ctx)
     source: refreshToken,
     rar: at.rar,
   });
+
+  if (shouldRotate) {
+    // Detached housekeeping, started after the token writes so it never queues ahead of them in
+    // the pool; the refresh never waits on it, and a failed prune never fails it.
+    void trySafe(
+      queries.oidcModelInstances.pruneConsumedRefreshTokensByGrantId(grantId),
+      (error) => {
+        getConsoleLogFromContext(ctx).warn(
+          `Failed to prune consumed refresh tokens of grant ${grantId}:`,
+          error
+        );
+        void appInsights.trackException(error, buildAppInsightsTelemetry(ctx));
+      }
+    );
+  }
 };
 /* eslint-enable complexity, @silverhand/fp/no-let, @typescript-eslint/no-non-null-assertion, @silverhand/fp/no-mutation, unicorn/no-array-method-this-argument */

--- a/packages/core/src/queries/oidc-model-instance.prune.test.ts
+++ b/packages/core/src/queries/oidc-model-instance.prune.test.ts
@@ -1,0 +1,95 @@
+import { OidcModelInstances } from '@logto/schemas';
+import { createMockPool, sql } from '@silverhand/slonik';
+import { subHours } from 'date-fns';
+
+import { convertToIdentifiers } from '#src/utils/sql.js';
+import type { QueryType } from '#src/utils/test-utils.js';
+import { expectSqlAssert } from '#src/utils/test-utils.js';
+
+const { jest } = import.meta;
+
+const mockQuery: jest.MockedFunction<QueryType> = jest.fn();
+
+const pool = createMockPool({
+  query: async (sql, values) => {
+    return mockQuery(sql, values);
+  },
+});
+
+const { createOidcModelInstanceQueries } = await import('./oidc-model-instance.js');
+const { pruneConsumedRefreshTokensByGrantId } = createOidcModelInstanceQueries(pool);
+
+describe('pruneConsumedRefreshTokensByGrantId', () => {
+  const { table, fields } = convertToIdentifiers(OidcModelInstances);
+
+  afterEach(() => {
+    mockQuery.mockReset();
+    jest.useRealTimers();
+  });
+
+  it('deletes one bounded batch consumed more than a week ago', async () => {
+    const grantId = 'target-id';
+    const now = new Date('2026-09-02T00:00:00.000Z');
+    jest.useFakeTimers({ now });
+    const expectSql = sql`
+      delete from ${table}
+      where ${fields.id} in (
+        select ${fields.id}
+        from ${table}
+        where ${fields.modelName}='RefreshToken'
+        and ${fields.payload} ? 'grantId'
+        and ${fields.payload}->>'grantId'=$1
+        and ${fields.consumedAt} < to_timestamp($2)
+        limit $3
+        for update skip locked
+      )
+    `;
+
+    // @ts-expect-error - mock delete query
+    mockQuery.mockImplementationOnce(async (sql, values) => {
+      expectSqlAssert(sql, expectSql.sql);
+      expect(values).toEqual([grantId, subHours(now, 7 * 24).valueOf() / 1000, 100]);
+
+      return { rowCount: 7 };
+    });
+
+    await expect(pruneConsumedRefreshTokensByGrantId(grantId)).resolves.toBe(7);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips a grant that is already being pruned', async () => {
+    // @ts-expect-error - mock delete query
+    mockQuery.mockImplementation(async () => ({ rowCount: 1 }));
+
+    const [first, second] = await Promise.all([
+      pruneConsumedRefreshTokensByGrantId('same-grant'),
+      pruneConsumedRefreshTokensByGrantId('same-grant'),
+    ]);
+
+    expect([first, second]).toEqual([1, 0]);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps concurrent prunes across grants', async () => {
+    // @ts-expect-error - mock delete query
+    mockQuery.mockImplementation(async () => ({ rowCount: 1 }));
+
+    const results = await Promise.all(
+      ['a', 'b', 'c', 'd', 'e'].map(async (grantId) => pruneConsumedRefreshTokensByGrantId(grantId))
+    );
+
+    expect(results).toEqual([1, 1, 1, 1, 0]);
+    expect(mockQuery).toHaveBeenCalledTimes(4);
+  });
+
+  it('releases the in-flight mark when the query fails', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('statement timeout'));
+    await expect(pruneConsumedRefreshTokensByGrantId('failing-grant')).rejects.toThrow(
+      'statement timeout'
+    );
+
+    // @ts-expect-error - mock delete query
+    mockQuery.mockImplementationOnce(async () => ({ rowCount: 2 }));
+    await expect(pruneConsumedRefreshTokensByGrantId('failing-grant')).resolves.toBe(2);
+  });
+});

--- a/packages/core/src/queries/oidc-model-instance.ts
+++ b/packages/core/src/queries/oidc-model-instance.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- every OIDC model query lives here */
 import type { Application, OidcModelInstance, OidcModelInstancePayload } from '@logto/schemas';
 import { Applications, CimdGrantClientSnapshots, OidcModelInstances } from '@logto/schemas';
 import { ConsoleLog } from '@logto/shared';
@@ -6,7 +7,7 @@ import { conditional } from '@silverhand/essentials';
 import type { CommonQueryMethods, SqlSqlToken, ValueExpression } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
 import chalk from 'chalk';
-import { addSeconds, isBefore } from 'date-fns';
+import { addSeconds, isBefore, subHours } from 'date-fns';
 
 import { buildInsertIntoWithPool } from '#src/database/insert-into.js';
 import { convertToIdentifiers, convertToTimestamp } from '#src/utils/sql.js';
@@ -39,6 +40,16 @@ const refreshTokenReuseInterval = 3;
  * the statement timeout.
  */
 const revokeInstanceBatchSize = 500;
+/** Small because it runs on every refresh token rotation. */
+const pruneConsumedRefreshTokenBatchSize = 100;
+/**
+ * How long a consumed refresh token is kept before a later rotation of the same grant prunes it.
+ * Consumed tokens exist to detect reuse, so this is also the reuse-detection window: a token
+ * replayed after it is still rejected, but the grant may no longer be revoked.
+ */
+const consumedRefreshTokenRetentionDays = 7;
+/** Prunes run detached from the token response; this bounds the pool connections they can hold. */
+const maxConcurrentPrunes = 4;
 /** Safety valve so a revocation request stays bounded even for pathological instance counts. */
 const maxRevokeInstanceBatches = 1000;
 /** Fixed-length array to drive the bounded batch loop without a mutable counter. */
@@ -70,6 +81,10 @@ const withConsumed = <T>(
 // eslint-disable-next-line @typescript-eslint/ban-types
 const convertResult = (result: QueryResult | null, modelName: string) =>
   conditional(result && withConsumed(result.payload, modelName, result.consumedAt));
+
+/** Matches the partial grant-id index, which requires the key-existence clause. */
+const grantIdCondition = (grantId: string) => sql`${fields.payload} ? 'grantId'
+  and ${fields.payload}->>'grantId'=${grantId}`;
 
 const findByModel = (modelName: string) => sql`
   select ${fields.payload}, ${fields.consumedAt}
@@ -232,12 +247,7 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
   };
 
   const revokeInstanceByGrantId = async (modelName: string, grantId: string) =>
-    revokeInstancesInBatches(
-      modelName,
-      `grantId ${grantId}`,
-      sql`${fields.payload} ? 'grantId'
-          and ${fields.payload}->>'grantId'=${grantId}`
-    );
+    revokeInstancesInBatches(modelName, `grantId ${grantId}`, grantIdCondition(grantId));
 
   const revokeInstanceByUserId = async (modelName: string, userId: string) =>
     revokeInstancesInBatches(
@@ -246,6 +256,43 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
       sql`${fields.payload} ? 'accountId'
           and ${fields.payload}->>'accountId'=${userId}`
     );
+
+  /**
+   * Delete one bounded batch of the grant's refresh tokens consumed longer ago than
+   * `consumedRefreshTokenRetentionDays`. Rows locked by a concurrent revocation are skipped rather
+   * than waited for, since that revocation deletes them anyway.
+   */
+  /** Grants of this tenant with a prune in flight; a skipped prune is retried on the next rotation. */
+  const pruningGrantIds = new Set<string>();
+
+  const pruneConsumedRefreshTokensByGrantId = async (grantId: string) => {
+    if (pruningGrantIds.has(grantId) || pruningGrantIds.size >= maxConcurrentPrunes) {
+      return 0;
+    }
+
+    pruningGrantIds.add(grantId);
+
+    try {
+      // Hours rather than days so the window is exact across daylight-saving changes.
+      const consumedBefore = subHours(new Date(), consumedRefreshTokenRetentionDays * 24);
+      const { rowCount } = await pool.query(sql`
+        delete from ${table}
+        where ${fields.id} in (
+          select ${fields.id}
+          from ${table}
+          where ${fields.modelName}='RefreshToken'
+          and ${grantIdCondition(grantId)}
+          and ${fields.consumedAt} < ${convertToTimestamp(consumedBefore)}
+          limit ${pruneConsumedRefreshTokenBatchSize}
+          for update skip locked
+        )
+      `);
+
+      return rowCount;
+    } finally {
+      pruningGrantIds.delete(grantId);
+    }
+  };
 
   const findUserActiveApplicationGrants = async (
     userId: string,
@@ -372,9 +419,11 @@ export const createOidcModelInstanceQueries = (pool: CommonQueryMethods) => {
     destroyInstanceById,
     revokeInstanceByGrantId,
     revokeInstanceByUserId,
+    pruneConsumedRefreshTokensByGrantId,
     findUserActiveApplicationGrants,
     findUserActiveCimdGrants,
     findUserActiveGrantsByClientId,
     findUserActiveSessionUidByGrantId,
   };
 };
+/* eslint-enable max-lines */

--- a/packages/integration-tests/src/tests/api/oidc/consumed-refresh-token-pruning.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/consumed-refresh-token-pruning.test.ts
@@ -1,0 +1,116 @@
+import { defaultTenantId } from '@logto/schemas';
+import { assert, assertEnv } from '@silverhand/essentials';
+import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { deleteApplication } from '#src/api/application.js';
+import {
+  assertRefreshTokenInvalidGrant,
+  createAppAndSignInWithPassword,
+  refreshTokens,
+} from '#src/helpers/session.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
+import { generateNewUser } from '#src/helpers/user.js';
+import { waitFor } from '#src/utils.js';
+
+const isConsumedRefreshTokenOf = (userId: string, clientId: string) => sql`
+  tenant_id = ${defaultTenantId}
+  and model_name = 'RefreshToken'
+  and payload->>'accountId' = ${userId}
+  and payload->>'clientId' = ${clientId}
+  and consumed_at is not null
+`;
+
+/**
+ * Rotation keeps a consumed refresh token so a replay can be detected. Each rotation prunes the
+ * grant's consumed tokens older than the 7-day retention window, so a frequently refreshed grant
+ * stays bounded. Reuse detection on a grant that has never been pruned is covered by
+ * `provider-semantics.test.ts`.
+ */
+describe('consumed refresh token pruning on rotation', () => {
+  /* eslint-disable @silverhand/fp/no-let -- fixture assigned in beforeAll */
+  let pool: DatabasePool;
+  /* eslint-enable @silverhand/fp/no-let */
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- fixture assigned in beforeAll
+    pool = await createPool(assertEnv('DB_URL'), { interceptors: createInterceptorsPreset() });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  const countConsumedRefreshTokens = async (userId: string, clientId: string) => {
+    const { count } = await pool.one<{ count: number }>(sql`
+      select count(*)::int as count from oidc_model_instances
+      where ${isConsumedRefreshTokenOf(userId, clientId)}
+    `);
+    return count;
+  };
+
+  /** The prune runs detached from the token response, so give it a moment to land. */
+  const expectConsumedRefreshTokens = async (
+    userId: string,
+    clientId: string,
+    expected: number
+  ) => {
+    for (const _ of Array.from({ length: 20 })) {
+      // eslint-disable-next-line no-await-in-loop -- polling until the detached prune lands
+      if ((await countConsumedRefreshTokens(userId, clientId)) === expected) {
+        return;
+      }
+      // eslint-disable-next-line no-await-in-loop -- polling until the detached prune lands
+      await waitFor(250);
+    }
+
+    await expect(countConsumedRefreshTokens(userId, clientId)).resolves.toBe(expected);
+  };
+
+  it('prunes aged consumed tokens on rotation and keeps recent ones', async () => {
+    const { user, userProfile } = await generateNewUser({ username: true, password: true });
+    const { app, refreshToken: initial } = await createAppAndSignInWithPassword({
+      username: userProfile.username,
+      password: userProfile.password,
+    });
+    assert(initial, new Error('No refresh token issued'));
+    const clientId = app.id;
+
+    const exchange = async (refreshToken: string) => {
+      const { refreshToken: rotated } = await refreshTokens({ clientId, refreshToken });
+      assert(rotated, new Error('No rotated refresh token issued'));
+      return rotated;
+    };
+
+    // Two rotations leave two consumed tokens behind.
+    const second = await exchange(initial);
+    const third = await exchange(second);
+    await expect(countConsumedRefreshTokens(user.id, clientId)).resolves.toBe(2);
+
+    // Age them past the 7-day window; the next rotation prunes them.
+    await pool.query(sql`
+      update oidc_model_instances set consumed_at = now() - interval '8 days'
+      where ${isConsumedRefreshTokenOf(user.id, clientId)}
+    `);
+    const fourth = await exchange(third);
+
+    // Only the token consumed by that rotation remains, since it is inside the window.
+    await expectConsumedRefreshTokens(user.id, clientId, 1);
+
+    // A pruned token is rejected without revoking the grant: the live chain keeps working.
+    await assertRefreshTokenInvalidGrant({ clientId, refreshToken: initial });
+    const fifth = await exchange(fourth);
+
+    // The unpruned consumed token still trips reuse detection past the 3-second leeway and revokes
+    // the grant. Age it past the leeway instead of sleeping.
+    await pool.query(sql`
+      update oidc_model_instances set consumed_at = consumed_at - interval '4 seconds'
+      where ${isConsumedRefreshTokenOf(user.id, clientId)}
+    `);
+    await assertRefreshTokenInvalidGrant({ clientId, refreshToken: third });
+    await assertRefreshTokenInvalidGrant({ clientId, refreshToken: fifth });
+
+    await Promise.all([deleteApplication(app.id), deleteUser(user.id)]);
+  });
+});


### PR DESCRIPTION
## Summary
Refs LOG-14153 (parent: LOG-14099).

### Context
Refresh-token rotation keeps every consumed token until its TTL so a replay can be detected and the grant revoked. A client that refreshes constantly accumulated 165k consumed refresh tokens on a single grant in production. Revoking such a grant takes hundreds of batches, and under concurrent replay-triggered revokes it hits `statement_timeout` on `/oidc/token` and `/oidc/token/revocation`.

### What changed
- `packages/core/src/queries/oidc-model-instance.ts`: new `pruneConsumedRefreshTokensByGrantId(grantId)` deletes up to 100 of a grant's refresh tokens consumed more than 7 days ago (`consumedRefreshTokenRetentionDays`) in one statement. The subselect uses `for update skip locked`, so a prune never waits on or deadlocks with a concurrent revocation of the same grant; rows it skips are deleted by that revocation anyway. A per-tenant in-flight registry dedupes concurrent prunes of one grant and caps concurrent prunes at 4. The grant-id predicate shared with `revokeInstanceByGrantId` is lifted into `grantIdCondition`.
- `packages/core/src/oidc/grants/refresh-token.ts`: the rotation block kicks the prune off detached (`void trySafe(...)`). A failure is logged with the grant id and tracked in App Insights, and never fails the refresh.
- Unit tests for the query (SQL shape and binds, same-grant dedupe, concurrency cap, in-flight release on failure) and the handler (prunes on rotation, does not prune without rotation, still issues tokens when pruning fails).
- Integration test: aged consumed tokens are pruned by the next rotation, the recently consumed one is kept, a pruned token is rejected without revoking the grant, and an unpruned consumed token still trips reuse detection after a prune.

### Expected result
- A grant holds at most about 7 days of consumed refresh tokens plus the live one; existing heavy grants shed up to 100 rows per rotation while the client keeps rotating.
- Token responses are unaffected: the prune is detached, and the statement is bounded. On a normal grant it touches a handful of rows; on a synthetic 200k-row grant it measured ~120 ms.
- Security trade-off, also stated in the changeset: a consumed token replayed after 7 days is still rejected with `invalid_grant`, but no longer revokes the grant. The reuse-detection window shrinks from the token's own TTL (14 days by default) to 7 days; behaviour inside the window is unchanged. The 3-second concurrent-exchange leeway is unaffected.

### Reviewer notes
- No new index, deliberately. Putting `consumed_at` into any index disables HOT updates for every `consume()`, turning the hottest write on this table into a ten-index write for all clients. The prune seeks the grant's rows through the existing partial grant-id index and heap-filters `consumed_at`.
- The prune runs on every rotation but is a no-op for any grant younger than a week. The cap and dedupe make it self-limiting during a database stall; a skipped prune is retried on the grant's next rotation.
- Deferred follow-ups are tracked on LOG-14153: capping a consumed token's `expires_at` at consume time so the expired-row job also sweeps consumed tokens, a per-app retention setting, and revoke dedupe.

## Testing
Unit tests, integration tests

## Checklist
- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [ ] necessary TSDoc comments