### PR TITLE
feat(core): record the authentication context on sign-in and registration and carry it into the ID token

### DIFF
--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -781,4 +781,34 @@ describe('findAccount', () => {
     ).rejects.toMatchError(new errors.InvalidGrant('user is suspended'));
   });
 });
+describe('authentication context provider metadata', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  afterEach(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  it('should advertise the Logto ACR values and the acr / amr / auth_time claims when dev features are enabled', () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+    const configuration = getProviderConfiguration(createProvider(new MockTenant()));
+    // `claimsSupported` is derived by the provider at construction and is not part of its typings.
+    const claimsSupported: unknown = Reflect.get(configuration, 'claimsSupported');
+
+    expect([...configuration.acrValues]).toEqual(['urn:logto:acr:1fa', 'urn:logto:acr:mfa']);
+    expect(claimsSupported).toContain('acr');
+    expect(claimsSupported).toContain('amr');
+    expect(claimsSupported).toContain('auth_time');
+  });
+
+  it('should keep the provider metadata unchanged when dev features are disabled', () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    const configuration = getProviderConfiguration(createProvider(new MockTenant()));
+    const claimsSupported: unknown = Reflect.get(configuration, 'claimsSupported');
+
+    expect([...configuration.acrValues]).toEqual([]);
+    expect(claimsSupported).not.toContain('acr');
+    expect(claimsSupported).not.toContain('amr');
+    expect(claimsSupported).toContain('auth_time');
+  });
+});
 /* eslint-enable max-lines */

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -440,9 +440,11 @@ export default function initOidc(
     // https://github.com/panva/node-oidc-provider/blob/main/recipes/claim_configuration.md
     // Note node-provider will append `claims` here to the default claims instead of overriding
     claims: EnvSet.values.isDevFeaturesEnabled
-      ? // `amr` is a standalone claim (not bound to a scope); it is advertised in
-        // `claims_supported` and issued from the session's authentication context.
-        { ...userClaims, amr: null }
+      ? // The provider only puts a claim into the ID token when some granted scope lists it (or the
+        // request asks for it through `claims` / `acr_values` / `max_age`). Listing the
+        // authentication context under `openid` makes every ID token carry `acr`, `amr`, and
+        // `auth_time` from the session, and advertises them in `claims_supported`.
+        { ...userClaims, openid: ['sub', 'acr', 'amr', 'auth_time'] }
       : userClaims,
     // Advertise the Logto ACR classes as `acr_values_supported`; the provider also re-adds the
     // built-in `acr` claim to `claims_supported` once at least one value is configured.

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -12,6 +12,7 @@ import {
   extraParamsObjectGuard,
   inSeconds,
   logtoCookieKey,
+  logtoAcrValues,
   ExtraParamsKey,
   type Json,
 } from '@logto/schemas';
@@ -438,7 +439,14 @@ export default function initOidc(
       ctx.URL.origin === origin || isOriginAllowed(origin, client.metadata(), client.redirectUris),
     // https://github.com/panva/node-oidc-provider/blob/main/recipes/claim_configuration.md
     // Note node-provider will append `claims` here to the default claims instead of overriding
-    claims: userClaims,
+    claims: EnvSet.values.isDevFeaturesEnabled
+      ? // `amr` is a standalone claim (not bound to a scope); it is advertised in
+        // `claims_supported` and issued from the session's authentication context.
+        { ...userClaims, amr: null }
+      : userClaims,
+    // Advertise the Logto ACR classes as `acr_values_supported`; the provider also re-adds the
+    // built-in `acr` claim to `claims_supported` once at least one value is configured.
+    ...conditional(EnvSet.values.isDevFeaturesEnabled && { acrValues: [...logtoAcrValues] }),
     // https://github.com/panva/node-oidc-provider/tree/main/docs#findaccount
     findAccount: async (_ctx, sub) => {
       // The user may be deleted after the token is issued

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -5,6 +5,7 @@ import {
   adminTenantId,
   AuthenticationFactor,
   AuthenticationFactorClass,
+  AuthenticationMethodReference,
   AuthenticationProofRole,
   type AuthenticationProof,
   type CreateUser,
@@ -48,7 +49,7 @@ const passwordProof = (role: AuthenticationProofRole, at: number): Authenticatio
   id: 'password',
   factor: AuthenticationFactor.Password,
   class: AuthenticationFactorClass.FirstFactor,
-  amr: ['pwd'],
+  amr: [AuthenticationMethodReference.Password],
   role,
   at,
 });

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -331,6 +331,63 @@ describe('ExperienceInteraction class', () => {
       );
     });
 
+    it('seeds the derived authentication context into the login result when dev features are enabled', async () => {
+      setDevFeaturesEnabled(true);
+      const { experienceInteraction, provider } = createSignInInteraction({
+        interactionResult: {
+          verificationRecords: [
+            {
+              id: 'password',
+              type: VerificationType.Password,
+              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
+              verified: true,
+              verifiedAt: 1_700_000_000,
+            },
+          ],
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(provider.interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          login: {
+            accountId: mockUser.id,
+            acr: 'urn:logto:acr:1fa',
+            amr: ['pwd'],
+            ts: 1_700_000_000,
+          },
+        })
+      );
+    });
+
+    it('finishes with the account id only when dev features are disabled', async () => {
+      setDevFeaturesEnabled(false);
+      const { experienceInteraction, provider } = createSignInInteraction({
+        interactionResult: {
+          verificationRecords: [
+            {
+              id: 'password',
+              type: VerificationType.Password,
+              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
+              verified: true,
+              verifiedAt: 1_700_000_000,
+            },
+          ],
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(provider.interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ login: { accountId: mockUser.id } })
+      );
+    });
+
     it('does not include password in the PostSignIn action event', async () => {
       const { experienceInteraction, runActionHandler } = createSignInInteraction();
 

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -11,6 +11,7 @@ import {
   SignInIdentifier,
   SignInMode,
   type User,
+  UsersPasswordEncryptionMethod,
   VerificationType,
 } from '@logto/schemas';
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
@@ -132,6 +133,7 @@ const createSignInInteraction = ({
   const signInUserQueries = {
     ...userQueries,
     findUserById: jest.fn().mockResolvedValue(user),
+    findUserByUsername: jest.fn().mockResolvedValue(user),
     updateUserById: jest.fn().mockResolvedValue(user),
   };
   const runActionHandler = jest.fn(
@@ -342,6 +344,16 @@ describe('ExperienceInteraction class', () => {
               identifier: { type: SignInIdentifier.Username, value: mockUser.username },
               verified: true,
               verifiedAt: 1_700_000_000,
+            },
+            // A registration password proposed for an unused username is not a proof of the
+            // signed-in account and must not reach the login result.
+            {
+              id: 'new-password-identity',
+              type: VerificationType.NewPasswordIdentity,
+              identifier: { type: SignInIdentifier.Username, value: 'unused' },
+              passwordEncrypted: 'encrypted',
+              passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
+              verifiedAt: 1_600_000_000,
             },
           ],
         },

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -134,6 +134,7 @@ const createSignInInteraction = ({
     ...userQueries,
     findUserById: jest.fn().mockResolvedValue(user),
     findUserByUsername: jest.fn().mockResolvedValue(user),
+    findUserByEmail: jest.fn().mockResolvedValue(user),
     updateUserById: jest.fn().mockResolvedValue(user),
   };
   const runActionHandler = jest.fn(
@@ -337,6 +338,7 @@ describe('ExperienceInteraction class', () => {
       setDevFeaturesEnabled(true);
       const { experienceInteraction, provider } = createSignInInteraction({
         interactionResult: {
+          identifiedVerificationIds: ['password'],
           verificationRecords: [
             {
               id: 'password',
@@ -373,6 +375,42 @@ describe('ExperienceInteraction class', () => {
           },
         })
       );
+    });
+
+    it('records every verification record that identified the user', async () => {
+      const { experienceInteraction } = createSignInInteraction({
+        interactionResult: {
+          userId: undefined,
+          verificationRecords: [
+            {
+              id: 'password',
+              type: VerificationType.Password,
+              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
+              verified: true,
+            },
+            {
+              id: 'email',
+              type: VerificationType.EmailVerificationCode,
+              identifier: { type: SignInIdentifier.Email, value: mockEmail },
+              templateType: TemplateType.SignIn,
+              verified: true,
+            },
+          ],
+        },
+      });
+
+      await experienceInteraction.identifyUser('password');
+      expect(experienceInteraction.toJson()).toMatchObject({
+        userId: mockUser.id,
+        identifiedVerificationIds: ['password'],
+      });
+
+      // A second record that identifies the same user is recorded as well.
+      await experienceInteraction.identifyUser('email');
+      expect(experienceInteraction.toJson().identifiedVerificationIds).toEqual([
+        'password',
+        'email',
+      ]);
     });
 
     it('finishes with the account id only when dev features are disabled', async () => {

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -3,6 +3,10 @@ import { TemplateType } from '@logto/connector-kit';
 import {
   adminConsoleApplicationId,
   adminTenantId,
+  AuthenticationFactor,
+  AuthenticationFactorClass,
+  AuthenticationProofRole,
+  type AuthenticationProof,
   type CreateUser,
   InteractionEvent,
   LogtoActionKey,
@@ -39,6 +43,15 @@ mockEsm('#src/utils/tenant.js', () => ({
 }));
 
 const mockEmail = 'foo@bar.com';
+/** The proof a password records in the given role. */
+const passwordProof = (role: AuthenticationProofRole, at: number): AuthenticationProof => ({
+  id: 'password',
+  factor: AuthenticationFactor.Password,
+  class: AuthenticationFactorClass.FirstFactor,
+  amr: ['pwd'],
+  role,
+  at,
+});
 const userQueries = {
   hasActiveUsers: jest.fn().mockResolvedValue(false),
   hasUserWithEmail: jest.fn().mockResolvedValue(false),
@@ -279,6 +292,17 @@ describe('ExperienceInteraction class', () => {
       experienceInteraction.setVerificationRecord(emailVerificationRecord);
       await experienceInteraction.createUser(emailVerificationRecord.id);
 
+      // Creating the account from the record is the `create` proof of the new account.
+      expect(experienceInteraction.toJson().authenticationProofs).toMatchObject([
+        {
+          id: emailVerificationRecord.id,
+          factor: AuthenticationFactor.Email,
+          class: AuthenticationFactorClass.FirstFactor,
+          amr: ['otp'],
+          role: AuthenticationProofRole.Create,
+        },
+      ]);
+
       expect(userLibraries.insertUser).toHaveBeenCalledWith(
         {
           id: 'uid',
@@ -334,11 +358,11 @@ describe('ExperienceInteraction class', () => {
       );
     });
 
-    it('seeds the derived authentication context into the login result when dev features are enabled', async () => {
+    it('seeds the aggregated authentication context into the login result when dev features are enabled', async () => {
       setDevFeaturesEnabled(true);
       const { experienceInteraction, provider } = createSignInInteraction({
         interactionResult: {
-          identifiedVerificationIds: ['password'],
+          authenticationProofs: [passwordProof(AuthenticationProofRole.Identify, 1_700_000_000)],
           verificationRecords: [
             {
               id: 'password',
@@ -347,8 +371,8 @@ describe('ExperienceInteraction class', () => {
               verified: true,
               verifiedAt: 1_700_000_000,
             },
-            // A registration password proposed for an unused username is not a proof of the
-            // signed-in account and must not reach the login result.
+            // A verified record that no touchpoint consumed is not a proof and must not reach
+            // the login result.
             {
               id: 'new-password-identity',
               type: VerificationType.NewPasswordIdentity,
@@ -379,29 +403,21 @@ describe('ExperienceInteraction class', () => {
 
     it('seeds the context a registration established into the login result when dev features are enabled', async () => {
       setDevFeaturesEnabled(true);
-      // `createUser()` already created the account from the registration password; nothing
-      // identified the user, so the record counts because its username is the account's.
+      // An email + password registration: `createUser()` consumed the email code and the profile
+      // established the password.
       const { experienceInteraction, provider } = createSignInInteraction({
         interactionEvent: InteractionEvent.Register,
         interactionResult: {
-          verificationRecords: [
-            {
-              id: 'new-password-identity',
-              type: VerificationType.NewPasswordIdentity,
-              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
-              passwordEncrypted: 'encrypted',
-              passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
-              verifiedAt: 1_700_000_000,
-            },
-            // A code verified for an address that was never written to the account.
+          authenticationProofs: [
             {
               id: 'email',
-              type: VerificationType.EmailVerificationCode,
-              identifier: { type: SignInIdentifier.Email, value: 'other@example.com' },
-              templateType: TemplateType.Register,
-              verified: true,
-              verifiedAt: 1_600_000_000,
+              factor: AuthenticationFactor.Email,
+              class: AuthenticationFactorClass.FirstFactor,
+              amr: ['otp'],
+              role: AuthenticationProofRole.Create,
+              at: 1_600_000_000,
             },
+            passwordProof(AuthenticationProofRole.Bind, 1_700_000_000),
           ],
         },
       });
@@ -415,14 +431,14 @@ describe('ExperienceInteraction class', () => {
           login: {
             accountId: mockUser.id,
             acr: 'urn:logto:acr:1fa',
-            amr: ['pwd'],
-            ts: 1_700_000_000,
+            amr: ['otp', 'pwd'],
+            ts: 1_600_000_000,
           },
         })
       );
     });
 
-    it('records every verification record that identified the user', async () => {
+    it('records an identify proof for every verification record that identified the user', async () => {
       const { experienceInteraction } = createSignInInteraction({
         interactionResult: {
           userId: undefined,
@@ -432,6 +448,7 @@ describe('ExperienceInteraction class', () => {
               type: VerificationType.Password,
               identifier: { type: SignInIdentifier.Username, value: mockUser.username },
               verified: true,
+              verifiedAt: 1_700_000_000,
             },
             {
               id: 'email',
@@ -439,6 +456,7 @@ describe('ExperienceInteraction class', () => {
               identifier: { type: SignInIdentifier.Email, value: mockEmail },
               templateType: TemplateType.SignIn,
               verified: true,
+              verifiedAt: 1_700_000_100,
             },
           ],
         },
@@ -447,15 +465,83 @@ describe('ExperienceInteraction class', () => {
       await experienceInteraction.identifyUser('password');
       expect(experienceInteraction.toJson()).toMatchObject({
         userId: mockUser.id,
-        identifiedVerificationIds: ['password'],
+        authenticationProofs: [passwordProof(AuthenticationProofRole.Identify, 1_700_000_000)],
       });
 
       // A second record that identifies the same user is recorded as well.
       await experienceInteraction.identifyUser('email');
-      expect(experienceInteraction.toJson().identifiedVerificationIds).toEqual([
-        'password',
-        'email',
+      expect(experienceInteraction.toJson().authenticationProofs).toMatchObject([
+        { id: 'password', role: AuthenticationProofRole.Identify },
+        { id: 'email', role: AuthenticationProofRole.Identify, factor: AuthenticationFactor.Email },
       ]);
+    });
+
+    it('records the proof for a password established through the profile once', () => {
+      const { experienceInteraction } = createSignInInteraction();
+      const digest = {
+        passwordEncrypted: 'encrypted',
+        passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
+      };
+
+      experienceInteraction.profile.unsafeSet(digest);
+      experienceInteraction.profile.unsafeSet(digest);
+
+      expect(experienceInteraction.toJson().authenticationProofs).toMatchObject([
+        {
+          id: 'password',
+          factor: AuthenticationFactor.Password,
+          class: AuthenticationFactorClass.FirstFactor,
+          amr: ['pwd'],
+          role: AuthenticationProofRole.Bind,
+        },
+      ]);
+    });
+
+    it('clears the proofs when the interaction event changes, like the profile', async () => {
+      const { experienceInteraction } = createSignInInteraction({
+        interactionResult: {
+          authenticationProofs: [passwordProof(AuthenticationProofRole.Identify, 1_700_000_000)],
+        },
+      });
+
+      await experienceInteraction.setInteractionEvent(InteractionEvent.SignIn);
+      expect(experienceInteraction.toJson().authenticationProofs).toHaveLength(1);
+
+      await experienceInteraction.setInteractionEvent(InteractionEvent.Register);
+      expect(experienceInteraction.toJson().authenticationProofs).toEqual([]);
+    });
+
+    it('does not let the proofs outlive the interaction', async () => {
+      const { experienceInteraction, provider } = createSignInInteraction({
+        interactionEvent: InteractionEvent.ForgotPassword,
+        interactionResult: {
+          profile: {
+            passwordEncrypted: 'encrypted',
+            passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
+          },
+          authenticationProofs: [passwordProof(AuthenticationProofRole.Bind, 1_700_000_000)],
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(provider.interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        {}
+      );
+      expect(experienceInteraction.toJson().authenticationProofs).toEqual([]);
+    });
+
+    it('keeps the proofs out of the sanitized interaction data', () => {
+      const { experienceInteraction } = createSignInInteraction({
+        interactionResult: {
+          authenticationProofs: [passwordProof(AuthenticationProofRole.Identify, 1_700_000_000)],
+        },
+      });
+
+      expect(experienceInteraction.toJson().authenticationProofs).toHaveLength(1);
+      expect(experienceInteraction.toSanitizedJson()).not.toHaveProperty('authenticationProofs');
     });
 
     it('finishes with the account id only when dev features are disabled', async () => {

--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -377,6 +377,51 @@ describe('ExperienceInteraction class', () => {
       );
     });
 
+    it('seeds the context a registration established into the login result when dev features are enabled', async () => {
+      setDevFeaturesEnabled(true);
+      // `createUser()` already created the account from the registration password; nothing
+      // identified the user, so the record counts because its username is the account's.
+      const { experienceInteraction, provider } = createSignInInteraction({
+        interactionEvent: InteractionEvent.Register,
+        interactionResult: {
+          verificationRecords: [
+            {
+              id: 'new-password-identity',
+              type: VerificationType.NewPasswordIdentity,
+              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
+              passwordEncrypted: 'encrypted',
+              passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
+              verifiedAt: 1_700_000_000,
+            },
+            // A code verified for an address that was never written to the account.
+            {
+              id: 'email',
+              type: VerificationType.EmailVerificationCode,
+              identifier: { type: SignInIdentifier.Email, value: 'other@example.com' },
+              templateType: TemplateType.Register,
+              verified: true,
+              verifiedAt: 1_600_000_000,
+            },
+          ],
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(provider.interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          login: {
+            accountId: mockUser.id,
+            acr: 'urn:logto:acr:1fa',
+            amr: ['pwd'],
+            ts: 1_700_000_000,
+          },
+        })
+      );
+    });
+
     it('records every verification record that identified the user', async () => {
       const { experienceInteraction } = createSignInInteraction({
         interactionResult: {

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -555,7 +555,11 @@ export default class ExperienceInteraction {
     // nothing and the provider stamps `auth_time` itself.
     const authenticationContext =
       EnvSet.values.isDevFeaturesEnabled && this.#interactionEvent === InteractionEvent.SignIn
-        ? await deriveAuthenticationContext(this.verificationRecordsArray, user.id)
+        ? await deriveAuthenticationContext(
+            this.verificationRecordsArray,
+            user.id,
+            new MfaValidator(await this.signInExperienceValidator.getMfaSettings(), user)
+          )
         : undefined;
 
     // Revalidate the new profile data if any

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -424,22 +424,6 @@ export default class ExperienceInteraction {
     return record;
   }
 
-  /** Fetch a verification record for creating the account from it, recording the `create` proof. */
-  private consumeForCreate(verificationId: string) {
-    const record = this.getVerificationRecordById(verificationId);
-    this.authenticationProofs.stage(record, AuthenticationProofRole.Create);
-
-    return record;
-  }
-
-  /** Fetch a verification record for identifying the user with it, recording the `identify` proof. */
-  private consumeForIdentify(verificationId: string) {
-    const record = this.getVerificationRecordById(verificationId);
-    this.authenticationProofs.stage(record, AuthenticationProofRole.Identify);
-
-    return record;
-  }
-
   /**
    * Validate the interaction verification records against the sign-in experience and user MFA settings.
    * The interaction is verified if at least one user enabled MFA verification record is present and verified.
@@ -970,6 +954,22 @@ export default class ExperienceInteraction {
     );
 
     return verificationRecord;
+  }
+
+  /** Fetch a verification record for creating the account from it, recording the `create` proof. */
+  private consumeForCreate(verificationId: string) {
+    const record = this.getVerificationRecordById(verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Create);
+
+    return record;
+  }
+
+  /** Fetch a verification record for identifying the user with it, recording the `identify` proof. */
+  private consumeForIdentify(verificationId: string) {
+    const record = this.getVerificationRecordById(verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Identify);
+
+    return record;
   }
 
   private get hasVerifiedSsoIdentity() {

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -13,6 +13,7 @@ import {
 import { maskEmail, maskPhone } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayload } from '#src/libraries/user.utils.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
@@ -39,6 +40,7 @@ import {
 import { validatePostSignInActionResult } from './libraries/action-result-validation.js';
 import { AdaptiveMfaValidator } from './libraries/adaptive-mfa-validator/index.js';
 import { type AdaptiveMfaResult } from './libraries/adaptive-mfa-validator/types.js';
+import { deriveAuthenticationContext } from './libraries/authentication-context.js';
 import { CaptchaValidator } from './libraries/captcha-validator.js';
 import { MfaValidator } from './libraries/mfa-validator.js';
 import { ProvisionLibrary } from './libraries/provision-library.js';
@@ -673,7 +675,17 @@ export default class ExperienceInteraction {
     const trustedDeviceOptInDecision = this.trustedDevice.consumeOptInDecision();
 
     const redirectTo = await provider.interactionResult(this.ctx.req, this.ctx.res, {
-      login: { accountId: user.id },
+      login: {
+        accountId: user.id,
+        // Seed the authentication context this interaction achieved onto the OIDC session, so
+        // the ID token carries `acr` / `amr` / `auth_time`. A sign-in without a counted record
+        // (or a register) seeds nothing and the provider stamps `auth_time` itself.
+        ...conditional(
+          EnvSet.values.isDevFeaturesEnabled &&
+            this.#interactionEvent === InteractionEvent.SignIn &&
+            deriveAuthenticationContext(this.verificationRecordsArray)
+        ),
+      },
       // Persist the interaction status to the OIDC session after interaction submission
       ...this.toJson(),
     });

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -559,18 +559,22 @@ export default class ExperienceInteraction {
       await this.guardMfaVerificationStatus(log);
     }
 
-    // Derive the authentication context this sign-in achieved before anything is written to the
-    // account, so that a record whose identifier or identity is only being added by this
-    // submission does not count as a proof of the account. It seeds the OIDC session so the ID
-    // token carries `acr` / `amr` / `auth_time`; a sign-in without a proof (or a register) seeds
-    // nothing and the provider stamps `auth_time` itself.
-    const authenticationContext =
-      EnvSet.values.isDevFeaturesEnabled && this.#interactionEvent === InteractionEvent.SignIn
-        ? deriveAuthenticationContext(this.verificationRecordsArray, {
-            user,
-            identifiedVerificationIds: this.identifiedVerificationIds,
-          })
-        : undefined;
+    // Derive the authentication context this sign-in or registration achieved before anything is
+    // written to an existing account, so that a record whose identifier or identity is only being
+    // added by this submission does not count as a proof of that account. A registration is the
+    // opposite case: `createUser()` already created the account from this interaction's records,
+    // so a record for one of its identifiers and a factor this submission binds are proofs of it.
+    // The context seeds the OIDC session so the ID token carries `acr` / `amr` / `auth_time`; an
+    // interaction without a proof seeds nothing and the provider stamps `auth_time` itself.
+    const authenticationContext = conditional(
+      EnvSet.values.isDevFeaturesEnabled &&
+        deriveAuthenticationContext(this.verificationRecordsArray, {
+          user,
+          identifiedVerificationIds: this.identifiedVerificationIds,
+          isNewAccount: this.#interactionEvent === InteractionEvent.Register,
+          bindMfaFactors: new Set(this.mfa.bindMfaFactorsArray.map(({ type }) => type)),
+        })
+    );
 
     // Revalidate the new profile data if any
     await this.profile.validateAvailability();

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -557,8 +557,8 @@ export default class ExperienceInteraction {
       EnvSet.values.isDevFeaturesEnabled && this.#interactionEvent === InteractionEvent.SignIn
         ? await deriveAuthenticationContext(
             this.verificationRecordsArray,
-            user.id,
-            new MfaValidator(await this.signInExperienceValidator.getMfaSettings(), user)
+            user,
+            await this.signInExperienceValidator.getMfaSettings()
           )
         : undefined;
 

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -78,6 +78,12 @@ export default class ExperienceInteraction {
   private readonly verificationRecords = new VerificationRecordsMap();
   /** The userId of the user for the current interaction. Only available once the user is identified. */
   private userId?: string;
+  /**
+   * The ids of the verification records that identified `userId`: the one `identifyUser()` first
+   * identified the user with, and any later one that identified the same user. The
+   * authentication context counts an identifier record as a proof only when it is one of them.
+   */
+  private readonly identifiedVerificationIds = new Set<string>();
   private userCache?: User;
   private readonly adaptiveMfaValidator: AdaptiveMfaValidator;
 
@@ -150,6 +156,7 @@ export default class ExperienceInteraction {
       profile = {},
       mfa = {},
       userId,
+      identifiedVerificationIds = [],
       trustedDeviceOptIn,
       interactionEvent,
       captcha = {
@@ -160,6 +167,7 @@ export default class ExperienceInteraction {
 
     this.#interactionEvent = interactionEvent;
     this.userId = userId;
+    this.identifiedVerificationIds = new Set(identifiedVerificationIds);
     this.profile = new Profile(libraries, queries, profile, interactionContext);
     this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.trustedDevice = new TrustedDevice(ctx, tenant, {
@@ -257,12 +265,15 @@ export default class ExperienceInteraction {
         this.userId === id,
         new RequestError({ code: 'session.identity_conflict', status: 409 })
       );
+      // The record identified the same user, so it is one of the identifying records as well.
+      this.identifiedVerificationIds.add(verificationId);
       return;
     }
 
     // Update the current interaction with the identified user
     this.userCache = user;
     this.userId = id;
+    this.identifiedVerificationIds.add(verificationId);
 
     // Sync social/enterprise SSO identity profile data.
     // Note: The profile data is not saved to the user profile until the user submits the interaction.
@@ -555,11 +566,11 @@ export default class ExperienceInteraction {
     // nothing and the provider stamps `auth_time` itself.
     const authenticationContext =
       EnvSet.values.isDevFeaturesEnabled && this.#interactionEvent === InteractionEvent.SignIn
-        ? await deriveAuthenticationContext(
-            this.verificationRecordsArray,
+        ? deriveAuthenticationContext(this.verificationRecordsArray, {
             user,
-            await this.signInExperienceValidator.getMfaSettings()
-          )
+            mfaSettings: await this.signInExperienceValidator.getMfaSettings(),
+            identifiedVerificationIds: this.identifiedVerificationIds,
+          })
         : undefined;
 
     // Revalidate the new profile data if any
@@ -752,6 +763,7 @@ export default class ExperienceInteraction {
     return {
       interactionEvent,
       userId,
+      identifiedVerificationIds: [...this.identifiedVerificationIds],
       ...this.trustedDevice.data,
       profile: this.profile.data,
       mfa: this.mfa.data,

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -548,6 +548,16 @@ export default class ExperienceInteraction {
       await this.guardMfaVerificationStatus(log);
     }
 
+    // Derive the authentication context this sign-in achieved before anything is written to the
+    // account, so that a record whose identifier or identity is only being added by this
+    // submission does not count as a proof of the account. It seeds the OIDC session so the ID
+    // token carries `acr` / `amr` / `auth_time`; a sign-in without a proof (or a register) seeds
+    // nothing and the provider stamps `auth_time` itself.
+    const authenticationContext =
+      EnvSet.values.isDevFeaturesEnabled && this.#interactionEvent === InteractionEvent.SignIn
+        ? await deriveAuthenticationContext(this.verificationRecordsArray, user.id)
+        : undefined;
+
     // Revalidate the new profile data if any
     await this.profile.validateAvailability();
 
@@ -677,14 +687,7 @@ export default class ExperienceInteraction {
     const redirectTo = await provider.interactionResult(this.ctx.req, this.ctx.res, {
       login: {
         accountId: user.id,
-        // Seed the authentication context this interaction achieved onto the OIDC session, so
-        // the ID token carries `acr` / `amr` / `auth_time`. A sign-in without a counted record
-        // (or a register) seeds nothing and the provider stamps `auth_time` itself.
-        ...conditional(
-          EnvSet.values.isDevFeaturesEnabled &&
-            this.#interactionEvent === InteractionEvent.SignIn &&
-            deriveAuthenticationContext(this.verificationRecordsArray)
-        ),
+        ...authenticationContext,
       },
       // Persist the interaction status to the OIDC session after interaction submission
       ...this.toJson(),

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -568,7 +568,6 @@ export default class ExperienceInteraction {
       EnvSet.values.isDevFeaturesEnabled && this.#interactionEvent === InteractionEvent.SignIn
         ? deriveAuthenticationContext(this.verificationRecordsArray, {
             user,
-            mfaSettings: await this.signInExperienceValidator.getMfaSettings(),
             identifiedVerificationIds: this.identifiedVerificationIds,
           })
         : undefined;

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -2,6 +2,7 @@
 
 import { appInsights } from '@logto/app-insights/node';
 import {
+  AuthenticationProofRole,
   InteractionEvent,
   InteractionHookEvent,
   LogtoActionKey,
@@ -40,9 +41,10 @@ import {
 import { validatePostSignInActionResult } from './libraries/action-result-validation.js';
 import { AdaptiveMfaValidator } from './libraries/adaptive-mfa-validator/index.js';
 import { type AdaptiveMfaResult } from './libraries/adaptive-mfa-validator/types.js';
-import { deriveAuthenticationContext } from './libraries/authentication-context.js';
+import { aggregateAuthenticationContext } from './libraries/authentication-context.js';
+import { AuthenticationProofs } from './libraries/authentication-proofs.js';
 import { CaptchaValidator } from './libraries/captcha-validator.js';
-import { MfaValidator } from './libraries/mfa-validator.js';
+import { MfaValidator, isMfaVerificationRecord } from './libraries/mfa-validator.js';
 import { ProvisionLibrary } from './libraries/provision-library.js';
 import { SignInExperienceValidator } from './libraries/sign-in-experience-validator.js';
 import { UserUpdateLibrary } from './libraries/user-update-library.js';
@@ -79,11 +81,11 @@ export default class ExperienceInteraction {
   /** The userId of the user for the current interaction. Only available once the user is identified. */
   private userId?: string;
   /**
-   * The ids of the verification records that identified `userId`: the one `identifyUser()` first
-   * identified the user with, and any later one that identified the same user. The
-   * authentication context counts an identifier record as a proof only when it is one of them.
+   * What the user proved about the account in this interaction, recorded at the touchpoint that
+   * consumed each credential. Staged like `profile` and `mfa`, persisted by {@link save}, and
+   * cleared wherever `profile.data` is cleared; see {@link AuthenticationProofs}.
    */
-  private readonly identifiedVerificationIds = new Set<string>();
+  private readonly authenticationProofs: AuthenticationProofs;
   private userCache?: User;
   private readonly adaptiveMfaValidator: AdaptiveMfaValidator;
 
@@ -122,9 +124,12 @@ export default class ExperienceInteraction {
     const interactionContext: InteractionContext = {
       getInteractionEvent: () => this.#interactionEvent,
       getIdentifiedUser: async () => this.getIdentifiedUser(),
-      getVerificationRecordByTypeAndId: (type, verificationId) =>
-        this.getVerificationRecordByTypeAndId(type, verificationId),
-      getVerificationRecordById: (verificationId) => this.getVerificationRecordById(verificationId),
+      consumeForBind: (verificationId) => this.consumeForBind(verificationId),
+      consumeForBindByType: (type, verificationId) =>
+        this.consumeForBindByType(type, verificationId),
+      recordEstablishedPassword: () => {
+        this.authenticationProofs.stageEstablishedPassword();
+      },
       getCurrentProfile: () => this.profile.data,
     };
 
@@ -137,6 +142,7 @@ export default class ExperienceInteraction {
 
     if (typeof interactionData === 'string') {
       this.#interactionEvent = interactionData;
+      this.authenticationProofs = new AuthenticationProofs();
       this.profile = new Profile(libraries, queries, {}, interactionContext);
       this.mfa = new Mfa(libraries, queries, {}, interactionContext);
       this.trustedDevice = new TrustedDevice(ctx, tenant, {});
@@ -156,7 +162,7 @@ export default class ExperienceInteraction {
       profile = {},
       mfa = {},
       userId,
-      identifiedVerificationIds = [],
+      authenticationProofs = [],
       trustedDeviceOptIn,
       interactionEvent,
       captcha = {
@@ -167,7 +173,7 @@ export default class ExperienceInteraction {
 
     this.#interactionEvent = interactionEvent;
     this.userId = userId;
-    this.identifiedVerificationIds = new Set(identifiedVerificationIds);
+    this.authenticationProofs = new AuthenticationProofs(authenticationProofs);
     this.profile = new Profile(libraries, queries, profile, interactionContext);
     this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.trustedDevice = new TrustedDevice(ctx, tenant, {
@@ -192,6 +198,8 @@ export default class ExperienceInteraction {
    * Switch the interaction event for the current interaction sign-in <> register
    *
    * - any pending profile data will be cleared
+   * - any authentication proof will be cleared, so that a proof recorded for an abandoned attempt
+   *   at one event can never inflate the context of another
    *
    * @throws RequestError with 403 if the interaction event is not allowed by the `SignInExperienceValidator`
    * @throws RequestError with 400 if the interaction event is `ForgotPassword` and the current interaction event is not `ForgotPassword`
@@ -213,6 +221,7 @@ export default class ExperienceInteraction {
 
     if (this.#interactionEvent !== interactionEvent) {
       this.profile.cleanUp();
+      this.authenticationProofs.clear();
     }
 
     this.#interactionEvent = interactionEvent;
@@ -240,7 +249,7 @@ export default class ExperienceInteraction {
       new RequestError({ code: 'session.invalid_interaction_type', status: 400 })
     );
 
-    const verificationRecord = this.getVerificationRecordById(verificationId);
+    const verificationRecord = this.consumeForIdentify(verificationId);
 
     log?.append({
       verification: verificationRecord.toJson(),
@@ -265,15 +274,12 @@ export default class ExperienceInteraction {
         this.userId === id,
         new RequestError({ code: 'session.identity_conflict', status: 409 })
       );
-      // The record identified the same user, so it is one of the identifying records as well.
-      this.identifiedVerificationIds.add(verificationId);
       return;
     }
 
     // Update the current interaction with the identified user
     this.userCache = user;
     this.userId = id;
-    this.identifiedVerificationIds.add(verificationId);
 
     // Sync social/enterprise SSO identity profile data.
     // Note: The profile data is not saved to the user profile until the user submits the interaction.
@@ -305,7 +311,7 @@ export default class ExperienceInteraction {
     );
 
     if (verificationId) {
-      const verificationRecord = this.getVerificationRecordById(verificationId);
+      const verificationRecord = this.consumeForCreate(verificationId);
       const verificationData = verificationRecord.toJson();
 
       log?.append({
@@ -371,6 +377,70 @@ export default class ExperienceInteraction {
   }
 
   /**
+   * Fetch a verification record for binding the credential it carries to the account, recording
+   * the `bind` proof. This and {@link consumeForBindByType} are the only ways `Profile` and `Mfa`
+   * reach a record, so a bind cannot forget to record its proof; see {@link AuthenticationProofs}.
+   */
+  public consumeForBind(verificationId: string): VerificationRecord {
+    const record = this.getVerificationRecordById(verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Bind);
+
+    return record;
+  }
+
+  /** The typed variant of {@link consumeForBind}. */
+  public consumeForBindByType<K extends keyof VerificationRecordMap>(
+    type: K,
+    verificationId: string
+  ): VerificationRecordMap[K] {
+    const record = this.getVerificationRecordByTypeAndId(type, verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Bind);
+
+    return record;
+  }
+
+  /**
+   * Record the `mfa` proof for an MFA challenge the user just answered. For a challenge record,
+   * verifying is the use: the MFA gate scans for a verified record and no later step consumes it,
+   * so the verify routes call this right after a successful verification. A new-enrollment record
+   * is never a challenge; its proof is the `bind` one recorded when the factor is added.
+   *
+   * @throws {RequestError} with 404 if the verification record is not found
+   * @throws {RequestError} with 400 if the record is not a verified MFA challenge
+   */
+  public consumeForMfa<K extends keyof VerificationRecordMap>(
+    type: K,
+    verificationId: string
+  ): VerificationRecordMap[K] {
+    const record = this.getVerificationRecordByTypeAndId(type, verificationId);
+
+    assertThat(
+      isMfaVerificationRecord(record) && record.isVerified && !record.isNewBindMfaVerification,
+      new RequestError({ code: 'session.verification_failed', status: 400 })
+    );
+
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Mfa);
+
+    return record;
+  }
+
+  /** Fetch a verification record for creating the account from it, recording the `create` proof. */
+  private consumeForCreate(verificationId: string) {
+    const record = this.getVerificationRecordById(verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Create);
+
+    return record;
+  }
+
+  /** Fetch a verification record for identifying the user with it, recording the `identify` proof. */
+  private consumeForIdentify(verificationId: string) {
+    const record = this.getVerificationRecordById(verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Identify);
+
+    return record;
+  }
+
+  /**
    * Validate the interaction verification records against the sign-in experience and user MFA settings.
    * The interaction is verified if at least one user enabled MFA verification record is present and verified.
    *
@@ -393,6 +463,8 @@ export default class ExperienceInteraction {
 
     const mfaValidator = new MfaValidator(mfaSettings, user, adaptiveMfaResult);
 
+    // Declared non-proof: an adaptive-MFA non-trigger result skips the gate and proves nothing,
+    // so it records no authentication proof.
     if (!mfaValidator.isMfaRequired) {
       return;
     }
@@ -403,6 +475,8 @@ export default class ExperienceInteraction {
       return;
     }
 
+    // Declared non-proof: a trusted device satisfies the MFA gate but proves nothing now, so it
+    // records no authentication proof and the context stays at what the first factor reached.
     const isMfaVerifiedWithTrustedDevice = await this.trustedDevice.tryVerifyMfa(user.id);
 
     this.assignAdaptiveMfaHookResult(user.id, adaptiveMfaResult);
@@ -559,21 +633,13 @@ export default class ExperienceInteraction {
       await this.guardMfaVerificationStatus(log);
     }
 
-    // Derive the authentication context this sign-in or registration achieved before anything is
-    // written to an existing account, so that a record whose identifier or identity is only being
-    // added by this submission does not count as a proof of that account. A registration is the
-    // opposite case: `createUser()` already created the account from this interaction's records,
-    // so a record for one of its identifiers and a factor this submission binds are proofs of it.
-    // The context seeds the OIDC session so the ID token carries `acr` / `amr` / `auth_time`; an
-    // interaction without a proof seeds nothing and the provider stamps `auth_time` itself.
+    // Aggregate the authentication context this sign-in or registration achieved from the proofs
+    // its touchpoints recorded. The context seeds the OIDC session so the ID token carries `acr` /
+    // `amr` / `auth_time`; an interaction without a proof seeds nothing and the provider stamps
+    // `auth_time` itself.
     const authenticationContext = conditional(
       EnvSet.values.isDevFeaturesEnabled &&
-        deriveAuthenticationContext(this.verificationRecordsArray, {
-          user,
-          identifiedVerificationIds: this.identifiedVerificationIds,
-          isNewAccount: this.#interactionEvent === InteractionEvent.Register,
-          bindMfaFactors: new Set(this.mfa.bindMfaFactorsArray.map(({ type }) => type)),
-        })
+        aggregateAuthenticationContext(this.authenticationProofs.proofs)
     );
 
     // Revalidate the new profile data if any
@@ -766,7 +832,7 @@ export default class ExperienceInteraction {
     return {
       interactionEvent,
       userId,
-      identifiedVerificationIds: [...this.identifiedVerificationIds],
+      authenticationProofs: this.authenticationProofs.data,
       ...this.trustedDevice.data,
       profile: this.profile.data,
       mfa: this.mfa.data,
@@ -777,8 +843,13 @@ export default class ExperienceInteraction {
   }
 
   public toSanitizedJson(): SanitizedInteractionStorageData {
-    // The trusted-device opt-in decision is internal authentication state.
-    const { trustedDeviceOptIn: _, ...interactionStorage } = this.toJson();
+    // The trusted-device opt-in decision and the authentication proofs are internal
+    // authentication state; a proof's role in particular never leaves the server.
+    const {
+      trustedDeviceOptIn: _,
+      authenticationProofs: __,
+      ...interactionStorage
+    } = this.toJson();
 
     return {
       ...interactionStorage,
@@ -922,6 +993,8 @@ export default class ExperienceInteraction {
    */
   private async cleanUp() {
     const { provider } = this.tenant;
+    // Proofs are interaction-scoped and must never be visible to a subsequent interaction.
+    this.authenticationProofs.clear();
     await provider.interactionResult(this.ctx.req, this.ctx.res, {});
   }
 }

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -1,0 +1,164 @@
+import { TemplateType } from '@logto/connector-kit';
+import { SignInIdentifier, VerificationType } from '@logto/schemas';
+
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+import { BackupCodeVerification } from '../verifications/backup-code-verification.js';
+import { EmailCodeVerification } from '../verifications/code-verification.js';
+import { PasswordVerification } from '../verifications/password-verification.js';
+import { SocialVerification } from '../verifications/social-verification.js';
+import { TotpVerification } from '../verifications/totp-verification.js';
+import {
+  SignInPasskeyVerification,
+  WebAuthnVerification,
+} from '../verifications/web-authn-verification.js';
+
+import { deriveAuthenticationContext } from './authentication-context.js';
+
+const { libraries, queries } = new MockTenant();
+
+const password = (verifiedAt?: number, verified = true) =>
+  new PasswordVerification(libraries, queries, {
+    id: 'password',
+    type: VerificationType.Password,
+    identifier: { type: SignInIdentifier.Username, value: 'foo' },
+    verified,
+    verifiedAt,
+  });
+
+const emailCode = (verifiedAt?: number) =>
+  new EmailCodeVerification(libraries, queries, {
+    id: 'email',
+    type: VerificationType.EmailVerificationCode,
+    identifier: { type: SignInIdentifier.Email, value: 'foo@bar.com' },
+    templateType: TemplateType.SignIn,
+    verified: true,
+    verifiedAt,
+  });
+
+const totp = ({ verifiedAt, secret }: { verifiedAt?: number; secret?: string } = {}) =>
+  new TotpVerification(libraries, queries, {
+    id: 'totp',
+    type: VerificationType.TOTP,
+    userId: 'user',
+    verified: true,
+    verifiedAt,
+    secret,
+  });
+
+const backupCode = (verifiedAt?: number) =>
+  new BackupCodeVerification(libraries, queries, {
+    id: 'backup',
+    type: VerificationType.BackupCode,
+    userId: 'user',
+    code: 'code',
+    verifiedAt,
+  });
+
+const webAuthn = (verifiedAt?: number) =>
+  new WebAuthnVerification(libraries, queries, {
+    id: 'webauthn',
+    type: VerificationType.WebAuthn,
+    userId: 'user',
+    verified: true,
+    verifiedAt,
+  });
+
+const signInPasskey = (verifiedAt?: number) =>
+  new SignInPasskeyVerification(libraries, queries, {
+    id: 'passkey',
+    type: VerificationType.SignInPasskey,
+    userId: 'user',
+    verified: true,
+    verifiedAt,
+  });
+
+const social = (verifiedAt?: number) =>
+  new SocialVerification(libraries, queries, {
+    id: 'social',
+    type: VerificationType.Social,
+    connectorId: 'connector',
+    socialUserInfo: { id: 'social-user' },
+    verifiedAt,
+  });
+
+describe('deriveAuthenticationContext', () => {
+  it('reaches 1fa with a password', () => {
+    expect(deriveAuthenticationContext([password(100)])).toEqual({
+      acr: 'urn:logto:acr:1fa',
+      amr: ['pwd'],
+      ts: 100,
+    });
+  });
+
+  it('reaches 1fa with a primary email code', () => {
+    expect(deriveAuthenticationContext([emailCode(100)])).toEqual({
+      acr: 'urn:logto:acr:1fa',
+      amr: ['otp'],
+      ts: 100,
+    });
+  });
+
+  it('reaches mfa with a password and a TOTP, taking the earliest timestamp', () => {
+    expect(deriveAuthenticationContext([password(200), totp({ verifiedAt: 100 })])).toEqual({
+      acr: 'urn:logto:acr:mfa',
+      amr: ['pwd', 'otp', 'mfa'],
+      ts: 100,
+    });
+  });
+
+  it('reaches only 1fa with a TOTP alone', () => {
+    expect(deriveAuthenticationContext([totp({ verifiedAt: 100 })])).toEqual({
+      acr: 'urn:logto:acr:1fa',
+      amr: ['otp'],
+      ts: 100,
+    });
+  });
+
+  it('reaches only 1fa with two mfa-class factors and no first factor', () => {
+    expect(deriveAuthenticationContext([totp({ verifiedAt: 100 }), backupCode(200)])).toEqual({
+      acr: 'urn:logto:acr:1fa',
+      amr: ['otp'],
+      ts: 100,
+    });
+  });
+
+  it.each([webAuthn, signInPasskey])(
+    'reaches mfa with a user-verified WebAuthn assertion alone',
+    (build) => {
+      expect(deriveAuthenticationContext([build(100)])).toEqual({
+        acr: 'urn:logto:acr:mfa',
+        amr: ['pop', 'user', 'mfa'],
+        ts: 100,
+      });
+    }
+  );
+
+  it('records only fed for a social sign-in', () => {
+    expect(deriveAuthenticationContext([social(100)])).toEqual({ amr: ['fed'], ts: 100 });
+  });
+
+  it('keeps fed next to a Logto-verifiable factor', () => {
+    expect(deriveAuthenticationContext([social(100), password(200)])).toEqual({
+      acr: 'urn:logto:acr:1fa',
+      amr: ['fed', 'pwd'],
+      ts: 100,
+    });
+  });
+
+  it('ignores unverified records and factors enrolled in this interaction', () => {
+    expect(
+      deriveAuthenticationContext([password(100, false), totp({ verifiedAt: 50, secret: 'new' })])
+    ).toEqual({});
+    expect(
+      deriveAuthenticationContext([password(100), totp({ verifiedAt: 50, secret: 'new' })])
+    ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+  });
+
+  it('omits ts when no counted record carries verifiedAt', () => {
+    expect(deriveAuthenticationContext([password()])).toEqual({
+      acr: 'urn:logto:acr:1fa',
+      amr: ['pwd'],
+    });
+  });
+});

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -34,7 +34,6 @@ import {
 } from '../verifications/web-authn-verification.js';
 
 import { deriveAuthenticationContext } from './authentication-context.js';
-import { MfaValidator } from './mfa-validator.js';
 
 const { jest } = import.meta;
 
@@ -54,14 +53,11 @@ const user: User = {
     mockUserBackupCodeMfaVerification,
   ],
 };
-const allFactorsEnabled = new MfaValidator(
-  { ...mockSignInExperience.mfa, factors: Object.values(MfaFactor) },
-  user
-);
-const noFactorEnabled = new MfaValidator({ ...mockSignInExperience.mfa, factors: [] }, user);
+const allFactorsEnabled = { ...mockSignInExperience.mfa, factors: Object.values(MfaFactor) };
+const noFactorEnabled = { ...mockSignInExperience.mfa, factors: [] };
 
 const derive = async (records: Parameters<typeof deriveAuthenticationContext>[0]) =>
-  deriveAuthenticationContext(records, userId, allFactorsEnabled);
+  deriveAuthenticationContext(records, user, allFactorsEnabled);
 
 /** Marks an identifier record that identifies no account. */
 const noAccount = Symbol('no account');
@@ -344,10 +340,41 @@ describe('deriveAuthenticationContext', () => {
       await expect(
         deriveAuthenticationContext(
           [password(100), totp({ verifiedAt: 200 }), mfaEmailCode(300)],
-          userId,
+          user,
           noFactorEnabled
         )
       ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+      // A backup code set the user never enrolled is not eligible either.
+      await expect(
+        deriveAuthenticationContext(
+          [password(100), backupCode(200)],
+          { ...user, mfaVerifications: [mockUserTotpMfaVerification] },
+          allFactorsEnabled
+        )
+      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+    });
+
+    it('keeps the proof of the last backup code once every code is marked used', async () => {
+      // `verify()` marks the code used before the submission reloads the user, so the reloaded
+      // user has no unused code left and would no longer be offered a backup code challenge.
+      const reloadedUser: User = {
+        ...user,
+        mfaVerifications: [
+          mockUserTotpMfaVerification,
+          {
+            ...mockUserBackupCodeMfaVerification,
+            codes: [{ code: 'code', usedAt: new Date().toISOString() }],
+          },
+        ],
+      };
+
+      await expect(
+        deriveAuthenticationContext(
+          [password(100), backupCode(200)],
+          reloadedUser,
+          allFactorsEnabled
+        )
+      ).resolves.toEqual({ acr: 'urn:logto:acr:mfa', amr: ['pwd', 'otp', 'mfa'], ts: 100 });
     });
 
     it('ignores an identifier record that identifies no account', async () => {

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -16,23 +16,24 @@ const { Create, Identify, Bind } = AuthenticationProofRole;
 const firstFactorAcr = 'urn:logto:acr:1fa';
 const mfaAcr = 'urn:logto:acr:mfa';
 
-let sequence = 0;
-
-/** A proof at a strictly increasing time, so `ts` is always the first proof listed. */
+/** A proof; `at` is assigned by {@link aggregate} from the position in the list. */
 const proof = (
   factor: AuthenticationFactor,
   factorClass: AuthenticationFactorClass | undefined,
   amr: AuthenticationMethodReference[],
   role: AuthenticationProofRole = Identify
 ): AuthenticationProof => ({
-  id: `${factor}-${role}-${sequence}`,
+  id: `${factor}-${role}`,
   factor,
   ...(factorClass && { class: factorClass }),
   amr,
   role,
-  // eslint-disable-next-line @silverhand/fp/no-mutation
-  at: 100 + sequence++,
+  at: 0,
 });
+
+/** Aggregate proofs recorded at strictly increasing times, so `ts` is always the first one. */
+const aggregate = (proofs: AuthenticationProof[]) =>
+  aggregateAuthenticationContext(proofs.map((proof, index) => ({ ...proof, at: 100 + index })));
 
 const password = (role?: AuthenticationProofRole) =>
   proof(AuthenticationFactor.Password, FirstFactor, [Password], role);
@@ -90,13 +91,7 @@ describe('aggregateAuthenticationContext', () => {
         ['fed', 'pop', 'user', 'mfa'],
       ],
     ])('%s', (_, build, acr, amr) => {
-      const proofs = build();
-
-      expect(aggregateAuthenticationContext(proofs)).toEqual({
-        ...(acr && { acr }),
-        amr,
-        ts: proofs[0]!.at,
-      });
+      expect(aggregate(build())).toEqual({ ...(acr && { acr }), amr, ts: 100 });
     });
   });
 
@@ -173,13 +168,7 @@ describe('aggregateAuthenticationContext', () => {
         ['otp', 'pwd', 'mfa'],
       ],
     ])('%s', (_, build, acr, amr) => {
-      const proofs = build();
-
-      expect(aggregateAuthenticationContext(proofs)).toEqual({
-        ...(acr && { acr }),
-        amr,
-        ts: proofs[0]!.at,
-      });
+      expect(aggregate(build())).toEqual({ ...(acr && { acr }), amr, ts: 100 });
     });
   });
 
@@ -188,9 +177,9 @@ describe('aggregateAuthenticationContext', () => {
   });
 
   it('takes the earliest proof as the authentication time regardless of order', () => {
-    const late = totp(AuthenticationProofRole.Mfa);
-    const early = password();
+    const late = { ...totp(AuthenticationProofRole.Mfa), at: 200 };
+    const early = { ...password(), at: 100 };
 
-    expect(aggregateAuthenticationContext([late, early]).ts).toBe(early.at);
+    expect(aggregateAuthenticationContext([late, early]).ts).toBe(100);
   });
 });

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -14,7 +14,6 @@ import {
   mockUserTotpMfaVerification,
   mockUserWebAuthnMfaVerification,
 } from '#src/__mocks__/user.js';
-import RequestError from '#src/errors/RequestError/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
 import { BackupCodeVerification } from '../verifications/backup-code-verification.js';
@@ -35,8 +34,6 @@ import {
 
 import { deriveAuthenticationContext } from './authentication-context.js';
 
-const { jest } = import.meta;
-
 const { libraries, queries } = new MockTenant();
 const userId = mockUser.id;
 const email = 'foo@bar.com';
@@ -56,92 +53,75 @@ const user: User = {
 const allFactorsEnabled = { ...mockSignInExperience.mfa, factors: Object.values(MfaFactor) };
 const noFactorEnabled = { ...mockSignInExperience.mfa, factors: [] };
 
-const derive = async (records: Parameters<typeof deriveAuthenticationContext>[0]) =>
-  deriveAuthenticationContext(records, user, allFactorsEnabled);
+/** The ids of the identifier records below; the interaction records them at identification. */
+const identifiedVerificationIds = new Set(['password', 'email', 'phone']);
 
-/** Marks an identifier record that identifies no account. */
-const noAccount = Symbol('no account');
+type Options = Partial<Parameters<typeof deriveAuthenticationContext>[1]>;
 
-/**
- * Stub which account an identifier record identifies: the given user, or none (the record then
- * rejects the way a real one does for an unregistered identifier or an unlinked identity).
- */
-const identifying = <T extends { identifyUser: () => Promise<User> }>(
-  record: T,
-  identifiedUserId: string | typeof noAccount = userId
-): T => {
-  const target: { identifyUser: () => Promise<User> } = record;
-  jest.spyOn(target, 'identifyUser').mockImplementation(async () => {
-    if (identifiedUserId === noAccount) {
-      throw new RequestError({ code: 'user.user_not_exist', status: 404 });
-    }
-
-    return { ...user, id: identifiedUserId };
+const derive = (
+  records: Parameters<typeof deriveAuthenticationContext>[0],
+  options: Options = {}
+) =>
+  deriveAuthenticationContext(records, {
+    user,
+    mfaSettings: allFactorsEnabled,
+    identifiedVerificationIds,
+    ...options,
   });
 
-  return record;
-};
+const password = ({
+  verifiedAt,
+  verified = true,
+  id = 'password',
+}: { verifiedAt?: number; verified?: boolean; id?: string } = {}) =>
+  new PasswordVerification(libraries, queries, {
+    id,
+    type: VerificationType.Password,
+    identifier: { type: SignInIdentifier.Username, value: 'foo' },
+    verified,
+    verifiedAt,
+  });
 
-const password = (verifiedAt?: number, verified = true) =>
-  identifying(
-    new PasswordVerification(libraries, queries, {
-      id: 'password',
-      type: VerificationType.Password,
-      identifier: { type: SignInIdentifier.Username, value: 'foo' },
-      verified,
-      verifiedAt,
-    })
-  );
-
-const emailCode = (verifiedAt?: number, identifiedUserId: string | typeof noAccount = userId) =>
-  identifying(
-    new EmailCodeVerification(libraries, queries, {
-      id: 'email',
-      type: VerificationType.EmailVerificationCode,
-      identifier: { type: SignInIdentifier.Email, value: email },
-      templateType: TemplateType.SignIn,
-      verified: true,
-      verifiedAt,
-    }),
-    identifiedUserId
-  );
+const emailCode = (verifiedAt?: number, id = 'email') =>
+  new EmailCodeVerification(libraries, queries, {
+    id,
+    type: VerificationType.EmailVerificationCode,
+    identifier: { type: SignInIdentifier.Email, value: email },
+    templateType: TemplateType.SignIn,
+    verified: true,
+    verifiedAt,
+  });
 
 const phoneCode = (verifiedAt?: number) =>
-  identifying(
-    new PhoneCodeVerification(libraries, queries, {
-      id: 'phone',
-      type: VerificationType.PhoneVerificationCode,
-      identifier: { type: SignInIdentifier.Phone, value: phone },
-      templateType: TemplateType.SignIn,
-      verified: true,
-      verifiedAt,
-    })
-  );
+  new PhoneCodeVerification(libraries, queries, {
+    id: 'phone',
+    type: VerificationType.PhoneVerificationCode,
+    identifier: { type: SignInIdentifier.Phone, value: phone },
+    templateType: TemplateType.SignIn,
+    verified: true,
+    verifiedAt,
+  });
 
-/** An MFA code sent to the user's primary email, as the MFA verification-code route creates it. */
-const mfaEmailCode = (verifiedAt?: number) =>
-  identifying(
-    new MfaEmailCodeVerification(libraries, queries, {
-      id: 'mfa-email',
-      type: VerificationType.MfaEmailVerificationCode,
-      identifier: { type: SignInIdentifier.Email, value: email },
-      templateType: TemplateType.MfaVerification,
-      verified: true,
-      verifiedAt,
-    })
-  );
+/** An MFA code sent to the given email, as the MFA verification-code route creates it. */
+const mfaEmailCode = (verifiedAt?: number, address = email) =>
+  new MfaEmailCodeVerification(libraries, queries, {
+    id: 'mfa-email',
+    type: VerificationType.MfaEmailVerificationCode,
+    identifier: { type: SignInIdentifier.Email, value: address },
+    templateType: TemplateType.MfaVerification,
+    verified: true,
+    verifiedAt,
+  });
 
 const mfaPhoneCode = (verifiedAt?: number) =>
-  identifying(
-    new MfaPhoneCodeVerification(libraries, queries, {
-      id: 'mfa-phone',
-      type: VerificationType.MfaPhoneVerificationCode,
-      identifier: { type: SignInIdentifier.Phone, value: phone },
-      templateType: TemplateType.MfaVerification,
-      verified: true,
-      verifiedAt,
-    })
-  );
+  new MfaPhoneCodeVerification(libraries, queries, {
+    id: 'mfa-phone',
+    type: VerificationType.MfaPhoneVerificationCode,
+    identifier: { type: SignInIdentifier.Phone, value: phone },
+    templateType: TemplateType.MfaVerification,
+    verified: true,
+    verifiedAt,
+  });
 
 const totp = ({
   verifiedAt,
@@ -206,48 +186,48 @@ const newPasswordIdentity = (verifiedAt?: number) =>
   });
 
 describe('deriveAuthenticationContext', () => {
-  it('reaches 1fa with a password', async () => {
-    await expect(derive([password(100)])).resolves.toEqual({
+  it('reaches 1fa with a password', () => {
+    expect(derive([password({ verifiedAt: 100 })])).toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['pwd'],
       ts: 100,
     });
   });
 
-  it('reaches 1fa with a primary email code', async () => {
-    await expect(derive([emailCode(100)])).resolves.toEqual({
+  it('reaches 1fa with a primary email code', () => {
+    expect(derive([emailCode(100)])).toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['otp'],
       ts: 100,
     });
   });
 
-  it('reaches mfa with a password and a TOTP, taking the earliest timestamp', async () => {
-    await expect(derive([password(200), totp({ verifiedAt: 100 })])).resolves.toEqual({
+  it('reaches mfa with a password and a TOTP, taking the earliest timestamp', () => {
+    expect(derive([password({ verifiedAt: 200 }), totp({ verifiedAt: 100 })])).toEqual({
       acr: 'urn:logto:acr:mfa',
       amr: ['pwd', 'otp', 'mfa'],
       ts: 100,
     });
   });
 
-  it('reaches mfa with a primary email code and an MFA phone code', async () => {
-    await expect(derive([emailCode(100), mfaPhoneCode(200)])).resolves.toEqual({
+  it('reaches mfa with a primary email code and an MFA phone code', () => {
+    expect(derive([emailCode(100), mfaPhoneCode(200)])).toEqual({
       acr: 'urn:logto:acr:mfa',
       amr: ['otp', 'sms', 'mfa'],
       ts: 100,
     });
   });
 
-  it('reaches only 1fa with a TOTP alone', async () => {
-    await expect(derive([totp({ verifiedAt: 100 })])).resolves.toEqual({
+  it('reaches only 1fa with a TOTP alone', () => {
+    expect(derive([totp({ verifiedAt: 100 })])).toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['otp'],
       ts: 100,
     });
   });
 
-  it('reaches only 1fa with two mfa-class factors and no first factor', async () => {
-    await expect(derive([totp({ verifiedAt: 100 }), backupCode(200)])).resolves.toEqual({
+  it('reaches only 1fa with two mfa-class factors and no first factor', () => {
+    expect(derive([totp({ verifiedAt: 100 }), backupCode(200)])).toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['otp'],
       ts: 100,
@@ -256,8 +236,8 @@ describe('deriveAuthenticationContext', () => {
 
   it.each([webAuthn, signInPasskey])(
     'reaches mfa with a user-verified WebAuthn assertion alone',
-    async (build) => {
-      await expect(derive([build(100)])).resolves.toEqual({
+    (build) => {
+      expect(derive([build(100)])).toEqual({
         acr: 'urn:logto:acr:mfa',
         amr: ['pop', 'user', 'mfa'],
         ts: 100,
@@ -265,58 +245,66 @@ describe('deriveAuthenticationContext', () => {
     }
   );
 
-  it('records only fed for a social sign-in', async () => {
-    await expect(derive([social(100)])).resolves.toEqual({ amr: ['fed'], ts: 100 });
+  it('records only fed for a social sign-in', () => {
+    expect(derive([social(100)])).toEqual({ amr: ['fed'], ts: 100 });
   });
 
-  it('keeps fed next to a Logto-verifiable factor', async () => {
-    await expect(derive([social(100), password(200)])).resolves.toEqual({
+  it('keeps fed next to a Logto-verifiable factor', () => {
+    expect(derive([social(100), password({ verifiedAt: 200 })])).toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['fed', 'pwd'],
       ts: 100,
     });
   });
 
-  it('ignores unverified records and factors enrolled in this interaction', async () => {
-    await expect(
-      derive([password(100, false), totp({ verifiedAt: 50, secret: 'new' })])
-    ).resolves.toEqual({});
-    await expect(derive([password(100), totp({ verifiedAt: 50, secret: 'new' })])).resolves.toEqual(
-      { acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 }
-    );
-  });
-
-  it('omits ts when no counted record carries verifiedAt', async () => {
-    await expect(derive([password()])).resolves.toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['pwd'],
+  it('keeps fed for an identity that is only being linked by this submission', () => {
+    // A linking social record never identified the user through its stored identity.
+    expect(derive([social(50)], { identifiedVerificationIds: new Set() })).toEqual({
+      amr: ['fed'],
+      ts: 50,
     });
   });
 
+  it('ignores unverified records and factors enrolled in this interaction', () => {
+    expect(
+      derive([
+        password({ verifiedAt: 100, verified: false }),
+        totp({ verifiedAt: 50, secret: 'new' }),
+      ])
+    ).toEqual({});
+    expect(
+      derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 50, secret: 'new' })])
+    ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+  });
+
+  it('omits ts when no counted record carries verifiedAt', () => {
+    expect(derive([password()])).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'] });
+  });
+
   describe('one factor never fills both roles', () => {
-    it('stays at 1fa when the MFA code went to the same email as the first factor', async () => {
-      await expect(derive([emailCode(100), mfaEmailCode(200)])).resolves.toEqual({
+    it('stays at 1fa when the MFA code went to the same email as the first factor', () => {
+      expect(derive([emailCode(100), mfaEmailCode(200)])).toEqual({
         acr: 'urn:logto:acr:1fa',
         amr: ['otp'],
         ts: 100,
       });
     });
 
-    it('stays at 1fa when the MFA code went to the same phone as the first factor', async () => {
-      await expect(derive([phoneCode(100), mfaPhoneCode(200)])).resolves.toEqual({
+    it('stays at 1fa when the MFA code went to the same phone as the first factor', () => {
+      expect(derive([phoneCode(100), mfaPhoneCode(200)])).toEqual({
         acr: 'urn:logto:acr:1fa',
         amr: ['sms'],
         ts: 100,
       });
     });
 
-    it('still reaches mfa when another factor supplies the first factor', async () => {
-      await expect(derive([password(100), mfaEmailCode(200)])).resolves.toEqual({
+    it('still reaches mfa when another factor supplies the first factor', () => {
+      expect(derive([password({ verifiedAt: 100 }), mfaEmailCode(200)])).toEqual({
         acr: 'urn:logto:acr:mfa',
         amr: ['pwd', 'otp', 'mfa'],
         ts: 100,
       });
-      await expect(derive([emailCode(100), password(150), mfaEmailCode(200)])).resolves.toEqual({
+      expect(derive([emailCode(100), password({ verifiedAt: 150 }), mfaEmailCode(200)])).toEqual({
         acr: 'urn:logto:acr:mfa',
         amr: ['otp', 'pwd', 'mfa'],
         ts: 100,
@@ -325,36 +313,49 @@ describe('deriveAuthenticationContext', () => {
   });
 
   describe('records that are not proofs of the identified user', () => {
-    it('never counts a new-password-identity record, even next to a real proof', async () => {
-      await expect(derive([social(100), newPasswordIdentity(50)])).resolves.toEqual({
+    it('never counts a new-password-identity record, even next to a real proof', () => {
+      expect(derive([social(100), newPasswordIdentity(50)])).toEqual({ amr: ['fed'], ts: 100 });
+      // Without the registration password, a TOTP alone reaches only 1fa.
+      expect(derive([social(100), newPasswordIdentity(50), totp({ verifiedAt: 200 })])).toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['fed', 'otp'],
+        ts: 100,
+      });
+    });
+
+    it('ignores an identifier record that did not identify the user', () => {
+      // A code for an address the user is adding, or a password verified for another account,
+      // is never passed to `identifyUser()` for this user.
+      expect(derive([social(100), emailCode(50, 'added-email')])).toEqual({
         amr: ['fed'],
         ts: 100,
       });
-      // Without the registration password, a TOTP alone reaches only 1fa.
-      await expect(
-        derive([social(100), newPasswordIdentity(50), totp({ verifiedAt: 200 })])
-      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['fed', 'otp'], ts: 100 });
+      expect(derive([password({ verifiedAt: 50, id: 'other-account' })])).toEqual({});
     });
 
-    it('ignores an MFA record of a factor the user has not enabled', async () => {
-      await expect(
-        deriveAuthenticationContext(
-          [password(100), totp({ verifiedAt: 200 }), mfaEmailCode(300)],
-          user,
-          noFactorEnabled
-        )
-      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+    it('ignores an MFA record of a factor the user has not enabled', () => {
+      expect(
+        derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 200 }), mfaEmailCode(300)], {
+          mfaSettings: noFactorEnabled,
+        })
+      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
       // A backup code set the user never enrolled is not eligible either.
-      await expect(
-        deriveAuthenticationContext(
-          [password(100), backupCode(200)],
-          { ...user, mfaVerifications: [mockUserTotpMfaVerification] },
-          allFactorsEnabled
-        )
-      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+      expect(
+        derive([password({ verifiedAt: 100 }), backupCode(200)], {
+          user: { ...user, mfaVerifications: [mockUserTotpMfaVerification] },
+        })
+      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
     });
 
-    it('keeps the proof of the last backup code once every code is marked used', async () => {
+    it('ignores an MFA code that was not sent to the primary contact of the user', () => {
+      expect(derive([password({ verifiedAt: 100 }), mfaEmailCode(200, 'other@bar.com')])).toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['pwd'],
+        ts: 100,
+      });
+    });
+
+    it('keeps the proof of the last backup code once every code is marked used', () => {
       // `verify()` marks the code used before the submission reloads the user, so the reloaded
       // user has no unused code left and would no longer be offered a backup code challenge.
       const reloadedUser: User = {
@@ -368,48 +369,16 @@ describe('deriveAuthenticationContext', () => {
         ],
       };
 
-      await expect(
-        deriveAuthenticationContext(
-          [password(100), backupCode(200)],
-          reloadedUser,
-          allFactorsEnabled
-        )
-      ).resolves.toEqual({ acr: 'urn:logto:acr:mfa', amr: ['pwd', 'otp', 'mfa'], ts: 100 });
+      expect(
+        derive([password({ verifiedAt: 100 }), backupCode(200)], { user: reloadedUser })
+      ).toEqual({ acr: 'urn:logto:acr:mfa', amr: ['pwd', 'otp', 'mfa'], ts: 100 });
     });
 
-    it('ignores an identifier record that identifies no account', async () => {
-      await expect(derive([social(100), emailCode(50, noAccount)])).resolves.toEqual({
-        amr: ['fed'],
-        ts: 100,
-      });
-    });
-
-    it('ignores an identifier record that identifies another account', async () => {
-      await expect(derive([emailCode(50, 'someone-else')])).resolves.toEqual({});
-    });
-
-    it('keeps fed for an identity that is only being linked by this submission', async () => {
-      const record = social(50);
-      jest
-        .spyOn(record, 'identifyUser')
-        .mockRejectedValue(new RequestError({ code: 'user.identity_not_exist', status: 404 }));
-
-      await expect(derive([record])).resolves.toEqual({ amr: ['fed'], ts: 50 });
-      expect(record.identifyUser).not.toHaveBeenCalled();
-    });
-
-    it('ignores factor records created for another user', async () => {
-      await expect(
-        derive([password(100), totp({ verifiedAt: 50, ownerId: 'someone-else' })])
-      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
-      await expect(derive([signInPasskey(100, 'someone-else')])).resolves.toEqual({});
-    });
-
-    it('propagates an unexpected identification failure', async () => {
-      const record = password(100);
-      jest.spyOn(record, 'identifyUser').mockRejectedValue(new Error('database down'));
-
-      await expect(derive([record])).rejects.toThrow('database down');
+    it('ignores factor records created for another user', () => {
+      expect(
+        derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 50, ownerId: 'someone-else' })])
+      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+      expect(derive([signInPasskey(100, 'someone-else')])).toEqual({});
     });
   });
 });

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -1,440 +1,196 @@
-import { TemplateType } from '@logto/connector-kit';
 import {
-  MfaFactor,
-  SignInIdentifier,
-  UsersPasswordEncryptionMethod,
-  VerificationType,
-  type User,
+  AuthenticationFactor,
+  AuthenticationFactorClass,
+  AuthenticationMethodReference,
+  AuthenticationProofRole,
+  type AuthenticationProof,
 } from '@logto/schemas';
 
-import {
-  mockUser,
-  mockUserBackupCodeMfaVerification,
-  mockUserTotpMfaVerification,
-  mockUserWebAuthnMfaVerification,
-} from '#src/__mocks__/user.js';
-import { MockTenant } from '#src/test-utils/tenant.js';
+import { aggregateAuthenticationContext } from './authentication-context.js';
 
-import { BackupCodeVerification } from '../verifications/backup-code-verification.js';
-import {
-  EmailCodeVerification,
-  MfaEmailCodeVerification,
-  MfaPhoneCodeVerification,
-  PhoneCodeVerification,
-} from '../verifications/code-verification.js';
-import { NewPasswordIdentityVerification } from '../verifications/new-password-identity-verification.js';
-import { OneTimeTokenVerification } from '../verifications/one-time-token-verification.js';
-import { PasswordVerification } from '../verifications/password-verification.js';
-import { SocialVerification } from '../verifications/social-verification.js';
-import { TotpVerification } from '../verifications/totp-verification.js';
-import {
-  SignInPasskeyVerification,
-  WebAuthnVerification,
-} from '../verifications/web-authn-verification.js';
+const { FirstFactor, Mfa, Both } = AuthenticationFactorClass;
+const { Password, Otp, Sms, ProofOfPossession, UserPresence, Federated } =
+  AuthenticationMethodReference;
+const { Create, Identify, Bind } = AuthenticationProofRole;
 
-import { deriveAuthenticationContext } from './authentication-context.js';
+const firstFactorAcr = 'urn:logto:acr:1fa';
+const mfaAcr = 'urn:logto:acr:mfa';
 
-const { libraries, queries } = new MockTenant();
-const userId = mockUser.id;
-const username = 'foo';
-const email = 'foo@bar.com';
-const phone = '+11234567890';
+let sequence = 0;
 
-/** A user with every MFA factor enrolled. */
-const user: User = {
-  ...mockUser,
-  username,
-  primaryEmail: email,
-  primaryPhone: phone,
-  mfaVerifications: [
-    mockUserTotpMfaVerification,
-    mockUserWebAuthnMfaVerification,
-    mockUserBackupCodeMfaVerification,
-  ],
-};
+/** A proof at a strictly increasing time, so `ts` is always the first proof listed. */
+const proof = (
+  factor: AuthenticationFactor,
+  factorClass: AuthenticationFactorClass | undefined,
+  amr: AuthenticationMethodReference[],
+  role: AuthenticationProofRole = Identify
+): AuthenticationProof => ({
+  id: `${factor}-${role}-${sequence}`,
+  factor,
+  ...(factorClass && { class: factorClass }),
+  amr,
+  role,
+  // eslint-disable-next-line @silverhand/fp/no-mutation
+  at: 100 + sequence++,
+});
 
-/** The ids of the identifier records below; the interaction records them at identification. */
-const identifiedVerificationIds = new Set(['password', 'email', 'phone', 'one-time-token']);
-
-type Options = Partial<Parameters<typeof deriveAuthenticationContext>[1]>;
-
-const derive = (
-  records: Parameters<typeof deriveAuthenticationContext>[0],
-  options: Options = {}
-) => deriveAuthenticationContext(records, { user, identifiedVerificationIds, ...options });
-
-/** The interaction created `user` from its records, so nothing identified the user. */
-const deriveForNewAccount = (
-  records: Parameters<typeof deriveAuthenticationContext>[0],
-  bindMfaFactors: MfaFactor[] = []
-) =>
-  derive(records, {
-    identifiedVerificationIds: new Set(),
-    isNewAccount: true,
-    bindMfaFactors: new Set(bindMfaFactors),
-  });
-
-const password = ({
-  verifiedAt,
-  verified = true,
-  id = 'password',
-}: { verifiedAt?: number; verified?: boolean; id?: string } = {}) =>
-  new PasswordVerification(libraries, queries, {
-    id,
-    type: VerificationType.Password,
-    identifier: { type: SignInIdentifier.Username, value: username },
-    verified,
-    verifiedAt,
-  });
-
-const emailCode = (verifiedAt?: number, id = 'email', address = email) =>
-  new EmailCodeVerification(libraries, queries, {
-    id,
-    type: VerificationType.EmailVerificationCode,
-    identifier: { type: SignInIdentifier.Email, value: address },
-    templateType: TemplateType.SignIn,
-    verified: true,
-    verifiedAt,
-  });
-
-const phoneCode = (verifiedAt?: number) =>
-  new PhoneCodeVerification(libraries, queries, {
-    id: 'phone',
-    type: VerificationType.PhoneVerificationCode,
-    identifier: { type: SignInIdentifier.Phone, value: phone },
-    templateType: TemplateType.SignIn,
-    verified: true,
-    verifiedAt,
-  });
-
-const oneTimeToken = (verifiedAt?: number) =>
-  new OneTimeTokenVerification(libraries, queries, {
-    id: 'one-time-token',
-    type: VerificationType.OneTimeToken,
-    identifier: { type: SignInIdentifier.Email, value: email },
-    verified: true,
-    verifiedAt,
-  });
-
-/** An MFA code sent to the given email, as the MFA verification-code route creates it. */
-const mfaEmailCode = (verifiedAt?: number, address = email) =>
-  new MfaEmailCodeVerification(libraries, queries, {
-    id: 'mfa-email',
-    type: VerificationType.MfaEmailVerificationCode,
-    identifier: { type: SignInIdentifier.Email, value: address },
-    templateType: TemplateType.MfaVerification,
-    verified: true,
-    verifiedAt,
-  });
-
-const mfaPhoneCode = (verifiedAt?: number) =>
-  new MfaPhoneCodeVerification(libraries, queries, {
-    id: 'mfa-phone',
-    type: VerificationType.MfaPhoneVerificationCode,
-    identifier: { type: SignInIdentifier.Phone, value: phone },
-    templateType: TemplateType.MfaVerification,
-    verified: true,
-    verifiedAt,
-  });
-
-const totp = ({
-  verifiedAt,
-  secret,
-  ownerId = userId,
-}: { verifiedAt?: number; secret?: string; ownerId?: string } = {}) =>
-  new TotpVerification(libraries, queries, {
-    id: 'totp',
-    type: VerificationType.TOTP,
-    userId: ownerId,
-    verified: true,
-    verifiedAt,
-    secret,
-  });
-
-const backupCode = (verifiedAt?: number) =>
-  new BackupCodeVerification(libraries, queries, {
-    id: 'backup',
-    type: VerificationType.BackupCode,
-    userId,
-    code: 'code',
-    verifiedAt,
-  });
-
-const webAuthn = (verifiedAt?: number) =>
-  new WebAuthnVerification(libraries, queries, {
-    id: 'webauthn',
-    type: VerificationType.WebAuthn,
-    userId,
-    verified: true,
-    verifiedAt,
-  });
-
-const signInPasskey = (verifiedAt?: number, ownerId = userId) =>
-  new SignInPasskeyVerification(libraries, queries, {
-    id: 'passkey',
-    type: VerificationType.SignInPasskey,
-    userId: ownerId,
-    verified: true,
-    verifiedAt,
-  });
-
-/** A verified social assertion; whether the identity is linked to the account is irrelevant. */
-const social = (verifiedAt?: number) =>
-  new SocialVerification(libraries, queries, {
-    id: 'social',
-    type: VerificationType.Social,
-    connectorId: 'connector',
-    socialUserInfo: { id: 'social-user' },
-    verifiedAt,
-  });
-
-/** A verified registration record: a policy-compliant password proposed for the given username. */
-const newPasswordIdentity = (verifiedAt?: number, value = 'unused') =>
-  new NewPasswordIdentityVerification(libraries, queries, {
-    id: 'new-password-identity',
-    type: VerificationType.NewPasswordIdentity,
-    identifier: { type: SignInIdentifier.Username, value },
-    passwordEncrypted: 'encrypted',
-    passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
-    verifiedAt,
-  });
-
-describe('deriveAuthenticationContext', () => {
-  it('reaches 1fa with a password', () => {
-    expect(derive([password({ verifiedAt: 100 })])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['pwd'],
-      ts: 100,
-    });
-  });
-
-  it('reaches 1fa with a primary email code', () => {
-    expect(derive([emailCode(100)])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['otp'],
-      ts: 100,
-    });
-  });
-
-  it('reaches mfa with a password and a TOTP, taking the earliest timestamp', () => {
-    expect(derive([password({ verifiedAt: 200 }), totp({ verifiedAt: 100 })])).toEqual({
-      acr: 'urn:logto:acr:mfa',
-      amr: ['pwd', 'otp', 'mfa'],
-      ts: 100,
-    });
-  });
-
-  it('reaches mfa with a primary email code and an MFA phone code', () => {
-    expect(derive([emailCode(100), mfaPhoneCode(200)])).toEqual({
-      acr: 'urn:logto:acr:mfa',
-      amr: ['otp', 'sms', 'mfa'],
-      ts: 100,
-    });
-  });
-
-  it('reaches mfa with a password and a backup code', () => {
-    expect(derive([password({ verifiedAt: 100 }), backupCode(200)])).toEqual({
-      acr: 'urn:logto:acr:mfa',
-      amr: ['pwd', 'otp', 'mfa'],
-      ts: 100,
-    });
-  });
-
-  it('reaches only 1fa with a TOTP alone', () => {
-    expect(derive([totp({ verifiedAt: 100 })])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['otp'],
-      ts: 100,
-    });
-  });
-
-  it('reaches only 1fa with two mfa-class factors and no first factor', () => {
-    expect(derive([totp({ verifiedAt: 100 }), backupCode(200)])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['otp'],
-      ts: 100,
-    });
-  });
-
-  it.each([webAuthn, signInPasskey])(
-    'reaches mfa with a user-verified WebAuthn assertion alone',
-    (build) => {
-      expect(derive([build(100)])).toEqual({
-        acr: 'urn:logto:acr:mfa',
-        amr: ['pop', 'user', 'mfa'],
-        ts: 100,
-      });
-    }
+const password = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Password, FirstFactor, [Password], role);
+const email = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Email, FirstFactor, [Otp], role);
+const phone = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Phone, FirstFactor, [Sms], role);
+const mfaEmail = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Email, Mfa, [Otp], role);
+const totp = (role?: AuthenticationProofRole) => proof(AuthenticationFactor.Totp, Mfa, [Otp], role);
+const backupCode = () =>
+  proof(AuthenticationFactor.BackupCode, Mfa, [Otp], AuthenticationProofRole.Mfa);
+const webAuthn = (role?: AuthenticationProofRole) =>
+  proof(
+    AuthenticationFactor.WebAuthn,
+    Both,
+    [ProofOfPossession, UserPresence, AuthenticationMethodReference.Mfa],
+    role
   );
+const federated = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Federated, undefined, [Federated], role);
 
-  it('records only fed for a social sign-in', () => {
-    expect(derive([social(100)])).toEqual({ amr: ['fed'], ts: 100 });
-  });
-
-  it('keeps fed next to a Logto-verifiable factor', () => {
-    expect(derive([social(100), password({ verifiedAt: 200 })])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['fed', 'pwd'],
-      ts: 100,
-    });
-  });
-
-  it('keeps fed for an identity that is only being linked by this submission', () => {
-    // A linking social record never identified the user through its stored identity.
-    expect(derive([social(50)], { identifiedVerificationIds: new Set() })).toEqual({
-      amr: ['fed'],
-      ts: 50,
-    });
-  });
-
-  it('ignores unverified records and factors enrolled in this interaction', () => {
-    expect(
-      derive([
-        password({ verifiedAt: 100, verified: false }),
-        totp({ verifiedAt: 50, secret: 'new' }),
-      ])
-    ).toEqual({});
-    expect(
-      derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 50, secret: 'new' })])
-    ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
-  });
-
-  it('omits ts when no counted record carries verifiedAt', () => {
-    expect(derive([password()])).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'] });
-  });
-
-  describe('one factor never fills both roles', () => {
-    it('stays at 1fa when the MFA code went to the same mailbox as a one-time token', () => {
-      expect(derive([oneTimeToken(100), mfaEmailCode(200)])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['otp'],
-        ts: 100,
-      });
-    });
-
+/**
+ * The case matrix of the ACR / AMR tech design, section 6, row for row. The design is the
+ * specification; a policy change must update both.
+ */
+describe('aggregateAuthenticationContext', () => {
+  describe('registration', () => {
     it.each([
-      ['email', () => [emailCode(100), mfaEmailCode(200)], ['otp']],
-      ['phone', () => [phoneCode(100), mfaPhoneCode(200)], ['sms']],
-    ] as const)(
-      'stays at 1fa when the MFA code went to the same %s as the first factor',
-      (_, build, amr) => {
-        expect(derive(build())).toEqual({ acr: 'urn:logto:acr:1fa', amr, ts: 100 });
-      }
-    );
+      ['Username + password', () => [password(Bind)], firstFactorAcr, ['pwd']],
+      ['Email + password', () => [email(Create), password(Bind)], firstFactorAcr, ['otp', 'pwd']],
+      ['Phone + password', () => [phone(Create), password(Bind)], firstFactorAcr, ['sms', 'pwd']],
+      ['Email code only', () => [email(Create)], firstFactorAcr, ['otp']],
+      ['Social', () => [federated(Create)], undefined, ['fed']],
+      ['Enterprise SSO', () => [federated(Create)], undefined, ['fed']],
+      [
+        'Username + password, then enrol TOTP',
+        () => [password(Bind), totp(Bind)],
+        mfaAcr,
+        ['pwd', 'otp', 'mfa'],
+      ],
+      // A social registration that enrols a TOTP under the tenant's MFA policy: an mfa-class
+      // factor without a Logto-verifiable first factor reaches only 1fa.
+      [
+        'Social, then enrol TOTP',
+        () => [federated(Create), totp(Bind)],
+        firstFactorAcr,
+        ['fed', 'otp'],
+      ],
+      // A user-verified passkey enrolled and bound in the registration is self-sufficient.
+      [
+        'Social, then enrol passkey',
+        () => [federated(Create), webAuthn(Bind)],
+        mfaAcr,
+        ['fed', 'pop', 'user', 'mfa'],
+      ],
+    ])('%s', (_, build, acr, amr) => {
+      const proofs = build();
 
-    it('still reaches mfa when another factor supplies the first factor', () => {
-      expect(derive([password({ verifiedAt: 100 }), mfaEmailCode(200)])).toEqual({
-        acr: 'urn:logto:acr:mfa',
-        amr: ['pwd', 'otp', 'mfa'],
-        ts: 100,
-      });
-      expect(derive([emailCode(100), password({ verifiedAt: 150 }), mfaEmailCode(200)])).toEqual({
-        acr: 'urn:logto:acr:mfa',
-        amr: ['otp', 'pwd', 'mfa'],
-        ts: 100,
+      expect(aggregateAuthenticationContext(proofs)).toEqual({
+        ...(acr && { acr }),
+        amr,
+        ts: proofs[0]!.at,
       });
     });
   });
 
-  describe('a new account', () => {
-    it('reaches 1fa with the password the account was created with', () => {
-      expect(deriveForNewAccount([newPasswordIdentity(100, username)])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['pwd'],
-        ts: 100,
+  describe('sign-in', () => {
+    it.each([
+      ['Password', () => [password()], firstFactorAcr, ['pwd']],
+      ['Email code', () => [email()], firstFactorAcr, ['otp']],
+      [
+        'Password + TOTP',
+        () => [password(), totp(AuthenticationProofRole.Mfa)],
+        mfaAcr,
+        ['pwd', 'otp', 'mfa'],
+      ],
+      ['Password + backup code', () => [password(), backupCode()], mfaAcr, ['pwd', 'otp', 'mfa']],
+      ['Passkey sign-in', () => [webAuthn()], mfaAcr, ['pop', 'user', 'mfa']],
+      [
+        'Password + WebAuthn MFA',
+        () => [password(), webAuthn(AuthenticationProofRole.Mfa)],
+        mfaAcr,
+        ['pwd', 'pop', 'user', 'mfa'],
+      ],
+      ['Social (already linked)', () => [federated()], undefined, ['fed']],
+      ['Social, linking to an existing account', () => [federated()], undefined, ['fed']],
+      ['Enterprise SSO, first sign-in (auto-link)', () => [federated()], undefined, ['fed']],
+      [
+        'Social + TOTP',
+        () => [federated(), totp(AuthenticationProofRole.Mfa)],
+        firstFactorAcr,
+        ['fed', 'otp'],
+      ],
+      [
+        'Password + trusted device (MFA gate bypassed)',
+        () => [password()],
+        firstFactorAcr,
+        ['pwd'],
+      ],
+      [
+        'Password, then bind new TOTP',
+        () => [password(), totp(Bind)],
+        mfaAcr,
+        ['pwd', 'otp', 'mfa'],
+      ],
+      [
+        'Password → set email → bind email MFA',
+        () => [password(), email(Bind), mfaEmail(Bind)],
+        mfaAcr,
+        ['pwd', 'otp', 'mfa'],
+      ],
+      [
+        'Email code + MFA code to the same address',
+        () => [email(), mfaEmail(AuthenticationProofRole.Mfa)],
+        firstFactorAcr,
+        ['otp'],
+      ],
+      // A second proof of the same factor in the other role is still one factor.
+      [
+        'Password + password set again',
+        () => [password(), password(Bind)],
+        firstFactorAcr,
+        ['pwd'],
+      ],
+      ['TOTP alone', () => [totp(AuthenticationProofRole.Mfa)], firstFactorAcr, ['otp']],
+      [
+        'Two mfa-class factors and no first factor',
+        () => [totp(AuthenticationProofRole.Mfa), backupCode()],
+        firstFactorAcr,
+        ['otp'],
+      ],
+      // Another first factor supplies the distinct pair even when the mailbox is repeated.
+      [
+        'Email code + password + MFA code to the same address',
+        () => [email(), password(), mfaEmail(AuthenticationProofRole.Mfa)],
+        mfaAcr,
+        ['otp', 'pwd', 'mfa'],
+      ],
+    ])('%s', (_, build, acr, amr) => {
+      const proofs = build();
+
+      expect(aggregateAuthenticationContext(proofs)).toEqual({
+        ...(acr && { acr }),
+        amr,
+        ts: proofs[0]!.at,
       });
-    });
-
-    it('reaches 1fa with the verified email or phone the account was created with', () => {
-      expect(deriveForNewAccount([emailCode(100)])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['otp'],
-        ts: 100,
-      });
-      expect(deriveForNewAccount([phoneCode(100)])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['sms'],
-        ts: 100,
-      });
-    });
-
-    it('records only fed for a social registration', () => {
-      expect(deriveForNewAccount([social(100)])).toEqual({ amr: ['fed'], ts: 100 });
-    });
-
-    it('counts a factor enrolled in this interaction when the submission binds it', () => {
-      const enrolledTotp = totp({ verifiedAt: 200, secret: 'new' });
-
-      expect(
-        deriveForNewAccount([newPasswordIdentity(100, username), enrolledTotp], [MfaFactor.TOTP])
-      ).toEqual({ acr: 'urn:logto:acr:mfa', amr: ['pwd', 'otp', 'mfa'], ts: 100 });
-      // An mfa-class factor without a Logto-verifiable first factor reaches only 1fa.
-      expect(deriveForNewAccount([social(100), enrolledTotp], [MfaFactor.TOTP])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['fed', 'otp'],
-        ts: 100,
-      });
-    });
-
-    it('ignores an enrollment the submission does not bind', () => {
-      expect(
-        deriveForNewAccount([newPasswordIdentity(100, username), totp({ secret: 'new' })])
-      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
-    });
-
-    it('ignores a verified identifier that was not written to the account', () => {
-      // The user verified a code for one address, then registered with a social identity.
-      expect(deriveForNewAccount([social(100), emailCode(50, 'other', 'other@bar.com')])).toEqual({
-        amr: ['fed'],
-        ts: 100,
-      });
-      expect(deriveForNewAccount([newPasswordIdentity(100)])).toEqual({});
-    });
-
-    it('never counts an enrollment for an existing account', () => {
-      expect(
-        derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 50, secret: 'new' })], {
-          bindMfaFactors: new Set([MfaFactor.TOTP]),
-        })
-      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
     });
   });
 
-  describe('records that are not proofs of the identified user', () => {
-    it('ignores an identifier record that did not identify the user', () => {
-      // A code for an address the user is adding, or a password verified for another account,
-      // is never passed to `identifyUser()` for this user.
-      expect(derive([social(100), emailCode(50, 'added-email')])).toEqual({
-        amr: ['fed'],
-        ts: 100,
-      });
-      expect(derive([password({ verifiedAt: 50, id: 'other-account' })])).toEqual({});
-    });
+  it('seeds nothing for an interaction without a proof', () => {
+    expect(aggregateAuthenticationContext([])).toEqual({});
+  });
 
-    it('ignores a registration password that never identified the user', () => {
-      // The route only accepts the record in a Register interaction, and `identifyUser()` never
-      // records it; a stored one from before the route guard still counts nothing.
-      expect(derive([social(100), newPasswordIdentity(50)])).toEqual({ amr: ['fed'], ts: 100 });
-      expect(derive([social(100), newPasswordIdentity(50), totp({ verifiedAt: 200 })])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['fed', 'otp'],
-        ts: 100,
-      });
-    });
+  it('takes the earliest proof as the authentication time regardless of order', () => {
+    const late = totp(AuthenticationProofRole.Mfa);
+    const early = password();
 
-    it('ignores an MFA code that was not sent to the primary contact of the user', () => {
-      expect(derive([password({ verifiedAt: 100 }), mfaEmailCode(200, 'other@bar.com')])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['pwd'],
-        ts: 100,
-      });
-    });
-
-    it('ignores factor records created for another user', () => {
-      expect(
-        derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 50, ownerId: 'someone-else' })])
-      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
-      expect(derive([signInPasskey(100, 'someone-else')])).toEqual({});
-    });
+    expect(aggregateAuthenticationContext([late, early]).ts).toBe(early.at);
   });
 });

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -1,10 +1,18 @@
 import { TemplateType } from '@logto/connector-kit';
-import { SignInIdentifier, VerificationType } from '@logto/schemas';
+import {
+  SignInIdentifier,
+  UsersPasswordEncryptionMethod,
+  VerificationType,
+  type User,
+} from '@logto/schemas';
 
+import { mockUser } from '#src/__mocks__/user.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
 import { BackupCodeVerification } from '../verifications/backup-code-verification.js';
 import { EmailCodeVerification } from '../verifications/code-verification.js';
+import { NewPasswordIdentityVerification } from '../verifications/new-password-identity-verification.js';
 import { PasswordVerification } from '../verifications/password-verification.js';
 import { SocialVerification } from '../verifications/social-verification.js';
 import { TotpVerification } from '../verifications/totp-verification.js';
@@ -15,32 +23,67 @@ import {
 
 import { deriveAuthenticationContext } from './authentication-context.js';
 
+const { jest } = import.meta;
+
 const { libraries, queries } = new MockTenant();
+const userId = mockUser.id;
+
+/** Marks an identifier record that identifies no account. */
+const noAccount = Symbol('no account');
+
+/**
+ * Stub which account an identifier record identifies: the given user, or none (the record then
+ * rejects the way a real one does for an unregistered identifier or an unlinked identity).
+ */
+const identifying = <T extends { identifyUser: () => Promise<User> }>(
+  record: T,
+  identifiedUserId: string | typeof noAccount = userId
+): T => {
+  const target: { identifyUser: () => Promise<User> } = record;
+  jest.spyOn(target, 'identifyUser').mockImplementation(async () => {
+    if (identifiedUserId === noAccount) {
+      throw new RequestError({ code: 'user.user_not_exist', status: 404 });
+    }
+
+    return { ...mockUser, id: identifiedUserId };
+  });
+
+  return record;
+};
 
 const password = (verifiedAt?: number, verified = true) =>
-  new PasswordVerification(libraries, queries, {
-    id: 'password',
-    type: VerificationType.Password,
-    identifier: { type: SignInIdentifier.Username, value: 'foo' },
-    verified,
-    verifiedAt,
-  });
+  identifying(
+    new PasswordVerification(libraries, queries, {
+      id: 'password',
+      type: VerificationType.Password,
+      identifier: { type: SignInIdentifier.Username, value: 'foo' },
+      verified,
+      verifiedAt,
+    })
+  );
 
-const emailCode = (verifiedAt?: number) =>
-  new EmailCodeVerification(libraries, queries, {
-    id: 'email',
-    type: VerificationType.EmailVerificationCode,
-    identifier: { type: SignInIdentifier.Email, value: 'foo@bar.com' },
-    templateType: TemplateType.SignIn,
-    verified: true,
-    verifiedAt,
-  });
+const emailCode = (verifiedAt?: number, identifiedUserId: string | typeof noAccount = userId) =>
+  identifying(
+    new EmailCodeVerification(libraries, queries, {
+      id: 'email',
+      type: VerificationType.EmailVerificationCode,
+      identifier: { type: SignInIdentifier.Email, value: 'foo@bar.com' },
+      templateType: TemplateType.SignIn,
+      verified: true,
+      verifiedAt,
+    }),
+    identifiedUserId
+  );
 
-const totp = ({ verifiedAt, secret }: { verifiedAt?: number; secret?: string } = {}) =>
+const totp = ({
+  verifiedAt,
+  secret,
+  ownerId = userId,
+}: { verifiedAt?: number; secret?: string; ownerId?: string } = {}) =>
   new TotpVerification(libraries, queries, {
     id: 'totp',
     type: VerificationType.TOTP,
-    userId: 'user',
+    userId: ownerId,
     verified: true,
     verifiedAt,
     secret,
@@ -50,7 +93,7 @@ const backupCode = (verifiedAt?: number) =>
   new BackupCodeVerification(libraries, queries, {
     id: 'backup',
     type: VerificationType.BackupCode,
-    userId: 'user',
+    userId,
     code: 'code',
     verifiedAt,
   });
@@ -59,64 +102,84 @@ const webAuthn = (verifiedAt?: number) =>
   new WebAuthnVerification(libraries, queries, {
     id: 'webauthn',
     type: VerificationType.WebAuthn,
-    userId: 'user',
+    userId,
     verified: true,
     verifiedAt,
   });
 
-const signInPasskey = (verifiedAt?: number) =>
+const signInPasskey = (verifiedAt?: number, ownerId = userId) =>
   new SignInPasskeyVerification(libraries, queries, {
     id: 'passkey',
     type: VerificationType.SignInPasskey,
-    userId: 'user',
+    userId: ownerId,
     verified: true,
     verifiedAt,
   });
 
-const social = (verifiedAt?: number) =>
-  new SocialVerification(libraries, queries, {
-    id: 'social',
-    type: VerificationType.Social,
-    connectorId: 'connector',
-    socialUserInfo: { id: 'social-user' },
+const social = (verifiedAt?: number, identifiedUserId: string | typeof noAccount = userId) =>
+  identifying(
+    new SocialVerification(libraries, queries, {
+      id: 'social',
+      type: VerificationType.Social,
+      connectorId: 'connector',
+      socialUserInfo: { id: 'social-user' },
+      verifiedAt,
+    }),
+    identifiedUserId
+  );
+
+/** A verified registration record: a policy-compliant password proposed for an unused username. */
+const newPasswordIdentity = (verifiedAt?: number) =>
+  new NewPasswordIdentityVerification(libraries, queries, {
+    id: 'new-password-identity',
+    type: VerificationType.NewPasswordIdentity,
+    identifier: { type: SignInIdentifier.Username, value: 'unused' },
+    passwordEncrypted: 'encrypted',
+    passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
     verifiedAt,
   });
 
 describe('deriveAuthenticationContext', () => {
-  it('reaches 1fa with a password', () => {
-    expect(deriveAuthenticationContext([password(100)])).toEqual({
+  it('reaches 1fa with a password', async () => {
+    await expect(deriveAuthenticationContext([password(100)], userId)).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['pwd'],
       ts: 100,
     });
   });
 
-  it('reaches 1fa with a primary email code', () => {
-    expect(deriveAuthenticationContext([emailCode(100)])).toEqual({
+  it('reaches 1fa with a primary email code', async () => {
+    await expect(deriveAuthenticationContext([emailCode(100)], userId)).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['otp'],
       ts: 100,
     });
   });
 
-  it('reaches mfa with a password and a TOTP, taking the earliest timestamp', () => {
-    expect(deriveAuthenticationContext([password(200), totp({ verifiedAt: 100 })])).toEqual({
+  it('reaches mfa with a password and a TOTP, taking the earliest timestamp', async () => {
+    await expect(
+      deriveAuthenticationContext([password(200), totp({ verifiedAt: 100 })], userId)
+    ).resolves.toEqual({
       acr: 'urn:logto:acr:mfa',
       amr: ['pwd', 'otp', 'mfa'],
       ts: 100,
     });
   });
 
-  it('reaches only 1fa with a TOTP alone', () => {
-    expect(deriveAuthenticationContext([totp({ verifiedAt: 100 })])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['otp'],
-      ts: 100,
-    });
+  it('reaches only 1fa with a TOTP alone', async () => {
+    await expect(deriveAuthenticationContext([totp({ verifiedAt: 100 })], userId)).resolves.toEqual(
+      {
+        acr: 'urn:logto:acr:1fa',
+        amr: ['otp'],
+        ts: 100,
+      }
+    );
   });
 
-  it('reaches only 1fa with two mfa-class factors and no first factor', () => {
-    expect(deriveAuthenticationContext([totp({ verifiedAt: 100 }), backupCode(200)])).toEqual({
+  it('reaches only 1fa with two mfa-class factors and no first factor', async () => {
+    await expect(
+      deriveAuthenticationContext([totp({ verifiedAt: 100 }), backupCode(200)], userId)
+    ).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['otp'],
       ts: 100,
@@ -125,8 +188,8 @@ describe('deriveAuthenticationContext', () => {
 
   it.each([webAuthn, signInPasskey])(
     'reaches mfa with a user-verified WebAuthn assertion alone',
-    (build) => {
-      expect(deriveAuthenticationContext([build(100)])).toEqual({
+    async (build) => {
+      await expect(deriveAuthenticationContext([build(100)], userId)).resolves.toEqual({
         acr: 'urn:logto:acr:mfa',
         amr: ['pop', 'user', 'mfa'],
         ts: 100,
@@ -134,31 +197,91 @@ describe('deriveAuthenticationContext', () => {
     }
   );
 
-  it('records only fed for a social sign-in', () => {
-    expect(deriveAuthenticationContext([social(100)])).toEqual({ amr: ['fed'], ts: 100 });
+  it('records only fed for a social sign-in', async () => {
+    await expect(deriveAuthenticationContext([social(100)], userId)).resolves.toEqual({
+      amr: ['fed'],
+      ts: 100,
+    });
   });
 
-  it('keeps fed next to a Logto-verifiable factor', () => {
-    expect(deriveAuthenticationContext([social(100), password(200)])).toEqual({
+  it('keeps fed next to a Logto-verifiable factor', async () => {
+    await expect(
+      deriveAuthenticationContext([social(100), password(200)], userId)
+    ).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['fed', 'pwd'],
       ts: 100,
     });
   });
 
-  it('ignores unverified records and factors enrolled in this interaction', () => {
-    expect(
-      deriveAuthenticationContext([password(100, false), totp({ verifiedAt: 50, secret: 'new' })])
-    ).toEqual({});
-    expect(
-      deriveAuthenticationContext([password(100), totp({ verifiedAt: 50, secret: 'new' })])
-    ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+  it('ignores unverified records and factors enrolled in this interaction', async () => {
+    await expect(
+      deriveAuthenticationContext(
+        [password(100, false), totp({ verifiedAt: 50, secret: 'new' })],
+        userId
+      )
+    ).resolves.toEqual({});
+    await expect(
+      deriveAuthenticationContext([password(100), totp({ verifiedAt: 50, secret: 'new' })], userId)
+    ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
   });
 
-  it('omits ts when no counted record carries verifiedAt', () => {
-    expect(deriveAuthenticationContext([password()])).toEqual({
+  it('omits ts when no counted record carries verifiedAt', async () => {
+    await expect(deriveAuthenticationContext([password()], userId)).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['pwd'],
+    });
+  });
+
+  describe('records that are not proofs of the identified user', () => {
+    it('never counts a new-password-identity record, even next to a real proof', async () => {
+      await expect(
+        deriveAuthenticationContext([social(100), newPasswordIdentity(50)], userId)
+      ).resolves.toEqual({ amr: ['fed'], ts: 100 });
+      // Without the registration password, a TOTP alone reaches only 1fa.
+      await expect(
+        deriveAuthenticationContext(
+          [social(100), newPasswordIdentity(50), totp({ verifiedAt: 200 })],
+          userId
+        )
+      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['fed', 'otp'], ts: 100 });
+    });
+
+    it('ignores an identifier record that identifies no account', async () => {
+      await expect(
+        deriveAuthenticationContext([social(100), emailCode(50, noAccount)], userId)
+      ).resolves.toEqual({ amr: ['fed'], ts: 100 });
+    });
+
+    it('ignores an identifier record that identifies another account', async () => {
+      await expect(
+        deriveAuthenticationContext([emailCode(50, 'someone-else')], userId)
+      ).resolves.toEqual({});
+    });
+
+    it('ignores a social identity that is not linked to the account', async () => {
+      await expect(
+        deriveAuthenticationContext([password(100), social(50, noAccount)], userId)
+      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+    });
+
+    it('ignores factor records created for another user', async () => {
+      await expect(
+        deriveAuthenticationContext(
+          [password(100), totp({ verifiedAt: 50, ownerId: 'someone-else' })],
+          userId
+        )
+      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+      await expect(
+        deriveAuthenticationContext([signInPasskey(100, 'someone-else')], userId)
+      ).resolves.toEqual({});
+    });
+
+    it('propagates an unexpected identification failure', async () => {
+      const record = password(100);
+      jest.spyOn(record, 'identifyUser').mockRejectedValue(new Error('database down'));
+
+      await expect(deriveAuthenticationContext([record], userId)).rejects.toThrow('database down');
     });
   });
 });

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -188,17 +188,15 @@ const signInPasskey = (verifiedAt?: number, ownerId = userId) =>
     verifiedAt,
   });
 
-const social = (verifiedAt?: number, identifiedUserId: string | typeof noAccount = userId) =>
-  identifying(
-    new SocialVerification(libraries, queries, {
-      id: 'social',
-      type: VerificationType.Social,
-      connectorId: 'connector',
-      socialUserInfo: { id: 'social-user' },
-      verifiedAt,
-    }),
-    identifiedUserId
-  );
+/** A verified social assertion; whether the identity is linked to the account is irrelevant. */
+const social = (verifiedAt?: number) =>
+  new SocialVerification(libraries, queries, {
+    id: 'social',
+    type: VerificationType.Social,
+    connectorId: 'connector',
+    socialUserInfo: { id: 'social-user' },
+    verifiedAt,
+  });
 
 /** A verified registration record: a policy-compliant password proposed for an unused username. */
 const newPasswordIdentity = (verifiedAt?: number) =>
@@ -363,12 +361,14 @@ describe('deriveAuthenticationContext', () => {
       await expect(derive([emailCode(50, 'someone-else')])).resolves.toEqual({});
     });
 
-    it('ignores a social identity that is not linked to the account', async () => {
-      await expect(derive([password(100), social(50, noAccount)])).resolves.toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['pwd'],
-        ts: 100,
-      });
+    it('keeps fed for an identity that is only being linked by this submission', async () => {
+      const record = social(50);
+      jest
+        .spyOn(record, 'identifyUser')
+        .mockRejectedValue(new RequestError({ code: 'user.identity_not_exist', status: 404 }));
+
+      await expect(derive([record])).resolves.toEqual({ amr: ['fed'], ts: 50 });
+      expect(record.identifyUser).not.toHaveBeenCalled();
     });
 
     it('ignores factor records created for another user', async () => {

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -1,17 +1,29 @@
 import { TemplateType } from '@logto/connector-kit';
 import {
+  MfaFactor,
   SignInIdentifier,
   UsersPasswordEncryptionMethod,
   VerificationType,
   type User,
 } from '@logto/schemas';
 
-import { mockUser } from '#src/__mocks__/user.js';
+import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
+import {
+  mockUser,
+  mockUserBackupCodeMfaVerification,
+  mockUserTotpMfaVerification,
+  mockUserWebAuthnMfaVerification,
+} from '#src/__mocks__/user.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { MockTenant } from '#src/test-utils/tenant.js';
 
 import { BackupCodeVerification } from '../verifications/backup-code-verification.js';
-import { EmailCodeVerification } from '../verifications/code-verification.js';
+import {
+  EmailCodeVerification,
+  MfaEmailCodeVerification,
+  MfaPhoneCodeVerification,
+  PhoneCodeVerification,
+} from '../verifications/code-verification.js';
 import { NewPasswordIdentityVerification } from '../verifications/new-password-identity-verification.js';
 import { PasswordVerification } from '../verifications/password-verification.js';
 import { SocialVerification } from '../verifications/social-verification.js';
@@ -22,11 +34,34 @@ import {
 } from '../verifications/web-authn-verification.js';
 
 import { deriveAuthenticationContext } from './authentication-context.js';
+import { MfaValidator } from './mfa-validator.js';
 
 const { jest } = import.meta;
 
 const { libraries, queries } = new MockTenant();
 const userId = mockUser.id;
+const email = 'foo@bar.com';
+const phone = '+11234567890';
+
+/** A user with every MFA factor enrolled, and the sign-in experience enabling all of them. */
+const user: User = {
+  ...mockUser,
+  primaryEmail: email,
+  primaryPhone: phone,
+  mfaVerifications: [
+    mockUserTotpMfaVerification,
+    mockUserWebAuthnMfaVerification,
+    mockUserBackupCodeMfaVerification,
+  ],
+};
+const allFactorsEnabled = new MfaValidator(
+  { ...mockSignInExperience.mfa, factors: Object.values(MfaFactor) },
+  user
+);
+const noFactorEnabled = new MfaValidator({ ...mockSignInExperience.mfa, factors: [] }, user);
+
+const derive = async (records: Parameters<typeof deriveAuthenticationContext>[0]) =>
+  deriveAuthenticationContext(records, userId, allFactorsEnabled);
 
 /** Marks an identifier record that identifies no account. */
 const noAccount = Symbol('no account');
@@ -45,7 +80,7 @@ const identifying = <T extends { identifyUser: () => Promise<User> }>(
       throw new RequestError({ code: 'user.user_not_exist', status: 404 });
     }
 
-    return { ...mockUser, id: identifiedUserId };
+    return { ...user, id: identifiedUserId };
   });
 
   return record;
@@ -67,12 +102,49 @@ const emailCode = (verifiedAt?: number, identifiedUserId: string | typeof noAcco
     new EmailCodeVerification(libraries, queries, {
       id: 'email',
       type: VerificationType.EmailVerificationCode,
-      identifier: { type: SignInIdentifier.Email, value: 'foo@bar.com' },
+      identifier: { type: SignInIdentifier.Email, value: email },
       templateType: TemplateType.SignIn,
       verified: true,
       verifiedAt,
     }),
     identifiedUserId
+  );
+
+const phoneCode = (verifiedAt?: number) =>
+  identifying(
+    new PhoneCodeVerification(libraries, queries, {
+      id: 'phone',
+      type: VerificationType.PhoneVerificationCode,
+      identifier: { type: SignInIdentifier.Phone, value: phone },
+      templateType: TemplateType.SignIn,
+      verified: true,
+      verifiedAt,
+    })
+  );
+
+/** An MFA code sent to the user's primary email, as the MFA verification-code route creates it. */
+const mfaEmailCode = (verifiedAt?: number) =>
+  identifying(
+    new MfaEmailCodeVerification(libraries, queries, {
+      id: 'mfa-email',
+      type: VerificationType.MfaEmailVerificationCode,
+      identifier: { type: SignInIdentifier.Email, value: email },
+      templateType: TemplateType.MfaVerification,
+      verified: true,
+      verifiedAt,
+    })
+  );
+
+const mfaPhoneCode = (verifiedAt?: number) =>
+  identifying(
+    new MfaPhoneCodeVerification(libraries, queries, {
+      id: 'mfa-phone',
+      type: VerificationType.MfaPhoneVerificationCode,
+      identifier: { type: SignInIdentifier.Phone, value: phone },
+      templateType: TemplateType.MfaVerification,
+      verified: true,
+      verifiedAt,
+    })
   );
 
 const totp = ({
@@ -141,7 +213,7 @@ const newPasswordIdentity = (verifiedAt?: number) =>
 
 describe('deriveAuthenticationContext', () => {
   it('reaches 1fa with a password', async () => {
-    await expect(deriveAuthenticationContext([password(100)], userId)).resolves.toEqual({
+    await expect(derive([password(100)])).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['pwd'],
       ts: 100,
@@ -149,7 +221,7 @@ describe('deriveAuthenticationContext', () => {
   });
 
   it('reaches 1fa with a primary email code', async () => {
-    await expect(deriveAuthenticationContext([emailCode(100)], userId)).resolves.toEqual({
+    await expect(derive([emailCode(100)])).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['otp'],
       ts: 100,
@@ -157,29 +229,31 @@ describe('deriveAuthenticationContext', () => {
   });
 
   it('reaches mfa with a password and a TOTP, taking the earliest timestamp', async () => {
-    await expect(
-      deriveAuthenticationContext([password(200), totp({ verifiedAt: 100 })], userId)
-    ).resolves.toEqual({
+    await expect(derive([password(200), totp({ verifiedAt: 100 })])).resolves.toEqual({
       acr: 'urn:logto:acr:mfa',
       amr: ['pwd', 'otp', 'mfa'],
       ts: 100,
     });
   });
 
+  it('reaches mfa with a primary email code and an MFA phone code', async () => {
+    await expect(derive([emailCode(100), mfaPhoneCode(200)])).resolves.toEqual({
+      acr: 'urn:logto:acr:mfa',
+      amr: ['otp', 'sms', 'mfa'],
+      ts: 100,
+    });
+  });
+
   it('reaches only 1fa with a TOTP alone', async () => {
-    await expect(deriveAuthenticationContext([totp({ verifiedAt: 100 })], userId)).resolves.toEqual(
-      {
-        acr: 'urn:logto:acr:1fa',
-        amr: ['otp'],
-        ts: 100,
-      }
-    );
+    await expect(derive([totp({ verifiedAt: 100 })])).resolves.toEqual({
+      acr: 'urn:logto:acr:1fa',
+      amr: ['otp'],
+      ts: 100,
+    });
   });
 
   it('reaches only 1fa with two mfa-class factors and no first factor', async () => {
-    await expect(
-      deriveAuthenticationContext([totp({ verifiedAt: 100 }), backupCode(200)], userId)
-    ).resolves.toEqual({
+    await expect(derive([totp({ verifiedAt: 100 }), backupCode(200)])).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['otp'],
       ts: 100,
@@ -189,7 +263,7 @@ describe('deriveAuthenticationContext', () => {
   it.each([webAuthn, signInPasskey])(
     'reaches mfa with a user-verified WebAuthn assertion alone',
     async (build) => {
-      await expect(deriveAuthenticationContext([build(100)], userId)).resolves.toEqual({
+      await expect(derive([build(100)])).resolves.toEqual({
         acr: 'urn:logto:acr:mfa',
         amr: ['pop', 'user', 'mfa'],
         ts: 100,
@@ -198,16 +272,11 @@ describe('deriveAuthenticationContext', () => {
   );
 
   it('records only fed for a social sign-in', async () => {
-    await expect(deriveAuthenticationContext([social(100)], userId)).resolves.toEqual({
-      amr: ['fed'],
-      ts: 100,
-    });
+    await expect(derive([social(100)])).resolves.toEqual({ amr: ['fed'], ts: 100 });
   });
 
   it('keeps fed next to a Logto-verifiable factor', async () => {
-    await expect(
-      deriveAuthenticationContext([social(100), password(200)], userId)
-    ).resolves.toEqual({
+    await expect(derive([social(100), password(200)])).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['fed', 'pwd'],
       ts: 100,
@@ -216,72 +285,104 @@ describe('deriveAuthenticationContext', () => {
 
   it('ignores unverified records and factors enrolled in this interaction', async () => {
     await expect(
-      deriveAuthenticationContext(
-        [password(100, false), totp({ verifiedAt: 50, secret: 'new' })],
-        userId
-      )
+      derive([password(100, false), totp({ verifiedAt: 50, secret: 'new' })])
     ).resolves.toEqual({});
-    await expect(
-      deriveAuthenticationContext([password(100), totp({ verifiedAt: 50, secret: 'new' })], userId)
-    ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+    await expect(derive([password(100), totp({ verifiedAt: 50, secret: 'new' })])).resolves.toEqual(
+      { acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 }
+    );
   });
 
   it('omits ts when no counted record carries verifiedAt', async () => {
-    await expect(deriveAuthenticationContext([password()], userId)).resolves.toEqual({
+    await expect(derive([password()])).resolves.toEqual({
       acr: 'urn:logto:acr:1fa',
       amr: ['pwd'],
     });
   });
 
+  describe('one factor never fills both roles', () => {
+    it('stays at 1fa when the MFA code went to the same email as the first factor', async () => {
+      await expect(derive([emailCode(100), mfaEmailCode(200)])).resolves.toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['otp'],
+        ts: 100,
+      });
+    });
+
+    it('stays at 1fa when the MFA code went to the same phone as the first factor', async () => {
+      await expect(derive([phoneCode(100), mfaPhoneCode(200)])).resolves.toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['sms'],
+        ts: 100,
+      });
+    });
+
+    it('still reaches mfa when another factor supplies the first factor', async () => {
+      await expect(derive([password(100), mfaEmailCode(200)])).resolves.toEqual({
+        acr: 'urn:logto:acr:mfa',
+        amr: ['pwd', 'otp', 'mfa'],
+        ts: 100,
+      });
+      await expect(derive([emailCode(100), password(150), mfaEmailCode(200)])).resolves.toEqual({
+        acr: 'urn:logto:acr:mfa',
+        amr: ['otp', 'pwd', 'mfa'],
+        ts: 100,
+      });
+    });
+  });
+
   describe('records that are not proofs of the identified user', () => {
     it('never counts a new-password-identity record, even next to a real proof', async () => {
-      await expect(
-        deriveAuthenticationContext([social(100), newPasswordIdentity(50)], userId)
-      ).resolves.toEqual({ amr: ['fed'], ts: 100 });
+      await expect(derive([social(100), newPasswordIdentity(50)])).resolves.toEqual({
+        amr: ['fed'],
+        ts: 100,
+      });
       // Without the registration password, a TOTP alone reaches only 1fa.
       await expect(
-        deriveAuthenticationContext(
-          [social(100), newPasswordIdentity(50), totp({ verifiedAt: 200 })],
-          userId
-        )
+        derive([social(100), newPasswordIdentity(50), totp({ verifiedAt: 200 })])
       ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['fed', 'otp'], ts: 100 });
     });
 
-    it('ignores an identifier record that identifies no account', async () => {
+    it('ignores an MFA record of a factor the user has not enabled', async () => {
       await expect(
-        deriveAuthenticationContext([social(100), emailCode(50, noAccount)], userId)
-      ).resolves.toEqual({ amr: ['fed'], ts: 100 });
+        deriveAuthenticationContext(
+          [password(100), totp({ verifiedAt: 200 }), mfaEmailCode(300)],
+          userId,
+          noFactorEnabled
+        )
+      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+    });
+
+    it('ignores an identifier record that identifies no account', async () => {
+      await expect(derive([social(100), emailCode(50, noAccount)])).resolves.toEqual({
+        amr: ['fed'],
+        ts: 100,
+      });
     });
 
     it('ignores an identifier record that identifies another account', async () => {
-      await expect(
-        deriveAuthenticationContext([emailCode(50, 'someone-else')], userId)
-      ).resolves.toEqual({});
+      await expect(derive([emailCode(50, 'someone-else')])).resolves.toEqual({});
     });
 
     it('ignores a social identity that is not linked to the account', async () => {
-      await expect(
-        deriveAuthenticationContext([password(100), social(50, noAccount)], userId)
-      ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+      await expect(derive([password(100), social(50, noAccount)])).resolves.toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['pwd'],
+        ts: 100,
+      });
     });
 
     it('ignores factor records created for another user', async () => {
       await expect(
-        deriveAuthenticationContext(
-          [password(100), totp({ verifiedAt: 50, ownerId: 'someone-else' })],
-          userId
-        )
+        derive([password(100), totp({ verifiedAt: 50, ownerId: 'someone-else' })])
       ).resolves.toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
-      await expect(
-        deriveAuthenticationContext([signInPasskey(100, 'someone-else')], userId)
-      ).resolves.toEqual({});
+      await expect(derive([signInPasskey(100, 'someone-else')])).resolves.toEqual({});
     });
 
     it('propagates an unexpected identification failure', async () => {
       const record = password(100);
       jest.spyOn(record, 'identifyUser').mockRejectedValue(new Error('database down'));
 
-      await expect(deriveAuthenticationContext([record], userId)).rejects.toThrow('database down');
+      await expect(derive([record])).rejects.toThrow('database down');
     });
   });
 });

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -1,13 +1,11 @@
 import { TemplateType } from '@logto/connector-kit';
 import {
-  MfaFactor,
   SignInIdentifier,
   UsersPasswordEncryptionMethod,
   VerificationType,
   type User,
 } from '@logto/schemas';
 
-import { mockSignInExperience } from '#src/__mocks__/sign-in-experience.js';
 import {
   mockUser,
   mockUserBackupCodeMfaVerification,
@@ -24,6 +22,7 @@ import {
   PhoneCodeVerification,
 } from '../verifications/code-verification.js';
 import { NewPasswordIdentityVerification } from '../verifications/new-password-identity-verification.js';
+import { OneTimeTokenVerification } from '../verifications/one-time-token-verification.js';
 import { PasswordVerification } from '../verifications/password-verification.js';
 import { SocialVerification } from '../verifications/social-verification.js';
 import { TotpVerification } from '../verifications/totp-verification.js';
@@ -39,7 +38,7 @@ const userId = mockUser.id;
 const email = 'foo@bar.com';
 const phone = '+11234567890';
 
-/** A user with every MFA factor enrolled, and the sign-in experience enabling all of them. */
+/** A user with every MFA factor enrolled. */
 const user: User = {
   ...mockUser,
   primaryEmail: email,
@@ -50,24 +49,16 @@ const user: User = {
     mockUserBackupCodeMfaVerification,
   ],
 };
-const allFactorsEnabled = { ...mockSignInExperience.mfa, factors: Object.values(MfaFactor) };
-const noFactorEnabled = { ...mockSignInExperience.mfa, factors: [] };
 
 /** The ids of the identifier records below; the interaction records them at identification. */
-const identifiedVerificationIds = new Set(['password', 'email', 'phone']);
+const identifiedVerificationIds = new Set(['password', 'email', 'phone', 'one-time-token']);
 
 type Options = Partial<Parameters<typeof deriveAuthenticationContext>[1]>;
 
 const derive = (
   records: Parameters<typeof deriveAuthenticationContext>[0],
   options: Options = {}
-) =>
-  deriveAuthenticationContext(records, {
-    user,
-    mfaSettings: allFactorsEnabled,
-    identifiedVerificationIds,
-    ...options,
-  });
+) => deriveAuthenticationContext(records, { user, identifiedVerificationIds, ...options });
 
 const password = ({
   verifiedAt,
@@ -98,6 +89,15 @@ const phoneCode = (verifiedAt?: number) =>
     type: VerificationType.PhoneVerificationCode,
     identifier: { type: SignInIdentifier.Phone, value: phone },
     templateType: TemplateType.SignIn,
+    verified: true,
+    verifiedAt,
+  });
+
+const oneTimeToken = (verifiedAt?: number) =>
+  new OneTimeTokenVerification(libraries, queries, {
+    id: 'one-time-token',
+    type: VerificationType.OneTimeToken,
+    identifier: { type: SignInIdentifier.Email, value: email },
     verified: true,
     verifiedAt,
   });
@@ -218,6 +218,14 @@ describe('deriveAuthenticationContext', () => {
     });
   });
 
+  it('reaches mfa with a password and a backup code', () => {
+    expect(derive([password({ verifiedAt: 100 }), backupCode(200)])).toEqual({
+      acr: 'urn:logto:acr:mfa',
+      amr: ['pwd', 'otp', 'mfa'],
+      ts: 100,
+    });
+  });
+
   it('reaches only 1fa with a TOTP alone', () => {
     expect(derive([totp({ verifiedAt: 100 })])).toEqual({
       acr: 'urn:logto:acr:1fa',
@@ -282,21 +290,23 @@ describe('deriveAuthenticationContext', () => {
   });
 
   describe('one factor never fills both roles', () => {
-    it('stays at 1fa when the MFA code went to the same email as the first factor', () => {
-      expect(derive([emailCode(100), mfaEmailCode(200)])).toEqual({
+    it('stays at 1fa when the MFA code went to the same mailbox as a one-time token', () => {
+      expect(derive([oneTimeToken(100), mfaEmailCode(200)])).toEqual({
         acr: 'urn:logto:acr:1fa',
         amr: ['otp'],
         ts: 100,
       });
     });
 
-    it('stays at 1fa when the MFA code went to the same phone as the first factor', () => {
-      expect(derive([phoneCode(100), mfaPhoneCode(200)])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['sms'],
-        ts: 100,
-      });
-    });
+    it.each([
+      ['email', () => [emailCode(100), mfaEmailCode(200)], ['otp']],
+      ['phone', () => [phoneCode(100), mfaPhoneCode(200)], ['sms']],
+    ] as const)(
+      'stays at 1fa when the MFA code went to the same %s as the first factor',
+      (_, build, amr) => {
+        expect(derive(build())).toEqual({ acr: 'urn:logto:acr:1fa', amr, ts: 100 });
+      }
+    );
 
     it('still reaches mfa when another factor supplies the first factor', () => {
       expect(derive([password({ verifiedAt: 100 }), mfaEmailCode(200)])).toEqual({
@@ -313,16 +323,6 @@ describe('deriveAuthenticationContext', () => {
   });
 
   describe('records that are not proofs of the identified user', () => {
-    it('never counts a new-password-identity record, even next to a real proof', () => {
-      expect(derive([social(100), newPasswordIdentity(50)])).toEqual({ amr: ['fed'], ts: 100 });
-      // Without the registration password, a TOTP alone reaches only 1fa.
-      expect(derive([social(100), newPasswordIdentity(50), totp({ verifiedAt: 200 })])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['fed', 'otp'],
-        ts: 100,
-      });
-    });
-
     it('ignores an identifier record that did not identify the user', () => {
       // A code for an address the user is adding, or a password verified for another account,
       // is never passed to `identifyUser()` for this user.
@@ -333,18 +333,15 @@ describe('deriveAuthenticationContext', () => {
       expect(derive([password({ verifiedAt: 50, id: 'other-account' })])).toEqual({});
     });
 
-    it('ignores an MFA record of a factor the user has not enabled', () => {
-      expect(
-        derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 200 }), mfaEmailCode(300)], {
-          mfaSettings: noFactorEnabled,
-        })
-      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
-      // A backup code set the user never enrolled is not eligible either.
-      expect(
-        derive([password({ verifiedAt: 100 }), backupCode(200)], {
-          user: { ...user, mfaVerifications: [mockUserTotpMfaVerification] },
-        })
-      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+    it('ignores a registration password that never identified the user', () => {
+      // The route only accepts the record in a Register interaction, and `identifyUser()` never
+      // records it; a stored one from before the route guard still counts nothing.
+      expect(derive([social(100), newPasswordIdentity(50)])).toEqual({ amr: ['fed'], ts: 100 });
+      expect(derive([social(100), newPasswordIdentity(50), totp({ verifiedAt: 200 })])).toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['fed', 'otp'],
+        ts: 100,
+      });
     });
 
     it('ignores an MFA code that was not sent to the primary contact of the user', () => {
@@ -353,25 +350,6 @@ describe('deriveAuthenticationContext', () => {
         amr: ['pwd'],
         ts: 100,
       });
-    });
-
-    it('keeps the proof of the last backup code once every code is marked used', () => {
-      // `verify()` marks the code used before the submission reloads the user, so the reloaded
-      // user has no unused code left and would no longer be offered a backup code challenge.
-      const reloadedUser: User = {
-        ...user,
-        mfaVerifications: [
-          mockUserTotpMfaVerification,
-          {
-            ...mockUserBackupCodeMfaVerification,
-            codes: [{ code: 'code', usedAt: new Date().toISOString() }],
-          },
-        ],
-      };
-
-      expect(
-        derive([password({ verifiedAt: 100 }), backupCode(200)], { user: reloadedUser })
-      ).toEqual({ acr: 'urn:logto:acr:mfa', amr: ['pwd', 'otp', 'mfa'], ts: 100 });
     });
 
     it('ignores factor records created for another user', () => {

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -1,5 +1,6 @@
 import { TemplateType } from '@logto/connector-kit';
 import {
+  MfaFactor,
   SignInIdentifier,
   UsersPasswordEncryptionMethod,
   VerificationType,
@@ -35,12 +36,14 @@ import { deriveAuthenticationContext } from './authentication-context.js';
 
 const { libraries, queries } = new MockTenant();
 const userId = mockUser.id;
+const username = 'foo';
 const email = 'foo@bar.com';
 const phone = '+11234567890';
 
 /** A user with every MFA factor enrolled. */
 const user: User = {
   ...mockUser,
+  username,
   primaryEmail: email,
   primaryPhone: phone,
   mfaVerifications: [
@@ -60,6 +63,17 @@ const derive = (
   options: Options = {}
 ) => deriveAuthenticationContext(records, { user, identifiedVerificationIds, ...options });
 
+/** The interaction created `user` from its records, so nothing identified the user. */
+const deriveForNewAccount = (
+  records: Parameters<typeof deriveAuthenticationContext>[0],
+  bindMfaFactors: MfaFactor[] = []
+) =>
+  derive(records, {
+    identifiedVerificationIds: new Set(),
+    isNewAccount: true,
+    bindMfaFactors: new Set(bindMfaFactors),
+  });
+
 const password = ({
   verifiedAt,
   verified = true,
@@ -68,16 +82,16 @@ const password = ({
   new PasswordVerification(libraries, queries, {
     id,
     type: VerificationType.Password,
-    identifier: { type: SignInIdentifier.Username, value: 'foo' },
+    identifier: { type: SignInIdentifier.Username, value: username },
     verified,
     verifiedAt,
   });
 
-const emailCode = (verifiedAt?: number, id = 'email') =>
+const emailCode = (verifiedAt?: number, id = 'email', address = email) =>
   new EmailCodeVerification(libraries, queries, {
     id,
     type: VerificationType.EmailVerificationCode,
-    identifier: { type: SignInIdentifier.Email, value: email },
+    identifier: { type: SignInIdentifier.Email, value: address },
     templateType: TemplateType.SignIn,
     verified: true,
     verifiedAt,
@@ -174,12 +188,12 @@ const social = (verifiedAt?: number) =>
     verifiedAt,
   });
 
-/** A verified registration record: a policy-compliant password proposed for an unused username. */
-const newPasswordIdentity = (verifiedAt?: number) =>
+/** A verified registration record: a policy-compliant password proposed for the given username. */
+const newPasswordIdentity = (verifiedAt?: number, value = 'unused') =>
   new NewPasswordIdentityVerification(libraries, queries, {
     id: 'new-password-identity',
     type: VerificationType.NewPasswordIdentity,
-    identifier: { type: SignInIdentifier.Username, value: 'unused' },
+    identifier: { type: SignInIdentifier.Username, value },
     passwordEncrypted: 'encrypted',
     passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
     verifiedAt,
@@ -319,6 +333,70 @@ describe('deriveAuthenticationContext', () => {
         amr: ['otp', 'pwd', 'mfa'],
         ts: 100,
       });
+    });
+  });
+
+  describe('a new account', () => {
+    it('reaches 1fa with the password the account was created with', () => {
+      expect(deriveForNewAccount([newPasswordIdentity(100, username)])).toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['pwd'],
+        ts: 100,
+      });
+    });
+
+    it('reaches 1fa with the verified email or phone the account was created with', () => {
+      expect(deriveForNewAccount([emailCode(100)])).toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['otp'],
+        ts: 100,
+      });
+      expect(deriveForNewAccount([phoneCode(100)])).toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['sms'],
+        ts: 100,
+      });
+    });
+
+    it('records only fed for a social registration', () => {
+      expect(deriveForNewAccount([social(100)])).toEqual({ amr: ['fed'], ts: 100 });
+    });
+
+    it('counts a factor enrolled in this interaction when the submission binds it', () => {
+      const enrolledTotp = totp({ verifiedAt: 200, secret: 'new' });
+
+      expect(
+        deriveForNewAccount([newPasswordIdentity(100, username), enrolledTotp], [MfaFactor.TOTP])
+      ).toEqual({ acr: 'urn:logto:acr:mfa', amr: ['pwd', 'otp', 'mfa'], ts: 100 });
+      // An mfa-class factor without a Logto-verifiable first factor reaches only 1fa.
+      expect(deriveForNewAccount([social(100), enrolledTotp], [MfaFactor.TOTP])).toEqual({
+        acr: 'urn:logto:acr:1fa',
+        amr: ['fed', 'otp'],
+        ts: 100,
+      });
+    });
+
+    it('ignores an enrollment the submission does not bind', () => {
+      expect(
+        deriveForNewAccount([newPasswordIdentity(100, username), totp({ secret: 'new' })])
+      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
+    });
+
+    it('ignores a verified identifier that was not written to the account', () => {
+      // The user verified a code for one address, then registered with a social identity.
+      expect(deriveForNewAccount([social(100), emailCode(50, 'other', 'other@bar.com')])).toEqual({
+        amr: ['fed'],
+        ts: 100,
+      });
+      expect(deriveForNewAccount([newPasswordIdentity(100)])).toEqual({});
+    });
+
+    it('never counts an enrollment for an existing account', () => {
+      expect(
+        derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 50, secret: 'new' })], {
+          bindMfaFactors: new Set([MfaFactor.TOTP]),
+        })
+      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
     });
   });
 

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -8,6 +8,8 @@ import {
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
+import RequestError from '#src/errors/RequestError/index.js';
+
 import { type VerificationRecord } from '../verifications/index.js';
 
 /** The authentication context an interaction achieved, in the shape of the provider's `login` result. */
@@ -19,11 +21,55 @@ type AuthenticationContext = {
 };
 
 /**
- * Whether a record counts toward the achieved context: it must be verified, and a factor enrolled
- * in this interaction never counts (that extension is owned by the step-up establishment work).
+ * Whether a record is a proof that the identified user authenticated in this interaction.
+ *
+ * A verified record is not a proof by itself. An interaction can hold verified records that never
+ * authenticated the identified account: a password proposed for a username nobody owns, a code
+ * sent to an address the user is adding to their profile, a social identity being linked, or a
+ * factor enrolled in this interaction. Only a record bound to the identified user counts:
+ *
+ * - An MFA record (TOTP, backup code, WebAuthn) is created for a user and verified against that
+ *   user's enrolled factors; it counts when it is not a new enrollment and its `userId` matches.
+ * - A sign-in passkey record resolves its `userId` from the asserted credential.
+ * - An identifier record (password, verification code, one-time token, social, enterprise SSO)
+ *   counts when the account it identifies is the identified user.
+ * - A new-password-identity record only proposes a password for an account that does not exist
+ *   yet, so it never counts.
  */
-const isCountedRecord = (record: VerificationRecord) =>
-  record.isVerified && !('isNewBindMfaVerification' in record && record.isNewBindMfaVerification);
+const isProofOfUser = async (record: VerificationRecord, userId: string): Promise<boolean> => {
+  if (!record.isVerified) {
+    return false;
+  }
+
+  if (
+    record.type === VerificationType.TOTP ||
+    record.type === VerificationType.BackupCode ||
+    record.type === VerificationType.WebAuthn
+  ) {
+    return !record.isNewBindMfaVerification && record.userId === userId;
+  }
+
+  if (record.type === VerificationType.SignInPasskey) {
+    return record.userId === userId;
+  }
+
+  if (!('identifyUser' in record)) {
+    return false;
+  }
+
+  try {
+    const { id } = await record.identifyUser();
+    return id === userId;
+  } catch (error: unknown) {
+    // The record identifies no account (a code for an unregistered address, an identity that is
+    // not linked yet): it is not a proof for this user.
+    if (error instanceof RequestError) {
+      return false;
+    }
+
+    throw error;
+  }
+};
 
 /**
  * Whether the record is a WebAuthn assertion. Logto always requires user verification for WebAuthn
@@ -34,7 +80,11 @@ const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
   type === VerificationType.WebAuthn || type === VerificationType.SignInPasskey;
 
 /**
- * Derive the authentication context achieved by the verification records of one interaction.
+ * Derive the authentication context the identified user achieved through the verification records
+ * of one interaction. Only records that are proofs of that user count; see {@link isProofOfUser}.
+ *
+ * Call it before the submission writes anything to the account: a record whose identifier or
+ * identity is only being added by this submission must not become a proof once written.
  *
  * - A `1fa`-class record (password, primary email / phone code, one-time token) reaches
  *   `urn:logto:acr:1fa`; an `mfa`-class record alone also reaches only `urn:logto:acr:1fa`.
@@ -44,10 +94,12 @@ const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
  * - `ts` is the earliest `verifiedAt` among counted records, the most conservative value for a
  *   downstream `max_age` check; it is absent when no counted record carries one.
  */
-export const deriveAuthenticationContext = (
-  records: VerificationRecord[]
-): AuthenticationContext => {
-  const counted = records.filter((record) => isCountedRecord(record));
+export const deriveAuthenticationContext = async (
+  records: VerificationRecord[],
+  userId: string
+): Promise<AuthenticationContext> => {
+  const proofs = await Promise.all(records.map(async (record) => isProofOfUser(record, userId)));
+  const counted = records.filter((_, index) => proofs[index]);
   const classes = new Set(counted.map(({ type }) => getAuthenticationFactorClass(type)));
   const hasFirstFactor = classes.has(AuthenticationFactorClass.FirstFactor);
   const hasMfaRecord = classes.has(AuthenticationFactorClass.Mfa);

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -2,11 +2,13 @@ import {
   AuthenticationFactor,
   AuthenticationFactorClass,
   LogtoAcr,
+  MfaFactor,
   SignInIdentifier,
   VerificationType,
   buildAuthenticationMethodReferences,
   getAuthenticationFactor,
   getAuthenticationFactorClass,
+  type AdditionalIdentifier,
   type AuthenticationMethodReference,
   type User,
 } from '@logto/schemas';
@@ -29,18 +31,80 @@ type IdentifiedUserContext = {
   user: User;
   /** The ids of the verification records that identified the user. */
   identifiedVerificationIds: ReadonlySet<string>;
+  /**
+   * Whether this interaction created `user` (a Register interaction). Every credential on such an
+   * account was written by this interaction, so a record for one of the account's identifiers and
+   * a factor enrolled in this interaction are proofs of it; the interaction is its own subject
+   * proof. Defaults to `false`.
+   */
+  isNewAccount?: boolean;
+  /**
+   * The MFA factors this submission writes to the user (`Mfa.bindMfaFactorsArray`). A factor
+   * enrolled in this interaction counts only when it is one of them; a verified enrollment that
+   * was never bound is not a factor of the account. Defaults to none.
+   */
+  bindMfaFactors?: ReadonlySet<MfaFactor>;
+};
+
+/** Whether the identifier is one of the user's stored sign-in identifiers. */
+const isIdentifierOfUser = (
+  user: User,
+  { type, value }: { type: SignInIdentifier | AdditionalIdentifier; value: string }
+): boolean => {
+  switch (type) {
+    case SignInIdentifier.Username: {
+      return user.username === value;
+    }
+    case SignInIdentifier.Email: {
+      return user.primaryEmail === value;
+    }
+    case SignInIdentifier.Phone: {
+      return user.primaryPhone === value;
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
+/** The factor a new-enrollment MFA record enrolls; only TOTP and WebAuthn records enroll one. */
+const enrolledFactor = ({ type }: VerificationRecord): MfaFactor | undefined => {
+  switch (type) {
+    case VerificationType.TOTP: {
+      return MfaFactor.TOTP;
+    }
+    case VerificationType.WebAuthn: {
+      return MfaFactor.WebAuthn;
+    }
+    default: {
+      return undefined;
+    }
+  }
 };
 
 /**
- * Whether an MFA record is a proof of the user: verified, not a factor enrolled in this
- * interaction, and bound to the user. TOTP, backup code and WebAuthn records are created for a
- * user and carry that user's id. An MFA email / phone code is sent to the identified user's
- * primary contact, which the MFA verification-code route reads from the user, so the record's
- * identifier must be that contact.
+ * Whether an MFA record is a proof of the user: verified and bound to the user. TOTP, backup code
+ * and WebAuthn records are created for a user and carry that user's id. An MFA email / phone code
+ * is sent to the identified user's primary contact, which the MFA verification-code route reads
+ * from the user, so the record's identifier must be that contact.
+ *
+ * A factor enrolled in this interaction counts only for a new account, and only when the
+ * submission binds it (`bindMfaFactors`). Counting an enrollment for an existing account belongs
+ * to the step-up establishment rules and is not part of this derivation yet.
  */
-const isMfaProofOfUser = (record: VerificationRecord, user: User): boolean => {
-  if (!isMfaVerificationRecord(record) || record.isNewBindMfaVerification) {
+const isMfaProofOfUser = (
+  record: VerificationRecord,
+  { user, isNewAccount = false, bindMfaFactors }: IdentifiedUserContext
+): boolean => {
+  if (!isMfaVerificationRecord(record)) {
     return false;
+  }
+
+  if (record.isNewBindMfaVerification) {
+    const factor = enrolledFactor(record);
+    if (!isNewAccount || !factor || !bindMfaFactors?.has(factor)) {
+      return false;
+    }
   }
 
   if ('userId' in record) {
@@ -67,18 +131,19 @@ const isMfaProofOfUser = (record: VerificationRecord, user: User): boolean => {
  *   links the identity (the record resolves no account until the submission writes the link).
  * - Any other record (password, verification code, one-time token, new-password identity) counts
  *   when it is one of the records that identified the user, which the interaction recorded at
- *   identification time.
+ *   identification time. For a new account, which never identifies a user, it counts instead when
+ *   its identifier is one of the account's identifiers: the interaction wrote that identifier,
+ *   with the password of a new-password identity, to the account it created.
  */
-const isProofOfUser = (
-  record: VerificationRecord,
-  { user, identifiedVerificationIds }: IdentifiedUserContext
-): boolean => {
+const isProofOfUser = (record: VerificationRecord, context: IdentifiedUserContext): boolean => {
+  const { user, identifiedVerificationIds, isNewAccount = false } = context;
+
   if (!record.isVerified) {
     return false;
   }
 
   if (isMfaVerificationRecord(record)) {
-    return isMfaProofOfUser(record, user);
+    return isMfaProofOfUser(record, context);
   }
 
   if (record.type === VerificationType.SignInPasskey) {
@@ -89,7 +154,11 @@ const isProofOfUser = (
     return true;
   }
 
-  return identifiedVerificationIds.has(record.id);
+  if (identifiedVerificationIds.has(record.id)) {
+    return true;
+  }
+
+  return isNewAccount && 'identifier' in record && isIdentifierOfUser(user, record.identifier);
 };
 
 /**
@@ -112,6 +181,8 @@ const factorsOfClass = (records: VerificationRecord[], factorClass: Authenticati
  * Derive the authentication context the identified user achieved through the verification records
  * of one interaction. Only records that are proofs of that user count; see {@link isProofOfUser}.
  * The derivation reads only what the interaction already holds and never queries the database.
+ * It runs for a SignIn and for a Register alike: a registration establishes every credential of
+ * the account it creates, and the interaction is its own subject proof.
  *
  * - A `1fa`-class proof (password, primary email / phone code, one-time token) reaches
  *   `urn:logto:acr:1fa`; an `mfa`-class proof alone also reaches only `urn:logto:acr:1fa`.

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -2,6 +2,7 @@ import {
   AuthenticationFactorClass,
   LogtoAcr,
   MfaFactor,
+  SignInIdentifier,
   VerificationType,
   buildAuthenticationMethodReferences,
   getAuthenticationFactorClass,
@@ -10,8 +11,6 @@ import {
   type User,
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
-
-import RequestError from '#src/errors/RequestError/index.js';
 
 import { getAllUserEnabledMfaVerifications } from '../helpers.js';
 import { type VerificationRecord } from '../verifications/index.js';
@@ -24,6 +23,14 @@ type AuthenticationContext = {
   amr?: AuthenticationMethodReference[];
   /** Epoch seconds of the authentication event; becomes `auth_time`. */
   ts?: number;
+};
+
+/** What the derivation knows about the identified user; see `ExperienceInteraction`. */
+type IdentifiedUserContext = {
+  user: User;
+  mfaSettings: Mfa;
+  /** The ids of the verification records that identified the user. */
+  identifiedVerificationIds: ReadonlySet<string>;
 };
 
 /**
@@ -60,82 +67,6 @@ const authenticationFactors: Readonly<Record<VerificationType, AuthenticationFac
   });
 
 /**
- * Whether a record is a proof that the identified user authenticated in this interaction.
- *
- * A verified record is not a proof by itself. An interaction can hold verified records that never
- * authenticated the identified account: a password proposed for a username nobody owns, a code
- * sent to an address the user is adding to their profile, a factor enrolled in this interaction,
- * or an MFA code requested for a factor the user has not enabled. Only a record bound to the
- * identified user counts:
- *
- * - An MFA record (TOTP, backup code, WebAuthn, MFA email / phone code) counts only when it is
- *   not a new enrollment and its factor is eligible for the user; see
- *   {@link getEligibleMfaFactors}. TOTP, backup code and WebAuthn records are created for a user
- *   and must carry that user's id; MFA email / phone codes are identifier records checked like
- *   the ones below.
- * - A sign-in passkey record resolves its `userId` from the asserted credential.
- * - A social or enterprise SSO record contributes only `fed`, never an ACR, so a verified
- *   assertion counts as is. Gating it on the stored identity would drop the very sign-in that
- *   links the identity (the record resolves no account until the submission writes the link).
- * - An identifier record (password, verification code, one-time token) counts when the account
- *   it identifies is the identified user.
- * - A new-password-identity record only proposes a password for an account that does not exist
- *   yet, so it never counts.
- */
-const isProofOfUser = async (
-  record: VerificationRecord,
-  userId: string,
-  eligibleMfaFactors: Set<MfaFactor>
-): Promise<boolean> => {
-  if (!record.isVerified) {
-    return false;
-  }
-
-  if (
-    isMfaVerificationRecord(record) &&
-    (record.isNewBindMfaVerification ||
-      !eligibleMfaFactors.has(mfaVerificationTypeToMfaFactorMap[record.type]))
-  ) {
-    return false;
-  }
-
-  // TOTP, backup code and WebAuthn records are created for a user; a sign-in passkey record
-  // resolves its user from the asserted credential.
-  if ('userId' in record) {
-    return record.userId === userId;
-  }
-
-  if (authenticationFactors[record.type] === AuthenticationFactor.Federated) {
-    return true;
-  }
-
-  if (!('identifyUser' in record)) {
-    return false;
-  }
-
-  try {
-    const { id } = await record.identifyUser();
-    return id === userId;
-  } catch (error: unknown) {
-    // The record identifies no account (a code for an unregistered address): it is not a proof
-    // for this user.
-    if (error instanceof RequestError) {
-      return false;
-    }
-
-    throw error;
-  }
-};
-
-/**
- * Whether the record is a WebAuthn assertion. Logto always requires user verification for WebAuthn
- * (`requireUserVerification: true` in the verification helpers), so a verified record is a
- * user-verified passkey and reaches `urn:logto:acr:mfa` on its own.
- */
-const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
-  type === VerificationType.WebAuthn || type === VerificationType.SignInPasskey;
-
-/**
  * The MFA factors a completed proof in this interaction can be of: enabled in the sign-in
  * experience and enrolled by, or implicit for, the user.
  *
@@ -153,6 +84,89 @@ const getEligibleMfaFactors = (user: User, mfaSettings: Mfa): Set<MfaFactor> =>
       : []),
   ]);
 
+/**
+ * Whether an MFA record is a proof of the user: verified, not a factor enrolled in this
+ * interaction, of an eligible factor (see {@link getEligibleMfaFactors}), and bound to the user.
+ * TOTP, backup code and WebAuthn records are created for a user and carry that user's id. An MFA
+ * email / phone code is sent to the identified user's primary contact, which the MFA
+ * verification-code route reads from the user, so the record's identifier must be that contact.
+ */
+const isMfaProofOfUser = (
+  record: VerificationRecord,
+  user: User,
+  eligibleMfaFactors: Set<MfaFactor>
+): boolean => {
+  if (!isMfaVerificationRecord(record)) {
+    return false;
+  }
+
+  if (
+    record.isNewBindMfaVerification ||
+    !eligibleMfaFactors.has(mfaVerificationTypeToMfaFactorMap[record.type])
+  ) {
+    return false;
+  }
+
+  if ('userId' in record) {
+    return record.userId === user.id;
+  }
+
+  const { type, value } = record.identifier;
+  return value === (type === SignInIdentifier.Email ? user.primaryEmail : user.primaryPhone);
+};
+
+/**
+ * Whether a record is a proof that the identified user authenticated in this interaction.
+ *
+ * A verified record is not a proof by itself. An interaction can hold verified records that never
+ * authenticated the identified account: a password proposed for a username nobody owns, a code
+ * sent to an address the user is adding to their profile, a factor enrolled in this interaction,
+ * or an MFA code requested for a factor the user has not enabled. Only a record bound to the
+ * identified user counts:
+ *
+ * - An MFA record (TOTP, backup code, WebAuthn, MFA email / phone code) counts per
+ *   {@link isMfaProofOfUser}.
+ * - A sign-in passkey record resolves its `userId` from the asserted credential.
+ * - A social or enterprise SSO record contributes only `fed`, never an ACR, so a verified
+ *   assertion counts as is. Gating it on the stored identity would drop the very sign-in that
+ *   links the identity (the record resolves no account until the submission writes the link).
+ * - An identifier record (password, verification code, one-time token) counts when it is one of
+ *   the records that identified the user, which the interaction recorded at identification time.
+ * - A new-password-identity record only proposes a password for an account that does not exist
+ *   yet; it never identifies a user, so it never counts.
+ */
+const isProofOfUser = (
+  record: VerificationRecord,
+  { user, identifiedVerificationIds }: IdentifiedUserContext,
+  eligibleMfaFactors: Set<MfaFactor>
+): boolean => {
+  if (!record.isVerified) {
+    return false;
+  }
+
+  if (isMfaVerificationRecord(record)) {
+    return isMfaProofOfUser(record, user, eligibleMfaFactors);
+  }
+
+  if (record.type === VerificationType.SignInPasskey) {
+    return record.userId === user.id;
+  }
+
+  if (authenticationFactors[record.type] === AuthenticationFactor.Federated) {
+    return true;
+  }
+
+  return identifiedVerificationIds.has(record.id);
+};
+
+/**
+ * Whether the record is a WebAuthn assertion. Logto always requires user verification for WebAuthn
+ * (`requireUserVerification: true` in the verification helpers), so a verified record is a
+ * user-verified passkey and reaches `urn:logto:acr:mfa` on its own.
+ */
+const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
+  type === VerificationType.WebAuthn || type === VerificationType.SignInPasskey;
+
 /** The factors with a counted record of the given class. */
 const factorsOfClass = (records: VerificationRecord[], factorClass: AuthenticationFactorClass) =>
   new Set(
@@ -164,9 +178,7 @@ const factorsOfClass = (records: VerificationRecord[], factorClass: Authenticati
 /**
  * Derive the authentication context the identified user achieved through the verification records
  * of one interaction. Only records that are proofs of that user count; see {@link isProofOfUser}.
- *
- * Call it before the submission writes anything to the account: a record whose identifier or
- * identity is only being added by this submission must not become a proof once written.
+ * The derivation reads only what the interaction already holds and never queries the database.
  *
  * - A `1fa`-class proof (password, primary email / phone code, one-time token) reaches
  *   `urn:logto:acr:1fa`; an `mfa`-class proof alone also reaches only `urn:logto:acr:1fa`.
@@ -177,16 +189,12 @@ const factorsOfClass = (records: VerificationRecord[], factorClass: Authenticati
  * - `ts` is the earliest `verifiedAt` among counted records, the most conservative value for a
  *   downstream `max_age` check; it is absent when no counted record carries one.
  */
-export const deriveAuthenticationContext = async (
+export const deriveAuthenticationContext = (
   records: VerificationRecord[],
-  user: User,
-  mfaSettings: Mfa
-): Promise<AuthenticationContext> => {
-  const eligibleMfaFactors = getEligibleMfaFactors(user, mfaSettings);
-  const proofs = await Promise.all(
-    records.map(async (record) => isProofOfUser(record, user.id, eligibleMfaFactors))
-  );
-  const counted = records.filter((_, index) => proofs[index]);
+  context: IdentifiedUserContext
+): AuthenticationContext => {
+  const eligibleMfaFactors = getEligibleMfaFactors(context.user, context.mfaSettings);
+  const counted = records.filter((record) => isProofOfUser(record, context, eligibleMfaFactors));
   const firstFactors = factorsOfClass(counted, AuthenticationFactorClass.FirstFactor);
   const mfaFactors = factorsOfClass(counted, AuthenticationFactorClass.Mfa);
   const hasDistinctMfaFactor = [...mfaFactors].some(

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -1,18 +1,22 @@
 import {
   AuthenticationFactorClass,
   LogtoAcr,
+  MfaFactor,
   VerificationType,
   buildAuthenticationMethodReferences,
   getAuthenticationFactorClass,
   type AuthenticationMethodReference,
+  type Mfa,
+  type User,
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
 import RequestError from '#src/errors/RequestError/index.js';
 
+import { getAllUserEnabledMfaVerifications } from '../helpers.js';
 import { type VerificationRecord } from '../verifications/index.js';
 
-import { isMfaVerificationRecord, type MfaValidator } from './mfa-validator.js';
+import { isMfaVerificationRecord, mfaVerificationTypeToMfaFactorMap } from './mfa-validator.js';
 
 /** The authentication context an interaction achieved, in the shape of the provider's `login` result. */
 type AuthenticationContext = {
@@ -64,10 +68,11 @@ const authenticationFactors: Readonly<Record<VerificationType, AuthenticationFac
  * or an MFA code requested for a factor the user has not enabled. Only a record bound to the
  * identified user counts:
  *
- * - An MFA record (TOTP, backup code, WebAuthn, MFA email / phone code) counts only when the
- *   {@link MfaValidator} accepts it: verified, not a new enrollment, and of a factor enabled for
- *   the user. TOTP, backup code and WebAuthn records are created for a user and must carry that
- *   user's id; MFA email / phone codes are identifier records checked like the ones below.
+ * - An MFA record (TOTP, backup code, WebAuthn, MFA email / phone code) counts only when it is
+ *   not a new enrollment and its factor is eligible for the user; see
+ *   {@link getEligibleMfaFactors}. TOTP, backup code and WebAuthn records are created for a user
+ *   and must carry that user's id; MFA email / phone codes are identifier records checked like
+ *   the ones below.
  * - A sign-in passkey record resolves its `userId` from the asserted credential.
  * - A social or enterprise SSO record contributes only `fed`, never an ACR, so a verified
  *   assertion counts as is. Gating it on the stored identity would drop the very sign-in that
@@ -80,13 +85,17 @@ const authenticationFactors: Readonly<Record<VerificationType, AuthenticationFac
 const isProofOfUser = async (
   record: VerificationRecord,
   userId: string,
-  eligibleMfaRecords: Set<VerificationRecord>
+  eligibleMfaFactors: Set<MfaFactor>
 ): Promise<boolean> => {
   if (!record.isVerified) {
     return false;
   }
 
-  if (isMfaVerificationRecord(record) && !eligibleMfaRecords.has(record)) {
+  if (
+    isMfaVerificationRecord(record) &&
+    (record.isNewBindMfaVerification ||
+      !eligibleMfaFactors.has(mfaVerificationTypeToMfaFactorMap[record.type]))
+  ) {
     return false;
   }
 
@@ -126,6 +135,24 @@ const isProofOfUser = async (
 const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
   type === VerificationType.WebAuthn || type === VerificationType.SignInPasskey;
 
+/**
+ * The MFA factors a completed proof in this interaction can be of: enabled in the sign-in
+ * experience and enrolled by, or implicit for, the user.
+ *
+ * {@link getAllUserEnabledMfaVerifications} decides what a new challenge may offer, so it drops a
+ * backup code set whose codes are all used. A code consumed in this interaction is still a proof,
+ * and the last one is marked used before the submission reloads the user, so the backup code
+ * factor stays eligible as long as it is enabled and enrolled.
+ */
+const getEligibleMfaFactors = (user: User, mfaSettings: Mfa): Set<MfaFactor> =>
+  new Set([
+    ...getAllUserEnabledMfaVerifications(mfaSettings, user),
+    ...(mfaSettings.factors.includes(MfaFactor.BackupCode) &&
+    user.mfaVerifications.some(({ type }) => type === MfaFactor.BackupCode)
+      ? [MfaFactor.BackupCode]
+      : []),
+  ]);
+
 /** The factors with a counted record of the given class. */
 const factorsOfClass = (records: VerificationRecord[], factorClass: AuthenticationFactorClass) =>
   new Set(
@@ -152,14 +179,12 @@ const factorsOfClass = (records: VerificationRecord[], factorClass: Authenticati
  */
 export const deriveAuthenticationContext = async (
   records: VerificationRecord[],
-  userId: string,
-  mfaValidator: MfaValidator
+  user: User,
+  mfaSettings: Mfa
 ): Promise<AuthenticationContext> => {
-  const eligibleMfaRecords = new Set<VerificationRecord>(
-    mfaValidator.getVerifiedMfaVerificationRecords(records)
-  );
+  const eligibleMfaFactors = getEligibleMfaFactors(user, mfaSettings);
   const proofs = await Promise.all(
-    records.map(async (record) => isProofOfUser(record, userId, eligibleMfaRecords))
+    records.map(async (record) => isProofOfUser(record, user.id, eligibleMfaFactors))
   );
   const counted = records.filter((_, index) => proofs[index]);
   const firstFactors = factorsOfClass(counted, AuthenticationFactorClass.FirstFactor);

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -8,7 +8,7 @@ import {
 import { conditional } from '@silverhand/essentials';
 
 /** The authentication context an interaction achieved, in the shape of the provider's `login` result. */
-export type AuthenticationContext = {
+type AuthenticationContext = {
   acr?: LogtoAcr;
   amr?: AuthenticationMethodReference[];
   /** Epoch seconds of the authentication event; becomes `auth_time`. */

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -1,0 +1,72 @@
+import {
+  AuthenticationFactorClass,
+  LogtoAcr,
+  VerificationType,
+  buildAuthenticationMethodReferences,
+  getAuthenticationFactorClass,
+  type AuthenticationMethodReference,
+} from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+
+import { type VerificationRecord } from '../verifications/index.js';
+
+/** The authentication context an interaction achieved, in the shape of the provider's `login` result. */
+type AuthenticationContext = {
+  acr?: LogtoAcr;
+  amr?: AuthenticationMethodReference[];
+  /** Epoch seconds of the authentication event; becomes `auth_time`. */
+  ts?: number;
+};
+
+/**
+ * Whether a record counts toward the achieved context: it must be verified, and a factor enrolled
+ * in this interaction never counts (that extension is owned by the step-up establishment work).
+ */
+const isCountedRecord = (record: VerificationRecord) =>
+  record.isVerified && !('isNewBindMfaVerification' in record && record.isNewBindMfaVerification);
+
+/**
+ * Whether the record is a WebAuthn assertion. Logto always requires user verification for WebAuthn
+ * (`requireUserVerification: true` in the verification helpers), so a verified record is a
+ * user-verified passkey and reaches `urn:logto:acr:mfa` on its own.
+ */
+const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
+  type === VerificationType.WebAuthn || type === VerificationType.SignInPasskey;
+
+/**
+ * Derive the authentication context achieved by the verification records of one interaction.
+ *
+ * - A `1fa`-class record (password, primary email / phone code, one-time token) reaches
+ *   `urn:logto:acr:1fa`; an `mfa`-class record alone also reaches only `urn:logto:acr:1fa`.
+ * - A `1fa`-class record plus an `mfa`-class record, or a user-verified WebAuthn assertion alone,
+ *   reaches `urn:logto:acr:mfa`.
+ * - Social / enterprise SSO contribute `fed` to `amr` and nothing to the ACR.
+ * - `ts` is the earliest `verifiedAt` among counted records, the most conservative value for a
+ *   downstream `max_age` check; it is absent when no counted record carries one.
+ */
+export const deriveAuthenticationContext = (
+  records: VerificationRecord[]
+): AuthenticationContext => {
+  const counted = records.filter((record) => isCountedRecord(record));
+  const classes = new Set(counted.map(({ type }) => getAuthenticationFactorClass(type)));
+  const hasFirstFactor = classes.has(AuthenticationFactorClass.FirstFactor);
+  const hasMfaRecord = classes.has(AuthenticationFactorClass.Mfa);
+
+  const acr =
+    (hasFirstFactor && hasMfaRecord) || counted.some((record) => isUserVerifiedWebAuthn(record))
+      ? LogtoAcr.Mfa
+      : conditional((hasFirstFactor || hasMfaRecord) && LogtoAcr.FirstFactor);
+  const amr = buildAuthenticationMethodReferences(
+    counted.map(({ type }) => type),
+    acr
+  );
+  const timestamps = counted
+    .map(({ verifiedAt }) => verifiedAt)
+    .filter((verifiedAt): verifiedAt is number => typeof verifiedAt === 'number');
+
+  return {
+    ...conditional(acr && { acr }),
+    ...conditional(amr.length > 0 && { amr }),
+    ...conditional(timestamps.length > 0 && { ts: Math.min(...timestamps) }),
+  };
+};

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -12,6 +12,8 @@ import RequestError from '#src/errors/RequestError/index.js';
 
 import { type VerificationRecord } from '../verifications/index.js';
 
+import { isMfaVerificationRecord, type MfaValidator } from './mfa-validator.js';
+
 /** The authentication context an interaction achieved, in the shape of the provider's `login` result. */
 type AuthenticationContext = {
   acr?: LogtoAcr;
@@ -21,35 +23,76 @@ type AuthenticationContext = {
 };
 
 /**
+ * The factor a verification record is a proof of. Repeated proofs of one factor count once, and
+ * `urn:logto:acr:mfa` needs a `1fa`-class and an `mfa`-class proof of two different factors: a
+ * primary email code and an MFA email code are two proofs of the same contact, not two factors.
+ */
+enum AuthenticationFactor {
+  Password = 'password',
+  Email = 'email',
+  Phone = 'phone',
+  Totp = 'totp',
+  BackupCode = 'backupCode',
+  WebAuthn = 'webAuthn',
+  Federated = 'federated',
+}
+
+/** Keyed by every {@link VerificationType}, so a new type fails at compile time until mapped. */
+const authenticationFactors: Readonly<Record<VerificationType, AuthenticationFactor>> =
+  Object.freeze({
+    [VerificationType.Password]: AuthenticationFactor.Password,
+    [VerificationType.NewPasswordIdentity]: AuthenticationFactor.Password,
+    [VerificationType.EmailVerificationCode]: AuthenticationFactor.Email,
+    [VerificationType.MfaEmailVerificationCode]: AuthenticationFactor.Email,
+    [VerificationType.OneTimeToken]: AuthenticationFactor.Email,
+    [VerificationType.PhoneVerificationCode]: AuthenticationFactor.Phone,
+    [VerificationType.MfaPhoneVerificationCode]: AuthenticationFactor.Phone,
+    [VerificationType.TOTP]: AuthenticationFactor.Totp,
+    [VerificationType.BackupCode]: AuthenticationFactor.BackupCode,
+    [VerificationType.WebAuthn]: AuthenticationFactor.WebAuthn,
+    [VerificationType.SignInPasskey]: AuthenticationFactor.WebAuthn,
+    [VerificationType.Social]: AuthenticationFactor.Federated,
+    [VerificationType.EnterpriseSso]: AuthenticationFactor.Federated,
+  });
+
+/**
  * Whether a record is a proof that the identified user authenticated in this interaction.
  *
  * A verified record is not a proof by itself. An interaction can hold verified records that never
  * authenticated the identified account: a password proposed for a username nobody owns, a code
- * sent to an address the user is adding to their profile, a social identity being linked, or a
- * factor enrolled in this interaction. Only a record bound to the identified user counts:
+ * sent to an address the user is adding to their profile, a social identity being linked, a
+ * factor enrolled in this interaction, or an MFA code requested for a factor the user has not
+ * enabled. Only a record bound to the identified user counts:
  *
- * - An MFA record (TOTP, backup code, WebAuthn) is created for a user and verified against that
- *   user's enrolled factors; it counts when it is not a new enrollment and its `userId` matches.
+ * - An MFA record (TOTP, backup code, WebAuthn, MFA email / phone code) counts only when the
+ *   {@link MfaValidator} accepts it: verified, not a new enrollment, and of a factor enabled for
+ *   the user. TOTP, backup code and WebAuthn records are created for a user and must carry that
+ *   user's id; MFA email / phone codes are identifier records checked like the ones below.
  * - A sign-in passkey record resolves its `userId` from the asserted credential.
  * - An identifier record (password, verification code, one-time token, social, enterprise SSO)
  *   counts when the account it identifies is the identified user.
  * - A new-password-identity record only proposes a password for an account that does not exist
  *   yet, so it never counts.
  */
-const isProofOfUser = async (record: VerificationRecord, userId: string): Promise<boolean> => {
+const isProofOfUser = async (
+  record: VerificationRecord,
+  userId: string,
+  eligibleMfaRecords: Set<VerificationRecord>
+): Promise<boolean> => {
   if (!record.isVerified) {
+    return false;
+  }
+
+  if (isMfaVerificationRecord(record) && !eligibleMfaRecords.has(record)) {
     return false;
   }
 
   if (
     record.type === VerificationType.TOTP ||
     record.type === VerificationType.BackupCode ||
-    record.type === VerificationType.WebAuthn
+    record.type === VerificationType.WebAuthn ||
+    record.type === VerificationType.SignInPasskey
   ) {
-    return !record.isNewBindMfaVerification && record.userId === userId;
-  }
-
-  if (record.type === VerificationType.SignInPasskey) {
     return record.userId === userId;
   }
 
@@ -79,6 +122,14 @@ const isProofOfUser = async (record: VerificationRecord, userId: string): Promis
 const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
   type === VerificationType.WebAuthn || type === VerificationType.SignInPasskey;
 
+/** The factors with a counted record of the given class. */
+const factorsOfClass = (records: VerificationRecord[], factorClass: AuthenticationFactorClass) =>
+  new Set(
+    records
+      .filter(({ type }) => getAuthenticationFactorClass(type) === factorClass)
+      .map(({ type }) => authenticationFactors[type])
+  );
+
 /**
  * Derive the authentication context the identified user achieved through the verification records
  * of one interaction. Only records that are proofs of that user count; see {@link isProofOfUser}.
@@ -86,28 +137,37 @@ const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
  * Call it before the submission writes anything to the account: a record whose identifier or
  * identity is only being added by this submission must not become a proof once written.
  *
- * - A `1fa`-class record (password, primary email / phone code, one-time token) reaches
- *   `urn:logto:acr:1fa`; an `mfa`-class record alone also reaches only `urn:logto:acr:1fa`.
- * - A `1fa`-class record plus an `mfa`-class record, or a user-verified WebAuthn assertion alone,
- *   reaches `urn:logto:acr:mfa`.
+ * - A `1fa`-class proof (password, primary email / phone code, one-time token) reaches
+ *   `urn:logto:acr:1fa`; an `mfa`-class proof alone also reaches only `urn:logto:acr:1fa`.
+ * - A `1fa`-class proof plus an `mfa`-class proof of a different factor, or a user-verified
+ *   WebAuthn assertion alone, reaches `urn:logto:acr:mfa`. Repeated proofs of one factor count
+ *   once, so a primary email code plus an MFA email code stays at `urn:logto:acr:1fa`.
  * - Social / enterprise SSO contribute `fed` to `amr` and nothing to the ACR.
  * - `ts` is the earliest `verifiedAt` among counted records, the most conservative value for a
  *   downstream `max_age` check; it is absent when no counted record carries one.
  */
 export const deriveAuthenticationContext = async (
   records: VerificationRecord[],
-  userId: string
+  userId: string,
+  mfaValidator: MfaValidator
 ): Promise<AuthenticationContext> => {
-  const proofs = await Promise.all(records.map(async (record) => isProofOfUser(record, userId)));
+  const eligibleMfaRecords = new Set<VerificationRecord>(
+    mfaValidator.getVerifiedMfaVerificationRecords(records)
+  );
+  const proofs = await Promise.all(
+    records.map(async (record) => isProofOfUser(record, userId, eligibleMfaRecords))
+  );
   const counted = records.filter((_, index) => proofs[index]);
-  const classes = new Set(counted.map(({ type }) => getAuthenticationFactorClass(type)));
-  const hasFirstFactor = classes.has(AuthenticationFactorClass.FirstFactor);
-  const hasMfaRecord = classes.has(AuthenticationFactorClass.Mfa);
+  const firstFactors = factorsOfClass(counted, AuthenticationFactorClass.FirstFactor);
+  const mfaFactors = factorsOfClass(counted, AuthenticationFactorClass.Mfa);
+  const hasDistinctMfaFactor = [...mfaFactors].some(
+    (factor) => firstFactors.size > (firstFactors.has(factor) ? 1 : 0)
+  );
 
   const acr =
-    (hasFirstFactor && hasMfaRecord) || counted.some((record) => isUserVerifiedWebAuthn(record))
+    hasDistinctMfaFactor || counted.some((record) => isUserVerifiedWebAuthn(record))
       ? LogtoAcr.Mfa
-      : conditional((hasFirstFactor || hasMfaRecord) && LogtoAcr.FirstFactor);
+      : conditional((firstFactors.size > 0 || mfaFactors.size > 0) && LogtoAcr.FirstFactor);
   const amr = buildAuthenticationMethodReferences(
     counted.map(({ type }) => type),
     acr

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -60,17 +60,20 @@ const authenticationFactors: Readonly<Record<VerificationType, AuthenticationFac
  *
  * A verified record is not a proof by itself. An interaction can hold verified records that never
  * authenticated the identified account: a password proposed for a username nobody owns, a code
- * sent to an address the user is adding to their profile, a social identity being linked, a
- * factor enrolled in this interaction, or an MFA code requested for a factor the user has not
- * enabled. Only a record bound to the identified user counts:
+ * sent to an address the user is adding to their profile, a factor enrolled in this interaction,
+ * or an MFA code requested for a factor the user has not enabled. Only a record bound to the
+ * identified user counts:
  *
  * - An MFA record (TOTP, backup code, WebAuthn, MFA email / phone code) counts only when the
  *   {@link MfaValidator} accepts it: verified, not a new enrollment, and of a factor enabled for
  *   the user. TOTP, backup code and WebAuthn records are created for a user and must carry that
  *   user's id; MFA email / phone codes are identifier records checked like the ones below.
  * - A sign-in passkey record resolves its `userId` from the asserted credential.
- * - An identifier record (password, verification code, one-time token, social, enterprise SSO)
- *   counts when the account it identifies is the identified user.
+ * - A social or enterprise SSO record contributes only `fed`, never an ACR, so a verified
+ *   assertion counts as is. Gating it on the stored identity would drop the very sign-in that
+ *   links the identity (the record resolves no account until the submission writes the link).
+ * - An identifier record (password, verification code, one-time token) counts when the account
+ *   it identifies is the identified user.
  * - A new-password-identity record only proposes a password for an account that does not exist
  *   yet, so it never counts.
  */
@@ -87,13 +90,14 @@ const isProofOfUser = async (
     return false;
   }
 
-  if (
-    record.type === VerificationType.TOTP ||
-    record.type === VerificationType.BackupCode ||
-    record.type === VerificationType.WebAuthn ||
-    record.type === VerificationType.SignInPasskey
-  ) {
+  // TOTP, backup code and WebAuthn records are created for a user; a sign-in passkey record
+  // resolves its user from the asserted credential.
+  if ('userId' in record) {
     return record.userId === userId;
+  }
+
+  if (authenticationFactors[record.type] === AuthenticationFactor.Federated) {
+    return true;
   }
 
   if (!('identifyUser' in record)) {
@@ -104,8 +108,8 @@ const isProofOfUser = async (
     const { id } = await record.identifyUser();
     return id === userId;
   } catch (error: unknown) {
-    // The record identifies no account (a code for an unregistered address, an identity that is
-    // not linked yet): it is not a proof for this user.
+    // The record identifies no account (a code for an unregistered address): it is not a proof
+    // for this user.
     if (error instanceof RequestError) {
       return false;
     }

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -1,21 +1,20 @@
 import {
+  AuthenticationFactor,
   AuthenticationFactorClass,
   LogtoAcr,
-  MfaFactor,
   SignInIdentifier,
   VerificationType,
   buildAuthenticationMethodReferences,
+  getAuthenticationFactor,
   getAuthenticationFactorClass,
   type AuthenticationMethodReference,
-  type Mfa,
   type User,
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
-import { getAllUserEnabledMfaVerifications } from '../helpers.js';
 import { type VerificationRecord } from '../verifications/index.js';
 
-import { isMfaVerificationRecord, mfaVerificationTypeToMfaFactorMap } from './mfa-validator.js';
+import { isMfaVerificationRecord } from './mfa-validator.js';
 
 /** The authentication context an interaction achieved, in the shape of the provider's `login` result. */
 type AuthenticationContext = {
@@ -28,82 +27,19 @@ type AuthenticationContext = {
 /** What the derivation knows about the identified user; see `ExperienceInteraction`. */
 type IdentifiedUserContext = {
   user: User;
-  mfaSettings: Mfa;
   /** The ids of the verification records that identified the user. */
   identifiedVerificationIds: ReadonlySet<string>;
 };
 
 /**
- * The factor a verification record is a proof of. Repeated proofs of one factor count once, and
- * `urn:logto:acr:mfa` needs a `1fa`-class and an `mfa`-class proof of two different factors: a
- * primary email code and an MFA email code are two proofs of the same contact, not two factors.
- */
-enum AuthenticationFactor {
-  Password = 'password',
-  Email = 'email',
-  Phone = 'phone',
-  Totp = 'totp',
-  BackupCode = 'backupCode',
-  WebAuthn = 'webAuthn',
-  Federated = 'federated',
-}
-
-/** Keyed by every {@link VerificationType}, so a new type fails at compile time until mapped. */
-const authenticationFactors: Readonly<Record<VerificationType, AuthenticationFactor>> =
-  Object.freeze({
-    [VerificationType.Password]: AuthenticationFactor.Password,
-    [VerificationType.NewPasswordIdentity]: AuthenticationFactor.Password,
-    [VerificationType.EmailVerificationCode]: AuthenticationFactor.Email,
-    [VerificationType.MfaEmailVerificationCode]: AuthenticationFactor.Email,
-    [VerificationType.OneTimeToken]: AuthenticationFactor.Email,
-    [VerificationType.PhoneVerificationCode]: AuthenticationFactor.Phone,
-    [VerificationType.MfaPhoneVerificationCode]: AuthenticationFactor.Phone,
-    [VerificationType.TOTP]: AuthenticationFactor.Totp,
-    [VerificationType.BackupCode]: AuthenticationFactor.BackupCode,
-    [VerificationType.WebAuthn]: AuthenticationFactor.WebAuthn,
-    [VerificationType.SignInPasskey]: AuthenticationFactor.WebAuthn,
-    [VerificationType.Social]: AuthenticationFactor.Federated,
-    [VerificationType.EnterpriseSso]: AuthenticationFactor.Federated,
-  });
-
-/**
- * The MFA factors a completed proof in this interaction can be of: enabled in the sign-in
- * experience and enrolled by, or implicit for, the user.
- *
- * {@link getAllUserEnabledMfaVerifications} decides what a new challenge may offer, so it drops a
- * backup code set whose codes are all used. A code consumed in this interaction is still a proof,
- * and the last one is marked used before the submission reloads the user, so the backup code
- * factor stays eligible as long as it is enabled and enrolled.
- */
-const getEligibleMfaFactors = (user: User, mfaSettings: Mfa): Set<MfaFactor> =>
-  new Set([
-    ...getAllUserEnabledMfaVerifications(mfaSettings, user),
-    ...(mfaSettings.factors.includes(MfaFactor.BackupCode) &&
-    user.mfaVerifications.some(({ type }) => type === MfaFactor.BackupCode)
-      ? [MfaFactor.BackupCode]
-      : []),
-  ]);
-
-/**
  * Whether an MFA record is a proof of the user: verified, not a factor enrolled in this
- * interaction, of an eligible factor (see {@link getEligibleMfaFactors}), and bound to the user.
- * TOTP, backup code and WebAuthn records are created for a user and carry that user's id. An MFA
- * email / phone code is sent to the identified user's primary contact, which the MFA
- * verification-code route reads from the user, so the record's identifier must be that contact.
+ * interaction, and bound to the user. TOTP, backup code and WebAuthn records are created for a
+ * user and carry that user's id. An MFA email / phone code is sent to the identified user's
+ * primary contact, which the MFA verification-code route reads from the user, so the record's
+ * identifier must be that contact.
  */
-const isMfaProofOfUser = (
-  record: VerificationRecord,
-  user: User,
-  eligibleMfaFactors: Set<MfaFactor>
-): boolean => {
-  if (!isMfaVerificationRecord(record)) {
-    return false;
-  }
-
-  if (
-    record.isNewBindMfaVerification ||
-    !eligibleMfaFactors.has(mfaVerificationTypeToMfaFactorMap[record.type])
-  ) {
+const isMfaProofOfUser = (record: VerificationRecord, user: User): boolean => {
+  if (!isMfaVerificationRecord(record) || record.isNewBindMfaVerification) {
     return false;
   }
 
@@ -119,10 +55,9 @@ const isMfaProofOfUser = (
  * Whether a record is a proof that the identified user authenticated in this interaction.
  *
  * A verified record is not a proof by itself. An interaction can hold verified records that never
- * authenticated the identified account: a password proposed for a username nobody owns, a code
- * sent to an address the user is adding to their profile, a factor enrolled in this interaction,
- * or an MFA code requested for a factor the user has not enabled. Only a record bound to the
- * identified user counts:
+ * authenticated the identified account: a code sent to an address the user is adding to their
+ * profile, or a factor enrolled in this interaction. Only a record bound to the identified user
+ * counts:
  *
  * - An MFA record (TOTP, backup code, WebAuthn, MFA email / phone code) counts per
  *   {@link isMfaProofOfUser}.
@@ -130,29 +65,27 @@ const isMfaProofOfUser = (
  * - A social or enterprise SSO record contributes only `fed`, never an ACR, so a verified
  *   assertion counts as is. Gating it on the stored identity would drop the very sign-in that
  *   links the identity (the record resolves no account until the submission writes the link).
- * - An identifier record (password, verification code, one-time token) counts when it is one of
- *   the records that identified the user, which the interaction recorded at identification time.
- * - A new-password-identity record only proposes a password for an account that does not exist
- *   yet; it never identifies a user, so it never counts.
+ * - Any other record (password, verification code, one-time token, new-password identity) counts
+ *   when it is one of the records that identified the user, which the interaction recorded at
+ *   identification time.
  */
 const isProofOfUser = (
   record: VerificationRecord,
-  { user, identifiedVerificationIds }: IdentifiedUserContext,
-  eligibleMfaFactors: Set<MfaFactor>
+  { user, identifiedVerificationIds }: IdentifiedUserContext
 ): boolean => {
   if (!record.isVerified) {
     return false;
   }
 
   if (isMfaVerificationRecord(record)) {
-    return isMfaProofOfUser(record, user, eligibleMfaFactors);
+    return isMfaProofOfUser(record, user);
   }
 
   if (record.type === VerificationType.SignInPasskey) {
     return record.userId === user.id;
   }
 
-  if (authenticationFactors[record.type] === AuthenticationFactor.Federated) {
+  if (getAuthenticationFactor(record.type) === AuthenticationFactor.Federated) {
     return true;
   }
 
@@ -172,7 +105,7 @@ const factorsOfClass = (records: VerificationRecord[], factorClass: Authenticati
   new Set(
     records
       .filter(({ type }) => getAuthenticationFactorClass(type) === factorClass)
-      .map(({ type }) => authenticationFactors[type])
+      .map(({ type }) => getAuthenticationFactor(type))
   );
 
 /**
@@ -184,7 +117,7 @@ const factorsOfClass = (records: VerificationRecord[], factorClass: Authenticati
  *   `urn:logto:acr:1fa`; an `mfa`-class proof alone also reaches only `urn:logto:acr:1fa`.
  * - A `1fa`-class proof plus an `mfa`-class proof of a different factor, or a user-verified
  *   WebAuthn assertion alone, reaches `urn:logto:acr:mfa`. Repeated proofs of one factor count
- *   once, so a primary email code plus an MFA email code stays at `urn:logto:acr:1fa`.
+ *   once, so a one-time token plus an MFA email code stays at `urn:logto:acr:1fa`.
  * - Social / enterprise SSO contribute `fed` to `amr` and nothing to the ACR.
  * - `ts` is the earliest `verifiedAt` among counted records, the most conservative value for a
  *   downstream `max_age` check; it is absent when no counted record carries one.
@@ -193,8 +126,7 @@ export const deriveAuthenticationContext = (
   records: VerificationRecord[],
   context: IdentifiedUserContext
 ): AuthenticationContext => {
-  const eligibleMfaFactors = getEligibleMfaFactors(context.user, context.mfaSettings);
-  const counted = records.filter((record) => isProofOfUser(record, context, eligibleMfaFactors));
+  const counted = records.filter((record) => isProofOfUser(record, context));
   const firstFactors = factorsOfClass(counted, AuthenticationFactorClass.FirstFactor);
   const mfaFactors = factorsOfClass(counted, AuthenticationFactorClass.Mfa);
   const hasDistinctMfaFactor = [...mfaFactors].some(

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -1,224 +1,73 @@
 import {
-  AuthenticationFactor,
   AuthenticationFactorClass,
   LogtoAcr,
-  MfaFactor,
-  SignInIdentifier,
-  VerificationType,
   buildAuthenticationMethodReferences,
-  getAuthenticationFactor,
-  getAuthenticationFactorClass,
-  type AdditionalIdentifier,
   type AuthenticationMethodReference,
-  type User,
+  type AuthenticationProof,
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
-import { type VerificationRecord } from '../verifications/index.js';
-
-import { isMfaVerificationRecord } from './mfa-validator.js';
-
 /** The authentication context an interaction achieved, in the shape of the provider's `login` result. */
-type AuthenticationContext = {
+export type AuthenticationContext = {
   acr?: LogtoAcr;
   amr?: AuthenticationMethodReference[];
   /** Epoch seconds of the authentication event; becomes `auth_time`. */
   ts?: number;
 };
 
-/** What the derivation knows about the identified user; see `ExperienceInteraction`. */
-type IdentifiedUserContext = {
-  user: User;
-  /** The ids of the verification records that identified the user. */
-  identifiedVerificationIds: ReadonlySet<string>;
-  /**
-   * Whether this interaction created `user` (a Register interaction). Every credential on such an
-   * account was written by this interaction, so a record for one of the account's identifiers and
-   * a factor enrolled in this interaction are proofs of it; the interaction is its own subject
-   * proof. Defaults to `false`.
-   */
-  isNewAccount?: boolean;
-  /**
-   * The MFA factors this submission writes to the user (`Mfa.bindMfaFactorsArray`). A factor
-   * enrolled in this interaction counts only when it is one of them; a verified enrollment that
-   * was never bound is not a factor of the account. Defaults to none.
-   */
-  bindMfaFactors?: ReadonlySet<MfaFactor>;
-};
-
-/** Whether the identifier is one of the user's stored sign-in identifiers. */
-const isIdentifierOfUser = (
-  user: User,
-  { type, value }: { type: SignInIdentifier | AdditionalIdentifier; value: string }
-): boolean => {
-  switch (type) {
-    case SignInIdentifier.Username: {
-      return user.username === value;
-    }
-    case SignInIdentifier.Email: {
-      return user.primaryEmail === value;
-    }
-    case SignInIdentifier.Phone: {
-      return user.primaryPhone === value;
-    }
-    default: {
-      return false;
-    }
-  }
-};
-
-/** The factor a new-enrollment MFA record enrolls; only TOTP and WebAuthn records enroll one. */
-const enrolledFactor = ({ type }: VerificationRecord): MfaFactor | undefined => {
-  switch (type) {
-    case VerificationType.TOTP: {
-      return MfaFactor.TOTP;
-    }
-    case VerificationType.WebAuthn: {
-      return MfaFactor.WebAuthn;
-    }
-    default: {
-      return undefined;
-    }
-  }
-};
-
-/**
- * Whether an MFA record is a proof of the user: verified and bound to the user. TOTP, backup code
- * and WebAuthn records are created for a user and carry that user's id. An MFA email / phone code
- * is sent to the identified user's primary contact, which the MFA verification-code route reads
- * from the user, so the record's identifier must be that contact.
- *
- * A factor enrolled in this interaction counts only for a new account, and only when the
- * submission binds it (`bindMfaFactors`). Counting an enrollment for an existing account belongs
- * to the step-up establishment rules and is not part of this derivation yet.
- */
-const isMfaProofOfUser = (
-  record: VerificationRecord,
-  { user, isNewAccount = false, bindMfaFactors }: IdentifiedUserContext
-): boolean => {
-  if (!isMfaVerificationRecord(record)) {
-    return false;
-  }
-
-  if (record.isNewBindMfaVerification) {
-    const factor = enrolledFactor(record);
-    if (!isNewAccount || !factor || !bindMfaFactors?.has(factor)) {
-      return false;
-    }
-  }
-
-  if ('userId' in record) {
-    return record.userId === user.id;
-  }
-
-  const { type, value } = record.identifier;
-  return value === (type === SignInIdentifier.Email ? user.primaryEmail : user.primaryPhone);
-};
-
-/**
- * Whether a record is a proof that the identified user authenticated in this interaction.
- *
- * A verified record is not a proof by itself. An interaction can hold verified records that never
- * authenticated the identified account: a code sent to an address the user is adding to their
- * profile, or a factor enrolled in this interaction. Only a record bound to the identified user
- * counts:
- *
- * - An MFA record (TOTP, backup code, WebAuthn, MFA email / phone code) counts per
- *   {@link isMfaProofOfUser}.
- * - A sign-in passkey record resolves its `userId` from the asserted credential.
- * - A social or enterprise SSO record contributes only `fed`, never an ACR, so a verified
- *   assertion counts as is. Gating it on the stored identity would drop the very sign-in that
- *   links the identity (the record resolves no account until the submission writes the link).
- * - Any other record (password, verification code, one-time token, new-password identity) counts
- *   when it is one of the records that identified the user, which the interaction recorded at
- *   identification time. For a new account, which never identifies a user, it counts instead when
- *   its identifier is one of the account's identifiers: the interaction wrote that identifier,
- *   with the password of a new-password identity, to the account it created.
- */
-const isProofOfUser = (record: VerificationRecord, context: IdentifiedUserContext): boolean => {
-  const { user, identifiedVerificationIds, isNewAccount = false } = context;
-
-  if (!record.isVerified) {
-    return false;
-  }
-
-  if (isMfaVerificationRecord(record)) {
-    return isMfaProofOfUser(record, context);
-  }
-
-  if (record.type === VerificationType.SignInPasskey) {
-    return record.userId === user.id;
-  }
-
-  if (getAuthenticationFactor(record.type) === AuthenticationFactor.Federated) {
-    return true;
-  }
-
-  if (identifiedVerificationIds.has(record.id)) {
-    return true;
-  }
-
-  return isNewAccount && 'identifier' in record && isIdentifierOfUser(user, record.identifier);
-};
-
-/**
- * Whether the record is a WebAuthn assertion. Logto always requires user verification for WebAuthn
- * (`requireUserVerification: true` in the verification helpers), so a verified record is a
- * user-verified passkey and reaches `urn:logto:acr:mfa` on its own.
- */
-const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
-  type === VerificationType.WebAuthn || type === VerificationType.SignInPasskey;
-
-/** The factors with a counted record of the given class. */
-const factorsOfClass = (records: VerificationRecord[], factorClass: AuthenticationFactorClass) =>
+/** The distinct factors of the proofs whose class fills the given role. */
+const factorsOfRole = (
+  proofs: readonly AuthenticationProof[],
+  role: AuthenticationFactorClass.FirstFactor | AuthenticationFactorClass.Mfa
+) =>
   new Set(
-    records
-      .filter(({ type }) => getAuthenticationFactorClass(type) === factorClass)
-      .map(({ type }) => getAuthenticationFactor(type))
+    proofs
+      .filter(({ class: factorClass }) =>
+        factorClass ? [role, AuthenticationFactorClass.Both].includes(factorClass) : false
+      )
+      .map(({ factor }) => factor)
   );
 
 /**
- * Derive the authentication context the identified user achieved through the verification records
- * of one interaction. Only records that are proofs of that user count; see {@link isProofOfUser}.
- * The derivation reads only what the interaction already holds and never queries the database.
- * It runs for a SignIn and for a Register alike: a registration establishes every credential of
- * the account it creates, and the interaction is its own subject proof.
+ * Aggregate the authentication context an interaction achieved from the proofs it recorded. The
+ * aggregation reads nothing but the proof list: which credentials count was decided at the
+ * touchpoints that recorded them (see `AuthenticationProofs`), and the role of a proof plays no
+ * part here.
  *
- * - A `1fa`-class proof (password, primary email / phone code, one-time token) reaches
- *   `urn:logto:acr:1fa`; an `mfa`-class proof alone also reaches only `urn:logto:acr:1fa`.
- * - A `1fa`-class proof plus an `mfa`-class proof of a different factor, or a user-verified
- *   WebAuthn assertion alone, reaches `urn:logto:acr:mfa`. Repeated proofs of one factor count
- *   once, so a one-time token plus an MFA email code stays at `urn:logto:acr:1fa`.
- * - Social / enterprise SSO contribute `fed` to `amr` and nothing to the ACR.
- * - `ts` is the earliest `verifiedAt` among counted records, the most conservative value for a
- *   downstream `max_age` check; it is absent when no counted record carries one.
+ * - A `1fa`-class proof reaches `urn:logto:acr:1fa`; an `mfa`-class proof alone also reaches only
+ *   `urn:logto:acr:1fa`.
+ * - A `1fa`-class proof plus an `mfa`-class proof of a different factor, or a `both`-class proof
+ *   (a user-verified WebAuthn authenticator) alone, reaches `urn:logto:acr:mfa`. Repeated proofs
+ *   of one factor count once, so a one-time token plus an MFA email code stays at
+ *   `urn:logto:acr:1fa`.
+ * - Federated proofs carry no class: they contribute `fed` to `amr` and nothing to the ACR.
+ * - `amr` is the union of the proofs' references in first-seen order with `mfa` last; `ts` is the
+ *   earliest proof, the most conservative value for a downstream `max_age` check.
  */
-export const deriveAuthenticationContext = (
-  records: VerificationRecord[],
-  context: IdentifiedUserContext
+export const aggregateAuthenticationContext = (
+  proofs: readonly AuthenticationProof[]
 ): AuthenticationContext => {
-  const counted = records.filter((record) => isProofOfUser(record, context));
-  const firstFactors = factorsOfClass(counted, AuthenticationFactorClass.FirstFactor);
-  const mfaFactors = factorsOfClass(counted, AuthenticationFactorClass.Mfa);
-  const hasDistinctMfaFactor = [...mfaFactors].some(
-    (factor) => firstFactors.size > (firstFactors.has(factor) ? 1 : 0)
+  const firstFactors = factorsOfRole(proofs, AuthenticationFactorClass.FirstFactor);
+  const mfaFactors = factorsOfRole(proofs, AuthenticationFactorClass.Mfa);
+  const hasDistinctPair = [...mfaFactors].some((factor) =>
+    [...firstFactors].some((firstFactor) => firstFactor !== factor)
+  );
+  const hasSelfSufficient = proofs.some(
+    ({ class: factorClass }) => factorClass === AuthenticationFactorClass.Both
   );
 
   const acr =
-    hasDistinctMfaFactor || counted.some((record) => isUserVerifiedWebAuthn(record))
+    hasDistinctPair || hasSelfSufficient
       ? LogtoAcr.Mfa
       : conditional((firstFactors.size > 0 || mfaFactors.size > 0) && LogtoAcr.FirstFactor);
   const amr = buildAuthenticationMethodReferences(
-    counted.map(({ type }) => type),
+    proofs.map(({ amr }) => amr),
     acr
   );
-  const timestamps = counted
-    .map(({ verifiedAt }) => verifiedAt)
-    .filter((verifiedAt): verifiedAt is number => typeof verifiedAt === 'number');
 
   return {
     ...conditional(acr && { acr }),
     ...conditional(amr.length > 0 && { amr }),
-    ...conditional(timestamps.length > 0 && { ts: Math.min(...timestamps) }),
+    ...conditional(proofs.length > 0 && { ts: Math.min(...proofs.map(({ at }) => at)) }),
   };
 };

--- a/packages/core/src/routes/experience/classes/libraries/authentication-proofs.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-proofs.test.ts
@@ -1,0 +1,179 @@
+import { TemplateType } from '@logto/connector-kit';
+import {
+  AuthenticationFactor,
+  AuthenticationFactorClass,
+  AuthenticationProofRole,
+  SignInIdentifier,
+  VerificationType,
+} from '@logto/schemas';
+
+import { mockUser } from '#src/__mocks__/user.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+import { BackupCodeVerification } from '../verifications/backup-code-verification.js';
+import { MfaEmailCodeVerification } from '../verifications/code-verification.js';
+import { PasswordVerification } from '../verifications/password-verification.js';
+import { SocialVerification } from '../verifications/social-verification.js';
+import { TotpVerification } from '../verifications/totp-verification.js';
+import { WebAuthnVerification } from '../verifications/web-authn-verification.js';
+
+import { AuthenticationProofs } from './authentication-proofs.js';
+
+const { libraries, queries } = new MockTenant();
+const { Create, Identify, Bind, Mfa } = AuthenticationProofRole;
+
+const password = new PasswordVerification(libraries, queries, {
+  id: 'password',
+  type: VerificationType.Password,
+  identifier: { type: SignInIdentifier.Username, value: 'foo' },
+  verified: true,
+  verifiedAt: 100,
+});
+
+const totp = new TotpVerification(libraries, queries, {
+  id: 'totp',
+  type: VerificationType.TOTP,
+  userId: mockUser.id,
+  verified: true,
+  verifiedAt: 200,
+});
+
+const backupCode = new BackupCodeVerification(libraries, queries, {
+  id: 'backup-code',
+  type: VerificationType.BackupCode,
+  userId: mockUser.id,
+  code: 'code',
+  verifiedAt: 300,
+});
+
+const webAuthn = new WebAuthnVerification(libraries, queries, {
+  id: 'web-authn',
+  type: VerificationType.WebAuthn,
+  userId: mockUser.id,
+  verified: true,
+  verifiedAt: 400,
+});
+
+const social = new SocialVerification(libraries, queries, {
+  id: 'social',
+  type: VerificationType.Social,
+  connectorId: 'connector',
+  socialUserInfo: { id: 'social-user' },
+  verifiedAt: 500,
+});
+
+/** A pre-verified MFA code record as the MFA bind site creates it; it carries no `verifiedAt`. */
+const syntheticMfaEmailCode = new MfaEmailCodeVerification(libraries, queries, {
+  id: 'mfa-email',
+  type: VerificationType.MfaEmailVerificationCode,
+  identifier: { type: SignInIdentifier.Email, value: 'foo@bar.com' },
+  templateType: TemplateType.MfaVerification,
+  verified: true,
+});
+
+describe('AuthenticationProofs', () => {
+  it('records the factor, class, AMR values and verification time of a record', () => {
+    const proofs = new AuthenticationProofs();
+
+    proofs.stage(password, Identify);
+    proofs.stage(totp, Mfa);
+    proofs.stage(webAuthn, Bind);
+    proofs.stage(social, Create);
+
+    expect(proofs.proofs).toEqual([
+      {
+        id: 'password',
+        factor: AuthenticationFactor.Password,
+        class: AuthenticationFactorClass.FirstFactor,
+        amr: ['pwd'],
+        role: Identify,
+        at: 100,
+      },
+      {
+        id: 'totp',
+        factor: AuthenticationFactor.Totp,
+        class: AuthenticationFactorClass.Mfa,
+        amr: ['otp'],
+        role: Mfa,
+        at: 200,
+      },
+      {
+        id: 'web-authn',
+        factor: AuthenticationFactor.WebAuthn,
+        class: AuthenticationFactorClass.Both,
+        amr: ['pop', 'user', 'mfa'],
+        role: Bind,
+        at: 400,
+      },
+      {
+        id: 'social',
+        factor: AuthenticationFactor.Federated,
+        class: undefined,
+        amr: ['fed'],
+        role: Create,
+        at: 500,
+      },
+    ]);
+  });
+
+  it('falls back to the current time for a record without a verification time', () => {
+    const proofs = new AuthenticationProofs();
+    const before = Math.floor(Date.now() / 1000);
+
+    proofs.stage(syntheticMfaEmailCode, Bind);
+
+    const [proof] = proofs.proofs;
+    expect(proof?.at).toBeGreaterThanOrEqual(before);
+    expect(proof?.at).toBeLessThanOrEqual(Math.floor(Date.now() / 1000));
+  });
+
+  it('keys proofs by record and role, so a retry overwrites and a second role is kept', () => {
+    const proofs = new AuthenticationProofs();
+
+    proofs.stage(password, Identify);
+    proofs.stage(password, Identify);
+    expect(proofs.proofs).toHaveLength(1);
+
+    proofs.stage(password, Bind);
+    expect(proofs.proofs.map(({ role }) => role)).toEqual([Identify, Bind]);
+  });
+
+  it('records a backup code challenge but not a backup code bind', () => {
+    const proofs = new AuthenticationProofs();
+
+    proofs.stage(backupCode, Bind);
+    expect(proofs.proofs).toEqual([]);
+
+    proofs.stage(backupCode, Mfa);
+    expect(proofs.proofs).toMatchObject([{ id: 'backup-code', role: Mfa }]);
+  });
+
+  it('records a password established through the profile', () => {
+    const proofs = new AuthenticationProofs();
+
+    proofs.stageEstablishedPassword();
+
+    expect(proofs.proofs).toMatchObject([
+      {
+        id: 'password',
+        factor: AuthenticationFactor.Password,
+        class: AuthenticationFactorClass.FirstFactor,
+        amr: ['pwd'],
+        role: Bind,
+      },
+    ]);
+  });
+
+  it('round-trips through its data and can be cleared', () => {
+    const proofs = new AuthenticationProofs();
+    proofs.stage(password, Identify);
+    proofs.stage(totp, Mfa);
+
+    const restored = new AuthenticationProofs(proofs.data);
+    expect(restored.proofs).toEqual(proofs.proofs);
+
+    restored.clear();
+    expect(restored.proofs).toEqual([]);
+    expect(restored.data).toEqual([]);
+  });
+});

--- a/packages/core/src/routes/experience/classes/libraries/authentication-proofs.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-proofs.ts
@@ -16,6 +16,8 @@ import { getEpochTime } from '../verifications/verification-record.js';
 /** The id of the proof for a password established through the profile, which has no record. */
 const establishedPasswordProofId = 'password';
 
+const keyOf = ({ id, role }: Pick<AuthenticationProof, 'id' | 'role'>) => `${id}:${role}`;
+
 /**
  * The authentication proofs of one interaction: what the user proved about the account, recorded
  * at the single touchpoint that consumed each credential (`createUser()`, `identifyUser()`, a
@@ -34,12 +36,8 @@ export class AuthenticationProofs {
 
   constructor(data: AuthenticationProof[] = []) {
     for (const proof of data) {
-      this.#proofs.set(AuthenticationProofs.key(proof), proof);
+      this.#proofs.set(keyOf(proof), proof);
     }
-  }
-
-  private static key({ id, role }: Pick<AuthenticationProof, 'id' | 'role'>) {
-    return `${id}:${role}`;
   }
 
   get proofs(): readonly AuthenticationProof[] {
@@ -95,6 +93,6 @@ export class AuthenticationProofs {
   }
 
   private set(proof: AuthenticationProof) {
-    this.#proofs.set(AuthenticationProofs.key(proof), proof);
+    this.#proofs.set(keyOf(proof), proof);
   }
 }

--- a/packages/core/src/routes/experience/classes/libraries/authentication-proofs.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-proofs.ts
@@ -1,0 +1,100 @@
+import {
+  AuthenticationFactor,
+  AuthenticationFactorClass,
+  AuthenticationMethodReference,
+  AuthenticationProofRole,
+  VerificationType,
+  getAuthenticationFactor,
+  getAuthenticationFactorClass,
+  getAuthenticationMethodReferences,
+  type AuthenticationProof,
+} from '@logto/schemas';
+
+import { type VerificationRecord } from '../verifications/index.js';
+import { getEpochTime } from '../verifications/verification-record.js';
+
+/** The id of the proof for a password established through the profile, which has no record. */
+const establishedPasswordProofId = 'password';
+
+/**
+ * The authentication proofs of one interaction: what the user proved about the account, recorded
+ * at the single touchpoint that consumed each credential (`createUser()`, `identifyUser()`, a
+ * profile or MFA bind, an MFA challenge, or the profile's password transition).
+ *
+ * The collection is staged in memory and persisted by `ExperienceInteraction.save()` together with
+ * the effect that produced each proof: an operation that throws never reaches `save()`, so it
+ * leaves no proof behind. It has the lifetime of `profile.data` and is cleared in the same places.
+ *
+ * Entries are keyed by record id and role, so a retry overwrites rather than duplicates. Every
+ * entry is kept: `auth_time` wants the earliest proof and step-up freshness will want the latest
+ * proof of a factor, so nothing is collapsed on write.
+ */
+export class AuthenticationProofs {
+  readonly #proofs = new Map<string, AuthenticationProof>();
+
+  constructor(data: AuthenticationProof[] = []) {
+    for (const proof of data) {
+      this.#proofs.set(AuthenticationProofs.key(proof), proof);
+    }
+  }
+
+  private static key({ id, role }: Pick<AuthenticationProof, 'id' | 'role'>) {
+    return `${id}:${role}`;
+  }
+
+  get proofs(): readonly AuthenticationProof[] {
+    return [...this.#proofs.values()];
+  }
+
+  get data(): AuthenticationProof[] {
+    return this.proofs.map((proof) => ({ ...proof }));
+  }
+
+  /**
+   * Stage the proof a verification record contributes in the given role. The factor, class and AMR
+   * values come from the record type; `at` is the record's verification time.
+   *
+   * Declared non-proofs, written here so that their absence reads as a decision:
+   *
+   * - Binding backup codes (`BackupCode` in the `bind` role) generates recovery codes and proves
+   *   nothing; only a backup code challenge is a proof.
+   */
+  stage(record: VerificationRecord, role: AuthenticationProofRole) {
+    if (record.type === VerificationType.BackupCode && role === AuthenticationProofRole.Bind) {
+      return;
+    }
+
+    this.set({
+      id: record.id,
+      factor: getAuthenticationFactor(record.type),
+      class: getAuthenticationFactorClass(record.type),
+      amr: [...getAuthenticationMethodReferences(record.type)],
+      role,
+      at: record.verifiedAt ?? getEpochTime(),
+    });
+  }
+
+  /**
+   * Stage the proof for a password established through the profile: setting a password is the
+   * establishment itself, and there is no verification record to consume.
+   */
+  stageEstablishedPassword() {
+    this.set({
+      id: establishedPasswordProofId,
+      factor: AuthenticationFactor.Password,
+      class: AuthenticationFactorClass.FirstFactor,
+      amr: [AuthenticationMethodReference.Password],
+      role: AuthenticationProofRole.Bind,
+      at: getEpochTime(),
+    });
+  }
+
+  /** Drop every proof; called wherever `profile.data` is cleared. */
+  clear() {
+    this.#proofs.clear();
+  }
+
+  private set(proof: AuthenticationProof) {
+    this.#proofs.set(AuthenticationProofs.key(proof), proof);
+  }
+}

--- a/packages/core/src/routes/experience/classes/libraries/authentication-proofs.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-proofs.ts
@@ -45,7 +45,7 @@ export class AuthenticationProofs {
   }
 
   get data(): AuthenticationProof[] {
-    return this.proofs.map((proof) => ({ ...proof }));
+    return this.proofs.map((proof) => ({ ...proof, amr: [...proof.amr] }));
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
@@ -38,7 +38,7 @@ type MfaVerificationType =
   | VerificationType.MfaEmailVerificationCode
   | VerificationType.MfaPhoneVerificationCode;
 
-const mfaVerificationTypeToMfaFactorMap = Object.freeze({
+export const mfaVerificationTypeToMfaFactorMap = Object.freeze({
   [VerificationType.TOTP]: MfaFactor.TOTP,
   [VerificationType.BackupCode]: MfaFactor.BackupCode,
   [VerificationType.WebAuthn]: MfaFactor.WebAuthn,
@@ -149,11 +149,7 @@ export class MfaValidator {
     );
   }
 
-  /**
-   * The verified MFA records that count for the user: verified, not a factor enrolled in this
-   * interaction, and of a factor enabled for the user under the sign-in experience settings.
-   */
-  getVerifiedMfaVerificationRecords(
+  private getVerifiedMfaVerificationRecords(
     verificationRecords: VerificationRecord[],
     currentProfile?: InteractionProfile
   ) {

--- a/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
@@ -38,7 +38,7 @@ type MfaVerificationType =
   | VerificationType.MfaEmailVerificationCode
   | VerificationType.MfaPhoneVerificationCode;
 
-export const mfaVerificationTypeToMfaFactorMap = Object.freeze({
+const mfaVerificationTypeToMfaFactorMap = Object.freeze({
   [VerificationType.TOTP]: MfaFactor.TOTP,
   [VerificationType.BackupCode]: MfaFactor.BackupCode,
   [VerificationType.WebAuthn]: MfaFactor.WebAuthn,

--- a/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
@@ -53,7 +53,7 @@ type MfaVerificationRecord =
   | MfaEmailCodeVerification
   | MfaPhoneCodeVerification;
 
-const isMfaVerificationRecord = (
+export const isMfaVerificationRecord = (
   verification: VerificationRecord
 ): verification is MfaVerificationRecord => {
   return mfaVerificationTypes.includes(verification.type);
@@ -149,7 +149,11 @@ export class MfaValidator {
     );
   }
 
-  private getVerifiedMfaVerificationRecords(
+  /**
+   * The verified MFA records that count for the user: verified, not a factor enrolled in this
+   * interaction, and of a factor enabled for the user under the sign-in experience settings.
+   */
+  getVerifiedMfaVerificationRecords(
     verificationRecords: VerificationRecord[],
     currentProfile?: InteractionProfile
   ) {

--- a/packages/core/src/routes/experience/classes/mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/mfa.test.ts
@@ -45,10 +45,13 @@ const createMfa = ({
   const interactionContext: InteractionContext = {
     getInteractionEvent: () => interactionEvent,
     getIdentifiedUser,
-    getVerificationRecordById: () => {
+    consumeForBind: () => {
       throw new Error('should not be called');
     },
-    getVerificationRecordByTypeAndId: () => {
+    consumeForBindByType: () => {
+      throw new Error('should not be called');
+    },
+    recordEstablishedPassword: () => {
       throw new Error('should not be called');
     },
     getCurrentProfile: () => currentProfile,

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -255,7 +255,7 @@ export class Mfa {
    * - Any existing TOTP factor will be replaced with the new one.
    */
   async addTotpByVerificationId(verificationId: string, log?: LogEntry) {
-    const verificationRecord = this.interactionContext.getVerificationRecordByTypeAndId(
+    const verificationRecord = this.interactionContext.consumeForBindByType(
       VerificationType.TOTP,
       verificationId
     );
@@ -288,7 +288,7 @@ export class Mfa {
    * @throws {RequestError} with status 400 if WebAuthn is not enabled in the sign-in experience
    */
   async addWebAuthnByVerificationId(verificationId: string, log?: LogEntry) {
-    const verificationRecord = this.interactionContext.getVerificationRecordByTypeAndId(
+    const verificationRecord = this.interactionContext.consumeForBindByType(
       VerificationType.WebAuthn,
       verificationId
     );
@@ -313,7 +313,7 @@ export class Mfa {
    * @throws {RequestError} with status 422 if the backup code is the only MFA factor
    */
   async addBackupCodeByVerificationId(verificationId: string, log?: LogEntry) {
-    const verificationRecord = this.interactionContext.getVerificationRecordByTypeAndId(
+    const verificationRecord = this.interactionContext.consumeForBindByType(
       VerificationType.BackupCode,
       verificationId
     );

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -320,7 +320,7 @@ export class Profile {
   /**
    * The single write path into `#data`. Setting a password is the establishment of that credential
    * and has no verification record, so the authentication proof is recorded on the transition of
-   * `passwordEncrypted` from unset to set; every path in funnels through here, including any added
+   * `passwordEncrypted` from unset to set; every path funnels through here, including any added
    * later.
    */
   private write(data: InteractionProfile) {

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -88,7 +88,7 @@ export class Profile {
     verificationId: string,
     log?: LogEntry
   ) {
-    const verificationRecord = this.interactionContext.getVerificationRecordById(verificationId);
+    const verificationRecord = this.interactionContext.consumeForBind(verificationId);
 
     // Assert the verification record type matches the identifier type
     switch (type) {
@@ -274,10 +274,10 @@ export class Profile {
    * - skip profile existence check in the current user account.
    */
   unsafeSet(profile: InteractionProfile) {
-    this.#data = {
+    this.write({
       ...this.#data,
       ...profile,
-    };
+    });
   }
 
   /**
@@ -285,10 +285,26 @@ export class Profile {
    * Avoid overwriting the existing profile data.
    */
   unsafePrepend(profile: InteractionProfile) {
-    this.#data = {
+    this.write({
       ...profile,
       ...this.#data,
-    };
+    });
+  }
+
+  /**
+   * The single write path into `#data`. Setting a password is the establishment of that credential
+   * and has no verification record, so the authentication proof is recorded on the transition of
+   * `passwordEncrypted` from unset to set; every path in funnels through here, including any added
+   * later.
+   */
+  private write(data: InteractionProfile) {
+    const isPasswordEstablished = !this.#data.passwordEncrypted && Boolean(data.passwordEncrypted);
+
+    this.#data = data;
+
+    if (isPasswordEstablished) {
+      this.interactionContext.recordEstablishedPassword();
+    }
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -292,22 +292,6 @@ export class Profile {
   }
 
   /**
-   * The single write path into `#data`. Setting a password is the establishment of that credential
-   * and has no verification record, so the authentication proof is recorded on the transition of
-   * `passwordEncrypted` from unset to set; every path in funnels through here, including any added
-   * later.
-   */
-  private write(data: InteractionProfile) {
-    const isPasswordEstablished = !this.#data.passwordEncrypted && Boolean(data.passwordEncrypted);
-
-    this.#data = data;
-
-    if (isPasswordEstablished) {
-      this.interactionContext.recordEstablishedPassword();
-    }
-  }
-
-  /**
    * Clean up the user related profile data from interaction storage after successfully creating the user,
    * keeping only the `submitted` flag to indicate whether the user has submitted the profile form.
    */
@@ -331,5 +315,21 @@ export class Profile {
     }
 
     return getIdentifiedUser();
+  }
+
+  /**
+   * The single write path into `#data`. Setting a password is the establishment of that credential
+   * and has no verification record, so the authentication proof is recorded on the transition of
+   * `passwordEncrypted` from unset to set; every path in funnels through here, including any added
+   * later.
+   */
+  private write(data: InteractionProfile) {
+    const isPasswordEstablished = !this.#data.passwordEncrypted && Boolean(data.passwordEncrypted);
+
+    this.#data = data;
+
+    if (isPasswordEstablished) {
+      this.interactionContext.recordEstablishedPassword();
+    }
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/backup-code-verification.ts
@@ -13,7 +13,7 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { type MfaVerificationRecord } from './verification-record.js';
+import { type MfaVerificationRecord, getEpochTime } from './verification-record.js';
 
 export {
   type BackupCodeVerificationRecordData,
@@ -40,6 +40,8 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
   public readonly id: string;
   public readonly type = VerificationType.BackupCode;
   public readonly userId: string;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
   private code?: string;
   private backupCodes?: string[];
 
@@ -48,12 +50,13 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
     private readonly queries: Queries,
     data: BackupCodeVerificationRecordData
   ) {
-    const { id, userId, code, backupCodes } = data;
+    const { id, userId, code, backupCodes, verifiedAt } = data;
 
     this.id = id;
     this.userId = userId;
     this.code = code;
     this.backupCodes = backupCodes;
+    this.verifiedAt = verifiedAt;
   }
 
   get isVerified() {
@@ -117,6 +120,7 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
     });
 
     this.code = code;
+    this.verifiedAt = getEpochTime();
   }
 
   toBindMfa(): BindBackupCode {
@@ -129,7 +133,7 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
   }
 
   toJson(): BackupCodeVerificationRecordData {
-    const { id, type, userId, code, backupCodes } = this;
+    const { id, type, userId, code, backupCodes, verifiedAt } = this;
 
     return {
       id,
@@ -137,12 +141,13 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
       userId,
       code,
       backupCodes,
+      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedBackupCodeVerificationRecordData {
-    const { id, type, userId, code } = this;
+    const { id, type, userId, code, verifiedAt } = this;
 
-    return { id, type, userId, code };
+    return { id, type, userId, code, verifiedAt };
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -23,7 +23,7 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { findUserByIdentifier } from '../utils.js';
 
-import { type IdentifierVerificationRecord } from './verification-record.js';
+import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
 
 export {
   type CodeVerificationRecordData,
@@ -69,6 +69,8 @@ abstract class CodeVerification<T extends CodeVerificationType>
    * The template type for sending the verification code, the connector will use this to get the correct template.
    */
   public readonly templateType: TemplateType;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
   public abstract readonly type: T;
   protected verified: boolean;
 
@@ -77,12 +79,13 @@ abstract class CodeVerification<T extends CodeVerificationType>
     private readonly queries: Queries,
     data: CodeVerificationRecordData<T>
   ) {
-    const { id, identifier, verified, templateType } = data;
+    const { id, identifier, verified, verifiedAt, templateType } = data;
 
     this.id = id;
     this.identifier = identifier;
     this.templateType = templateType;
     this.verified = verified;
+    this.verifiedAt = verifiedAt;
   }
 
   /** Returns true if the identifier has been verified by a given code */
@@ -142,6 +145,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
     );
 
     this.verified = true;
+    this.verifiedAt = getEpochTime();
   }
 
   async identifyUser(): Promise<User> {
@@ -166,7 +170,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
   }
 
   toJson(): CodeVerificationRecordData<T> {
-    const { id, type, identifier, templateType, verified } = this;
+    const { id, type, identifier, templateType, verified, verifiedAt } = this;
 
     return {
       id,
@@ -174,6 +178,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
       identifier,
       templateType,
       verified,
+      verifiedAt,
     };
   }
 

--- a/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
@@ -29,7 +29,7 @@ import { safeParseUnknownJson } from '#src/utils/json.js';
 
 import type { InteractionProfile } from '../../types.js';
 
-import { type IdentifierVerificationRecord } from './verification-record.js';
+import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
 
 export {
   type EnterpriseSsoVerificationRecordData,
@@ -60,6 +60,8 @@ export class EnterpriseSsoVerification
   public enterpriseSsoUserInfo?: ExtendedSocialUserInfo;
   public encryptedTokenSet?: EncryptedTokenSet;
   public issuer?: string;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 
   private connectorDataCache?: SupportedSsoConnector;
 
@@ -68,7 +70,7 @@ export class EnterpriseSsoVerification
     private readonly queries: Queries,
     data: EnterpriseSsoVerificationRecordData
   ) {
-    const { id, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer } =
+    const { id, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer, verifiedAt } =
       enterpriseSsoVerificationRecordDataGuard.parse(data);
 
     this.id = id;
@@ -76,6 +78,7 @@ export class EnterpriseSsoVerification
     this.enterpriseSsoUserInfo = enterpriseSsoUserInfo;
     this.issuer = issuer;
     this.encryptedTokenSet = encryptedTokenSet;
+    this.verifiedAt = verifiedAt;
   }
 
   /** Returns true if the enterprise SSO identity has been verified */
@@ -132,6 +135,7 @@ export class EnterpriseSsoVerification
     this.issuer = issuer;
     this.enterpriseSsoUserInfo = userInfo;
     this.encryptedTokenSet = encryptedTokenSet;
+    this.verifiedAt = getEpochTime();
   }
 
   /**
@@ -236,7 +240,8 @@ export class EnterpriseSsoVerification
   }
 
   toJson(): EnterpriseSsoVerificationRecordData {
-    const { id, type, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer } = this;
+    const { id, type, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer, verifiedAt } =
+      this;
 
     return {
       id,
@@ -245,13 +250,14 @@ export class EnterpriseSsoVerification
       enterpriseSsoUserInfo,
       encryptedTokenSet,
       issuer,
+      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedEnterpriseSsoVerificationRecordData {
-    const { id, type, connectorId, enterpriseSsoUserInfo, issuer } = this;
+    const { id, type, connectorId, enterpriseSsoUserInfo, issuer, verifiedAt } = this;
 
-    return { id, type, connectorId, enterpriseSsoUserInfo, issuer };
+    return { id, type, connectorId, enterpriseSsoUserInfo, issuer, verifiedAt };
   }
 
   private async findUserSsoIdentityByEnterpriseSsoUserInfo(): Promise<

--- a/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
@@ -17,7 +17,7 @@ import { ProfileValidator } from '../libraries/profile-validator.js';
 import { SignInExperienceValidator } from '../libraries/sign-in-experience-validator.js';
 import { interactionIdentifierToUserProfile } from '../utils.js';
 
-import { type VerificationRecord } from './verification-record.js';
+import { type VerificationRecord, getEpochTime } from './verification-record.js';
 
 export {
   type NewPasswordIdentityVerificationRecordData,
@@ -49,6 +49,8 @@ export class NewPasswordIdentityVerification
   readonly id: string;
   readonly identifier: InteractionIdentifier;
 
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
   private passwordEncrypted?: string;
   private passwordEncryptionMethod?: UsersPasswordEncryptionMethod.Argon2i;
 
@@ -60,12 +62,13 @@ export class NewPasswordIdentityVerification
     private readonly queries: Queries,
     data: NewPasswordIdentityVerificationRecordData
   ) {
-    const { id, identifier, passwordEncrypted, passwordEncryptionMethod } = data;
+    const { id, identifier, passwordEncrypted, passwordEncryptionMethod, verifiedAt } = data;
 
     this.id = id;
     this.identifier = identifier;
     this.passwordEncrypted = passwordEncrypted;
     this.passwordEncryptionMethod = passwordEncryptionMethod;
+    this.verifiedAt = verifiedAt;
     this.signInExperienceValidator = new SignInExperienceValidator(libraries, queries);
     this.profileValidator = new ProfileValidator(queries, this.signInExperienceValidator);
   }
@@ -97,6 +100,7 @@ export class NewPasswordIdentityVerification
 
     this.passwordEncrypted = passwordEncrypted;
     this.passwordEncryptionMethod = passwordEncryptionMethod;
+    this.verifiedAt = getEpochTime();
   }
 
   toUserProfile() {
@@ -117,7 +121,7 @@ export class NewPasswordIdentityVerification
   }
 
   toJson(): NewPasswordIdentityVerificationRecordData {
-    const { id, type, identifier, passwordEncrypted, passwordEncryptionMethod } = this;
+    const { id, type, identifier, passwordEncrypted, passwordEncryptionMethod, verifiedAt } = this;
 
     return {
       id,
@@ -125,11 +129,12 @@ export class NewPasswordIdentityVerification
       identifier,
       passwordEncrypted,
       passwordEncryptionMethod,
+      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedNewPasswordIdentityVerificationRecordData {
-    const { id, type, identifier } = this;
-    return { id, type, identifier };
+    const { id, type, identifier, verifiedAt } = this;
+    return { id, type, identifier, verifiedAt };
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -17,7 +17,7 @@ import assertThat from '#src/utils/assert-that.js';
 import { type InteractionProfile } from '../../types.js';
 import { findUserByIdentifier } from '../utils.js';
 
-import { type IdentifierVerificationRecord } from './verification-record.js';
+import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
 
 export {
   type OneTimeTokenVerificationRecordData,
@@ -44,6 +44,8 @@ export class OneTimeTokenVerification
   readonly type = VerificationType.OneTimeToken;
   readonly id: string;
   readonly identifier: InteractionIdentifier<SignInIdentifier.Email>;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
   private context?: OneTimeTokenContext;
   private verified: boolean;
 
@@ -58,11 +60,12 @@ export class OneTimeTokenVerification
     private readonly queries: Queries,
     data: OneTimeTokenVerificationRecordData
   ) {
-    const { id, identifier, verified, oneTimeTokenContext } = data;
+    const { id, identifier, verified, verifiedAt, oneTimeTokenContext } = data;
 
     this.id = id;
     this.identifier = identifier;
     this.verified = verified;
+    this.verifiedAt = verifiedAt;
     this.context = oneTimeTokenContext;
   }
 
@@ -85,6 +88,7 @@ export class OneTimeTokenVerification
       interactionEvent
     );
     this.verified = true;
+    this.verifiedAt = getEpochTime();
     this.context = tokenRecord.context;
   }
 
@@ -129,9 +133,9 @@ export class OneTimeTokenVerification
   }
 
   toJson(): OneTimeTokenVerificationRecordData {
-    const { id, type, identifier, verified, context } = this;
+    const { id, type, identifier, verified, verifiedAt, context } = this;
 
-    return { id, type, identifier, verified, oneTimeTokenContext: context };
+    return { id, type, identifier, verified, verifiedAt, oneTimeTokenContext: context };
   }
 
   toSanitizedJson(): OneTimeTokenVerificationRecordData {

--- a/packages/core/src/routes/experience/classes/verifications/password-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/password-verification.ts
@@ -14,7 +14,7 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { findUserByIdentifier } from '../utils.js';
 
-import { type IdentifierVerificationRecord } from './verification-record.js';
+import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
 
 export {
   type PasswordVerificationRecordData,
@@ -37,6 +37,8 @@ export class PasswordVerification
   readonly type = VerificationType.Password;
   readonly identifier: VerificationIdentifier;
   readonly id: string;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
   private verified: boolean;
 
   /**
@@ -50,11 +52,12 @@ export class PasswordVerification
     private readonly queries: Queries,
     data: PasswordVerificationRecordData
   ) {
-    const { id, identifier, verified } = data;
+    const { id, identifier, verified, verifiedAt } = data;
 
     this.id = id;
     this.identifier = identifier;
     this.verified = verified;
+    this.verifiedAt = verifiedAt;
   }
 
   /** Returns whether the password verification has succeeded. */
@@ -64,6 +67,7 @@ export class PasswordVerification
 
   markAsVerified(): void {
     this.verified = true;
+    this.verifiedAt = getEpochTime();
   }
 
   /**
@@ -84,6 +88,7 @@ export class PasswordVerification
     );
 
     this.verified = true;
+    this.verifiedAt = getEpochTime();
 
     return verifiedUser;
   }
@@ -110,13 +115,14 @@ export class PasswordVerification
   }
 
   toJson(): PasswordVerificationRecordData {
-    const { id, type, identifier, verified } = this;
+    const { id, type, identifier, verified, verifiedAt } = this;
 
     return {
       id,
       type,
       identifier,
       verified,
+      verifiedAt,
     };
   }
 

--- a/packages/core/src/routes/experience/classes/verifications/social-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.ts
@@ -38,7 +38,7 @@ import { type LogtoConnector } from '#src/utils/connectors/types.js';
 
 import type { InteractionProfile } from '../../types.js';
 
-import { type IdentifierVerificationRecord } from './verification-record.js';
+import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
 
 export {
   type SocialVerificationRecordData,
@@ -72,6 +72,8 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   public socialUserInfo?: SocialUserInfo;
   public encryptedTokenSet?: EncryptedTokenSet;
   public connectorSession: ConnectorSession;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
   private connectorDataCache?: LogtoConnector;
 
   constructor(
@@ -79,12 +81,13 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
     private readonly queries: Queries,
     data: SocialVerificationRecordData
   ) {
-    const { id, connectorId, socialUserInfo, encryptedTokenSet, connectorSession } =
+    const { id, connectorId, socialUserInfo, encryptedTokenSet, connectorSession, verifiedAt } =
       socialVerificationRecordDataGuard.parse(data);
 
     this.id = id;
     this.connectorId = connectorId;
     this.socialUserInfo = socialUserInfo;
+    this.verifiedAt = verifiedAt;
     this.encryptedTokenSet = encryptedTokenSet;
     this.connectorSession = connectorSession ?? {};
   }
@@ -171,6 +174,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
 
     this.socialUserInfo = userInfo;
     this.encryptedTokenSet = encryptedTokenSet;
+    this.verifiedAt = getEpochTime();
   }
 
   /**
@@ -301,7 +305,15 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   }
 
   toJson(): SocialVerificationRecordData {
-    const { id, type, connectorId, socialUserInfo, encryptedTokenSet, connectorSession } = this;
+    const {
+      id,
+      type,
+      connectorId,
+      socialUserInfo,
+      encryptedTokenSet,
+      connectorSession,
+      verifiedAt,
+    } = this;
 
     return {
       id,
@@ -310,13 +322,14 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
       socialUserInfo,
       encryptedTokenSet,
       connectorSession,
+      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedSocialVerificationRecordData {
-    const { id, type, connectorId, socialUserInfo } = this;
+    const { id, type, connectorId, socialUserInfo, verifiedAt } = this;
 
-    return { id, type, connectorId, socialUserInfo };
+    return { id, type, connectorId, socialUserInfo, verifiedAt };
   }
 
   private async findUserBySocialIdentity(): Promise<User | undefined> {

--- a/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
@@ -22,7 +22,7 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { type MfaVerificationRecord } from './verification-record.js';
+import { type MfaVerificationRecord, getEpochTime } from './verification-record.js';
 
 export {
   type TotpVerificationRecordData,
@@ -58,6 +58,8 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
   public readonly id: string;
   public readonly type = VerificationType.TOTP;
   public readonly userId: string;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
   private verified: boolean;
   #secret?: string;
 
@@ -66,12 +68,14 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
     private readonly queries: Queries,
     data: TotpVerificationRecordData
   ) {
-    const { id, userId, secret, verified } = totpVerificationRecordDataGuard.parse(data);
+    const { id, userId, secret, verified, verifiedAt } =
+      totpVerificationRecordDataGuard.parse(data);
 
     this.id = id;
     this.userId = userId;
     this.#secret = secret;
     this.verified = verified;
+    this.verifiedAt = verifiedAt;
   }
 
   get isVerified() {
@@ -116,6 +120,7 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
     );
 
     this.verified = true;
+    this.verifiedAt = getEpochTime();
   }
 
   /**
@@ -153,6 +158,7 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
     assertThat(updatedUser, 'session.mfa.invalid_totp_code');
 
     this.verified = true;
+    this.verifiedAt = getEpochTime();
   }
 
   toBindMfa(): BindTotp {
@@ -165,7 +171,7 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
   }
 
   toJson(): TotpVerificationRecordData {
-    const { id, type, secret, verified, userId } = this;
+    const { id, type, secret, verified, verifiedAt, userId } = this;
 
     return {
       id,
@@ -173,13 +179,14 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
       userId,
       secret,
       verified,
+      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedTotpVerificationRecordData {
-    const { id, type, userId, verified } = this;
+    const { id, type, userId, verified, verifiedAt } = this;
 
-    return { id, type, userId, verified };
+    return { id, type, userId, verified, verifiedAt };
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/verifications/verification-record.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-record.ts
@@ -5,6 +5,9 @@ type Data<T> = {
   type: T;
 };
 
+/** Epoch seconds, the unit `auth_time` / `verifiedAt` are recorded in. */
+export const getEpochTime = () => Math.floor(Date.now() / 1000);
+
 /** The abstract class for all verification records. */
 export abstract class VerificationRecord<
   T extends VerificationType = VerificationType,

--- a/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
@@ -31,6 +31,7 @@ import assertThat from '#src/utils/assert-that.js';
 import {
   type IdentifierVerificationRecord,
   type MfaVerificationRecord,
+  getEpochTime,
 } from './verification-record.js';
 
 export {
@@ -46,6 +47,8 @@ abstract class BaseWebAuthnVerification {
   readonly id: string;
   userId?: string;
   verified: boolean;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
   registrationChallenge?: string;
   registrationRpId?: string;
   registrationInfo?: BindWebAuthn;
@@ -59,6 +62,7 @@ abstract class BaseWebAuthnVerification {
     this.id = data.id;
     this.userId = data.userId;
     this.verified = data.verified;
+    this.verifiedAt = data.verifiedAt;
     this.registrationChallenge = data.registrationChallenge;
     this.registrationRpId = data.registrationRpId;
     this.registrationInfo = data.registrationInfo;
@@ -133,6 +137,7 @@ abstract class BaseWebAuthnVerification {
     const { credentialID, credentialPublicKey, counter } = registrationInfo;
 
     this.verified = true;
+    this.verifiedAt = getEpochTime();
 
     this.registrationInfo = {
       type: MfaFactor.WebAuthn,
@@ -232,6 +237,7 @@ export class WebAuthnVerification
     assertThat(result, 'session.mfa.webauthn_verification_failed');
 
     this.verified = true;
+    this.verifiedAt = getEpochTime();
 
     await this.queries.users.updateUserById(user.id, {
       mfaVerifications: mfaVerifications.map((mfa) => {
@@ -265,6 +271,7 @@ export class WebAuthnVerification
       type: this.type,
       userId: this.userId,
       verified: this.verified,
+      verifiedAt: this.verifiedAt,
       registrationChallenge: this.registrationChallenge,
       authenticationChallenge: this.authenticationChallenge,
       registrationRpId: this.registrationRpId,
@@ -273,8 +280,8 @@ export class WebAuthnVerification
   }
 
   toSanitizedJson(): SanitizedWebAuthnVerificationRecordData {
-    const { id, type, userId, verified } = this;
-    return { id, type, userId, verified };
+    const { id, type, userId, verified, verifiedAt } = this;
+    return { id, type, userId, verified, verifiedAt };
   }
 }
 
@@ -346,6 +353,7 @@ export class SignInPasskeyVerification
     assertThat(result, 'session.mfa.webauthn_verification_failed');
 
     this.verified = true;
+    this.verifiedAt = getEpochTime();
     this.userId = userId;
 
     await updateUserById(userId, {
@@ -383,6 +391,7 @@ export class SignInPasskeyVerification
       type: this.type,
       userId: this.userId,
       verified: this.verified,
+      verifiedAt: this.verifiedAt,
       registrationChallenge: this.registrationChallenge,
       authenticationChallenge: this.authenticationChallenge,
       registrationRpId: this.registrationRpId,
@@ -392,7 +401,7 @@ export class SignInPasskeyVerification
   }
 
   toSanitizedJson(): SanitizedSignInPasskeyVerificationRecordData {
-    const { id, type, userId, verified } = this;
-    return { id, type, userId, verified };
+    const { id, type, userId, verified, verifiedAt } = this;
+    return { id, type, userId, verified, verifiedAt };
   }
 }

--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -6,6 +6,7 @@ import {
   updateProfileApiPayloadGuard,
   uploadFileGuard,
   userAssetsGuard,
+  VerificationType,
 } from '@logto/schemas';
 import { addDays, format } from 'date-fns';
 import { type MiddlewareType } from 'koa';
@@ -414,6 +415,12 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
               true
             );
             experienceInteraction.setVerificationRecord(codeVerification);
+            // The email is now an MFA factor of the account: record that `bind` proof next to
+            // the `1fa` one the profile bind recorded for the same mailbox.
+            experienceInteraction.consumeForBindByType(
+              VerificationType.MfaEmailVerificationCode,
+              codeVerification.id
+            );
           }
           break;
         }
@@ -437,6 +444,10 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
               true
             );
             experienceInteraction.setVerificationRecord(codeVerification);
+            experienceInteraction.consumeForBindByType(
+              VerificationType.MfaPhoneVerificationCode,
+              codeVerification.id
+            );
           }
           break;
         }

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -198,6 +198,8 @@ export type WithHooksAndLogsContext<ContextT extends WithLogContext = WithLogCon
 export type InteractionStorage = {
   interactionEvent: InteractionEvent;
   userId?: string;
+  /** The ids of the verification records that identified `userId`; see `ExperienceInteraction.identifyUser()`. */
+  identifiedVerificationIds?: string[];
   trustedDeviceOptIn?:
     | {
         trusted: false;
@@ -219,6 +221,7 @@ export type InteractionStorage = {
 export const interactionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
+  identifiedVerificationIds: z.string().array().optional(),
   trustedDeviceOptIn: z
     .discriminatedUnion('trusted', [
       z.object({ trusted: z.literal(false) }),
@@ -243,6 +246,7 @@ export const interactionStorageGuard = z.object({
 export type SanitizedInteractionStorageData = {
   interactionEvent: InteractionEvent;
   userId?: string;
+  identifiedVerificationIds?: string[];
   profile?: SanitizedInteractionProfile;
   verificationRecords?: SanitizedVerificationRecordData[];
   mfa?: SanitizedMfaData;
@@ -260,6 +264,7 @@ export type SanitizedInteractionStorageData = {
 export const sanitizedInteractionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
+  identifiedVerificationIds: z.string().array().optional(),
   profile: sanitizedInteractionProfileGuard,
   verificationRecords: publicVerificationRecordDataGuard.array().optional(),
   mfa: sanitizedMfaDataGuard.optional(),

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -1,5 +1,7 @@
 import { type SocialUserInfo, socialUserInfoGuard, type ToZodObject } from '@logto/connector-kit';
 import {
+  type AuthenticationProof,
+  authenticationProofGuard,
   type CreateUser,
   encryptedTokenSetGuard,
   InteractionEvent,
@@ -165,16 +167,25 @@ const sanitizedInteractionProfileGuard = interactionProfileGuard.omit({
 }) satisfies ToZodObject<SanitizedInteractionProfile>;
 
 /**
- * The interaction context provides the callback functions to get the user and verification record from the interaction
+ * The interaction context provides the callback functions to get the user and verification record from the interaction.
+ *
+ * There is deliberately no raw verification-record getter here. Every time `Profile` or `Mfa`
+ * reaches a record it consumes the record's credential, and the consumer must say so: the
+ * `consumeFor…` methods record the authentication proof for the role they name. Re-adding a raw
+ * getter would let a write path reach a record without recording what it did with it.
  */
 export type InteractionContext = {
   getInteractionEvent: () => InteractionEvent;
   getIdentifiedUser: () => Promise<User>;
-  getVerificationRecordById: (verificationId: string) => VerificationRecord;
-  getVerificationRecordByTypeAndId: <K extends keyof VerificationRecordMap>(
+  /** Fetch a record to bind the credential it carries to the account, recording the `bind` proof. */
+  consumeForBind: (verificationId: string) => VerificationRecord;
+  /** The typed variant of `consumeForBind`. */
+  consumeForBindByType: <K extends keyof VerificationRecordMap>(
     type: K,
     verificationId: string
   ) => VerificationRecordMap[K];
+  /** Record the proof for a password established through the profile, which has no record. */
+  recordEstablishedPassword: () => void;
   getCurrentProfile: () => InteractionProfile;
 };
 
@@ -198,8 +209,8 @@ export type WithHooksAndLogsContext<ContextT extends WithLogContext = WithLogCon
 export type InteractionStorage = {
   interactionEvent: InteractionEvent;
   userId?: string;
-  /** The ids of the verification records that identified `userId`; see `ExperienceInteraction.identifyUser()`. */
-  identifiedVerificationIds?: string[];
+  /** The authentication proofs recorded so far; see `AuthenticationProofs`. */
+  authenticationProofs?: AuthenticationProof[];
   trustedDeviceOptIn?:
     | {
         trusted: false;
@@ -221,7 +232,7 @@ export type InteractionStorage = {
 export const interactionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
-  identifiedVerificationIds: z.string().array().optional(),
+  authenticationProofs: authenticationProofGuard.array().optional(),
   trustedDeviceOptIn: z
     .discriminatedUnion('trusted', [
       z.object({ trusted: z.literal(false) }),
@@ -246,7 +257,6 @@ export const interactionStorageGuard = z.object({
 export type SanitizedInteractionStorageData = {
   interactionEvent: InteractionEvent;
   userId?: string;
-  identifiedVerificationIds?: string[];
   profile?: SanitizedInteractionProfile;
   verificationRecords?: SanitizedVerificationRecordData[];
   mfa?: SanitizedMfaData;
@@ -264,7 +274,6 @@ export type SanitizedInteractionStorageData = {
 export const sanitizedInteractionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
-  identifiedVerificationIds: z.string().array().optional(),
   profile: sanitizedInteractionProfileGuard,
   verificationRecords: publicVerificationRecordDataGuard.array().optional(),
   mfa: sanitizedMfaDataGuard.optional(),

--- a/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
@@ -122,6 +122,10 @@ export default function backupCodeVerificationRoutes<T extends ExperienceInterac
       );
 
       ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
+      ctx.experienceInteraction.consumeForMfa(
+        VerificationType.BackupCode,
+        backupCodeVerificationRecord.id
+      );
 
       await ctx.experienceInteraction.save();
 

--- a/packages/core/src/routes/experience/verification-routes/mfa-sentinel-guard.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/mfa-sentinel-guard.test.ts
@@ -148,6 +148,7 @@ describe('MFA verification routes sentinel guard', () => {
       experienceInteraction: {
         identifiedUserId: mockUser.id,
         setVerificationRecord: jest.fn(),
+        consumeForMfa: jest.fn(),
         save: jest.fn().mockImplementation(resolveVoid),
       },
       verificationAuditLog: {
@@ -194,6 +195,7 @@ describe('MFA verification routes sentinel guard', () => {
       experienceInteraction: {
         identifiedUserId: mockUser.id,
         setVerificationRecord: jest.fn(),
+        consumeForMfa: jest.fn(),
         save: jest.fn().mockImplementation(resolveVoid),
       },
       verificationAuditLog: {
@@ -244,6 +246,7 @@ describe('MFA verification routes sentinel guard', () => {
       experienceInteraction: {
         identifiedUserId: mockUser.id,
         getVerificationRecordByTypeAndId: jest.fn(() => webAuthnVerificationRecord),
+        consumeForMfa: jest.fn(),
         save: jest.fn().mockImplementation(resolveVoid),
       },
       verificationAuditLog: {
@@ -265,6 +268,10 @@ describe('MFA verification routes sentinel guard', () => {
     await handler(ctx, jest.fn().mockImplementation(resolveVoid));
 
     expect(ctx.experienceInteraction.getVerificationRecordByTypeAndId).toHaveBeenCalledWith(
+      VerificationType.WebAuthn,
+      webAuthnVerificationRecord.id
+    );
+    expect(ctx.experienceInteraction.consumeForMfa).toHaveBeenCalledWith(
       VerificationType.WebAuthn,
       webAuthnVerificationRecord.id
     );

--- a/packages/core/src/routes/experience/verification-routes/new-password-identity-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/new-password-identity-verification.ts
@@ -1,11 +1,13 @@
 import { usernameRegEx } from '@logto/core-kit';
-import { SignInIdentifier, VerificationType } from '@logto/schemas';
+import { InteractionEvent, SignInIdentifier, VerificationType } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
+import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
+import assertThat from '#src/utils/assert-that.js';
 
 import { NewPasswordIdentityVerification } from '../classes/verifications/new-password-identity-verification.js';
 import { experienceRoutes } from '../const.js';
@@ -38,6 +40,13 @@ export default function newPasswordIdentityVerificationRoutes<
     async (ctx, next) => {
       const { identifier, password } = ctx.guard.body;
       const { experienceInteraction, verificationAuditLog } = ctx;
+
+      // The record only proposes a password for an account that does not exist yet. In any other
+      // event it would sit next to the identified user's records without ever authenticating them.
+      assertThat(
+        experienceInteraction.interactionEvent === InteractionEvent.Register,
+        new RequestError({ code: 'session.invalid_interaction_type', status: 400 })
+      );
 
       verificationAuditLog.append({
         payload: {

--- a/packages/core/src/routes/experience/verification-routes/totp-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/totp-verification.ts
@@ -154,6 +154,7 @@ export default function totpVerificationRoutes<T extends ExperienceInteractionRo
       );
 
       ctx.experienceInteraction.setVerificationRecord(totpVerificationRecord);
+      ctx.experienceInteraction.consumeForMfa(VerificationType.TOTP, totpVerificationRecord.id);
 
       await ctx.experienceInteraction.save();
 

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,10 +1,12 @@
 import {
   defaultMessageRateLimitPolicy,
   InteractionEvent,
+  MfaFactor,
   SentinelActivityAction,
   SignInIdentifier,
 } from '@logto/schemas';
 
+import RequestError from '#src/errors/RequestError/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -28,7 +30,7 @@ async function resolveVoid(): Promise<void> {
   await Promise.resolve();
 }
 
-const { sendCode } = await import('./verification-code-helpers.js');
+const { sendCode, getMfaIdentifier } = await import('./verification-code-helpers.js');
 
 // Provide a permissive activity store so the message rate guard allows sends by default.
 const mockSentinelActivities = {
@@ -399,5 +401,64 @@ describe('sendCode parameter passing', () => {
     expect(
       mockExperienceInteraction.signInExperienceValidator.isRegistrationDisabled
     ).not.toHaveBeenCalled();
+  });
+});
+
+describe('getMfaIdentifier', () => {
+  const findUserById = jest
+    .fn()
+    .mockResolvedValue({ primaryEmail: 'foo@example.com', primaryPhone: '+11234567890' });
+  const queries = { users: { findUserById } } as unknown as Queries;
+
+  beforeEach(() => {
+    findUserById.mockClear();
+  });
+
+  const buildInteraction = (factors: MfaFactor[]) =>
+    ({
+      identifiedUserId: 'identified-user-id',
+      signInExperienceValidator: { getMfaSettings: jest.fn().mockResolvedValue({ factors }) },
+    }) as unknown as Parameters<typeof getMfaIdentifier>[0]['experienceInteraction'];
+
+  it('resolves the primary contact of the identified user when the factor is enabled', async () => {
+    await expect(
+      getMfaIdentifier({
+        identifierType: SignInIdentifier.Email,
+        experienceInteraction: buildInteraction([MfaFactor.EmailVerificationCode]),
+        queries,
+      })
+    ).resolves.toEqual({ type: SignInIdentifier.Email, value: 'foo@example.com' });
+  });
+
+  it.each([
+    [SignInIdentifier.Email, [MfaFactor.PhoneVerificationCode]],
+    [SignInIdentifier.Phone, [MfaFactor.EmailVerificationCode]],
+    [SignInIdentifier.Email, []],
+  ] as const)(
+    'refuses a %s code when the sign-in experience does not enable that factor',
+    async (identifierType, factors) => {
+      await expect(
+        getMfaIdentifier({
+          identifierType,
+          experienceInteraction: buildInteraction([...factors]),
+          queries,
+        })
+      ).rejects.toMatchError(
+        new RequestError({ code: 'session.mfa.mfa_factor_not_enabled', status: 400 })
+      );
+      expect(findUserById).not.toHaveBeenCalled();
+    }
+  );
+
+  it('refuses a code before any user is identified', async () => {
+    await expect(
+      getMfaIdentifier({
+        identifierType: SignInIdentifier.Email,
+        experienceInteraction: {
+          identifiedUserId: undefined,
+        } as unknown as Parameters<typeof getMfaIdentifier>[0]['experienceInteraction'],
+        queries,
+      })
+    ).rejects.toMatchError(new RequestError({ code: 'session.identifier_not_found', status: 400 }));
   });
 });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -264,6 +264,15 @@ export const verifyCode = async ({
     codeVerificationRecord.verify(identifier, code)
   );
 
+  // For an MFA challenge, verifying is the use: record the `mfa` proof here. A primary email /
+  // phone code is consumed later, by identification or by a profile bind, which records its proof.
+  if (
+    verificationType === VerificationType.MfaEmailVerificationCode ||
+    verificationType === VerificationType.MfaPhoneVerificationCode
+  ) {
+    experienceInteraction.consumeForMfa(verificationType, codeVerificationRecord.id);
+  }
+
   // Save state
   await experienceInteraction.save();
 

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -1,5 +1,6 @@
 import {
   InteractionEvent,
+  MfaFactor,
   SentinelActivityAction,
   SignInIdentifier,
   type VerificationCodeIdentifier,
@@ -278,7 +279,9 @@ type GetMfaIdentifierParams = {
 };
 
 /**
- * Helper to get MFA identifier from user profile
+ * Helper to get MFA identifier from user profile. The factor must be enabled in the sign-in
+ * experience: otherwise a sign-in could request a second code for the very contact that already
+ * identified the user, which is a second proof of the same factor and not a second factor.
  * @internal
  */
 export const getMfaIdentifier = async ({
@@ -289,6 +292,19 @@ export const getMfaIdentifier = async ({
   if (!experienceInteraction.identifiedUserId) {
     throw new RequestError({
       code: 'session.identifier_not_found',
+      status: 400,
+    });
+  }
+
+  const { factors } = await experienceInteraction.signInExperienceValidator.getMfaSettings();
+  const factor =
+    identifierType === SignInIdentifier.Email
+      ? MfaFactor.EmailVerificationCode
+      : MfaFactor.PhoneVerificationCode;
+
+  if (!factors.includes(factor)) {
+    throw new RequestError({
+      code: 'session.mfa.mfa_factor_not_enabled',
       status: 400,
     });
   }

--- a/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
@@ -263,6 +263,8 @@ export default function webAuthnVerificationRoute<T extends ExperienceInteractio
         webAuthnVerification.verifyWebAuthnAuthentication(ctx, payload)
       );
 
+      experienceInteraction.consumeForMfa(VerificationType.WebAuthn, webAuthnVerification.id);
+
       await experienceInteraction.save();
 
       ctx.body = {

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/new-password-identity-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/new-password-identity-verification.test.ts
@@ -1,4 +1,4 @@
-import { SignInIdentifier } from '@logto/schemas';
+import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
 
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { initExperienceClient } from '#src/helpers/client.js';
@@ -36,12 +36,25 @@ describe('password verifications', () => {
     });
   });
 
+  it('should reject the verification outside a register interaction', async () => {
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const client = await initExperienceClient();
+
+    await expectRejects(
+      client.createNewPasswordIdentityVerification({
+        identifier: { type: SignInIdentifier.Username, value: username },
+        password,
+      }),
+      { code: 'session.invalid_interaction_type', status: 400 }
+    );
+  });
+
   describe('invalid identifier check', () => {
     it('should throw error if username is registered', async () => {
       const { username, password } = generateNewUserProfile({ username: true, password: true });
       await userApi.create({ username, password });
 
-      const client = await initExperienceClient();
+      const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
 
       await expectRejects(
         client.createNewPasswordIdentityVerification({
@@ -66,7 +79,7 @@ describe('password verifications', () => {
 
       await userApi.create({ primaryEmail, password });
 
-      const client = await initExperienceClient();
+      const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
 
       await expectRejects(
         client.createNewPasswordIdentityVerification({
@@ -95,7 +108,7 @@ describe('password verifications', () => {
     ];
 
     it.each(invalidPasswords)('should reject invalid password %p', async (password) => {
-      const client = await initExperienceClient();
+      const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
 
       await expectRejects(
         client.createNewPasswordIdentityVerification({
@@ -114,7 +127,7 @@ describe('password verifications', () => {
   });
 
   it('should create new password identity verification successfully', async () => {
-    const client = await initExperienceClient();
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
 
     const { verificationId } = await client.createNewPasswordIdentityVerification({
       identifier: {

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
@@ -1,0 +1,220 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { Prompt } from '@logto/node';
+import {
+  InteractionEvent,
+  MfaFactor,
+  SignInIdentifier,
+  demoAppApplicationId,
+} from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { type ExperienceClient } from '#src/client/experience/index.js';
+import { demoAppRedirectUri } from '#src/constants.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import {
+  clearConnectorsByTypes,
+  setEmailConnector,
+  setSmsConnector,
+  setSocialConnector,
+} from '#src/helpers/connector.js';
+import {
+  successfullyCreateSocialVerification,
+  successfullyVerifySocialAuthorization,
+} from '#src/helpers/experience/social-verification.js';
+import { successfullyCreateAndVerifyTotp } from '#src/helpers/experience/totp-verification.js';
+import {
+  successfullySendVerificationCode,
+  successfullyVerifyVerificationCode,
+} from '#src/helpers/experience/verification-code.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableAllVerificationCodeSignInMethods,
+  enableMandatoryMfaWithTotp,
+  resetMfaSettings,
+  resetPasswordPolicy,
+} from '#src/helpers/sign-in-experience.js';
+import { generateNewUserProfile } from '#src/helpers/user.js';
+import { devFeatureTest } from '#src/utils.js';
+
+const firstFactorAcr = 'urn:logto:acr:1fa';
+const mfaAcr = 'urn:logto:acr:mfa';
+
+const nowInSeconds = () => Math.floor(Date.now() / 1000);
+
+const registerClient = async () =>
+  initExperienceClient({ interactionEvent: InteractionEvent.Register });
+
+/** Start a sign-in on a fresh client, as a social user who turns out to be new would. */
+const initClient = async () =>
+  initExperienceClient({
+    config: { appId: demoAppApplicationId, prompt: Prompt.Consent, scopes: ['offline_access'] },
+    redirectUri: demoAppRedirectUri,
+  });
+
+/** Verify a registration password for a fresh username and create the account with it. */
+const registerWithUsernamePassword = async (client: ExperienceClient) => {
+  const { username, password } = generateNewUserProfile({ username: true, password: true });
+  const { verificationId } = await client.createNewPasswordIdentityVerification({
+    identifier: { type: SignInIdentifier.Username, value: username },
+    password,
+  });
+  await client.identifyUser({ verificationId });
+};
+
+/** Submit the registration, read the ID token claims, and delete the account. */
+const finishRegistration = async (client: ExperienceClient) => {
+  const { redirectTo } = await client.submitInteraction();
+  await processSession(client, redirectTo);
+  const claims = await client.getIdTokenClaims();
+  await logoutClient(client);
+  await deleteUser(claims.sub);
+  return claims;
+};
+
+/**
+ * A registration creates the account from the interaction's records, so every credential it
+ * establishes is a proof of that account and the ID token carries it like a sign-in would.
+ */
+devFeatureTest.describe('authentication context claims on registration', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await updateSignInExperience({ adaptiveMfa: { enabled: false } });
+  });
+
+  afterAll(async () => {
+    await resetMfaSettings();
+  });
+
+  describe('username and password', () => {
+    beforeAll(async () => {
+      // Disable the password policy so the generated password is accepted.
+      await updateSignInExperience({
+        signUp: { identifiers: [SignInIdentifier.Username], password: true, verify: false },
+        passwordPolicy: {},
+      });
+    });
+
+    afterAll(async () => {
+      await resetPasswordPolicy();
+      await enableAllPasswordSignInMethods();
+    });
+
+    it('issues acr=1fa, amr=[pwd], and a fresh auth_time for the password the account was created with', async () => {
+      const client = await registerClient();
+      const before = nowInSeconds();
+      await registerWithUsernamePassword(client);
+
+      const claims = await finishRegistration(client);
+
+      expect(claims).toMatchObject({ acr: firstFactorAcr, amr: ['pwd'] });
+      expect(claims.auth_time).toBeGreaterThanOrEqual(before);
+      expect(claims.auth_time).toBeLessThanOrEqual(nowInSeconds());
+    });
+
+    it('issues acr=mfa and amr=[pwd, otp, mfa] when the registration enrolls a mandatory TOTP', async () => {
+      await enableMandatoryMfaWithTotp();
+      const client = await registerClient();
+      await registerWithUsernamePassword(client);
+
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.missing_mfa',
+        status: 422,
+      });
+      const totpVerificationId = await successfullyCreateAndVerifyTotp(client);
+      await client.bindMfa(MfaFactor.TOTP, totpVerificationId);
+
+      const claims = await finishRegistration(client);
+
+      expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
+
+      await resetMfaSettings();
+    });
+  });
+
+  describe('verification code', () => {
+    beforeAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+      await Promise.all([setEmailConnector(), setSmsConnector()]);
+      await enableAllVerificationCodeSignInMethods({
+        identifiers: [SignInIdentifier.Email, SignInIdentifier.Phone],
+        password: false,
+        verify: true,
+      });
+    });
+
+    afterAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+      await enableAllPasswordSignInMethods();
+    });
+
+    it.each([
+      { identifierType: SignInIdentifier.Email, profileKey: 'primaryEmail', amr: ['otp'] },
+      { identifierType: SignInIdentifier.Phone, profileKey: 'primaryPhone', amr: ['sms'] },
+    ] as const)(
+      'issues acr=1fa and amr=$amr for the verified $identifierType the account was created with',
+      async ({ identifierType, profileKey, amr }) => {
+        const profile = generateNewUserProfile({ primaryEmail: true, primaryPhone: true });
+        const identifier = { type: identifierType, value: profile[profileKey] };
+        const client = await registerClient();
+        const { verificationId, code } = await successfullySendVerificationCode(client, {
+          identifier,
+          interactionEvent: InteractionEvent.Register,
+        });
+        await successfullyVerifyVerificationCode(client, { identifier, verificationId, code });
+        await client.identifyUser({ verificationId });
+
+        const claims = await finishRegistration(client);
+
+        expect(claims).toMatchObject({ acr: firstFactorAcr, amr });
+        expect(typeof claims.auth_time).toBe('number');
+      }
+    );
+  });
+
+  describe('social', () => {
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let connectorId: string;
+
+    beforeAll(async () => {
+      // Let a social user register without a username or password.
+      await enableAllPasswordSignInMethods({ identifiers: [], password: false, verify: false });
+      await clearConnectorsByTypes([ConnectorType.Social]);
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      ({ id: connectorId } = await setSocialConnector());
+    });
+
+    afterAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Social]);
+      await enableAllPasswordSignInMethods();
+    });
+
+    it('issues amr=[fed] and no acr for a social registration', async () => {
+      const client = await initClient();
+      const state = 'state';
+      const redirectUri = 'http://localhost:3000';
+      const { verificationId } = await successfullyCreateSocialVerification(client, connectorId, {
+        redirectUri,
+        state,
+      });
+      await successfullyVerifySocialAuthorization(client, connectorId, {
+        verificationId,
+        connectorData: { state, redirectUri, code: 'fake_code', userId: generateStandardId() },
+      });
+      await expectRejects(client.identifyUser({ verificationId }), {
+        code: 'user.identity_not_exist',
+        status: 404,
+      });
+      await client.updateInteractionEvent({ interactionEvent: InteractionEvent.Register });
+      await client.identifyUser({ verificationId });
+
+      const claims = await finishRegistration(client);
+
+      expect(claims.amr).toEqual(['fed']);
+      expect(claims).not.toHaveProperty('acr');
+      expect(typeof claims.auth_time).toBe('number');
+    });
+  });
+});

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
@@ -199,7 +199,7 @@ devFeatureTest.describe('authentication context claims on registration', () => {
         primaryEmail: true,
         password: true,
       });
-      const identifier = { type: SignInIdentifier.Email, value: primaryEmail };
+      const identifier = { type: SignInIdentifier.Email, value: primaryEmail } as const;
       const client = await registerClient();
       const { verificationId, code } = await successfullySendVerificationCode(client, {
         identifier,

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
@@ -174,6 +174,51 @@ devFeatureTest.describe('authentication context claims on registration', () => {
     );
   });
 
+  describe('verification code and password', () => {
+    beforeAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email]);
+      await setEmailConnector();
+      await enableAllVerificationCodeSignInMethods({
+        identifiers: [SignInIdentifier.Email],
+        password: true,
+        verify: true,
+      });
+      await updateSignInExperience({ passwordPolicy: {} });
+    });
+
+    afterAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email]);
+      await resetPasswordPolicy();
+      await enableAllPasswordSignInMethods();
+    });
+
+    it('issues acr=1fa and amr=[otp, pwd] for the verified email and the password set on the profile', async () => {
+      // The password is set through the profile and has no verification record; the profile's
+      // password transition records its proof. Two first factors are still one assurance level.
+      const { primaryEmail, password } = generateNewUserProfile({
+        primaryEmail: true,
+        password: true,
+      });
+      const identifier = { type: SignInIdentifier.Email, value: primaryEmail };
+      const client = await registerClient();
+      const { verificationId, code } = await successfullySendVerificationCode(client, {
+        identifier,
+        interactionEvent: InteractionEvent.Register,
+      });
+      await successfullyVerifyVerificationCode(client, { identifier, verificationId, code });
+      await client.identifyUser({ verificationId });
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.missing_profile',
+        status: 422,
+      });
+      await client.updateProfile({ type: 'password', value: password });
+
+      const claims = await finishRegistration(client);
+
+      expect(claims).toMatchObject({ acr: firstFactorAcr, amr: ['otp', 'pwd'] });
+    });
+  });
+
   describe('social', () => {
     // eslint-disable-next-line @silverhand/fp/no-let
     let connectorId: string;

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -37,7 +37,10 @@ import {
   successfullyCreateSocialVerification,
   successfullyVerifySocialAuthorization,
 } from '#src/helpers/experience/social-verification.js';
-import { successfullyVerifyTotp } from '#src/helpers/experience/totp-verification.js';
+import {
+  successfullyCreateAndVerifyTotp,
+  successfullyVerifyTotp,
+} from '#src/helpers/experience/totp-verification.js';
 import {
   successfullySendVerificationCode,
   successfullyVerifyVerificationCode,
@@ -46,6 +49,7 @@ import { expectRejects } from '#src/helpers/index.js';
 import {
   enableAllPasswordSignInMethods,
   enableAllVerificationCodeSignInMethods,
+  enableMandatoryMfaWithTotp,
   enableMandatoryMfaWithTotpAndBackupCode,
   resetMfaSettings,
 } from '#src/helpers/sign-in-experience.js';
@@ -156,6 +160,29 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
 
     expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
     expect(typeof claims.auth_time).toBe('number');
+
+    await logoutClient(client);
+    await resetMfaSettings();
+  });
+
+  it('issues acr=mfa and amr=[pwd, otp, mfa] when the sign-in enrolls the first TOTP of the account', async () => {
+    // A factor established by the interaction and written to the account counts like one it
+    // verified; this is what makes an MFA step-up satisfiable for a user without a factor.
+    await enableMandatoryMfaWithTotp();
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    await userApi.create({ username, password });
+
+    const client = await initClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_mfa',
+      status: 422,
+    });
+    const totpVerificationId = await successfullyCreateAndVerifyTotp(client);
+    await client.bindMfa(MfaFactor.TOTP, totpVerificationId);
+    const claims = await finishSignIn(client);
+
+    expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
 
     await logoutClient(client);
     await resetMfaSettings();

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -275,6 +275,41 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
       await logoutClient(client);
     });
 
+    it('keeps fed on the sign-in that links the identity to an existing account', async () => {
+      const { primaryEmail } = generateNewUserProfile({ primaryEmail: true });
+      const existingUser = await userApi.create({ primaryEmail });
+      const linkingSocialUserId = generateStandardId();
+
+      const client = await initClient();
+      const state = 'state';
+      const redirectUri = 'http://localhost:3000';
+      const { verificationId } = await successfullyCreateSocialVerification(client, connectorId, {
+        redirectUri,
+        state,
+      });
+      await successfullyVerifySocialAuthorization(client, connectorId, {
+        verificationId,
+        connectorData: {
+          state,
+          redirectUri,
+          code: 'fake_code',
+          userId: linkingSocialUserId,
+          email: primaryEmail,
+        },
+      });
+      // The identity is not stored yet; the user is identified by the related email and the
+      // link is written by the submission.
+      await client.identifyUser({ verificationId, linkSocialIdentity: true });
+      const claims = await finishSignIn(client);
+
+      expect(claims.sub).toBe(existingUser.id);
+      expect(claims.amr).toEqual(['fed']);
+      expect(claims).not.toHaveProperty('acr');
+      expect(typeof claims.auth_time).toBe('number');
+
+      await logoutClient(client);
+    });
+
     it('does not count an unused registration password as a proof of the account', async () => {
       const client = await identifySocialUser();
       await verifyUnusedRegistrationPassword(client);

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -39,11 +39,10 @@ import {
 } from '#src/helpers/experience/social-verification.js';
 import { successfullyVerifyTotp } from '#src/helpers/experience/totp-verification.js';
 import {
-  successfullySendMfaVerificationCode,
   successfullySendVerificationCode,
-  successfullyVerifyMfaVerificationCode,
   successfullyVerifyVerificationCode,
 } from '#src/helpers/experience/verification-code.js';
+import { expectRejects } from '#src/helpers/index.js';
 import {
   enableAllPasswordSignInMethods,
   enableAllVerificationCodeSignInMethods,
@@ -97,18 +96,6 @@ const refreshIdToken = async (client: ExperienceClient) => {
   }
 
   return decodeIdToken(json.id_token);
-};
-
-/**
- * Verify a registration password for an unused username in a sign-in interaction. The route accepts
- * it, but it never authenticates the identified account.
- */
-const verifyUnusedRegistrationPassword = async (client: ExperienceClient) => {
-  const { username, password } = generateNewUserProfile({ username: true, password: true });
-  await client.createNewPasswordIdentityVerification({
-    identifier: { type: SignInIdentifier.Username, value: username },
-    password,
-  });
 };
 
 devFeatureTest.describe('authentication context claims on sign-in', () => {
@@ -224,39 +211,30 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
     });
 
     it.each([
-      { identifierType: SignInIdentifier.Email, profileKey: 'primaryEmail', amr: ['otp'] },
-      { identifierType: SignInIdentifier.Phone, profileKey: 'primaryPhone', amr: ['sms'] },
+      { identifierType: SignInIdentifier.Email, profileKey: 'primaryEmail' },
+      { identifierType: SignInIdentifier.Phone, profileKey: 'primaryPhone' },
     ] as const)(
-      'does not count an MFA code sent to the same $identifierType as a second factor',
-      async ({ identifierType, profileKey, amr }) => {
+      'refuses an MFA code for the $identifierType that identified the user when the factor is not enabled',
+      async ({ identifierType, profileKey }) => {
         const profile = generateNewUserProfile({ primaryEmail: true, primaryPhone: true });
-        const user = await userApi.create(profile);
+        await userApi.create(profile);
         const identifier = { type: identifierType, value: profile[profileKey] };
 
-        const client = await initClient();
+        const client = await initExperienceClient();
         const { verificationId, code } = await successfullySendVerificationCode(client, {
           identifier,
           interactionEvent: InteractionEvent.SignIn,
         });
         await successfullyVerifyVerificationCode(client, { identifier, verificationId, code });
         await client.identifyUser({ verificationId });
-        // The MFA code route resolves the identified user's primary contact and does not require
-        // the factor to be enabled, so this is a second proof of the same contact.
-        const mfaCode = await successfullySendMfaVerificationCode(client, {
-          identifierType,
-          expectedIdentifierValue: identifier.value,
-        });
-        await successfullyVerifyMfaVerificationCode(client, {
-          identifierType,
-          verificationId: mfaCode.verificationId,
-          code: mfaCode.code,
-        });
-        const claims = await finishSignIn(client);
 
-        expect(claims.sub).toBe(user.id);
-        expect(claims).toMatchObject({ acr: firstFactorAcr, amr });
-
-        await logoutClient(client);
+        // A second code to the same contact would be a second proof of the same factor. The route
+        // refuses it because the sign-in experience does not enable that MFA factor; sign-in with
+        // a contact and MFA through the same contact cannot both be enabled.
+        await expectRejects(client.sendMfaVerificationCode({ identifierType }), {
+          code: 'session.mfa.mfa_factor_not_enabled',
+          status: 400,
+        });
       }
     );
   });
@@ -352,37 +330,26 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
       await logoutClient(client);
     });
 
-    it('does not count an unused registration password as a proof of the account', async () => {
+    it('refuses a registration password in a sign-in interaction', async () => {
+      const { username, password } = generateNewUserProfile({ username: true, password: true });
       const client = await identifySocialUser();
-      await verifyUnusedRegistrationPassword(client);
-      const claims = await finishSignIn(client);
 
+      // A password proposed for an unused username never authenticates the identified account, so
+      // the route only accepts it in a Register interaction.
+      await expectRejects(
+        client.createNewPasswordIdentityVerification({
+          identifier: { type: SignInIdentifier.Username, value: username },
+          password,
+        }),
+        { code: 'session.invalid_interaction_type', status: 400 }
+      );
+
+      const claims = await finishSignIn(client);
       expect(claims.sub).toBe(userId);
       expect(claims.amr).toEqual(['fed']);
       expect(claims).not.toHaveProperty('acr');
 
       await logoutClient(client);
-    });
-
-    it('reaches only 1fa with a TOTP when the password record is an unused registration one', async () => {
-      const totp = await createUserMfaVerification(userId, MfaFactor.TOTP);
-      await createUserMfaVerification(userId, MfaFactor.BackupCode);
-      await enableMandatoryMfaWithTotpAndBackupCode();
-
-      if (totp.type !== MfaFactor.TOTP) {
-        throw new TypeError('unexpected mfa type');
-      }
-
-      const client = await identifySocialUser();
-      await verifyUnusedRegistrationPassword(client);
-      await successfullyVerifyTotp(client, { code: authenticator.generate(totp.secret) });
-      const claims = await finishSignIn(client);
-
-      expect(claims.sub).toBe(userId);
-      expect(claims).toMatchObject({ acr: firstFactorAcr, amr: ['fed', 'otp'] });
-
-      await logoutClient(client);
-      await resetMfaSettings();
     });
   });
 });

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -1,0 +1,174 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { decodeIdToken } from '@logto/js';
+import { Prompt } from '@logto/node';
+import { GrantType, MfaFactor, demoAppApplicationId } from '@logto/schemas';
+import { formUrlEncodedHeaders, generateStandardId } from '@logto/shared';
+import { isKeyInObject } from '@silverhand/essentials';
+import ky from 'ky';
+import { authenticator } from 'otplib';
+
+import { createUserMfaVerification, deleteUser } from '#src/api/admin-user.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { type ExperienceClient } from '#src/client/experience/index.js';
+import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import { clearConnectorsByTypes, setSocialConnector } from '#src/helpers/connector.js';
+import {
+  identifyUserWithUsernamePassword,
+  signInWithSocial,
+} from '#src/helpers/experience/index.js';
+import {
+  successfullyCreateSocialVerification,
+  successfullyVerifySocialAuthorization,
+} from '#src/helpers/experience/social-verification.js';
+import { successfullyVerifyTotp } from '#src/helpers/experience/totp-verification.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableMandatoryMfaWithTotpAndBackupCode,
+  resetMfaSettings,
+} from '#src/helpers/sign-in-experience.js';
+import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest } from '#src/utils.js';
+
+const firstFactorAcr = 'urn:logto:acr:1fa';
+const mfaAcr = 'urn:logto:acr:mfa';
+
+const nowInSeconds = () => Math.floor(Date.now() / 1000);
+
+/** Start an authorization that always prompts for sign-in and issues a refresh token. */
+const initClient = async () =>
+  initExperienceClient({
+    config: {
+      appId: demoAppApplicationId,
+      prompt: Prompt.Login,
+      scopes: ['offline_access'],
+    },
+    redirectUri: demoAppRedirectUri,
+  });
+
+const finishSignIn = async (client: ExperienceClient) => {
+  const { redirectTo } = await client.submitInteraction();
+  await processSession(client, redirectTo);
+  return client.getIdTokenClaims();
+};
+
+/** Rotate the refresh token through the token endpoint and decode the new ID token. */
+const refreshIdToken = async (client: ExperienceClient) => {
+  const refreshToken = await client.getRefreshToken();
+  const json = await ky
+    .post(`${logtoUrl}/oidc/token`, {
+      headers: formUrlEncodedHeaders,
+      body: new URLSearchParams({
+        grant_type: GrantType.RefreshToken,
+        client_id: demoAppApplicationId,
+        refresh_token: refreshToken ?? '',
+      }),
+    })
+    .json();
+
+  if (!isKeyInObject(json, 'id_token') || typeof json.id_token !== 'string') {
+    throw new TypeError('The refresh token grant did not return an ID token');
+  }
+
+  return decodeIdToken(json.id_token);
+};
+
+devFeatureTest.describe('authentication context claims on sign-in', () => {
+  const userApi = new UserApiTest();
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await updateSignInExperience({ adaptiveMfa: { enabled: false } });
+  });
+
+  afterAll(async () => {
+    await resetMfaSettings();
+    await userApi.cleanUp();
+  });
+
+  it('issues acr=1fa, amr=[pwd], and a fresh auth_time for a password sign-in, preserved across refresh', async () => {
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    await userApi.create({ username, password });
+    const client = await initClient();
+    const before = nowInSeconds();
+
+    await identifyUserWithUsernamePassword(client, username, password);
+    const claims = await finishSignIn(client);
+
+    expect(claims).toMatchObject({ acr: firstFactorAcr, amr: ['pwd'] });
+    expect(claims.auth_time).toBeGreaterThanOrEqual(before);
+    expect(claims.auth_time).toBeLessThanOrEqual(nowInSeconds());
+
+    // Refreshing never makes the authentication more recent.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1100);
+    });
+    const refreshed = await refreshIdToken(client);
+    expect(refreshed).toMatchObject({
+      acr: firstFactorAcr,
+      amr: ['pwd'],
+      auth_time: claims.auth_time,
+    });
+
+    await logoutClient(client);
+  });
+
+  it('issues acr=mfa and amr=[pwd, otp, mfa] for a password sign-in verified with TOTP', async () => {
+    await enableMandatoryMfaWithTotpAndBackupCode();
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({ username, password });
+    const totp = await createUserMfaVerification(user.id, MfaFactor.TOTP);
+    await createUserMfaVerification(user.id, MfaFactor.BackupCode);
+
+    if (totp.type !== MfaFactor.TOTP) {
+      throw new TypeError('unexpected mfa type');
+    }
+
+    const client = await initClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+    await successfullyVerifyTotp(client, { code: authenticator.generate(totp.secret) });
+    const claims = await finishSignIn(client);
+
+    expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
+    expect(typeof claims.auth_time).toBe('number');
+
+    await logoutClient(client);
+    await resetMfaSettings();
+  });
+
+  it('issues amr=[fed] and no acr for a social sign-in', async () => {
+    // Let a social user register without a username or password.
+    await enableAllPasswordSignInMethods({ identifiers: [], password: false, verify: false });
+    await clearConnectorsByTypes([ConnectorType.Social]);
+    const { id: connectorId } = await setSocialConnector();
+    const socialUserId = generateStandardId();
+    const socialUserInfo = { id: socialUserId };
+
+    // Register the social user first; only a sign-in seeds the authentication context.
+    const userId = await signInWithSocial(connectorId, socialUserInfo, { registerNewUser: true });
+
+    const client = await initClient();
+    const state = 'state';
+    const redirectUri = 'http://localhost:3000';
+    const { verificationId } = await successfullyCreateSocialVerification(client, connectorId, {
+      redirectUri,
+      state,
+    });
+    await successfullyVerifySocialAuthorization(client, connectorId, {
+      verificationId,
+      connectorData: { state, redirectUri, code: 'fake_code', userId: socialUserId },
+    });
+    await client.identifyUser({ verificationId });
+    const claims = await finishSignIn(client);
+
+    expect(claims.sub).toBe(userId);
+    expect(claims.amr).toEqual(['fed']);
+    expect(claims).not.toHaveProperty('acr');
+    expect(typeof claims.auth_time).toBe('number');
+
+    await logoutClient(client);
+    await clearConnectorsByTypes([ConnectorType.Social]);
+    await deleteUser(userId);
+    await enableAllPasswordSignInMethods();
+  });
+});

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -1,7 +1,13 @@
 import { ConnectorType } from '@logto/connector-kit';
 import { decodeIdToken } from '@logto/js';
 import { Prompt } from '@logto/node';
-import { GrantType, MfaFactor, SignInIdentifier, demoAppApplicationId } from '@logto/schemas';
+import {
+  GrantType,
+  InteractionEvent,
+  MfaFactor,
+  SignInIdentifier,
+  demoAppApplicationId,
+} from '@logto/schemas';
 import { formUrlEncodedHeaders, generateStandardId } from '@logto/shared';
 import { isKeyInObject } from '@silverhand/essentials';
 import ky from 'ky';
@@ -12,7 +18,12 @@ import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { type ExperienceClient } from '#src/client/experience/index.js';
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
 import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
-import { clearConnectorsByTypes, setSocialConnector } from '#src/helpers/connector.js';
+import {
+  clearConnectorsByTypes,
+  setEmailConnector,
+  setSmsConnector,
+  setSocialConnector,
+} from '#src/helpers/connector.js';
 import {
   identifyUserWithUsernamePassword,
   signInWithSocial,
@@ -23,7 +34,14 @@ import {
 } from '#src/helpers/experience/social-verification.js';
 import { successfullyVerifyTotp } from '#src/helpers/experience/totp-verification.js';
 import {
+  successfullySendMfaVerificationCode,
+  successfullySendVerificationCode,
+  successfullyVerifyMfaVerificationCode,
+  successfullyVerifyVerificationCode,
+} from '#src/helpers/experience/verification-code.js';
+import {
   enableAllPasswordSignInMethods,
+  enableAllVerificationCodeSignInMethods,
   enableMandatoryMfaWithTotpAndBackupCode,
   resetMfaSettings,
 } from '#src/helpers/sign-in-experience.js';
@@ -149,6 +167,56 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
 
     await logoutClient(client);
     await resetMfaSettings();
+  });
+
+  describe('verification code sign-in', () => {
+    beforeAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+      await Promise.all([setEmailConnector(), setSmsConnector()]);
+      await enableAllVerificationCodeSignInMethods();
+    });
+
+    afterAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+      await enableAllPasswordSignInMethods();
+    });
+
+    it.each([
+      { identifierType: SignInIdentifier.Email, profileKey: 'primaryEmail', amr: ['otp'] },
+      { identifierType: SignInIdentifier.Phone, profileKey: 'primaryPhone', amr: ['sms'] },
+    ] as const)(
+      'does not count an MFA code sent to the same $identifierType as a second factor',
+      async ({ identifierType, profileKey, amr }) => {
+        const profile = generateNewUserProfile({ primaryEmail: true, primaryPhone: true });
+        const user = await userApi.create(profile);
+        const identifier = { type: identifierType, value: profile[profileKey] };
+
+        const client = await initClient();
+        const { verificationId, code } = await successfullySendVerificationCode(client, {
+          identifier,
+          interactionEvent: InteractionEvent.SignIn,
+        });
+        await successfullyVerifyVerificationCode(client, { identifier, verificationId, code });
+        await client.identifyUser({ verificationId });
+        // The MFA code route resolves the identified user's primary contact and does not require
+        // the factor to be enabled, so this is a second proof of the same contact.
+        const mfaCode = await successfullySendMfaVerificationCode(client, {
+          identifierType,
+          expectedIdentifierValue: identifier.value,
+        });
+        await successfullyVerifyMfaVerificationCode(client, {
+          identifierType,
+          verificationId: mfaCode.verificationId,
+          code: mfaCode.code,
+        });
+        const claims = await finishSignIn(client);
+
+        expect(claims.sub).toBe(user.id);
+        expect(claims).toMatchObject({ acr: firstFactorAcr, amr });
+
+        await logoutClient(client);
+      }
+    );
   });
 
   describe('social sign-in', () => {

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -35,12 +35,15 @@ const mfaAcr = 'urn:logto:acr:mfa';
 
 const nowInSeconds = () => Math.floor(Date.now() / 1000);
 
-/** Start an authorization that always prompts for sign-in and issues a refresh token. */
+/**
+ * Start an authorization on a fresh client (so a sign-in is always required) that issues a
+ * refresh token: the provider only issues one for `offline_access` under `prompt=consent`.
+ */
 const initClient = async () =>
   initExperienceClient({
     config: {
       appId: demoAppApplicationId,
-      prompt: Prompt.Login,
+      prompt: Prompt.Consent,
       scopes: ['offline_access'],
     },
     redirectUri: demoAppRedirectUri,

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -1,7 +1,7 @@
 import { ConnectorType } from '@logto/connector-kit';
 import { decodeIdToken } from '@logto/js';
 import { Prompt } from '@logto/node';
-import { GrantType, MfaFactor, demoAppApplicationId } from '@logto/schemas';
+import { GrantType, MfaFactor, SignInIdentifier, demoAppApplicationId } from '@logto/schemas';
 import { formUrlEncodedHeaders, generateStandardId } from '@logto/shared';
 import { isKeyInObject } from '@silverhand/essentials';
 import ky from 'ky';
@@ -76,6 +76,18 @@ const refreshIdToken = async (client: ExperienceClient) => {
   return decodeIdToken(json.id_token);
 };
 
+/**
+ * Verify a registration password for an unused username in a sign-in interaction. The route accepts
+ * it, but it never authenticates the identified account.
+ */
+const verifyUnusedRegistrationPassword = async (client: ExperienceClient) => {
+  const { username, password } = generateNewUserProfile({ username: true, password: true });
+  await client.createNewPasswordIdentityVerification({
+    identifier: { type: SignInIdentifier.Username, value: username },
+    password,
+  });
+};
+
 devFeatureTest.describe('authentication context claims on sign-in', () => {
   const userApi = new UserApiTest();
 
@@ -139,39 +151,93 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
     await resetMfaSettings();
   });
 
-  it('issues amr=[fed] and no acr for a social sign-in', async () => {
-    // Let a social user register without a username or password.
-    await enableAllPasswordSignInMethods({ identifiers: [], password: false, verify: false });
-    await clearConnectorsByTypes([ConnectorType.Social]);
-    const { id: connectorId } = await setSocialConnector();
-    const socialUserId = generateStandardId();
-    const socialUserInfo = { id: socialUserId };
+  describe('social sign-in', () => {
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let connectorId: string;
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let socialUserId: string;
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let userId: string;
 
-    // Register the social user first; only a sign-in seeds the authentication context.
-    const userId = await signInWithSocial(connectorId, socialUserInfo, { registerNewUser: true });
-
-    const client = await initClient();
-    const state = 'state';
-    const redirectUri = 'http://localhost:3000';
-    const { verificationId } = await successfullyCreateSocialVerification(client, connectorId, {
-      redirectUri,
-      state,
+    beforeAll(async () => {
+      // Let a social user register without a username or password.
+      await enableAllPasswordSignInMethods({ identifiers: [], password: false, verify: false });
+      await clearConnectorsByTypes([ConnectorType.Social]);
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      ({ id: connectorId } = await setSocialConnector());
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      socialUserId = generateStandardId();
+      // Register the social user first; only a sign-in seeds the authentication context.
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      userId = await signInWithSocial(connectorId, { id: socialUserId }, { registerNewUser: true });
     });
-    await successfullyVerifySocialAuthorization(client, connectorId, {
-      verificationId,
-      connectorData: { state, redirectUri, code: 'fake_code', userId: socialUserId },
+
+    afterAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Social]);
+      await deleteUser(userId);
+      await enableAllPasswordSignInMethods();
     });
-    await client.identifyUser({ verificationId });
-    const claims = await finishSignIn(client);
 
-    expect(claims.sub).toBe(userId);
-    expect(claims.amr).toEqual(['fed']);
-    expect(claims).not.toHaveProperty('acr');
-    expect(typeof claims.auth_time).toBe('number');
+    /** Start a sign-in on a fresh client and identify the social user without submitting. */
+    const identifySocialUser = async () => {
+      const client = await initClient();
+      const state = 'state';
+      const redirectUri = 'http://localhost:3000';
+      const { verificationId } = await successfullyCreateSocialVerification(client, connectorId, {
+        redirectUri,
+        state,
+      });
+      await successfullyVerifySocialAuthorization(client, connectorId, {
+        verificationId,
+        connectorData: { state, redirectUri, code: 'fake_code', userId: socialUserId },
+      });
+      await client.identifyUser({ verificationId });
+      return client;
+    };
 
-    await logoutClient(client);
-    await clearConnectorsByTypes([ConnectorType.Social]);
-    await deleteUser(userId);
-    await enableAllPasswordSignInMethods();
+    it('issues amr=[fed] and no acr', async () => {
+      const client = await identifySocialUser();
+      const claims = await finishSignIn(client);
+
+      expect(claims.sub).toBe(userId);
+      expect(claims.amr).toEqual(['fed']);
+      expect(claims).not.toHaveProperty('acr');
+      expect(typeof claims.auth_time).toBe('number');
+
+      await logoutClient(client);
+    });
+
+    it('does not count an unused registration password as a proof of the account', async () => {
+      const client = await identifySocialUser();
+      await verifyUnusedRegistrationPassword(client);
+      const claims = await finishSignIn(client);
+
+      expect(claims.sub).toBe(userId);
+      expect(claims.amr).toEqual(['fed']);
+      expect(claims).not.toHaveProperty('acr');
+
+      await logoutClient(client);
+    });
+
+    it('reaches only 1fa with a TOTP when the password record is an unused registration one', async () => {
+      const totp = await createUserMfaVerification(userId, MfaFactor.TOTP);
+      await createUserMfaVerification(userId, MfaFactor.BackupCode);
+      await enableMandatoryMfaWithTotpAndBackupCode();
+
+      if (totp.type !== MfaFactor.TOTP) {
+        throw new TypeError('unexpected mfa type');
+      }
+
+      const client = await identifySocialUser();
+      await verifyUnusedRegistrationPassword(client);
+      await successfullyVerifyTotp(client, { code: authenticator.generate(totp.secret) });
+      const claims = await finishSignIn(client);
+
+      expect(claims.sub).toBe(userId);
+      expect(claims).toMatchObject({ acr: firstFactorAcr, amr: ['fed', 'otp'] });
+
+      await logoutClient(client);
+      await resetMfaSettings();
+    });
   });
 });

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -5,6 +5,7 @@ import {
   GrantType,
   InteractionEvent,
   MfaFactor,
+  MfaPolicy,
   SignInIdentifier,
   demoAppApplicationId,
 } from '@logto/schemas';
@@ -13,7 +14,11 @@ import { isKeyInObject } from '@silverhand/essentials';
 import ky from 'ky';
 import { authenticator } from 'otplib';
 
-import { createUserMfaVerification, deleteUser } from '#src/api/admin-user.js';
+import {
+  createUserMfaVerification,
+  deleteUser,
+  updateUserLogtoConfig,
+} from '#src/api/admin-user.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { type ExperienceClient } from '#src/client/experience/index.js';
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
@@ -164,6 +169,43 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
 
     expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
     expect(typeof claims.auth_time).toBe('number');
+
+    await logoutClient(client);
+    await resetMfaSettings();
+  });
+
+  it('keeps the proof of the last backup code, which is marked used before submission', async () => {
+    // A sign-in that completes without an MFA challenge, so the consumed code is the only proof.
+    await updateSignInExperience({
+      mfa: { factors: [MfaFactor.TOTP, MfaFactor.BackupCode], policy: MfaPolicy.NoPrompt },
+    });
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({ username, password });
+    await createUserMfaVerification(user.id, MfaFactor.TOTP);
+    const backupCodes = await createUserMfaVerification(user.id, MfaFactor.BackupCode);
+    await updateUserLogtoConfig(user.id, { mfa: { skipMfaOnSignIn: true }, passkeySignIn: {} });
+
+    if (backupCodes.type !== MfaFactor.BackupCode) {
+      throw new TypeError('unexpected mfa type');
+    }
+
+    const [lastCode, ...otherCodes] = backupCodes.codes;
+
+    // Consume every other code first; each verification marks its code used in the database.
+    const consumer = await initClient();
+    await identifyUserWithUsernamePassword(consumer, username, password);
+    for (const code of otherCodes) {
+      // eslint-disable-next-line no-await-in-loop -- Each code must be consumed in sequence.
+      await consumer.verifyBackupCode({ code });
+    }
+
+    const client = await initClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+    await client.verifyBackupCode({ code: lastCode! });
+    const claims = await finishSignIn(client);
+
+    expect(claims.sub).toBe(user.id);
+    expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
 
     await logoutClient(client);
     await resetMfaSettings();

--- a/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
@@ -171,6 +171,9 @@ describe('OIDC discovery', () => {
         "claims_parameter_supported": false,
         "claims_supported": [
           "sub",
+          "acr",
+          "amr",
+          "auth_time",
           "name",
           "family_name",
           "given_name",
@@ -199,11 +202,8 @@ describe('OIDC discovery', () => {
           "organizations",
           "organization_data",
           "organization_roles",
-          "acr",
           "sid",
-          "auth_time",
           "iss",
-          "amr",
         ],
         "code_challenge_methods_supported": [
           "S256",

--- a/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
@@ -1,6 +1,7 @@
 import ky from 'ky';
 
 import { discoveryUrl, logtoUrl } from '#src/constants.js';
+import { devFeatureDisabledTest, devFeatureTest } from '#src/utils.js';
 
 const normalizeEndpoint = (value: unknown): unknown => {
   if (typeof value === 'string') {
@@ -26,7 +27,7 @@ describe('OIDC discovery', () => {
    * advertises `ES384`. An instance seeded with an RSA signing key reports different
    * `id_token_signing_alg_values_supported` and fails this snapshot.
    */
-  it('exposes the reviewed provider metadata', async () => {
+  devFeatureDisabledTest.it('exposes the reviewed provider metadata', async () => {
     const discovery = await ky.get(discoveryUrl).json();
 
     expect(normalizeEndpoint(discovery)).toMatchInlineSnapshot(`
@@ -144,6 +145,138 @@ describe('OIDC discovery', () => {
       }
     `);
   });
+
+  /**
+   * The step-up authentication context (`acr_values_supported`, `acr`, `amr`) is advertised only
+   * while it is behind the dev feature flag; the disabled snapshot must stay byte-for-byte unchanged.
+   */
+  devFeatureTest.it(
+    'exposes the reviewed provider metadata with the step-up authentication context',
+    async () => {
+      const discovery = await ky.get(discoveryUrl).json();
+
+      expect(normalizeEndpoint(discovery)).toMatchInlineSnapshot(`
+      {
+        "acr_values_supported": [
+          "urn:logto:acr:1fa",
+          "urn:logto:acr:mfa",
+        ],
+        "authorization_endpoint": "<logto-url>/oidc/auth",
+        "authorization_response_iss_parameter_supported": true,
+        "backchannel_logout_session_supported": true,
+        "backchannel_logout_supported": true,
+        "claim_types_supported": [
+          "normal",
+        ],
+        "claims_parameter_supported": false,
+        "claims_supported": [
+          "sub",
+          "name",
+          "family_name",
+          "given_name",
+          "middle_name",
+          "nickname",
+          "preferred_username",
+          "profile",
+          "picture",
+          "website",
+          "gender",
+          "birthdate",
+          "zoneinfo",
+          "locale",
+          "updated_at",
+          "username",
+          "created_at",
+          "email",
+          "email_verified",
+          "phone_number",
+          "phone_number_verified",
+          "address",
+          "custom_data",
+          "identities",
+          "sso_identities",
+          "roles",
+          "organizations",
+          "organization_data",
+          "organization_roles",
+          "acr",
+          "sid",
+          "auth_time",
+          "iss",
+          "amr",
+        ],
+        "code_challenge_methods_supported": [
+          "S256",
+        ],
+        "device_authorization_endpoint": "<logto-url>/oidc/device/auth",
+        "end_session_endpoint": "<logto-url>/oidc/session/end",
+        "grant_types_supported": [
+          "implicit",
+          "authorization_code",
+          "refresh_token",
+          "client_credentials",
+          "urn:ietf:params:oauth:grant-type:device_code",
+          "urn:ietf:params:oauth:grant-type:token-exchange",
+        ],
+        "id_token_signing_alg_values_supported": [
+          "ES384",
+        ],
+        "introspection_endpoint": "<logto-url>/oidc/token/introspection",
+        "issuer": "<logto-url>/oidc",
+        "jwks_uri": "<logto-url>/oidc/jwks",
+        "pushed_authorization_request_endpoint": "<logto-url>/oidc/request",
+        "request_uri_parameter_supported": false,
+        "response_modes_supported": [
+          "form_post",
+          "fragment",
+          "query",
+        ],
+        "response_types_supported": [
+          "code id_token",
+          "code",
+          "id_token",
+          "none",
+        ],
+        "revocation_endpoint": "<logto-url>/oidc/token/revocation",
+        "scopes_supported": [
+          "openid",
+          "offline_access",
+          "profile",
+          "email",
+          "phone",
+          "address",
+          "custom_data",
+          "identities",
+          "roles",
+          "urn:logto:scope:organizations",
+          "urn:logto:scope:organization_roles",
+          "urn:logto:scope:sessions",
+          "urn:logto:scope:trusted_devices",
+        ],
+        "subject_types_supported": [
+          "public",
+        ],
+        "token_endpoint": "<logto-url>/oidc/token",
+        "token_endpoint_auth_methods_supported": [
+          "client_secret_basic",
+          "client_secret_jwt",
+          "client_secret_post",
+          "private_key_jwt",
+          "none",
+        ],
+        "token_endpoint_auth_signing_alg_values_supported": [
+          "HS256",
+          "RS256",
+          "PS256",
+          "ES256",
+          "Ed25519",
+          "EdDSA",
+        ],
+        "userinfo_endpoint": "<logto-url>/oidc/me",
+      }
+    `);
+    }
+  );
 
   /**
    * Since oidc-provider 9.2.0 the RFC 8414 `/.well-known/oauth-authorization-server` route is

--- a/packages/schemas/src/types/authentication-context.test.ts
+++ b/packages/schemas/src/types/authentication-context.test.ts
@@ -4,7 +4,9 @@ import {
   AuthenticationFactor,
   AuthenticationFactorClass,
   AuthenticationMethodReference,
+  AuthenticationProofRole,
   LogtoAcr,
+  authenticationProofGuard,
   buildAuthenticationMethodReferences,
   getAuthenticationFactor,
   getAuthenticationFactorClass,
@@ -35,11 +37,18 @@ describe('getAuthenticationFactorClass', () => {
     VerificationType.MfaEmailVerificationCode,
     VerificationType.MfaPhoneVerificationCode,
     VerificationType.BackupCode,
-    VerificationType.WebAuthn,
-    VerificationType.SignInPasskey,
   ])('classifies %s as mfa', (type) => {
     expect(getAuthenticationFactorClass(type)).toBe(AuthenticationFactorClass.Mfa);
   });
+
+  // A user-verified WebAuthn authenticator is possession plus user verification in one act, and
+  // Logto requires user verification for the registration and the authentication ceremony alike.
+  it.each([VerificationType.WebAuthn, VerificationType.SignInPasskey])(
+    'classifies %s as both',
+    (type) => {
+      expect(getAuthenticationFactorClass(type)).toBe(AuthenticationFactorClass.Both);
+    }
+  );
 
   it.each([VerificationType.Social, VerificationType.EnterpriseSso])(
     'gives %s no class',
@@ -107,11 +116,14 @@ describe('getAuthenticationMethodReferences', () => {
   });
 });
 
+const references = (...types: VerificationType[]) =>
+  types.map((type) => getAuthenticationMethodReferences(type));
+
 describe('buildAuthenticationMethodReferences', () => {
   it('unions references in first-seen order without duplicates', () => {
     expect(
       buildAuthenticationMethodReferences(
-        [VerificationType.Password, VerificationType.TOTP, VerificationType.BackupCode],
+        references(VerificationType.Password, VerificationType.TOTP, VerificationType.BackupCode),
         LogtoAcr.FirstFactor
       )
     ).toEqual(['pwd', 'otp']);
@@ -120,37 +132,82 @@ describe('buildAuthenticationMethodReferences', () => {
   it('appends `mfa` when the achieved ACR is mfa', () => {
     expect(
       buildAuthenticationMethodReferences(
-        [VerificationType.Password, VerificationType.TOTP],
+        references(VerificationType.Password, VerificationType.TOTP),
         LogtoAcr.Mfa
       )
     ).toEqual(['pwd', 'otp', 'mfa']);
   });
 
   it('does not duplicate `mfa` for WebAuthn', () => {
-    expect(buildAuthenticationMethodReferences([VerificationType.WebAuthn], LogtoAcr.Mfa)).toEqual([
-      'pop',
-      'user',
-      'mfa',
-    ]);
+    expect(
+      buildAuthenticationMethodReferences(references(VerificationType.WebAuthn), LogtoAcr.Mfa)
+    ).toEqual(['pop', 'user', 'mfa']);
   });
 
   it('keeps `mfa` last when a WebAuthn record precedes another factor', () => {
     expect(
       buildAuthenticationMethodReferences(
-        [VerificationType.WebAuthn, VerificationType.Password],
+        references(VerificationType.WebAuthn, VerificationType.Password),
         LogtoAcr.Mfa
       )
     ).toEqual(['pop', 'user', 'pwd', 'mfa']);
     // WebAuthn carries `mfa` on its own even when no ACR is passed.
     expect(
-      buildAuthenticationMethodReferences([VerificationType.WebAuthn, VerificationType.Password])
+      buildAuthenticationMethodReferences(
+        references(VerificationType.WebAuthn, VerificationType.Password)
+      )
     ).toEqual(['pop', 'user', 'pwd', 'mfa']);
   });
 
   it('keeps `fed` next to an established factor without an ACR', () => {
     expect(
-      buildAuthenticationMethodReferences([VerificationType.Social, VerificationType.Password])
+      buildAuthenticationMethodReferences(
+        references(VerificationType.Social, VerificationType.Password)
+      )
     ).toEqual(['fed', 'pwd']);
-    expect(buildAuthenticationMethodReferences([VerificationType.Social])).toEqual(['fed']);
+    expect(buildAuthenticationMethodReferences(references(VerificationType.Social))).toEqual([
+      'fed',
+    ]);
+  });
+
+  it('returns nothing for no references', () => {
+    expect(buildAuthenticationMethodReferences([])).toEqual([]);
+  });
+});
+
+describe('authenticationProofGuard', () => {
+  it('accepts a proof with and without a class', () => {
+    expect(
+      authenticationProofGuard.safeParse({
+        id: 'totp',
+        factor: AuthenticationFactor.Totp,
+        class: AuthenticationFactorClass.Mfa,
+        amr: ['otp'],
+        role: AuthenticationProofRole.Mfa,
+        at: 1_700_000_000,
+      }).success
+    ).toBe(true);
+    expect(
+      authenticationProofGuard.safeParse({
+        id: 'social',
+        factor: AuthenticationFactor.Federated,
+        amr: ['fed'],
+        role: AuthenticationProofRole.Identify,
+        at: 1_700_000_000,
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects a non-integer or negative timestamp', () => {
+    const proof = {
+      id: 'password',
+      factor: AuthenticationFactor.Password,
+      class: AuthenticationFactorClass.FirstFactor,
+      amr: ['pwd'],
+      role: AuthenticationProofRole.Identify,
+    };
+
+    expect(authenticationProofGuard.safeParse({ ...proof, at: 1.5 }).success).toBe(false);
+    expect(authenticationProofGuard.safeParse({ ...proof, at: -1 }).success).toBe(false);
   });
 });

--- a/packages/schemas/src/types/authentication-context.test.ts
+++ b/packages/schemas/src/types/authentication-context.test.ts
@@ -144,6 +144,19 @@ describe('buildAuthenticationMethodReferences', () => {
     ]);
   });
 
+  it('keeps `mfa` last when a WebAuthn record precedes another factor', () => {
+    expect(
+      buildAuthenticationMethodReferences(
+        [VerificationType.WebAuthn, VerificationType.Password],
+        LogtoAcr.Mfa
+      )
+    ).toEqual(['pop', 'user', 'pwd', 'mfa']);
+    // WebAuthn carries `mfa` on its own even when no ACR is passed.
+    expect(
+      buildAuthenticationMethodReferences([VerificationType.WebAuthn, VerificationType.Password])
+    ).toEqual(['pop', 'user', 'pwd', 'mfa']);
+  });
+
   it('keeps `fed` next to an established factor without an ACR', () => {
     expect(
       buildAuthenticationMethodReferences([VerificationType.Social, VerificationType.Password])

--- a/packages/schemas/src/types/authentication-context.test.ts
+++ b/packages/schemas/src/types/authentication-context.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  AuthenticationFactor,
   AuthenticationFactorClass,
   AuthenticationMethodReference,
   LogtoAcr,
   buildAuthenticationMethodReferences,
+  getAuthenticationFactor,
   getAuthenticationFactorClass,
   getAuthenticationMethodReferences,
   logtoAcrValues,
@@ -45,6 +47,26 @@ describe('getAuthenticationFactorClass', () => {
       expect(getAuthenticationFactorClass(type)).toBeUndefined();
     }
   );
+});
+
+describe('getAuthenticationFactor', () => {
+  it.each([
+    [VerificationType.Password, AuthenticationFactor.Password],
+    [VerificationType.NewPasswordIdentity, AuthenticationFactor.Password],
+    [VerificationType.EmailVerificationCode, AuthenticationFactor.Email],
+    [VerificationType.MfaEmailVerificationCode, AuthenticationFactor.Email],
+    [VerificationType.OneTimeToken, AuthenticationFactor.Email],
+    [VerificationType.PhoneVerificationCode, AuthenticationFactor.Phone],
+    [VerificationType.MfaPhoneVerificationCode, AuthenticationFactor.Phone],
+    [VerificationType.TOTP, AuthenticationFactor.Totp],
+    [VerificationType.BackupCode, AuthenticationFactor.BackupCode],
+    [VerificationType.WebAuthn, AuthenticationFactor.WebAuthn],
+    [VerificationType.SignInPasskey, AuthenticationFactor.WebAuthn],
+    [VerificationType.Social, AuthenticationFactor.Federated],
+    [VerificationType.EnterpriseSso, AuthenticationFactor.Federated],
+  ])('maps %s to the %s factor', (type, expected) => {
+    expect(getAuthenticationFactor(type)).toBe(expected);
+  });
 });
 
 describe('getAuthenticationMethodReferences', () => {

--- a/packages/schemas/src/types/authentication-context.test.ts
+++ b/packages/schemas/src/types/authentication-context.test.ts
@@ -4,11 +4,9 @@ import {
   AuthenticationFactorClass,
   AuthenticationMethodReference,
   LogtoAcr,
-  acrSatisfies,
   buildAuthenticationMethodReferences,
   getAuthenticationFactorClass,
   getAuthenticationMethodReferences,
-  isLogtoAcr,
   logtoAcrValues,
 } from './authentication-context.js';
 import { VerificationType } from './verification-records/verification-type.js';
@@ -16,36 +14,6 @@ import { VerificationType } from './verification-records/verification-type.js';
 describe('logtoAcrValues', () => {
   it('advertises exactly the two Logto classes in order', () => {
     expect(logtoAcrValues).toEqual(['urn:logto:acr:1fa', 'urn:logto:acr:mfa']);
-  });
-
-  it.each(['urn:logto:acr:1fa', 'urn:logto:acr:mfa'])('recognizes %s', (value) => {
-    expect(isLogtoAcr(value)).toBe(true);
-  });
-
-  it.each(['phr', 'urn:logto:acr:3fa', '', undefined, 1])('rejects %o', (value) => {
-    expect(isLogtoAcr(value)).toBe(false);
-  });
-});
-
-describe('acrSatisfies', () => {
-  it.each([
-    [LogtoAcr.FirstFactor, LogtoAcr.FirstFactor, true],
-    [LogtoAcr.Mfa, LogtoAcr.Mfa, true],
-    [LogtoAcr.Mfa, LogtoAcr.FirstFactor, true],
-    [LogtoAcr.FirstFactor, LogtoAcr.Mfa, false],
-  ])('achieved %s vs requested %s → %s', (achieved, requested, expected) => {
-    expect(acrSatisfies(achieved, requested)).toBe(expected);
-  });
-
-  it('never satisfies an unsupported requested value', () => {
-    expect(acrSatisfies(LogtoAcr.Mfa, 'phr')).toBe(false);
-    expect(acrSatisfies(LogtoAcr.Mfa, 'urn:logto:acr:3fa')).toBe(false);
-  });
-
-  it('never satisfies from an unsupported or missing achieved value', () => {
-    expect(acrSatisfies('phr', LogtoAcr.FirstFactor)).toBe(false);
-    expect(acrSatisfies(undefined, LogtoAcr.FirstFactor)).toBe(false);
-    expect(acrSatisfies('', LogtoAcr.FirstFactor)).toBe(false);
   });
 });
 

--- a/packages/schemas/src/types/authentication-context.test.ts
+++ b/packages/schemas/src/types/authentication-context.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AuthenticationFactorClass,
+  AuthenticationMethodReference,
+  LogtoAcr,
+  acrSatisfies,
+  buildAuthenticationMethodReferences,
+  getAuthenticationFactorClass,
+  getAuthenticationMethodReferences,
+  isLogtoAcr,
+  logtoAcrValues,
+} from './authentication-context.js';
+import { VerificationType } from './verification-records/verification-type.js';
+
+describe('logtoAcrValues', () => {
+  it('advertises exactly the two Logto classes in order', () => {
+    expect(logtoAcrValues).toEqual(['urn:logto:acr:1fa', 'urn:logto:acr:mfa']);
+  });
+
+  it.each(['urn:logto:acr:1fa', 'urn:logto:acr:mfa'])('recognizes %s', (value) => {
+    expect(isLogtoAcr(value)).toBe(true);
+  });
+
+  it.each(['phr', 'urn:logto:acr:3fa', '', undefined, 1])('rejects %o', (value) => {
+    expect(isLogtoAcr(value)).toBe(false);
+  });
+});
+
+describe('acrSatisfies', () => {
+  it.each([
+    [LogtoAcr.FirstFactor, LogtoAcr.FirstFactor, true],
+    [LogtoAcr.Mfa, LogtoAcr.Mfa, true],
+    [LogtoAcr.Mfa, LogtoAcr.FirstFactor, true],
+    [LogtoAcr.FirstFactor, LogtoAcr.Mfa, false],
+  ])('achieved %s vs requested %s → %s', (achieved, requested, expected) => {
+    expect(acrSatisfies(achieved, requested)).toBe(expected);
+  });
+
+  it('never satisfies an unsupported requested value', () => {
+    expect(acrSatisfies(LogtoAcr.Mfa, 'phr')).toBe(false);
+    expect(acrSatisfies(LogtoAcr.Mfa, 'urn:logto:acr:3fa')).toBe(false);
+  });
+
+  it('never satisfies from an unsupported or missing achieved value', () => {
+    expect(acrSatisfies('phr', LogtoAcr.FirstFactor)).toBe(false);
+    expect(acrSatisfies(undefined, LogtoAcr.FirstFactor)).toBe(false);
+    expect(acrSatisfies('', LogtoAcr.FirstFactor)).toBe(false);
+  });
+});
+
+describe('getAuthenticationFactorClass', () => {
+  it.each([
+    VerificationType.Password,
+    VerificationType.EmailVerificationCode,
+    VerificationType.PhoneVerificationCode,
+    VerificationType.OneTimeToken,
+    VerificationType.NewPasswordIdentity,
+  ])('classifies %s as 1fa', (type) => {
+    expect(getAuthenticationFactorClass(type)).toBe(AuthenticationFactorClass.FirstFactor);
+  });
+
+  it.each([
+    VerificationType.TOTP,
+    VerificationType.MfaEmailVerificationCode,
+    VerificationType.MfaPhoneVerificationCode,
+    VerificationType.BackupCode,
+    VerificationType.WebAuthn,
+    VerificationType.SignInPasskey,
+  ])('classifies %s as mfa', (type) => {
+    expect(getAuthenticationFactorClass(type)).toBe(AuthenticationFactorClass.Mfa);
+  });
+
+  it.each([VerificationType.Social, VerificationType.EnterpriseSso])(
+    'gives %s no class',
+    (type) => {
+      expect(getAuthenticationFactorClass(type)).toBeUndefined();
+    }
+  );
+});
+
+describe('getAuthenticationMethodReferences', () => {
+  it.each([
+    [VerificationType.Password, ['pwd']],
+    [VerificationType.NewPasswordIdentity, ['pwd']],
+    [VerificationType.EmailVerificationCode, ['otp']],
+    [VerificationType.OneTimeToken, ['otp']],
+    [VerificationType.TOTP, ['otp']],
+    [VerificationType.MfaEmailVerificationCode, ['otp']],
+    [VerificationType.BackupCode, ['otp']],
+    [VerificationType.PhoneVerificationCode, ['sms']],
+    [VerificationType.MfaPhoneVerificationCode, ['sms']],
+    [VerificationType.WebAuthn, ['pop', 'user', 'mfa']],
+    [VerificationType.SignInPasskey, ['pop', 'user', 'mfa']],
+    [VerificationType.Social, ['fed']],
+    [VerificationType.EnterpriseSso, ['fed']],
+  ])('maps %s to %j', (type, expected) => {
+    expect(getAuthenticationMethodReferences(type)).toEqual(expected);
+  });
+
+  it('maps every verification type', () => {
+    for (const type of Object.values(VerificationType)) {
+      expect(getAuthenticationMethodReferences(type).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('emits `fed` as the only unregistered AMR value', () => {
+    // RFC 8176 / IANA registered values used by Logto.
+    const registered = new Set(['pwd', 'otp', 'sms', 'pop', 'user', 'mfa']);
+    const emitted = new Set(
+      Object.values(VerificationType).flatMap((type) => getAuthenticationMethodReferences(type))
+    );
+
+    expect([...emitted].filter((value) => !registered.has(value))).toEqual([
+      AuthenticationMethodReference.Federated,
+    ]);
+  });
+});
+
+describe('buildAuthenticationMethodReferences', () => {
+  it('unions references in first-seen order without duplicates', () => {
+    expect(
+      buildAuthenticationMethodReferences(
+        [VerificationType.Password, VerificationType.TOTP, VerificationType.BackupCode],
+        LogtoAcr.FirstFactor
+      )
+    ).toEqual(['pwd', 'otp']);
+  });
+
+  it('appends `mfa` when the achieved ACR is mfa', () => {
+    expect(
+      buildAuthenticationMethodReferences(
+        [VerificationType.Password, VerificationType.TOTP],
+        LogtoAcr.Mfa
+      )
+    ).toEqual(['pwd', 'otp', 'mfa']);
+  });
+
+  it('does not duplicate `mfa` for WebAuthn', () => {
+    expect(buildAuthenticationMethodReferences([VerificationType.WebAuthn], LogtoAcr.Mfa)).toEqual([
+      'pop',
+      'user',
+      'mfa',
+    ]);
+  });
+
+  it('keeps `fed` next to an established factor without an ACR', () => {
+    expect(
+      buildAuthenticationMethodReferences([VerificationType.Social, VerificationType.Password])
+    ).toEqual(['fed', 'pwd']);
+    expect(buildAuthenticationMethodReferences([VerificationType.Social])).toEqual(['fed']);
+  });
+});

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -75,7 +75,8 @@ const authenticationFactorClasses: Readonly<
   [VerificationType.EmailVerificationCode]: AuthenticationFactorClass.FirstFactor,
   [VerificationType.PhoneVerificationCode]: AuthenticationFactorClass.FirstFactor,
   [VerificationType.OneTimeToken]: AuthenticationFactorClass.FirstFactor,
-  // A password established in this interaction counts as a verified first factor.
+  // The class of a password established by a registration. The account does not exist while the
+  // record is verified, so the sign-in derivation in core never counts the record as a proof.
   [VerificationType.NewPasswordIdentity]: AuthenticationFactorClass.FirstFactor,
   [VerificationType.TOTP]: AuthenticationFactorClass.Mfa,
   [VerificationType.MfaEmailVerificationCode]: AuthenticationFactorClass.Mfa,

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -6,6 +6,10 @@
  * @see {@link https://openid.net/specs/openid-connect-core-1_0.html#IDToken | OpenID Connect Core `acr` / `amr`}
  * @see {@link https://www.rfc-editor.org/rfc/rfc8176.html | RFC 8176 Authentication Method Reference Values}
  */
+import { z } from 'zod';
+
+import { type ToZodObject } from '../utils/zod.js';
+
 import { VerificationType } from './verification-records/verification-type.js';
 
 /** The Logto-defined ACR values. Only these can be requested through `acr_values`. */
@@ -48,25 +52,30 @@ export enum AuthenticationMethodReference {
   Federated = 'fed',
 }
 
-/** The class a verification record contributes toward an ACR. */
+/** The class a proof contributes toward an ACR. */
 export enum AuthenticationFactorClass {
   /** Contributes {@link LogtoAcr.FirstFactor}. */
   FirstFactor = '1fa',
   /**
-   * Contributes an `mfa`-class record. Combined with a {@link AuthenticationFactorClass.FirstFactor}
-   * record from a different factor it reaches {@link LogtoAcr.Mfa}; alone it reaches only
-   * {@link LogtoAcr.FirstFactor}, except WebAuthn / passkey with required user verification.
+   * Contributes an `mfa`-class proof. Combined with a {@link AuthenticationFactorClass.FirstFactor}
+   * proof of a different factor it reaches {@link LogtoAcr.Mfa}; alone it reaches only
+   * {@link LogtoAcr.FirstFactor}.
    */
   Mfa = 'mfa',
+  /**
+   * Satisfies the `1fa` and the `mfa` role by itself: a user-verified WebAuthn authenticator is
+   * possession plus user verification in one act, so it reaches {@link LogtoAcr.Mfa} alone.
+   */
+  Both = 'both',
 }
 
 /**
- * The class each verification type contributes: `1fa`-class, `mfa`-class, or `undefined` for
- * social / enterprise SSO, which contribute `fed` to AMR but nothing to the ACR.
+ * The class each verification type contributes: `1fa`-class, `mfa`-class, `both`, or `undefined`
+ * for social / enterprise SSO, which contribute `fed` to AMR but nothing to the ACR.
  *
  * The record is keyed by every {@link VerificationType}, so a new type fails at compile time until
- * it is mapped here. Whether a WebAuthn assertion actually required user verification is decided at
- * derivation time; this table only says which class the type can contribute.
+ * it is mapped here. Logto requires user verification for every WebAuthn ceremony, registration and
+ * authentication alike, so a verified WebAuthn record is user-verified by construction.
  */
 const authenticationFactorClasses: Readonly<
   Record<VerificationType, AuthenticationFactorClass | undefined>
@@ -75,15 +84,14 @@ const authenticationFactorClasses: Readonly<
   [VerificationType.EmailVerificationCode]: AuthenticationFactorClass.FirstFactor,
   [VerificationType.PhoneVerificationCode]: AuthenticationFactorClass.FirstFactor,
   [VerificationType.OneTimeToken]: AuthenticationFactorClass.FirstFactor,
-  // The class of a password established by a registration. The account does not exist while the
-  // record is verified, so the sign-in derivation in core never counts the record as a proof.
+  // A password established by a registration; it is a proof once `createUser()` consumes it.
   [VerificationType.NewPasswordIdentity]: AuthenticationFactorClass.FirstFactor,
   [VerificationType.TOTP]: AuthenticationFactorClass.Mfa,
   [VerificationType.MfaEmailVerificationCode]: AuthenticationFactorClass.Mfa,
   [VerificationType.MfaPhoneVerificationCode]: AuthenticationFactorClass.Mfa,
   [VerificationType.BackupCode]: AuthenticationFactorClass.Mfa,
-  [VerificationType.WebAuthn]: AuthenticationFactorClass.Mfa,
-  [VerificationType.SignInPasskey]: AuthenticationFactorClass.Mfa,
+  [VerificationType.WebAuthn]: AuthenticationFactorClass.Both,
+  [VerificationType.SignInPasskey]: AuthenticationFactorClass.Both,
   [VerificationType.Social]: undefined,
   [VerificationType.EnterpriseSso]: undefined,
 });
@@ -171,20 +179,62 @@ export const getAuthenticationMethodReferences = (
 ): readonly AuthenticationMethodReference[] => authenticationMethodReferences[type];
 
 /**
- * Build the `amr` claim for a set of counted verification types and the ACR they achieved:
- * the union of each type's references in first-seen order, with `mfa` always last, present
- * whenever a counted type carries it (WebAuthn) or the achieved ACR is {@link LogtoAcr.Mfa}.
+ * Build the `amr` claim from the references each counted proof contributes and the ACR they
+ * achieved: the union in first-seen order, with `mfa` always last, present whenever a proof carries
+ * it (WebAuthn) or the achieved ACR is {@link LogtoAcr.Mfa}.
  */
 export const buildAuthenticationMethodReferences = (
-  types: Iterable<VerificationType>,
+  references: Iterable<readonly AuthenticationMethodReference[]>,
   achievedAcr?: LogtoAcr
 ): AuthenticationMethodReference[] => {
-  const references = [...types].flatMap((type) => getAuthenticationMethodReferences(type));
+  const flattened = [...references].flat();
   const hasMfa =
-    achievedAcr === LogtoAcr.Mfa || references.includes(AuthenticationMethodReference.Mfa);
+    achievedAcr === LogtoAcr.Mfa || flattened.includes(AuthenticationMethodReference.Mfa);
 
   return [
-    ...new Set(references.filter((reference) => reference !== AuthenticationMethodReference.Mfa)),
+    ...new Set(flattened.filter((reference) => reference !== AuthenticationMethodReference.Mfa)),
     ...(hasMfa ? [AuthenticationMethodReference.Mfa] : []),
   ];
 };
+
+/**
+ * Why a proof was recorded: the touchpoint that consumed the credential. Aggregation into `acr` /
+ * `amr` ignores the role; it exists for the MFA gate and for step-up freshness, and never reaches
+ * a token.
+ */
+export enum AuthenticationProofRole {
+  /** `createUser()` created the account from the record. */
+  Create = 'create',
+  /** `identifyUser()` identified the user with the record. */
+  Identify = 'identify',
+  /** The credential or factor was written to the account by this interaction. */
+  Bind = 'bind',
+  /** An MFA challenge was answered with the record. */
+  Mfa = 'mfa',
+}
+
+/**
+ * A proof that the identified user authenticated in the interaction, recorded at the single
+ * touchpoint that consumed the credential. What counts is decided where the interaction relies on
+ * the credential, never by inspecting verification records afterwards.
+ */
+export type AuthenticationProof = {
+  /** The verification record id, or `password` for a password established through the profile. */
+  id: string;
+  factor: AuthenticationFactor;
+  /** Absent for a federated proof, which contributes `fed` to AMR and nothing to the ACR. */
+  class?: AuthenticationFactorClass;
+  amr: AuthenticationMethodReference[];
+  role: AuthenticationProofRole;
+  /** Epoch seconds the credential was verified; becomes `auth_time`. */
+  at: number;
+};
+
+export const authenticationProofGuard = z.object({
+  id: z.string(),
+  factor: z.nativeEnum(AuthenticationFactor),
+  class: z.nativeEnum(AuthenticationFactorClass).optional(),
+  amr: z.nativeEnum(AuthenticationMethodReference).array(),
+  role: z.nativeEnum(AuthenticationProofRole),
+  at: z.number().int().nonnegative(),
+}) satisfies ToZodObject<AuthenticationProof>;

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -167,20 +167,12 @@ export const buildAuthenticationMethodReferences = (
   types: Iterable<VerificationType>,
   achievedAcr?: LogtoAcr
 ): AuthenticationMethodReference[] => {
-  const references = new Set<AuthenticationMethodReference>();
-  // eslint-disable-next-line @silverhand/fp/no-let
-  let hasMfa = achievedAcr === LogtoAcr.Mfa;
+  const references = [...types].flatMap((type) => getAuthenticationMethodReferences(type));
+  const hasMfa =
+    achievedAcr === LogtoAcr.Mfa || references.includes(AuthenticationMethodReference.Mfa);
 
-  for (const type of types) {
-    for (const reference of getAuthenticationMethodReferences(type)) {
-      if (reference === AuthenticationMethodReference.Mfa) {
-        // eslint-disable-next-line @silverhand/fp/no-mutation
-        hasMfa = true;
-      } else {
-        references.add(reference);
-      }
-    }
-  }
-
-  return hasMfa ? [...references, AuthenticationMethodReference.Mfa] : [...references];
+  return [
+    ...new Set(references.filter((reference) => reference !== AuthenticationMethodReference.Mfa)),
+    ...(hasMfa ? [AuthenticationMethodReference.Mfa] : []),
+  ];
 };

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -26,32 +26,6 @@ export enum LogtoAcr {
 /** The ACR values advertised in Discovery as `acr_values_supported`, in the provider order. */
 export const logtoAcrValues = Object.freeze([LogtoAcr.FirstFactor, LogtoAcr.Mfa] as const);
 
-export const isLogtoAcr = (value: unknown): value is LogtoAcr =>
-  typeof value === 'string' && Object.values<string>(LogtoAcr).includes(value);
-
-/**
- * The explicit satisfaction map: each achieved class lists every requested class it satisfies.
- * `mfa → 1fa`; there is no implicit ordering beyond this table.
- */
-const acrSatisfactionMap: Readonly<Record<LogtoAcr, readonly LogtoAcr[]>> = Object.freeze({
-  [LogtoAcr.FirstFactor]: [LogtoAcr.FirstFactor],
-  [LogtoAcr.Mfa]: [LogtoAcr.Mfa, LogtoAcr.FirstFactor],
-});
-
-/**
- * Whether an achieved ACR satisfies a requested one.
- *
- * - An unsupported value on either side never satisfies anything.
- * - A missing achieved ACR (e.g. a social / SSO session) never satisfies anything.
- */
-export const acrSatisfies = (achieved: unknown, requested: unknown): boolean => {
-  if (!isLogtoAcr(achieved) || !isLogtoAcr(requested)) {
-    return false;
-  }
-
-  return acrSatisfactionMap[achieved].includes(requested);
-};
-
 /**
  * The AMR values Logto emits. All except {@link AuthenticationMethodReference.Federated} are
  * registered in RFC 8176; `fed` is the de facto industry value for authentication delegated to an

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -1,0 +1,183 @@
+/**
+ * @file The authoritative vocabulary for the authentication context Logto records on a sign-in or
+ * step-up: the supported Authentication Context Class Reference (ACR) values, their satisfaction
+ * relation, and the Authentication Methods References (AMR) each verification contributes.
+ *
+ * @see {@link https://openid.net/specs/openid-connect-core-1_0.html#IDToken | OpenID Connect Core `acr` / `amr`}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc8176.html | RFC 8176 Authentication Method Reference Values}
+ */
+import { VerificationType } from './verification-records/verification-type.js';
+
+/** The Logto-defined ACR values. Only these can be requested through `acr_values`. */
+export enum LogtoAcr {
+  /**
+   * At least one active factor that Logto can directly verify: password, the user's primary
+   * email / phone verification code, or an enrolled MFA factor. Social and enterprise SSO never
+   * satisfy this class.
+   */
+  FirstFactor = 'urn:logto:acr:1fa',
+  /**
+   * A Logto-verifiable {@link LogtoAcr.FirstFactor} context plus an `mfa`-class record from a
+   * different factor, or WebAuthn / passkey with required user verification alone.
+   */
+  Mfa = 'urn:logto:acr:mfa',
+}
+
+/** The ACR values advertised in Discovery as `acr_values_supported`, in the provider order. */
+export const logtoAcrValues = Object.freeze([LogtoAcr.FirstFactor, LogtoAcr.Mfa] as const);
+
+export const isLogtoAcr = (value: unknown): value is LogtoAcr =>
+  typeof value === 'string' && Object.values<string>(LogtoAcr).includes(value);
+
+/**
+ * The explicit satisfaction map: each achieved class lists every requested class it satisfies.
+ * `mfa → 1fa`; there is no implicit ordering beyond this table.
+ */
+const acrSatisfactionMap: Readonly<Record<LogtoAcr, readonly LogtoAcr[]>> = Object.freeze({
+  [LogtoAcr.FirstFactor]: [LogtoAcr.FirstFactor],
+  [LogtoAcr.Mfa]: [LogtoAcr.Mfa, LogtoAcr.FirstFactor],
+});
+
+/**
+ * Whether an achieved ACR satisfies a requested one.
+ *
+ * - An unsupported value on either side never satisfies anything.
+ * - A missing achieved ACR (e.g. a social / SSO session) never satisfies anything.
+ */
+export const acrSatisfies = (achieved: unknown, requested: unknown): boolean => {
+  if (!isLogtoAcr(achieved) || !isLogtoAcr(requested)) {
+    return false;
+  }
+
+  return acrSatisfactionMap[achieved].includes(requested);
+};
+
+/**
+ * The AMR values Logto emits. All except {@link AuthenticationMethodReference.Federated} are
+ * registered in RFC 8176; `fed` is the de facto industry value for authentication delegated to an
+ * upstream identity provider and is the only unregistered value Logto emits.
+ */
+export enum AuthenticationMethodReference {
+  /** Password-based authentication. */
+  Password = 'pwd',
+  /** One-time password: email verification code, TOTP, backup code, or one-time token. */
+  Otp = 'otp',
+  /** Verification code delivered by SMS. */
+  Sms = 'sms',
+  /** Proof-of-possession of a key, e.g. WebAuthn. */
+  ProofOfPossession = 'pop',
+  /** User presence / verification by the authenticator, e.g. WebAuthn user verification. */
+  UserPresence = 'user',
+  /** Multiple-factor authentication; appended whenever the achieved ACR is {@link LogtoAcr.Mfa}. */
+  Mfa = 'mfa',
+  /** Federated authentication assertion from a social or enterprise SSO provider. */
+  Federated = 'fed',
+}
+
+/** The class a verification record contributes toward an ACR. */
+export enum AuthenticationFactorClass {
+  /** Contributes {@link LogtoAcr.FirstFactor}. */
+  FirstFactor = '1fa',
+  /**
+   * Contributes an `mfa`-class record. Combined with a {@link AuthenticationFactorClass.FirstFactor}
+   * record from a different factor it reaches {@link LogtoAcr.Mfa}; alone it reaches only
+   * {@link LogtoAcr.FirstFactor}, except WebAuthn / passkey with required user verification.
+   */
+  Mfa = 'mfa',
+}
+
+/**
+ * The class each verification type contributes: `1fa`-class, `mfa`-class, or `undefined` for
+ * social / enterprise SSO, which contribute `fed` to AMR but nothing to the ACR.
+ *
+ * The record is keyed by every {@link VerificationType}, so a new type fails at compile time until
+ * it is mapped here. Whether a WebAuthn assertion actually required user verification is decided at
+ * derivation time; this table only says which class the type can contribute.
+ */
+const authenticationFactorClasses: Readonly<
+  Record<VerificationType, AuthenticationFactorClass | undefined>
+> = Object.freeze({
+  [VerificationType.Password]: AuthenticationFactorClass.FirstFactor,
+  [VerificationType.EmailVerificationCode]: AuthenticationFactorClass.FirstFactor,
+  [VerificationType.PhoneVerificationCode]: AuthenticationFactorClass.FirstFactor,
+  [VerificationType.OneTimeToken]: AuthenticationFactorClass.FirstFactor,
+  // A password established in this interaction counts as a verified first factor.
+  [VerificationType.NewPasswordIdentity]: AuthenticationFactorClass.FirstFactor,
+  [VerificationType.TOTP]: AuthenticationFactorClass.Mfa,
+  [VerificationType.MfaEmailVerificationCode]: AuthenticationFactorClass.Mfa,
+  [VerificationType.MfaPhoneVerificationCode]: AuthenticationFactorClass.Mfa,
+  [VerificationType.BackupCode]: AuthenticationFactorClass.Mfa,
+  [VerificationType.WebAuthn]: AuthenticationFactorClass.Mfa,
+  [VerificationType.SignInPasskey]: AuthenticationFactorClass.Mfa,
+  [VerificationType.Social]: undefined,
+  [VerificationType.EnterpriseSso]: undefined,
+});
+
+/** Classify a verification type; see {@link authenticationFactorClasses}. */
+export const getAuthenticationFactorClass = (
+  type: VerificationType
+): AuthenticationFactorClass | undefined => authenticationFactorClasses[type];
+
+/**
+ * The AMR values a single verification type contributes, per the step-up tech design. The record
+ * is keyed by every {@link VerificationType}, so a new type fails at compile time until it is
+ * mapped here.
+ *
+ * The trailing `mfa` marker for an achieved {@link LogtoAcr.Mfa} is added by
+ * {@link buildAuthenticationMethodReferences}, not here; WebAuthn carries it inherently because a
+ * user-verified passkey is a multi-factor authenticator on its own.
+ */
+const authenticationMethodReferences: Readonly<
+  Record<VerificationType, readonly AuthenticationMethodReference[]>
+> = Object.freeze({
+  [VerificationType.Password]: [AuthenticationMethodReference.Password],
+  [VerificationType.NewPasswordIdentity]: [AuthenticationMethodReference.Password],
+  [VerificationType.EmailVerificationCode]: [AuthenticationMethodReference.Otp],
+  [VerificationType.OneTimeToken]: [AuthenticationMethodReference.Otp],
+  [VerificationType.TOTP]: [AuthenticationMethodReference.Otp],
+  [VerificationType.MfaEmailVerificationCode]: [AuthenticationMethodReference.Otp],
+  [VerificationType.BackupCode]: [AuthenticationMethodReference.Otp],
+  [VerificationType.PhoneVerificationCode]: [AuthenticationMethodReference.Sms],
+  [VerificationType.MfaPhoneVerificationCode]: [AuthenticationMethodReference.Sms],
+  [VerificationType.WebAuthn]: [
+    AuthenticationMethodReference.ProofOfPossession,
+    AuthenticationMethodReference.UserPresence,
+    AuthenticationMethodReference.Mfa,
+  ],
+  [VerificationType.SignInPasskey]: [
+    AuthenticationMethodReference.ProofOfPossession,
+    AuthenticationMethodReference.UserPresence,
+    AuthenticationMethodReference.Mfa,
+  ],
+  [VerificationType.Social]: [AuthenticationMethodReference.Federated],
+  [VerificationType.EnterpriseSso]: [AuthenticationMethodReference.Federated],
+});
+
+/** The AMR values a verification type contributes; see {@link authenticationMethodReferences}. */
+export const getAuthenticationMethodReferences = (
+  type: VerificationType
+): readonly AuthenticationMethodReference[] => authenticationMethodReferences[type];
+
+/**
+ * Build the `amr` claim for a set of counted verification types and the ACR they achieved:
+ * the union of each type's references in first-seen order, with `mfa` appended whenever the
+ * achieved ACR is {@link LogtoAcr.Mfa}.
+ */
+export const buildAuthenticationMethodReferences = (
+  types: Iterable<VerificationType>,
+  achievedAcr?: LogtoAcr
+): AuthenticationMethodReference[] => {
+  const references = new Set<AuthenticationMethodReference>();
+
+  for (const type of types) {
+    for (const reference of getAuthenticationMethodReferences(type)) {
+      references.add(reference);
+    }
+  }
+
+  if (achievedAcr === LogtoAcr.Mfa) {
+    references.add(AuthenticationMethodReference.Mfa);
+  }
+
+  return [...references];
+};

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -94,6 +94,43 @@ export const getAuthenticationFactorClass = (
 ): AuthenticationFactorClass | undefined => authenticationFactorClasses[type];
 
 /**
+ * The factor a verification record is a proof of. Repeated proofs of one factor count once, and
+ * {@link LogtoAcr.Mfa} needs a `1fa`-class and an `mfa`-class proof of two different factors: a
+ * one-time token and an MFA email code are two proofs of the same mailbox, not two factors.
+ */
+export enum AuthenticationFactor {
+  Password = 'password',
+  Email = 'email',
+  Phone = 'phone',
+  Totp = 'totp',
+  BackupCode = 'backupCode',
+  WebAuthn = 'webAuthn',
+  Federated = 'federated',
+}
+
+/** Keyed by every {@link VerificationType}, so a new type fails at compile time until mapped. */
+const authenticationFactors: Readonly<Record<VerificationType, AuthenticationFactor>> =
+  Object.freeze({
+    [VerificationType.Password]: AuthenticationFactor.Password,
+    [VerificationType.NewPasswordIdentity]: AuthenticationFactor.Password,
+    [VerificationType.EmailVerificationCode]: AuthenticationFactor.Email,
+    [VerificationType.MfaEmailVerificationCode]: AuthenticationFactor.Email,
+    [VerificationType.OneTimeToken]: AuthenticationFactor.Email,
+    [VerificationType.PhoneVerificationCode]: AuthenticationFactor.Phone,
+    [VerificationType.MfaPhoneVerificationCode]: AuthenticationFactor.Phone,
+    [VerificationType.TOTP]: AuthenticationFactor.Totp,
+    [VerificationType.BackupCode]: AuthenticationFactor.BackupCode,
+    [VerificationType.WebAuthn]: AuthenticationFactor.WebAuthn,
+    [VerificationType.SignInPasskey]: AuthenticationFactor.WebAuthn,
+    [VerificationType.Social]: AuthenticationFactor.Federated,
+    [VerificationType.EnterpriseSso]: AuthenticationFactor.Federated,
+  });
+
+/** The factor a verification type is a proof of; see {@link authenticationFactors}. */
+export const getAuthenticationFactor = (type: VerificationType): AuthenticationFactor =>
+  authenticationFactors[type];
+
+/**
  * The AMR values a single verification type contributes, per the step-up tech design. The record
  * is keyed by every {@link VerificationType}, so a new type fails at compile time until it is
  * mapped here.

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -160,24 +160,27 @@ export const getAuthenticationMethodReferences = (
 
 /**
  * Build the `amr` claim for a set of counted verification types and the ACR they achieved:
- * the union of each type's references in first-seen order, with `mfa` appended whenever the
- * achieved ACR is {@link LogtoAcr.Mfa}.
+ * the union of each type's references in first-seen order, with `mfa` always last, present
+ * whenever a counted type carries it (WebAuthn) or the achieved ACR is {@link LogtoAcr.Mfa}.
  */
 export const buildAuthenticationMethodReferences = (
   types: Iterable<VerificationType>,
   achievedAcr?: LogtoAcr
 ): AuthenticationMethodReference[] => {
   const references = new Set<AuthenticationMethodReference>();
+  // eslint-disable-next-line @silverhand/fp/no-let
+  let hasMfa = achievedAcr === LogtoAcr.Mfa;
 
   for (const type of types) {
     for (const reference of getAuthenticationMethodReferences(type)) {
-      references.add(reference);
+      if (reference === AuthenticationMethodReference.Mfa) {
+        // eslint-disable-next-line @silverhand/fp/no-mutation
+        hasMfa = true;
+      } else {
+        references.add(reference);
+      }
     }
   }
 
-  if (achievedAcr === LogtoAcr.Mfa) {
-    references.add(AuthenticationMethodReference.Mfa);
-  }
-
-  return [...references];
+  return hasMfa ? [...references, AuthenticationMethodReference.Mfa] : [...references];
 };

--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -37,3 +37,4 @@ export * from './secrets.js';
 export * from './user-logto-config.js';
 export * from './user-sessions.js';
 export * from './trusted-device.js';
+export * from './authentication-context.js';

--- a/packages/schemas/src/types/verification-records/backup-code-verification.ts
+++ b/packages/schemas/src/types/verification-records/backup-code-verification.ts
@@ -20,7 +20,7 @@ export const backupCodeVerificationRecordDataGuard = z.object({
   userId: z.string(),
   code: z.string().optional(),
   backupCodes: z.string().array().optional(),
-  verifiedAt: z.number().optional(),
+  verifiedAt: z.number().int().nonnegative().optional(),
 }) satisfies ToZodObject<BackupCodeVerificationRecordData>;
 
 export type SanitizedBackupCodeVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/backup-code-verification.ts
+++ b/packages/schemas/src/types/verification-records/backup-code-verification.ts
@@ -11,6 +11,8 @@ export type BackupCodeVerificationRecordData = {
   userId: string;
   code?: string;
   backupCodes?: string[];
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 };
 export const backupCodeVerificationRecordDataGuard = z.object({
   id: z.string(),
@@ -18,6 +20,7 @@ export const backupCodeVerificationRecordDataGuard = z.object({
   userId: z.string(),
   code: z.string().optional(),
   backupCodes: z.string().array().optional(),
+  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<BackupCodeVerificationRecordData>;
 
 export type SanitizedBackupCodeVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/code-verification.ts
+++ b/packages/schemas/src/types/verification-records/code-verification.ts
@@ -30,12 +30,15 @@ export type CodeVerificationRecordData<T extends CodeVerificationType = CodeVeri
   identifier: VerificationCodeIdentifierOf<T>;
   templateType: TemplateType;
   verified: boolean;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 };
 
 const basicCodeVerificationRecordDataGuard = z.object({
   id: z.string(),
   templateType: z.nativeEnum(TemplateType),
   verified: z.boolean(),
+  verifiedAt: z.number().optional(),
 });
 
 export const emailCodeVerificationRecordDataGuard = basicCodeVerificationRecordDataGuard.extend({

--- a/packages/schemas/src/types/verification-records/code-verification.ts
+++ b/packages/schemas/src/types/verification-records/code-verification.ts
@@ -38,7 +38,7 @@ const basicCodeVerificationRecordDataGuard = z.object({
   id: z.string(),
   templateType: z.nativeEnum(TemplateType),
   verified: z.boolean(),
-  verifiedAt: z.number().optional(),
+  verifiedAt: z.number().int().nonnegative().optional(),
 });
 
 export const emailCodeVerificationRecordDataGuard = basicCodeVerificationRecordDataGuard.extend({

--- a/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
+++ b/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
@@ -17,6 +17,8 @@ export type EnterpriseSsoVerificationRecordData = {
   enterpriseSsoUserInfo?: ExtendedSocialUserInfo;
   encryptedTokenSet?: EncryptedTokenSet;
   issuer?: string;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 };
 
 export const enterpriseSsoVerificationRecordDataGuard = z.object({
@@ -26,6 +28,7 @@ export const enterpriseSsoVerificationRecordDataGuard = z.object({
   enterpriseSsoUserInfo: extendedSocialUserInfoGuard.optional(),
   encryptedTokenSet: encryptedTokenSetGuard.optional(),
   issuer: z.string().optional(),
+  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<EnterpriseSsoVerificationRecordData>;
 
 export type SanitizedEnterpriseSsoVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
+++ b/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
@@ -28,7 +28,7 @@ export const enterpriseSsoVerificationRecordDataGuard = z.object({
   enterpriseSsoUserInfo: extendedSocialUserInfoGuard.optional(),
   encryptedTokenSet: encryptedTokenSetGuard.optional(),
   issuer: z.string().optional(),
-  verifiedAt: z.number().optional(),
+  verifiedAt: z.number().int().nonnegative().optional(),
 }) satisfies ToZodObject<EnterpriseSsoVerificationRecordData>;
 
 export type SanitizedEnterpriseSsoVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/new-password-identity-verification.ts
+++ b/packages/schemas/src/types/verification-records/new-password-identity-verification.ts
@@ -32,7 +32,7 @@ export const newPasswordIdentityVerificationRecordDataGuard = z.object({
   identifier: interactionIdentifierGuard,
   passwordEncrypted: z.string().optional(),
   passwordEncryptionMethod: z.literal(UsersPasswordEncryptionMethod.Argon2i).optional(),
-  verifiedAt: z.number().optional(),
+  verifiedAt: z.number().int().nonnegative().optional(),
 }) satisfies ToZodObject<NewPasswordIdentityVerificationRecordData>;
 
 export type SanitizedNewPasswordIdentityVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/new-password-identity-verification.ts
+++ b/packages/schemas/src/types/verification-records/new-password-identity-verification.ts
@@ -22,6 +22,8 @@ export type NewPasswordIdentityVerificationRecordData = {
   identifier: InteractionIdentifier;
   passwordEncrypted?: string;
   passwordEncryptionMethod?: UsersPasswordEncryptionMethod.Argon2i;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 };
 
 export const newPasswordIdentityVerificationRecordDataGuard = z.object({
@@ -30,6 +32,7 @@ export const newPasswordIdentityVerificationRecordDataGuard = z.object({
   identifier: interactionIdentifierGuard,
   passwordEncrypted: z.string().optional(),
   passwordEncryptionMethod: z.literal(UsersPasswordEncryptionMethod.Argon2i).optional(),
+  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<NewPasswordIdentityVerificationRecordData>;
 
 export type SanitizedNewPasswordIdentityVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/one-time-token-verification.ts
+++ b/packages/schemas/src/types/verification-records/one-time-token-verification.ts
@@ -29,5 +29,5 @@ export const oneTimeTokenVerificationRecordDataGuard = z.object({
     value: z.string(),
   }),
   oneTimeTokenContext: oneTimeTokenContextGuard.optional(),
-  verifiedAt: z.number().optional(),
+  verifiedAt: z.number().int().nonnegative().optional(),
 }) satisfies ToZodObject<OneTimeTokenVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/one-time-token-verification.ts
+++ b/packages/schemas/src/types/verification-records/one-time-token-verification.ts
@@ -16,6 +16,8 @@ export type OneTimeTokenVerificationRecordData = {
   identifier: InteractionIdentifier<SignInIdentifier.Email>;
   verified: boolean;
   oneTimeTokenContext?: OneTimeTokenContext;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 };
 
 export const oneTimeTokenVerificationRecordDataGuard = z.object({
@@ -27,4 +29,5 @@ export const oneTimeTokenVerificationRecordDataGuard = z.object({
     value: z.string(),
   }),
   oneTimeTokenContext: oneTimeTokenContextGuard.optional(),
+  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<OneTimeTokenVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/password-verification.ts
+++ b/packages/schemas/src/types/verification-records/password-verification.ts
@@ -10,6 +10,8 @@ export type PasswordVerificationRecordData = {
   type: VerificationType.Password;
   identifier: VerificationIdentifier;
   verified: boolean;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 };
 
 export const passwordVerificationRecordDataGuard = z.object({
@@ -17,4 +19,5 @@ export const passwordVerificationRecordDataGuard = z.object({
   type: z.literal(VerificationType.Password),
   identifier: verificationIdentifierGuard,
   verified: z.boolean(),
+  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<PasswordVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/password-verification.ts
+++ b/packages/schemas/src/types/verification-records/password-verification.ts
@@ -19,5 +19,5 @@ export const passwordVerificationRecordDataGuard = z.object({
   type: z.literal(VerificationType.Password),
   identifier: verificationIdentifierGuard,
   verified: z.boolean(),
-  verifiedAt: z.number().optional(),
+  verifiedAt: z.number().int().nonnegative().optional(),
 }) satisfies ToZodObject<PasswordVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/social-verification.ts
+++ b/packages/schemas/src/types/verification-records/social-verification.ts
@@ -25,6 +25,8 @@ export type SocialVerificationRecordData = {
    * The connector session result
    */
   connectorSession?: ConnectorSession;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 };
 
 export const socialVerificationRecordDataGuard = z.object({
@@ -34,6 +36,7 @@ export const socialVerificationRecordDataGuard = z.object({
   socialUserInfo: socialUserInfoGuard.optional(),
   encryptedTokenSet: encryptedTokenSetGuard.optional(),
   connectorSession: connectorSessionGuard.optional(),
+  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<SocialVerificationRecordData>;
 
 export type SanitizedSocialVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/social-verification.ts
+++ b/packages/schemas/src/types/verification-records/social-verification.ts
@@ -36,7 +36,7 @@ export const socialVerificationRecordDataGuard = z.object({
   socialUserInfo: socialUserInfoGuard.optional(),
   encryptedTokenSet: encryptedTokenSetGuard.optional(),
   connectorSession: connectorSessionGuard.optional(),
-  verifiedAt: z.number().optional(),
+  verifiedAt: z.number().int().nonnegative().optional(),
 }) satisfies ToZodObject<SocialVerificationRecordData>;
 
 export type SanitizedSocialVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/totp-verification.ts
+++ b/packages/schemas/src/types/verification-records/totp-verification.ts
@@ -21,7 +21,7 @@ export const totpVerificationRecordDataGuard = z.object({
   userId: z.string(),
   secret: z.string().optional(),
   verified: z.boolean(),
-  verifiedAt: z.number().optional(),
+  verifiedAt: z.number().int().nonnegative().optional(),
 }) satisfies ToZodObject<TotpVerificationRecordData>;
 
 export type SanitizedTotpVerificationRecordData = Omit<TotpVerificationRecordData, 'secret'>;

--- a/packages/schemas/src/types/verification-records/totp-verification.ts
+++ b/packages/schemas/src/types/verification-records/totp-verification.ts
@@ -11,6 +11,8 @@ export type TotpVerificationRecordData = {
   userId: string;
   secret?: string;
   verified: boolean;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 };
 
 export const totpVerificationRecordDataGuard = z.object({
@@ -19,6 +21,7 @@ export const totpVerificationRecordDataGuard = z.object({
   userId: z.string(),
   secret: z.string().optional(),
   verified: z.boolean(),
+  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<TotpVerificationRecordData>;
 
 export type SanitizedTotpVerificationRecordData = Omit<TotpVerificationRecordData, 'secret'>;

--- a/packages/schemas/src/types/verification-records/web-authn-verification.ts
+++ b/packages/schemas/src/types/verification-records/web-authn-verification.ts
@@ -26,7 +26,7 @@ const baseWebAuthnVerificationRecordDataGuard = z.object({
   registrationRpId: z.string().optional(),
   authenticationChallenge: z.string().optional(),
   registrationInfo: bindWebAuthnGuard.optional(),
-  verifiedAt: z.number().optional(),
+  verifiedAt: z.number().int().nonnegative().optional(),
 }) satisfies ToZodObject<BaseWebAuthnVerificationRecordData>;
 
 export type WebAuthnVerificationRecordData = BaseWebAuthnVerificationRecordData & {

--- a/packages/schemas/src/types/verification-records/web-authn-verification.ts
+++ b/packages/schemas/src/types/verification-records/web-authn-verification.ts
@@ -15,6 +15,8 @@ type BaseWebAuthnVerificationRecordData = {
   /** The challenge generated for the WebAuthn authentication */
   authenticationChallenge?: string;
   registrationInfo?: BindWebAuthn;
+  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
+  verifiedAt?: number;
 };
 
 const baseWebAuthnVerificationRecordDataGuard = z.object({
@@ -24,6 +26,7 @@ const baseWebAuthnVerificationRecordDataGuard = z.object({
   registrationRpId: z.string().optional(),
   authenticationChallenge: z.string().optional(),
   registrationInfo: bindWebAuthnGuard.optional(),
+  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<BaseWebAuthnVerificationRecordData>;
 
 export type WebAuthnVerificationRecordData = BaseWebAuthnVerificationRecordData & {


### PR DESCRIPTION
## Summary

First slice of the OIDC step-up project (LOG-14095, milestone M1): every Experience sign-in and registration records the authentication context Logto can observe, the ID token carries it, and Discovery advertises it. Everything is behind the dev feature flag.

Linear: https://linear.app/silverhand/issue/LOG-14095
Design: [Authentication Context (ACR / AMR) — Tech Design](https://app.notion.com/p/silverhand/Authentication-Context-ACR-AMR-Tech-Design-3d026f6af1dc814b9500c9b5988bb1c6) (scopes 1 to 3 of its PR split; scope 4, the MFA gate over proofs, and scope 5, enforcement, are not part of this PR).

### The model

**A proof is recorded at the single touchpoint that consumes a credential, never derived from verification records afterwards.** A verified record is not a used record: a registration password sitting in a social sign-in, a code for an address being added, or a record nobody consumed must not count. So the interaction keeps an `AuthenticationProof` list (`{ id, factor, class, amr, role, at }`), staged like `profile` and `mfa` and persisted by `save()` together with the effect that produced each proof, and `submit()` aggregates `acr` / `amr` / `ts` from that list alone.

### `@logto/schemas`

- `verification-records/*`: every record data type and guard gains an optional `verifiedAt` (non-negative integer epoch seconds).
- `types/authentication-context.ts`: `LogtoAcr` and `logtoAcrValues`; the per-type factor, class and AMR tables (all `Record`, so a new type fails at compile time); `AuthenticationFactorClass` is `1fa` | `mfa` | `both`, with WebAuthn / passkey as `both` since Logto requires user verification for the registration and the authentication ceremony alike; `AuthenticationProof`, `AuthenticationProofRole` (`create` | `identify` | `bind` | `mfa`) and `authenticationProofGuard`; `buildAuthenticationMethodReferences` unions AMR lists in first-seen order with `mfa` always last.

### `@logto/core`

- **Verification records** set `verifiedAt` when verification succeeds and include it in `toJson()` / `toSanitizedJson()`.
- **`AuthenticationProofs`** (`classes/libraries/authentication-proofs.ts`): the proof collection, keyed by `(recordId, role)` so a retry overwrites; every entry is kept (`auth_time` wants the earliest, step-up freshness will want the latest). It has the lifetime of `profile.data`: cleared when the interaction event changes and by `cleanUp()`, and excluded from the sanitized projection (`role` never leaves the server).
- **One choke point per credential**:
  - `createUser(id)` records `create`; `identifyUser(id)` records `identify` (also for a second record that identifies the same user).
  - The raw `getVerificationRecordById` / `getVerificationRecordByTypeAndId` are removed from `InteractionContext`; `Profile` and `Mfa` reach a record only through `consumeForBind` / `consumeForBindByType`, which record `bind`. A write path structurally cannot forget to record what it did.
  - The MFA challenge verify routes (TOTP, backup code, WebAuthn authentication, MFA email / phone code) call `consumeForMfa` right after a successful verification, since for a challenge record verifying is the use. A new-enrollment record is refused there; its only proof is the `bind` one recorded when the factor is added, so a verified but unbound enrollment counts nothing.
  - A password has no record: `Profile` records its proof on the `passwordEncrypted` unset-to-set transition, the single write path into its data, so username / password registrations and a password set through `POST /profile` count.
  - The email / phone MFA bind site records the `mfa`-class `bind` proof next to the `1fa` one the profile bind recorded for the same contact.
  - Declared non-proofs, written in code as decisions: binding backup codes, trusted-device fulfilment, an adaptive-MFA non-trigger.
- **`aggregateAuthenticationContext(proofs)`** (`classes/libraries/authentication-context.ts`), design section 4.3: `1fa` needs a `1fa`-class proof; `mfa` needs a `1fa`-class and an `mfa`-class proof of two *different* factors, or a `both`-class proof alone; repeated proofs of one factor count once; federated proofs contribute `fed` and no ACR; `ts` is the earliest proof. The role plays no part in aggregation.
- **Policy consequences**: a factor bound during a sign-in on an existing account counts (design C4, deliberate, so a step-up to `mfa` is satisfiable for a user without a factor); a social registration that enrols a passkey reaches `mfa`; an email code + profile password registration records `amr=["otp","pwd"]`.
- **Route guards** kept from the earlier revision: `POST /verification/new-password-identity` requires a Register interaction, and `POST /verification/mfa-verification-code` refuses a factor the sign-in experience does not enable.
- **`submit()`** aggregates for SignIn and Register when the dev flag is on and seeds `login: { accountId, acr, amr, ts }`. ForgotPassword is untouched (its password proof is recorded and discarded with the interaction).
- **Provider configuration** (`oidc/init.ts`), behind the dev flag: `acrValues` advertises `acr_values_supported`, and `acr` / `amr` / `auth_time` are listed under the `openid` scope and in `claims_supported`.

## Testing

- `packages/schemas`: `authentication-context.test.ts` covers the tables, the `both` class, the AMR builder and the proof guard; lint, `tsc` and vitest clean locally.
- `packages/core`: `authentication-context.test.ts` is the design's section 6 case matrix as an `it.each` table (registration and sign-in rows, plus the same-factor and no-first-factor edge rows); `authentication-proofs.test.ts` covers staging, keying, the backup-code non-proof, the profile password proof and the data round trip; `experience-interaction.test.ts` asserts the `create` and `identify` proofs, the password transition, the login result for a sign-in and an email + password registration, that proofs are cleared on an event change and do not outlive the interaction, and that they stay out of the sanitized data; `mfa-sentinel-guard.test.ts` asserts the WebAuthn route records the `mfa` proof; two `init.test.ts` cases for Discovery.
- `packages/integration-tests`: `discovery.test.ts` flag-off / flag-on snapshots; `authentication-context.test.ts` asserts the ID token for a password sign-in (preserved across refresh), password + TOTP, a sign-in that binds its first TOTP under a mandatory policy, password + the last backup code, social sign-in including the linking sign-in, and the two route guards; `authentication-context-registration.test.ts` asserts username / password, mandatory TOTP enrollment, email and phone code, email code + profile password, and social registration.
- The core unit suite and the integration suite are left to CI: this session's environment cannot fetch the `oidc-provider` fork, so core's dependencies could not be installed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfdaHyZDx4VgujQn2vKpvz