### PR TITLE
style(account,console): update trusted device management UI styles

### DIFF
--- a/packages/account/src/pages/Security/TrustedDevicesSection/TrustedDeviceRow.tsx
+++ b/packages/account/src/pages/Security/TrustedDevicesSection/TrustedDeviceRow.tsx
@@ -34,24 +34,28 @@ const TrustedDeviceRow = ({ trustedDevice, isEditable, onRemove }: Props) => {
       <div className={styles.deviceInfo}>
         <div className={styles.deviceTitleLine}>
           <div className={styles.deviceTitle}>{name ?? id}</div>
-          {isCurrent && (
-            <span className={styles.currentTag}>
-              <span className={styles.currentDot} />
-              {t('account_center.security.trusted_devices.current_device')}
-            </span>
-          )}
         </div>
         <div className={styles.meta}>{id}</div>
       </div>
       <div className={styles.deviceDetails}>
-        <div className={styles.expiry}>
-          {t('account_center.security.trusted_devices.expires_on', {
-            date: expiryDateFormatter.format(expiresAt),
-          })}
+        <div className={styles.deviceDetailsColumn}>
+          <div className={styles.expiry}>
+            {t('account_center.security.trusted_devices.expires_on', {
+              date: expiryDateFormatter.format(expiresAt),
+            })}
+          </div>
+          <div className={styles.meta}>
+            {location ?? t('account_center.security.trusted_devices.unknown_location')}
+          </div>
         </div>
-        <div className={styles.meta}>
-          {location ?? t('account_center.security.trusted_devices.unknown_location')}
-        </div>
+        {isCurrent && (
+          <div className={styles.currentTagRow}>
+            <span className={styles.currentTag}>
+              <span className={styles.currentDot} />
+              {t('account_center.security.trusted_devices.current_device')}
+            </span>
+          </div>
+        )}
       </div>
       {isEditable && (
         <button type="button" className={styles.removeButton} onClick={onRemove}>

--- a/packages/account/src/pages/Security/TrustedDevicesSection/index.module.scss
+++ b/packages/account/src/pages/Security/TrustedDevicesSection/index.module.scss
@@ -2,10 +2,10 @@
 
 .row {
   display: grid;
-  grid-template-columns: minmax(0, 235px) minmax(0, 1fr) auto;
-  column-gap: _.unit(4);
+  grid-template-columns: minmax(0, 200px) minmax(0, 1fr) auto;
+  column-gap: _.unit(6);
   align-items: center;
-  padding: _.unit(4) _.unit(4);
+  padding: _.unit(5) _.unit(6);
   min-height: 84px;
 
   &:not(:last-child) {
@@ -13,8 +13,16 @@
   }
 }
 
-.deviceInfo,
 .deviceDetails {
+  display: flex;
+  align-items: center;
+  gap: _.unit(6);
+  min-width: 0;
+}
+
+.deviceInfo,
+.deviceDetailsColumn {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: _.unit(1);
@@ -45,10 +53,17 @@
   white-space: nowrap;
 }
 
+.currentTagRow {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: _.unit(2);
+}
+
 .currentTag {
   display: inline-flex;
   align-items: center;
-  gap: _.unit(1);
+  gap: _.unit(2);
   flex-shrink: 0;
   padding: _.unit(0.5) _.unit(2);
   border-radius: 14px;
@@ -59,8 +74,8 @@
 }
 
 .currentDot {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   background: var(--color-success-default);
 }
@@ -109,6 +124,9 @@
 
   .deviceDetails {
     grid-column: 1;
+    flex-direction: column;
+    align-items: stretch;
+    gap: _.unit(1);
   }
 
   .removeButton {

--- a/packages/console/src/pages/UserDetails/UserSettings/UserSessions/index.module.scss
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserSessions/index.module.scss
@@ -18,6 +18,11 @@
   }
 }
 
+.action {
+  display: flex;
+  justify-content: center;
+}
+
 /* The session ID has no break opportunities of its own. */
 .tooltip {
   word-break: break-all;

--- a/packages/console/src/pages/UserDetails/UserSettings/UserSessions/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserSessions/index.tsx
@@ -57,13 +57,13 @@ function UserSessions({ userId }: Props) {
               {
                 title: t('user_details.sessions.name_column'),
                 dataIndex: 'name',
-                colSpan: 6,
+                colSpan: 7,
                 render: ({ name }) => name ?? '-',
               },
               {
                 title: t('user_details.sessions.session_id_column'),
                 dataIndex: 'sessionId',
-                colSpan: 5,
+                colSpan: 6,
                 render: ({ sessionId }) => (
                   <div className={styles.sessionId}>
                     <Tooltip
@@ -88,14 +88,16 @@ function UserSessions({ userId }: Props) {
                 dataIndex: 'action',
                 colSpan: 2,
                 render: ({ sessionId }) => (
-                  <Button
-                    title="general.manage"
-                    type="text"
-                    size="small"
-                    onClick={() => {
-                      navigate(`/users/${userId}/sessions/${sessionId}`);
-                    }}
-                  />
+                  <div className={styles.action}>
+                    <Button
+                      title="general.manage"
+                      type="text"
+                      size="small"
+                      onClick={() => {
+                        navigate(`/users/${userId}/sessions/${sessionId}`);
+                      }}
+                    />
+                  </div>
                 ),
               },
             ]}

--- a/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.tsx
+++ b/packages/console/src/pages/UserDetails/UserSettings/UserTrustedDevices/index.tsx
@@ -124,16 +124,16 @@ function UserTrustedDevices({ userId }: Props) {
                 ),
               },
               {
+                title: t('user_details.personal_access_tokens.expires_at'),
+                dataIndex: 'expiresAt',
+                colSpan: 6,
+                render: ({ expiresAt }) => expiryDateFormatter.format(expiresAt),
+              },
+              {
                 title: t('user_details.sessions.location_column'),
                 dataIndex: 'location',
                 colSpan: 5,
                 render: ({ location }) => location ?? '-',
-              },
-              {
-                title: t('user_details.personal_access_tokens.expires_at'),
-                dataIndex: 'expiresAt',
-                colSpan: 4,
-                render: ({ expiresAt }) => expiryDateFormatter.format(expiresAt),
               },
               {
                 title: null,


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Updated trusted device related console and account center UIs.

Before:
<img width="2064" height="1076" alt="image" src="https://github.com/user-attachments/assets/63c10687-11f7-40e4-98f4-c0d00165c591" />

After:
<img width="2076" height="1278" alt="image" src="https://github.com/user-attachments/assets/aa158a31-a87c-4056-8677-0643a911b045" />

Before:
<img width="1622" height="818" alt="image" src="https://github.com/user-attachments/assets/cfd9b33a-db6e-458e-bd51-34a175e0312f" />

After:
<img width="1588" height="824" alt="image" src="https://github.com/user-attachments/assets/9682e6cc-7aa5-4e06-8672-7dc53e07004e" />

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Manually checked the UI components on my local machine.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
