### PR TITLE
refactor(core): record the authentication context at identification time

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -11,7 +11,6 @@ import {
   SignInIdentifier,
   SignInMode,
   type User,
-  UsersPasswordEncryptionMethod,
   VerificationType,
 } from '@logto/schemas';
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
@@ -334,29 +333,13 @@ describe('ExperienceInteraction class', () => {
       );
     });
 
-    it('seeds the derived authentication context into the login result when dev features are enabled', async () => {
+    it('seeds the authentication context into the login result when dev features are enabled', async () => {
       setDevFeaturesEnabled(true);
       const { experienceInteraction, provider } = createSignInInteraction({
         interactionResult: {
-          identifiedVerificationIds: ['password'],
-          verificationRecords: [
-            {
-              id: 'password',
-              type: VerificationType.Password,
-              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
-              verified: true,
-              verifiedAt: 1_700_000_000,
-            },
-            // A registration password proposed for an unused username is not a proof of the
-            // signed-in account and must not reach the login result.
-            {
-              id: 'new-password-identity',
-              type: VerificationType.NewPasswordIdentity,
-              identifier: { type: SignInIdentifier.Username, value: 'unused' },
-              passwordEncrypted: 'encrypted',
-              passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
-              verifiedAt: 1_600_000_000,
-            },
+          identifiedVerifications: [
+            { type: VerificationType.Password, verifiedAt: 1_700_000_000 },
+            { type: VerificationType.Social, verifiedAt: 1_700_000_010 },
           ],
         },
       });
@@ -370,14 +353,15 @@ describe('ExperienceInteraction class', () => {
           login: {
             accountId: mockUser.id,
             acr: 'urn:logto:acr:1fa',
-            amr: ['pwd'],
+            amr: ['pwd', 'fed'],
             ts: 1_700_000_000,
           },
         })
       );
     });
 
-    it('records every verification record that identified the user', async () => {
+    it('records every verification that identified the user', async () => {
+      const now = jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
       const { experienceInteraction } = createSignInInteraction({
         interactionResult: {
           userId: undefined,
@@ -402,30 +386,24 @@ describe('ExperienceInteraction class', () => {
       await experienceInteraction.identifyUser('password');
       expect(experienceInteraction.toJson()).toMatchObject({
         userId: mockUser.id,
-        identifiedVerificationIds: ['password'],
+        identifiedVerifications: [{ type: VerificationType.Password, verifiedAt: 1_700_000_000 }],
       });
 
       // A second record that identifies the same user is recorded as well.
+      now.mockReturnValue(1_700_000_005_000);
       await experienceInteraction.identifyUser('email');
-      expect(experienceInteraction.toJson().identifiedVerificationIds).toEqual([
-        'password',
-        'email',
+      expect(experienceInteraction.toJson().identifiedVerifications).toEqual([
+        { type: VerificationType.Password, verifiedAt: 1_700_000_000 },
+        { type: VerificationType.EmailVerificationCode, verifiedAt: 1_700_000_005 },
       ]);
+      now.mockRestore();
     });
 
     it('finishes with the account id only when dev features are disabled', async () => {
       setDevFeaturesEnabled(false);
       const { experienceInteraction, provider } = createSignInInteraction({
         interactionResult: {
-          verificationRecords: [
-            {
-              id: 'password',
-              type: VerificationType.Password,
-              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
-              verified: true,
-              verifiedAt: 1_700_000_000,
-            },
-          ],
+          identifiedVerifications: [{ type: VerificationType.Password, verifiedAt: 1_700_000_000 }],
         },
       });
 

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -24,6 +24,7 @@ import { buildAppInsightsTelemetry } from '#src/utils/request.js';
 
 import {
   interactionStorageGuard,
+  type IdentifiedVerification,
   type InteractionStorage,
   type Interaction,
   type InteractionContext,
@@ -40,7 +41,7 @@ import {
 import { validatePostSignInActionResult } from './libraries/action-result-validation.js';
 import { AdaptiveMfaValidator } from './libraries/adaptive-mfa-validator/index.js';
 import { type AdaptiveMfaResult } from './libraries/adaptive-mfa-validator/types.js';
-import { deriveAuthenticationContext } from './libraries/authentication-context.js';
+import { buildAuthenticationContext } from './libraries/authentication-context.js';
 import { CaptchaValidator } from './libraries/captcha-validator.js';
 import { MfaValidator } from './libraries/mfa-validator.js';
 import { ProvisionLibrary } from './libraries/provision-library.js';
@@ -79,11 +80,11 @@ export default class ExperienceInteraction {
   /** The userId of the user for the current interaction. Only available once the user is identified. */
   private userId?: string;
   /**
-   * The ids of the verification records that identified `userId`: the one `identifyUser()` first
-   * identified the user with, and any later one that identified the same user. The
-   * authentication context counts an identifier record as a proof only when it is one of them.
+   * The verifications that identified `userId`: the one `identifyUser()` first identified the user
+   * with, and any later one that identified the same user. A sign-in builds its authentication
+   * context (`acr` / `amr` / `auth_time`) from them.
    */
-  private readonly identifiedVerificationIds = new Set<string>();
+  private readonly identifiedVerifications: IdentifiedVerification[] = [];
   private userCache?: User;
   private readonly adaptiveMfaValidator: AdaptiveMfaValidator;
 
@@ -156,7 +157,7 @@ export default class ExperienceInteraction {
       profile = {},
       mfa = {},
       userId,
-      identifiedVerificationIds = [],
+      identifiedVerifications = [],
       trustedDeviceOptIn,
       interactionEvent,
       captcha = {
@@ -167,7 +168,7 @@ export default class ExperienceInteraction {
 
     this.#interactionEvent = interactionEvent;
     this.userId = userId;
-    this.identifiedVerificationIds = new Set(identifiedVerificationIds);
+    this.identifiedVerifications = identifiedVerifications;
     this.profile = new Profile(libraries, queries, profile, interactionContext);
     this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.trustedDevice = new TrustedDevice(ctx, tenant, {
@@ -265,15 +266,14 @@ export default class ExperienceInteraction {
         this.userId === id,
         new RequestError({ code: 'session.identity_conflict', status: 409 })
       );
-      // The record identified the same user, so it is one of the identifying records as well.
-      this.identifiedVerificationIds.add(verificationId);
+      this.recordIdentifiedVerification(verificationRecord);
       return;
     }
 
     // Update the current interaction with the identified user
     this.userCache = user;
     this.userId = id;
-    this.identifiedVerificationIds.add(verificationId);
+    this.recordIdentifiedVerification(verificationRecord);
 
     // Sync social/enterprise SSO identity profile data.
     // Note: The profile data is not saved to the user profile until the user submits the interaction.
@@ -283,6 +283,12 @@ export default class ExperienceInteraction {
       log.append({ syncedProfile });
       this.profile.unsafeSet(syncedProfile);
     }
+  }
+
+  /** Remember that the record identified the user, together with when it did. */
+  private recordIdentifiedVerification({ type }: VerificationRecord) {
+    // eslint-disable-next-line @silverhand/fp/no-mutating-methods -- The list is interaction state.
+    this.identifiedVerifications.push({ type, verifiedAt: Math.floor(Date.now() / 1000) });
   }
 
   /**
@@ -559,19 +565,6 @@ export default class ExperienceInteraction {
       await this.guardMfaVerificationStatus(log);
     }
 
-    // Derive the authentication context this sign-in achieved before anything is written to the
-    // account, so that a record whose identifier or identity is only being added by this
-    // submission does not count as a proof of the account. It seeds the OIDC session so the ID
-    // token carries `acr` / `amr` / `auth_time`; a sign-in without a proof (or a register) seeds
-    // nothing and the provider stamps `auth_time` itself.
-    const authenticationContext =
-      EnvSet.values.isDevFeaturesEnabled && this.#interactionEvent === InteractionEvent.SignIn
-        ? deriveAuthenticationContext(this.verificationRecordsArray, {
-            user,
-            identifiedVerificationIds: this.identifiedVerificationIds,
-          })
-        : undefined;
-
     // Revalidate the new profile data if any
     await this.profile.validateAvailability();
 
@@ -701,7 +694,14 @@ export default class ExperienceInteraction {
     const redirectTo = await provider.interactionResult(this.ctx.req, this.ctx.res, {
       login: {
         accountId: user.id,
-        ...authenticationContext,
+        // Seed the authentication context of the sign-in into the OIDC session so the ID token
+        // carries `acr` / `amr` / `auth_time`. A register seeds nothing and the provider stamps
+        // `auth_time` itself.
+        ...conditional(
+          EnvSet.values.isDevFeaturesEnabled &&
+            this.#interactionEvent === InteractionEvent.SignIn &&
+            buildAuthenticationContext(this.identifiedVerifications)
+        ),
       },
       // Persist the interaction status to the OIDC session after interaction submission
       ...this.toJson(),
@@ -762,7 +762,7 @@ export default class ExperienceInteraction {
     return {
       interactionEvent,
       userId,
-      identifiedVerificationIds: [...this.identifiedVerificationIds],
+      identifiedVerifications: this.identifiedVerifications,
       ...this.trustedDevice.data,
       profile: this.profile.data,
       mfa: this.mfa.data,

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -1,362 +1,47 @@
-import { TemplateType } from '@logto/connector-kit';
-import {
-  SignInIdentifier,
-  UsersPasswordEncryptionMethod,
-  VerificationType,
-  type User,
-} from '@logto/schemas';
+import { VerificationType } from '@logto/schemas';
 
-import {
-  mockUser,
-  mockUserBackupCodeMfaVerification,
-  mockUserTotpMfaVerification,
-  mockUserWebAuthnMfaVerification,
-} from '#src/__mocks__/user.js';
-import { MockTenant } from '#src/test-utils/tenant.js';
+import { buildAuthenticationContext } from './authentication-context.js';
 
-import { BackupCodeVerification } from '../verifications/backup-code-verification.js';
-import {
-  EmailCodeVerification,
-  MfaEmailCodeVerification,
-  MfaPhoneCodeVerification,
-  PhoneCodeVerification,
-} from '../verifications/code-verification.js';
-import { NewPasswordIdentityVerification } from '../verifications/new-password-identity-verification.js';
-import { OneTimeTokenVerification } from '../verifications/one-time-token-verification.js';
-import { PasswordVerification } from '../verifications/password-verification.js';
-import { SocialVerification } from '../verifications/social-verification.js';
-import { TotpVerification } from '../verifications/totp-verification.js';
-import {
-  SignInPasskeyVerification,
-  WebAuthnVerification,
-} from '../verifications/web-authn-verification.js';
-
-import { deriveAuthenticationContext } from './authentication-context.js';
-
-const { libraries, queries } = new MockTenant();
-const userId = mockUser.id;
-const email = 'foo@bar.com';
-const phone = '+11234567890';
-
-/** A user with every MFA factor enrolled. */
-const user: User = {
-  ...mockUser,
-  primaryEmail: email,
-  primaryPhone: phone,
-  mfaVerifications: [
-    mockUserTotpMfaVerification,
-    mockUserWebAuthnMfaVerification,
-    mockUserBackupCodeMfaVerification,
-  ],
-};
-
-/** The ids of the identifier records below; the interaction records them at identification. */
-const identifiedVerificationIds = new Set(['password', 'email', 'phone', 'one-time-token']);
-
-type Options = Partial<Parameters<typeof deriveAuthenticationContext>[1]>;
-
-const derive = (
-  records: Parameters<typeof deriveAuthenticationContext>[0],
-  options: Options = {}
-) => deriveAuthenticationContext(records, { user, identifiedVerificationIds, ...options });
-
-const password = ({
-  verifiedAt,
-  verified = true,
-  id = 'password',
-}: { verifiedAt?: number; verified?: boolean; id?: string } = {}) =>
-  new PasswordVerification(libraries, queries, {
-    id,
-    type: VerificationType.Password,
-    identifier: { type: SignInIdentifier.Username, value: 'foo' },
-    verified,
-    verifiedAt,
+describe('buildAuthenticationContext', () => {
+  it('yields an empty context when nothing identified the user', () => {
+    expect(buildAuthenticationContext([])).toEqual({});
   });
 
-const emailCode = (verifiedAt?: number, id = 'email') =>
-  new EmailCodeVerification(libraries, queries, {
-    id,
-    type: VerificationType.EmailVerificationCode,
-    identifier: { type: SignInIdentifier.Email, value: email },
-    templateType: TemplateType.SignIn,
-    verified: true,
-    verifiedAt,
-  });
-
-const phoneCode = (verifiedAt?: number) =>
-  new PhoneCodeVerification(libraries, queries, {
-    id: 'phone',
-    type: VerificationType.PhoneVerificationCode,
-    identifier: { type: SignInIdentifier.Phone, value: phone },
-    templateType: TemplateType.SignIn,
-    verified: true,
-    verifiedAt,
-  });
-
-const oneTimeToken = (verifiedAt?: number) =>
-  new OneTimeTokenVerification(libraries, queries, {
-    id: 'one-time-token',
-    type: VerificationType.OneTimeToken,
-    identifier: { type: SignInIdentifier.Email, value: email },
-    verified: true,
-    verifiedAt,
-  });
-
-/** An MFA code sent to the given email, as the MFA verification-code route creates it. */
-const mfaEmailCode = (verifiedAt?: number, address = email) =>
-  new MfaEmailCodeVerification(libraries, queries, {
-    id: 'mfa-email',
-    type: VerificationType.MfaEmailVerificationCode,
-    identifier: { type: SignInIdentifier.Email, value: address },
-    templateType: TemplateType.MfaVerification,
-    verified: true,
-    verifiedAt,
-  });
-
-const mfaPhoneCode = (verifiedAt?: number) =>
-  new MfaPhoneCodeVerification(libraries, queries, {
-    id: 'mfa-phone',
-    type: VerificationType.MfaPhoneVerificationCode,
-    identifier: { type: SignInIdentifier.Phone, value: phone },
-    templateType: TemplateType.MfaVerification,
-    verified: true,
-    verifiedAt,
-  });
-
-const totp = ({
-  verifiedAt,
-  secret,
-  ownerId = userId,
-}: { verifiedAt?: number; secret?: string; ownerId?: string } = {}) =>
-  new TotpVerification(libraries, queries, {
-    id: 'totp',
-    type: VerificationType.TOTP,
-    userId: ownerId,
-    verified: true,
-    verifiedAt,
-    secret,
-  });
-
-const backupCode = (verifiedAt?: number) =>
-  new BackupCodeVerification(libraries, queries, {
-    id: 'backup',
-    type: VerificationType.BackupCode,
-    userId,
-    code: 'code',
-    verifiedAt,
-  });
-
-const webAuthn = (verifiedAt?: number) =>
-  new WebAuthnVerification(libraries, queries, {
-    id: 'webauthn',
-    type: VerificationType.WebAuthn,
-    userId,
-    verified: true,
-    verifiedAt,
-  });
-
-const signInPasskey = (verifiedAt?: number, ownerId = userId) =>
-  new SignInPasskeyVerification(libraries, queries, {
-    id: 'passkey',
-    type: VerificationType.SignInPasskey,
-    userId: ownerId,
-    verified: true,
-    verifiedAt,
-  });
-
-/** A verified social assertion; whether the identity is linked to the account is irrelevant. */
-const social = (verifiedAt?: number) =>
-  new SocialVerification(libraries, queries, {
-    id: 'social',
-    type: VerificationType.Social,
-    connectorId: 'connector',
-    socialUserInfo: { id: 'social-user' },
-    verifiedAt,
-  });
-
-/** A verified registration record: a policy-compliant password proposed for an unused username. */
-const newPasswordIdentity = (verifiedAt?: number) =>
-  new NewPasswordIdentityVerification(libraries, queries, {
-    id: 'new-password-identity',
-    type: VerificationType.NewPasswordIdentity,
-    identifier: { type: SignInIdentifier.Username, value: 'unused' },
-    passwordEncrypted: 'encrypted',
-    passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
-    verifiedAt,
-  });
-
-describe('deriveAuthenticationContext', () => {
-  it('reaches 1fa with a password', () => {
-    expect(derive([password({ verifiedAt: 100 })])).toEqual({
+  it.each([
+    [VerificationType.Password, 'pwd'],
+    [VerificationType.EmailVerificationCode, 'otp'],
+    [VerificationType.PhoneVerificationCode, 'sms'],
+    [VerificationType.OneTimeToken, 'otp'],
+  ])('reaches 1fa for a %s sign-in', (type, reference) => {
+    expect(buildAuthenticationContext([{ type, verifiedAt: 1000 }])).toEqual({
       acr: 'urn:logto:acr:1fa',
-      amr: ['pwd'],
-      ts: 100,
+      amr: [reference],
+      ts: 1000,
     });
   });
 
-  it('reaches 1fa with a primary email code', () => {
-    expect(derive([emailCode(100)])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['otp'],
-      ts: 100,
-    });
+  it('reaches mfa for a passkey sign-in', () => {
+    expect(
+      buildAuthenticationContext([{ type: VerificationType.SignInPasskey, verifiedAt: 1000 }])
+    ).toEqual({ acr: 'urn:logto:acr:mfa', amr: ['pop', 'user', 'mfa'], ts: 1000 });
   });
 
-  it('reaches mfa with a password and a TOTP, taking the earliest timestamp', () => {
-    expect(derive([password({ verifiedAt: 200 }), totp({ verifiedAt: 100 })])).toEqual({
-      acr: 'urn:logto:acr:mfa',
-      amr: ['pwd', 'otp', 'mfa'],
-      ts: 100,
-    });
-  });
-
-  it('reaches mfa with a primary email code and an MFA phone code', () => {
-    expect(derive([emailCode(100), mfaPhoneCode(200)])).toEqual({
-      acr: 'urn:logto:acr:mfa',
-      amr: ['otp', 'sms', 'mfa'],
-      ts: 100,
-    });
-  });
-
-  it('reaches mfa with a password and a backup code', () => {
-    expect(derive([password({ verifiedAt: 100 }), backupCode(200)])).toEqual({
-      acr: 'urn:logto:acr:mfa',
-      amr: ['pwd', 'otp', 'mfa'],
-      ts: 100,
-    });
-  });
-
-  it('reaches only 1fa with a TOTP alone', () => {
-    expect(derive([totp({ verifiedAt: 100 })])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['otp'],
-      ts: 100,
-    });
-  });
-
-  it('reaches only 1fa with two mfa-class factors and no first factor', () => {
-    expect(derive([totp({ verifiedAt: 100 }), backupCode(200)])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['otp'],
-      ts: 100,
-    });
-  });
-
-  it.each([webAuthn, signInPasskey])(
-    'reaches mfa with a user-verified WebAuthn assertion alone',
-    (build) => {
-      expect(derive([build(100)])).toEqual({
-        acr: 'urn:logto:acr:mfa',
-        amr: ['pop', 'user', 'mfa'],
-        ts: 100,
+  it.each([VerificationType.Social, VerificationType.EnterpriseSso])(
+    'yields fed and no acr for a %s sign-in',
+    (type) => {
+      expect(buildAuthenticationContext([{ type, verifiedAt: 1000 }])).toEqual({
+        amr: ['fed'],
+        ts: 1000,
       });
     }
   );
 
-  it('records only fed for a social sign-in', () => {
-    expect(derive([social(100)])).toEqual({ amr: ['fed'], ts: 100 });
-  });
-
-  it('keeps fed next to a Logto-verifiable factor', () => {
-    expect(derive([social(100), password({ verifiedAt: 200 })])).toEqual({
-      acr: 'urn:logto:acr:1fa',
-      amr: ['fed', 'pwd'],
-      ts: 100,
-    });
-  });
-
-  it('keeps fed for an identity that is only being linked by this submission', () => {
-    // A linking social record never identified the user through its stored identity.
-    expect(derive([social(50)], { identifiedVerificationIds: new Set() })).toEqual({
-      amr: ['fed'],
-      ts: 50,
-    });
-  });
-
-  it('ignores unverified records and factors enrolled in this interaction', () => {
+  it('unions the references of every identifying verification and keeps the earliest time', () => {
     expect(
-      derive([
-        password({ verifiedAt: 100, verified: false }),
-        totp({ verifiedAt: 50, secret: 'new' }),
+      buildAuthenticationContext([
+        { type: VerificationType.Password, verifiedAt: 2000 },
+        { type: VerificationType.Social, verifiedAt: 1000 },
       ])
-    ).toEqual({});
-    expect(
-      derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 50, secret: 'new' })])
-    ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
-  });
-
-  it('omits ts when no counted record carries verifiedAt', () => {
-    expect(derive([password()])).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'] });
-  });
-
-  describe('one factor never fills both roles', () => {
-    it('stays at 1fa when the MFA code went to the same mailbox as a one-time token', () => {
-      expect(derive([oneTimeToken(100), mfaEmailCode(200)])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['otp'],
-        ts: 100,
-      });
-    });
-
-    it.each([
-      ['email', () => [emailCode(100), mfaEmailCode(200)], ['otp']],
-      ['phone', () => [phoneCode(100), mfaPhoneCode(200)], ['sms']],
-    ] as const)(
-      'stays at 1fa when the MFA code went to the same %s as the first factor',
-      (_, build, amr) => {
-        expect(derive(build())).toEqual({ acr: 'urn:logto:acr:1fa', amr, ts: 100 });
-      }
-    );
-
-    it('still reaches mfa when another factor supplies the first factor', () => {
-      expect(derive([password({ verifiedAt: 100 }), mfaEmailCode(200)])).toEqual({
-        acr: 'urn:logto:acr:mfa',
-        amr: ['pwd', 'otp', 'mfa'],
-        ts: 100,
-      });
-      expect(derive([emailCode(100), password({ verifiedAt: 150 }), mfaEmailCode(200)])).toEqual({
-        acr: 'urn:logto:acr:mfa',
-        amr: ['otp', 'pwd', 'mfa'],
-        ts: 100,
-      });
-    });
-  });
-
-  describe('records that are not proofs of the identified user', () => {
-    it('ignores an identifier record that did not identify the user', () => {
-      // A code for an address the user is adding, or a password verified for another account,
-      // is never passed to `identifyUser()` for this user.
-      expect(derive([social(100), emailCode(50, 'added-email')])).toEqual({
-        amr: ['fed'],
-        ts: 100,
-      });
-      expect(derive([password({ verifiedAt: 50, id: 'other-account' })])).toEqual({});
-    });
-
-    it('ignores a registration password that never identified the user', () => {
-      // The route only accepts the record in a Register interaction, and `identifyUser()` never
-      // records it; a stored one from before the route guard still counts nothing.
-      expect(derive([social(100), newPasswordIdentity(50)])).toEqual({ amr: ['fed'], ts: 100 });
-      expect(derive([social(100), newPasswordIdentity(50), totp({ verifiedAt: 200 })])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['fed', 'otp'],
-        ts: 100,
-      });
-    });
-
-    it('ignores an MFA code that was not sent to the primary contact of the user', () => {
-      expect(derive([password({ verifiedAt: 100 }), mfaEmailCode(200, 'other@bar.com')])).toEqual({
-        acr: 'urn:logto:acr:1fa',
-        amr: ['pwd'],
-        ts: 100,
-      });
-    });
-
-    it('ignores factor records created for another user', () => {
-      expect(
-        derive([password({ verifiedAt: 100 }), totp({ verifiedAt: 50, ownerId: 'someone-else' })])
-      ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd'], ts: 100 });
-      expect(derive([signInPasskey(100, 'someone-else')])).toEqual({});
-    });
+    ).toEqual({ acr: 'urn:logto:acr:1fa', amr: ['pwd', 'fed'], ts: 1000 });
   });
 });

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -1,153 +1,39 @@
 import {
-  AuthenticationFactor,
-  AuthenticationFactorClass,
-  LogtoAcr,
-  SignInIdentifier,
-  VerificationType,
   buildAuthenticationMethodReferences,
-  getAuthenticationFactor,
-  getAuthenticationFactorClass,
+  getAchievedAcr,
   type AuthenticationMethodReference,
-  type User,
+  type LogtoAcr,
 } from '@logto/schemas';
 import { conditional } from '@silverhand/essentials';
 
-import { type VerificationRecord } from '../verifications/index.js';
+import { type IdentifiedVerification } from '../../types.js';
 
-import { isMfaVerificationRecord } from './mfa-validator.js';
-
-/** The authentication context an interaction achieved, in the shape of the provider's `login` result. */
-type AuthenticationContext = {
+/** The authentication context of a sign-in, in the shape of the provider's `login` result. */
+export type AuthenticationContext = {
   acr?: LogtoAcr;
   amr?: AuthenticationMethodReference[];
   /** Epoch seconds of the authentication event; becomes `auth_time`. */
   ts?: number;
 };
 
-/** What the derivation knows about the identified user; see `ExperienceInteraction`. */
-type IdentifiedUserContext = {
-  user: User;
-  /** The ids of the verification records that identified the user. */
-  identifiedVerificationIds: ReadonlySet<string>;
-};
-
 /**
- * Whether an MFA record is a proof of the user: verified, not a factor enrolled in this
- * interaction, and bound to the user. TOTP, backup code and WebAuthn records are created for a
- * user and carry that user's id. An MFA email / phone code is sent to the identified user's
- * primary contact, which the MFA verification-code route reads from the user, so the record's
- * identifier must be that contact.
+ * Build the authentication context of a sign-in from the verifications that identified the user.
+ * `ts` is the earliest identification, the most conservative value for a downstream `max_age`
+ * check. An empty list yields an empty context.
  */
-const isMfaProofOfUser = (record: VerificationRecord, user: User): boolean => {
-  if (!isMfaVerificationRecord(record) || record.isNewBindMfaVerification) {
-    return false;
-  }
-
-  if ('userId' in record) {
-    return record.userId === user.id;
-  }
-
-  const { type, value } = record.identifier;
-  return value === (type === SignInIdentifier.Email ? user.primaryEmail : user.primaryPhone);
-};
-
-/**
- * Whether a record is a proof that the identified user authenticated in this interaction.
- *
- * A verified record is not a proof by itself. An interaction can hold verified records that never
- * authenticated the identified account: a code sent to an address the user is adding to their
- * profile, or a factor enrolled in this interaction. Only a record bound to the identified user
- * counts:
- *
- * - An MFA record (TOTP, backup code, WebAuthn, MFA email / phone code) counts per
- *   {@link isMfaProofOfUser}.
- * - A sign-in passkey record resolves its `userId` from the asserted credential.
- * - A social or enterprise SSO record contributes only `fed`, never an ACR, so a verified
- *   assertion counts as is. Gating it on the stored identity would drop the very sign-in that
- *   links the identity (the record resolves no account until the submission writes the link).
- * - Any other record (password, verification code, one-time token, new-password identity) counts
- *   when it is one of the records that identified the user, which the interaction recorded at
- *   identification time.
- */
-const isProofOfUser = (
-  record: VerificationRecord,
-  { user, identifiedVerificationIds }: IdentifiedUserContext
-): boolean => {
-  if (!record.isVerified) {
-    return false;
-  }
-
-  if (isMfaVerificationRecord(record)) {
-    return isMfaProofOfUser(record, user);
-  }
-
-  if (record.type === VerificationType.SignInPasskey) {
-    return record.userId === user.id;
-  }
-
-  if (getAuthenticationFactor(record.type) === AuthenticationFactor.Federated) {
-    return true;
-  }
-
-  return identifiedVerificationIds.has(record.id);
-};
-
-/**
- * Whether the record is a WebAuthn assertion. Logto always requires user verification for WebAuthn
- * (`requireUserVerification: true` in the verification helpers), so a verified record is a
- * user-verified passkey and reaches `urn:logto:acr:mfa` on its own.
- */
-const isUserVerifiedWebAuthn = ({ type }: VerificationRecord) =>
-  type === VerificationType.WebAuthn || type === VerificationType.SignInPasskey;
-
-/** The factors with a counted record of the given class. */
-const factorsOfClass = (records: VerificationRecord[], factorClass: AuthenticationFactorClass) =>
-  new Set(
-    records
-      .filter(({ type }) => getAuthenticationFactorClass(type) === factorClass)
-      .map(({ type }) => getAuthenticationFactor(type))
-  );
-
-/**
- * Derive the authentication context the identified user achieved through the verification records
- * of one interaction. Only records that are proofs of that user count; see {@link isProofOfUser}.
- * The derivation reads only what the interaction already holds and never queries the database.
- *
- * - A `1fa`-class proof (password, primary email / phone code, one-time token) reaches
- *   `urn:logto:acr:1fa`; an `mfa`-class proof alone also reaches only `urn:logto:acr:1fa`.
- * - A `1fa`-class proof plus an `mfa`-class proof of a different factor, or a user-verified
- *   WebAuthn assertion alone, reaches `urn:logto:acr:mfa`. Repeated proofs of one factor count
- *   once, so a one-time token plus an MFA email code stays at `urn:logto:acr:1fa`.
- * - Social / enterprise SSO contribute `fed` to `amr` and nothing to the ACR.
- * - `ts` is the earliest `verifiedAt` among counted records, the most conservative value for a
- *   downstream `max_age` check; it is absent when no counted record carries one.
- */
-export const deriveAuthenticationContext = (
-  records: VerificationRecord[],
-  context: IdentifiedUserContext
+export const buildAuthenticationContext = (
+  identifiedVerifications: readonly IdentifiedVerification[]
 ): AuthenticationContext => {
-  const counted = records.filter((record) => isProofOfUser(record, context));
-  const firstFactors = factorsOfClass(counted, AuthenticationFactorClass.FirstFactor);
-  const mfaFactors = factorsOfClass(counted, AuthenticationFactorClass.Mfa);
-  const hasDistinctMfaFactor = [...mfaFactors].some(
-    (factor) => firstFactors.size > (firstFactors.has(factor) ? 1 : 0)
-  );
-
-  const acr =
-    hasDistinctMfaFactor || counted.some((record) => isUserVerifiedWebAuthn(record))
-      ? LogtoAcr.Mfa
-      : conditional((firstFactors.size > 0 || mfaFactors.size > 0) && LogtoAcr.FirstFactor);
-  const amr = buildAuthenticationMethodReferences(
-    counted.map(({ type }) => type),
-    acr
-  );
-  const timestamps = counted
-    .map(({ verifiedAt }) => verifiedAt)
-    .filter((verifiedAt): verifiedAt is number => typeof verifiedAt === 'number');
+  const amr = buildAuthenticationMethodReferences(identifiedVerifications.map(({ type }) => type));
+  const acr = getAchievedAcr(amr);
 
   return {
     ...conditional(acr && { acr }),
     ...conditional(amr.length > 0 && { amr }),
-    ...conditional(timestamps.length > 0 && { ts: Math.min(...timestamps) }),
+    ...conditional(
+      identifiedVerifications.length > 0 && {
+        ts: Math.min(...identifiedVerifications.map(({ verifiedAt }) => verifiedAt)),
+      }
+    ),
   };
 };

--- a/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
@@ -53,7 +53,7 @@ type MfaVerificationRecord =
   | MfaEmailCodeVerification
   | MfaPhoneCodeVerification;
 
-export const isMfaVerificationRecord = (
+const isMfaVerificationRecord = (
   verification: VerificationRecord
 ): verification is MfaVerificationRecord => {
   return mfaVerificationTypes.includes(verification.type);

--- a/packages/core/src/routes/experience/classes/verifications/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/backup-code-verification.ts
@@ -13,7 +13,7 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { type MfaVerificationRecord, getEpochTime } from './verification-record.js';
+import { type MfaVerificationRecord } from './verification-record.js';
 
 export {
   type BackupCodeVerificationRecordData,
@@ -40,8 +40,6 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
   public readonly id: string;
   public readonly type = VerificationType.BackupCode;
   public readonly userId: string;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
   private code?: string;
   private backupCodes?: string[];
 
@@ -50,13 +48,12 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
     private readonly queries: Queries,
     data: BackupCodeVerificationRecordData
   ) {
-    const { id, userId, code, backupCodes, verifiedAt } = data;
+    const { id, userId, code, backupCodes } = data;
 
     this.id = id;
     this.userId = userId;
     this.code = code;
     this.backupCodes = backupCodes;
-    this.verifiedAt = verifiedAt;
   }
 
   get isVerified() {
@@ -120,7 +117,6 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
     });
 
     this.code = code;
-    this.verifiedAt = getEpochTime();
   }
 
   toBindMfa(): BindBackupCode {
@@ -133,7 +129,7 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
   }
 
   toJson(): BackupCodeVerificationRecordData {
-    const { id, type, userId, code, backupCodes, verifiedAt } = this;
+    const { id, type, userId, code, backupCodes } = this;
 
     return {
       id,
@@ -141,13 +137,12 @@ export class BackupCodeVerification implements MfaVerificationRecord<Verificatio
       userId,
       code,
       backupCodes,
-      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedBackupCodeVerificationRecordData {
-    const { id, type, userId, code, verifiedAt } = this;
+    const { id, type, userId, code } = this;
 
-    return { id, type, userId, code, verifiedAt };
+    return { id, type, userId, code };
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/code-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/code-verification.ts
@@ -23,7 +23,7 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { findUserByIdentifier } from '../utils.js';
 
-import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
+import { type IdentifierVerificationRecord } from './verification-record.js';
 
 export {
   type CodeVerificationRecordData,
@@ -69,8 +69,6 @@ abstract class CodeVerification<T extends CodeVerificationType>
    * The template type for sending the verification code, the connector will use this to get the correct template.
    */
   public readonly templateType: TemplateType;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
   public abstract readonly type: T;
   protected verified: boolean;
 
@@ -79,13 +77,12 @@ abstract class CodeVerification<T extends CodeVerificationType>
     private readonly queries: Queries,
     data: CodeVerificationRecordData<T>
   ) {
-    const { id, identifier, verified, verifiedAt, templateType } = data;
+    const { id, identifier, verified, templateType } = data;
 
     this.id = id;
     this.identifier = identifier;
     this.templateType = templateType;
     this.verified = verified;
-    this.verifiedAt = verifiedAt;
   }
 
   /** Returns true if the identifier has been verified by a given code */
@@ -145,7 +142,6 @@ abstract class CodeVerification<T extends CodeVerificationType>
     );
 
     this.verified = true;
-    this.verifiedAt = getEpochTime();
   }
 
   async identifyUser(): Promise<User> {
@@ -170,7 +166,7 @@ abstract class CodeVerification<T extends CodeVerificationType>
   }
 
   toJson(): CodeVerificationRecordData<T> {
-    const { id, type, identifier, templateType, verified, verifiedAt } = this;
+    const { id, type, identifier, templateType, verified } = this;
 
     return {
       id,
@@ -178,7 +174,6 @@ abstract class CodeVerification<T extends CodeVerificationType>
       identifier,
       templateType,
       verified,
-      verifiedAt,
     };
   }
 

--- a/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/enterprise-sso-verification.ts
@@ -29,7 +29,7 @@ import { safeParseUnknownJson } from '#src/utils/json.js';
 
 import type { InteractionProfile } from '../../types.js';
 
-import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
+import { type IdentifierVerificationRecord } from './verification-record.js';
 
 export {
   type EnterpriseSsoVerificationRecordData,
@@ -60,8 +60,6 @@ export class EnterpriseSsoVerification
   public enterpriseSsoUserInfo?: ExtendedSocialUserInfo;
   public encryptedTokenSet?: EncryptedTokenSet;
   public issuer?: string;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 
   private connectorDataCache?: SupportedSsoConnector;
 
@@ -70,7 +68,7 @@ export class EnterpriseSsoVerification
     private readonly queries: Queries,
     data: EnterpriseSsoVerificationRecordData
   ) {
-    const { id, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer, verifiedAt } =
+    const { id, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer } =
       enterpriseSsoVerificationRecordDataGuard.parse(data);
 
     this.id = id;
@@ -78,7 +76,6 @@ export class EnterpriseSsoVerification
     this.enterpriseSsoUserInfo = enterpriseSsoUserInfo;
     this.issuer = issuer;
     this.encryptedTokenSet = encryptedTokenSet;
-    this.verifiedAt = verifiedAt;
   }
 
   /** Returns true if the enterprise SSO identity has been verified */
@@ -135,7 +132,6 @@ export class EnterpriseSsoVerification
     this.issuer = issuer;
     this.enterpriseSsoUserInfo = userInfo;
     this.encryptedTokenSet = encryptedTokenSet;
-    this.verifiedAt = getEpochTime();
   }
 
   /**
@@ -240,8 +236,7 @@ export class EnterpriseSsoVerification
   }
 
   toJson(): EnterpriseSsoVerificationRecordData {
-    const { id, type, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer, verifiedAt } =
-      this;
+    const { id, type, connectorId, enterpriseSsoUserInfo, encryptedTokenSet, issuer } = this;
 
     return {
       id,
@@ -250,14 +245,13 @@ export class EnterpriseSsoVerification
       enterpriseSsoUserInfo,
       encryptedTokenSet,
       issuer,
-      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedEnterpriseSsoVerificationRecordData {
-    const { id, type, connectorId, enterpriseSsoUserInfo, issuer, verifiedAt } = this;
+    const { id, type, connectorId, enterpriseSsoUserInfo, issuer } = this;
 
-    return { id, type, connectorId, enterpriseSsoUserInfo, issuer, verifiedAt };
+    return { id, type, connectorId, enterpriseSsoUserInfo, issuer };
   }
 
   private async findUserSsoIdentityByEnterpriseSsoUserInfo(): Promise<

--- a/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/new-password-identity-verification.ts
@@ -17,7 +17,7 @@ import { ProfileValidator } from '../libraries/profile-validator.js';
 import { SignInExperienceValidator } from '../libraries/sign-in-experience-validator.js';
 import { interactionIdentifierToUserProfile } from '../utils.js';
 
-import { type VerificationRecord, getEpochTime } from './verification-record.js';
+import { type VerificationRecord } from './verification-record.js';
 
 export {
   type NewPasswordIdentityVerificationRecordData,
@@ -49,8 +49,6 @@ export class NewPasswordIdentityVerification
   readonly id: string;
   readonly identifier: InteractionIdentifier;
 
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
   private passwordEncrypted?: string;
   private passwordEncryptionMethod?: UsersPasswordEncryptionMethod.Argon2i;
 
@@ -62,13 +60,12 @@ export class NewPasswordIdentityVerification
     private readonly queries: Queries,
     data: NewPasswordIdentityVerificationRecordData
   ) {
-    const { id, identifier, passwordEncrypted, passwordEncryptionMethod, verifiedAt } = data;
+    const { id, identifier, passwordEncrypted, passwordEncryptionMethod } = data;
 
     this.id = id;
     this.identifier = identifier;
     this.passwordEncrypted = passwordEncrypted;
     this.passwordEncryptionMethod = passwordEncryptionMethod;
-    this.verifiedAt = verifiedAt;
     this.signInExperienceValidator = new SignInExperienceValidator(libraries, queries);
     this.profileValidator = new ProfileValidator(queries, this.signInExperienceValidator);
   }
@@ -100,7 +97,6 @@ export class NewPasswordIdentityVerification
 
     this.passwordEncrypted = passwordEncrypted;
     this.passwordEncryptionMethod = passwordEncryptionMethod;
-    this.verifiedAt = getEpochTime();
   }
 
   toUserProfile() {
@@ -121,7 +117,7 @@ export class NewPasswordIdentityVerification
   }
 
   toJson(): NewPasswordIdentityVerificationRecordData {
-    const { id, type, identifier, passwordEncrypted, passwordEncryptionMethod, verifiedAt } = this;
+    const { id, type, identifier, passwordEncrypted, passwordEncryptionMethod } = this;
 
     return {
       id,
@@ -129,12 +125,11 @@ export class NewPasswordIdentityVerification
       identifier,
       passwordEncrypted,
       passwordEncryptionMethod,
-      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedNewPasswordIdentityVerificationRecordData {
-    const { id, type, identifier, verifiedAt } = this;
-    return { id, type, identifier, verifiedAt };
+    const { id, type, identifier } = this;
+    return { id, type, identifier };
   }
 }

--- a/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/one-time-token-verification.ts
@@ -17,7 +17,7 @@ import assertThat from '#src/utils/assert-that.js';
 import { type InteractionProfile } from '../../types.js';
 import { findUserByIdentifier } from '../utils.js';
 
-import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
+import { type IdentifierVerificationRecord } from './verification-record.js';
 
 export {
   type OneTimeTokenVerificationRecordData,
@@ -44,8 +44,6 @@ export class OneTimeTokenVerification
   readonly type = VerificationType.OneTimeToken;
   readonly id: string;
   readonly identifier: InteractionIdentifier<SignInIdentifier.Email>;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
   private context?: OneTimeTokenContext;
   private verified: boolean;
 
@@ -60,12 +58,11 @@ export class OneTimeTokenVerification
     private readonly queries: Queries,
     data: OneTimeTokenVerificationRecordData
   ) {
-    const { id, identifier, verified, verifiedAt, oneTimeTokenContext } = data;
+    const { id, identifier, verified, oneTimeTokenContext } = data;
 
     this.id = id;
     this.identifier = identifier;
     this.verified = verified;
-    this.verifiedAt = verifiedAt;
     this.context = oneTimeTokenContext;
   }
 
@@ -88,7 +85,6 @@ export class OneTimeTokenVerification
       interactionEvent
     );
     this.verified = true;
-    this.verifiedAt = getEpochTime();
     this.context = tokenRecord.context;
   }
 
@@ -133,9 +129,9 @@ export class OneTimeTokenVerification
   }
 
   toJson(): OneTimeTokenVerificationRecordData {
-    const { id, type, identifier, verified, verifiedAt, context } = this;
+    const { id, type, identifier, verified, context } = this;
 
-    return { id, type, identifier, verified, verifiedAt, oneTimeTokenContext: context };
+    return { id, type, identifier, verified, oneTimeTokenContext: context };
   }
 
   toSanitizedJson(): OneTimeTokenVerificationRecordData {

--- a/packages/core/src/routes/experience/classes/verifications/password-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/password-verification.ts
@@ -14,7 +14,7 @@ import assertThat from '#src/utils/assert-that.js';
 
 import { findUserByIdentifier } from '../utils.js';
 
-import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
+import { type IdentifierVerificationRecord } from './verification-record.js';
 
 export {
   type PasswordVerificationRecordData,
@@ -37,8 +37,6 @@ export class PasswordVerification
   readonly type = VerificationType.Password;
   readonly identifier: VerificationIdentifier;
   readonly id: string;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
   private verified: boolean;
 
   /**
@@ -52,12 +50,11 @@ export class PasswordVerification
     private readonly queries: Queries,
     data: PasswordVerificationRecordData
   ) {
-    const { id, identifier, verified, verifiedAt } = data;
+    const { id, identifier, verified } = data;
 
     this.id = id;
     this.identifier = identifier;
     this.verified = verified;
-    this.verifiedAt = verifiedAt;
   }
 
   /** Returns whether the password verification has succeeded. */
@@ -67,7 +64,6 @@ export class PasswordVerification
 
   markAsVerified(): void {
     this.verified = true;
-    this.verifiedAt = getEpochTime();
   }
 
   /**
@@ -88,7 +84,6 @@ export class PasswordVerification
     );
 
     this.verified = true;
-    this.verifiedAt = getEpochTime();
 
     return verifiedUser;
   }
@@ -115,14 +110,13 @@ export class PasswordVerification
   }
 
   toJson(): PasswordVerificationRecordData {
-    const { id, type, identifier, verified, verifiedAt } = this;
+    const { id, type, identifier, verified } = this;
 
     return {
       id,
       type,
       identifier,
       verified,
-      verifiedAt,
     };
   }
 

--- a/packages/core/src/routes/experience/classes/verifications/social-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/social-verification.ts
@@ -38,7 +38,7 @@ import { type LogtoConnector } from '#src/utils/connectors/types.js';
 
 import type { InteractionProfile } from '../../types.js';
 
-import { type IdentifierVerificationRecord, getEpochTime } from './verification-record.js';
+import { type IdentifierVerificationRecord } from './verification-record.js';
 
 export {
   type SocialVerificationRecordData,
@@ -72,8 +72,6 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   public socialUserInfo?: SocialUserInfo;
   public encryptedTokenSet?: EncryptedTokenSet;
   public connectorSession: ConnectorSession;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
   private connectorDataCache?: LogtoConnector;
 
   constructor(
@@ -81,13 +79,12 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
     private readonly queries: Queries,
     data: SocialVerificationRecordData
   ) {
-    const { id, connectorId, socialUserInfo, encryptedTokenSet, connectorSession, verifiedAt } =
+    const { id, connectorId, socialUserInfo, encryptedTokenSet, connectorSession } =
       socialVerificationRecordDataGuard.parse(data);
 
     this.id = id;
     this.connectorId = connectorId;
     this.socialUserInfo = socialUserInfo;
-    this.verifiedAt = verifiedAt;
     this.encryptedTokenSet = encryptedTokenSet;
     this.connectorSession = connectorSession ?? {};
   }
@@ -174,7 +171,6 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
 
     this.socialUserInfo = userInfo;
     this.encryptedTokenSet = encryptedTokenSet;
-    this.verifiedAt = getEpochTime();
   }
 
   /**
@@ -305,15 +301,7 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
   }
 
   toJson(): SocialVerificationRecordData {
-    const {
-      id,
-      type,
-      connectorId,
-      socialUserInfo,
-      encryptedTokenSet,
-      connectorSession,
-      verifiedAt,
-    } = this;
+    const { id, type, connectorId, socialUserInfo, encryptedTokenSet, connectorSession } = this;
 
     return {
       id,
@@ -322,14 +310,13 @@ export class SocialVerification implements IdentifierVerificationRecord<Verifica
       socialUserInfo,
       encryptedTokenSet,
       connectorSession,
-      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedSocialVerificationRecordData {
-    const { id, type, connectorId, socialUserInfo, verifiedAt } = this;
+    const { id, type, connectorId, socialUserInfo } = this;
 
-    return { id, type, connectorId, socialUserInfo, verifiedAt };
+    return { id, type, connectorId, socialUserInfo };
   }
 
   private async findUserBySocialIdentity(): Promise<User | undefined> {

--- a/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/totp-verification.ts
@@ -22,7 +22,7 @@ import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 import assertThat from '#src/utils/assert-that.js';
 
-import { type MfaVerificationRecord, getEpochTime } from './verification-record.js';
+import { type MfaVerificationRecord } from './verification-record.js';
 
 export {
   type TotpVerificationRecordData,
@@ -58,8 +58,6 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
   public readonly id: string;
   public readonly type = VerificationType.TOTP;
   public readonly userId: string;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
   private verified: boolean;
   #secret?: string;
 
@@ -68,14 +66,12 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
     private readonly queries: Queries,
     data: TotpVerificationRecordData
   ) {
-    const { id, userId, secret, verified, verifiedAt } =
-      totpVerificationRecordDataGuard.parse(data);
+    const { id, userId, secret, verified } = totpVerificationRecordDataGuard.parse(data);
 
     this.id = id;
     this.userId = userId;
     this.#secret = secret;
     this.verified = verified;
-    this.verifiedAt = verifiedAt;
   }
 
   get isVerified() {
@@ -120,7 +116,6 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
     );
 
     this.verified = true;
-    this.verifiedAt = getEpochTime();
   }
 
   /**
@@ -158,7 +153,6 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
     assertThat(updatedUser, 'session.mfa.invalid_totp_code');
 
     this.verified = true;
-    this.verifiedAt = getEpochTime();
   }
 
   toBindMfa(): BindTotp {
@@ -171,7 +165,7 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
   }
 
   toJson(): TotpVerificationRecordData {
-    const { id, type, secret, verified, verifiedAt, userId } = this;
+    const { id, type, secret, verified, userId } = this;
 
     return {
       id,
@@ -179,14 +173,13 @@ export class TotpVerification implements MfaVerificationRecord<VerificationType.
       userId,
       secret,
       verified,
-      verifiedAt,
     };
   }
 
   toSanitizedJson(): SanitizedTotpVerificationRecordData {
-    const { id, type, userId, verified, verifiedAt } = this;
+    const { id, type, userId, verified } = this;
 
-    return { id, type, userId, verified, verifiedAt };
+    return { id, type, userId, verified };
   }
 
   /**

--- a/packages/core/src/routes/experience/classes/verifications/verification-record.ts
+++ b/packages/core/src/routes/experience/classes/verifications/verification-record.ts
@@ -5,9 +5,6 @@ type Data<T> = {
   type: T;
 };
 
-/** Epoch seconds, the unit `auth_time` / `verifiedAt` are recorded in. */
-export const getEpochTime = () => Math.floor(Date.now() / 1000);
-
 /** The abstract class for all verification records. */
 export abstract class VerificationRecord<
   T extends VerificationType = VerificationType,

--- a/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/classes/verifications/web-authn-verification.ts
@@ -31,7 +31,6 @@ import assertThat from '#src/utils/assert-that.js';
 import {
   type IdentifierVerificationRecord,
   type MfaVerificationRecord,
-  getEpochTime,
 } from './verification-record.js';
 
 export {
@@ -47,8 +46,6 @@ abstract class BaseWebAuthnVerification {
   readonly id: string;
   userId?: string;
   verified: boolean;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
   registrationChallenge?: string;
   registrationRpId?: string;
   registrationInfo?: BindWebAuthn;
@@ -62,7 +59,6 @@ abstract class BaseWebAuthnVerification {
     this.id = data.id;
     this.userId = data.userId;
     this.verified = data.verified;
-    this.verifiedAt = data.verifiedAt;
     this.registrationChallenge = data.registrationChallenge;
     this.registrationRpId = data.registrationRpId;
     this.registrationInfo = data.registrationInfo;
@@ -137,7 +133,6 @@ abstract class BaseWebAuthnVerification {
     const { credentialID, credentialPublicKey, counter } = registrationInfo;
 
     this.verified = true;
-    this.verifiedAt = getEpochTime();
 
     this.registrationInfo = {
       type: MfaFactor.WebAuthn,
@@ -237,7 +232,6 @@ export class WebAuthnVerification
     assertThat(result, 'session.mfa.webauthn_verification_failed');
 
     this.verified = true;
-    this.verifiedAt = getEpochTime();
 
     await this.queries.users.updateUserById(user.id, {
       mfaVerifications: mfaVerifications.map((mfa) => {
@@ -271,7 +265,6 @@ export class WebAuthnVerification
       type: this.type,
       userId: this.userId,
       verified: this.verified,
-      verifiedAt: this.verifiedAt,
       registrationChallenge: this.registrationChallenge,
       authenticationChallenge: this.authenticationChallenge,
       registrationRpId: this.registrationRpId,
@@ -280,8 +273,8 @@ export class WebAuthnVerification
   }
 
   toSanitizedJson(): SanitizedWebAuthnVerificationRecordData {
-    const { id, type, userId, verified, verifiedAt } = this;
-    return { id, type, userId, verified, verifiedAt };
+    const { id, type, userId, verified } = this;
+    return { id, type, userId, verified };
   }
 }
 
@@ -353,7 +346,6 @@ export class SignInPasskeyVerification
     assertThat(result, 'session.mfa.webauthn_verification_failed');
 
     this.verified = true;
-    this.verifiedAt = getEpochTime();
     this.userId = userId;
 
     await updateUserById(userId, {
@@ -391,7 +383,6 @@ export class SignInPasskeyVerification
       type: this.type,
       userId: this.userId,
       verified: this.verified,
-      verifiedAt: this.verifiedAt,
       registrationChallenge: this.registrationChallenge,
       authenticationChallenge: this.authenticationChallenge,
       registrationRpId: this.registrationRpId,
@@ -401,7 +392,7 @@ export class SignInPasskeyVerification
   }
 
   toSanitizedJson(): SanitizedSignInPasskeyVerificationRecordData {
-    const { id, type, userId, verified, verifiedAt } = this;
-    return { id, type, userId, verified, verifiedAt };
+    const { id, type, userId, verified } = this;
+    return { id, type, userId, verified };
   }
 }

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -10,6 +10,7 @@ import {
   Users,
   UserSsoIdentities,
   type UserSsoIdentity,
+  VerificationType,
   webAuthnAuthenticationOptionsGuard,
 } from '@logto/schemas';
 import type { Provider } from 'oidc-provider';
@@ -191,6 +192,21 @@ export type WithHooksAndLogsContext<ContextT extends WithLogContext = WithLogCon
   WithExperienceInteractionHooksContext;
 
 /**
+ * A verification that identified the user of the interaction: the type of the record and the
+ * epoch seconds at which it did so. This is what the authentication context (`acr` / `amr` /
+ * `auth_time`) of a sign-in is built from.
+ */
+export type IdentifiedVerification = {
+  type: VerificationType;
+  verifiedAt: number;
+};
+
+export const identifiedVerificationGuard = z.object({
+  type: z.nativeEnum(VerificationType),
+  verifiedAt: z.number().int().nonnegative(),
+}) satisfies ToZodObject<IdentifiedVerification>;
+
+/**
  * Interaction storage is used to store the interaction data during the interaction process.
  * It is used to pass data between different interaction steps and to store the interaction state.
  * It is stored in the oidc provider interaction session.
@@ -198,8 +214,8 @@ export type WithHooksAndLogsContext<ContextT extends WithLogContext = WithLogCon
 export type InteractionStorage = {
   interactionEvent: InteractionEvent;
   userId?: string;
-  /** The ids of the verification records that identified `userId`; see `ExperienceInteraction.identifyUser()`. */
-  identifiedVerificationIds?: string[];
+  /** The verifications that identified `userId`; see `ExperienceInteraction.identifyUser()`. */
+  identifiedVerifications?: IdentifiedVerification[];
   trustedDeviceOptIn?:
     | {
         trusted: false;
@@ -221,7 +237,7 @@ export type InteractionStorage = {
 export const interactionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
-  identifiedVerificationIds: z.string().array().optional(),
+  identifiedVerifications: identifiedVerificationGuard.array().optional(),
   trustedDeviceOptIn: z
     .discriminatedUnion('trusted', [
       z.object({ trusted: z.literal(false) }),
@@ -246,7 +262,7 @@ export const interactionStorageGuard = z.object({
 export type SanitizedInteractionStorageData = {
   interactionEvent: InteractionEvent;
   userId?: string;
-  identifiedVerificationIds?: string[];
+  identifiedVerifications?: IdentifiedVerification[];
   profile?: SanitizedInteractionProfile;
   verificationRecords?: SanitizedVerificationRecordData[];
   mfa?: SanitizedMfaData;
@@ -264,7 +280,7 @@ export type SanitizedInteractionStorageData = {
 export const sanitizedInteractionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
-  identifiedVerificationIds: z.string().array().optional(),
+  identifiedVerifications: identifiedVerificationGuard.array().optional(),
   profile: sanitizedInteractionProfileGuard,
   verificationRecords: publicVerificationRecordDataGuard.array().optional(),
   mfa: sanitizedMfaDataGuard.optional(),

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,12 +1,10 @@
 import {
   defaultMessageRateLimitPolicy,
   InteractionEvent,
-  MfaFactor,
   SentinelActivityAction,
   SignInIdentifier,
 } from '@logto/schemas';
 
-import RequestError from '#src/errors/RequestError/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -30,7 +28,7 @@ async function resolveVoid(): Promise<void> {
   await Promise.resolve();
 }
 
-const { sendCode, getMfaIdentifier } = await import('./verification-code-helpers.js');
+const { sendCode } = await import('./verification-code-helpers.js');
 
 // Provide a permissive activity store so the message rate guard allows sends by default.
 const mockSentinelActivities = {
@@ -401,64 +399,5 @@ describe('sendCode parameter passing', () => {
     expect(
       mockExperienceInteraction.signInExperienceValidator.isRegistrationDisabled
     ).not.toHaveBeenCalled();
-  });
-});
-
-describe('getMfaIdentifier', () => {
-  const findUserById = jest
-    .fn()
-    .mockResolvedValue({ primaryEmail: 'foo@example.com', primaryPhone: '+11234567890' });
-  const queries = { users: { findUserById } } as unknown as Queries;
-
-  beforeEach(() => {
-    findUserById.mockClear();
-  });
-
-  const buildInteraction = (factors: MfaFactor[]) =>
-    ({
-      identifiedUserId: 'identified-user-id',
-      signInExperienceValidator: { getMfaSettings: jest.fn().mockResolvedValue({ factors }) },
-    }) as unknown as Parameters<typeof getMfaIdentifier>[0]['experienceInteraction'];
-
-  it('resolves the primary contact of the identified user when the factor is enabled', async () => {
-    await expect(
-      getMfaIdentifier({
-        identifierType: SignInIdentifier.Email,
-        experienceInteraction: buildInteraction([MfaFactor.EmailVerificationCode]),
-        queries,
-      })
-    ).resolves.toEqual({ type: SignInIdentifier.Email, value: 'foo@example.com' });
-  });
-
-  it.each([
-    [SignInIdentifier.Email, [MfaFactor.PhoneVerificationCode]],
-    [SignInIdentifier.Phone, [MfaFactor.EmailVerificationCode]],
-    [SignInIdentifier.Email, []],
-  ] as const)(
-    'refuses a %s code when the sign-in experience does not enable that factor',
-    async (identifierType, factors) => {
-      await expect(
-        getMfaIdentifier({
-          identifierType,
-          experienceInteraction: buildInteraction([...factors]),
-          queries,
-        })
-      ).rejects.toMatchError(
-        new RequestError({ code: 'session.mfa.mfa_factor_not_enabled', status: 400 })
-      );
-      expect(findUserById).not.toHaveBeenCalled();
-    }
-  );
-
-  it('refuses a code before any user is identified', async () => {
-    await expect(
-      getMfaIdentifier({
-        identifierType: SignInIdentifier.Email,
-        experienceInteraction: {
-          identifiedUserId: undefined,
-        } as unknown as Parameters<typeof getMfaIdentifier>[0]['experienceInteraction'],
-        queries,
-      })
-    ).rejects.toMatchError(new RequestError({ code: 'session.identifier_not_found', status: 400 }));
   });
 });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -1,6 +1,5 @@
 import {
   InteractionEvent,
-  MfaFactor,
   SentinelActivityAction,
   SignInIdentifier,
   type VerificationCodeIdentifier,
@@ -279,9 +278,7 @@ type GetMfaIdentifierParams = {
 };
 
 /**
- * Helper to get MFA identifier from user profile. The factor must be enabled in the sign-in
- * experience: otherwise a sign-in could request a second code for the very contact that already
- * identified the user, which is a second proof of the same factor and not a second factor.
+ * Helper to get MFA identifier from user profile
  * @internal
  */
 export const getMfaIdentifier = async ({
@@ -292,19 +289,6 @@ export const getMfaIdentifier = async ({
   if (!experienceInteraction.identifiedUserId) {
     throw new RequestError({
       code: 'session.identifier_not_found',
-      status: 400,
-    });
-  }
-
-  const { factors } = await experienceInteraction.signInExperienceValidator.getMfaSettings();
-  const factor =
-    identifierType === SignInIdentifier.Email
-      ? MfaFactor.EmailVerificationCode
-      : MfaFactor.PhoneVerificationCode;
-
-  if (!factors.includes(factor)) {
-    throw new RequestError({
-      code: 'session.mfa.mfa_factor_not_enabled',
       status: 400,
     });
   }

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -1,34 +1,16 @@
 import { ConnectorType } from '@logto/connector-kit';
 import { decodeIdToken } from '@logto/js';
 import { Prompt } from '@logto/node';
-import {
-  GrantType,
-  InteractionEvent,
-  MfaFactor,
-  MfaPolicy,
-  SignInIdentifier,
-  demoAppApplicationId,
-} from '@logto/schemas';
+import { GrantType, SignInIdentifier, demoAppApplicationId } from '@logto/schemas';
 import { formUrlEncodedHeaders, generateStandardId } from '@logto/shared';
 import { isKeyInObject } from '@silverhand/essentials';
 import ky from 'ky';
-import { authenticator } from 'otplib';
 
-import {
-  createUserMfaVerification,
-  deleteUser,
-  updateUserLogtoConfig,
-} from '#src/api/admin-user.js';
-import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { deleteUser } from '#src/api/admin-user.js';
 import { type ExperienceClient } from '#src/client/experience/index.js';
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
 import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
-import {
-  clearConnectorsByTypes,
-  setEmailConnector,
-  setSmsConnector,
-  setSocialConnector,
-} from '#src/helpers/connector.js';
+import { clearConnectorsByTypes, setSocialConnector } from '#src/helpers/connector.js';
 import {
   identifyUserWithUsernamePassword,
   signInWithSocial,
@@ -37,23 +19,12 @@ import {
   successfullyCreateSocialVerification,
   successfullyVerifySocialAuthorization,
 } from '#src/helpers/experience/social-verification.js';
-import { successfullyVerifyTotp } from '#src/helpers/experience/totp-verification.js';
-import {
-  successfullySendVerificationCode,
-  successfullyVerifyVerificationCode,
-} from '#src/helpers/experience/verification-code.js';
 import { expectRejects } from '#src/helpers/index.js';
-import {
-  enableAllPasswordSignInMethods,
-  enableAllVerificationCodeSignInMethods,
-  enableMandatoryMfaWithTotpAndBackupCode,
-  resetMfaSettings,
-} from '#src/helpers/sign-in-experience.js';
+import { enableAllPasswordSignInMethods } from '#src/helpers/sign-in-experience.js';
 import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
 import { devFeatureTest } from '#src/utils.js';
 
 const firstFactorAcr = 'urn:logto:acr:1fa';
-const mfaAcr = 'urn:logto:acr:mfa';
 
 const nowInSeconds = () => Math.floor(Date.now() / 1000);
 
@@ -103,11 +74,9 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
 
   beforeAll(async () => {
     await enableAllPasswordSignInMethods();
-    await updateSignInExperience({ adaptiveMfa: { enabled: false } });
   });
 
   afterAll(async () => {
-    await resetMfaSettings();
     await userApi.cleanUp();
   });
 
@@ -136,107 +105,6 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
     });
 
     await logoutClient(client);
-  });
-
-  it('issues acr=mfa and amr=[pwd, otp, mfa] for a password sign-in verified with TOTP', async () => {
-    await enableMandatoryMfaWithTotpAndBackupCode();
-    const { username, password } = generateNewUserProfile({ username: true, password: true });
-    const user = await userApi.create({ username, password });
-    const totp = await createUserMfaVerification(user.id, MfaFactor.TOTP);
-    await createUserMfaVerification(user.id, MfaFactor.BackupCode);
-
-    if (totp.type !== MfaFactor.TOTP) {
-      throw new TypeError('unexpected mfa type');
-    }
-
-    const client = await initClient();
-    await identifyUserWithUsernamePassword(client, username, password);
-    await successfullyVerifyTotp(client, { code: authenticator.generate(totp.secret) });
-    const claims = await finishSignIn(client);
-
-    expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
-    expect(typeof claims.auth_time).toBe('number');
-
-    await logoutClient(client);
-    await resetMfaSettings();
-  });
-
-  it('keeps the proof of the last backup code, which is marked used before submission', async () => {
-    // A sign-in that completes without an MFA challenge, so the consumed code is the only proof.
-    await updateSignInExperience({
-      mfa: { factors: [MfaFactor.TOTP, MfaFactor.BackupCode], policy: MfaPolicy.NoPrompt },
-    });
-    const { username, password } = generateNewUserProfile({ username: true, password: true });
-    const user = await userApi.create({ username, password });
-    await createUserMfaVerification(user.id, MfaFactor.TOTP);
-    const backupCodes = await createUserMfaVerification(user.id, MfaFactor.BackupCode);
-    await updateUserLogtoConfig(user.id, { mfa: { skipMfaOnSignIn: true }, passkeySignIn: {} });
-
-    if (backupCodes.type !== MfaFactor.BackupCode) {
-      throw new TypeError('unexpected mfa type');
-    }
-
-    const [lastCode, ...otherCodes] = backupCodes.codes;
-
-    // Consume every other code first; each verification marks its code used in the database.
-    const consumer = await initClient();
-    await identifyUserWithUsernamePassword(consumer, username, password);
-    for (const code of otherCodes) {
-      // eslint-disable-next-line no-await-in-loop -- Each code must be consumed in sequence.
-      await consumer.verifyBackupCode({ code });
-    }
-
-    const client = await initClient();
-    await identifyUserWithUsernamePassword(client, username, password);
-    await client.verifyBackupCode({ code: lastCode! });
-    const claims = await finishSignIn(client);
-
-    expect(claims.sub).toBe(user.id);
-    expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
-
-    await logoutClient(client);
-    await resetMfaSettings();
-  });
-
-  describe('verification code sign-in', () => {
-    beforeAll(async () => {
-      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
-      await Promise.all([setEmailConnector(), setSmsConnector()]);
-      await enableAllVerificationCodeSignInMethods();
-    });
-
-    afterAll(async () => {
-      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
-      await enableAllPasswordSignInMethods();
-    });
-
-    it.each([
-      { identifierType: SignInIdentifier.Email, profileKey: 'primaryEmail' },
-      { identifierType: SignInIdentifier.Phone, profileKey: 'primaryPhone' },
-    ] as const)(
-      'refuses an MFA code for the $identifierType that identified the user when the factor is not enabled',
-      async ({ identifierType, profileKey }) => {
-        const profile = generateNewUserProfile({ primaryEmail: true, primaryPhone: true });
-        await userApi.create(profile);
-        const identifier = { type: identifierType, value: profile[profileKey] };
-
-        const client = await initExperienceClient();
-        const { verificationId, code } = await successfullySendVerificationCode(client, {
-          identifier,
-          interactionEvent: InteractionEvent.SignIn,
-        });
-        await successfullyVerifyVerificationCode(client, { identifier, verificationId, code });
-        await client.identifyUser({ verificationId });
-
-        // A second code to the same contact would be a second proof of the same factor. The route
-        // refuses it because the sign-in experience does not enable that MFA factor; sign-in with
-        // a contact and MFA through the same contact cannot both be enabled.
-        await expectRejects(client.sendMfaVerificationCode({ identifierType }), {
-          code: 'session.mfa.mfa_factor_not_enabled',
-          status: 400,
-        });
-      }
-    );
   });
 
   describe('social sign-in', () => {

--- a/packages/schemas/src/types/authentication-context.test.ts
+++ b/packages/schemas/src/types/authentication-context.test.ts
@@ -1,13 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  AuthenticationFactor,
-  AuthenticationFactorClass,
   AuthenticationMethodReference,
   LogtoAcr,
   buildAuthenticationMethodReferences,
-  getAuthenticationFactor,
-  getAuthenticationFactorClass,
+  getAchievedAcr,
   getAuthenticationMethodReferences,
   logtoAcrValues,
 } from './authentication-context.js';
@@ -16,56 +13,6 @@ import { VerificationType } from './verification-records/verification-type.js';
 describe('logtoAcrValues', () => {
   it('advertises exactly the two Logto classes in order', () => {
     expect(logtoAcrValues).toEqual(['urn:logto:acr:1fa', 'urn:logto:acr:mfa']);
-  });
-});
-
-describe('getAuthenticationFactorClass', () => {
-  it.each([
-    VerificationType.Password,
-    VerificationType.EmailVerificationCode,
-    VerificationType.PhoneVerificationCode,
-    VerificationType.OneTimeToken,
-    VerificationType.NewPasswordIdentity,
-  ])('classifies %s as 1fa', (type) => {
-    expect(getAuthenticationFactorClass(type)).toBe(AuthenticationFactorClass.FirstFactor);
-  });
-
-  it.each([
-    VerificationType.TOTP,
-    VerificationType.MfaEmailVerificationCode,
-    VerificationType.MfaPhoneVerificationCode,
-    VerificationType.BackupCode,
-    VerificationType.WebAuthn,
-    VerificationType.SignInPasskey,
-  ])('classifies %s as mfa', (type) => {
-    expect(getAuthenticationFactorClass(type)).toBe(AuthenticationFactorClass.Mfa);
-  });
-
-  it.each([VerificationType.Social, VerificationType.EnterpriseSso])(
-    'gives %s no class',
-    (type) => {
-      expect(getAuthenticationFactorClass(type)).toBeUndefined();
-    }
-  );
-});
-
-describe('getAuthenticationFactor', () => {
-  it.each([
-    [VerificationType.Password, AuthenticationFactor.Password],
-    [VerificationType.NewPasswordIdentity, AuthenticationFactor.Password],
-    [VerificationType.EmailVerificationCode, AuthenticationFactor.Email],
-    [VerificationType.MfaEmailVerificationCode, AuthenticationFactor.Email],
-    [VerificationType.OneTimeToken, AuthenticationFactor.Email],
-    [VerificationType.PhoneVerificationCode, AuthenticationFactor.Phone],
-    [VerificationType.MfaPhoneVerificationCode, AuthenticationFactor.Phone],
-    [VerificationType.TOTP, AuthenticationFactor.Totp],
-    [VerificationType.BackupCode, AuthenticationFactor.BackupCode],
-    [VerificationType.WebAuthn, AuthenticationFactor.WebAuthn],
-    [VerificationType.SignInPasskey, AuthenticationFactor.WebAuthn],
-    [VerificationType.Social, AuthenticationFactor.Federated],
-    [VerificationType.EnterpriseSso, AuthenticationFactor.Federated],
-  ])('maps %s to the %s factor', (type, expected) => {
-    expect(getAuthenticationFactor(type)).toBe(expected);
   });
 });
 
@@ -87,70 +34,51 @@ describe('getAuthenticationMethodReferences', () => {
   ])('maps %s to %j', (type, expected) => {
     expect(getAuthenticationMethodReferences(type)).toEqual(expected);
   });
-
-  it('maps every verification type', () => {
-    for (const type of Object.values(VerificationType)) {
-      expect(getAuthenticationMethodReferences(type).length).toBeGreaterThan(0);
-    }
-  });
-
-  it('emits `fed` as the only unregistered AMR value', () => {
-    // RFC 8176 / IANA registered values used by Logto.
-    const registered = new Set(['pwd', 'otp', 'sms', 'pop', 'user', 'mfa']);
-    const emitted = new Set(
-      Object.values(VerificationType).flatMap((type) => getAuthenticationMethodReferences(type))
-    );
-
-    expect([...emitted].filter((value) => !registered.has(value))).toEqual([
-      AuthenticationMethodReference.Federated,
-    ]);
-  });
 });
 
 describe('buildAuthenticationMethodReferences', () => {
+  it('returns an empty list for no types', () => {
+    expect(buildAuthenticationMethodReferences([])).toEqual([]);
+  });
+
   it('unions references in first-seen order without duplicates', () => {
     expect(
-      buildAuthenticationMethodReferences(
-        [VerificationType.Password, VerificationType.TOTP, VerificationType.BackupCode],
-        LogtoAcr.FirstFactor
-      )
-    ).toEqual(['pwd', 'otp']);
+      buildAuthenticationMethodReferences([
+        VerificationType.Password,
+        VerificationType.EmailVerificationCode,
+        VerificationType.Social,
+        VerificationType.OneTimeToken,
+      ])
+    ).toEqual(['pwd', 'otp', 'fed']);
   });
 
-  it('appends `mfa` when the achieved ACR is mfa', () => {
+  it('keeps mfa last whenever a type carries it', () => {
     expect(
-      buildAuthenticationMethodReferences(
-        [VerificationType.Password, VerificationType.TOTP],
-        LogtoAcr.Mfa
-      )
-    ).toEqual(['pwd', 'otp', 'mfa']);
+      buildAuthenticationMethodReferences([VerificationType.SignInPasskey, VerificationType.Social])
+    ).toEqual(['pop', 'user', 'fed', 'mfa']);
+  });
+});
+
+describe('getAchievedAcr', () => {
+  it('reaches mfa when the references carry mfa', () => {
+    expect(
+      getAchievedAcr([
+        AuthenticationMethodReference.ProofOfPossession,
+        AuthenticationMethodReference.UserPresence,
+        AuthenticationMethodReference.Mfa,
+      ])
+    ).toBe(LogtoAcr.Mfa);
   });
 
-  it('does not duplicate `mfa` for WebAuthn', () => {
-    expect(buildAuthenticationMethodReferences([VerificationType.WebAuthn], LogtoAcr.Mfa)).toEqual([
-      'pop',
-      'user',
-      'mfa',
-    ]);
+  it('reaches 1fa for a factor Logto verified itself', () => {
+    expect(getAchievedAcr([AuthenticationMethodReference.Password])).toBe(LogtoAcr.FirstFactor);
+    expect(
+      getAchievedAcr([AuthenticationMethodReference.Federated, AuthenticationMethodReference.Otp])
+    ).toBe(LogtoAcr.FirstFactor);
   });
 
-  it('keeps `mfa` last when a WebAuthn record precedes another factor', () => {
-    expect(
-      buildAuthenticationMethodReferences(
-        [VerificationType.WebAuthn, VerificationType.Password],
-        LogtoAcr.Mfa
-      )
-    ).toEqual(['pop', 'user', 'pwd', 'mfa']);
-    // WebAuthn carries `mfa` on its own even when no ACR is passed.
-    expect(
-      buildAuthenticationMethodReferences([VerificationType.WebAuthn, VerificationType.Password])
-    ).toEqual(['pop', 'user', 'pwd', 'mfa']);
-  });
-
-  it('keeps `fed` next to an established factor without an ACR', () => {
-    expect(
-      buildAuthenticationMethodReferences([VerificationType.Social, VerificationType.Password])
-    ).toEqual(['fed', 'pwd']);
-    expect(buildAuthenticationMethodReferences([VerificationType.Social])).toEqual(['fed']);
+  it('reaches no ACR for a federated assertion alone or no references', () => {
+    expect(getAchievedAcr([AuthenticationMethodReference.Federated])).toBeUndefined();
+    expect(getAchievedAcr([])).toBeUndefined();
   });
 });

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -1,7 +1,7 @@
 /**
- * @file The authoritative vocabulary for the authentication context Logto records on a sign-in or
- * step-up: the supported Authentication Context Class Reference (ACR) values, their satisfaction
- * relation, and the Authentication Methods References (AMR) each verification contributes.
+ * @file The vocabulary for the authentication context Logto records on a sign-in: the supported
+ * Authentication Context Class Reference (ACR) values and the Authentication Methods References
+ * (AMR) each verification type contributes.
  *
  * @see {@link https://openid.net/specs/openid-connect-core-1_0.html#IDToken | OpenID Connect Core `acr` / `amr`}
  * @see {@link https://www.rfc-editor.org/rfc/rfc8176.html | RFC 8176 Authentication Method Reference Values}
@@ -12,13 +12,13 @@ import { VerificationType } from './verification-records/verification-type.js';
 export enum LogtoAcr {
   /**
    * At least one active factor that Logto can directly verify: password, the user's primary
-   * email / phone verification code, or an enrolled MFA factor. Social and enterprise SSO never
-   * satisfy this class.
+   * email / phone verification code, or a one-time token. Social and enterprise SSO never satisfy
+   * this class.
    */
   FirstFactor = 'urn:logto:acr:1fa',
   /**
-   * A Logto-verifiable {@link LogtoAcr.FirstFactor} context plus an `mfa`-class record from a
-   * different factor, or WebAuthn / passkey with required user verification alone.
+   * A {@link LogtoAcr.FirstFactor} context plus a second factor, or a user-verified WebAuthn
+   * assertion alone.
    */
   Mfa = 'urn:logto:acr:mfa',
 }
@@ -42,102 +42,19 @@ export enum AuthenticationMethodReference {
   ProofOfPossession = 'pop',
   /** User presence / verification by the authenticator, e.g. WebAuthn user verification. */
   UserPresence = 'user',
-  /** Multiple-factor authentication; appended whenever the achieved ACR is {@link LogtoAcr.Mfa}. */
+  /** Multiple-factor authentication; present whenever the achieved ACR is {@link LogtoAcr.Mfa}. */
   Mfa = 'mfa',
   /** Federated authentication assertion from a social or enterprise SSO provider. */
   Federated = 'fed',
 }
-
-/** The class a verification record contributes toward an ACR. */
-export enum AuthenticationFactorClass {
-  /** Contributes {@link LogtoAcr.FirstFactor}. */
-  FirstFactor = '1fa',
-  /**
-   * Contributes an `mfa`-class record. Combined with a {@link AuthenticationFactorClass.FirstFactor}
-   * record from a different factor it reaches {@link LogtoAcr.Mfa}; alone it reaches only
-   * {@link LogtoAcr.FirstFactor}, except WebAuthn / passkey with required user verification.
-   */
-  Mfa = 'mfa',
-}
-
-/**
- * The class each verification type contributes: `1fa`-class, `mfa`-class, or `undefined` for
- * social / enterprise SSO, which contribute `fed` to AMR but nothing to the ACR.
- *
- * The record is keyed by every {@link VerificationType}, so a new type fails at compile time until
- * it is mapped here. Whether a WebAuthn assertion actually required user verification is decided at
- * derivation time; this table only says which class the type can contribute.
- */
-const authenticationFactorClasses: Readonly<
-  Record<VerificationType, AuthenticationFactorClass | undefined>
-> = Object.freeze({
-  [VerificationType.Password]: AuthenticationFactorClass.FirstFactor,
-  [VerificationType.EmailVerificationCode]: AuthenticationFactorClass.FirstFactor,
-  [VerificationType.PhoneVerificationCode]: AuthenticationFactorClass.FirstFactor,
-  [VerificationType.OneTimeToken]: AuthenticationFactorClass.FirstFactor,
-  // The class of a password established by a registration. The account does not exist while the
-  // record is verified, so the sign-in derivation in core never counts the record as a proof.
-  [VerificationType.NewPasswordIdentity]: AuthenticationFactorClass.FirstFactor,
-  [VerificationType.TOTP]: AuthenticationFactorClass.Mfa,
-  [VerificationType.MfaEmailVerificationCode]: AuthenticationFactorClass.Mfa,
-  [VerificationType.MfaPhoneVerificationCode]: AuthenticationFactorClass.Mfa,
-  [VerificationType.BackupCode]: AuthenticationFactorClass.Mfa,
-  [VerificationType.WebAuthn]: AuthenticationFactorClass.Mfa,
-  [VerificationType.SignInPasskey]: AuthenticationFactorClass.Mfa,
-  [VerificationType.Social]: undefined,
-  [VerificationType.EnterpriseSso]: undefined,
-});
-
-/** Classify a verification type; see {@link authenticationFactorClasses}. */
-export const getAuthenticationFactorClass = (
-  type: VerificationType
-): AuthenticationFactorClass | undefined => authenticationFactorClasses[type];
-
-/**
- * The factor a verification record is a proof of. Repeated proofs of one factor count once, and
- * {@link LogtoAcr.Mfa} needs a `1fa`-class and an `mfa`-class proof of two different factors: a
- * one-time token and an MFA email code are two proofs of the same mailbox, not two factors.
- */
-export enum AuthenticationFactor {
-  Password = 'password',
-  Email = 'email',
-  Phone = 'phone',
-  Totp = 'totp',
-  BackupCode = 'backupCode',
-  WebAuthn = 'webAuthn',
-  Federated = 'federated',
-}
-
-/** Keyed by every {@link VerificationType}, so a new type fails at compile time until mapped. */
-const authenticationFactors: Readonly<Record<VerificationType, AuthenticationFactor>> =
-  Object.freeze({
-    [VerificationType.Password]: AuthenticationFactor.Password,
-    [VerificationType.NewPasswordIdentity]: AuthenticationFactor.Password,
-    [VerificationType.EmailVerificationCode]: AuthenticationFactor.Email,
-    [VerificationType.MfaEmailVerificationCode]: AuthenticationFactor.Email,
-    [VerificationType.OneTimeToken]: AuthenticationFactor.Email,
-    [VerificationType.PhoneVerificationCode]: AuthenticationFactor.Phone,
-    [VerificationType.MfaPhoneVerificationCode]: AuthenticationFactor.Phone,
-    [VerificationType.TOTP]: AuthenticationFactor.Totp,
-    [VerificationType.BackupCode]: AuthenticationFactor.BackupCode,
-    [VerificationType.WebAuthn]: AuthenticationFactor.WebAuthn,
-    [VerificationType.SignInPasskey]: AuthenticationFactor.WebAuthn,
-    [VerificationType.Social]: AuthenticationFactor.Federated,
-    [VerificationType.EnterpriseSso]: AuthenticationFactor.Federated,
-  });
-
-/** The factor a verification type is a proof of; see {@link authenticationFactors}. */
-export const getAuthenticationFactor = (type: VerificationType): AuthenticationFactor =>
-  authenticationFactors[type];
 
 /**
  * The AMR values a single verification type contributes, per the step-up tech design. The record
  * is keyed by every {@link VerificationType}, so a new type fails at compile time until it is
  * mapped here.
  *
- * The trailing `mfa` marker for an achieved {@link LogtoAcr.Mfa} is added by
- * {@link buildAuthenticationMethodReferences}, not here; WebAuthn carries it inherently because a
- * user-verified passkey is a multi-factor authenticator on its own.
+ * WebAuthn carries `mfa` inherently: Logto always requires user verification, so a verified
+ * passkey assertion is a multi-factor authenticator on its own.
  */
 const authenticationMethodReferences: Readonly<
   Record<VerificationType, readonly AuthenticationMethodReference[]>
@@ -171,20 +88,36 @@ export const getAuthenticationMethodReferences = (
 ): readonly AuthenticationMethodReference[] => authenticationMethodReferences[type];
 
 /**
- * Build the `amr` claim for a set of counted verification types and the ACR they achieved:
- * the union of each type's references in first-seen order, with `mfa` always last, present
- * whenever a counted type carries it (WebAuthn) or the achieved ACR is {@link LogtoAcr.Mfa}.
+ * Build the `amr` claim for the verification types that authenticated the user: the union of each
+ * type's references in first-seen order, with `mfa` always last when any type carries it.
  */
 export const buildAuthenticationMethodReferences = (
-  types: Iterable<VerificationType>,
-  achievedAcr?: LogtoAcr
+  types: Iterable<VerificationType>
 ): AuthenticationMethodReference[] => {
-  const references = [...types].flatMap((type) => getAuthenticationMethodReferences(type));
-  const hasMfa =
-    achievedAcr === LogtoAcr.Mfa || references.includes(AuthenticationMethodReference.Mfa);
+  const references = [
+    ...new Set([...types].flatMap((type) => getAuthenticationMethodReferences(type))),
+  ];
+  const hasMfa = references.includes(AuthenticationMethodReference.Mfa);
 
   return [
-    ...new Set(references.filter((reference) => reference !== AuthenticationMethodReference.Mfa)),
+    ...references.filter((reference) => reference !== AuthenticationMethodReference.Mfa),
     ...(hasMfa ? [AuthenticationMethodReference.Mfa] : []),
   ];
+};
+
+/**
+ * The ACR the `amr` claim achieved: `mfa` marks {@link LogtoAcr.Mfa}; any other reference except
+ * `fed` is a factor Logto verified itself and reaches {@link LogtoAcr.FirstFactor}; a federated
+ * assertion alone reaches no ACR.
+ */
+export const getAchievedAcr = (
+  references: readonly AuthenticationMethodReference[]
+): LogtoAcr | undefined => {
+  if (references.includes(AuthenticationMethodReference.Mfa)) {
+    return LogtoAcr.Mfa;
+  }
+
+  return references.some((reference) => reference !== AuthenticationMethodReference.Federated)
+    ? LogtoAcr.FirstFactor
+    : undefined;
 };

--- a/packages/schemas/src/types/verification-records/backup-code-verification.ts
+++ b/packages/schemas/src/types/verification-records/backup-code-verification.ts
@@ -11,8 +11,6 @@ export type BackupCodeVerificationRecordData = {
   userId: string;
   code?: string;
   backupCodes?: string[];
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 };
 export const backupCodeVerificationRecordDataGuard = z.object({
   id: z.string(),
@@ -20,7 +18,6 @@ export const backupCodeVerificationRecordDataGuard = z.object({
   userId: z.string(),
   code: z.string().optional(),
   backupCodes: z.string().array().optional(),
-  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<BackupCodeVerificationRecordData>;
 
 export type SanitizedBackupCodeVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/code-verification.ts
+++ b/packages/schemas/src/types/verification-records/code-verification.ts
@@ -30,15 +30,12 @@ export type CodeVerificationRecordData<T extends CodeVerificationType = CodeVeri
   identifier: VerificationCodeIdentifierOf<T>;
   templateType: TemplateType;
   verified: boolean;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 };
 
 const basicCodeVerificationRecordDataGuard = z.object({
   id: z.string(),
   templateType: z.nativeEnum(TemplateType),
   verified: z.boolean(),
-  verifiedAt: z.number().optional(),
 });
 
 export const emailCodeVerificationRecordDataGuard = basicCodeVerificationRecordDataGuard.extend({

--- a/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
+++ b/packages/schemas/src/types/verification-records/enterprise-sso-verification.ts
@@ -17,8 +17,6 @@ export type EnterpriseSsoVerificationRecordData = {
   enterpriseSsoUserInfo?: ExtendedSocialUserInfo;
   encryptedTokenSet?: EncryptedTokenSet;
   issuer?: string;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 };
 
 export const enterpriseSsoVerificationRecordDataGuard = z.object({
@@ -28,7 +26,6 @@ export const enterpriseSsoVerificationRecordDataGuard = z.object({
   enterpriseSsoUserInfo: extendedSocialUserInfoGuard.optional(),
   encryptedTokenSet: encryptedTokenSetGuard.optional(),
   issuer: z.string().optional(),
-  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<EnterpriseSsoVerificationRecordData>;
 
 export type SanitizedEnterpriseSsoVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/new-password-identity-verification.ts
+++ b/packages/schemas/src/types/verification-records/new-password-identity-verification.ts
@@ -22,8 +22,6 @@ export type NewPasswordIdentityVerificationRecordData = {
   identifier: InteractionIdentifier;
   passwordEncrypted?: string;
   passwordEncryptionMethod?: UsersPasswordEncryptionMethod.Argon2i;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 };
 
 export const newPasswordIdentityVerificationRecordDataGuard = z.object({
@@ -32,7 +30,6 @@ export const newPasswordIdentityVerificationRecordDataGuard = z.object({
   identifier: interactionIdentifierGuard,
   passwordEncrypted: z.string().optional(),
   passwordEncryptionMethod: z.literal(UsersPasswordEncryptionMethod.Argon2i).optional(),
-  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<NewPasswordIdentityVerificationRecordData>;
 
 export type SanitizedNewPasswordIdentityVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/one-time-token-verification.ts
+++ b/packages/schemas/src/types/verification-records/one-time-token-verification.ts
@@ -16,8 +16,6 @@ export type OneTimeTokenVerificationRecordData = {
   identifier: InteractionIdentifier<SignInIdentifier.Email>;
   verified: boolean;
   oneTimeTokenContext?: OneTimeTokenContext;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 };
 
 export const oneTimeTokenVerificationRecordDataGuard = z.object({
@@ -29,5 +27,4 @@ export const oneTimeTokenVerificationRecordDataGuard = z.object({
     value: z.string(),
   }),
   oneTimeTokenContext: oneTimeTokenContextGuard.optional(),
-  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<OneTimeTokenVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/password-verification.ts
+++ b/packages/schemas/src/types/verification-records/password-verification.ts
@@ -10,8 +10,6 @@ export type PasswordVerificationRecordData = {
   type: VerificationType.Password;
   identifier: VerificationIdentifier;
   verified: boolean;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 };
 
 export const passwordVerificationRecordDataGuard = z.object({
@@ -19,5 +17,4 @@ export const passwordVerificationRecordDataGuard = z.object({
   type: z.literal(VerificationType.Password),
   identifier: verificationIdentifierGuard,
   verified: z.boolean(),
-  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<PasswordVerificationRecordData>;

--- a/packages/schemas/src/types/verification-records/social-verification.ts
+++ b/packages/schemas/src/types/verification-records/social-verification.ts
@@ -25,8 +25,6 @@ export type SocialVerificationRecordData = {
    * The connector session result
    */
   connectorSession?: ConnectorSession;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 };
 
 export const socialVerificationRecordDataGuard = z.object({
@@ -36,7 +34,6 @@ export const socialVerificationRecordDataGuard = z.object({
   socialUserInfo: socialUserInfoGuard.optional(),
   encryptedTokenSet: encryptedTokenSetGuard.optional(),
   connectorSession: connectorSessionGuard.optional(),
-  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<SocialVerificationRecordData>;
 
 export type SanitizedSocialVerificationRecordData = Omit<

--- a/packages/schemas/src/types/verification-records/totp-verification.ts
+++ b/packages/schemas/src/types/verification-records/totp-verification.ts
@@ -11,8 +11,6 @@ export type TotpVerificationRecordData = {
   userId: string;
   secret?: string;
   verified: boolean;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 };
 
 export const totpVerificationRecordDataGuard = z.object({
@@ -21,7 +19,6 @@ export const totpVerificationRecordDataGuard = z.object({
   userId: z.string(),
   secret: z.string().optional(),
   verified: z.boolean(),
-  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<TotpVerificationRecordData>;
 
 export type SanitizedTotpVerificationRecordData = Omit<TotpVerificationRecordData, 'secret'>;

--- a/packages/schemas/src/types/verification-records/web-authn-verification.ts
+++ b/packages/schemas/src/types/verification-records/web-authn-verification.ts
@@ -15,8 +15,6 @@ type BaseWebAuthnVerificationRecordData = {
   /** The challenge generated for the WebAuthn authentication */
   authenticationChallenge?: string;
   registrationInfo?: BindWebAuthn;
-  /** Epoch seconds when the verification succeeded; feeds the `auth_time` claim. */
-  verifiedAt?: number;
 };
 
 const baseWebAuthnVerificationRecordDataGuard = z.object({
@@ -26,7 +24,6 @@ const baseWebAuthnVerificationRecordDataGuard = z.object({
   registrationRpId: z.string().optional(),
   authenticationChallenge: z.string().optional(),
   registrationInfo: bindWebAuthnGuard.optional(),
-  verifiedAt: z.number().optional(),
 }) satisfies ToZodObject<BaseWebAuthnVerificationRecordData>;
 
 export type WebAuthnVerificationRecordData = BaseWebAuthnVerificationRecordData & {


### PR DESCRIPTION
## Summary

Closed: the team has since decided that a registration and factors bound in the same interaction count toward `amr` as well. Neither passes through `identifyUser()`, so recording the context there cannot capture them. The record-scanning derivation in #9546 is the right shape for that rule; the change has been reverted on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UD4c4Y6WDjvB4eRGmsYvHj