### PR TITLE
fix(core): guard the registration password and MFA code routes at the route level

### DIFF
--- a/packages/core/src/routes/experience/verification-routes/new-password-identity-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/new-password-identity-verification.ts
@@ -1,11 +1,13 @@
 import { usernameRegEx } from '@logto/core-kit';
-import { SignInIdentifier, VerificationType } from '@logto/schemas';
+import { InteractionEvent, SignInIdentifier, VerificationType } from '@logto/schemas';
 import { Action } from '@logto/schemas/lib/types/log/interaction.js';
 import type Router from 'koa-router';
 import { z } from 'zod';
 
+import RequestError from '#src/errors/RequestError/index.js';
 import koaGuard from '#src/middleware/koa-guard.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
+import assertThat from '#src/utils/assert-that.js';
 
 import { NewPasswordIdentityVerification } from '../classes/verifications/new-password-identity-verification.js';
 import { experienceRoutes } from '../const.js';
@@ -38,6 +40,13 @@ export default function newPasswordIdentityVerificationRoutes<
     async (ctx, next) => {
       const { identifier, password } = ctx.guard.body;
       const { experienceInteraction, verificationAuditLog } = ctx;
+
+      // The record only proposes a password for an account that does not exist yet. In any other
+      // event it would sit next to the identified user's records without ever authenticating them.
+      assertThat(
+        experienceInteraction.interactionEvent === InteractionEvent.Register,
+        new RequestError({ code: 'session.invalid_interaction_type', status: 400 })
+      );
 
       verificationAuditLog.append({
         payload: {

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.test.ts
@@ -1,10 +1,12 @@
 import {
   defaultMessageRateLimitPolicy,
   InteractionEvent,
+  MfaFactor,
   SentinelActivityAction,
   SignInIdentifier,
 } from '@logto/schemas';
 
+import RequestError from '#src/errors/RequestError/index.js';
 import type Libraries from '#src/tenants/Libraries.js';
 import type Queries from '#src/tenants/Queries.js';
 
@@ -28,7 +30,7 @@ async function resolveVoid(): Promise<void> {
   await Promise.resolve();
 }
 
-const { sendCode } = await import('./verification-code-helpers.js');
+const { sendCode, getMfaIdentifier } = await import('./verification-code-helpers.js');
 
 // Provide a permissive activity store so the message rate guard allows sends by default.
 const mockSentinelActivities = {
@@ -399,5 +401,64 @@ describe('sendCode parameter passing', () => {
     expect(
       mockExperienceInteraction.signInExperienceValidator.isRegistrationDisabled
     ).not.toHaveBeenCalled();
+  });
+});
+
+describe('getMfaIdentifier', () => {
+  const findUserById = jest
+    .fn()
+    .mockResolvedValue({ primaryEmail: 'foo@example.com', primaryPhone: '+11234567890' });
+  const queries = { users: { findUserById } } as unknown as Queries;
+
+  beforeEach(() => {
+    findUserById.mockClear();
+  });
+
+  const buildInteraction = (factors: MfaFactor[]) =>
+    ({
+      identifiedUserId: 'identified-user-id',
+      signInExperienceValidator: { getMfaSettings: jest.fn().mockResolvedValue({ factors }) },
+    }) as unknown as Parameters<typeof getMfaIdentifier>[0]['experienceInteraction'];
+
+  it('resolves the primary contact of the identified user when the factor is enabled', async () => {
+    await expect(
+      getMfaIdentifier({
+        identifierType: SignInIdentifier.Email,
+        experienceInteraction: buildInteraction([MfaFactor.EmailVerificationCode]),
+        queries,
+      })
+    ).resolves.toEqual({ type: SignInIdentifier.Email, value: 'foo@example.com' });
+  });
+
+  it.each([
+    [SignInIdentifier.Email, [MfaFactor.PhoneVerificationCode]],
+    [SignInIdentifier.Phone, [MfaFactor.EmailVerificationCode]],
+    [SignInIdentifier.Email, []],
+  ] as const)(
+    'refuses a %s code when the sign-in experience does not enable that factor',
+    async (identifierType, factors) => {
+      await expect(
+        getMfaIdentifier({
+          identifierType,
+          experienceInteraction: buildInteraction([...factors]),
+          queries,
+        })
+      ).rejects.toMatchError(
+        new RequestError({ code: 'session.mfa.mfa_factor_not_enabled', status: 400 })
+      );
+      expect(findUserById).not.toHaveBeenCalled();
+    }
+  );
+
+  it('refuses a code before any user is identified', async () => {
+    await expect(
+      getMfaIdentifier({
+        identifierType: SignInIdentifier.Email,
+        experienceInteraction: {
+          identifiedUserId: undefined,
+        } as unknown as Parameters<typeof getMfaIdentifier>[0]['experienceInteraction'],
+        queries,
+      })
+    ).rejects.toMatchError(new RequestError({ code: 'session.identifier_not_found', status: 400 }));
   });
 });

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -1,5 +1,6 @@
 import {
   InteractionEvent,
+  MfaFactor,
   SentinelActivityAction,
   SignInIdentifier,
   type VerificationCodeIdentifier,
@@ -278,7 +279,9 @@ type GetMfaIdentifierParams = {
 };
 
 /**
- * Helper to get MFA identifier from user profile
+ * Helper to get MFA identifier from user profile. The factor must be enabled in the sign-in
+ * experience: otherwise a sign-in could request a second code for the very contact that already
+ * identified the user, which is a second proof of the same factor and not a second factor.
  * @internal
  */
 export const getMfaIdentifier = async ({
@@ -289,6 +292,19 @@ export const getMfaIdentifier = async ({
   if (!experienceInteraction.identifiedUserId) {
     throw new RequestError({
       code: 'session.identifier_not_found',
+      status: 400,
+    });
+  }
+
+  const { factors } = await experienceInteraction.signInExperienceValidator.getMfaSettings();
+  const factor =
+    identifierType === SignInIdentifier.Email
+      ? MfaFactor.EmailVerificationCode
+      : MfaFactor.PhoneVerificationCode;
+
+  if (!factors.includes(factor)) {
+    throw new RequestError({
+      code: 'session.mfa.mfa_factor_not_enabled',
       status: 400,
     });
   }

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/email-phone-mfa-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/email-phone-mfa-verification.test.ts
@@ -14,10 +14,14 @@ import {
 import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
 import {
   successfullySendMfaVerificationCode,
+  successfullySendVerificationCode,
   successfullyVerifyMfaVerificationCode,
+  successfullyVerifyVerificationCode,
 } from '#src/helpers/experience/verification-code.js';
+import { expectRejects } from '#src/helpers/index.js';
 import {
   enableAllPasswordSignInMethods,
+  enableAllVerificationCodeSignInMethods,
   enableMandatoryMfaWithEmail,
   enableMandatoryMfaWithPhone,
   resetMfaSettings,
@@ -95,3 +99,48 @@ describe.each(mfaTestCases)(
     });
   }
 );
+
+describe('MFA verification code factor guard', () => {
+  const userApi = new UserApiTest();
+
+  beforeAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+    await Promise.all([setEmailConnector(), setSmsConnector()]);
+    await enableAllVerificationCodeSignInMethods();
+    await resetMfaSettings();
+  });
+
+  afterAll(async () => {
+    await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+    await enableAllPasswordSignInMethods();
+    await userApi.cleanUp();
+  });
+
+  it.each([
+    { identifierType: SignInIdentifier.Email, profileKey: 'primaryEmail' },
+    { identifierType: SignInIdentifier.Phone, profileKey: 'primaryPhone' },
+  ] as const)(
+    'refuses an MFA code for the $identifierType that identified the user when the factor is not enabled',
+    async ({ identifierType, profileKey }) => {
+      const profile = generateNewUserProfile({ primaryEmail: true, primaryPhone: true });
+      await userApi.create(profile);
+      const identifier = { type: identifierType, value: profile[profileKey] };
+
+      const client = await initExperienceClient();
+      const { verificationId, code } = await successfullySendVerificationCode(client, {
+        identifier,
+        interactionEvent: InteractionEvent.SignIn,
+      });
+      await successfullyVerifyVerificationCode(client, { identifier, verificationId, code });
+      await client.identifyUser({ verificationId });
+
+      // A second code to the same contact would only re-prove the contact that already identified
+      // the user. The route refuses it because the sign-in experience does not enable that MFA
+      // factor; sign-in with a contact and MFA through the same contact cannot both be enabled.
+      await expectRejects(client.sendMfaVerificationCode({ identifierType }), {
+        code: 'session.mfa.mfa_factor_not_enabled',
+        status: 400,
+      });
+    }
+  );
+});

--- a/packages/integration-tests/src/tests/api/experience-api/verifications/new-password-identity-verification.test.ts
+++ b/packages/integration-tests/src/tests/api/experience-api/verifications/new-password-identity-verification.test.ts
@@ -1,4 +1,4 @@
-import { SignInIdentifier } from '@logto/schemas';
+import { InteractionEvent, SignInIdentifier } from '@logto/schemas';
 
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { initExperienceClient } from '#src/helpers/client.js';
@@ -36,12 +36,25 @@ describe('password verifications', () => {
     });
   });
 
+  it('should reject the verification outside a register interaction', async () => {
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const client = await initExperienceClient();
+
+    await expectRejects(
+      client.createNewPasswordIdentityVerification({
+        identifier: { type: SignInIdentifier.Username, value: username },
+        password,
+      }),
+      { code: 'session.invalid_interaction_type', status: 400 }
+    );
+  });
+
   describe('invalid identifier check', () => {
     it('should throw error if username is registered', async () => {
       const { username, password } = generateNewUserProfile({ username: true, password: true });
       await userApi.create({ username, password });
 
-      const client = await initExperienceClient();
+      const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
 
       await expectRejects(
         client.createNewPasswordIdentityVerification({
@@ -66,7 +79,7 @@ describe('password verifications', () => {
 
       await userApi.create({ primaryEmail, password });
 
-      const client = await initExperienceClient();
+      const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
 
       await expectRejects(
         client.createNewPasswordIdentityVerification({
@@ -95,7 +108,7 @@ describe('password verifications', () => {
     ];
 
     it.each(invalidPasswords)('should reject invalid password %p', async (password) => {
-      const client = await initExperienceClient();
+      const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
 
       await expectRejects(
         client.createNewPasswordIdentityVerification({
@@ -114,7 +127,7 @@ describe('password verifications', () => {
   });
 
   it('should create new password identity verification successfully', async () => {
-    const client = await initExperienceClient();
+    const client = await initExperienceClient({ interactionEvent: InteractionEvent.Register });
 
     const { verificationId } = await client.createNewPasswordIdentityVerification({
       identifier: {


### PR DESCRIPTION
## Summary

Split out of #9546 (part 1 of 3, independent of the other two). Two Experience verification routes could create records in interactions where they never authenticate the identified user:

- `POST /verification/new-password-identity` accepted a password proposed for an unused username in any interaction. The record only ever creates an account, so it now requires a Register interaction and otherwise responds `400 session.invalid_interaction_type`.
- `POST /verification/mfa-verification-code` resolved the identified user's primary contact without checking that the email / phone MFA factor is enabled, so a sign-in could request a second code for the very contact that already identified the user. It now responds `400 session.mfa.mfa_factor_not_enabled` for a factor the sign-in experience does not enable.

Both guards are prerequisites for the authentication context work: without them a sign-in could hold a second "proof" of a factor it never established.

## Testing

- `verification-code-helpers.test.ts`: `getMfaIdentifier` resolves the contact when the factor is enabled, refuses each contact type when it is not, and refuses a code before any user is identified.
- Integration: `new-password-identity-verification.test.ts` asserts the Register-only guard (the other cases now open a Register interaction); `email-phone-mfa-verification.test.ts` asserts that an email / phone code sign-in cannot request an MFA code for the same contact while that factor is not enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6suKhdhJjJKw4aVfXRkca

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6suKhdhJjJKw4aVfXRkca)_