### PR TITLE
feat(core,schemas): define Logto ACR values and AMR mapping and advertise them in Discovery

### DIFF
--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -781,4 +781,34 @@ describe('findAccount', () => {
     ).rejects.toMatchError(new errors.InvalidGrant('user is suspended'));
   });
 });
+describe('authentication context provider metadata', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  afterEach(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  it('should advertise the Logto ACR values and the acr / amr / auth_time claims when dev features are enabled', () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+    const configuration = getProviderConfiguration(createProvider(new MockTenant()));
+    // `claimsSupported` is derived by the provider at construction and is not part of its typings.
+    const claimsSupported: unknown = Reflect.get(configuration, 'claimsSupported');
+
+    expect([...configuration.acrValues]).toEqual(['urn:logto:acr:1fa', 'urn:logto:acr:mfa']);
+    expect(claimsSupported).toContain('acr');
+    expect(claimsSupported).toContain('amr');
+    expect(claimsSupported).toContain('auth_time');
+  });
+
+  it('should keep the provider metadata unchanged when dev features are disabled', () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+    const configuration = getProviderConfiguration(createProvider(new MockTenant()));
+    const claimsSupported: unknown = Reflect.get(configuration, 'claimsSupported');
+
+    expect([...configuration.acrValues]).toEqual([]);
+    expect(claimsSupported).not.toContain('acr');
+    expect(claimsSupported).not.toContain('amr');
+    expect(claimsSupported).toContain('auth_time');
+  });
+});
 /* eslint-enable max-lines */

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -12,6 +12,7 @@ import {
   extraParamsObjectGuard,
   inSeconds,
   logtoCookieKey,
+  logtoAcrValues,
   ExtraParamsKey,
   type Json,
 } from '@logto/schemas';
@@ -438,7 +439,16 @@ export default function initOidc(
       ctx.URL.origin === origin || isOriginAllowed(origin, client.metadata(), client.redirectUris),
     // https://github.com/panva/node-oidc-provider/blob/main/recipes/claim_configuration.md
     // Note node-provider will append `claims` here to the default claims instead of overriding
-    claims: userClaims,
+    claims: EnvSet.values.isDevFeaturesEnabled
+      ? // The provider only puts a claim into the ID token when some granted scope lists it (or the
+        // request asks for it through `claims` / `acr_values` / `max_age`). Listing the
+        // authentication context under `openid` makes every ID token carry `acr`, `amr`, and
+        // `auth_time` from the session, and advertises them in `claims_supported`.
+        { ...userClaims, openid: ['sub', 'acr', 'amr', 'auth_time'] }
+      : userClaims,
+    // Advertise the Logto ACR classes as `acr_values_supported`; the provider also re-adds the
+    // built-in `acr` claim to `claims_supported` once at least one value is configured.
+    ...conditional(EnvSet.values.isDevFeaturesEnabled && { acrValues: [...logtoAcrValues] }),
     // https://github.com/panva/node-oidc-provider/tree/main/docs#findaccount
     findAccount: async (_ctx, sub) => {
       // The user may be deleted after the token is issued

--- a/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/discovery.test.ts
@@ -1,6 +1,7 @@
 import ky from 'ky';
 
 import { discoveryUrl, logtoUrl } from '#src/constants.js';
+import { devFeatureDisabledTest, devFeatureTest } from '#src/utils.js';
 
 const normalizeEndpoint = (value: unknown): unknown => {
   if (typeof value === 'string') {
@@ -26,7 +27,7 @@ describe('OIDC discovery', () => {
    * advertises `ES384`. An instance seeded with an RSA signing key reports different
    * `id_token_signing_alg_values_supported` and fails this snapshot.
    */
-  it('exposes the reviewed provider metadata', async () => {
+  devFeatureDisabledTest.it('exposes the reviewed provider metadata', async () => {
     const discovery = await ky.get(discoveryUrl).json();
 
     expect(normalizeEndpoint(discovery)).toMatchInlineSnapshot(`
@@ -144,6 +145,138 @@ describe('OIDC discovery', () => {
       }
     `);
   });
+
+  /**
+   * The step-up authentication context (`acr_values_supported`, `acr`, `amr`) is advertised only
+   * while it is behind the dev feature flag; the disabled snapshot must stay byte-for-byte unchanged.
+   */
+  devFeatureTest.it(
+    'exposes the reviewed provider metadata with the step-up authentication context',
+    async () => {
+      const discovery = await ky.get(discoveryUrl).json();
+
+      expect(normalizeEndpoint(discovery)).toMatchInlineSnapshot(`
+      {
+        "acr_values_supported": [
+          "urn:logto:acr:1fa",
+          "urn:logto:acr:mfa",
+        ],
+        "authorization_endpoint": "<logto-url>/oidc/auth",
+        "authorization_response_iss_parameter_supported": true,
+        "backchannel_logout_session_supported": true,
+        "backchannel_logout_supported": true,
+        "claim_types_supported": [
+          "normal",
+        ],
+        "claims_parameter_supported": false,
+        "claims_supported": [
+          "sub",
+          "acr",
+          "amr",
+          "auth_time",
+          "name",
+          "family_name",
+          "given_name",
+          "middle_name",
+          "nickname",
+          "preferred_username",
+          "profile",
+          "picture",
+          "website",
+          "gender",
+          "birthdate",
+          "zoneinfo",
+          "locale",
+          "updated_at",
+          "username",
+          "created_at",
+          "email",
+          "email_verified",
+          "phone_number",
+          "phone_number_verified",
+          "address",
+          "custom_data",
+          "identities",
+          "sso_identities",
+          "roles",
+          "organizations",
+          "organization_data",
+          "organization_roles",
+          "sid",
+          "iss",
+        ],
+        "code_challenge_methods_supported": [
+          "S256",
+        ],
+        "device_authorization_endpoint": "<logto-url>/oidc/device/auth",
+        "end_session_endpoint": "<logto-url>/oidc/session/end",
+        "grant_types_supported": [
+          "implicit",
+          "authorization_code",
+          "refresh_token",
+          "client_credentials",
+          "urn:ietf:params:oauth:grant-type:device_code",
+          "urn:ietf:params:oauth:grant-type:token-exchange",
+        ],
+        "id_token_signing_alg_values_supported": [
+          "ES384",
+        ],
+        "introspection_endpoint": "<logto-url>/oidc/token/introspection",
+        "issuer": "<logto-url>/oidc",
+        "jwks_uri": "<logto-url>/oidc/jwks",
+        "pushed_authorization_request_endpoint": "<logto-url>/oidc/request",
+        "request_uri_parameter_supported": false,
+        "response_modes_supported": [
+          "form_post",
+          "fragment",
+          "query",
+        ],
+        "response_types_supported": [
+          "code id_token",
+          "code",
+          "id_token",
+          "none",
+        ],
+        "revocation_endpoint": "<logto-url>/oidc/token/revocation",
+        "scopes_supported": [
+          "openid",
+          "offline_access",
+          "profile",
+          "email",
+          "phone",
+          "address",
+          "custom_data",
+          "identities",
+          "roles",
+          "urn:logto:scope:organizations",
+          "urn:logto:scope:organization_roles",
+          "urn:logto:scope:sessions",
+          "urn:logto:scope:trusted_devices",
+        ],
+        "subject_types_supported": [
+          "public",
+        ],
+        "token_endpoint": "<logto-url>/oidc/token",
+        "token_endpoint_auth_methods_supported": [
+          "client_secret_basic",
+          "client_secret_jwt",
+          "client_secret_post",
+          "private_key_jwt",
+          "none",
+        ],
+        "token_endpoint_auth_signing_alg_values_supported": [
+          "HS256",
+          "RS256",
+          "PS256",
+          "ES256",
+          "Ed25519",
+          "EdDSA",
+        ],
+        "userinfo_endpoint": "<logto-url>/oidc/me",
+      }
+    `);
+    }
+  );
 
   /**
    * Since oidc-provider 9.2.0 the RFC 8414 `/.well-known/oauth-authorization-server` route is

--- a/packages/schemas/src/types/authentication-context.test.ts
+++ b/packages/schemas/src/types/authentication-context.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AuthenticationFactor,
+  AuthenticationFactorClass,
+  AuthenticationMethodReference,
+  LogtoAcr,
+  buildAuthenticationMethodReferences,
+  getAuthenticationFactor,
+  getAuthenticationFactorClass,
+  getAuthenticationMethodReferences,
+  logtoAcrValues,
+} from './authentication-context.js';
+import { VerificationType } from './verification-records/verification-type.js';
+
+describe('logtoAcrValues', () => {
+  it('advertises exactly the two Logto classes in order', () => {
+    expect(logtoAcrValues).toEqual(['urn:logto:acr:1fa', 'urn:logto:acr:mfa']);
+  });
+});
+
+describe('getAuthenticationFactorClass', () => {
+  it.each([
+    VerificationType.Password,
+    VerificationType.EmailVerificationCode,
+    VerificationType.PhoneVerificationCode,
+    VerificationType.OneTimeToken,
+    VerificationType.NewPasswordIdentity,
+  ])('classifies %s as 1fa', (type) => {
+    expect(getAuthenticationFactorClass(type)).toBe(AuthenticationFactorClass.FirstFactor);
+  });
+
+  it.each([
+    VerificationType.TOTP,
+    VerificationType.MfaEmailVerificationCode,
+    VerificationType.MfaPhoneVerificationCode,
+    VerificationType.BackupCode,
+  ])('classifies %s as mfa', (type) => {
+    expect(getAuthenticationFactorClass(type)).toBe(AuthenticationFactorClass.Mfa);
+  });
+
+  // A user-verified WebAuthn authenticator is possession plus user verification in one act, and
+  // Logto requires user verification for the registration and the authentication ceremony alike.
+  it.each([VerificationType.WebAuthn, VerificationType.SignInPasskey])(
+    'classifies %s as both',
+    (type) => {
+      expect(getAuthenticationFactorClass(type)).toBe(AuthenticationFactorClass.Both);
+    }
+  );
+
+  it.each([VerificationType.Social, VerificationType.EnterpriseSso])(
+    'gives %s no class',
+    (type) => {
+      expect(getAuthenticationFactorClass(type)).toBeUndefined();
+    }
+  );
+});
+
+describe('getAuthenticationFactor', () => {
+  it.each([
+    [VerificationType.Password, AuthenticationFactor.Password],
+    [VerificationType.NewPasswordIdentity, AuthenticationFactor.Password],
+    [VerificationType.EmailVerificationCode, AuthenticationFactor.Email],
+    [VerificationType.MfaEmailVerificationCode, AuthenticationFactor.Email],
+    [VerificationType.OneTimeToken, AuthenticationFactor.Email],
+    [VerificationType.PhoneVerificationCode, AuthenticationFactor.Phone],
+    [VerificationType.MfaPhoneVerificationCode, AuthenticationFactor.Phone],
+    [VerificationType.TOTP, AuthenticationFactor.Totp],
+    [VerificationType.BackupCode, AuthenticationFactor.BackupCode],
+    [VerificationType.WebAuthn, AuthenticationFactor.WebAuthn],
+    [VerificationType.SignInPasskey, AuthenticationFactor.WebAuthn],
+    [VerificationType.Social, AuthenticationFactor.Federated],
+    [VerificationType.EnterpriseSso, AuthenticationFactor.Federated],
+  ])('maps %s to the %s factor', (type, expected) => {
+    expect(getAuthenticationFactor(type)).toBe(expected);
+  });
+});
+
+describe('getAuthenticationMethodReferences', () => {
+  it.each([
+    [VerificationType.Password, ['pwd']],
+    [VerificationType.NewPasswordIdentity, ['pwd']],
+    [VerificationType.EmailVerificationCode, ['otp']],
+    [VerificationType.OneTimeToken, ['otp']],
+    [VerificationType.TOTP, ['otp']],
+    [VerificationType.MfaEmailVerificationCode, ['otp']],
+    [VerificationType.BackupCode, ['otp']],
+    [VerificationType.PhoneVerificationCode, ['sms']],
+    [VerificationType.MfaPhoneVerificationCode, ['sms']],
+    [VerificationType.WebAuthn, ['pop', 'user', 'mfa']],
+    [VerificationType.SignInPasskey, ['pop', 'user', 'mfa']],
+    [VerificationType.Social, ['fed']],
+    [VerificationType.EnterpriseSso, ['fed']],
+  ])('maps %s to %j', (type, expected) => {
+    expect(getAuthenticationMethodReferences(type)).toEqual(expected);
+  });
+
+  it('maps every verification type', () => {
+    for (const type of Object.values(VerificationType)) {
+      expect(getAuthenticationMethodReferences(type).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('emits `fed` as the only unregistered AMR value', () => {
+    // RFC 8176 / IANA registered values used by Logto.
+    const registered = new Set(['pwd', 'otp', 'sms', 'pop', 'user', 'mfa']);
+    const emitted = new Set(
+      Object.values(VerificationType).flatMap((type) => getAuthenticationMethodReferences(type))
+    );
+
+    expect([...emitted].filter((value) => !registered.has(value))).toEqual([
+      AuthenticationMethodReference.Federated,
+    ]);
+  });
+});
+
+const references = (...types: VerificationType[]) =>
+  types.map((type) => getAuthenticationMethodReferences(type));
+
+describe('buildAuthenticationMethodReferences', () => {
+  it('unions references in first-seen order without duplicates', () => {
+    expect(
+      buildAuthenticationMethodReferences(
+        references(VerificationType.Password, VerificationType.TOTP, VerificationType.BackupCode),
+        LogtoAcr.FirstFactor
+      )
+    ).toEqual(['pwd', 'otp']);
+  });
+
+  it('appends `mfa` when the achieved ACR is mfa', () => {
+    expect(
+      buildAuthenticationMethodReferences(
+        references(VerificationType.Password, VerificationType.TOTP),
+        LogtoAcr.Mfa
+      )
+    ).toEqual(['pwd', 'otp', 'mfa']);
+  });
+
+  it('does not duplicate `mfa` for WebAuthn', () => {
+    expect(
+      buildAuthenticationMethodReferences(references(VerificationType.WebAuthn), LogtoAcr.Mfa)
+    ).toEqual(['pop', 'user', 'mfa']);
+  });
+
+  it('keeps `mfa` last when a WebAuthn record precedes another factor', () => {
+    expect(
+      buildAuthenticationMethodReferences(
+        references(VerificationType.WebAuthn, VerificationType.Password),
+        LogtoAcr.Mfa
+      )
+    ).toEqual(['pop', 'user', 'pwd', 'mfa']);
+    // WebAuthn carries `mfa` on its own even when no ACR is passed.
+    expect(
+      buildAuthenticationMethodReferences(
+        references(VerificationType.WebAuthn, VerificationType.Password)
+      )
+    ).toEqual(['pop', 'user', 'pwd', 'mfa']);
+  });
+
+  it('keeps `fed` next to an established factor without an ACR', () => {
+    expect(
+      buildAuthenticationMethodReferences(
+        references(VerificationType.Social, VerificationType.Password)
+      )
+    ).toEqual(['fed', 'pwd']);
+    expect(buildAuthenticationMethodReferences(references(VerificationType.Social))).toEqual([
+      'fed',
+    ]);
+  });
+
+  it('returns nothing for no references', () => {
+    expect(buildAuthenticationMethodReferences([])).toEqual([]);
+  });
+});

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -1,0 +1,194 @@
+/**
+ * @file The authoritative vocabulary for the authentication context Logto records on a sign-in or
+ * step-up: the supported Authentication Context Class Reference (ACR) values and the
+ * Authentication Methods References (AMR) each verification contributes.
+ *
+ * @see {@link https://openid.net/specs/openid-connect-core-1_0.html#IDToken | OpenID Connect Core `acr` / `amr`}
+ * @see {@link https://www.rfc-editor.org/rfc/rfc8176.html | RFC 8176 Authentication Method Reference Values}
+ */
+import { VerificationType } from './verification-records/verification-type.js';
+
+/** The Logto-defined ACR values. Only these can be requested through `acr_values`. */
+export enum LogtoAcr {
+  /**
+   * At least one active factor that Logto can directly verify: password, the user's primary
+   * email / phone verification code, or an enrolled MFA factor. Social and enterprise SSO never
+   * satisfy this class.
+   */
+  FirstFactor = 'urn:logto:acr:1fa',
+  /**
+   * A Logto-verifiable {@link LogtoAcr.FirstFactor} context plus an `mfa`-class record from a
+   * different factor, or WebAuthn / passkey with required user verification alone.
+   */
+  Mfa = 'urn:logto:acr:mfa',
+}
+
+/** The ACR values advertised in Discovery as `acr_values_supported`, in the provider order. */
+export const logtoAcrValues = Object.freeze([LogtoAcr.FirstFactor, LogtoAcr.Mfa] as const);
+
+/**
+ * The AMR values Logto emits. All except {@link AuthenticationMethodReference.Federated} are
+ * registered in RFC 8176; `fed` is the de facto industry value for authentication delegated to an
+ * upstream identity provider and is the only unregistered value Logto emits.
+ */
+export enum AuthenticationMethodReference {
+  /** Password-based authentication. */
+  Password = 'pwd',
+  /** One-time password: email verification code, TOTP, backup code, or one-time token. */
+  Otp = 'otp',
+  /** Verification code delivered by SMS. */
+  Sms = 'sms',
+  /** Proof-of-possession of a key, e.g. WebAuthn. */
+  ProofOfPossession = 'pop',
+  /** User presence / verification by the authenticator, e.g. WebAuthn user verification. */
+  UserPresence = 'user',
+  /** Multiple-factor authentication; appended whenever the achieved ACR is {@link LogtoAcr.Mfa}. */
+  Mfa = 'mfa',
+  /** Federated authentication assertion from a social or enterprise SSO provider. */
+  Federated = 'fed',
+}
+
+/** The class a proof contributes toward an ACR. */
+export enum AuthenticationFactorClass {
+  /** Contributes {@link LogtoAcr.FirstFactor}. */
+  FirstFactor = '1fa',
+  /**
+   * Contributes an `mfa`-class proof. Combined with a {@link AuthenticationFactorClass.FirstFactor}
+   * proof of a different factor it reaches {@link LogtoAcr.Mfa}; alone it reaches only
+   * {@link LogtoAcr.FirstFactor}.
+   */
+  Mfa = 'mfa',
+  /**
+   * Satisfies the `1fa` and the `mfa` role by itself: a user-verified WebAuthn authenticator is
+   * possession plus user verification in one act, so it reaches {@link LogtoAcr.Mfa} alone.
+   */
+  Both = 'both',
+}
+
+/**
+ * The class each verification type contributes: `1fa`-class, `mfa`-class, `both`, or `undefined`
+ * for social / enterprise SSO, which contribute `fed` to AMR but nothing to the ACR.
+ *
+ * The record is keyed by every {@link VerificationType}, so a new type fails at compile time until
+ * it is mapped here. Logto requires user verification for every WebAuthn ceremony, registration and
+ * authentication alike, so a verified WebAuthn record is user-verified by construction.
+ */
+const authenticationFactorClasses: Readonly<
+  Record<VerificationType, AuthenticationFactorClass | undefined>
+> = Object.freeze({
+  [VerificationType.Password]: AuthenticationFactorClass.FirstFactor,
+  [VerificationType.EmailVerificationCode]: AuthenticationFactorClass.FirstFactor,
+  [VerificationType.PhoneVerificationCode]: AuthenticationFactorClass.FirstFactor,
+  [VerificationType.OneTimeToken]: AuthenticationFactorClass.FirstFactor,
+  // A password established by a registration; it is a proof once `createUser()` consumes it.
+  [VerificationType.NewPasswordIdentity]: AuthenticationFactorClass.FirstFactor,
+  [VerificationType.TOTP]: AuthenticationFactorClass.Mfa,
+  [VerificationType.MfaEmailVerificationCode]: AuthenticationFactorClass.Mfa,
+  [VerificationType.MfaPhoneVerificationCode]: AuthenticationFactorClass.Mfa,
+  [VerificationType.BackupCode]: AuthenticationFactorClass.Mfa,
+  [VerificationType.WebAuthn]: AuthenticationFactorClass.Both,
+  [VerificationType.SignInPasskey]: AuthenticationFactorClass.Both,
+  [VerificationType.Social]: undefined,
+  [VerificationType.EnterpriseSso]: undefined,
+});
+
+/** Classify a verification type; see {@link authenticationFactorClasses}. */
+export const getAuthenticationFactorClass = (
+  type: VerificationType
+): AuthenticationFactorClass | undefined => authenticationFactorClasses[type];
+
+/**
+ * The factor a verification record is a proof of. Repeated proofs of one factor count once, and
+ * {@link LogtoAcr.Mfa} needs a `1fa`-class and an `mfa`-class proof of two different factors: a
+ * one-time token and an MFA email code are two proofs of the same mailbox, not two factors.
+ */
+export enum AuthenticationFactor {
+  Password = 'password',
+  Email = 'email',
+  Phone = 'phone',
+  Totp = 'totp',
+  BackupCode = 'backupCode',
+  WebAuthn = 'webAuthn',
+  Federated = 'federated',
+}
+
+/** Keyed by every {@link VerificationType}, so a new type fails at compile time until mapped. */
+const authenticationFactors: Readonly<Record<VerificationType, AuthenticationFactor>> =
+  Object.freeze({
+    [VerificationType.Password]: AuthenticationFactor.Password,
+    [VerificationType.NewPasswordIdentity]: AuthenticationFactor.Password,
+    [VerificationType.EmailVerificationCode]: AuthenticationFactor.Email,
+    [VerificationType.MfaEmailVerificationCode]: AuthenticationFactor.Email,
+    [VerificationType.OneTimeToken]: AuthenticationFactor.Email,
+    [VerificationType.PhoneVerificationCode]: AuthenticationFactor.Phone,
+    [VerificationType.MfaPhoneVerificationCode]: AuthenticationFactor.Phone,
+    [VerificationType.TOTP]: AuthenticationFactor.Totp,
+    [VerificationType.BackupCode]: AuthenticationFactor.BackupCode,
+    [VerificationType.WebAuthn]: AuthenticationFactor.WebAuthn,
+    [VerificationType.SignInPasskey]: AuthenticationFactor.WebAuthn,
+    [VerificationType.Social]: AuthenticationFactor.Federated,
+    [VerificationType.EnterpriseSso]: AuthenticationFactor.Federated,
+  });
+
+/** The factor a verification type is a proof of; see {@link authenticationFactors}. */
+export const getAuthenticationFactor = (type: VerificationType): AuthenticationFactor =>
+  authenticationFactors[type];
+
+/**
+ * The AMR values a single verification type contributes, per the step-up tech design. The record
+ * is keyed by every {@link VerificationType}, so a new type fails at compile time until it is
+ * mapped here.
+ *
+ * The trailing `mfa` marker for an achieved {@link LogtoAcr.Mfa} is added by
+ * {@link buildAuthenticationMethodReferences}, not here; WebAuthn carries it inherently because a
+ * user-verified passkey is a multi-factor authenticator on its own.
+ */
+const authenticationMethodReferences: Readonly<
+  Record<VerificationType, readonly AuthenticationMethodReference[]>
+> = Object.freeze({
+  [VerificationType.Password]: [AuthenticationMethodReference.Password],
+  [VerificationType.NewPasswordIdentity]: [AuthenticationMethodReference.Password],
+  [VerificationType.EmailVerificationCode]: [AuthenticationMethodReference.Otp],
+  [VerificationType.OneTimeToken]: [AuthenticationMethodReference.Otp],
+  [VerificationType.TOTP]: [AuthenticationMethodReference.Otp],
+  [VerificationType.MfaEmailVerificationCode]: [AuthenticationMethodReference.Otp],
+  [VerificationType.BackupCode]: [AuthenticationMethodReference.Otp],
+  [VerificationType.PhoneVerificationCode]: [AuthenticationMethodReference.Sms],
+  [VerificationType.MfaPhoneVerificationCode]: [AuthenticationMethodReference.Sms],
+  [VerificationType.WebAuthn]: [
+    AuthenticationMethodReference.ProofOfPossession,
+    AuthenticationMethodReference.UserPresence,
+    AuthenticationMethodReference.Mfa,
+  ],
+  [VerificationType.SignInPasskey]: [
+    AuthenticationMethodReference.ProofOfPossession,
+    AuthenticationMethodReference.UserPresence,
+    AuthenticationMethodReference.Mfa,
+  ],
+  [VerificationType.Social]: [AuthenticationMethodReference.Federated],
+  [VerificationType.EnterpriseSso]: [AuthenticationMethodReference.Federated],
+});
+
+/** The AMR values a verification type contributes; see {@link authenticationMethodReferences}. */
+export const getAuthenticationMethodReferences = (
+  type: VerificationType
+): readonly AuthenticationMethodReference[] => authenticationMethodReferences[type];
+
+/**
+ * Build the `amr` claim from the references each counted proof contributes and the ACR they
+ * achieved: the union in first-seen order, with `mfa` always last, present whenever a proof carries
+ * it (WebAuthn) or the achieved ACR is {@link LogtoAcr.Mfa}.
+ */
+export const buildAuthenticationMethodReferences = (
+  references: Iterable<readonly AuthenticationMethodReference[]>,
+  achievedAcr?: LogtoAcr
+): AuthenticationMethodReference[] => {
+  const flattened = [...references].flat();
+  const hasMfa =
+    achievedAcr === LogtoAcr.Mfa || flattened.includes(AuthenticationMethodReference.Mfa);
+
+  return [
+    ...new Set(flattened.filter((reference) => reference !== AuthenticationMethodReference.Mfa)),
+    ...(hasMfa ? [AuthenticationMethodReference.Mfa] : []),
+  ];
+};

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -48,19 +48,28 @@ export enum AuthenticationMethodReference {
   Federated = 'fed',
 }
 
-/** The class a proof contributes toward an ACR. */
+/**
+ * The role a proof can fill when proofs are combined into an ACR. This is not the ACR a proof
+ * reaches on its own: any proof with a class reaches {@link LogtoAcr.FirstFactor} alone, and the
+ * class only decides which side of the pair the proof can stand on when
+ * {@link LogtoAcr.Mfa} is derived. That level needs a `1fa`-role proof and an `mfa`-role proof of
+ * two different factors, so two `mfa`-class factors, such as a TOTP and a backup code, never reach
+ * it together.
+ */
 export enum AuthenticationFactorClass {
-  /** Contributes {@link LogtoAcr.FirstFactor}. */
+  /** Fills the `1fa` role: a password or a primary email / phone code. */
   FirstFactor = '1fa',
   /**
-   * Contributes an `mfa`-class proof. Combined with a {@link AuthenticationFactorClass.FirstFactor}
-   * proof of a different factor it reaches {@link LogtoAcr.Mfa}; alone it reaches only
-   * {@link LogtoAcr.FirstFactor}.
+   * Fills the `mfa` role: TOTP, a backup code or an MFA email / phone code. Alone it reaches
+   * {@link LogtoAcr.FirstFactor}; paired with a `1fa`-role proof of a different factor it reaches
+   * {@link LogtoAcr.Mfa}.
    */
   Mfa = 'mfa',
   /**
-   * Satisfies the `1fa` and the `mfa` role by itself: a user-verified WebAuthn authenticator is
-   * possession plus user verification in one act, so it reaches {@link LogtoAcr.Mfa} alone.
+   * Fills both roles by itself, so it reaches {@link LogtoAcr.Mfa} alone: a user-verified WebAuthn
+   * authenticator is possession plus user verification in one act. Kept as a class rather than a
+   * special case on the factor so that every "can fill this role" check stays a class comparison
+   * and this table stays the single place that decides.
    */
   Both = 'both',
 }

--- a/packages/schemas/src/types/index.ts
+++ b/packages/schemas/src/types/index.ts
@@ -37,3 +37,4 @@ export * from './secrets.js';
 export * from './user-logto-config.js';
 export * from './user-sessions.js';
 export * from './trusted-device.js';
+export * from './authentication-context.js';


### PR DESCRIPTION
## Summary

Split out of #9546 (part 2 of 3, independent of part 1). This is the authentication context vocabulary and the Discovery advertisement, with nothing yet recorded in a token. Everything is behind the dev feature flag.

Linear: https://linear.app/silverhand/issue/LOG-14095
Design: [Authentication Context (ACR / AMR) — Tech Design](https://app.notion.com/p/silverhand/Authentication-Context-ACR-AMR-Tech-Design-3d026f6af1dc814b9500c9b5988bb1c6)

### `@logto/schemas`

`types/authentication-context.ts`:

- `LogtoAcr` (`urn:logto:acr:1fa`, `urn:logto:acr:mfa`) and `logtoAcrValues`.
- The per-`VerificationType` factor, factor class and AMR tables. All three are `Record`s keyed by every `VerificationType`, so a new type fails at compile time until it is mapped.
- `AuthenticationFactorClass` is `1fa` | `mfa` | `both`; WebAuthn / passkey is `both` because Logto requires user verification for the registration and the authentication ceremony alike. Social and enterprise SSO have no class and contribute only `fed`.
- `buildAuthenticationMethodReferences` unions AMR lists in first-seen order with `mfa` always last.

### `@logto/core`

`oidc/init.ts`, behind the dev flag: `acrValues` advertises `acr_values_supported`, and `acr` / `amr` / `auth_time` are listed under the `openid` scope so they appear in `claims_supported` and, once seeded, in every ID token. With the flag off the Discovery document is unchanged.

## Testing

- `packages/schemas`: `authentication-context.test.ts` covers the ACR values, the class and factor tables, the AMR table and the ordering of the builder.
- `packages/core`: two `init.test.ts` cases for the provider configuration with the flag on and off.
- `packages/integration-tests`: `discovery.test.ts` snapshots with the flag off and on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6suKhdhJjJKw4aVfXRkca

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6suKhdhJjJKw4aVfXRkca)_