### PR TITLE
feat(core,schemas): record authentication proofs and carry acr / amr into the ID token

### DIFF
--- a/packages/core/src/routes/experience/classes/experience-interaction.test.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.test.ts
@@ -3,6 +3,11 @@ import { TemplateType } from '@logto/connector-kit';
 import {
   adminConsoleApplicationId,
   adminTenantId,
+  AuthenticationFactor,
+  AuthenticationFactorClass,
+  AuthenticationMethodReference,
+  AuthenticationProofRole,
+  type AuthenticationProof,
   type CreateUser,
   InteractionEvent,
   LogtoActionKey,
@@ -11,6 +16,7 @@ import {
   SignInIdentifier,
   SignInMode,
   type User,
+  UsersPasswordEncryptionMethod,
   VerificationType,
 } from '@logto/schemas';
 import { createMockUtils, pickDefault } from '@logto/shared/esm';
@@ -38,6 +44,14 @@ mockEsm('#src/utils/tenant.js', () => ({
 }));
 
 const mockEmail = 'foo@bar.com';
+/** The proof a password records in the given role. */
+const passwordProof = (role: AuthenticationProofRole): AuthenticationProof => ({
+  id: 'password',
+  factor: AuthenticationFactor.Password,
+  class: AuthenticationFactorClass.FirstFactor,
+  amr: [AuthenticationMethodReference.Password],
+  role,
+});
 const userQueries = {
   hasActiveUsers: jest.fn().mockResolvedValue(false),
   hasUserWithEmail: jest.fn().mockResolvedValue(false),
@@ -132,6 +146,8 @@ const createSignInInteraction = ({
   const signInUserQueries = {
     ...userQueries,
     findUserById: jest.fn().mockResolvedValue(user),
+    findUserByUsername: jest.fn().mockResolvedValue(user),
+    findUserByEmail: jest.fn().mockResolvedValue(user),
     updateUserById: jest.fn().mockResolvedValue(user),
   };
   const runActionHandler = jest.fn(
@@ -276,6 +292,17 @@ describe('ExperienceInteraction class', () => {
       experienceInteraction.setVerificationRecord(emailVerificationRecord);
       await experienceInteraction.createUser(emailVerificationRecord.id);
 
+      // Creating the account from the record is the `create` proof of the new account.
+      expect(experienceInteraction.toJson().authenticationProofs).toMatchObject([
+        {
+          id: emailVerificationRecord.id,
+          factor: AuthenticationFactor.Email,
+          class: AuthenticationFactorClass.FirstFactor,
+          amr: ['otp'],
+          role: AuthenticationProofRole.Create,
+        },
+      ]);
+
       expect(userLibraries.insertUser).toHaveBeenCalledWith(
         {
           id: 'uid',
@@ -328,6 +355,209 @@ describe('ExperienceInteraction class', () => {
       });
       expect(runActionHandler.mock.invocationCallOrder[0]).toBeLessThan(
         (provider.interactionResult as jest.Mock).mock.invocationCallOrder[0]!
+      );
+    });
+
+    it('seeds the aggregated authentication context into the login result when dev features are enabled', async () => {
+      setDevFeaturesEnabled(true);
+      const { experienceInteraction, provider } = createSignInInteraction({
+        interactionResult: {
+          authenticationProofs: [passwordProof(AuthenticationProofRole.Identify)],
+          verificationRecords: [
+            {
+              id: 'password',
+              type: VerificationType.Password,
+              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
+              verified: true,
+            },
+            // A verified record that no touchpoint consumed is not a proof and must not reach
+            // the login result.
+            {
+              id: 'new-password-identity',
+              type: VerificationType.NewPasswordIdentity,
+              identifier: { type: SignInIdentifier.Username, value: 'unused' },
+              passwordEncrypted: 'encrypted',
+              passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
+            },
+          ],
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(provider.interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          login: {
+            accountId: mockUser.id,
+            acr: 'urn:logto:acr:1fa',
+            amr: ['pwd'],
+          },
+        })
+      );
+    });
+
+    it('seeds the context a registration established into the login result when dev features are enabled', async () => {
+      setDevFeaturesEnabled(true);
+      // An email + password registration: `createUser()` consumed the email code and the profile
+      // established the password.
+      const { experienceInteraction, provider } = createSignInInteraction({
+        interactionEvent: InteractionEvent.Register,
+        interactionResult: {
+          authenticationProofs: [
+            {
+              id: 'email',
+              factor: AuthenticationFactor.Email,
+              class: AuthenticationFactorClass.FirstFactor,
+              amr: ['otp'],
+              role: AuthenticationProofRole.Create,
+            },
+            passwordProof(AuthenticationProofRole.Bind),
+          ],
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(provider.interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          login: {
+            accountId: mockUser.id,
+            acr: 'urn:logto:acr:1fa',
+            amr: ['otp', 'pwd'],
+          },
+        })
+      );
+    });
+
+    it('records an identify proof for every verification record that identified the user', async () => {
+      const { experienceInteraction } = createSignInInteraction({
+        interactionResult: {
+          userId: undefined,
+          verificationRecords: [
+            {
+              id: 'password',
+              type: VerificationType.Password,
+              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
+              verified: true,
+            },
+            {
+              id: 'email',
+              type: VerificationType.EmailVerificationCode,
+              identifier: { type: SignInIdentifier.Email, value: mockEmail },
+              templateType: TemplateType.SignIn,
+              verified: true,
+            },
+          ],
+        },
+      });
+
+      await experienceInteraction.identifyUser('password');
+      expect(experienceInteraction.toJson()).toMatchObject({
+        userId: mockUser.id,
+        authenticationProofs: [passwordProof(AuthenticationProofRole.Identify)],
+      });
+
+      // A second record that identifies the same user is recorded as well.
+      await experienceInteraction.identifyUser('email');
+      expect(experienceInteraction.toJson().authenticationProofs).toMatchObject([
+        { id: 'password', role: AuthenticationProofRole.Identify },
+        { id: 'email', role: AuthenticationProofRole.Identify, factor: AuthenticationFactor.Email },
+      ]);
+    });
+
+    it('records the proof for a password established through the profile once', () => {
+      const { experienceInteraction } = createSignInInteraction();
+      const digest = {
+        passwordEncrypted: 'encrypted',
+        passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
+      };
+
+      experienceInteraction.profile.unsafeSet(digest);
+      experienceInteraction.profile.unsafeSet(digest);
+
+      expect(experienceInteraction.toJson().authenticationProofs).toMatchObject([
+        {
+          id: 'password',
+          factor: AuthenticationFactor.Password,
+          class: AuthenticationFactorClass.FirstFactor,
+          amr: ['pwd'],
+          role: AuthenticationProofRole.Bind,
+        },
+      ]);
+    });
+
+    it('clears the proofs when the interaction event changes, like the profile', async () => {
+      const { experienceInteraction } = createSignInInteraction({
+        interactionResult: {
+          authenticationProofs: [passwordProof(AuthenticationProofRole.Identify)],
+        },
+      });
+
+      await experienceInteraction.setInteractionEvent(InteractionEvent.SignIn);
+      expect(experienceInteraction.toJson().authenticationProofs).toHaveLength(1);
+
+      await experienceInteraction.setInteractionEvent(InteractionEvent.Register);
+      expect(experienceInteraction.toJson().authenticationProofs).toEqual([]);
+    });
+
+    it('does not let the proofs outlive the interaction', async () => {
+      const { experienceInteraction, provider } = createSignInInteraction({
+        interactionEvent: InteractionEvent.ForgotPassword,
+        interactionResult: {
+          profile: {
+            passwordEncrypted: 'encrypted',
+            passwordEncryptionMethod: UsersPasswordEncryptionMethod.Argon2i,
+          },
+          authenticationProofs: [passwordProof(AuthenticationProofRole.Bind)],
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(provider.interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        {}
+      );
+      expect(experienceInteraction.toJson().authenticationProofs).toEqual([]);
+    });
+
+    it('keeps the proofs out of the sanitized interaction data', () => {
+      const { experienceInteraction } = createSignInInteraction({
+        interactionResult: {
+          authenticationProofs: [passwordProof(AuthenticationProofRole.Identify)],
+        },
+      });
+
+      expect(experienceInteraction.toJson().authenticationProofs).toHaveLength(1);
+      expect(experienceInteraction.toSanitizedJson()).not.toHaveProperty('authenticationProofs');
+    });
+
+    it('finishes with the account id only when dev features are disabled', async () => {
+      setDevFeaturesEnabled(false);
+      const { experienceInteraction, provider } = createSignInInteraction({
+        interactionResult: {
+          verificationRecords: [
+            {
+              id: 'password',
+              type: VerificationType.Password,
+              identifier: { type: SignInIdentifier.Username, value: mockUser.username },
+              verified: true,
+            },
+          ],
+        },
+      });
+
+      await experienceInteraction.submit();
+
+      expect(provider.interactionResult).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ login: { accountId: mockUser.id } })
       );
     });
 

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -2,6 +2,7 @@
 
 import { appInsights } from '@logto/app-insights/node';
 import {
+  AuthenticationProofRole,
   InteractionEvent,
   InteractionHookEvent,
   LogtoActionKey,
@@ -13,6 +14,7 @@ import {
 import { maskEmail, maskPhone } from '@logto/shared';
 import { conditional, trySafe } from '@silverhand/essentials';
 
+import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
 import { buildUserPasswordPayload } from '#src/libraries/user.utils.js';
 import { type LogEntry } from '#src/middleware/koa-audit-log.js';
@@ -39,8 +41,10 @@ import {
 import { validatePostSignInActionResult } from './libraries/action-result-validation.js';
 import { AdaptiveMfaValidator } from './libraries/adaptive-mfa-validator/index.js';
 import { type AdaptiveMfaResult } from './libraries/adaptive-mfa-validator/types.js';
+import { aggregateAuthenticationContext } from './libraries/authentication-context.js';
+import { AuthenticationProofs } from './libraries/authentication-proofs.js';
 import { CaptchaValidator } from './libraries/captcha-validator.js';
-import { MfaValidator } from './libraries/mfa-validator.js';
+import { MfaValidator, isMfaVerificationRecord } from './libraries/mfa-validator.js';
 import { ProvisionLibrary } from './libraries/provision-library.js';
 import { SignInExperienceValidator } from './libraries/sign-in-experience-validator.js';
 import { UserUpdateLibrary } from './libraries/user-update-library.js';
@@ -76,6 +80,12 @@ export default class ExperienceInteraction {
   private readonly verificationRecords = new VerificationRecordsMap();
   /** The userId of the user for the current interaction. Only available once the user is identified. */
   private userId?: string;
+  /**
+   * What the user proved about the account in this interaction, recorded at the touchpoint that
+   * consumed each credential. Staged like `profile` and `mfa`, persisted by {@link save}, and
+   * cleared wherever `profile.data` is cleared; see {@link AuthenticationProofs}.
+   */
+  private readonly authenticationProofs: AuthenticationProofs;
   private userCache?: User;
   private readonly adaptiveMfaValidator: AdaptiveMfaValidator;
 
@@ -114,9 +124,12 @@ export default class ExperienceInteraction {
     const interactionContext: InteractionContext = {
       getInteractionEvent: () => this.#interactionEvent,
       getIdentifiedUser: async () => this.getIdentifiedUser(),
-      getVerificationRecordByTypeAndId: (type, verificationId) =>
-        this.getVerificationRecordByTypeAndId(type, verificationId),
-      getVerificationRecordById: (verificationId) => this.getVerificationRecordById(verificationId),
+      consumeForBind: (verificationId) => this.consumeForBind(verificationId),
+      consumeForBindByType: (type, verificationId) =>
+        this.consumeForBindByType(type, verificationId),
+      recordEstablishedPassword: () => {
+        this.authenticationProofs.stageEstablishedPassword();
+      },
       getCurrentProfile: () => this.profile.data,
     };
 
@@ -129,6 +142,7 @@ export default class ExperienceInteraction {
 
     if (typeof interactionData === 'string') {
       this.#interactionEvent = interactionData;
+      this.authenticationProofs = new AuthenticationProofs();
       this.profile = new Profile(libraries, queries, {}, interactionContext);
       this.mfa = new Mfa(libraries, queries, {}, interactionContext);
       this.trustedDevice = new TrustedDevice(ctx, tenant, {});
@@ -148,6 +162,7 @@ export default class ExperienceInteraction {
       profile = {},
       mfa = {},
       userId,
+      authenticationProofs = [],
       trustedDeviceOptIn,
       interactionEvent,
       captcha = {
@@ -158,6 +173,7 @@ export default class ExperienceInteraction {
 
     this.#interactionEvent = interactionEvent;
     this.userId = userId;
+    this.authenticationProofs = new AuthenticationProofs(authenticationProofs);
     this.profile = new Profile(libraries, queries, profile, interactionContext);
     this.mfa = new Mfa(libraries, queries, mfa, interactionContext);
     this.trustedDevice = new TrustedDevice(ctx, tenant, {
@@ -182,6 +198,8 @@ export default class ExperienceInteraction {
    * Switch the interaction event for the current interaction sign-in <> register
    *
    * - any pending profile data will be cleared
+   * - any authentication proof will be cleared, so that a proof recorded for an abandoned attempt
+   *   at one event can never inflate the context of another
    *
    * @throws RequestError with 403 if the interaction event is not allowed by the `SignInExperienceValidator`
    * @throws RequestError with 400 if the interaction event is `ForgotPassword` and the current interaction event is not `ForgotPassword`
@@ -203,6 +221,7 @@ export default class ExperienceInteraction {
 
     if (this.#interactionEvent !== interactionEvent) {
       this.profile.cleanUp();
+      this.authenticationProofs.clear();
     }
 
     this.#interactionEvent = interactionEvent;
@@ -230,7 +249,7 @@ export default class ExperienceInteraction {
       new RequestError({ code: 'session.invalid_interaction_type', status: 400 })
     );
 
-    const verificationRecord = this.getVerificationRecordById(verificationId);
+    const verificationRecord = this.consumeForIdentify(verificationId);
 
     log?.append({
       verification: verificationRecord.toJson(),
@@ -292,7 +311,7 @@ export default class ExperienceInteraction {
     );
 
     if (verificationId) {
-      const verificationRecord = this.getVerificationRecordById(verificationId);
+      const verificationRecord = this.consumeForCreate(verificationId);
       const verificationData = verificationRecord.toJson();
 
       log?.append({
@@ -358,6 +377,54 @@ export default class ExperienceInteraction {
   }
 
   /**
+   * Fetch a verification record for binding the credential it carries to the account, recording
+   * the `bind` proof. This and {@link consumeForBindByType} are the only ways `Profile` and `Mfa`
+   * reach a record, so a bind cannot forget to record its proof; see {@link AuthenticationProofs}.
+   */
+  public consumeForBind(verificationId: string): VerificationRecord {
+    const record = this.getVerificationRecordById(verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Bind);
+
+    return record;
+  }
+
+  /** The typed variant of {@link consumeForBind}. */
+  public consumeForBindByType<K extends keyof VerificationRecordMap>(
+    type: K,
+    verificationId: string
+  ): VerificationRecordMap[K] {
+    const record = this.getVerificationRecordByTypeAndId(type, verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Bind);
+
+    return record;
+  }
+
+  /**
+   * Record the `mfa` proof for an MFA challenge the user just answered. For a challenge record,
+   * verifying is the use: the MFA gate scans for a verified record and no later step consumes it,
+   * so the verify routes call this right after a successful verification. A new-enrollment record
+   * is never a challenge; its proof is the `bind` one recorded when the factor is added.
+   *
+   * @throws {RequestError} with 404 if the verification record is not found
+   * @throws {RequestError} with 400 if the record is not a verified MFA challenge
+   */
+  public consumeForMfa<K extends keyof VerificationRecordMap>(
+    type: K,
+    verificationId: string
+  ): VerificationRecordMap[K] {
+    const record = this.getVerificationRecordByTypeAndId(type, verificationId);
+
+    assertThat(
+      isMfaVerificationRecord(record) && record.isVerified && !record.isNewBindMfaVerification,
+      new RequestError({ code: 'session.verification_failed', status: 400 })
+    );
+
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Mfa);
+
+    return record;
+  }
+
+  /**
    * Validate the interaction verification records against the sign-in experience and user MFA settings.
    * The interaction is verified if at least one user enabled MFA verification record is present and verified.
    *
@@ -380,6 +447,8 @@ export default class ExperienceInteraction {
 
     const mfaValidator = new MfaValidator(mfaSettings, user, adaptiveMfaResult);
 
+    // Declared non-proof: an adaptive-MFA non-trigger result skips the gate and proves nothing,
+    // so it records no authentication proof.
     if (!mfaValidator.isMfaRequired) {
       return;
     }
@@ -390,6 +459,8 @@ export default class ExperienceInteraction {
       return;
     }
 
+    // Declared non-proof: a trusted device satisfies the MFA gate but proves nothing now, so it
+    // records no authentication proof and the context stays at what the first factor reached.
     const isMfaVerifiedWithTrustedDevice = await this.trustedDevice.tryVerifyMfa(user.id);
 
     this.assignAdaptiveMfaHookResult(user.id, adaptiveMfaResult);
@@ -546,6 +617,15 @@ export default class ExperienceInteraction {
       await this.guardMfaVerificationStatus(log);
     }
 
+    // Aggregate the authentication context this sign-in or registration achieved from the proofs
+    // its touchpoints recorded. The context seeds the OIDC session so the ID token carries `acr` /
+    // `amr` / `auth_time`; an interaction without a proof seeds nothing and the provider stamps
+    // `auth_time` itself.
+    const authenticationContext = conditional(
+      EnvSet.values.isDevFeaturesEnabled &&
+        aggregateAuthenticationContext(this.authenticationProofs.proofs)
+    );
+
     // Revalidate the new profile data if any
     await this.profile.validateAvailability();
 
@@ -673,7 +753,10 @@ export default class ExperienceInteraction {
     const trustedDeviceOptInDecision = this.trustedDevice.consumeOptInDecision();
 
     const redirectTo = await provider.interactionResult(this.ctx.req, this.ctx.res, {
-      login: { accountId: user.id },
+      login: {
+        accountId: user.id,
+        ...authenticationContext,
+      },
       // Persist the interaction status to the OIDC session after interaction submission
       ...this.toJson(),
     });
@@ -733,6 +816,7 @@ export default class ExperienceInteraction {
     return {
       interactionEvent,
       userId,
+      authenticationProofs: this.authenticationProofs.data,
       ...this.trustedDevice.data,
       profile: this.profile.data,
       mfa: this.mfa.data,
@@ -743,8 +827,13 @@ export default class ExperienceInteraction {
   }
 
   public toSanitizedJson(): SanitizedInteractionStorageData {
-    // The trusted-device opt-in decision is internal authentication state.
-    const { trustedDeviceOptIn: _, ...interactionStorage } = this.toJson();
+    // The trusted-device opt-in decision and the authentication proofs are internal
+    // authentication state; a proof's role in particular never leaves the server.
+    const {
+      trustedDeviceOptIn: _,
+      authenticationProofs: __,
+      ...interactionStorage
+    } = this.toJson();
 
     return {
       ...interactionStorage,
@@ -867,6 +956,22 @@ export default class ExperienceInteraction {
     return verificationRecord;
   }
 
+  /** Fetch a verification record for creating the account from it, recording the `create` proof. */
+  private consumeForCreate(verificationId: string) {
+    const record = this.getVerificationRecordById(verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Create);
+
+    return record;
+  }
+
+  /** Fetch a verification record for identifying the user with it, recording the `identify` proof. */
+  private consumeForIdentify(verificationId: string) {
+    const record = this.getVerificationRecordById(verificationId);
+    this.authenticationProofs.stage(record, AuthenticationProofRole.Identify);
+
+    return record;
+  }
+
   private get hasVerifiedSsoIdentity() {
     const ssoVerificationRecord = this.verificationRecords.get(VerificationType.EnterpriseSso);
 
@@ -888,6 +993,8 @@ export default class ExperienceInteraction {
    */
   private async cleanUp() {
     const { provider } = this.tenant;
+    // Proofs are interaction-scoped and must never be visible to a subsequent interaction.
+    this.authenticationProofs.clear();
     await provider.interactionResult(this.ctx.req, this.ctx.res, {});
   }
 }

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.test.ts
@@ -1,0 +1,174 @@
+import {
+  AuthenticationFactor,
+  AuthenticationFactorClass,
+  AuthenticationMethodReference,
+  AuthenticationProofRole,
+  type AuthenticationProof,
+} from '@logto/schemas';
+
+import { aggregateAuthenticationContext } from './authentication-context.js';
+
+const { FirstFactor, Mfa, Both } = AuthenticationFactorClass;
+const { Password, Otp, Sms, ProofOfPossession, UserPresence, Federated } =
+  AuthenticationMethodReference;
+const { Create, Identify, Bind } = AuthenticationProofRole;
+
+const firstFactorAcr = 'urn:logto:acr:1fa';
+const mfaAcr = 'urn:logto:acr:mfa';
+
+const proof = (
+  factor: AuthenticationFactor,
+  factorClass: AuthenticationFactorClass | undefined,
+  amr: AuthenticationMethodReference[],
+  role: AuthenticationProofRole = Identify
+): AuthenticationProof => ({
+  id: `${factor}-${role}`,
+  factor,
+  ...(factorClass && { class: factorClass }),
+  amr,
+  role,
+});
+
+const aggregate = (proofs: AuthenticationProof[]) => aggregateAuthenticationContext(proofs);
+
+const password = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Password, FirstFactor, [Password], role);
+const email = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Email, FirstFactor, [Otp], role);
+const phone = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Phone, FirstFactor, [Sms], role);
+const mfaEmail = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Email, Mfa, [Otp], role);
+const totp = (role?: AuthenticationProofRole) => proof(AuthenticationFactor.Totp, Mfa, [Otp], role);
+const backupCode = () =>
+  proof(AuthenticationFactor.BackupCode, Mfa, [Otp], AuthenticationProofRole.Mfa);
+const webAuthn = (role?: AuthenticationProofRole) =>
+  proof(
+    AuthenticationFactor.WebAuthn,
+    Both,
+    [ProofOfPossession, UserPresence, AuthenticationMethodReference.Mfa],
+    role
+  );
+const federated = (role?: AuthenticationProofRole) =>
+  proof(AuthenticationFactor.Federated, undefined, [Federated], role);
+
+/**
+ * The case matrix of the ACR / AMR tech design, section 6, row for row. The design is the
+ * specification; a policy change must update both.
+ */
+describe('aggregateAuthenticationContext', () => {
+  describe('registration', () => {
+    it.each([
+      ['Username + password', () => [password(Bind)], firstFactorAcr, ['pwd']],
+      ['Email + password', () => [email(Create), password(Bind)], firstFactorAcr, ['otp', 'pwd']],
+      ['Phone + password', () => [phone(Create), password(Bind)], firstFactorAcr, ['sms', 'pwd']],
+      ['Email code only', () => [email(Create)], firstFactorAcr, ['otp']],
+      ['Social', () => [federated(Create)], undefined, ['fed']],
+      ['Enterprise SSO', () => [federated(Create)], undefined, ['fed']],
+      [
+        'Username + password, then enrol TOTP',
+        () => [password(Bind), totp(Bind)],
+        mfaAcr,
+        ['pwd', 'otp', 'mfa'],
+      ],
+      // A social registration that enrols a TOTP under the tenant's MFA policy: an mfa-class
+      // factor without a Logto-verifiable first factor reaches only 1fa.
+      [
+        'Social, then enrol TOTP',
+        () => [federated(Create), totp(Bind)],
+        firstFactorAcr,
+        ['fed', 'otp'],
+      ],
+      // A user-verified passkey enrolled and bound in the registration is self-sufficient.
+      [
+        'Social, then enrol passkey',
+        () => [federated(Create), webAuthn(Bind)],
+        mfaAcr,
+        ['fed', 'pop', 'user', 'mfa'],
+      ],
+    ])('%s', (_, build, acr, amr) => {
+      expect(aggregate(build())).toEqual({ ...(acr && { acr }), amr });
+    });
+  });
+
+  describe('sign-in', () => {
+    it.each([
+      ['Password', () => [password()], firstFactorAcr, ['pwd']],
+      ['Email code', () => [email()], firstFactorAcr, ['otp']],
+      [
+        'Password + TOTP',
+        () => [password(), totp(AuthenticationProofRole.Mfa)],
+        mfaAcr,
+        ['pwd', 'otp', 'mfa'],
+      ],
+      ['Password + backup code', () => [password(), backupCode()], mfaAcr, ['pwd', 'otp', 'mfa']],
+      ['Passkey sign-in', () => [webAuthn()], mfaAcr, ['pop', 'user', 'mfa']],
+      [
+        'Password + WebAuthn MFA',
+        () => [password(), webAuthn(AuthenticationProofRole.Mfa)],
+        mfaAcr,
+        ['pwd', 'pop', 'user', 'mfa'],
+      ],
+      ['Social (already linked)', () => [federated()], undefined, ['fed']],
+      ['Social, linking to an existing account', () => [federated()], undefined, ['fed']],
+      ['Enterprise SSO, first sign-in (auto-link)', () => [federated()], undefined, ['fed']],
+      [
+        'Social + TOTP',
+        () => [federated(), totp(AuthenticationProofRole.Mfa)],
+        firstFactorAcr,
+        ['fed', 'otp'],
+      ],
+      [
+        'Password + trusted device (MFA gate bypassed)',
+        () => [password()],
+        firstFactorAcr,
+        ['pwd'],
+      ],
+      [
+        'Password, then bind new TOTP',
+        () => [password(), totp(Bind)],
+        mfaAcr,
+        ['pwd', 'otp', 'mfa'],
+      ],
+      [
+        'Password → set email → bind email MFA',
+        () => [password(), email(Bind), mfaEmail(Bind)],
+        mfaAcr,
+        ['pwd', 'otp', 'mfa'],
+      ],
+      [
+        'Email code + MFA code to the same address',
+        () => [email(), mfaEmail(AuthenticationProofRole.Mfa)],
+        firstFactorAcr,
+        ['otp'],
+      ],
+      // A second proof of the same factor in the other role is still one factor.
+      [
+        'Password + password set again',
+        () => [password(), password(Bind)],
+        firstFactorAcr,
+        ['pwd'],
+      ],
+      ['TOTP alone', () => [totp(AuthenticationProofRole.Mfa)], firstFactorAcr, ['otp']],
+      [
+        'Two mfa-class factors and no first factor',
+        () => [totp(AuthenticationProofRole.Mfa), backupCode()],
+        firstFactorAcr,
+        ['otp'],
+      ],
+      // Another first factor supplies the distinct pair even when the mailbox is repeated.
+      [
+        'Email code + password + MFA code to the same address',
+        () => [email(), password(), mfaEmail(AuthenticationProofRole.Mfa)],
+        mfaAcr,
+        ['otp', 'pwd', 'mfa'],
+      ],
+    ])('%s', (_, build, acr, amr) => {
+      expect(aggregate(build())).toEqual({ ...(acr && { acr }), amr });
+    });
+  });
+
+  it('seeds nothing for an interaction without a proof', () => {
+    expect(aggregateAuthenticationContext([])).toEqual({});
+  });
+});

--- a/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-context.ts
@@ -1,0 +1,70 @@
+import {
+  AuthenticationFactorClass,
+  LogtoAcr,
+  buildAuthenticationMethodReferences,
+  type AuthenticationMethodReference,
+  type AuthenticationProof,
+} from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+
+/** The authentication context an interaction achieved, in the shape of the provider's `login` result. */
+type AuthenticationContext = {
+  acr?: LogtoAcr;
+  amr?: AuthenticationMethodReference[];
+};
+
+/** The distinct factors of the proofs whose class fills the given role. */
+const factorsOfRole = (
+  proofs: readonly AuthenticationProof[],
+  role: AuthenticationFactorClass.FirstFactor | AuthenticationFactorClass.Mfa
+) =>
+  new Set(
+    proofs
+      .filter(({ class: factorClass }) =>
+        factorClass ? [role, AuthenticationFactorClass.Both].includes(factorClass) : false
+      )
+      .map(({ factor }) => factor)
+  );
+
+/**
+ * Aggregate the authentication context an interaction achieved from the proofs it recorded. The
+ * aggregation reads nothing but the proof list: which credentials count was decided at the
+ * touchpoints that recorded them (see `AuthenticationProofs`), and the role of a proof plays no
+ * part here.
+ *
+ * - A `1fa`-class proof reaches `urn:logto:acr:1fa`; an `mfa`-class proof alone also reaches only
+ *   `urn:logto:acr:1fa`.
+ * - A `1fa`-class proof plus an `mfa`-class proof of a different factor, or a `both`-class proof
+ *   (a user-verified WebAuthn authenticator) alone, reaches `urn:logto:acr:mfa`. Repeated proofs
+ *   of one factor count once, so a one-time token plus an MFA email code stays at
+ *   `urn:logto:acr:1fa`.
+ * - Federated proofs carry no class: they contribute `fed` to `amr` and nothing to the ACR.
+ * - `amr` is the union of the proofs' references in first-seen order with `mfa` last.
+ * - No `ts` is seeded: the provider stamps `auth_time` with the submission time itself.
+ */
+export const aggregateAuthenticationContext = (
+  proofs: readonly AuthenticationProof[]
+): AuthenticationContext => {
+  const firstFactors = factorsOfRole(proofs, AuthenticationFactorClass.FirstFactor);
+  const mfaFactors = factorsOfRole(proofs, AuthenticationFactorClass.Mfa);
+  const hasDistinctPair = [...mfaFactors].some((factor) =>
+    [...firstFactors].some((firstFactor) => firstFactor !== factor)
+  );
+  const hasSelfSufficient = proofs.some(
+    ({ class: factorClass }) => factorClass === AuthenticationFactorClass.Both
+  );
+
+  const acr =
+    hasDistinctPair || hasSelfSufficient
+      ? LogtoAcr.Mfa
+      : conditional((firstFactors.size > 0 || mfaFactors.size > 0) && LogtoAcr.FirstFactor);
+  const amr = buildAuthenticationMethodReferences(
+    proofs.map(({ amr }) => amr),
+    acr
+  );
+
+  return {
+    ...conditional(acr && { acr }),
+    ...conditional(amr.length > 0 && { amr }),
+  };
+};

--- a/packages/core/src/routes/experience/classes/libraries/authentication-proofs.test.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-proofs.test.ts
@@ -1,0 +1,148 @@
+import {
+  AuthenticationFactor,
+  AuthenticationFactorClass,
+  AuthenticationProofRole,
+  SignInIdentifier,
+  VerificationType,
+} from '@logto/schemas';
+
+import { mockUser } from '#src/__mocks__/user.js';
+import { MockTenant } from '#src/test-utils/tenant.js';
+
+import { BackupCodeVerification } from '../verifications/backup-code-verification.js';
+import { PasswordVerification } from '../verifications/password-verification.js';
+import { SocialVerification } from '../verifications/social-verification.js';
+import { TotpVerification } from '../verifications/totp-verification.js';
+import { WebAuthnVerification } from '../verifications/web-authn-verification.js';
+
+import { AuthenticationProofs } from './authentication-proofs.js';
+
+const { libraries, queries } = new MockTenant();
+const { Create, Identify, Bind, Mfa } = AuthenticationProofRole;
+
+const password = new PasswordVerification(libraries, queries, {
+  id: 'password',
+  type: VerificationType.Password,
+  identifier: { type: SignInIdentifier.Username, value: 'foo' },
+  verified: true,
+});
+
+const totp = new TotpVerification(libraries, queries, {
+  id: 'totp',
+  type: VerificationType.TOTP,
+  userId: mockUser.id,
+  verified: true,
+});
+
+const backupCode = new BackupCodeVerification(libraries, queries, {
+  id: 'backup-code',
+  type: VerificationType.BackupCode,
+  userId: mockUser.id,
+  code: 'code',
+});
+
+const webAuthn = new WebAuthnVerification(libraries, queries, {
+  id: 'web-authn',
+  type: VerificationType.WebAuthn,
+  userId: mockUser.id,
+  verified: true,
+});
+
+const social = new SocialVerification(libraries, queries, {
+  id: 'social',
+  type: VerificationType.Social,
+  connectorId: 'connector',
+  socialUserInfo: { id: 'social-user' },
+});
+
+describe('AuthenticationProofs', () => {
+  it('records the factor, class and AMR values of a record', () => {
+    const proofs = new AuthenticationProofs();
+
+    proofs.stage(password, Identify);
+    proofs.stage(totp, Mfa);
+    proofs.stage(webAuthn, Bind);
+    proofs.stage(social, Create);
+
+    expect(proofs.proofs).toEqual([
+      {
+        id: 'password',
+        factor: AuthenticationFactor.Password,
+        class: AuthenticationFactorClass.FirstFactor,
+        amr: ['pwd'],
+        role: Identify,
+      },
+      {
+        id: 'totp',
+        factor: AuthenticationFactor.Totp,
+        class: AuthenticationFactorClass.Mfa,
+        amr: ['otp'],
+        role: Mfa,
+      },
+      {
+        id: 'web-authn',
+        factor: AuthenticationFactor.WebAuthn,
+        class: AuthenticationFactorClass.Both,
+        amr: ['pop', 'user', 'mfa'],
+        role: Bind,
+      },
+      {
+        id: 'social',
+        factor: AuthenticationFactor.Federated,
+        class: undefined,
+        amr: ['fed'],
+        role: Create,
+      },
+    ]);
+  });
+
+  it('keys proofs by record and role, so a retry overwrites and a second role is kept', () => {
+    const proofs = new AuthenticationProofs();
+
+    proofs.stage(password, Identify);
+    proofs.stage(password, Identify);
+    expect(proofs.proofs).toHaveLength(1);
+
+    proofs.stage(password, Bind);
+    expect(proofs.proofs.map(({ role }) => role)).toEqual([Identify, Bind]);
+  });
+
+  it('records a backup code challenge but not a backup code bind', () => {
+    const proofs = new AuthenticationProofs();
+
+    proofs.stage(backupCode, Bind);
+    expect(proofs.proofs).toEqual([]);
+
+    proofs.stage(backupCode, Mfa);
+    expect(proofs.proofs).toMatchObject([{ id: 'backup-code', role: Mfa }]);
+  });
+
+  it('records a password established through the profile', () => {
+    const proofs = new AuthenticationProofs();
+
+    proofs.stageEstablishedPassword();
+
+    expect(proofs.proofs).toMatchObject([
+      {
+        id: 'password',
+        factor: AuthenticationFactor.Password,
+        class: AuthenticationFactorClass.FirstFactor,
+        amr: ['pwd'],
+        role: Bind,
+      },
+    ]);
+  });
+
+  it('round-trips through its data and can be cleared', () => {
+    const proofs = new AuthenticationProofs();
+    proofs.stage(password, Identify);
+    proofs.stage(totp, Mfa);
+
+    const restored = new AuthenticationProofs(proofs.data);
+    expect(restored.proofs).toEqual(proofs.proofs);
+
+    restored.clear();
+    expect(restored.proofs).toEqual([]);
+    expect(restored.data).toEqual([]);
+  });
+});

--- a/packages/core/src/routes/experience/classes/libraries/authentication-proofs.ts
+++ b/packages/core/src/routes/experience/classes/libraries/authentication-proofs.ts
@@ -1,0 +1,95 @@
+import {
+  AuthenticationFactor,
+  AuthenticationFactorClass,
+  AuthenticationMethodReference,
+  AuthenticationProofRole,
+  VerificationType,
+  getAuthenticationFactor,
+  getAuthenticationFactorClass,
+  getAuthenticationMethodReferences,
+  type AuthenticationProof,
+} from '@logto/schemas';
+
+import { type VerificationRecord } from '../verifications/index.js';
+
+/** The id of the proof for a password established through the profile, which has no record. */
+const establishedPasswordProofId = 'password';
+
+const keyOf = ({ id, role }: Pick<AuthenticationProof, 'id' | 'role'>) => `${id}:${role}`;
+
+/**
+ * The authentication proofs of one interaction: what the user proved about the account, recorded
+ * at the single touchpoint that consumed each credential (`createUser()`, `identifyUser()`, a
+ * profile or MFA bind, an MFA challenge, or the profile's password transition).
+ *
+ * The collection is staged in memory and persisted by `ExperienceInteraction.save()` together with
+ * the effect that produced each proof: an operation that throws never reaches `save()`, so it
+ * leaves no proof behind. It has the lifetime of `profile.data` and is cleared in the same places.
+ *
+ * Entries are keyed by record id and role, so a retry overwrites rather than duplicates. The
+ * proofs carry no timestamp: `auth_time` is stamped by the provider when the interaction is
+ * submitted, which is the moment the session is established.
+ */
+export class AuthenticationProofs {
+  readonly #proofs = new Map<string, AuthenticationProof>();
+
+  constructor(data: AuthenticationProof[] = []) {
+    for (const proof of data) {
+      this.#proofs.set(keyOf(proof), proof);
+    }
+  }
+
+  get proofs(): readonly AuthenticationProof[] {
+    return [...this.#proofs.values()];
+  }
+
+  get data(): AuthenticationProof[] {
+    return this.proofs.map((proof) => ({ ...proof, amr: [...proof.amr] }));
+  }
+
+  /**
+   * Stage the proof a verification record contributes in the given role. The factor, class and AMR
+   * values come from the record type.
+   *
+   * Declared non-proofs, written here so that their absence reads as a decision:
+   *
+   * - Binding backup codes (`BackupCode` in the `bind` role) generates recovery codes and proves
+   *   nothing; only a backup code challenge is a proof.
+   */
+  stage(record: VerificationRecord, role: AuthenticationProofRole) {
+    if (record.type === VerificationType.BackupCode && role === AuthenticationProofRole.Bind) {
+      return;
+    }
+
+    this.set({
+      id: record.id,
+      factor: getAuthenticationFactor(record.type),
+      class: getAuthenticationFactorClass(record.type),
+      amr: [...getAuthenticationMethodReferences(record.type)],
+      role,
+    });
+  }
+
+  /**
+   * Stage the proof for a password established through the profile: setting a password is the
+   * establishment itself, and there is no verification record to consume.
+   */
+  stageEstablishedPassword() {
+    this.set({
+      id: establishedPasswordProofId,
+      factor: AuthenticationFactor.Password,
+      class: AuthenticationFactorClass.FirstFactor,
+      amr: [AuthenticationMethodReference.Password],
+      role: AuthenticationProofRole.Bind,
+    });
+  }
+
+  /** Drop every proof; called wherever `profile.data` is cleared. */
+  clear() {
+    this.#proofs.clear();
+  }
+
+  private set(proof: AuthenticationProof) {
+    this.#proofs.set(keyOf(proof), proof);
+  }
+}

--- a/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
+++ b/packages/core/src/routes/experience/classes/libraries/mfa-validator.ts
@@ -53,7 +53,7 @@ type MfaVerificationRecord =
   | MfaEmailCodeVerification
   | MfaPhoneCodeVerification;
 
-const isMfaVerificationRecord = (
+export const isMfaVerificationRecord = (
   verification: VerificationRecord
 ): verification is MfaVerificationRecord => {
   return mfaVerificationTypes.includes(verification.type);

--- a/packages/core/src/routes/experience/classes/mfa.test.ts
+++ b/packages/core/src/routes/experience/classes/mfa.test.ts
@@ -45,10 +45,13 @@ const createMfa = ({
   const interactionContext: InteractionContext = {
     getInteractionEvent: () => interactionEvent,
     getIdentifiedUser,
-    getVerificationRecordById: () => {
+    consumeForBind: () => {
       throw new Error('should not be called');
     },
-    getVerificationRecordByTypeAndId: () => {
+    consumeForBindByType: () => {
+      throw new Error('should not be called');
+    },
+    recordEstablishedPassword: () => {
       throw new Error('should not be called');
     },
     getCurrentProfile: () => currentProfile,

--- a/packages/core/src/routes/experience/classes/mfa.ts
+++ b/packages/core/src/routes/experience/classes/mfa.ts
@@ -255,7 +255,7 @@ export class Mfa {
    * - Any existing TOTP factor will be replaced with the new one.
    */
   async addTotpByVerificationId(verificationId: string, log?: LogEntry) {
-    const verificationRecord = this.interactionContext.getVerificationRecordByTypeAndId(
+    const verificationRecord = this.interactionContext.consumeForBindByType(
       VerificationType.TOTP,
       verificationId
     );
@@ -288,7 +288,7 @@ export class Mfa {
    * @throws {RequestError} with status 400 if WebAuthn is not enabled in the sign-in experience
    */
   async addWebAuthnByVerificationId(verificationId: string, log?: LogEntry) {
-    const verificationRecord = this.interactionContext.getVerificationRecordByTypeAndId(
+    const verificationRecord = this.interactionContext.consumeForBindByType(
       VerificationType.WebAuthn,
       verificationId
     );
@@ -313,7 +313,7 @@ export class Mfa {
    * @throws {RequestError} with status 422 if the backup code is the only MFA factor
    */
   async addBackupCodeByVerificationId(verificationId: string, log?: LogEntry) {
-    const verificationRecord = this.interactionContext.getVerificationRecordByTypeAndId(
+    const verificationRecord = this.interactionContext.consumeForBindByType(
       VerificationType.BackupCode,
       verificationId
     );

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -318,10 +318,10 @@ export class Profile {
   }
 
   /**
-   * The single write path into `#data`. Setting a password is the establishment of that credential
-   * and has no verification record, so the authentication proof is recorded on the transition of
-   * `passwordEncrypted` from unset to set; every path funnels through here, including any added
-   * later.
+   * Shared write path for `unsafeSet()` and `unsafePrepend()`. Setting a password establishes that
+   * credential without a verification record, so record its authentication proof when
+   * `passwordEncrypted` transitions from unset to set. Profile submission and cleanup mutate
+   * `#data` separately and do not establish a password.
    */
   private write(data: InteractionProfile) {
     const isPasswordEstablished = !this.#data.passwordEncrypted && Boolean(data.passwordEncrypted);

--- a/packages/core/src/routes/experience/classes/profile.ts
+++ b/packages/core/src/routes/experience/classes/profile.ts
@@ -88,7 +88,7 @@ export class Profile {
     verificationId: string,
     log?: LogEntry
   ) {
-    const verificationRecord = this.interactionContext.getVerificationRecordById(verificationId);
+    const verificationRecord = this.interactionContext.consumeForBind(verificationId);
 
     // Assert the verification record type matches the identifier type
     switch (type) {
@@ -274,10 +274,10 @@ export class Profile {
    * - skip profile existence check in the current user account.
    */
   unsafeSet(profile: InteractionProfile) {
-    this.#data = {
+    this.write({
       ...this.#data,
       ...profile,
-    };
+    });
   }
 
   /**
@@ -285,10 +285,10 @@ export class Profile {
    * Avoid overwriting the existing profile data.
    */
   unsafePrepend(profile: InteractionProfile) {
-    this.#data = {
+    this.write({
       ...profile,
       ...this.#data,
-    };
+    });
   }
 
   /**
@@ -315,5 +315,21 @@ export class Profile {
     }
 
     return getIdentifiedUser();
+  }
+
+  /**
+   * The single write path into `#data`. Setting a password is the establishment of that credential
+   * and has no verification record, so the authentication proof is recorded on the transition of
+   * `passwordEncrypted` from unset to set; every path funnels through here, including any added
+   * later.
+   */
+  private write(data: InteractionProfile) {
+    const isPasswordEstablished = !this.#data.passwordEncrypted && Boolean(data.passwordEncrypted);
+
+    this.#data = data;
+
+    if (isPasswordEstablished) {
+      this.interactionContext.recordEstablishedPassword();
+    }
   }
 }

--- a/packages/core/src/routes/experience/profile-routes.ts
+++ b/packages/core/src/routes/experience/profile-routes.ts
@@ -6,6 +6,7 @@ import {
   updateProfileApiPayloadGuard,
   uploadFileGuard,
   userAssetsGuard,
+  VerificationType,
 } from '@logto/schemas';
 import { addDays, format } from 'date-fns';
 import { type MiddlewareType } from 'koa';
@@ -410,6 +411,12 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
               true
             );
             experienceInteraction.setVerificationRecord(codeVerification);
+            // The email is now an MFA factor of the account: record that `bind` proof next to
+            // the `1fa` one the profile bind recorded for the same mailbox.
+            experienceInteraction.consumeForBindByType(
+              VerificationType.MfaEmailVerificationCode,
+              codeVerification.id
+            );
           }
           break;
         }
@@ -433,6 +440,10 @@ export default function interactionProfileRoutes<T extends ExperienceInteraction
               true
             );
             experienceInteraction.setVerificationRecord(codeVerification);
+            experienceInteraction.consumeForBindByType(
+              VerificationType.MfaPhoneVerificationCode,
+              codeVerification.id
+            );
           }
           break;
         }

--- a/packages/core/src/routes/experience/types.ts
+++ b/packages/core/src/routes/experience/types.ts
@@ -1,5 +1,7 @@
 import { type SocialUserInfo, socialUserInfoGuard, type ToZodObject } from '@logto/connector-kit';
 import {
+  type AuthenticationProof,
+  authenticationProofGuard,
   type CreateUser,
   encryptedTokenSetGuard,
   InteractionEvent,
@@ -165,16 +167,25 @@ const sanitizedInteractionProfileGuard = interactionProfileGuard.omit({
 }) satisfies ToZodObject<SanitizedInteractionProfile>;
 
 /**
- * The interaction context provides the callback functions to get the user and verification record from the interaction
+ * The interaction context provides the callback functions to get the user and verification record from the interaction.
+ *
+ * There is deliberately no raw verification-record getter here. Every time `Profile` or `Mfa`
+ * reaches a record it consumes the record's credential, and the consumer must say so: the
+ * `consumeFor…` methods record the authentication proof for the role they name. Re-adding a raw
+ * getter would let a write path reach a record without recording what it did with it.
  */
 export type InteractionContext = {
   getInteractionEvent: () => InteractionEvent;
   getIdentifiedUser: () => Promise<User>;
-  getVerificationRecordById: (verificationId: string) => VerificationRecord;
-  getVerificationRecordByTypeAndId: <K extends keyof VerificationRecordMap>(
+  /** Fetch a record to bind the credential it carries to the account, recording the `bind` proof. */
+  consumeForBind: (verificationId: string) => VerificationRecord;
+  /** The typed variant of `consumeForBind`. */
+  consumeForBindByType: <K extends keyof VerificationRecordMap>(
     type: K,
     verificationId: string
   ) => VerificationRecordMap[K];
+  /** Record the proof for a password established through the profile, which has no record. */
+  recordEstablishedPassword: () => void;
   getCurrentProfile: () => InteractionProfile;
 };
 
@@ -198,6 +209,8 @@ export type WithHooksAndLogsContext<ContextT extends WithLogContext = WithLogCon
 export type InteractionStorage = {
   interactionEvent: InteractionEvent;
   userId?: string;
+  /** The authentication proofs recorded so far; see `AuthenticationProofs`. */
+  authenticationProofs?: AuthenticationProof[];
   trustedDeviceOptIn?:
     | {
         trusted: false;
@@ -219,6 +232,7 @@ export type InteractionStorage = {
 export const interactionStorageGuard = z.object({
   interactionEvent: z.nativeEnum(InteractionEvent),
   userId: z.string().optional(),
+  authenticationProofs: authenticationProofGuard.array().optional(),
   trustedDeviceOptIn: z
     .discriminatedUnion('trusted', [
       z.object({ trusted: z.literal(false) }),

--- a/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/backup-code-verification.ts
@@ -122,6 +122,10 @@ export default function backupCodeVerificationRoutes<T extends ExperienceInterac
       );
 
       ctx.experienceInteraction.setVerificationRecord(backupCodeVerificationRecord);
+      ctx.experienceInteraction.consumeForMfa(
+        VerificationType.BackupCode,
+        backupCodeVerificationRecord.id
+      );
 
       await ctx.experienceInteraction.save();
 

--- a/packages/core/src/routes/experience/verification-routes/mfa-sentinel-guard.test.ts
+++ b/packages/core/src/routes/experience/verification-routes/mfa-sentinel-guard.test.ts
@@ -148,6 +148,7 @@ describe('MFA verification routes sentinel guard', () => {
       experienceInteraction: {
         identifiedUserId: mockUser.id,
         setVerificationRecord: jest.fn(),
+        consumeForMfa: jest.fn(),
         save: jest.fn().mockImplementation(resolveVoid),
       },
       verificationAuditLog: {
@@ -194,6 +195,7 @@ describe('MFA verification routes sentinel guard', () => {
       experienceInteraction: {
         identifiedUserId: mockUser.id,
         setVerificationRecord: jest.fn(),
+        consumeForMfa: jest.fn(),
         save: jest.fn().mockImplementation(resolveVoid),
       },
       verificationAuditLog: {
@@ -244,6 +246,7 @@ describe('MFA verification routes sentinel guard', () => {
       experienceInteraction: {
         identifiedUserId: mockUser.id,
         getVerificationRecordByTypeAndId: jest.fn(() => webAuthnVerificationRecord),
+        consumeForMfa: jest.fn(),
         save: jest.fn().mockImplementation(resolveVoid),
       },
       verificationAuditLog: {
@@ -265,6 +268,10 @@ describe('MFA verification routes sentinel guard', () => {
     await handler(ctx, jest.fn().mockImplementation(resolveVoid));
 
     expect(ctx.experienceInteraction.getVerificationRecordByTypeAndId).toHaveBeenCalledWith(
+      VerificationType.WebAuthn,
+      webAuthnVerificationRecord.id
+    );
+    expect(ctx.experienceInteraction.consumeForMfa).toHaveBeenCalledWith(
       VerificationType.WebAuthn,
       webAuthnVerificationRecord.id
     );

--- a/packages/core/src/routes/experience/verification-routes/totp-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/totp-verification.ts
@@ -154,6 +154,7 @@ export default function totpVerificationRoutes<T extends ExperienceInteractionRo
       );
 
       ctx.experienceInteraction.setVerificationRecord(totpVerificationRecord);
+      ctx.experienceInteraction.consumeForMfa(VerificationType.TOTP, totpVerificationRecord.id);
 
       await ctx.experienceInteraction.save();
 

--- a/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
+++ b/packages/core/src/routes/experience/verification-routes/verification-code-helpers.ts
@@ -264,6 +264,15 @@ export const verifyCode = async ({
     codeVerificationRecord.verify(identifier, code)
   );
 
+  // For an MFA challenge, verifying is the use: record the `mfa` proof here. A primary email /
+  // phone code is consumed later, by identification or by a profile bind, which records its proof.
+  if (
+    verificationType === VerificationType.MfaEmailVerificationCode ||
+    verificationType === VerificationType.MfaPhoneVerificationCode
+  ) {
+    experienceInteraction.consumeForMfa(verificationType, codeVerificationRecord.id);
+  }
+
   // Save state
   await experienceInteraction.save();
 

--- a/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
+++ b/packages/core/src/routes/experience/verification-routes/web-authn-verification.ts
@@ -263,6 +263,8 @@ export default function webAuthnVerificationRoute<T extends ExperienceInteractio
         webAuthnVerification.verifyWebAuthnAuthentication(ctx, payload)
       );
 
+      experienceInteraction.consumeForMfa(VerificationType.WebAuthn, webAuthnVerification.id);
+
       await experienceInteraction.save();
 
       ctx.body = {

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
@@ -176,8 +176,8 @@ devFeatureTest.describe('authentication context claims on registration', () => {
 
   describe('verification code and password', () => {
     beforeAll(async () => {
-      await clearConnectorsByTypes([ConnectorType.Email]);
-      await setEmailConnector();
+      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+      await Promise.all([setEmailConnector(), setSmsConnector()]);
       await enableAllVerificationCodeSignInMethods({
         identifiers: [SignInIdentifier.Email],
         password: true,
@@ -187,7 +187,7 @@ devFeatureTest.describe('authentication context claims on registration', () => {
     });
 
     afterAll(async () => {
-      await clearConnectorsByTypes([ConnectorType.Email]);
+      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
       await resetPasswordPolicy();
       await enableAllPasswordSignInMethods();
     });

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
@@ -206,12 +206,12 @@ devFeatureTest.describe('authentication context claims on registration', () => {
         interactionEvent: InteractionEvent.Register,
       });
       await successfullyVerifyVerificationCode(client, { identifier, verificationId, code });
-      await client.identifyUser({ verificationId });
-      await expectRejects(client.submitInteraction(), {
+      await expectRejects(client.identifyUser({ verificationId }), {
         code: 'user.missing_profile',
         status: 422,
       });
       await client.updateProfile({ type: 'password', value: password });
+      await client.identifyUser();
 
       const claims = await finishRegistration(client);
 

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context-registration.test.ts
@@ -1,0 +1,265 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { Prompt } from '@logto/node';
+import {
+  InteractionEvent,
+  MfaFactor,
+  SignInIdentifier,
+  demoAppApplicationId,
+} from '@logto/schemas';
+import { generateStandardId } from '@logto/shared';
+
+import { deleteUser } from '#src/api/admin-user.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { type ExperienceClient } from '#src/client/experience/index.js';
+import { demoAppRedirectUri } from '#src/constants.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import {
+  clearConnectorsByTypes,
+  setEmailConnector,
+  setSmsConnector,
+  setSocialConnector,
+} from '#src/helpers/connector.js';
+import {
+  successfullyCreateSocialVerification,
+  successfullyVerifySocialAuthorization,
+} from '#src/helpers/experience/social-verification.js';
+import { successfullyCreateAndVerifyTotp } from '#src/helpers/experience/totp-verification.js';
+import {
+  successfullySendVerificationCode,
+  successfullyVerifyVerificationCode,
+} from '#src/helpers/experience/verification-code.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableAllVerificationCodeSignInMethods,
+  enableMandatoryMfaWithTotp,
+  resetMfaSettings,
+  resetPasswordPolicy,
+} from '#src/helpers/sign-in-experience.js';
+import { generateNewUserProfile } from '#src/helpers/user.js';
+import { devFeatureTest } from '#src/utils.js';
+
+const firstFactorAcr = 'urn:logto:acr:1fa';
+const mfaAcr = 'urn:logto:acr:mfa';
+
+const nowInSeconds = () => Math.floor(Date.now() / 1000);
+
+const registerClient = async () =>
+  initExperienceClient({ interactionEvent: InteractionEvent.Register });
+
+/** Start a sign-in on a fresh client, as a social user who turns out to be new would. */
+const initClient = async () =>
+  initExperienceClient({
+    config: { appId: demoAppApplicationId, prompt: Prompt.Consent, scopes: ['offline_access'] },
+    redirectUri: demoAppRedirectUri,
+  });
+
+/** Verify a registration password for a fresh username and create the account with it. */
+const registerWithUsernamePassword = async (client: ExperienceClient) => {
+  const { username, password } = generateNewUserProfile({ username: true, password: true });
+  const { verificationId } = await client.createNewPasswordIdentityVerification({
+    identifier: { type: SignInIdentifier.Username, value: username },
+    password,
+  });
+  await client.identifyUser({ verificationId });
+};
+
+/** Submit the registration, read the ID token claims, and delete the account. */
+const finishRegistration = async (client: ExperienceClient) => {
+  const { redirectTo } = await client.submitInteraction();
+  await processSession(client, redirectTo);
+  const claims = await client.getIdTokenClaims();
+  await logoutClient(client);
+  await deleteUser(claims.sub);
+  return claims;
+};
+
+/**
+ * A registration creates the account from the interaction's records, so every credential it
+ * establishes is a proof of that account and the ID token carries it like a sign-in would.
+ */
+devFeatureTest.describe('authentication context claims on registration', () => {
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await updateSignInExperience({ adaptiveMfa: { enabled: false } });
+  });
+
+  afterAll(async () => {
+    await resetMfaSettings();
+  });
+
+  describe('username and password', () => {
+    beforeAll(async () => {
+      // Disable the password policy so the generated password is accepted.
+      await updateSignInExperience({
+        signUp: { identifiers: [SignInIdentifier.Username], password: true, verify: false },
+        passwordPolicy: {},
+      });
+    });
+
+    afterAll(async () => {
+      await resetPasswordPolicy();
+      await enableAllPasswordSignInMethods();
+    });
+
+    it('issues acr=1fa, amr=[pwd], and a fresh auth_time for the password the account was created with', async () => {
+      const client = await registerClient();
+      const before = nowInSeconds();
+      await registerWithUsernamePassword(client);
+
+      const claims = await finishRegistration(client);
+
+      expect(claims).toMatchObject({ acr: firstFactorAcr, amr: ['pwd'] });
+      expect(claims.auth_time).toBeGreaterThanOrEqual(before);
+      expect(claims.auth_time).toBeLessThanOrEqual(nowInSeconds());
+    });
+
+    it('issues acr=mfa and amr=[pwd, otp, mfa] when the registration enrolls a mandatory TOTP', async () => {
+      await enableMandatoryMfaWithTotp();
+      const client = await registerClient();
+      await registerWithUsernamePassword(client);
+
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.missing_mfa',
+        status: 422,
+      });
+      const totpVerificationId = await successfullyCreateAndVerifyTotp(client);
+      await client.bindMfa(MfaFactor.TOTP, totpVerificationId);
+
+      const claims = await finishRegistration(client);
+
+      expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
+
+      await resetMfaSettings();
+    });
+  });
+
+  describe('verification code', () => {
+    beforeAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+      await Promise.all([setEmailConnector(), setSmsConnector()]);
+      await enableAllVerificationCodeSignInMethods({
+        identifiers: [SignInIdentifier.Email, SignInIdentifier.Phone],
+        password: false,
+        verify: true,
+      });
+    });
+
+    afterAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email, ConnectorType.Sms]);
+      await enableAllPasswordSignInMethods();
+    });
+
+    it.each([
+      { identifierType: SignInIdentifier.Email, profileKey: 'primaryEmail', amr: ['otp'] },
+      { identifierType: SignInIdentifier.Phone, profileKey: 'primaryPhone', amr: ['sms'] },
+    ] as const)(
+      'issues acr=1fa and amr=$amr for the verified $identifierType the account was created with',
+      async ({ identifierType, profileKey, amr }) => {
+        const profile = generateNewUserProfile({ primaryEmail: true, primaryPhone: true });
+        const identifier = { type: identifierType, value: profile[profileKey] };
+        const client = await registerClient();
+        const { verificationId, code } = await successfullySendVerificationCode(client, {
+          identifier,
+          interactionEvent: InteractionEvent.Register,
+        });
+        await successfullyVerifyVerificationCode(client, { identifier, verificationId, code });
+        await client.identifyUser({ verificationId });
+
+        const claims = await finishRegistration(client);
+
+        expect(claims).toMatchObject({ acr: firstFactorAcr, amr });
+        expect(typeof claims.auth_time).toBe('number');
+      }
+    );
+  });
+
+  describe('verification code and password', () => {
+    beforeAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email]);
+      await setEmailConnector();
+      await enableAllVerificationCodeSignInMethods({
+        identifiers: [SignInIdentifier.Email],
+        password: true,
+        verify: true,
+      });
+      await updateSignInExperience({ passwordPolicy: {} });
+    });
+
+    afterAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Email]);
+      await resetPasswordPolicy();
+      await enableAllPasswordSignInMethods();
+    });
+
+    it('issues acr=1fa and amr=[otp, pwd] for the verified email and the password set on the profile', async () => {
+      // The password is set through the profile and has no verification record; the profile's
+      // password transition records its proof. Two first factors are still one assurance level.
+      const { primaryEmail, password } = generateNewUserProfile({
+        primaryEmail: true,
+        password: true,
+      });
+      const identifier = { type: SignInIdentifier.Email, value: primaryEmail } as const;
+      const client = await registerClient();
+      const { verificationId, code } = await successfullySendVerificationCode(client, {
+        identifier,
+        interactionEvent: InteractionEvent.Register,
+      });
+      await successfullyVerifyVerificationCode(client, { identifier, verificationId, code });
+      await client.identifyUser({ verificationId });
+      await expectRejects(client.submitInteraction(), {
+        code: 'user.missing_profile',
+        status: 422,
+      });
+      await client.updateProfile({ type: 'password', value: password });
+
+      const claims = await finishRegistration(client);
+
+      expect(claims).toMatchObject({ acr: firstFactorAcr, amr: ['otp', 'pwd'] });
+    });
+  });
+
+  describe('social', () => {
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let connectorId: string;
+
+    beforeAll(async () => {
+      // Let a social user register without a username or password.
+      await enableAllPasswordSignInMethods({ identifiers: [], password: false, verify: false });
+      await clearConnectorsByTypes([ConnectorType.Social]);
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      ({ id: connectorId } = await setSocialConnector());
+    });
+
+    afterAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Social]);
+      await enableAllPasswordSignInMethods();
+    });
+
+    it('issues amr=[fed] and no acr for a social registration', async () => {
+      const client = await initClient();
+      const state = 'state';
+      const redirectUri = 'http://localhost:3000';
+      const { verificationId } = await successfullyCreateSocialVerification(client, connectorId, {
+        redirectUri,
+        state,
+      });
+      await successfullyVerifySocialAuthorization(client, connectorId, {
+        verificationId,
+        connectorData: { state, redirectUri, code: 'fake_code', userId: generateStandardId() },
+      });
+      await expectRejects(client.identifyUser({ verificationId }), {
+        code: 'user.identity_not_exist',
+        status: 404,
+      });
+      await client.updateInteractionEvent({ interactionEvent: InteractionEvent.Register });
+      await client.identifyUser({ verificationId });
+
+      const claims = await finishRegistration(client);
+
+      expect(claims.amr).toEqual(['fed']);
+      expect(claims).not.toHaveProperty('acr');
+      expect(typeof claims.auth_time).toBe('number');
+    });
+  });
+});

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -1,0 +1,302 @@
+import { ConnectorType } from '@logto/connector-kit';
+import { decodeIdToken } from '@logto/js';
+import { Prompt } from '@logto/node';
+import { GrantType, MfaFactor, MfaPolicy, demoAppApplicationId } from '@logto/schemas';
+import { formUrlEncodedHeaders, generateStandardId } from '@logto/shared';
+import { isKeyInObject } from '@silverhand/essentials';
+import ky from 'ky';
+import { authenticator } from 'otplib';
+
+import {
+  createUserMfaVerification,
+  deleteUser,
+  updateUserLogtoConfig,
+} from '#src/api/admin-user.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { type ExperienceClient } from '#src/client/experience/index.js';
+import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
+import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
+import { clearConnectorsByTypes, setSocialConnector } from '#src/helpers/connector.js';
+import {
+  identifyUserWithUsernamePassword,
+  signInWithSocial,
+} from '#src/helpers/experience/index.js';
+import {
+  successfullyCreateSocialVerification,
+  successfullyVerifySocialAuthorization,
+} from '#src/helpers/experience/social-verification.js';
+import {
+  successfullyCreateAndVerifyTotp,
+  successfullyVerifyTotp,
+} from '#src/helpers/experience/totp-verification.js';
+import { expectRejects } from '#src/helpers/index.js';
+import {
+  enableAllPasswordSignInMethods,
+  enableMandatoryMfaWithTotp,
+  enableMandatoryMfaWithTotpAndBackupCode,
+  resetMfaSettings,
+} from '#src/helpers/sign-in-experience.js';
+import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+import { devFeatureTest } from '#src/utils.js';
+
+const firstFactorAcr = 'urn:logto:acr:1fa';
+const mfaAcr = 'urn:logto:acr:mfa';
+
+const nowInSeconds = () => Math.floor(Date.now() / 1000);
+
+/**
+ * Start an authorization on a fresh client (so a sign-in is always required) that issues a
+ * refresh token: the provider only issues one for `offline_access` under `prompt=consent`.
+ */
+const initClient = async () =>
+  initExperienceClient({
+    config: {
+      appId: demoAppApplicationId,
+      prompt: Prompt.Consent,
+      scopes: ['offline_access'],
+    },
+    redirectUri: demoAppRedirectUri,
+  });
+
+const finishSignIn = async (client: ExperienceClient) => {
+  const { redirectTo } = await client.submitInteraction();
+  await processSession(client, redirectTo);
+  return client.getIdTokenClaims();
+};
+
+/** Rotate the refresh token through the token endpoint and decode the new ID token. */
+const refreshIdToken = async (client: ExperienceClient) => {
+  const refreshToken = await client.getRefreshToken();
+  const json = await ky
+    .post(`${logtoUrl}/oidc/token`, {
+      headers: formUrlEncodedHeaders,
+      body: new URLSearchParams({
+        grant_type: GrantType.RefreshToken,
+        client_id: demoAppApplicationId,
+        refresh_token: refreshToken ?? '',
+      }),
+    })
+    .json();
+
+  if (!isKeyInObject(json, 'id_token') || typeof json.id_token !== 'string') {
+    throw new TypeError('The refresh token grant did not return an ID token');
+  }
+
+  return decodeIdToken(json.id_token);
+};
+
+devFeatureTest.describe('authentication context claims on sign-in', () => {
+  const userApi = new UserApiTest();
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await updateSignInExperience({ adaptiveMfa: { enabled: false } });
+  });
+
+  afterAll(async () => {
+    await resetMfaSettings();
+    await userApi.cleanUp();
+  });
+
+  it('issues acr=1fa, amr=[pwd], and a fresh auth_time for a password sign-in, preserved across refresh', async () => {
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    await userApi.create({ username, password });
+    const client = await initClient();
+    const before = nowInSeconds();
+
+    await identifyUserWithUsernamePassword(client, username, password);
+    const claims = await finishSignIn(client);
+
+    expect(claims).toMatchObject({ acr: firstFactorAcr, amr: ['pwd'] });
+    expect(claims.auth_time).toBeGreaterThanOrEqual(before);
+    expect(claims.auth_time).toBeLessThanOrEqual(nowInSeconds());
+
+    // Refreshing never makes the authentication more recent.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1100);
+    });
+    const refreshed = await refreshIdToken(client);
+    expect(refreshed).toMatchObject({
+      acr: firstFactorAcr,
+      amr: ['pwd'],
+      auth_time: claims.auth_time,
+    });
+
+    await logoutClient(client);
+  });
+
+  it('issues acr=mfa and amr=[pwd, otp, mfa] for a password sign-in verified with TOTP', async () => {
+    await enableMandatoryMfaWithTotpAndBackupCode();
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({ username, password });
+    const totp = await createUserMfaVerification(user.id, MfaFactor.TOTP);
+    await createUserMfaVerification(user.id, MfaFactor.BackupCode);
+
+    if (totp.type !== MfaFactor.TOTP) {
+      throw new TypeError('unexpected mfa type');
+    }
+
+    const client = await initClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+    await successfullyVerifyTotp(client, { code: authenticator.generate(totp.secret) });
+    const claims = await finishSignIn(client);
+
+    expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
+    expect(typeof claims.auth_time).toBe('number');
+
+    await logoutClient(client);
+    await resetMfaSettings();
+  });
+
+  it('issues acr=mfa and amr=[pwd, otp, mfa] when the sign-in enrolls the first TOTP of the account', async () => {
+    // A factor established by the interaction and written to the account counts like one it
+    // verified; this is what makes an MFA step-up satisfiable for a user without a factor.
+    await enableMandatoryMfaWithTotp();
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    await userApi.create({ username, password });
+
+    const client = await initClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+    await expectRejects(client.submitInteraction(), {
+      code: 'user.missing_mfa',
+      status: 422,
+    });
+    const totpVerificationId = await successfullyCreateAndVerifyTotp(client);
+    await client.bindMfa(MfaFactor.TOTP, totpVerificationId);
+    const claims = await finishSignIn(client);
+
+    expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
+
+    await logoutClient(client);
+    await resetMfaSettings();
+  });
+
+  it('keeps the proof of the last backup code, which is marked used before submission', async () => {
+    // A sign-in that completes without an MFA challenge, so the consumed code is the only proof.
+    await updateSignInExperience({
+      mfa: { factors: [MfaFactor.TOTP, MfaFactor.BackupCode], policy: MfaPolicy.NoPrompt },
+    });
+    const { username, password } = generateNewUserProfile({ username: true, password: true });
+    const user = await userApi.create({ username, password });
+    await createUserMfaVerification(user.id, MfaFactor.TOTP);
+    const backupCodes = await createUserMfaVerification(user.id, MfaFactor.BackupCode);
+    await updateUserLogtoConfig(user.id, { mfa: { skipMfaOnSignIn: true }, passkeySignIn: {} });
+
+    if (backupCodes.type !== MfaFactor.BackupCode) {
+      throw new TypeError('unexpected mfa type');
+    }
+
+    const [lastCode, ...otherCodes] = backupCodes.codes;
+
+    // Consume every other code first; each verification marks its code used in the database.
+    const consumer = await initClient();
+    await identifyUserWithUsernamePassword(consumer, username, password);
+    for (const code of otherCodes) {
+      // eslint-disable-next-line no-await-in-loop -- Each code must be consumed in sequence.
+      await consumer.verifyBackupCode({ code });
+    }
+
+    const client = await initClient();
+    await identifyUserWithUsernamePassword(client, username, password);
+    await client.verifyBackupCode({ code: lastCode! });
+    const claims = await finishSignIn(client);
+
+    expect(claims.sub).toBe(user.id);
+    expect(claims).toMatchObject({ acr: mfaAcr, amr: ['pwd', 'otp', 'mfa'] });
+
+    await logoutClient(client);
+    await resetMfaSettings();
+  });
+
+  describe('social sign-in', () => {
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let connectorId: string;
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let socialUserId: string;
+    // eslint-disable-next-line @silverhand/fp/no-let
+    let userId: string;
+
+    beforeAll(async () => {
+      // Let a social user register without a username or password.
+      await enableAllPasswordSignInMethods({ identifiers: [], password: false, verify: false });
+      await clearConnectorsByTypes([ConnectorType.Social]);
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      ({ id: connectorId } = await setSocialConnector());
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      socialUserId = generateStandardId();
+      // Register the social user first; only a sign-in seeds the authentication context.
+      // eslint-disable-next-line @silverhand/fp/no-mutation
+      userId = await signInWithSocial(connectorId, { id: socialUserId }, { registerNewUser: true });
+    });
+
+    afterAll(async () => {
+      await clearConnectorsByTypes([ConnectorType.Social]);
+      await deleteUser(userId);
+      await enableAllPasswordSignInMethods();
+    });
+
+    /** Start a sign-in on a fresh client and identify the social user without submitting. */
+    const identifySocialUser = async () => {
+      const client = await initClient();
+      const state = 'state';
+      const redirectUri = 'http://localhost:3000';
+      const { verificationId } = await successfullyCreateSocialVerification(client, connectorId, {
+        redirectUri,
+        state,
+      });
+      await successfullyVerifySocialAuthorization(client, connectorId, {
+        verificationId,
+        connectorData: { state, redirectUri, code: 'fake_code', userId: socialUserId },
+      });
+      await client.identifyUser({ verificationId });
+      return client;
+    };
+
+    it('issues amr=[fed] and no acr', async () => {
+      const client = await identifySocialUser();
+      const claims = await finishSignIn(client);
+
+      expect(claims.sub).toBe(userId);
+      expect(claims.amr).toEqual(['fed']);
+      expect(claims).not.toHaveProperty('acr');
+      expect(typeof claims.auth_time).toBe('number');
+
+      await logoutClient(client);
+    });
+
+    it('keeps fed on the sign-in that links the identity to an existing account', async () => {
+      const { primaryEmail } = generateNewUserProfile({ primaryEmail: true });
+      const existingUser = await userApi.create({ primaryEmail });
+      const linkingSocialUserId = generateStandardId();
+
+      const client = await initClient();
+      const state = 'state';
+      const redirectUri = 'http://localhost:3000';
+      const { verificationId } = await successfullyCreateSocialVerification(client, connectorId, {
+        redirectUri,
+        state,
+      });
+      await successfullyVerifySocialAuthorization(client, connectorId, {
+        verificationId,
+        connectorData: {
+          state,
+          redirectUri,
+          code: 'fake_code',
+          userId: linkingSocialUserId,
+          email: primaryEmail,
+        },
+      });
+      // The identity is not stored yet; the user is identified by the related email and the
+      // link is written by the submission.
+      await client.identifyUser({ verificationId, linkSocialIdentity: true });
+      const claims = await finishSignIn(client);
+
+      expect(claims.sub).toBe(existingUser.id);
+      expect(claims.amr).toEqual(['fed']);
+      expect(claims).not.toHaveProperty('acr');
+      expect(typeof claims.auth_time).toBe('number');
+
+      await logoutClient(client);
+    });
+  });
+});

--- a/packages/schemas/src/types/authentication-context.test.ts
+++ b/packages/schemas/src/types/authentication-context.test.ts
@@ -176,6 +176,21 @@ describe('buildAuthenticationMethodReferences', () => {
 });
 
 describe('authenticationProofGuard', () => {
+  it.each([
+    { id: '', amr: ['otp'] },
+    { id: 'totp', amr: [] },
+  ])('rejects a proof with an empty id or AMR list: %j', ({ id, amr }) => {
+    expect(
+      authenticationProofGuard.safeParse({
+        id,
+        factor: AuthenticationFactor.Totp,
+        class: AuthenticationFactorClass.Mfa,
+        amr,
+        role: AuthenticationProofRole.Mfa,
+      }).success
+    ).toBe(false);
+  });
+
   it('accepts a proof with and without a class', () => {
     expect(
       authenticationProofGuard.safeParse({

--- a/packages/schemas/src/types/authentication-context.test.ts
+++ b/packages/schemas/src/types/authentication-context.test.ts
@@ -4,7 +4,9 @@ import {
   AuthenticationFactor,
   AuthenticationFactorClass,
   AuthenticationMethodReference,
+  AuthenticationProofRole,
   LogtoAcr,
+  authenticationProofGuard,
   buildAuthenticationMethodReferences,
   getAuthenticationFactor,
   getAuthenticationFactorClass,
@@ -170,5 +172,27 @@ describe('buildAuthenticationMethodReferences', () => {
 
   it('returns nothing for no references', () => {
     expect(buildAuthenticationMethodReferences([])).toEqual([]);
+  });
+});
+
+describe('authenticationProofGuard', () => {
+  it('accepts a proof with and without a class', () => {
+    expect(
+      authenticationProofGuard.safeParse({
+        id: 'totp',
+        factor: AuthenticationFactor.Totp,
+        class: AuthenticationFactorClass.Mfa,
+        amr: ['otp'],
+        role: AuthenticationProofRole.Mfa,
+      }).success
+    ).toBe(true);
+    expect(
+      authenticationProofGuard.safeParse({
+        id: 'social',
+        factor: AuthenticationFactor.Federated,
+        amr: ['fed'],
+        role: AuthenticationProofRole.Identify,
+      }).success
+    ).toBe(true);
   });
 });

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -1,11 +1,15 @@
 /**
  * @file The authoritative vocabulary for the authentication context Logto records on a sign-in or
- * step-up: the supported Authentication Context Class Reference (ACR) values and the
- * Authentication Methods References (AMR) each verification contributes.
+ * step-up: the supported Authentication Context Class Reference (ACR) values, their satisfaction
+ * relation, and the Authentication Methods References (AMR) each verification contributes.
  *
  * @see {@link https://openid.net/specs/openid-connect-core-1_0.html#IDToken | OpenID Connect Core `acr` / `amr`}
  * @see {@link https://www.rfc-editor.org/rfc/rfc8176.html | RFC 8176 Authentication Method Reference Values}
  */
+import { z } from 'zod';
+
+import { type ToZodObject } from '../utils/zod.js';
+
 import { VerificationType } from './verification-records/verification-type.js';
 
 /** The Logto-defined ACR values. Only these can be requested through `acr_values`. */
@@ -201,3 +205,42 @@ export const buildAuthenticationMethodReferences = (
     ...(hasMfa ? [AuthenticationMethodReference.Mfa] : []),
   ];
 };
+
+/**
+ * Why a proof was recorded: the touchpoint that consumed the credential. Aggregation into `acr` /
+ * `amr` ignores the role; it exists for the MFA gate and for step-up freshness, and never reaches
+ * a token.
+ */
+export enum AuthenticationProofRole {
+  /** `createUser()` created the account from the record. */
+  Create = 'create',
+  /** `identifyUser()` identified the user with the record. */
+  Identify = 'identify',
+  /** The credential or factor was written to the account by this interaction. */
+  Bind = 'bind',
+  /** An MFA challenge was answered with the record. */
+  Mfa = 'mfa',
+}
+
+/**
+ * A proof that the identified user authenticated in the interaction, recorded at the single
+ * touchpoint that consumed the credential. What counts is decided where the interaction relies on
+ * the credential, never by inspecting verification records afterwards.
+ */
+export type AuthenticationProof = {
+  /** The verification record id, or `password` for a password established through the profile. */
+  id: string;
+  factor: AuthenticationFactor;
+  /** Absent for a federated proof, which contributes `fed` to AMR and nothing to the ACR. */
+  class?: AuthenticationFactorClass;
+  amr: AuthenticationMethodReference[];
+  role: AuthenticationProofRole;
+};
+
+export const authenticationProofGuard = z.object({
+  id: z.string(),
+  factor: z.nativeEnum(AuthenticationFactor),
+  class: z.nativeEnum(AuthenticationFactorClass).optional(),
+  amr: z.nativeEnum(AuthenticationMethodReference).array(),
+  role: z.nativeEnum(AuthenticationProofRole),
+}) satisfies ToZodObject<AuthenticationProof>;

--- a/packages/schemas/src/types/authentication-context.ts
+++ b/packages/schemas/src/types/authentication-context.ts
@@ -238,9 +238,9 @@ export type AuthenticationProof = {
 };
 
 export const authenticationProofGuard = z.object({
-  id: z.string(),
+  id: z.string().min(1),
   factor: z.nativeEnum(AuthenticationFactor),
   class: z.nativeEnum(AuthenticationFactorClass).optional(),
-  amr: z.nativeEnum(AuthenticationMethodReference).array(),
+  amr: z.nativeEnum(AuthenticationMethodReference).array().min(1),
   role: z.nativeEnum(AuthenticationProofRole),
 }) satisfies ToZodObject<AuthenticationProof>;


### PR DESCRIPTION
## Summary

Split out of #9546 (part 3 of 3). Builds on the vocabulary from #9552 and the route guards from #9551, both merged; the branch is rebased onto `master`.

Every Experience sign-in and registration records the authentication context Logto can observe, and the ID token carries it as `acr` / `amr`. Everything is behind the dev feature flag.

Linear: https://linear.app/silverhand/issue/LOG-14095
Design: [Authentication Context (ACR / AMR) — Tech Design](https://app.notion.com/p/silverhand/Authentication-Context-ACR-AMR-Tech-Design-3d026f6af1dc814b9500c9b5988bb1c6)

### The model

**A proof is recorded at the single touchpoint that consumes a credential, never derived from verification records afterwards.** A verified record is not a used record: a registration password sitting in a social sign-in, a code for an address being added, or a record nobody consumed must not count. So the interaction keeps an `AuthenticationProof` list (`{ id, factor, class, amr, role }`), staged like `profile` and `mfa` and persisted by `save()` together with the effect that produced each proof, and `submit()` aggregates `acr` / `amr` from that list alone.

Compared with #9546, the proofs carry no timestamp and no `ts` is seeded: the provider stamps `auth_time` with the submission time, which is the moment the session is established. This removes the `verifiedAt` field from every verification record.

### `@logto/schemas`

`AuthenticationProof`, `AuthenticationProofRole` (`create` | `identify` | `bind` | `mfa`) and `authenticationProofGuard`, added next to the vocabulary from #9552.

### `@logto/core`

- **`AuthenticationProofs`** (`classes/libraries/authentication-proofs.ts`): the proof collection, keyed by `(recordId, role)` so a retry overwrites. It has the lifetime of `profile.data`: cleared when the interaction event changes and by `cleanUp()`, and excluded from the sanitized projection (`role` never leaves the server).
- **One choke point per credential**:
  - `createUser(id)` records `create`; `identifyUser(id)` records `identify` (also for a second record that identifies the same user).
  - The raw `getVerificationRecordById` / `getVerificationRecordByTypeAndId` are removed from `InteractionContext`; `Profile` and `Mfa` reach a record only through `consumeForBind` / `consumeForBindByType`, which record `bind`. A write path structurally cannot forget to record what it did.
  - The MFA challenge verify routes (TOTP, backup code, WebAuthn authentication, MFA email / phone code) call `consumeForMfa` right after a successful verification. A new-enrollment record is refused there; its only proof is the `bind` one recorded when the factor is added.
  - A password has no record: `Profile` records its proof on the `passwordEncrypted` unset-to-set transition, the single write path into its data, so username / password registrations and a password set through `POST /profile` count.
  - The email / phone MFA bind site records the `mfa`-class `bind` proof next to the `1fa` one the profile bind recorded for the same contact.
  - Declared non-proofs, written in code as decisions: binding backup codes, trusted-device fulfilment, an adaptive-MFA non-trigger.
- **`aggregateAuthenticationContext(proofs)`** (design section 4.3): `1fa` needs a `1fa`-class proof; `mfa` needs a `1fa`-class and an `mfa`-class proof of two *different* factors, or a `both`-class proof alone; repeated proofs of one factor count once; federated proofs contribute `fed` and no ACR. The role plays no part in aggregation.
- **Policy consequences**: a factor bound during a sign-in on an existing account counts (design C4, so a step-up to `mfa` is satisfiable for a user without a factor); a social registration that enrols a passkey reaches `mfa`; an email code + profile password registration records `amr=["otp","pwd"]`.
- **`submit()`** aggregates for SignIn and Register when the dev flag is on and seeds `login: { accountId, acr, amr }`. ForgotPassword is untouched.

## Testing

- `packages/schemas`: `authentication-context.test.ts` gains the proof guard cases.
- `packages/core`: `authentication-context.test.ts` is the design's section 6 case matrix as an `it.each` table; `authentication-proofs.test.ts` covers staging, keying, the backup-code non-proof, the profile password proof and the data round trip; `experience-interaction.test.ts` asserts the `create` and `identify` proofs, the password transition, the login result for a sign-in and an email + password registration, that proofs are cleared on an event change and do not outlive the interaction, and that they stay out of the sanitized data; `mfa-sentinel-guard.test.ts` asserts the WebAuthn route records the `mfa` proof.
- `packages/integration-tests`: `authentication-context.test.ts` asserts the ID token for a password sign-in (preserved across refresh), password + TOTP, a sign-in that binds its first TOTP under a mandatory policy, password + the last backup code, and social sign-in including the linking sign-in; `authentication-context-registration.test.ts` asserts username / password, mandatory TOTP enrollment, email and phone code, email code + profile password, and social registration.
- Locally: `tsc` for core, schemas and integration-tests, eslint on every changed file, the schemas vitest suite, and the 29 core jest suites under `routes/experience` plus `oidc/init.test.ts` all pass. The integration suite is left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6suKhdhJjJKw4aVfXRkca