### PR TITLE
feat(api): improve Management API client resilience

### DIFF
--- a/.changeset/olive-otters-sing.md
+++ b/.changeset/olive-otters-sing.md
@@ -4,14 +4,9 @@
 
 improve API SDK client reliability and ergonomics
 
-Token requests now reject redirects and time out after 10 seconds by default, with a configurable timeout that can be disabled using a non-positive value. Concurrent requests share one token fetch, and a 401 response invalidates the matching cached token so the next request fetches a fresh one. Repeated 401 responses do not cause continuous token fetching.
-
-Custom base URLs can include trailing slashes without producing double slashes in token requests.
-
-API clients now expose lowercase HTTP methods such as `.get()` and `.post()`, while keeping the existing uppercase methods available.
-
-Scope mismatch warnings are emitted once per distinct mismatched scope.
-
-Token request failures consistently use `ClientCredentialsError` and preserve the original error as the cause.
-
-Management API requests now time out after 10 seconds by default, with a configurable client-wide timeout that preserves per-request cancellation.
+- reject token request redirects, apply a configurable 10-second timeout, and share one token fetch across concurrent requests
+- invalidate a rejected cached token once without continuously fetching tokens for permanent `401` responses
+- normalize trailing slashes in custom base URLs
+- support lowercase API client methods such as `.get()` and `.post()` while keeping the uppercase methods available
+- apply a configurable 10-second timeout to Management API requests while preserving per-request cancellation
+- emit scope mismatch warnings once per distinct scope and preserve token request failure causes

--- a/.changeset/olive-otters-sing.md
+++ b/.changeset/olive-otters-sing.md
@@ -7,7 +7,7 @@ improve API SDK client reliability and ergonomics
 - reject token request redirects, support custom abort signals and a configurable 10-second timeout, and share one token fetch across concurrent requests
 - invalidate a rejected cached token once without continuously fetching tokens for permanent `401` responses
 - normalize trailing slashes in custom base URLs
-- allow explicit Management API endpoints without a placeholder tenant ID
+- support object-style Management API client configuration with a tenant ID or explicit base URL and API indicator
 - support lowercase API client methods such as `.get()` and `.post()` while keeping the uppercase methods available
 - apply a configurable 10-second timeout to Management API network requests while preserving per-request cancellation
 - emit scope mismatch warnings once per distinct scope and preserve token request failure causes

--- a/.changeset/olive-otters-sing.md
+++ b/.changeset/olive-otters-sing.md
@@ -7,6 +7,7 @@ improve API SDK client reliability and ergonomics
 - reject token request redirects, support custom abort signals and a configurable 10-second timeout, and share one token fetch across concurrent requests
 - invalidate a rejected cached token once without continuously fetching tokens for permanent `401` responses
 - normalize trailing slashes in custom base URLs
+- allow explicit Management API endpoints without a placeholder tenant ID
 - support lowercase API client methods such as `.get()` and `.post()` while keeping the uppercase methods available
 - apply a configurable 10-second timeout to Management API network requests while preserving per-request cancellation
 - emit scope mismatch warnings once per distinct scope and preserve token request failure causes

--- a/.changeset/olive-otters-sing.md
+++ b/.changeset/olive-otters-sing.md
@@ -1,0 +1,17 @@
+---
+'@logto/api': minor
+---
+
+improve API SDK client reliability and ergonomics
+
+Token requests now reject redirects and time out after 10 seconds by default, with a configurable timeout that can be disabled using a non-positive value. Concurrent requests share one token fetch, and a 401 response invalidates the matching cached token so the next request fetches a fresh one. Repeated 401 responses do not cause continuous token fetching.
+
+Custom base URLs can include trailing slashes without producing double slashes in token requests.
+
+API clients now expose lowercase HTTP methods such as `.get()` and `.post()`, while keeping the existing uppercase methods available.
+
+Scope mismatch warnings are emitted once per distinct mismatched scope.
+
+Token request failures consistently use `ClientCredentialsError` and preserve the original error as the cause.
+
+Management API requests now time out after 10 seconds by default, with a configurable client-wide timeout that preserves per-request cancellation.

--- a/.changeset/olive-otters-sing.md
+++ b/.changeset/olive-otters-sing.md
@@ -1,12 +1,12 @@
 ---
-'@logto/api': minor
+"@logto/api": minor
 ---
 
 improve API SDK client reliability and ergonomics
 
-- reject token request redirects, apply a configurable 10-second timeout, and share one token fetch across concurrent requests
+- reject token request redirects, support custom abort signals and a configurable 10-second timeout, and share one token fetch across concurrent requests
 - invalidate a rejected cached token once without continuously fetching tokens for permanent `401` responses
 - normalize trailing slashes in custom base URLs
 - support lowercase API client methods such as `.get()` and `.post()` while keeping the uppercase methods available
-- apply a configurable 10-second timeout to Management API requests while preserving per-request cancellation
+- apply a configurable 10-second timeout to Management API network requests while preserving per-request cancellation
 - emit scope mismatch warnings once per distinct scope and preserve token request failure causes

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -33,8 +33,9 @@ const { apiClient } = createManagementApi('your-tenant-id', {
   clientSecret: 'your-client-secret',
 });
 
-// Make API calls
+// Make API calls with lowercase or uppercase methods
 const response = await apiClient.get('/api/users');
+// const response = await apiClient.GET('/api/users');
 console.log(response.data);
 ```
 
@@ -48,26 +49,21 @@ const { apiClient } = createManagementApi('default', {
   clientSecret: 'your-client-secret',
   baseUrl: 'https://your-logto-instance.com',
   apiIndicator: 'https://your-logto-instance.com/api',
-  requestTimeout: 10,
 });
 ```
 
-`createManagementApi` caches access tokens and shares one token fetch across concurrent requests.
-Token requests reject redirects and time out after 10 seconds by default. Use `tokenRequestTimeout`
-to configure the timeout in seconds. Set it to `0`, a negative value, or `Infinity` to disable the
-timeout. `NaN` falls back to the 10-second default. If an API request returns `401`, the client
-invalidates the matching cached token so the next request fetches a new one. It waits for that
-replacement token to receive a successful API response before allowing another invalidation,
-avoiding repeated token fetches for permanent `401` responses. The failed API request is returned to
-the caller without an automatic retry.
+#### Timeouts
 
-API clients expose lowercase HTTP methods such as `.get()`, `.post()`, and `.delete()`. The existing
-uppercase methods remain available for compatibility.
-
-Management API requests time out after 10 seconds by default. Use `requestTimeout` to configure a
-client-wide timeout in seconds. Set it to `0`, a negative value, or `Infinity` to disable it. `NaN`
-falls back to the 10-second default. A per-request `signal` can still cancel an individual request
+Token fetches and Management API requests have separate 10-second timeouts. Use
+`tokenRequestTimeout` and `requestTimeout` to configure them in seconds. Set either option to `0` or a
+negative value to disable its timeout. A per-request `signal` can cancel an individual request
 earlier.
+
+#### Token refresh
+
+After a Management API request returns `401`, the next request fetches a new token. If the replacement
+token also receives a `401`, it remains cached until a request succeeds or the token expires. The SDK
+does not automatically retry the failed API request.
 
 #### Custom authentication
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -54,10 +54,15 @@ const { apiClient } = createManagementApi('default', {
 
 #### Timeouts
 
-Token fetches and Management API requests have separate 10-second timeouts. Use
-`tokenRequestTimeout` and `requestTimeout` to configure them in seconds. Set either option to `0` or a
-negative value to disable its timeout. A per-request `signal` can cancel an individual request
-earlier.
+Token fetches and Management API network requests have separate 10-second timeouts. The API request
+timeout starts after token retrieval, so a request that needs a new token can use both timeout
+periods. Use `tokenRequestTimeout` and `requestTimeout` to configure them in seconds. Set either option
+to `0` or a negative value to disable its timeout.
+
+Use `getTokenRequestSignal` to return a custom signal for each token request. The signal is composed
+with `tokenRequestTimeout`, and the first one to abort cancels the token request. A per-request
+`signal` is similarly composed with `requestTimeout` for the Management API request. Timeouts and
+custom cancellation reject the API call instead of returning a response object.
 
 #### Token refresh
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -44,7 +44,7 @@ console.log(response.data);
 ```ts
 import { createManagementApi } from '@logto/api/management';
 
-const { apiClient } = createManagementApi('default', {
+const { apiClient } = createManagementApi({
   clientId: 'your-client-id',
   clientSecret: 'your-client-secret',
   baseUrl: 'https://your-logto-instance.com',

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -27,8 +27,8 @@ For detailed setup instructions, visit: https://a.logto.io/m2m-mapi
 ```ts
 import { createManagementApi } from '@logto/api/management';
 
-// For Logto Cloud
-const { apiClient } = createManagementApi('your-tenant-id', {
+const { apiClient } = createManagementApi({
+  tenantId: 'your-tenant-id',
   clientId: 'your-client-id',
   clientSecret: 'your-client-secret',
 });
@@ -39,18 +39,23 @@ const response = await apiClient.get('/api/users');
 console.log(response.data);
 ```
 
+The positional `createManagementApi(tenantId, options)` form remains supported.
+
 #### Self-hosted / OSS
 
 ```ts
 import { createManagementApi } from '@logto/api/management';
 
 const { apiClient } = createManagementApi({
+  tenantId: 'default',
   clientId: 'your-client-id',
   clientSecret: 'your-client-secret',
   baseUrl: 'https://your-logto-instance.com',
-  apiIndicator: 'https://your-logto-instance.com/api',
 });
 ```
+
+If the Management API indicator cannot be derived from a tenant ID, omit `tenantId` and provide
+both `baseUrl` and `apiIndicator`.
 
 #### Timeouts
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -34,7 +34,7 @@ const { apiClient } = createManagementApi('your-tenant-id', {
 });
 
 // Make API calls
-const response = await apiClient.GET('/api/users');
+const response = await apiClient.get('/api/users');
 console.log(response.data);
 ```
 
@@ -48,8 +48,26 @@ const { apiClient } = createManagementApi('default', {
   clientSecret: 'your-client-secret',
   baseUrl: 'https://your-logto-instance.com',
   apiIndicator: 'https://your-logto-instance.com/api',
+  requestTimeout: 10,
 });
 ```
+
+`createManagementApi` caches access tokens and shares one token fetch across concurrent requests.
+Token requests reject redirects and time out after 10 seconds by default. Use `tokenRequestTimeout`
+to configure the timeout in seconds. Set it to `0`, a negative value, or `Infinity` to disable the
+timeout. `NaN` falls back to the 10-second default. If an API request returns `401`, the client
+invalidates the matching cached token so the next request fetches a new one. It waits for that
+replacement token to receive a successful API response before allowing another invalidation,
+avoiding repeated token fetches for permanent `401` responses. The failed API request is returned to
+the caller without an automatic retry.
+
+API clients expose lowercase HTTP methods such as `.get()`, `.post()`, and `.delete()`. The existing
+uppercase methods remain available for compatibility.
+
+Management API requests time out after 10 seconds by default. Use `requestTimeout` to configure a
+client-wide timeout in seconds. Set it to `0`, a negative value, or `Infinity` to disable it. `NaN`
+falls back to the 10-second default. A per-request `signal` can still cancel an individual request
+earlier.
 
 #### Custom authentication
 
@@ -67,7 +85,7 @@ const client = createApiClient({
 });
 
 // Type-safe API calls
-const response = await client.GET('/api/applications/{id}', {
+const response = await client.get('/api/applications/{id}', {
   params: { path: { id: 'your-app-id' } },
 });
 ```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -72,8 +72,8 @@ custom cancellation reject the API call instead of returning a response object.
 #### Token refresh
 
 After a Management API request returns `401`, the next request fetches a new token. If the replacement
-token also receives a `401`, it remains cached until a request succeeds or the token expires. The SDK
-does not automatically retry the failed API request.
+token also receives a `401`, it remains cached until the API returns a non-`401` response or the token
+expires. The SDK does not automatically retry the failed API request.
 
 #### Custom authentication
 

--- a/packages/api/src/api-client.test.ts
+++ b/packages/api/src/api-client.test.ts
@@ -2,6 +2,7 @@ import createClient, { type Middleware } from 'openapi-fetch';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { createApiClient } from './management.js';
+import { getAbortReason } from './timeout.js';
 
 vi.mock('openapi-fetch');
 
@@ -79,7 +80,19 @@ describe('createApiClient', () => {
   it('should compose the request timeout with a per-request signal', async () => {
     const timeoutController = new AbortController();
     const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
-    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response());
+    const abortError = new DOMException('Request aborted', 'AbortError');
+    const mockFetch = vi.fn<typeof fetch>().mockImplementation(
+      async (request) =>
+        new Promise<Response>((_resolve, reject) => {
+          if (!(request instanceof Request)) {
+            throw new TypeError('Expected a request');
+          }
+
+          request.signal.addEventListener('abort', () => {
+            reject(getAbortReason(request.signal, 'Request aborted'));
+          });
+        })
+    );
     vi.stubGlobal('fetch', mockFetch);
     createApiClient({
       baseUrl: 'https://test.logto.app',
@@ -89,16 +102,71 @@ describe('createApiClient', () => {
     const clientOptions = mockCreateClient.mock.calls[0]?.[0];
     expect(clientOptions?.fetch).toBeTypeOf('function');
     const requestController = new AbortController();
+    const requestInit = { cache: 'no-store' as const };
+    const timeoutFetch = clientOptions?.fetch as
+      | ((request: Request, requestInit?: RequestInit) => Promise<Response>)
+      | undefined;
 
-    await clientOptions?.fetch?.(
-      new Request('https://test.logto.app/api/users', { signal: requestController.signal })
+    if (!timeoutFetch) {
+      throw new TypeError('Expected a timeout fetch implementation');
+    }
+
+    const result = timeoutFetch(
+      new Request('https://test.logto.app/api/users', { signal: requestController.signal }),
+      requestInit
     );
+    const rejection = expect(result).rejects.toBe(abortError);
+
+    requestController.abort(abortError);
+    await rejection;
 
     expect(timeout).toHaveBeenCalledWith(20_000);
     const calledRequest = mockFetch.mock.calls[0]?.[0];
     expect(calledRequest).toBeInstanceOf(Request);
-    requestController.abort();
     expect(calledRequest instanceof Request && calledRequest.signal.aborted).toBe(true);
+    expect(mockFetch.mock.calls[0]?.[1]).toMatchObject(requestInit);
+  });
+
+  it('should round up sub-millisecond timeouts', async () => {
+    const timeoutController = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response());
+    vi.stubGlobal('fetch', mockFetch);
+    createApiClient({
+      baseUrl: 'https://test.logto.app',
+      getToken: async () => 'test-token',
+      requestTimeout: 0.0005,
+    });
+    const timeoutFetch = mockCreateClient.mock.calls[0]?.[0]?.fetch;
+
+    if (!timeoutFetch) {
+      throw new TypeError('Expected a timeout fetch implementation');
+    }
+
+    await timeoutFetch(new Request('https://test.logto.app/api/users'));
+
+    expect(timeout).toHaveBeenCalledWith(1);
+  });
+
+  it('should cap timeout signal delays', async () => {
+    const timeoutController = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response());
+    vi.stubGlobal('fetch', mockFetch);
+    createApiClient({
+      baseUrl: 'https://test.logto.app',
+      getToken: async () => 'test-token',
+      requestTimeout: Number.MAX_VALUE,
+    });
+    const timeoutFetch = mockCreateClient.mock.calls[0]?.[0]?.fetch;
+
+    if (!timeoutFetch) {
+      throw new TypeError('Expected a timeout fetch implementation');
+    }
+
+    await timeoutFetch(new Request('https://test.logto.app/api/users'));
+
+    expect(timeout).toHaveBeenCalledWith(2_147_483_647);
   });
 
   it.each([

--- a/packages/api/src/api-client.test.ts
+++ b/packages/api/src/api-client.test.ts
@@ -2,7 +2,6 @@ import createClient, { type Middleware } from 'openapi-fetch';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { createApiClient } from './management.js';
-import { getAbortReason } from './timeout.js';
 
 vi.mock('openapi-fetch');
 
@@ -46,53 +45,13 @@ describe('createApiClient', () => {
       fetch: expect.any(Function),
     });
 
-    expect(result).toMatchObject(mockApiClient);
-    expect(result.use).toBe(mockApiClient.use);
+    expect(result).toBe(mockApiClient);
   });
-
-  it('should use the default request timeout for NaN', () => {
-    createApiClient({
-      baseUrl: 'https://test.logto.app',
-      getToken: async () => 'test-token',
-      requestTimeout: Number.NaN,
-    });
-
-    expect(mockCreateClient).toHaveBeenCalledWith({
-      baseUrl: 'https://test.logto.app',
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
-      fetch: expect.any(Function),
-    });
-  });
-
-  it.each([0, -1, Number.POSITIVE_INFINITY])(
-    'should disable the request timeout for %s',
-    (requestTimeout) => {
-      createApiClient({
-        baseUrl: 'https://test.logto.app',
-        getToken: async () => 'test-token',
-        requestTimeout,
-      });
-
-      expect(mockCreateClient).toHaveBeenCalledWith({ baseUrl: 'https://test.logto.app' });
-    }
-  );
 
   it('should compose the request timeout with a per-request signal', async () => {
     const timeoutController = new AbortController();
     const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
-    const abortError = new DOMException('Request aborted', 'AbortError');
-    const mockFetch = vi.fn<typeof fetch>().mockImplementation(
-      async (request) =>
-        new Promise<Response>((_resolve, reject) => {
-          if (!(request instanceof Request)) {
-            throw new TypeError('Expected a request');
-          }
-
-          request.signal.addEventListener('abort', () => {
-            reject(getAbortReason(request.signal, 'Request aborted'));
-          });
-        })
-    );
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal('fetch', mockFetch);
     createApiClient({
       baseUrl: 'https://test.logto.app',
@@ -111,62 +70,22 @@ describe('createApiClient', () => {
       throw new TypeError('Expected a timeout fetch implementation');
     }
 
-    const result = timeoutFetch(
-      new Request('https://test.logto.app/api/users', { signal: requestController.signal }),
-      requestInit
-    );
-    const rejection = expect(result).rejects.toBe(abortError);
-
-    requestController.abort(abortError);
-    await rejection;
+    const request = new Request('https://test.logto.app/api/users', {
+      signal: requestController.signal,
+    });
+    await timeoutFetch(request, requestInit);
 
     expect(timeout).toHaveBeenCalledWith(20_000);
-    const calledRequest = mockFetch.mock.calls[0]?.[0];
-    expect(calledRequest).toBeInstanceOf(Request);
-    expect(calledRequest instanceof Request && calledRequest.signal.aborted).toBe(true);
-    expect(mockFetch.mock.calls[0]?.[1]).toMatchObject(requestInit);
-  });
+    expect(mockFetch.mock.calls[0]?.[0]).toBe(request);
+    const forwardedInit = mockFetch.mock.calls[0]?.[1];
+    expect(forwardedInit).toMatchObject(requestInit);
+    expect(forwardedInit?.signal).toBeInstanceOf(AbortSignal);
+    expect(forwardedInit?.signal).not.toBe(requestController.signal);
 
-  it('should round up sub-millisecond timeouts', async () => {
-    const timeoutController = new AbortController();
-    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
-    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response());
-    vi.stubGlobal('fetch', mockFetch);
-    createApiClient({
-      baseUrl: 'https://test.logto.app',
-      getToken: async () => 'test-token',
-      requestTimeout: 0.0005,
-    });
-    const timeoutFetch = mockCreateClient.mock.calls[0]?.[0]?.fetch;
-
-    if (!timeoutFetch) {
-      throw new TypeError('Expected a timeout fetch implementation');
-    }
-
-    await timeoutFetch(new Request('https://test.logto.app/api/users'));
-
-    expect(timeout).toHaveBeenCalledWith(1);
-  });
-
-  it('should cap timeout signal delays', async () => {
-    const timeoutController = new AbortController();
-    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
-    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response());
-    vi.stubGlobal('fetch', mockFetch);
-    createApiClient({
-      baseUrl: 'https://test.logto.app',
-      getToken: async () => 'test-token',
-      requestTimeout: Number.MAX_VALUE,
-    });
-    const timeoutFetch = mockCreateClient.mock.calls[0]?.[0]?.fetch;
-
-    if (!timeoutFetch) {
-      throw new TypeError('Expected a timeout fetch implementation');
-    }
-
-    await timeoutFetch(new Request('https://test.logto.app/api/users'));
-
-    expect(timeout).toHaveBeenCalledWith(2_147_483_647);
+    const abortError = new DOMException('Request aborted', 'AbortError');
+    requestController.abort(abortError);
+    expect(forwardedInit?.signal?.aborted).toBe(true);
+    expect(forwardedInit?.signal?.reason).toBe(abortError);
   });
 
   it.each([

--- a/packages/api/src/api-client.test.ts
+++ b/packages/api/src/api-client.test.ts
@@ -1,0 +1,180 @@
+import createClient, { type Middleware } from 'openapi-fetch';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { createApiClient } from './management.js';
+
+vi.mock('openapi-fetch');
+
+const mockCreateClient = vi.mocked(createClient);
+
+describe('createApiClient', () => {
+  const mockApiClient = {
+    use: vi.fn<(...middleware: Middleware[]) => void>(),
+    GET: vi.fn(),
+    PUT: vi.fn(),
+    POST: vi.fn(),
+    DELETE: vi.fn(),
+    OPTIONS: vi.fn(),
+    HEAD: vi.fn(),
+    PATCH: vi.fn(),
+    TRACE: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // @ts-expect-error -- Only the middleware registration is needed by these tests.
+    mockCreateClient.mockReturnValue(mockApiClient);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should create API client with provided options', () => {
+    const getToken = vi.fn().mockResolvedValue('test-token');
+
+    const result = createApiClient({
+      baseUrl: 'https://test.logto.app///',
+      getToken,
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      baseUrl: 'https://test.logto.app',
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
+      fetch: expect.any(Function),
+    });
+
+    expect(result).toMatchObject(mockApiClient);
+    expect(result.use).toBe(mockApiClient.use);
+  });
+
+  it('should use the default request timeout for NaN', () => {
+    createApiClient({
+      baseUrl: 'https://test.logto.app',
+      getToken: async () => 'test-token',
+      requestTimeout: Number.NaN,
+    });
+
+    expect(mockCreateClient).toHaveBeenCalledWith({
+      baseUrl: 'https://test.logto.app',
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
+      fetch: expect.any(Function),
+    });
+  });
+
+  it.each([0, -1, Number.POSITIVE_INFINITY])(
+    'should disable the request timeout for %s',
+    (requestTimeout) => {
+      createApiClient({
+        baseUrl: 'https://test.logto.app',
+        getToken: async () => 'test-token',
+        requestTimeout,
+      });
+
+      expect(mockCreateClient).toHaveBeenCalledWith({ baseUrl: 'https://test.logto.app' });
+    }
+  );
+
+  it('should compose the request timeout with a per-request signal', async () => {
+    const timeoutController = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+    const mockFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response());
+    vi.stubGlobal('fetch', mockFetch);
+    createApiClient({
+      baseUrl: 'https://test.logto.app',
+      getToken: async () => 'test-token',
+      requestTimeout: 20,
+    });
+    const clientOptions = mockCreateClient.mock.calls[0]?.[0];
+    expect(clientOptions?.fetch).toBeTypeOf('function');
+    const requestController = new AbortController();
+
+    await clientOptions?.fetch?.(
+      new Request('https://test.logto.app/api/users', { signal: requestController.signal })
+    );
+
+    expect(timeout).toHaveBeenCalledWith(20_000);
+    const calledRequest = mockFetch.mock.calls[0]?.[0];
+    expect(calledRequest).toBeInstanceOf(Request);
+    requestController.abort();
+    expect(calledRequest instanceof Request && calledRequest.signal.aborted).toBe(true);
+  });
+
+  it.each([
+    ['get', 'GET'],
+    ['put', 'PUT'],
+    ['post', 'POST'],
+    ['delete', 'DELETE'],
+    ['options', 'OPTIONS'],
+    ['head', 'HEAD'],
+    ['patch', 'PATCH'],
+    ['trace', 'TRACE'],
+  ] as const)('should expose %s as an alias of %s', (lowercaseMethod, uppercaseMethod) => {
+    const client = createApiClient({
+      baseUrl: 'https://test.logto.app',
+      getToken: async () => 'test-token',
+    });
+
+    expect(client[lowercaseMethod]).toBe(mockApiClient[uppercaseMethod]);
+  });
+
+  it('should configure middleware correctly', async () => {
+    const getToken = vi.fn().mockResolvedValue('test-token');
+
+    createApiClient({
+      baseUrl: 'https://test.logto.app',
+      getToken,
+    });
+
+    expect(mockApiClient.use).toHaveBeenCalledWith({
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
+      onRequest: expect.any(Function),
+    });
+
+    const middleware = mockApiClient.use.mock.calls[0]?.[0];
+    expect(middleware?.onRequest).toBeTypeOf('function');
+    const mockRequest = {
+      headers: {
+        set: vi.fn(),
+      },
+    };
+
+    const result = await middleware?.onRequest?.({
+      schemaPath: '/api/test',
+      // @ts-expect-error: Mock request object
+      request: mockRequest,
+    });
+
+    expect(getToken).toHaveBeenCalled();
+    expect(mockRequest.headers.set).toHaveBeenCalledWith('Authorization', 'Bearer test-token');
+    expect(result).toBe(mockRequest);
+  });
+
+  it('should skip auth for well-known endpoints', async () => {
+    const getToken = vi.fn().mockResolvedValue('test-token');
+
+    createApiClient({
+      baseUrl: 'https://test.logto.app',
+      getToken,
+    });
+
+    const middleware = mockApiClient.use.mock.calls[0]?.[0];
+    expect(middleware?.onRequest).toBeTypeOf('function');
+    const mockRequest = {
+      headers: {
+        set: vi.fn(),
+      },
+    };
+
+    const result = await middleware?.onRequest?.({
+      schemaPath: '/.well-known/openid-configuration',
+      // @ts-expect-error: Mock request object
+      request: mockRequest,
+    });
+
+    expect(getToken).not.toHaveBeenCalled();
+    expect(mockRequest.headers.set).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/api/src/api-client.test.ts
+++ b/packages/api/src/api-client.test.ts
@@ -48,6 +48,19 @@ describe('createApiClient', () => {
     expect(result).toBe(mockApiClient);
   });
 
+  it.each([0, -1, Number.POSITIVE_INFINITY])(
+    'should disable the request timeout for %s',
+    (requestTimeout) => {
+      createApiClient({
+        baseUrl: 'https://test.logto.app',
+        getToken: async () => 'test-token',
+        requestTimeout,
+      });
+
+      expect(mockCreateClient).toHaveBeenCalledWith({ baseUrl: 'https://test.logto.app' });
+    }
+  );
+
   it('should compose the request timeout with a per-request signal', async () => {
     const timeoutController = new AbortController();
     const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);

--- a/packages/api/src/client-credentials.resilience.test.ts
+++ b/packages/api/src/client-credentials.resilience.test.ts
@@ -43,46 +43,15 @@ describe('ClientCredentials token lifecycle', () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
-    it('should share a refresh across concurrent calls after expiry', async () => {
+    it('should not create a timeout timer when the timeout is disabled', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ access_token: 'old-token', expires_in: 120 }),
+        json: async () => ({ access_token: 'test-token', expires_in: 3600 }),
       });
-      const credentials = new ClientCredentials(defaultOptions);
-      await credentials.getAccessToken();
-      vi.advanceTimersByTime(61_000);
-      mockFetch.mockResolvedValue({
-        ok: true,
-        json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
-      });
+      const credentials = new ClientCredentials({ ...defaultOptions, tokenRequestTimeout: 0 });
 
-      const tokens = await Promise.all([
-        credentials.getAccessToken(),
-        credentials.getAccessToken(),
-      ]);
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(tokens.map(({ value }) => value)).toEqual(['new-token', 'new-token']);
-    });
-
-    it('should keep token fetches separate for different credentials instances', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ access_token: 'first-token', expires_in: 3600 }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ access_token: 'second-token', expires_in: 3600 }),
-        });
-
-      const tokens = await Promise.all([
-        new ClientCredentials(defaultOptions).getAccessToken(),
-        new ClientCredentials({ ...defaultOptions, clientId: 'another-client' }).getAccessToken(),
-      ]);
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(tokens.map(({ value }) => value)).toEqual(['first-token', 'second-token']);
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'test-token');
+      expect(vi.getTimerCount()).toBe(0);
     });
 
     it('should use one custom signal per shared token fetch and recover after cancellation', async () => {
@@ -151,98 +120,73 @@ describe('ClientCredentials token lifecycle', () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
-    it.each(['network', 'http', 'json', 'validation'])(
-      'should share a %s failure and allow a later fetch to succeed',
-      async (failure) => {
-        const error = new Error('Token request failed');
-        if (failure === 'network') {
-          mockFetch.mockRejectedValueOnce(error);
-        } else {
-          mockFetch.mockResolvedValueOnce({
-            ok: failure !== 'http',
-            status: 503,
-            statusText: 'Service Unavailable',
-            json: async () => {
-              if (failure === 'json') {
-                throw error;
-              }
-              return {};
-            },
-          });
+    it('should share a failure and allow a later fetch to succeed', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Token request failed'));
+      const credentials = new ClientCredentials(defaultOptions);
+      const results = await Promise.allSettled([
+        credentials.getAccessToken(),
+        credentials.getAccessToken(),
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(results.map(({ status }) => status)).toEqual(['rejected', 'rejected']);
+      expect(vi.getTimerCount()).toBe(0);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+      });
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should time out a pending fetch and allow a later fetch', async () => {
+      const onAbort = vi.fn();
+      mockFetch.mockImplementationOnce(async (_url: string, { signal }: RequestInit) => {
+        if (!signal) {
+          throw new Error('Missing abort signal');
         }
-        const credentials = new ClientCredentials(defaultOptions);
-
-        const results = await Promise.allSettled([
-          credentials.getAccessToken(),
-          credentials.getAccessToken(),
-        ]);
-
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(results.map(({ status }) => status)).toEqual(['rejected', 'rejected']);
-        expect(vi.getTimerCount()).toBe(0);
-
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
-        });
-        await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
-        expect(mockFetch).toHaveBeenCalledTimes(2);
-      }
-    );
-
-    it.each(['fetch', 'body'])(
-      'should time out during %s and allow a later fetch',
-      async (stage) => {
-        const onAbort = vi.fn();
-        mockFetch.mockImplementationOnce(async (_url: string, { signal }: RequestInit) => {
-          if (!signal) {
-            throw new Error('Missing abort signal');
-          }
-          const waitForAbort = async () =>
-            new Promise<never>((_resolve, reject) => {
-              signal.addEventListener('abort', () => {
-                onAbort();
-                reject(signal.reason instanceof Error ? signal.reason : new Error('Aborted'));
-              });
+        const waitForAbort = async () =>
+          new Promise<never>((_resolve, reject) => {
+            signal.addEventListener('abort', () => {
+              onAbort();
+              reject(signal.reason instanceof Error ? signal.reason : new Error('Aborted'));
             });
-          if (stage === 'fetch') {
-            return waitForAbort();
-          }
-          return { ok: true, json: waitForAbort };
-        });
-        const credentials = new ClientCredentials(defaultOptions);
-        const results = Promise.allSettled([
-          credentials.getAccessToken(),
-          credentials.getAccessToken(),
-        ]);
+          });
+        return waitForAbort();
+      });
+      const credentials = new ClientCredentials(defaultOptions);
+      const results = Promise.allSettled([
+        credentials.getAccessToken(),
+        credentials.getAccessToken(),
+      ]);
 
-        await vi.advanceTimersByTimeAsync(9999);
-        expect(onAbort).not.toHaveBeenCalled();
-        await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(9999);
+      expect(onAbort).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
 
-        expect(await results).toMatchObject([
-          {
-            status: 'rejected',
-            reason: { name: 'ClientCredentialsError', cause: { name: 'TimeoutError' } },
-          },
-          {
-            status: 'rejected',
-            reason: { name: 'ClientCredentialsError', cause: { name: 'TimeoutError' } },
-          },
-        ]);
-        expect(onAbort).toHaveBeenCalledTimes(1);
-        expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect(vi.getTimerCount()).toBe(0);
+      expect(await results).toMatchObject([
+        {
+          status: 'rejected',
+          reason: { name: 'ClientCredentialsError', cause: { name: 'TimeoutError' } },
+        },
+        {
+          status: 'rejected',
+          reason: { name: 'ClientCredentialsError', cause: { name: 'TimeoutError' } },
+        },
+      ]);
+      expect(onAbort).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
 
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
-        });
-        await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
-        expect(mockFetch).toHaveBeenCalledTimes(2);
-        expect(vi.getTimerCount()).toBe(0);
-      }
-    );
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+      });
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+    });
 
     it('should time out an unresponsive body reader and ignore its late result', async () => {
       const resolveBody = vi.fn<(value: unknown) => void>();
@@ -315,18 +259,6 @@ describe('ClientCredentials token lifecycle', () => {
       credentials.invalidateAccessToken('new-token');
       await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'third-token');
       expect(mockFetch).toHaveBeenCalledTimes(3);
-    });
-
-    it('should ignore invalidation before a token has been cached', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ access_token: 'test-token', expires_in: 3600 }),
-      });
-      const credentials = new ClientCredentials(defaultOptions);
-      credentials.invalidateAccessToken('unknown-token');
-
-      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'test-token');
-      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/api/src/client-credentials.resilience.test.ts
+++ b/packages/api/src/client-credentials.resilience.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { ClientCredentials, type ClientCredentialsOptions } from './client-credentials.js';
+import { getAbortReason } from './timeout.js';
 
 const mockFetch = vi.fn();
 
@@ -82,6 +83,72 @@ describe('ClientCredentials token lifecycle', () => {
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(tokens.map(({ value }) => value)).toEqual(['first-token', 'second-token']);
+    });
+
+    it('should use one custom signal per shared token fetch and recover after cancellation', async () => {
+      const firstTokenController = new AbortController();
+      const secondTokenController = new AbortController();
+      const getTokenRequestSignal = vi
+        .fn<() => AbortSignal>()
+        .mockReturnValueOnce(firstTokenController.signal)
+        .mockReturnValueOnce(secondTokenController.signal);
+      const abortError = new DOMException('Application shutdown', 'AbortError');
+      mockFetch.mockImplementationOnce(async (_url: string, { signal }: RequestInit) => {
+        if (!signal) {
+          throw new Error('Missing abort signal');
+        }
+
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            reject(getAbortReason(signal, 'Token request aborted'));
+          });
+        });
+      });
+      const credentials = new ClientCredentials({
+        ...defaultOptions,
+        getTokenRequestSignal,
+      });
+      const cancelled = Promise.allSettled([
+        credentials.getAccessToken(),
+        credentials.getAccessToken(),
+      ]);
+
+      firstTokenController.abort(abortError);
+
+      expect(await cancelled).toMatchObject([
+        { status: 'rejected', reason: { cause: abortError } },
+        { status: 'rejected', reason: { cause: abortError } },
+      ]);
+      expect(getTokenRequestSignal).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+      });
+
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+      expect(getTokenRequestSignal).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('should wrap token request signal factory errors', async () => {
+      const cause = new Error('Signal unavailable');
+      const credentials = new ClientCredentials({
+        ...defaultOptions,
+        getTokenRequestSignal: () => {
+          throw cause;
+        },
+      });
+
+      await expect(credentials.getAccessToken()).rejects.toMatchObject({
+        name: 'ClientCredentialsError',
+        cause,
+      });
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(vi.getTimerCount()).toBe(0);
     });
 
     it.each(['network', 'http', 'json', 'validation'])(

--- a/packages/api/src/client-credentials.resilience.test.ts
+++ b/packages/api/src/client-credentials.resilience.test.ts
@@ -54,6 +54,26 @@ describe('ClientCredentials token lifecycle', () => {
       expect(vi.getTimerCount()).toBe(0);
     });
 
+    it('should keep token fetches separate for different credentials instances', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'first-token', expires_in: 3600 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'second-token', expires_in: 3600 }),
+        });
+
+      const tokens = await Promise.all([
+        new ClientCredentials(defaultOptions).getAccessToken(),
+        new ClientCredentials({ ...defaultOptions, clientId: 'another-client' }).getAccessToken(),
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(tokens.map(({ value }) => value)).toEqual(['first-token', 'second-token']);
+    });
+
     it('should use one custom signal per shared token fetch and recover after cancellation', async () => {
       const firstTokenController = new AbortController();
       const secondTokenController = new AbortController();

--- a/packages/api/src/client-credentials.resilience.test.ts
+++ b/packages/api/src/client-credentials.resilience.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { ClientCredentials, type ClientCredentialsOptions } from './client-credentials.js';
+
+const mockFetch = vi.fn();
+
+describe('ClientCredentials token lifecycle', () => {
+  const defaultOptions: ClientCredentialsOptions = {
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    tokenEndpoint: 'https://example.com/token',
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe('getAccessToken', () => {
+    it('should share a token fetch across concurrent calls', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'test-token', expires_in: 3600 }),
+      });
+      const credentials = new ClientCredentials(defaultOptions);
+
+      const tokens = await Promise.all([
+        credentials.getAccessToken(),
+        credentials.getAccessToken(),
+        credentials.getAccessToken(),
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(tokens.map(({ value }) => value)).toEqual(['test-token', 'test-token', 'test-token']);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('should share a refresh across concurrent calls after expiry', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'old-token', expires_in: 120 }),
+      });
+      const credentials = new ClientCredentials(defaultOptions);
+      await credentials.getAccessToken();
+      vi.advanceTimersByTime(61_000);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+      });
+
+      const tokens = await Promise.all([
+        credentials.getAccessToken(),
+        credentials.getAccessToken(),
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(tokens.map(({ value }) => value)).toEqual(['new-token', 'new-token']);
+    });
+
+    it('should keep token fetches separate for different credentials instances', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'first-token', expires_in: 3600 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'second-token', expires_in: 3600 }),
+        });
+
+      const tokens = await Promise.all([
+        new ClientCredentials(defaultOptions).getAccessToken(),
+        new ClientCredentials({ ...defaultOptions, clientId: 'another-client' }).getAccessToken(),
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(tokens.map(({ value }) => value)).toEqual(['first-token', 'second-token']);
+    });
+
+    it.each(['network', 'http', 'json', 'validation'])(
+      'should share a %s failure and allow a later fetch to succeed',
+      async (failure) => {
+        const error = new Error('Token request failed');
+        if (failure === 'network') {
+          mockFetch.mockRejectedValueOnce(error);
+        } else {
+          mockFetch.mockResolvedValueOnce({
+            ok: failure !== 'http',
+            status: 503,
+            statusText: 'Service Unavailable',
+            json: async () => {
+              if (failure === 'json') {
+                throw error;
+              }
+              return {};
+            },
+          });
+        }
+        const credentials = new ClientCredentials(defaultOptions);
+
+        const results = await Promise.allSettled([
+          credentials.getAccessToken(),
+          credentials.getAccessToken(),
+        ]);
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(results.map(({ status }) => status)).toEqual(['rejected', 'rejected']);
+        expect(vi.getTimerCount()).toBe(0);
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+        });
+        await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+      }
+    );
+
+    it.each(['fetch', 'body'])(
+      'should time out during %s and allow a later fetch',
+      async (stage) => {
+        const onAbort = vi.fn();
+        mockFetch.mockImplementationOnce(async (_url: string, { signal }: RequestInit) => {
+          if (!signal) {
+            throw new Error('Missing abort signal');
+          }
+          const waitForAbort = async () =>
+            new Promise<never>((_resolve, reject) => {
+              signal.addEventListener('abort', () => {
+                onAbort();
+                reject(signal.reason instanceof Error ? signal.reason : new Error('Aborted'));
+              });
+            });
+          if (stage === 'fetch') {
+            return waitForAbort();
+          }
+          return { ok: true, json: waitForAbort };
+        });
+        const credentials = new ClientCredentials(defaultOptions);
+        const results = Promise.allSettled([
+          credentials.getAccessToken(),
+          credentials.getAccessToken(),
+        ]);
+
+        await vi.advanceTimersByTimeAsync(9999);
+        expect(onAbort).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+
+        expect(await results).toMatchObject([
+          {
+            status: 'rejected',
+            reason: { name: 'ClientCredentialsError', cause: { name: 'TimeoutError' } },
+          },
+          {
+            status: 'rejected',
+            reason: { name: 'ClientCredentialsError', cause: { name: 'TimeoutError' } },
+          },
+        ]);
+        expect(onAbort).toHaveBeenCalledTimes(1);
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        expect(vi.getTimerCount()).toBe(0);
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+        });
+        await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(vi.getTimerCount()).toBe(0);
+      }
+    );
+
+    it('should time out an unresponsive body reader and ignore its late result', async () => {
+      const resolveBody = vi.fn<(value: unknown) => void>();
+      const body = new Promise<unknown>((resolve) => {
+        resolveBody.mockImplementationOnce(resolve);
+      });
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => body });
+      const credentials = new ClientCredentials(defaultOptions);
+      const pending = expect(credentials.getAccessToken()).rejects.toMatchObject({
+        name: 'ClientCredentialsError',
+        cause: { name: 'TimeoutError' },
+      });
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await pending;
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+      });
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+
+      resolveBody({ access_token: 'timed-out-token', expires_in: 3600 });
+      await vi.advanceTimersByTimeAsync(0);
+
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+  });
+
+  describe('invalidateAccessToken', () => {
+    it('should allow one invalidation until the refreshed token succeeds', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'old-token', expires_in: 3600 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'third-token', expires_in: 3600 }),
+        });
+      const credentials = new ClientCredentials(defaultOptions);
+      await credentials.getAccessToken();
+
+      credentials.invalidateAccessToken('old-token');
+      const refresh = credentials.getAccessToken();
+      credentials.invalidateAccessToken('old-token');
+      const tokens = await Promise.all([refresh, credentials.getAccessToken()]);
+
+      expect(tokens.map(({ value }) => value)).toEqual(['new-token', 'new-token']);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // A permanent 401 must not trigger another token fetch.
+      credentials.invalidateAccessToken('new-token');
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // A late 401 for the old token must leave the refreshed token cached.
+      credentials.invalidateAccessToken('old-token');
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'new-token');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      // A successful response re-enables invalidation for a later revocation.
+      credentials.markAccessTokenAsValid('new-token');
+      credentials.invalidateAccessToken('new-token');
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'third-token');
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should ignore invalidation before a token has been cached', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'test-token', expires_in: 3600 }),
+      });
+      const credentials = new ClientCredentials(defaultOptions);
+      credentials.invalidateAccessToken('unknown-token');
+
+      await expect(credentials.getAccessToken()).resolves.toHaveProperty('value', 'test-token');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/api/src/client-credentials.test.ts
+++ b/packages/api/src/client-credentials.test.ts
@@ -6,10 +6,7 @@ import {
   type ClientCredentialsOptions,
 } from './client-credentials.js';
 
-// Mock fetch globally
 const mockFetch = vi.fn();
-// eslint-disable-next-line @silverhand/fp/no-mutation
-global.fetch = mockFetch;
 
 describe('ClientCredentialsError', () => {
   it('should create error with correct name', () => {
@@ -17,6 +14,13 @@ describe('ClientCredentialsError', () => {
     expect(error.name).toBe('ClientCredentialsError');
     expect(error.message).toBe('test message');
     expect(error).toBeInstanceOf(Error);
+  });
+
+  it('should preserve the error cause', () => {
+    const cause = new TypeError('fetch failed');
+    const error = new ClientCredentialsError('Failed to fetch access token', { cause });
+
+    expect(error.cause).toBe(cause);
   });
 });
 
@@ -28,11 +32,14 @@ describe('ClientCredentials', () => {
   };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
     vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -56,6 +63,55 @@ describe('ClientCredentials', () => {
     });
   });
 
+  describe('tokenRequestTimeout', () => {
+    it('should return the default value of 10 when not specified', () => {
+      expect(new ClientCredentials(defaultOptions).tokenRequestTimeout).toBe(10);
+    });
+
+    it('should return a custom value when specified', () => {
+      expect(
+        new ClientCredentials({ ...defaultOptions, tokenRequestTimeout: 20 }).tokenRequestTimeout
+      ).toBe(20);
+    });
+
+    it('should use the default timeout for NaN', () => {
+      expect(
+        new ClientCredentials({ ...defaultOptions, tokenRequestTimeout: Number.NaN })
+          .tokenRequestTimeout
+      ).toBe(10);
+    });
+
+    it.each([0, -1, Number.POSITIVE_INFINITY])(
+      'should disable the timeout for %s',
+      async (tokenRequestTimeout) => {
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ access_token: 'test-token', expires_in: 3600 }),
+        });
+        const credentials = new ClientCredentials({ ...defaultOptions, tokenRequestTimeout });
+        const token = credentials.getAccessToken();
+
+        expect(credentials.tokenRequestTimeout).toBe(0);
+        expect(vi.getTimerCount()).toBe(0);
+        await expect(token).resolves.toHaveProperty('value', 'test-token');
+      }
+    );
+  });
+
+  describe('network errors', () => {
+    it('should wrap fetch errors and preserve their cause', async () => {
+      const cause = new TypeError('fetch failed');
+      mockFetch.mockRejectedValueOnce(cause);
+      const credentials = new ClientCredentials(defaultOptions);
+
+      await expect(credentials.getAccessToken()).rejects.toMatchObject({
+        name: 'ClientCredentialsError',
+        message: 'Failed to fetch access token: fetch failed',
+        cause,
+      });
+    });
+  });
+
   describe('getAccessToken', () => {
     it('should fetch and return access token on first call', async () => {
       const mockResponse = {
@@ -74,6 +130,9 @@ describe('ClientCredentials', () => {
       expect(token.scope).toBeUndefined();
       expect(mockFetch).toHaveBeenCalledWith('https://example.com/token', {
         method: 'POST',
+        redirect: 'error',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Asymmetric matcher for the native signal.
+        signal: expect.any(AbortSignal),
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },
@@ -120,6 +179,9 @@ describe('ClientCredentials', () => {
       expect(token.scope).toBe('read write');
       expect(mockFetch).toHaveBeenCalledWith('https://example.com/token', {
         method: 'POST',
+        redirect: 'error',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Asymmetric matcher for the native signal.
+        signal: expect.any(AbortSignal),
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },

--- a/packages/api/src/client-credentials.test.ts
+++ b/packages/api/src/client-credentials.test.ts
@@ -63,41 +63,6 @@ describe('ClientCredentials', () => {
     });
   });
 
-  describe('tokenRequestTimeout', () => {
-    it('should return the default value of 10 when not specified', () => {
-      expect(new ClientCredentials(defaultOptions).tokenRequestTimeout).toBe(10);
-    });
-
-    it('should return a custom value when specified', () => {
-      expect(
-        new ClientCredentials({ ...defaultOptions, tokenRequestTimeout: 20 }).tokenRequestTimeout
-      ).toBe(20);
-    });
-
-    it('should use the default timeout for NaN', () => {
-      expect(
-        new ClientCredentials({ ...defaultOptions, tokenRequestTimeout: Number.NaN })
-          .tokenRequestTimeout
-      ).toBe(10);
-    });
-
-    it.each([0, -1, Number.POSITIVE_INFINITY])(
-      'should disable the timeout for %s',
-      async (tokenRequestTimeout) => {
-        mockFetch.mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({ access_token: 'test-token', expires_in: 3600 }),
-        });
-        const credentials = new ClientCredentials({ ...defaultOptions, tokenRequestTimeout });
-        const token = credentials.getAccessToken();
-
-        expect(credentials.tokenRequestTimeout).toBe(0);
-        expect(vi.getTimerCount()).toBe(0);
-        await expect(token).resolves.toHaveProperty('value', 'test-token');
-      }
-    );
-  });
-
   describe('network errors', () => {
     it('should wrap fetch errors and preserve their cause', async () => {
       const cause = new TypeError('fetch failed');
@@ -240,11 +205,14 @@ describe('ClientCredentials', () => {
       // Advance time past expiry
       vi.advanceTimersByTime(100 * 1000);
 
-      // Second call - should refresh token
-      const token = await credentials.getAccessToken();
+      // Concurrent calls should share the refresh.
+      const tokens = await Promise.all([
+        credentials.getAccessToken(),
+        credentials.getAccessToken(),
+      ]);
 
-      expect(token.value).toBe('test-token-2');
-      expect(token.scope).toBe('scope-2');
+      expect(tokens.map(({ value }) => value)).toEqual(['test-token-2', 'test-token-2']);
+      expect(tokens.map(({ scope }) => scope)).toEqual(['scope-2', 'scope-2']);
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/api/src/client-credentials.ts
+++ b/packages/api/src/client-credentials.ts
@@ -8,8 +8,8 @@ export type AccessToken = {
 };
 
 export class ClientCredentialsError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'ClientCredentialsError';
   }
 }
@@ -21,9 +21,17 @@ export type ClientCredentialsOptions = {
   tokenParams?: Record<string, string>;
   /**
    * The time in seconds before the access token expires to consider it valid.
+   * A value greater than or equal to the token lifetime causes every call to fetch a new token,
+   * so cached-token invalidation protection cannot persist across calls.
    * @default 60
    */
   accessTokenExpiryLeeway?: Seconds;
+  /**
+   * The maximum time in seconds allowed for fetching an access token.
+   * Non-positive and infinite values disable the timeout. `NaN` uses the default value.
+   * @default 10
+   */
+  tokenRequestTimeout?: Seconds;
 };
 
 /**
@@ -33,60 +41,147 @@ export type ClientCredentialsOptions = {
 export class ClientCredentials {
   protected accessToken?: AccessToken;
 
+  private accessTokenPromise?: Promise<AccessToken>;
+
+  private awaitingValidationAfterRefresh = false;
+
   get accessTokenExpiryLeeway(): Seconds {
     return this.options.accessTokenExpiryLeeway ?? 60;
+  }
+
+  get tokenRequestTimeout(): Seconds {
+    const timeout = this.options.tokenRequestTimeout;
+
+    if (timeout === undefined || Number.isNaN(timeout)) {
+      return 10;
+    }
+
+    return Number.isFinite(timeout) && timeout > 0 ? timeout : 0;
   }
 
   constructor(protected options: ClientCredentialsOptions) {}
 
   /**
    * Retrieves the access token, refreshing it if necessary.
-   * @returns The access token as a string.
+   * Concurrent calls share the same token request.
+   * @returns The access token and its metadata.
    */
   async getAccessToken(): Promise<AccessToken> {
     const now = new Date();
 
-    // If the access token is not set or has expired, refresh it
+    // Return the cached token if it is still valid.
     if (
-      !this.accessToken?.expiresAt ||
-      this.accessToken.expiresAt <= Math.floor(now.getTime() / 1000) + this.accessTokenExpiryLeeway
+      this.accessToken?.expiresAt &&
+      this.accessToken.expiresAt > Math.floor(now.getTime() / 1000) + this.accessTokenExpiryLeeway
     ) {
-      const response = await fetch(this.options.tokenEndpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-        body: new URLSearchParams({
-          grant_type: 'client_credentials',
-          client_id: this.options.clientId,
-          client_secret: this.options.clientSecret,
-          ...this.options.tokenParams,
-        }).toString(),
-      });
-
-      if (!response.ok) {
-        throw new ClientCredentialsError(
-          `Failed to fetch access token: ${response.status} ${response.statusText}`
-        );
-      }
-
-      const data: unknown = await response.json();
-
-      if (typeof data !== 'object' || data === null || !('access_token' in data)) {
-        throw new ClientCredentialsError('Invalid response from token endpoint');
-      }
-
-      if (!('expires_in' in data) || typeof data.expires_in !== 'number') {
-        throw new ClientCredentialsError('Invalid or missing expires_in in token response');
-      }
-
-      this.accessToken = {
-        value: String(data.access_token),
-        expiresAt: Math.floor(now.getTime() / 1000) + data.expires_in,
-        scope: 'scope' in data && typeof data.scope === 'string' ? data.scope : undefined,
-      };
+      return this.accessToken;
     }
 
-    return this.accessToken;
+    if (this.accessToken) {
+      // A natural expiry starts a new invalidation cycle.
+      this.awaitingValidationAfterRefresh = false;
+    }
+
+    if (this.accessTokenPromise) {
+      return this.accessTokenPromise;
+    }
+
+    try {
+      this.accessTokenPromise = this.fetchAccessToken();
+      this.accessToken = await this.accessTokenPromise;
+      return this.accessToken;
+    } finally {
+      this.accessTokenPromise = undefined;
+    }
+  }
+
+  /**
+   * Invalidates the cached token if it matches the token rejected by the API.
+   * A delayed response for an older token must not invalidate a newer cached token.
+   */
+  invalidateAccessToken(token: string): void {
+    if (this.accessToken?.value === token && !this.awaitingValidationAfterRefresh) {
+      this.accessToken = undefined;
+      this.awaitingValidationAfterRefresh = true;
+    }
+  }
+
+  /** Allows a future 401 to invalidate the token after it receives a successful API response. */
+  markAccessTokenAsValid(token: string): void {
+    if (this.accessToken?.value === token) {
+      this.awaitingValidationAfterRefresh = false;
+    }
+  }
+
+  private async fetchAccessToken(): Promise<AccessToken> {
+    const controller = new AbortController();
+    const timeoutError = new DOMException('Token request timed out', 'TimeoutError');
+    const timeout =
+      this.tokenRequestTimeout > 0
+        ? setTimeout(() => {
+            controller.abort(timeoutError);
+          }, this.tokenRequestTimeout * 1000)
+        : undefined;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      controller.signal.addEventListener('abort', () => {
+        reject(timeoutError);
+      });
+    });
+
+    try {
+      // Node.js 24 can leave response.json() pending after an aborted, stalled body.
+      return await Promise.race([this.requestAccessToken(controller.signal), aborted]);
+    } catch (error: unknown) {
+      if (error instanceof ClientCredentialsError) {
+        throw error;
+      }
+
+      throw new ClientCredentialsError(
+        `Failed to fetch access token: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error }
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private async requestAccessToken(signal: AbortSignal): Promise<AccessToken> {
+    const now = new Date();
+    const response = await fetch(this.options.tokenEndpoint, {
+      method: 'POST',
+      redirect: 'error',
+      signal,
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: this.options.clientId,
+        client_secret: this.options.clientSecret,
+        ...this.options.tokenParams,
+      }).toString(),
+    });
+
+    if (!response.ok) {
+      throw new ClientCredentialsError(
+        `Failed to fetch access token: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const data: unknown = await response.json();
+
+    if (typeof data !== 'object' || data === null || !('access_token' in data)) {
+      throw new ClientCredentialsError('Invalid response from token endpoint');
+    }
+
+    if (!('expires_in' in data) || typeof data.expires_in !== 'number') {
+      throw new ClientCredentialsError('Invalid or missing expires_in in token response');
+    }
+
+    return {
+      value: String(data.access_token),
+      expiresAt: Math.floor(now.getTime() / 1000) + data.expires_in,
+      scope: 'scope' in data && typeof data.scope === 'string' ? data.scope : undefined,
+    };
   }
 }

--- a/packages/api/src/client-credentials.ts
+++ b/packages/api/src/client-credentials.ts
@@ -1,3 +1,5 @@
+import { createTimeoutSignal, getAbortReason, normalizeTimeout } from './timeout.js';
+
 /** Indicates the number of seconds. */
 type Seconds = number;
 
@@ -32,6 +34,33 @@ export type ClientCredentialsOptions = {
    * @default 10
    */
   tokenRequestTimeout?: Seconds;
+  /**
+   * Returns an optional signal for each token request. The factory is called once per actual token
+   * fetch, so concurrent callers sharing a fetch also share its signal. The signal is composed with
+   * `tokenRequestTimeout`, and the first signal to abort cancels the request.
+   */
+  getTokenRequestSignal?: () => AbortSignal | undefined;
+};
+
+const createAbortPromise = (signal: AbortSignal) => {
+  // eslint-disable-next-line no-use-extend-native/no-use-extend-native -- `Promise.withResolvers` is standard since ES2024; the rule's built-in method list predates it.
+  const { promise, reject } = Promise.withResolvers<never>();
+  const handleAbort = () => {
+    reject(getAbortReason(signal, 'Token request aborted'));
+  };
+
+  if (signal.aborted) {
+    handleAbort();
+  } else {
+    signal.addEventListener('abort', handleAbort, { once: true });
+  }
+
+  return {
+    promise,
+    clear: () => {
+      signal.removeEventListener('abort', handleAbort);
+    },
+  };
 };
 
 /**
@@ -50,13 +79,7 @@ export class ClientCredentials {
   }
 
   get tokenRequestTimeout(): Seconds {
-    const timeout = this.options.tokenRequestTimeout;
-
-    if (timeout === undefined || Number.isNaN(timeout)) {
-      return 10;
-    }
-
-    return Number.isFinite(timeout) && timeout > 0 ? timeout : 0;
+    return normalizeTimeout(this.options.tokenRequestTimeout);
   }
 
   constructor(protected options: ClientCredentialsOptions) {}
@@ -114,23 +137,21 @@ export class ClientCredentials {
   }
 
   private async fetchAccessToken(): Promise<AccessToken> {
-    const controller = new AbortController();
-    const timeoutError = new DOMException('Token request timed out', 'TimeoutError');
-    const timeout =
-      this.tokenRequestTimeout > 0
-        ? setTimeout(() => {
-            controller.abort(timeoutError);
-          }, this.tokenRequestTimeout * 1000)
-        : undefined;
-    const aborted = new Promise<never>((_resolve, reject) => {
-      controller.signal.addEventListener('abort', () => {
-        reject(timeoutError);
-      });
-    });
+    const timeout = createTimeoutSignal(this.tokenRequestTimeout, 'Token request timed out');
 
     try {
-      // Node.js 24 can leave response.json() pending after an aborted, stalled body.
-      return await Promise.race([this.requestAccessToken(controller.signal), aborted]);
+      const customSignal = this.options.getTokenRequestSignal?.();
+      const signal = customSignal
+        ? AbortSignal.any([timeout.signal, customSignal])
+        : timeout.signal;
+      const abort = createAbortPromise(signal);
+
+      try {
+        // Node.js 24 can leave response.json() pending after an aborted, stalled body.
+        return await Promise.race([this.requestAccessToken(signal), abort.promise]);
+      } finally {
+        abort.clear();
+      }
     } catch (error: unknown) {
       if (error instanceof ClientCredentialsError) {
         throw error;
@@ -141,7 +162,7 @@ export class ClientCredentials {
         { cause: error }
       );
     } finally {
-      clearTimeout(timeout);
+      timeout.clear();
     }
   }
 

--- a/packages/api/src/client-credentials.ts
+++ b/packages/api/src/client-credentials.ts
@@ -147,7 +147,7 @@ export class ClientCredentials {
       const abort = createAbortPromise(signal);
 
       try {
-        // Node.js 24 can leave response.json() pending after an aborted, stalled body.
+        // Guard against Response implementations that do not propagate request aborts to json().
         return await Promise.race([this.requestAccessToken(signal), abort.promise]);
       } finally {
         abort.clear();

--- a/packages/api/src/client-credentials.ts
+++ b/packages/api/src/client-credentials.ts
@@ -129,7 +129,7 @@ export class ClientCredentials {
     }
   }
 
-  /** Allows a future 401 to invalidate the token after it receives a successful API response. */
+  /** Allows a future 401 to invalidate the token after the API accepts it. */
   markAccessTokenAsValid(token: string): void {
     if (this.accessToken?.value === token) {
       this.awaitingValidationAfterRefresh = false;

--- a/packages/api/src/management.integration.test.ts
+++ b/packages/api/src/management.integration.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createManagementApi } from './management.js';
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('Management API token recovery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('should use a fresh token on the request after a 401', async () => {
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: 'rejected-token', expires_in: 3600, scope: 'all' })
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: 'fresh-token', expires_in: 3600, scope: 'all' })
+      )
+      .mockResolvedValueOnce(jsonResponse([]));
+    vi.stubGlobal('fetch', mockFetch);
+    const { apiClient } = createManagementApi('test-tenant', {
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+    });
+
+    const firstResult = await apiClient.get('/api/users' as never);
+    const secondResult = await apiClient.get('/api/users' as never);
+
+    expect(firstResult.response.status).toBe(401);
+    expect(secondResult.response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+
+    const firstRequest = mockFetch.mock.calls[1]?.[0];
+    const secondRequest = mockFetch.mock.calls[3]?.[0];
+    expect(firstRequest).toBeInstanceOf(Request);
+    expect(secondRequest).toBeInstanceOf(Request);
+
+    if (!(firstRequest instanceof Request) || !(secondRequest instanceof Request)) {
+      throw new TypeError('Expected Management API requests');
+    }
+
+    expect(firstRequest.headers.get('Authorization')).toBe('Bearer rejected-token');
+    expect(secondRequest.headers.get('Authorization')).toBe('Bearer fresh-token');
+  });
+
+  it('should reuse the replacement token when the API keeps returning 401', async () => {
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: 'first-token', expires_in: 3600, scope: 'all' })
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: 'replacement-token', expires_in: 3600, scope: 'all' })
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401));
+    vi.stubGlobal('fetch', mockFetch);
+    const { apiClient } = createManagementApi('test-tenant', {
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+    });
+
+    const firstResult = await apiClient.get('/api/users' as never);
+    const secondResult = await apiClient.get('/api/users' as never);
+    const thirdResult = await apiClient.get('/api/users' as never);
+
+    expect([firstResult, secondResult, thirdResult].map(({ response }) => response.status)).toEqual(
+      [401, 401, 401]
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+
+    const apiRequests = [
+      mockFetch.mock.calls[1]?.[0],
+      mockFetch.mock.calls[3]?.[0],
+      mockFetch.mock.calls[4]?.[0],
+    ];
+    expect(apiRequests.every((request) => request instanceof Request)).toBe(true);
+    expect(
+      apiRequests.map((request) =>
+        request instanceof Request ? request.headers.get('Authorization') : undefined
+      )
+    ).toEqual(['Bearer first-token', 'Bearer replacement-token', 'Bearer replacement-token']);
+  });
+
+  it('should apply the client request timeout to Management API calls', async () => {
+    const timeoutController = new AbortController();
+    const timeoutError = new DOMException('Request timed out', 'TimeoutError');
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutController.signal);
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: 'test-token', expires_in: 3600, scope: 'all' })
+      )
+      .mockImplementationOnce(
+        async (request) =>
+          new Promise<Response>((_resolve, reject) => {
+            if (!(request instanceof Request)) {
+              throw new TypeError('Expected a Management API request');
+            }
+            request.signal.addEventListener('abort', () => {
+              reject(timeoutError);
+            });
+          })
+      );
+    vi.stubGlobal('fetch', mockFetch);
+    const { apiClient } = createManagementApi('test-tenant', {
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+      requestTimeout: 20,
+    });
+    const result = apiClient.get('/api/users' as never);
+    await vi.waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    expect(timeout).toHaveBeenCalledWith(20_000);
+    timeoutController.abort(timeoutError);
+    await expect(result).rejects.toBe(timeoutError);
+  });
+});

--- a/packages/api/src/management.integration.test.ts
+++ b/packages/api/src/management.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createManagementApi } from './management.js';
+import { getAbortReason } from './timeout.js';
 
 const jsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), {
@@ -107,7 +108,7 @@ describe('Management API token recovery', () => {
               throw new TypeError('Expected a Management API request');
             }
             request.signal.addEventListener('abort', () => {
-              reject(timeoutError);
+              reject(getAbortReason(request.signal, 'Management API request aborted'));
             });
           })
       );
@@ -118,12 +119,13 @@ describe('Management API token recovery', () => {
       requestTimeout: 20,
     });
     const result = apiClient.get('/api/users' as never);
+    const rejection = expect(result).rejects.toBe(timeoutError);
     await vi.waitFor(() => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     expect(timeout).toHaveBeenCalledWith(20_000);
     timeoutController.abort(timeoutError);
-    await expect(result).rejects.toBe(timeoutError);
+    await rejection;
   });
 });

--- a/packages/api/src/management.integration.test.ts
+++ b/packages/api/src/management.integration.test.ts
@@ -102,13 +102,15 @@ describe('Management API token recovery', () => {
         jsonResponse({ access_token: 'test-token', expires_in: 3600, scope: 'all' })
       )
       .mockImplementationOnce(
-        async (request) =>
+        async (_request, requestInit) =>
           new Promise<Response>((_resolve, reject) => {
-            if (!(request instanceof Request)) {
-              throw new TypeError('Expected a Management API request');
+            const signal = requestInit?.signal;
+
+            if (!(signal instanceof AbortSignal)) {
+              throw new TypeError('Expected a Management API request signal');
             }
-            request.signal.addEventListener('abort', () => {
-              reject(getAbortReason(request.signal, 'Management API request aborted'));
+            signal.addEventListener('abort', () => {
+              reject(getAbortReason(signal, 'Management API request aborted'));
             });
           })
       );

--- a/packages/api/src/management.integration.test.ts
+++ b/packages/api/src/management.integration.test.ts
@@ -92,6 +92,57 @@ describe('Management API token recovery', () => {
     ).toEqual(['Bearer first-token', 'Bearer replacement-token', 'Bearer replacement-token']);
   });
 
+  it('should allow a later 401 to invalidate a replacement token after a non-401 response', async () => {
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: 'first-token', expires_in: 3600, scope: 'all' })
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: 'replacement-token', expires_in: 3600, scope: 'all' })
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: 'Forbidden' }, 403))
+      .mockResolvedValueOnce(jsonResponse({ error: 'Unauthorized' }, 401))
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: 'third-token', expires_in: 3600, scope: 'all' })
+      )
+      .mockResolvedValueOnce(jsonResponse([]));
+    vi.stubGlobal('fetch', mockFetch);
+    const { apiClient } = createManagementApi('test-tenant', {
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+    });
+
+    const firstResult = await apiClient.get('/api/users' as never);
+    const secondResult = await apiClient.get('/api/users' as never);
+    const thirdResult = await apiClient.get('/api/users' as never);
+    const fourthResult = await apiClient.get('/api/users' as never);
+
+    expect(
+      [firstResult, secondResult, thirdResult, fourthResult].map(({ response }) => response.status)
+    ).toEqual([401, 403, 401, 200]);
+    expect(mockFetch).toHaveBeenCalledTimes(7);
+
+    const apiRequests = [
+      mockFetch.mock.calls[1]?.[0],
+      mockFetch.mock.calls[3]?.[0],
+      mockFetch.mock.calls[4]?.[0],
+      mockFetch.mock.calls[6]?.[0],
+    ];
+    expect(apiRequests.every((request) => request instanceof Request)).toBe(true);
+    expect(
+      apiRequests.map((request) =>
+        request instanceof Request ? request.headers.get('Authorization') : undefined
+      )
+    ).toEqual([
+      'Bearer first-token',
+      'Bearer replacement-token',
+      'Bearer replacement-token',
+      'Bearer third-token',
+    ]);
+  });
+
   it('should apply the client request timeout to Management API calls', async () => {
     const timeoutController = new AbortController();
     const timeoutError = new DOMException('Request timed out', 'TimeoutError');

--- a/packages/api/src/management.test.ts
+++ b/packages/api/src/management.test.ts
@@ -4,7 +4,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ClientCredentials } from './client-credentials.js';
 import {
   createManagementApi,
-  createApiClient,
   getBaseUrl,
   getManagementApiIndicator,
   allScope,
@@ -40,14 +39,16 @@ describe('Management API', () => {
 
   describe('createManagementApi', () => {
     const mockApiClient = {
-      use: vi.fn(),
+      use: vi.fn<(...middleware: Middleware[]) => void>(),
     };
     const mockClientCredentials = {
       getAccessToken: vi.fn(),
+      invalidateAccessToken: vi.fn(),
+      markAccessTokenAsValid: vi.fn(),
     };
 
     beforeEach(() => {
-      // @ts-expect-error
+      // @ts-expect-error -- Only the middleware registration is needed by these tests.
       mockCreateClient.mockReturnValue(mockApiClient);
       MockClientCredentials.mockImplementation(function () {
         return mockClientCredentials;
@@ -70,40 +71,58 @@ describe('Management API', () => {
           resource: 'https://test-tenant.logto.app/api',
           scope: allScope,
         },
+        tokenRequestTimeout: undefined,
       });
 
       expect(mockCreateClient).toHaveBeenCalledWith({
         baseUrl: 'https://test-tenant.logto.app',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
+        fetch: expect.any(Function),
       });
 
-      expect(result.apiClient).toBe(mockApiClient);
+      expect(result.apiClient).toMatchObject(mockApiClient);
+      expect(result.apiClient.use).toBe(mockApiClient.use);
       expect(result.clientCredentials).toBe(mockClientCredentials);
     });
 
-    it('should create management API with custom base URL and API indicator', () => {
-      const options: CreateManagementApiOptions = {
-        clientId: 'test-client-id',
-        clientSecret: 'test-client-secret',
-        baseUrl: 'https://custom.example.com',
-        apiIndicator: 'https://custom.example.com/custom-api',
-      };
+    it.each([
+      ['https://custom.example.com', 'https://custom.example.com'],
+      ['https://custom.example.com/', 'https://custom.example.com'],
+      ['https://custom.example.com///', 'https://custom.example.com'],
+      ['https://custom.example.com/logto', 'https://custom.example.com/logto'],
+      ['https://custom.example.com/logto/', 'https://custom.example.com/logto'],
+      ['https://custom.example.com/logto///', 'https://custom.example.com/logto'],
+    ])(
+      'should normalize custom base URL %s and preserve the API indicator',
+      (baseUrl, normalizedBaseUrl) => {
+        const options: CreateManagementApiOptions = {
+          clientId: 'test-client-id',
+          clientSecret: 'test-client-secret',
+          baseUrl,
+          apiIndicator: 'https://custom.example.com/custom-api/',
+          tokenRequestTimeout: 20,
+        };
 
-      createManagementApi('test-tenant', options);
+        createManagementApi('test-tenant', options);
 
-      expect(MockClientCredentials).toHaveBeenCalledWith({
-        clientId: 'test-client-id',
-        clientSecret: 'test-client-secret',
-        tokenEndpoint: 'https://custom.example.com/oidc/token',
-        tokenParams: {
-          resource: 'https://custom.example.com/custom-api',
-          scope: allScope,
-        },
-      });
+        expect(MockClientCredentials).toHaveBeenCalledWith({
+          clientId: 'test-client-id',
+          clientSecret: 'test-client-secret',
+          tokenEndpoint: `${normalizedBaseUrl}/oidc/token`,
+          tokenParams: {
+            resource: 'https://custom.example.com/custom-api/',
+            scope: allScope,
+          },
+          tokenRequestTimeout: 20,
+        });
 
-      expect(mockCreateClient).toHaveBeenCalledWith({
-        baseUrl: 'https://custom.example.com',
-      });
-    });
+        expect(mockCreateClient).toHaveBeenCalledWith({
+          baseUrl: normalizedBaseUrl,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
+          fetch: expect.any(Function),
+        });
+      }
+    );
 
     it('should configure API client middleware correctly', async () => {
       const options: CreateManagementApiOptions = {
@@ -119,19 +138,19 @@ describe('Management API', () => {
       createManagementApi('test-tenant', options);
 
       expect(mockApiClient.use).toHaveBeenCalledWith({
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
         onRequest: expect.any(Function),
       });
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const middleware: Middleware = mockApiClient.use.mock.calls[0]?.[0];
+      const middleware = mockApiClient.use.mock.calls[0]?.[0];
+      expect(middleware?.onRequest).toBeTypeOf('function');
       const mockRequest = {
         headers: {
           set: vi.fn(),
         },
       };
 
-      const result = await middleware.onRequest?.({
+      const result = await middleware?.onRequest?.({
         schemaPath: '/api/test',
         // @ts-expect-error: Mock request object
         request: mockRequest,
@@ -150,15 +169,15 @@ describe('Management API', () => {
 
       createManagementApi('test-tenant', options);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const middleware: Middleware = mockApiClient.use.mock.calls[0]?.[0];
+      const middleware = mockApiClient.use.mock.calls[0]?.[0];
+      expect(middleware?.onRequest).toBeTypeOf('function');
       const mockRequest = {
         headers: {
           set: vi.fn(),
         },
       };
 
-      const result = await middleware.onRequest?.({
+      const result = await middleware?.onRequest?.({
         schemaPath: '/.well-known/openid-configuration',
         // @ts-expect-error: Mock request object
         request: mockRequest,
@@ -170,124 +189,143 @@ describe('Management API', () => {
     });
 
     it('should warn when scope does not match expected value', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      // eslint-disable-next-line @typescript-eslint/no-empty-function -- Silence the expected warning in this test.
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const options: CreateManagementApiOptions = {
         clientId: 'test-client-id',
         clientSecret: 'test-client-secret',
       };
 
-      mockClientCredentials.getAccessToken.mockResolvedValue({
-        value: 'test-token',
-        scope: 'limited-scope',
-      });
+      mockClientCredentials.getAccessToken
+        .mockResolvedValueOnce({ value: 'first-token', scope: 'limited-scope' })
+        .mockResolvedValueOnce({ value: 'first-token', scope: 'limited-scope' })
+        .mockResolvedValueOnce({ value: 'second-token', scope: 'limited-scope' })
+        .mockResolvedValueOnce({ value: 'third-token', scope: 'read-only' });
 
       createManagementApi('test-tenant', options);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const middleware: Middleware = mockApiClient.use.mock.calls[0]?.[0];
+      const middleware = mockApiClient.use.mock.calls[0]?.[0];
+      expect(middleware?.onRequest).toBeTypeOf('function');
       const mockRequest = {
         headers: {
           set: vi.fn(),
         },
       };
 
-      await middleware.onRequest?.({
+      await middleware?.onRequest?.({
         schemaPath: '/api/test',
         // @ts-expect-error: Mock request object
+        request: mockRequest,
+      });
+      await middleware?.onRequest?.({
+        schemaPath: '/api/test',
+        // @ts-expect-error -- Only the request and schema path are used by this middleware.
+        request: mockRequest,
+      });
+      await middleware?.onRequest?.({
+        schemaPath: '/api/test',
+        // @ts-expect-error -- Only the request and schema path are used by this middleware.
+        request: mockRequest,
+      });
+      await middleware?.onRequest?.({
+        schemaPath: '/api/test',
+        // @ts-expect-error -- Only the request and schema path are used by this middleware.
         request: mockRequest,
       });
 
       expect(consoleSpy).toHaveBeenCalledWith(
         `The scope "limited-scope" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
       );
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
 
       consoleSpy.mockRestore();
     });
-  });
 
-  describe('createApiClient', () => {
-    const mockApiClient = {
-      use: vi.fn(),
-    };
-
-    beforeEach(() => {
-      // @ts-expect-error
-      mockCreateClient.mockReturnValue(mockApiClient);
-    });
-
-    it('should create API client with provided options', () => {
-      const getToken = vi.fn().mockResolvedValue('test-token');
-
-      const result = createApiClient({
-        baseUrl: 'https://test.logto.app',
-        getToken,
-      });
-
-      expect(mockCreateClient).toHaveBeenCalledWith({
-        baseUrl: 'https://test.logto.app',
-      });
-
-      expect(result).toBe(mockApiClient);
-    });
-
-    it('should configure middleware correctly', async () => {
-      const getToken = vi.fn().mockResolvedValue('test-token');
-
-      createApiClient({
-        baseUrl: 'https://test.logto.app',
-        getToken,
-      });
-
-      expect(mockApiClient.use).toHaveBeenCalledWith({
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        onRequest: expect.any(Function),
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const middleware: Middleware = mockApiClient.use.mock.calls[0]?.[0];
-      const mockRequest = {
-        headers: {
-          set: vi.fn(),
-        },
-      };
-
-      const result = await middleware.onRequest?.({
-        schemaPath: '/api/test',
-        // @ts-expect-error: Mock request object
-        request: mockRequest,
-      });
-
-      expect(getToken).toHaveBeenCalled();
-      expect(mockRequest.headers.set).toHaveBeenCalledWith('Authorization', 'Bearer test-token');
-      expect(result).toBe(mockRequest);
-    });
-
-    it('should skip auth for well-known endpoints', async () => {
-      const getToken = vi.fn().mockResolvedValue('test-token');
-
-      createApiClient({
-        baseUrl: 'https://test.logto.app',
-        getToken,
-      });
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const middleware: Middleware = mockApiClient.use.mock.calls[0]?.[0];
-      const mockRequest = {
-        headers: {
-          set: vi.fn(),
-        },
-      };
-
-      const result = await middleware.onRequest?.({
+    it.each([
+      {
+        status: 401,
+        schemaPath: '/api/users',
+        authorization: 'Bearer rejected-token',
+        invalidates: true,
+        validates: false,
+      },
+      {
+        status: 200,
+        schemaPath: '/api/users',
+        authorization: 'Bearer valid-token',
+        invalidates: false,
+        validates: true,
+      },
+      {
+        status: 403,
+        schemaPath: '/api/users',
+        authorization: 'Bearer valid-token',
+        invalidates: false,
+        validates: false,
+      },
+      {
+        status: 500,
+        schemaPath: '/api/users',
+        authorization: 'Bearer valid-token',
+        invalidates: false,
+        validates: false,
+      },
+      {
+        status: 401,
+        schemaPath: '/api/users',
+        authorization: '',
+        invalidates: false,
+        validates: false,
+      },
+      {
+        status: 401,
+        schemaPath: '/api/users',
+        authorization: 'Basic credentials',
+        invalidates: false,
+        validates: false,
+      },
+      {
+        status: 401,
         schemaPath: '/.well-known/openid-configuration',
-        // @ts-expect-error: Mock request object
-        request: mockRequest,
-      });
+        authorization: 'Bearer unrelated-token',
+        invalidates: false,
+        validates: false,
+      },
+    ])(
+      'should handle $status for $schemaPath with "$authorization"',
+      async ({ status, schemaPath, authorization, invalidates, validates }) => {
+        createManagementApi('test-tenant', {
+          clientId: 'test-client-id',
+          clientSecret: 'test-client-secret',
+        });
+        const middleware = mockApiClient.use.mock.calls[1]?.[0];
+        expect(middleware?.onResponse).toBeTypeOf('function');
+        const request = new Request(`https://test-tenant.logto.app${schemaPath}`, {
+          headers: authorization ? { Authorization: authorization } : undefined,
+        });
+        const response = new Response(null, { status });
 
-      expect(getToken).not.toHaveBeenCalled();
-      expect(mockRequest.headers.set).not.toHaveBeenCalled();
-      expect(result).toBeUndefined();
-    });
+        // @ts-expect-error -- This middleware only reads the request, response, and schema path.
+        const result = await middleware?.onResponse?.({ request, response, schemaPath });
+
+        if (invalidates) {
+          expect(mockClientCredentials.invalidateAccessToken).toHaveBeenCalledExactlyOnceWith(
+            'rejected-token'
+          );
+        } else {
+          expect(mockClientCredentials.invalidateAccessToken).not.toHaveBeenCalled();
+        }
+        if (validates) {
+          expect(mockClientCredentials.markAccessTokenAsValid).toHaveBeenCalledExactlyOnceWith(
+            'valid-token'
+          );
+        } else {
+          expect(mockClientCredentials.markAccessTokenAsValid).not.toHaveBeenCalled();
+        }
+        expect(mockClientCredentials.getAccessToken).not.toHaveBeenCalled();
+        expect(result).toBeUndefined();
+        expect(response.status).toBe(status);
+      }
+    );
   });
 });

--- a/packages/api/src/management.test.ts
+++ b/packages/api/src/management.test.ts
@@ -63,7 +63,7 @@ describe('Management API', () => {
 
       const result = createManagementApi('test-tenant', options);
 
-      expect(MockClientCredentials).toHaveBeenCalledWith({
+      expect(MockClientCredentials.mock.calls[0]?.[0]).toMatchObject({
         clientId: 'test-client-id',
         clientSecret: 'test-client-secret',
         tokenEndpoint: 'https://test-tenant.logto.app/oidc/token',
@@ -71,27 +71,14 @@ describe('Management API', () => {
           resource: 'https://test-tenant.logto.app/api',
           scope: allScope,
         },
-        tokenRequestTimeout: undefined,
-        getTokenRequestSignal: undefined,
       });
 
-      expect(mockCreateClient).toHaveBeenCalledWith({
-        baseUrl: 'https://test-tenant.logto.app',
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
-        fetch: expect.any(Function),
-      });
-
-      expect(result.apiClient).toMatchObject(mockApiClient);
-      expect(result.apiClient.use).toBe(mockApiClient.use);
+      expect(result.apiClient).toBe(mockApiClient);
       expect(result.clientCredentials).toBe(mockClientCredentials);
     });
 
     it.each([
-      ['https://custom.example.com', 'https://custom.example.com'],
-      ['https://custom.example.com/', 'https://custom.example.com'],
       ['https://custom.example.com///', 'https://custom.example.com'],
-      ['https://custom.example.com/logto', 'https://custom.example.com/logto'],
-      ['https://custom.example.com/logto/', 'https://custom.example.com/logto'],
       ['https://custom.example.com/logto///', 'https://custom.example.com/logto'],
     ])(
       'should normalize custom base URL %s and preserve the API indicator',
@@ -106,7 +93,7 @@ describe('Management API', () => {
 
         createManagementApi('test-tenant', options);
 
-        expect(MockClientCredentials).toHaveBeenCalledWith({
+        expect(MockClientCredentials.mock.calls[0]?.[0]).toMatchObject({
           clientId: 'test-client-id',
           clientSecret: 'test-client-secret',
           tokenEndpoint: `${normalizedBaseUrl}/oidc/token`,
@@ -115,7 +102,6 @@ describe('Management API', () => {
             scope: allScope,
           },
           tokenRequestTimeout: 20,
-          getTokenRequestSignal: undefined,
         });
 
         expect(mockCreateClient).toHaveBeenCalledWith({
@@ -135,81 +121,7 @@ describe('Management API', () => {
         getTokenRequestSignal,
       });
 
-      expect(MockClientCredentials).toHaveBeenCalledWith({
-        clientId: 'test-client-id',
-        clientSecret: 'test-client-secret',
-        tokenEndpoint: 'https://test-tenant.logto.app/oidc/token',
-        tokenParams: {
-          resource: 'https://test-tenant.logto.app/api',
-          scope: allScope,
-        },
-        tokenRequestTimeout: undefined,
-        getTokenRequestSignal,
-      });
-    });
-
-    it('should configure API client middleware correctly', async () => {
-      const options: CreateManagementApiOptions = {
-        clientId: 'test-client-id',
-        clientSecret: 'test-client-secret',
-      };
-
-      mockClientCredentials.getAccessToken.mockResolvedValue({
-        value: 'test-token',
-        scope: allScope,
-      });
-
-      createManagementApi('test-tenant', options);
-
-      expect(mockApiClient.use).toHaveBeenCalledWith({
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
-        onRequest: expect.any(Function),
-      });
-
-      const middleware = mockApiClient.use.mock.calls[0]?.[0];
-      expect(middleware?.onRequest).toBeTypeOf('function');
-      const mockRequest = {
-        headers: {
-          set: vi.fn(),
-        },
-      };
-
-      const result = await middleware?.onRequest?.({
-        schemaPath: '/api/test',
-        // @ts-expect-error: Mock request object
-        request: mockRequest,
-      });
-
-      expect(mockClientCredentials.getAccessToken).toHaveBeenCalled();
-      expect(mockRequest.headers.set).toHaveBeenCalledWith('Authorization', 'Bearer test-token');
-      expect(result).toBe(mockRequest);
-    });
-
-    it('should skip auth for well-known endpoints', async () => {
-      const options: CreateManagementApiOptions = {
-        clientId: 'test-client-id',
-        clientSecret: 'test-client-secret',
-      };
-
-      createManagementApi('test-tenant', options);
-
-      const middleware = mockApiClient.use.mock.calls[0]?.[0];
-      expect(middleware?.onRequest).toBeTypeOf('function');
-      const mockRequest = {
-        headers: {
-          set: vi.fn(),
-        },
-      };
-
-      const result = await middleware?.onRequest?.({
-        schemaPath: '/.well-known/openid-configuration',
-        // @ts-expect-error: Mock request object
-        request: mockRequest,
-      });
-
-      expect(mockClientCredentials.getAccessToken).not.toHaveBeenCalled();
-      expect(mockRequest.headers.set).not.toHaveBeenCalled();
-      expect(result).toBeUndefined();
+      expect(MockClientCredentials.mock.calls[0]?.[0]).toMatchObject({ getTokenRequestSignal });
     });
 
     it('should warn when scope does not match expected value', async () => {
@@ -284,37 +196,9 @@ describe('Management API', () => {
         validates: true,
       },
       {
-        status: 403,
-        schemaPath: '/api/users',
-        authorization: 'Bearer valid-token',
-        invalidates: false,
-        validates: false,
-      },
-      {
-        status: 500,
-        schemaPath: '/api/users',
-        authorization: 'Bearer valid-token',
-        invalidates: false,
-        validates: false,
-      },
-      {
-        status: 401,
-        schemaPath: '/api/users',
-        authorization: '',
-        invalidates: false,
-        validates: false,
-      },
-      {
         status: 401,
         schemaPath: '/api/users',
         authorization: 'Basic credentials',
-        invalidates: false,
-        validates: false,
-      },
-      {
-        status: 401,
-        schemaPath: '/.well-known/openid-configuration',
-        authorization: 'Bearer unrelated-token',
         invalidates: false,
         validates: false,
       },

--- a/packages/api/src/management.test.ts
+++ b/packages/api/src/management.test.ts
@@ -16,6 +16,11 @@ vi.mock('./client-credentials.js');
 const mockCreateClient = vi.mocked(createClient);
 const MockClientCredentials = vi.mocked(ClientCredentials);
 
+const createManagementApiFromJavaScript = createManagementApi as unknown as (
+  tenantIdOrConfig: unknown,
+  options?: unknown
+) => unknown;
+
 const assertInvalidManagementApiConfig = () => {
   // @ts-expect-error -- Object options without a tenant ID require both explicit endpoints.
   createManagementApi({
@@ -104,7 +109,7 @@ describe('Management API', () => {
       });
     });
 
-    it('should use explicit endpoints without a tenant ID', () => {
+    it('should use an explicit base URL and API indicator without a tenant ID', () => {
       createManagementApi({
         clientId: 'test-client-id',
         clientSecret: 'test-client-secret',
@@ -125,6 +130,25 @@ describe('Management API', () => {
 
     it('should require both explicit endpoints when the tenant ID is omitted', () => {
       expectTypeOf(assertInvalidManagementApiConfig).toBeFunction();
+    });
+
+    it('should reject a positional tenant ID without options at runtime', () => {
+      expect(() => createManagementApiFromJavaScript('test-tenant')).toThrow(
+        'Options are required when creating a Management API client by tenant ID'
+      );
+    });
+
+    it.each([
+      null,
+      {
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        baseUrl: 'https://custom.example.com',
+      },
+    ])('should reject invalid object configuration %# at runtime', (config) => {
+      expect(() => createManagementApiFromJavaScript(config)).toThrow(
+        'Provide a tenant ID or both baseUrl and apiIndicator'
+      );
     });
 
     it.each([

--- a/packages/api/src/management.test.ts
+++ b/packages/api/src/management.test.ts
@@ -1,5 +1,5 @@
 import createClient, { type Middleware } from 'openapi-fetch';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, expectTypeOf, vi, beforeEach, afterEach } from 'vitest';
 
 import { ClientCredentials } from './client-credentials.js';
 import {
@@ -15,6 +15,15 @@ vi.mock('./client-credentials.js');
 
 const mockCreateClient = vi.mocked(createClient);
 const MockClientCredentials = vi.mocked(ClientCredentials);
+
+const assertInvalidManagementApiConfig = () => {
+  // @ts-expect-error -- Object options without a tenant ID require both explicit endpoints.
+  createManagementApi({
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    baseUrl: 'https://custom.example.com',
+  });
+};
 
 describe('Management API', () => {
   beforeEach(() => {
@@ -75,6 +84,47 @@ describe('Management API', () => {
 
       expect(result.apiClient).toBe(mockApiClient);
       expect(result.clientCredentials).toBe(mockClientCredentials);
+    });
+
+    it('should derive endpoints from a tenant ID in object options', () => {
+      createManagementApi({
+        tenantId: 'test-tenant',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+      });
+
+      expect(MockClientCredentials.mock.calls[0]?.[0]).toMatchObject({
+        tokenEndpoint: 'https://test-tenant.logto.app/oidc/token',
+        tokenParams: { resource: 'https://test-tenant.logto.app/api' },
+      });
+      expect(mockCreateClient).toHaveBeenCalledWith({
+        baseUrl: 'https://test-tenant.logto.app',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
+        fetch: expect.any(Function),
+      });
+    });
+
+    it('should use explicit endpoints without a tenant ID', () => {
+      createManagementApi({
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        baseUrl: 'https://custom.example.com///',
+        apiIndicator: 'https://custom.example.com/custom-api',
+      });
+
+      expect(MockClientCredentials.mock.calls[0]?.[0]).toMatchObject({
+        tokenEndpoint: 'https://custom.example.com/oidc/token',
+        tokenParams: { resource: 'https://custom.example.com/custom-api' },
+      });
+      expect(mockCreateClient).toHaveBeenCalledWith({
+        baseUrl: 'https://custom.example.com',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
+        fetch: expect.any(Function),
+      });
+    });
+
+    it('should require both explicit endpoints when the tenant ID is omitted', () => {
+      expectTypeOf(assertInvalidManagementApiConfig).toBeFunction();
     });
 
     it.each([

--- a/packages/api/src/management.test.ts
+++ b/packages/api/src/management.test.ts
@@ -72,6 +72,7 @@ describe('Management API', () => {
           scope: allScope,
         },
         tokenRequestTimeout: undefined,
+        getTokenRequestSignal: undefined,
       });
 
       expect(mockCreateClient).toHaveBeenCalledWith({
@@ -114,6 +115,7 @@ describe('Management API', () => {
             scope: allScope,
           },
           tokenRequestTimeout: 20,
+          getTokenRequestSignal: undefined,
         });
 
         expect(mockCreateClient).toHaveBeenCalledWith({
@@ -123,6 +125,28 @@ describe('Management API', () => {
         });
       }
     );
+
+    it('should pass the token request signal factory to client credentials', () => {
+      const getTokenRequestSignal = vi.fn(() => new AbortController().signal);
+
+      createManagementApi('test-tenant', {
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        getTokenRequestSignal,
+      });
+
+      expect(MockClientCredentials).toHaveBeenCalledWith({
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        tokenEndpoint: 'https://test-tenant.logto.app/oidc/token',
+        tokenParams: {
+          resource: 'https://test-tenant.logto.app/api',
+          scope: allScope,
+        },
+        tokenRequestTimeout: undefined,
+        getTokenRequestSignal,
+      });
+    });
 
     it('should configure API client middleware correctly', async () => {
       const options: CreateManagementApiOptions = {
@@ -199,8 +223,8 @@ describe('Management API', () => {
       mockClientCredentials.getAccessToken
         .mockResolvedValueOnce({ value: 'first-token', scope: 'limited-scope' })
         .mockResolvedValueOnce({ value: 'first-token', scope: 'limited-scope' })
-        .mockResolvedValueOnce({ value: 'second-token', scope: 'limited-scope' })
-        .mockResolvedValueOnce({ value: 'third-token', scope: 'read-only' });
+        .mockResolvedValueOnce({ value: 'second-token', scope: 'read-only' })
+        .mockResolvedValueOnce({ value: 'third-token', scope: 'limited-scope' });
 
       createManagementApi('test-tenant', options);
 
@@ -235,6 +259,9 @@ describe('Management API', () => {
 
       expect(consoleSpy).toHaveBeenCalledWith(
         `The scope "limited-scope" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `The scope "read-only" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
       );
       expect(consoleSpy).toHaveBeenCalledTimes(2);
 

--- a/packages/api/src/management.test.ts
+++ b/packages/api/src/management.test.ts
@@ -109,6 +109,25 @@ describe('Management API', () => {
       });
     });
 
+    it('should combine an explicit base URL with the API indicator derived from the tenant ID', () => {
+      createManagementApi({
+        tenantId: 'default',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret',
+        baseUrl: 'https://my-oss-logto-instance.com/',
+      });
+
+      expect(MockClientCredentials.mock.calls[0]?.[0]).toMatchObject({
+        tokenEndpoint: 'https://my-oss-logto-instance.com/oidc/token',
+        tokenParams: { resource: 'https://default.logto.app/api' },
+      });
+      expect(mockCreateClient).toHaveBeenCalledWith({
+        baseUrl: 'https://my-oss-logto-instance.com',
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Vitest's asymmetric matcher accepts any function.
+        fetch: expect.any(Function),
+      });
+    });
+
     it('should use an explicit base URL and API indicator without a tenant ID', () => {
       createManagementApi({
         clientId: 'test-client-id',
@@ -148,6 +167,17 @@ describe('Management API', () => {
     ])('should reject invalid object configuration %# at runtime', (config) => {
       expect(() => createManagementApiFromJavaScript(config)).toThrow(
         'Provide a tenant ID or both baseUrl and apiIndicator'
+      );
+    });
+
+    it('should reject an empty tenant ID at runtime', () => {
+      const options = { clientId: 'test-client-id', clientSecret: 'test-client-secret' };
+
+      expect(() => createManagementApiFromJavaScript('', options)).toThrow(
+        'Tenant ID must not be empty'
+      );
+      expect(() => createManagementApiFromJavaScript({ tenantId: '', ...options })).toThrow(
+        'Tenant ID must not be empty'
       );
     });
 

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -21,6 +21,7 @@ export type CreateManagementApiOptions = {
   /**
    * Override the base URL generated from the tenant ID.
    * Useful for testing or custom deployments.
+   * Trailing slashes are ignored.
    */
   baseUrl?: string;
   /**
@@ -28,6 +29,18 @@ export type CreateManagementApiOptions = {
    * Useful for testing or custom deployments.
    */
   apiIndicator?: string;
+  /**
+   * The maximum time in seconds allowed for fetching an access token.
+   * Non-positive and infinite values disable the timeout. `NaN` uses the default value.
+   * @default 10
+   */
+  tokenRequestTimeout?: number;
+  /**
+   * The maximum time in seconds allowed for each Management API request.
+   * Non-positive and infinite values disable the timeout. `NaN` uses the default value.
+   * @default 10
+   */
+  requestTimeout?: number;
 };
 
 /**
@@ -36,6 +49,7 @@ export type CreateManagementApiOptions = {
 export type CreateApiClientOptions = {
   /**
    * The base URL for the Management API.
+   * Trailing slashes are ignored.
    */
   baseUrl: string;
   /**
@@ -43,6 +57,12 @@ export type CreateApiClientOptions = {
    * This function will be called for each request that requires authentication.
    */
   getToken: () => Promise<string>;
+  /**
+   * The maximum time in seconds allowed for each API request.
+   * Non-positive and infinite values disable the timeout. `NaN` uses the default value.
+   * @default 10
+   */
+  requestTimeout?: number;
 };
 
 /**
@@ -66,6 +86,70 @@ export const getManagementApiIndicator = (tenantId: string) => `${getBaseUrl(ten
  */
 export const allScope = 'all';
 
+const bearerTokenPrefix = 'Bearer ';
+
+const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/+$/u, '');
+
+const isWellKnownPath = (schemaPath: string) => schemaPath.includes('/.well-known/');
+
+const getRequestTimeout = (requestTimeout?: number) => {
+  if (requestTimeout === undefined || Number.isNaN(requestTimeout)) {
+    return 10;
+  }
+
+  return Number.isFinite(requestTimeout) && requestTimeout > 0 ? requestTimeout : 0;
+};
+
+const createRequestTimeoutFetch = (requestTimeout: number) => async (request: Request) => {
+  const timeoutSignal = AbortSignal.timeout(requestTimeout * 1000);
+  const signal = AbortSignal.any([request.signal, timeoutSignal]);
+  return fetch(new Request(request, { signal }));
+};
+
+class ScopeMismatchWarner {
+  private warnedScope?: string;
+
+  private hasWarned = false;
+
+  warn(scope?: string): void {
+    if (scope === allScope || (this.hasWarned && scope === this.warnedScope)) {
+      return;
+    }
+
+    this.warnedScope = scope;
+    this.hasWarned = true;
+    console.warn(
+      `The scope "${scope}" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
+    );
+  }
+}
+
+type LowercaseHttpMethods = {
+  get: Client<paths>['GET'];
+  put: Client<paths>['PUT'];
+  post: Client<paths>['POST'];
+  delete: Client<paths>['DELETE'];
+  options: Client<paths>['OPTIONS'];
+  head: Client<paths>['HEAD'];
+  patch: Client<paths>['PATCH'];
+  trace: Client<paths>['TRACE'];
+};
+
+/** A typed Management API client with lowercase HTTP methods. */
+export type ManagementApiClient = Client<paths> & LowercaseHttpMethods;
+
+const addLowercaseHttpMethods = (client: Client<paths>): ManagementApiClient => ({
+  ...client,
+  get: client.GET,
+  put: client.PUT,
+  post: client.POST,
+  delete: client.DELETE,
+  options: client.OPTIONS,
+  head: client.HEAD,
+  patch: client.PATCH,
+  trace: client.TRACE,
+});
+
 /**
  * Creates an API client with custom token authentication.
  *
@@ -85,27 +169,31 @@ export const allScope = 'all';
  *   getToken: async () => getYourToken(),
  * });
  *
- * const response = await client.GET('/api/applications/{id}', {
+ * const response = await client.get('/api/applications/{id}', {
  *   params: { path: { id: 'app-id' } },
  * });
  * ```
  */
-export function createApiClient(options: CreateApiClientOptions): Client<paths> {
+export function createApiClient(options: CreateApiClientOptions): ManagementApiClient {
   const { baseUrl, getToken } = options;
-  const client = createClient<paths>({ baseUrl });
+  const requestTimeout = getRequestTimeout(options.requestTimeout);
+  const client = createClient<paths>({
+    baseUrl: normalizeBaseUrl(baseUrl),
+    ...(requestTimeout > 0 && { fetch: createRequestTimeoutFetch(requestTimeout) }),
+  });
 
   client.use({
     async onRequest({ schemaPath, request }) {
-      if (schemaPath.includes('/.well-known/')) {
+      if (isWellKnownPath(schemaPath)) {
         return;
       }
       const token = await getToken();
-      request.headers.set('Authorization', `Bearer ${token}`);
+      request.headers.set('Authorization', `${bearerTokenPrefix}${token}`);
       return request;
     },
   });
 
-  return client;
+  return addLowercaseHttpMethods(client);
 }
 
 type ManagementApiReturnType = {
@@ -115,7 +203,7 @@ type ManagementApiReturnType = {
    * This client is configured to use the provided client credentials
    * and will automatically include the access token in requests.
    */
-  apiClient: Client<paths>;
+  apiClient: ManagementApiClient;
   /**
    * The client credentials instance used for authentication.
    */
@@ -148,7 +236,7 @@ type ManagementApiReturnType = {
  * });
  *
  * // Use apiClient to make requests to the Management API
- * const response = await apiClient.GET('/api/users');
+ * const response = await apiClient.get('/api/users');
  * console.log(response.data);
  * ```
  *
@@ -167,8 +255,8 @@ export function createManagementApi(
   tenantId: string,
   options: CreateManagementApiOptions
 ): ManagementApiReturnType {
-  const { clientId, clientSecret } = options;
-  const baseUrl = options.baseUrl ?? getBaseUrl(tenantId);
+  const { clientId, clientSecret, tokenRequestTimeout, requestTimeout } = options;
+  const baseUrl = normalizeBaseUrl(options.baseUrl ?? getBaseUrl(tenantId));
   const apiIndicator = options.apiIndicator ?? getManagementApiIndicator(tenantId);
   const clientCredentials = new ClientCredentials({
     clientId,
@@ -178,20 +266,42 @@ export function createManagementApi(
       resource: apiIndicator,
       scope: allScope,
     },
+    tokenRequestTimeout,
   });
+  const scopeMismatchWarner = new ScopeMismatchWarner();
 
   const apiClient = createApiClient({
     baseUrl,
+    requestTimeout,
     getToken: async () => {
       const { value, scope } = await clientCredentials.getAccessToken();
 
-      if (scope !== allScope) {
-        console.warn(
-          `The scope "${scope}" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
-        );
-      }
+      scopeMismatchWarner.warn(scope);
 
       return value;
+    },
+  });
+
+  apiClient.use({
+    onResponse({ schemaPath, request, response }) {
+      if (isWellKnownPath(schemaPath)) {
+        return;
+      }
+
+      const authorization = request.headers.get('Authorization');
+
+      if (!authorization?.startsWith(bearerTokenPrefix)) {
+        return;
+      }
+
+      const accessToken = authorization.slice(bearerTokenPrefix.length);
+
+      if (response.status === 401) {
+        // Do not retry here because the request body may have been consumed.
+        clientCredentials.invalidateAccessToken(accessToken);
+      } else if (response.ok) {
+        clientCredentials.markAccessTokenAsValid(accessToken);
+      }
     },
   });
 

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -20,14 +20,12 @@ export type CreateManagementApiOptions = {
    */
   clientSecret: string;
   /**
-   * Override the base URL generated from the tenant ID.
-   * Useful for testing or custom deployments.
+   * The base URL for the Logto instance. Required when the tenant ID is omitted.
    * Trailing slashes are ignored.
    */
   baseUrl?: string;
   /**
-   * Override the API indicator for the management API.
-   * Useful for testing or custom deployments.
+   * The API indicator for the Management API. Required when the tenant ID is omitted.
    */
   apiIndicator?: string;
   /**
@@ -50,6 +48,18 @@ export type CreateManagementApiOptions = {
    */
   requestTimeout?: number;
 };
+
+/**
+ * Object options for creating a Management API client. Provide a tenant ID to derive the
+ * endpoints, or provide both endpoints directly.
+ */
+export type CreateManagementApiConfig =
+  | (CreateManagementApiOptions & { tenantId: string })
+  | (CreateManagementApiOptions & {
+      tenantId?: never;
+      baseUrl: string;
+      apiIndicator: string;
+    });
 
 /**
  * Options for creating an API client with custom token authentication.
@@ -197,8 +207,23 @@ type ManagementApiReturnType = {
   clientCredentials: ClientCredentials;
 };
 
+const resolveManagementApiArguments = (
+  tenantIdOrConfig: string | CreateManagementApiConfig,
+  options?: CreateManagementApiOptions
+) => {
+  if (typeof tenantIdOrConfig !== 'string') {
+    return { tenantId: tenantIdOrConfig.tenantId, options: tenantIdOrConfig };
+  }
+
+  if (!options) {
+    throw new TypeError('Options are required when creating a Management API client by tenant ID');
+  }
+
+  return { tenantId: tenantIdOrConfig, options };
+};
+
 /**
- * Creates a Management API client with the specified tenant ID and options.
+ * Creates a Management API client from a tenant ID or explicit endpoints.
  *
  * Before using this function, ensure that you have created a machine-to-machine application in
  * Logto and granted it access to the Management API. See the documentation for more details:
@@ -208,9 +233,9 @@ type ManagementApiReturnType = {
  * This function sets up the API client with the necessary authentication using client credentials.
  * It will automatically handle token retrieval and renewal as needed.
  *
- * @param tenantId The tenant ID for which to create the Management API client. For OSS deployments,
- * you can pass any string as the tenant ID, for example, 'default'.
- * @param options The options for creating the Management API client, including client ID and secret.
+ * @param tenantIdOrConfig A tenant ID, or object options containing a tenant ID or explicit
+ * endpoints.
+ * @param options The client options when the first argument is a tenant ID.
  * @returns An object containing the API client and client credentials instance.
  * @example
  * ```ts
@@ -230,22 +255,37 @@ type ManagementApiReturnType = {
  * @example
  * ```ts
  * // OSS example
- * const { apiClient, clientCredentials } = createManagementApi('default', {
+ * const { apiClient, clientCredentials } = createManagementApi({
  *   clientId: 'my-client-id',
  *   clientSecret: 'my-client-secret',
  *   baseUrl: 'https://my-oss-logto-instance.com',
- *   apiIndicator: 'https://default.logto.app/api',
+ *   apiIndicator: 'https://my-oss-logto-instance.com/api',
  * });
  * ```
  */
+export function createManagementApi(config: CreateManagementApiConfig): ManagementApiReturnType;
 export function createManagementApi(
   tenantId: string,
   options: CreateManagementApiOptions
+): ManagementApiReturnType;
+export function createManagementApi(
+  tenantIdOrConfig: string | CreateManagementApiConfig,
+  legacyOptions?: CreateManagementApiOptions
 ): ManagementApiReturnType {
+  const { tenantId, options } = resolveManagementApiArguments(tenantIdOrConfig, legacyOptions);
   const { clientId, clientSecret, tokenRequestTimeout, getTokenRequestSignal, requestTimeout } =
     options;
-  const baseUrl = normalizeBaseUrl(options.baseUrl ?? getBaseUrl(tenantId));
-  const apiIndicator = options.apiIndicator ?? getManagementApiIndicator(tenantId);
+  const configuredBaseUrl =
+    options.baseUrl ?? (tenantId === undefined ? undefined : getBaseUrl(tenantId));
+  const apiIndicator =
+    options.apiIndicator ??
+    (tenantId === undefined ? undefined : getManagementApiIndicator(tenantId));
+
+  if (configuredBaseUrl === undefined || apiIndicator === undefined) {
+    throw new TypeError('Provide a tenant ID or both baseUrl and apiIndicator');
+  }
+
+  const baseUrl = normalizeBaseUrl(configuredBaseUrl);
   const clientCredentials = new ClientCredentials({
     clientId,
     clientSecret,

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -25,7 +25,7 @@ export type CreateManagementApiOptions = {
    */
   baseUrl?: string;
   /**
-   * The API indicator for the Management API. Required when the tenant ID is omitted.
+   * The resource indicator for the Management API. Required when the tenant ID is omitted.
    */
   apiIndicator?: string;
   /**
@@ -50,8 +50,8 @@ export type CreateManagementApiOptions = {
 };
 
 /**
- * Object options for creating a Management API client. Provide a tenant ID to derive the
- * endpoints, or provide both endpoints directly.
+ * Object options for creating a Management API client. Provide a tenant ID to derive the defaults,
+ * or provide both the base URL and API indicator directly.
  */
 export type CreateManagementApiConfig =
   | (CreateManagementApiOptions & { tenantId: string })
@@ -208,22 +208,28 @@ type ManagementApiReturnType = {
 };
 
 const resolveManagementApiArguments = (
-  tenantIdOrConfig: string | CreateManagementApiConfig,
+  tenantIdOrConfig: string | CreateManagementApiConfig | undefined,
   options?: CreateManagementApiOptions
 ) => {
-  if (typeof tenantIdOrConfig !== 'string') {
-    return { tenantId: tenantIdOrConfig.tenantId, options: tenantIdOrConfig };
+  if (typeof tenantIdOrConfig === 'string') {
+    if (!options) {
+      throw new TypeError(
+        'Options are required when creating a Management API client by tenant ID'
+      );
+    }
+
+    return { tenantId: tenantIdOrConfig, options };
   }
 
-  if (!options) {
-    throw new TypeError('Options are required when creating a Management API client by tenant ID');
+  if (!tenantIdOrConfig) {
+    throw new TypeError('Provide a tenant ID or both baseUrl and apiIndicator');
   }
 
-  return { tenantId: tenantIdOrConfig, options };
+  return { tenantId: tenantIdOrConfig.tenantId, options: tenantIdOrConfig };
 };
 
 /**
- * Creates a Management API client from a tenant ID or explicit endpoints.
+ * Creates a Management API client from a tenant ID or an explicit base URL and API indicator.
  *
  * Before using this function, ensure that you have created a machine-to-machine application in
  * Logto and granted it access to the Management API. See the documentation for more details:
@@ -233,8 +239,8 @@ const resolveManagementApiArguments = (
  * This function sets up the API client with the necessary authentication using client credentials.
  * It will automatically handle token retrieval and renewal as needed.
  *
- * @param tenantIdOrConfig A tenant ID, or object options containing a tenant ID or explicit
- * endpoints.
+ * @param tenantIdOrConfig A tenant ID, or object options containing a tenant ID or an explicit base
+ * URL and API indicator.
  * @param options The client options when the first argument is a tenant ID.
  * @returns An object containing the API client and client credentials instance.
  * @example
@@ -242,7 +248,8 @@ const resolveManagementApiArguments = (
  * import { createManagementApi } from '@logto/api/management';
  *
  * // Logto Cloud example
- * const { apiClient, clientCredentials } = createManagementApi('my-tenant-id', {
+ * const { apiClient, clientCredentials } = createManagementApi({
+ *   tenantId: 'my-tenant-id',
  *   clientId: 'my-client-id',
  *   clientSecret: 'my-client-secret',
  * });
@@ -256,10 +263,10 @@ const resolveManagementApiArguments = (
  * ```ts
  * // OSS example
  * const { apiClient, clientCredentials } = createManagementApi({
+ *   tenantId: 'default',
  *   clientId: 'my-client-id',
  *   clientSecret: 'my-client-secret',
  *   baseUrl: 'https://my-oss-logto-instance.com',
- *   apiIndicator: 'https://my-oss-logto-instance.com/api',
  * });
  * ```
  */
@@ -269,7 +276,7 @@ export function createManagementApi(
   options: CreateManagementApiOptions
 ): ManagementApiReturnType;
 export function createManagementApi(
-  tenantIdOrConfig: string | CreateManagementApiConfig,
+  tenantIdOrConfig: string | CreateManagementApiConfig | undefined,
   options?: CreateManagementApiOptions
 ): ManagementApiReturnType {
   const { tenantId, options: resolvedOptions } = resolveManagementApiArguments(

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -2,6 +2,7 @@ import createClient, { type Client } from 'openapi-fetch';
 
 import { ClientCredentials } from './client-credentials.js';
 import { type paths } from './generated-types/management.js';
+import { normalizeTimeout, toTimeoutMilliseconds } from './timeout.js';
 
 /**
  * Options for creating a Management API client.
@@ -36,7 +37,14 @@ export type CreateManagementApiOptions = {
    */
   tokenRequestTimeout?: number;
   /**
-   * The maximum time in seconds allowed for each Management API request.
+   * Returns an optional signal for each token request. The factory is called once per actual token
+   * fetch, so concurrent callers sharing a fetch also share its signal. The signal is composed with
+   * `tokenRequestTimeout`, and the first signal to abort cancels the request.
+   */
+  getTokenRequestSignal?: () => AbortSignal | undefined;
+  /**
+   * The maximum time in seconds allowed for the Management API network request after token
+   * retrieval. It is composed with per-request signals, and a timeout rejects the API call.
    * Non-positive and infinite values disable the timeout. `NaN` uses the default value.
    * @default 10
    */
@@ -58,7 +66,8 @@ export type CreateApiClientOptions = {
    */
   getToken: () => Promise<string>;
   /**
-   * The maximum time in seconds allowed for each API request.
+   * The maximum time in seconds allowed for the API network request after `getToken()` resolves.
+   * It is composed with per-request signals, and a timeout rejects the API call.
    * Non-positive and infinite values disable the timeout. `NaN` uses the default value.
    * @default 10
    */
@@ -92,32 +101,24 @@ const normalizeBaseUrl = (baseUrl: string) => baseUrl.replace(/\/+$/u, '');
 
 const isWellKnownPath = (schemaPath: string) => schemaPath.includes('/.well-known/');
 
-const getRequestTimeout = (requestTimeout?: number) => {
-  if (requestTimeout === undefined || Number.isNaN(requestTimeout)) {
-    return 10;
-  }
-
-  return Number.isFinite(requestTimeout) && requestTimeout > 0 ? requestTimeout : 0;
-};
-
-const createRequestTimeoutFetch = (requestTimeout: number) => async (request: Request) => {
-  const timeoutSignal = AbortSignal.timeout(requestTimeout * 1000);
-  const signal = AbortSignal.any([request.signal, timeoutSignal]);
-  return fetch(new Request(request, { signal }));
-};
+const createRequestTimeoutFetch =
+  (requestTimeout: number) => async (request: Request, requestInit?: RequestInit) => {
+    const signal = AbortSignal.any([
+      request.signal,
+      AbortSignal.timeout(toTimeoutMilliseconds(requestTimeout)),
+    ]);
+    return fetch(new Request(request, { signal }), { ...requestInit, signal });
+  };
 
 class ScopeMismatchWarner {
-  private warnedScope?: string;
-
-  private hasWarned = false;
+  private readonly warnedScopes = new Set<string | undefined>();
 
   warn(scope?: string): void {
-    if (scope === allScope || (this.hasWarned && scope === this.warnedScope)) {
+    if (scope === allScope || this.warnedScopes.has(scope)) {
       return;
     }
 
-    this.warnedScope = scope;
-    this.hasWarned = true;
+    this.warnedScopes.add(scope);
     console.warn(
       `The scope "${scope}" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
     );
@@ -176,7 +177,7 @@ const addLowercaseHttpMethods = (client: Client<paths>): ManagementApiClient => 
  */
 export function createApiClient(options: CreateApiClientOptions): ManagementApiClient {
   const { baseUrl, getToken } = options;
-  const requestTimeout = getRequestTimeout(options.requestTimeout);
+  const requestTimeout = normalizeTimeout(options.requestTimeout);
   const client = createClient<paths>({
     baseUrl: normalizeBaseUrl(baseUrl),
     ...(requestTimeout > 0 && { fetch: createRequestTimeoutFetch(requestTimeout) }),
@@ -255,7 +256,8 @@ export function createManagementApi(
   tenantId: string,
   options: CreateManagementApiOptions
 ): ManagementApiReturnType {
-  const { clientId, clientSecret, tokenRequestTimeout, requestTimeout } = options;
+  const { clientId, clientSecret, tokenRequestTimeout, getTokenRequestSignal, requestTimeout } =
+    options;
   const baseUrl = normalizeBaseUrl(options.baseUrl ?? getBaseUrl(tenantId));
   const apiIndicator = options.apiIndicator ?? getManagementApiIndicator(tenantId);
   const clientCredentials = new ClientCredentials({
@@ -267,6 +269,7 @@ export function createManagementApi(
       scope: allScope,
     },
     tokenRequestTimeout,
+    getTokenRequestSignal,
   });
   const scopeMismatchWarner = new ScopeMismatchWarner();
 

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -107,23 +107,8 @@ const createRequestTimeoutFetch =
       request.signal,
       AbortSignal.timeout(toTimeoutMilliseconds(requestTimeout)),
     ]);
-    return fetch(new Request(request, { signal }), { ...requestInit, signal });
+    return fetch(request, { ...requestInit, signal });
   };
-
-class ScopeMismatchWarner {
-  private readonly warnedScopes = new Set<string | undefined>();
-
-  warn(scope?: string): void {
-    if (scope === allScope || this.warnedScopes.has(scope)) {
-      return;
-    }
-
-    this.warnedScopes.add(scope);
-    console.warn(
-      `The scope "${scope}" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
-    );
-  }
-}
 
 type LowercaseHttpMethods = {
   get: Client<paths>['GET'];
@@ -139,17 +124,18 @@ type LowercaseHttpMethods = {
 /** A typed Management API client with lowercase HTTP methods. */
 export type ManagementApiClient = Client<paths> & LowercaseHttpMethods;
 
-const addLowercaseHttpMethods = (client: Client<paths>): ManagementApiClient => ({
-  ...client,
-  get: client.GET,
-  put: client.PUT,
-  post: client.POST,
-  delete: client.DELETE,
-  options: client.OPTIONS,
-  head: client.HEAD,
-  patch: client.PATCH,
-  trace: client.TRACE,
-});
+const addLowercaseHttpMethods = (client: Client<paths>): ManagementApiClient =>
+  // eslint-disable-next-line @silverhand/fp/no-mutating-assign -- Keep the original client identity while adding lowercase aliases.
+  Object.assign(client, {
+    get: client.GET,
+    put: client.PUT,
+    post: client.POST,
+    delete: client.DELETE,
+    options: client.OPTIONS,
+    head: client.HEAD,
+    patch: client.PATCH,
+    trace: client.TRACE,
+  });
 
 /**
  * Creates an API client with custom token authentication.
@@ -271,7 +257,7 @@ export function createManagementApi(
     tokenRequestTimeout,
     getTokenRequestSignal,
   });
-  const scopeMismatchWarner = new ScopeMismatchWarner();
+  const warnedScopes = new Set<string | undefined>();
 
   const apiClient = createApiClient({
     baseUrl,
@@ -279,7 +265,12 @@ export function createManagementApi(
     getToken: async () => {
       const { value, scope } = await clientCredentials.getAccessToken();
 
-      scopeMismatchWarner.warn(scope);
+      if (scope !== allScope && !warnedScopes.has(scope)) {
+        warnedScopes.add(scope);
+        console.warn(
+          `The scope "${scope}" is not equal to the expected value "${allScope}". This may cause issues with API access. See https://a.logto.io/m2m-mapi to learn more about configuring machine-to-machine access to the Management API.`
+        );
+      }
 
       return value;
     },

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -283,6 +283,11 @@ export function createManagementApi(
     tenantIdOrConfig,
     options
   );
+
+  if (tenantId !== undefined && tenantId.trim().length === 0) {
+    throw new TypeError('Tenant ID must not be empty');
+  }
+
   const { clientId, clientSecret, tokenRequestTimeout, getTokenRequestSignal, requestTimeout } =
     resolvedOptions;
   const configuredBaseUrl =

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -270,15 +270,18 @@ export function createManagementApi(
 ): ManagementApiReturnType;
 export function createManagementApi(
   tenantIdOrConfig: string | CreateManagementApiConfig,
-  legacyOptions?: CreateManagementApiOptions
+  options?: CreateManagementApiOptions
 ): ManagementApiReturnType {
-  const { tenantId, options } = resolveManagementApiArguments(tenantIdOrConfig, legacyOptions);
+  const { tenantId, options: resolvedOptions } = resolveManagementApiArguments(
+    tenantIdOrConfig,
+    options
+  );
   const { clientId, clientSecret, tokenRequestTimeout, getTokenRequestSignal, requestTimeout } =
-    options;
+    resolvedOptions;
   const configuredBaseUrl =
-    options.baseUrl ?? (tenantId === undefined ? undefined : getBaseUrl(tenantId));
+    resolvedOptions.baseUrl ?? (tenantId === undefined ? undefined : getBaseUrl(tenantId));
   const apiIndicator =
-    options.apiIndicator ??
+    resolvedOptions.apiIndicator ??
     (tenantId === undefined ? undefined : getManagementApiIndicator(tenantId));
 
   if (configuredBaseUrl === undefined || apiIndicator === undefined) {

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -348,7 +348,7 @@ export function createManagementApi(
       if (response.status === 401) {
         // Do not retry here because the request body may have been consumed.
         clientCredentials.invalidateAccessToken(accessToken);
-      } else if (response.ok) {
+      } else {
         clientCredentials.markAccessTokenAsValid(accessToken);
       }
     },

--- a/packages/api/src/timeout.test.ts
+++ b/packages/api/src/timeout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeTimeout, toTimeoutMilliseconds } from './timeout.js';
+
+describe('timeout helpers', () => {
+  it.each([
+    [undefined, 10],
+    [Number.NaN, 10],
+    [20, 20],
+    [0, 0],
+    [-1, 0],
+    [Number.POSITIVE_INFINITY, 0],
+  ])('should normalize %s seconds to %s', (timeout, expected) => {
+    expect(normalizeTimeout(timeout)).toBe(expected);
+  });
+
+  it.each([
+    [10, 10_000],
+    [0.0005, 1],
+    [Number.MAX_VALUE, 2_147_483_647],
+  ])('should convert %s seconds to %s milliseconds', (timeout, expected) => {
+    expect(toTimeoutMilliseconds(timeout)).toBe(expected);
+  });
+});

--- a/packages/api/src/timeout.ts
+++ b/packages/api/src/timeout.ts
@@ -1,0 +1,38 @@
+const defaultTimeout = 10;
+
+// Browsers and Node.js reliably support timer delays up to a signed 32-bit integer.
+const maximumTimeoutMilliseconds = 2_147_483_647;
+
+export const normalizeTimeout = (timeout?: number): number => {
+  if (timeout === undefined || Number.isNaN(timeout)) {
+    return defaultTimeout;
+  }
+
+  return Number.isFinite(timeout) && timeout > 0 ? timeout : 0;
+};
+
+export const getAbortReason = (signal: AbortSignal, fallbackMessage: string): Error => {
+  // eslint-disable-next-line prefer-destructuring -- Keep the DOM's any-typed reason narrowed to unknown.
+  const reason: unknown = signal.reason;
+  return reason instanceof Error ? reason : new Error(fallbackMessage, { cause: reason });
+};
+
+export const toTimeoutMilliseconds = (timeout: number) =>
+  Math.min(Math.max(Math.ceil(timeout * 1000), 1), maximumTimeoutMilliseconds);
+
+export const createTimeoutSignal = (timeout: number, message: string) => {
+  const controller = new AbortController();
+  const timer =
+    timeout > 0
+      ? setTimeout(() => {
+          controller.abort(new DOMException(message, 'TimeoutError'));
+        }, toTimeoutMilliseconds(timeout))
+      : undefined;
+
+  return {
+    signal: controller.signal,
+    clear: () => {
+      clearTimeout(timer);
+    },
+  };
+};


### PR DESCRIPTION
## Summary

Improves the API SDK's reliability and ergonomics for Management API calls.

- adds configurable 10-second defaults for token fetches and API requests, supports custom token abort signals, rejects token redirects, and shares concurrent token fetches
- invalidates a rejected cached token once while avoiding repeated token fetches for permanent `401` responses
- normalizes trailing slashes in custom base URLs, supports object-style client configuration, and exposes lowercase HTTP method aliases while preserving uppercase methods
- deduplicates scope mismatch warnings by scope and preserves token request error causes

## Testing

- Unit tests
- Integration tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
