### PR TITLE
feat(api): add Management API pagination iterator

### DIFF
--- a/.changeset/calm-ravens-paginate.md
+++ b/.changeset/calm-ravens-paginate.md
@@ -1,0 +1,5 @@
+---
+"@logto/api": minor
+---
+
+add a typed async iterator for paginated Management API endpoints

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -41,6 +41,26 @@ console.log(response.data);
 
 The positional `createManagementApi(tenantId, options)` form remains supported.
 
+#### Pagination
+
+Use `paginate()` to iterate over items from a paginated `GET` endpoint. The path, query parameters,
+path parameters, headers, and signal use the same generated types as `get()`.
+
+```ts
+for await (const user of apiClient.paginate('/api/users')) {
+  console.log(user);
+}
+```
+
+The iterator follows the Management API pagination headers and stops when there are no more items.
+It requests 100 items per page unless `page_size` is provided. When an audit log endpoint reports a
+capped total, the iterator continues until it receives an empty page because the final page is
+unknown. Breaking out of the loop stops further requests.
+
+API error responses throw `ManagementApiPaginationError`, which exposes `status`, response metadata
+and headers through `response`, and the parsed API error body as `cause`. The response body has
+already been read. Network, timeout, and abort errors propagate unchanged.
+
 #### Self-hosted / OSS
 
 ```ts

--- a/packages/api/src/api-client.test.ts
+++ b/packages/api/src/api-client.test.ts
@@ -119,6 +119,15 @@ describe('createApiClient', () => {
     expect(client[lowercaseMethod]).toBe(mockApiClient[uppercaseMethod]);
   });
 
+  it('should expose the pagination helper', () => {
+    const client = createApiClient({
+      baseUrl: 'https://test.logto.app',
+      getToken: async () => 'test-token',
+    });
+
+    expect(client.paginate).toBeTypeOf('function');
+  });
+
   it('should configure middleware correctly', async () => {
     const getToken = vi.fn().mockResolvedValue('test-token');
 

--- a/packages/api/src/management.integration.test.ts
+++ b/packages/api/src/management.integration.test.ts
@@ -3,10 +3,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createManagementApi } from './management.js';
 import { getAbortReason } from './timeout.js';
 
-const jsonResponse = (body: unknown, status = 200) =>
+const jsonResponse = (body: unknown, status = 200, headers?: Record<string, string>) =>
   new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
   });
 
 describe('Management API token recovery', () => {
@@ -180,5 +180,57 @@ describe('Management API token recovery', () => {
     expect(timeout).toHaveBeenCalledWith(20_000);
     timeoutController.abort(timeoutError);
     await rejection;
+  });
+
+  it('should authenticate every paginated Management API request', async () => {
+    const mockFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ access_token: 'test-token', expires_in: 3600, scope: 'all' })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([{ id: 'user-1' }], 200, {
+          Link: '<https://test-tenant.logto.app/api/users?page=2&page_size=1>; rel="next"',
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse([{ id: 'user-2' }]));
+    vi.stubGlobal('fetch', mockFetch);
+    const { apiClient } = createManagementApi('test-tenant', {
+      clientId: 'test-client-id',
+      clientSecret: 'test-client-secret',
+    });
+
+    const iterator = apiClient.paginate(
+      '/api/users' as never,
+      {
+        params: { query: { page_size: 1 } },
+      } as never
+    );
+
+    await expect(iterator.next()).resolves.toMatchObject({ done: false, value: { id: 'user-1' } });
+    await expect(iterator.next()).resolves.toMatchObject({ done: false, value: { id: 'user-2' } });
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    const firstRequest = mockFetch.mock.calls[1]?.[0];
+    const secondRequest = mockFetch.mock.calls[2]?.[0];
+
+    expect(firstRequest).toBeInstanceOf(Request);
+    expect(secondRequest).toBeInstanceOf(Request);
+
+    if (!(firstRequest instanceof Request) || !(secondRequest instanceof Request)) {
+      throw new TypeError('Expected paginated Management API requests');
+    }
+
+    expect(firstRequest.headers.get('Authorization')).toBe('Bearer test-token');
+    expect(secondRequest.headers.get('Authorization')).toBe('Bearer test-token');
+    expect(Object.fromEntries(new URL(firstRequest.url).searchParams)).toEqual({
+      page: '1',
+      page_size: '1',
+    });
+    expect(Object.fromEntries(new URL(secondRequest.url).searchParams)).toEqual({
+      page: '2',
+      page_size: '1',
+    });
   });
 });

--- a/packages/api/src/management.ts
+++ b/packages/api/src/management.ts
@@ -2,7 +2,10 @@ import createClient, { type Client } from 'openapi-fetch';
 
 import { ClientCredentials } from './client-credentials.js';
 import { type paths } from './generated-types/management.js';
+import { createPaginate, type PaginateMethod } from './pagination.js';
 import { normalizeTimeout, toTimeoutMilliseconds } from './timeout.js';
+
+export { ManagementApiPaginationError } from './pagination.js';
 
 /**
  * Options for creating a Management API client.
@@ -131,11 +134,15 @@ type LowercaseHttpMethods = {
   trace: Client<paths>['TRACE'];
 };
 
-/** A typed Management API client with lowercase HTTP methods. */
-export type ManagementApiClient = Client<paths> & LowercaseHttpMethods;
+type PaginationMethod = {
+  paginate: PaginateMethod<paths>;
+};
 
-const addLowercaseHttpMethods = (client: Client<paths>): ManagementApiClient =>
-  // eslint-disable-next-line @silverhand/fp/no-mutating-assign -- Keep the original client identity while adding lowercase aliases.
+/** A typed Management API client with lowercase HTTP methods and pagination support. */
+export type ManagementApiClient = Client<paths> & LowercaseHttpMethods & PaginationMethod;
+
+const addClientMethods = (client: Client<paths>): ManagementApiClient =>
+  // eslint-disable-next-line @silverhand/fp/no-mutating-assign -- Keep the original client identity while adding convenience methods.
   Object.assign(client, {
     get: client.GET,
     put: client.PUT,
@@ -145,6 +152,7 @@ const addLowercaseHttpMethods = (client: Client<paths>): ManagementApiClient =>
     head: client.HEAD,
     patch: client.PATCH,
     trace: client.TRACE,
+    paginate: createPaginate(client.GET),
   });
 
 /**
@@ -190,7 +198,7 @@ export function createApiClient(options: CreateApiClientOptions): ManagementApiC
     },
   });
 
-  return addLowercaseHttpMethods(client);
+  return addClientMethods(client);
 }
 
 type ManagementApiReturnType = {

--- a/packages/api/src/pagination.test.ts
+++ b/packages/api/src/pagination.test.ts
@@ -1,0 +1,304 @@
+import type { Client } from 'openapi-fetch';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+
+import { createPaginate, ManagementApiPaginationError } from './pagination.js';
+
+type User = {
+  id: string;
+};
+
+type TestPaths = {
+  '/api/users': {
+    get: {
+      parameters: {
+        query?: {
+          page?: number;
+          page_size?: number;
+          search?: string;
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            'application/json': User[];
+          };
+        };
+      };
+    };
+  };
+  '/api/organizations/{id}/users': {
+    get: {
+      parameters: {
+        path: {
+          id: string;
+        };
+        query?: {
+          page?: number;
+          page_size?: number;
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            'application/json': User[];
+          };
+        };
+      };
+    };
+  };
+  '/api/status': {
+    get: {
+      parameters: {
+        query?: {
+          page?: number;
+          page_size?: number;
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            'application/json': { status: string };
+          };
+        };
+      };
+    };
+  };
+  '/api/unpaginated-users': {
+    get: {
+      responses: {
+        200: {
+          content: {
+            'application/json': User[];
+          };
+        };
+      };
+    };
+  };
+};
+
+const createResponse = (headers?: HeadersInit, status = 200) =>
+  new Response(null, { headers, status });
+
+const collect = async <Item>(iterator: AsyncGenerator<Item, void, undefined>) => {
+  const collectRemaining = async (items: Item[]): Promise<Item[]> => {
+    const result = await iterator.next();
+
+    return result.done ? items : collectRemaining([...items, result.value]);
+  };
+
+  return collectRemaining([]);
+};
+
+describe('createPaginate', () => {
+  it('should infer the item type and only accept paginated array endpoints', () => {
+    const get = vi.fn();
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    expectTypeOf(paginate('/api/users')).toEqualTypeOf<AsyncGenerator<User, void, undefined>>();
+    expectTypeOf<Parameters<typeof paginate>[0]>().toEqualTypeOf<
+      '/api/users' | '/api/organizations/{id}/users'
+    >();
+
+    const assertInvalidCalls = () => {
+      // @ts-expect-error -- A paginated endpoint with a non-array response is excluded.
+      paginate('/api/status');
+      // @ts-expect-error -- An array endpoint without page parameters is excluded.
+      paginate('/api/unpaginated-users');
+      // @ts-expect-error -- Parsing as another body type would invalidate the yielded item type.
+      paginate('/api/users', { parseAs: 'stream' });
+      // @ts-expect-error -- Unknown top-level request options should not be silently accepted.
+      paginate('/api/users', { signl: new AbortController().signal });
+    };
+
+    expectTypeOf(assertInvalidCalls).toBeFunction();
+  });
+
+  it('should preserve request options and follow next links', async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ id: 'user-1' }, { id: 'user-2' }],
+        response: createResponse({
+          Link: [
+            '<https://example.com/api/users?page=1&page_size=2>; rel="first"',
+            '<https://example.com/api/users?page=1&page_size=2>; rel="prev"',
+            '<https://example.com/api/users?page=3&page_size=2>; rel="last"',
+            '<https://example.com/api/users?page=3&page_size=2>; rel="next"',
+          ].join(', '),
+        }),
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'user-3' }],
+        response: createResponse({
+          Link: [
+            '<https://example.com/api/users?page=1&page_size=2>; rel="first"',
+            '<https://example.com/api/users?page=2&page_size=2>; rel="prev"',
+            '<https://example.com/api/users?page=3&page_size=2>; rel="last"',
+          ].join(', '),
+        }),
+      });
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+    const { signal } = new AbortController();
+
+    const users = await collect(
+      paginate('/api/users', {
+        params: { query: { page: 2, page_size: 2, search: 'alice' } },
+        headers: { 'X-Test': 'value' },
+        signal,
+      })
+    );
+
+    expect(users).toEqual([{ id: 'user-1' }, { id: 'user-2' }, { id: 'user-3' }]);
+    expect(get).toHaveBeenNthCalledWith(1, '/api/users', {
+      params: { query: { page: 2, page_size: 2, search: 'alice' } },
+      headers: { 'X-Test': 'value' },
+      signal,
+    });
+    expect(get).toHaveBeenNthCalledWith(2, '/api/users', {
+      params: { query: { page: 3, page_size: 2, search: 'alice' } },
+      headers: { 'X-Test': 'value' },
+      signal,
+    });
+  });
+
+  it('should use a page size of 100 by default', async () => {
+    const get = vi.fn().mockResolvedValue({ data: [], response: createResponse() });
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    await collect(paginate('/api/users'));
+
+    expect(get).toHaveBeenCalledWith('/api/users', {
+      params: { query: { page: 1, page_size: 100 } },
+    });
+  });
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    0,
+    -1,
+    1.5,
+    Number.MAX_SAFE_INTEGER + 1,
+  ])('should reject invalid starting page %s', (page) => {
+    const get = vi.fn();
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    expect(() => paginate('/api/users', { params: { query: { page } } })).toThrowError(
+      new RangeError('The page parameter must be a positive safe integer')
+    );
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('should continue capped pagination until an empty page', async () => {
+    const cappedHeaders = { 'Total-Number-Is-Capped': 'true' };
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [{ id: 'user-21' }],
+        response: createResponse(cappedHeaders),
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'user-22' }],
+        response: createResponse(cappedHeaders),
+      })
+      .mockResolvedValueOnce({
+        data: [],
+        response: createResponse(cappedHeaders),
+      });
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    const users = await collect(
+      paginate('/api/users', { params: { query: { page: 21, page_size: 1 } } })
+    );
+
+    expect(users).toEqual([{ id: 'user-21' }, { id: 'user-22' }]);
+    expect(get.mock.calls.map(([, options]) => options.params.query.page)).toEqual([21, 22, 23]);
+  });
+
+  it('should preserve required path parameters', async () => {
+    const get = vi.fn().mockResolvedValue({ data: [], response: createResponse() });
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    await collect(
+      paginate('/api/organizations/{id}/users', {
+        params: { path: { id: 'organization-id' } },
+      })
+    );
+
+    expect(get).toHaveBeenCalledWith('/api/organizations/{id}/users', {
+      params: {
+        path: { id: 'organization-id' },
+        query: { page: 1, page_size: 100 },
+      },
+    });
+  });
+
+  it('should throw a structured pagination error for API error responses', async () => {
+    const apiError = { code: 'auth.unauthorized' };
+    const response = createResponse(undefined, 401);
+    const get = vi.fn().mockResolvedValue({
+      error: apiError,
+      response,
+    });
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    try {
+      await collect(paginate('/api/users'));
+      throw new Error('Expected pagination to reject');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(ManagementApiPaginationError);
+      expect(error).toMatchObject({
+        name: 'ManagementApiPaginationError',
+        message: 'Management API pagination request failed with status 401',
+        cause: apiError,
+        response,
+        status: 401,
+      });
+    }
+  });
+
+  it('should expose the response when an API error has no body', async () => {
+    const response = createResponse(undefined, 500);
+    const get = vi.fn().mockResolvedValue({ error: undefined, response });
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    try {
+      await collect(paginate('/api/users'));
+      throw new Error('Expected pagination to reject');
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(ManagementApiPaginationError);
+      expect(error).toMatchObject({ cause: undefined, response, status: 500 });
+    }
+  });
+
+  it('should reject parseAs at runtime', () => {
+    const get = vi.fn();
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    expect(() => paginate('/api/users', { parseAs: 'stream' } as never)).toThrow(
+      'The paginate method only supports JSON array responses'
+    );
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('should propagate request failures unchanged', async () => {
+    const abortError = new DOMException('Request aborted', 'AbortError');
+    const get = vi.fn().mockRejectedValue(abortError);
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    await expect(collect(paginate('/api/users'))).rejects.toBe(abortError);
+  });
+
+  it('should reject a response that does not contain an array', async () => {
+    const get = vi.fn().mockResolvedValue({
+      data: { id: 'user-1' },
+      response: createResponse(),
+    });
+    const paginate = createPaginate<TestPaths>(get as Client<TestPaths>['GET']);
+
+    await expect(collect(paginate('/api/users'))).rejects.toThrow(
+      'Expected a paginated Management API response to contain an array'
+    );
+  });
+});

--- a/packages/api/src/pagination.ts
+++ b/packages/api/src/pagination.ts
@@ -1,0 +1,183 @@
+import type {
+  Client,
+  ClientPathsWithMethod,
+  MaybeOptionalInit,
+  MethodResponse,
+} from 'openapi-fetch';
+
+type GetOperation<
+  Paths extends NonNullable<unknown>,
+  Path extends keyof Paths,
+> = Paths[Path] extends {
+  get: infer Operation;
+}
+  ? Operation
+  : never;
+
+type OperationQuery<Operation> = Operation extends {
+  parameters: { query?: infer Query };
+}
+  ? NonNullable<Query>
+  : never;
+
+type SupportsPagination<Operation> = [OperationQuery<Operation>] extends [never]
+  ? false
+  : 'page' extends keyof OperationQuery<Operation>
+    ? 'page_size' extends keyof OperationQuery<Operation>
+      ? true
+      : false
+    : false;
+
+type GetPath<Paths extends NonNullable<unknown>> = ClientPathsWithMethod<Client<Paths>, 'get'>;
+
+type PaginatedGetPath<Paths extends NonNullable<unknown>> = {
+  [Path in GetPath<Paths>]: SupportsPagination<GetOperation<Paths, Path>> extends true
+    ? MethodResponse<Client<Paths>, 'get', Path> extends readonly unknown[]
+      ? Path
+      : never
+    : never;
+}[GetPath<Paths>];
+
+type PaginationItem<Paths extends NonNullable<unknown>, Path extends PaginatedGetPath<Paths>> =
+  MethodResponse<Client<Paths>, 'get', Path> extends ReadonlyArray<infer Item> ? Item : never;
+
+type GetInit<
+  Paths extends NonNullable<unknown>,
+  Path extends PaginatedGetPath<Paths>,
+> = MaybeOptionalInit<{ get: GetOperation<Paths, Path> }, 'get'>;
+
+type PaginationOptions<
+  Paths extends NonNullable<unknown>,
+  Path extends PaginatedGetPath<Paths>,
+> = Omit<NonNullable<GetInit<Paths, Path>>, 'parseAs'> & { parseAs?: never };
+
+type PaginationInit<Paths extends NonNullable<unknown>, Path extends PaginatedGetPath<Paths>> =
+  undefined extends GetInit<Paths, Path>
+    ? [PaginationOptions<Paths, Path>?]
+    : [PaginationOptions<Paths, Path>];
+
+/** Iterates over items returned by a paginated Management API GET endpoint. */
+export type PaginateMethod<Paths extends NonNullable<unknown>> = <
+  Path extends PaginatedGetPath<Paths>,
+>(
+  path: Path,
+  ...init: PaginationInit<Paths, Path>
+) => AsyncGenerator<PaginationItem<Paths, Path>, void, undefined>;
+
+type RuntimePaginationOptions = {
+  [key: string]: unknown;
+  params?: {
+    [key: string]: unknown;
+    query?: Record<string, unknown>;
+  };
+  parseAs?: unknown;
+};
+
+type RuntimePageResult = {
+  data?: unknown;
+  error?: unknown;
+  response: Response;
+};
+
+type RuntimeGet = (path: string, options: RuntimePaginationOptions) => Promise<RuntimePageResult>;
+
+const defaultPageSize = 100;
+
+const hasNextLink = (headers: Headers) =>
+  headers
+    .get('Link')
+    ?.split(',')
+    .some((link) => /;\s*rel=(?:"next"|next)(?:\s*;|\s*$)/iu.test(link.trim())) ?? false;
+
+const isTotalNumberCapped = (headers: Headers) =>
+  headers.get('Total-Number-Is-Capped')?.toLowerCase() === 'true';
+
+/** An error response returned while iterating over a paginated Management API endpoint. */
+export class ManagementApiPaginationError extends Error {
+  /**
+   * The error response metadata and headers. Its body has already been read by openapi-fetch; the
+   * parsed error body is available as `cause`.
+   */
+  readonly response: Response;
+
+  readonly status: number;
+
+  constructor(response: Response, options?: ErrorOptions) {
+    super(`Management API pagination request failed with status ${response.status}`, options);
+    this.name = 'ManagementApiPaginationError';
+    this.response = response;
+    this.status = response.status;
+  }
+}
+
+/** Creates a typed pagination method backed by an openapi-fetch GET method. */
+export const createPaginate = <Paths extends NonNullable<unknown>>(
+  get: Client<Paths>['GET']
+): PaginateMethod<Paths> => {
+  // eslint-disable-next-line no-restricted-syntax -- The runtime adapter narrows openapi-fetch's generic GET method after the public type validates the path and options.
+  const getPage = get as RuntimeGet;
+
+  const paginate = (
+    path: string,
+    options: RuntimePaginationOptions = {}
+  ): AsyncGenerator<unknown, void, undefined> => {
+    const { params = {}, parseAs, ...requestOptions } = options;
+
+    if (parseAs !== undefined) {
+      throw new TypeError('The paginate method only supports JSON array responses');
+    }
+
+    const query = params.query ?? {};
+    const firstPage = query.page === undefined ? 1 : query.page;
+
+    if (typeof firstPage !== 'number' || !Number.isSafeInteger(firstPage) || firstPage < 1) {
+      throw new RangeError('The page parameter must be a positive safe integer');
+    }
+
+    const pageSize = query.page_size ?? defaultPageSize;
+
+    const iterate = async function* (): AsyncGenerator<unknown, void, undefined> {
+      /* eslint-disable-next-line @silverhand/fp/no-let, @silverhand/fp/no-mutation -- Pagination advances one page at a time without retaining prior page responses. */
+      for (let page = firstPage; page <= Number.MAX_SAFE_INTEGER; page += 1) {
+        // eslint-disable-next-line no-await-in-loop -- Each request depends on the previous response's pagination headers.
+        const result = await getPage(path, {
+          ...requestOptions,
+          params: {
+            ...params,
+            query: {
+              ...query,
+              page,
+              page_size: pageSize,
+            },
+          },
+        });
+
+        if ('error' in result) {
+          throw new ManagementApiPaginationError(result.response, { cause: result.error });
+        }
+
+        if (!Array.isArray(result.data)) {
+          throw new TypeError('Expected a paginated Management API response to contain an array');
+        }
+
+        if (result.data.length === 0) {
+          return;
+        }
+
+        yield* result.data;
+
+        if (
+          !isTotalNumberCapped(result.response.headers) &&
+          !hasNextLink(result.response.headers)
+        ) {
+          return;
+        }
+      }
+    };
+
+    return iterate();
+  };
+
+  // eslint-disable-next-line no-restricted-syntax -- The public generic type adds generated path and item types to the runtime iterator.
+  return paginate as PaginateMethod<Paths>;
+};


### PR DESCRIPTION
## Summary

Adds a typed async iterator for consuming paginated Management API endpoints.

- limits `paginate()` to GET endpoints with `page`, `page_size`, and array responses
- preserves typed request options, follows pagination headers, and streams one page at a time
- defaults to 100 items per page and handles capped totals by continuing until an empty page
- exposes structured API response errors while preserving timeout, abort, and network errors

## Testing

- Unit tests
- Integration tests

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
