### PR TITLE
feat(core): propagate authentication context into access tokens

### DIFF
--- a/packages/core/src/oidc/authentication-context-claims.test.ts
+++ b/packages/core/src/oidc/authentication-context-claims.test.ts
@@ -1,0 +1,167 @@
+import { GrantType } from '@logto/schemas';
+import { type AuthorizationCode, type Client } from 'oidc-provider';
+
+import { EnvSet } from '#src/env-set/index.js';
+import { createOidcContext } from '#src/test-utils/oidc-provider.js';
+
+import { getExtraTokenClaimsForAuthenticationContext } from './authentication-context-claims.js';
+
+type AuthenticationContext = Pick<AuthorizationCode, 'acr' | 'amr' | 'authTime'>;
+
+const { provider } = createOidcContext().oidc;
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- token constructors only read the client identifier in these tests
+const client = { clientId: 'client-id' } as Client;
+const tokenProperties = {
+  client,
+  accountId: 'account-id',
+  scope: 'openid',
+  grantId: 'grant-id',
+  gty: GrantType.AuthorizationCode,
+};
+const codeContext = {
+  acr: 'urn:logto:acr:1fa',
+  amr: ['pwd'],
+  authTime: 1000,
+};
+const refreshContext = {
+  acr: 'urn:logto:acr:mfa',
+  amr: ['pwd', 'otp', 'mfa'],
+  authTime: 2000,
+};
+
+const buildContext = (
+  grantType: string | undefined,
+  {
+    authorizationCode,
+    refreshToken,
+  }: { authorizationCode?: AuthenticationContext; refreshToken?: AuthenticationContext } = {}
+) => {
+  const session = new provider.Session();
+  session.loginAccount({
+    accountId: tokenProperties.accountId,
+    acr: 'session-acr',
+    amr: ['session-amr'],
+    loginTs: 3000,
+  });
+
+  return createOidcContext({
+    provider,
+    client,
+    session,
+    acr: 'request-acr',
+    amr: ['request-amr'],
+    params: { grant_type: grantType, acr_values: 'requested-acr' },
+    entities: {
+      ...(authorizationCode && {
+        AuthorizationCode: new provider.AuthorizationCode({
+          ...tokenProperties,
+          ...authorizationCode,
+        }),
+      }),
+      ...(refreshToken && {
+        RefreshToken: new provider.RefreshToken({ ...tokenProperties, ...refreshToken }),
+      }),
+    },
+  });
+};
+
+const createAccessToken = () =>
+  new provider.AccessToken({
+    ...tokenProperties,
+    extra: { acr: 'previous-acr', amr: ['previous-amr'], auth_time: 4000 },
+  });
+
+describe('getExtraTokenClaimsForAuthenticationContext', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+
+  beforeEach(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+  });
+
+  afterEach(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+  });
+
+  it.each([
+    [GrantType.AuthorizationCode, codeContext],
+    [GrantType.RefreshToken, refreshContext],
+  ])('should use the %s source when both grant entities are present', (grantType, source) => {
+    const ctx = buildContext(grantType, {
+      authorizationCode: codeContext,
+      refreshToken: refreshContext,
+    });
+
+    expect(getExtraTokenClaimsForAuthenticationContext(ctx, createAccessToken())).toEqual({
+      acr: source.acr,
+      amr: source.amr,
+      auth_time: source.authTime,
+    });
+  });
+
+  describe.each([GrantType.AuthorizationCode, GrantType.RefreshToken])('%s', (grantType) => {
+    const buildSourceContext = (source: AuthenticationContext) =>
+      buildContext(grantType, {
+        [grantType === GrantType.AuthorizationCode ? 'authorizationCode' : 'refreshToken']: source,
+      });
+
+    it.each([
+      { source: { acr: codeContext.acr }, expected: { acr: codeContext.acr } },
+      { source: { amr: codeContext.amr }, expected: { amr: codeContext.amr } },
+      { source: { authTime: codeContext.authTime }, expected: { auth_time: codeContext.authTime } },
+      { source: { amr: [], authTime: 0 }, expected: { amr: [], auth_time: 0 } },
+    ])('should copy only defined source values: $source', ({ source, expected }) => {
+      expect(
+        getExtraTokenClaimsForAuthenticationContext(buildSourceContext(source), createAccessToken())
+      ).toEqual(expected);
+    });
+
+    it('should omit authentication claims from legacy grant entities', () => {
+      expect(
+        getExtraTokenClaimsForAuthenticationContext(buildSourceContext({}), createAccessToken())
+      ).toBeUndefined();
+    });
+
+    it('should not fall back to unrelated entities, the session, request, or token extras', () => {
+      const ctx = buildContext(grantType, {
+        [grantType === GrantType.AuthorizationCode ? 'refreshToken' : 'authorizationCode']:
+          refreshContext,
+      });
+
+      expect(getExtraTokenClaimsForAuthenticationContext(ctx, createAccessToken())).toBeUndefined();
+    });
+
+    it('should not emit authentication context when dev features are disabled', () => {
+      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', false);
+
+      expect(
+        getExtraTokenClaimsForAuthenticationContext(
+          buildSourceContext(codeContext),
+          createAccessToken()
+        )
+      ).toBeUndefined();
+    });
+  });
+
+  it.each([GrantType.ClientCredentials, GrantType.TokenExchange, GrantType.DeviceCode, undefined])(
+    'should not reuse unrelated authentication context for grant %s',
+    (grantType) => {
+      const ctx = buildContext(grantType, {
+        authorizationCode: codeContext,
+        refreshToken: refreshContext,
+      });
+
+      expect(getExtraTokenClaimsForAuthenticationContext(ctx, createAccessToken())).toBeUndefined();
+    }
+  );
+
+  it.each([
+    new provider.ClientCredentials({ client, scope: 'read' }),
+    new provider.AuthorizationCode({ ...tokenProperties, ...codeContext }),
+    new provider.RefreshToken({ ...tokenProperties, ...refreshContext }),
+    {},
+  ])('should ignore non-user access tokens', (token) => {
+    const ctx = buildContext(GrantType.AuthorizationCode, { authorizationCode: codeContext });
+
+    expect(getExtraTokenClaimsForAuthenticationContext(ctx, token)).toBeUndefined();
+  });
+});

--- a/packages/core/src/oidc/authentication-context-claims.test.ts
+++ b/packages/core/src/oidc/authentication-context-claims.test.ts
@@ -72,7 +72,13 @@ const buildContext = (
         RefreshToken: new provider.RefreshToken({ ...tokenProperties, ...refreshToken }),
       }),
       ...(deviceCode && {
-        DeviceCode: new provider.DeviceCode({ ...tokenProperties, ...deviceCode }),
+        DeviceCode: new provider.DeviceCode({
+          ...tokenProperties,
+          ...deviceCode,
+          params: {},
+          userCode: 'ABCD-EFGH',
+          deviceInfo: {},
+        }),
       }),
     },
   });

--- a/packages/core/src/oidc/authentication-context-claims.test.ts
+++ b/packages/core/src/oidc/authentication-context-claims.test.ts
@@ -28,13 +28,23 @@ const refreshContext = {
   amr: ['pwd', 'otp', 'mfa'],
   authTime: 2000,
 };
+const deviceContext = {
+  acr: 'urn:logto:acr:1fa',
+  amr: ['otp'],
+  authTime: 2500,
+};
 
 const buildContext = (
   grantType: string | undefined,
   {
     authorizationCode,
+    deviceCode,
     refreshToken,
-  }: { authorizationCode?: AuthenticationContext; refreshToken?: AuthenticationContext } = {}
+  }: {
+    authorizationCode?: AuthenticationContext;
+    deviceCode?: AuthenticationContext;
+    refreshToken?: AuthenticationContext;
+  } = {}
 ) => {
   const session = new provider.Session();
   session.loginAccount({
@@ -61,6 +71,9 @@ const buildContext = (
       ...(refreshToken && {
         RefreshToken: new provider.RefreshToken({ ...tokenProperties, ...refreshToken }),
       }),
+      ...(deviceCode && {
+        DeviceCode: new provider.DeviceCode({ ...tokenProperties, ...deviceCode }),
+      }),
     },
   });
 };
@@ -85,10 +98,12 @@ describe('getExtraTokenClaimsForAuthenticationContext', () => {
   it.each([
     [GrantType.AuthorizationCode, codeContext],
     [GrantType.RefreshToken, refreshContext],
-  ])('should use the %s source when both grant entities are present', (grantType, source) => {
+    [GrantType.DeviceCode, deviceContext],
+  ])('should use the %s source when all grant entities are present', (grantType, source) => {
     const ctx = buildContext(grantType, {
       authorizationCode: codeContext,
       refreshToken: refreshContext,
+      deviceCode: deviceContext,
     });
 
     expect(getExtraTokenClaimsForAuthenticationContext(ctx, createAccessToken())).toEqual({
@@ -98,10 +113,14 @@ describe('getExtraTokenClaimsForAuthenticationContext', () => {
     });
   });
 
-  describe.each([GrantType.AuthorizationCode, GrantType.RefreshToken])('%s', (grantType) => {
+  describe.each([
+    [GrantType.AuthorizationCode, 'authorizationCode'],
+    [GrantType.RefreshToken, 'refreshToken'],
+    [GrantType.DeviceCode, 'deviceCode'],
+  ])('%s', (grantType, sourceKey) => {
     const buildSourceContext = (source: AuthenticationContext) =>
       buildContext(grantType, {
-        [grantType === GrantType.AuthorizationCode ? 'authorizationCode' : 'refreshToken']: source,
+        [sourceKey]: source,
       });
 
     it.each([
@@ -142,12 +161,31 @@ describe('getExtraTokenClaimsForAuthenticationContext', () => {
     });
   });
 
-  it.each([GrantType.ClientCredentials, GrantType.TokenExchange, GrantType.DeviceCode, undefined])(
+  it('should preserve device authentication context when issuing an access token via refresh', () => {
+    const deviceClaims = getExtraTokenClaimsForAuthenticationContext(
+      buildContext(GrantType.DeviceCode, { deviceCode: deviceContext }),
+      createAccessToken()
+    );
+    const refreshClaims = getExtraTokenClaimsForAuthenticationContext(
+      buildContext(GrantType.RefreshToken, { refreshToken: deviceContext }),
+      createAccessToken()
+    );
+
+    expect(deviceClaims).toEqual({
+      acr: deviceContext.acr,
+      amr: deviceContext.amr,
+      auth_time: deviceContext.authTime,
+    });
+    expect(refreshClaims).toEqual(deviceClaims);
+  });
+
+  it.each([GrantType.ClientCredentials, GrantType.TokenExchange, undefined])(
     'should not reuse unrelated authentication context for grant %s',
     (grantType) => {
       const ctx = buildContext(grantType, {
         authorizationCode: codeContext,
         refreshToken: refreshContext,
+        deviceCode: deviceContext,
       });
 
       expect(getExtraTokenClaimsForAuthenticationContext(ctx, createAccessToken())).toBeUndefined();

--- a/packages/core/src/oidc/authentication-context-claims.ts
+++ b/packages/core/src/oidc/authentication-context-claims.ts
@@ -1,0 +1,40 @@
+import { GrantType } from '@logto/schemas';
+import { conditional } from '@silverhand/essentials';
+import { type KoaContextWithOIDC, type UnknownObject } from 'oidc-provider';
+
+import { EnvSet } from '#src/env-set/index.js';
+
+/** Copy the authentication event captured by the source grant, including its original timestamp. */
+export const getExtraTokenClaimsForAuthenticationContext = (
+  ctx: KoaContextWithOIDC,
+  token: unknown
+): UnknownObject | undefined => {
+  // OIDC step-up authentication context is only available with dev features enabled.
+  if (!EnvSet.values.isDevFeaturesEnabled || !(token instanceof ctx.oidc.provider.AccessToken)) {
+    return;
+  }
+
+  const { entities, params } = ctx.oidc;
+  const grantType = params?.grant_type;
+  const source =
+    grantType === GrantType.AuthorizationCode
+      ? entities.AuthorizationCode
+      : conditional(grantType === GrantType.RefreshToken && entities.RefreshToken);
+
+  // Other grants must not acquire authentication context from the session or subject token.
+  if (!source) {
+    return;
+  }
+
+  const { acr, amr, authTime } = source;
+
+  if ([acr, amr, authTime].every((value) => value === undefined)) {
+    return;
+  }
+
+  return {
+    ...conditional(acr !== undefined && { acr }),
+    ...conditional(amr !== undefined && { amr }),
+    ...conditional(authTime !== undefined && { auth_time: authTime }),
+  };
+};

--- a/packages/core/src/oidc/authentication-context-claims.ts
+++ b/packages/core/src/oidc/authentication-context-claims.ts
@@ -17,9 +17,9 @@ export const getExtraTokenClaimsForAuthenticationContext = (
   const { entities, params } = ctx.oidc;
   const grantType = params?.grant_type;
   const source =
-    grantType === GrantType.AuthorizationCode
-      ? entities.AuthorizationCode
-      : conditional(grantType === GrantType.RefreshToken && entities.RefreshToken);
+    conditional(grantType === GrantType.AuthorizationCode && entities.AuthorizationCode) ??
+    conditional(grantType === GrantType.DeviceCode && entities.DeviceCode) ??
+    conditional(grantType === GrantType.RefreshToken && entities.RefreshToken);
 
   // Other grants must not acquire authentication context from the session or subject token.
   if (!source) {

--- a/packages/core/src/oidc/authentication-context-claims.ts
+++ b/packages/core/src/oidc/authentication-context-claims.ts
@@ -17,9 +17,11 @@ export const getExtraTokenClaimsForAuthenticationContext = (
   const { entities, params } = ctx.oidc;
   const grantType = params?.grant_type;
   const source =
-    conditional(grantType === GrantType.AuthorizationCode && entities.AuthorizationCode) ??
-    conditional(grantType === GrantType.DeviceCode && entities.DeviceCode) ??
-    conditional(grantType === GrantType.RefreshToken && entities.RefreshToken);
+    grantType === GrantType.AuthorizationCode
+      ? entities.AuthorizationCode
+      : grantType === GrantType.DeviceCode
+        ? entities.DeviceCode
+        : conditional(grantType === GrantType.RefreshToken && entities.RefreshToken);
 
   // Other grants must not acquire authentication context from the session or subject token.
   if (!source) {

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -905,7 +905,10 @@ describe('authentication context extra token claims', () => {
 
   it('should preserve token exchange actor claims without adding authentication context', async () => {
     Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
-    const provider = createProvider(new MockTenant());
+    const tenant = new MockTenant(undefined, undefined, undefined, undefined, {
+      getJwtCustomizer: jest.fn().mockRejectedValue(new Error('Customizer is not configured')),
+    });
+    const provider = createProvider(tenant);
     const configuration = getProviderConfiguration(provider);
     const client = createTestClient();
     assert(client);

--- a/packages/core/src/oidc/init.test.ts
+++ b/packages/core/src/oidc/init.test.ts
@@ -7,6 +7,7 @@ import { errors, type KoaContextWithOIDC } from 'oidc-provider';
 import { mockResource, mockUser } from '#src/__mocks__/index.js';
 import { EnvSet } from '#src/env-set/index.js';
 import RequestError from '#src/errors/RequestError/index.js';
+import { JwtCustomizerLibrary } from '#src/libraries/jwt-customizer.js';
 import { getProviderConfiguration } from '#src/oidc/oidc-provider-internals.js';
 import { mockEnvSet } from '#src/test-utils/env-set.js';
 import { createOidcContext } from '#src/test-utils/oidc-provider.js';
@@ -809,6 +810,118 @@ describe('authentication context provider metadata', () => {
     expect(claimsSupported).not.toContain('acr');
     expect(claimsSupported).not.toContain('amr');
     expect(claimsSupported).toContain('auth_time');
+  });
+});
+describe('authentication context extra token claims', () => {
+  const originalIsDevFeaturesEnabled = EnvSet.values.isDevFeaturesEnabled;
+  const originalIsCloud = EnvSet.values.isCloud;
+
+  afterEach(() => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', originalIsDevFeaturesEnabled);
+    Reflect.set(EnvSet.values, 'isCloud', originalIsCloud);
+    jest.restoreAllMocks();
+  });
+
+  it.each([true, false])(
+    'should preserve organization claims and apply customizer output last with dev features %s',
+    async (isDevFeaturesEnabled) => {
+      Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', isDevFeaturesEnabled);
+      Reflect.set(EnvSet.values, 'isCloud', false);
+      const customizedClaims = { acr: 'custom-acr', auth_time: 3000, custom_claim: true };
+      const runScriptLocally = jest
+        .spyOn(JwtCustomizerLibrary, 'runScriptLocally')
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce(customizedClaims);
+      const getJwtCustomizer = jest.fn().mockResolvedValue({ script: 'return {}' });
+      const tenant = new MockTenant(
+        undefined,
+        undefined,
+        undefined,
+        {
+          jwtCustomizers: {
+            getUserContext: jest.fn().mockResolvedValue({ id: accountId }),
+            getApplicationContext: jest.fn(),
+            getOrganizationContext: jest.fn(),
+          },
+        },
+        { getJwtCustomizer }
+      );
+      const provider = createProvider(tenant);
+      const configuration = getProviderConfiguration(provider);
+      const client = createTestClient();
+      assert(client);
+      const tokenProperties = {
+        client,
+        accountId,
+        scope: 'openid',
+        grantId: 'grant-id',
+        gty: GrantType.AuthorizationCode,
+      };
+      const ctx = createOidcContext({
+        provider,
+        client,
+        params: {
+          grant_type: GrantType.AuthorizationCode,
+          resource: indicator,
+          organization_id: 'org-id',
+        },
+        entities: {
+          AuthorizationCode: new provider.AuthorizationCode({
+            ...tokenProperties,
+            acr: 'urn:logto:acr:mfa',
+            amr: ['pwd', 'otp', 'mfa'],
+            authTime: 1000,
+          }),
+        },
+      });
+      Reflect.set(ctx, 'createLog', jest.fn().mockReturnValue({ append: jest.fn() }));
+      Reflect.set(ctx, 'prependAllLogEntries', jest.fn());
+      const token = new provider.AccessToken(tokenProperties);
+      const builtInClaims = {
+        organization_id: 'org-id',
+        ...(isDevFeaturesEnabled && {
+          acr: 'urn:logto:acr:mfa',
+          amr: ['pwd', 'otp', 'mfa'],
+          auth_time: 1000,
+        }),
+      };
+
+      await expect(configuration.extraTokenClaims(ctx, token)).resolves.toEqual(builtInClaims);
+      await expect(configuration.extraTokenClaims(ctx, token)).resolves.toEqual({
+        ...builtInClaims,
+        ...customizedClaims,
+      });
+
+      // Authentication context must also work when no other extra claims are configured.
+      getJwtCustomizer.mockRejectedValueOnce(new Error('Customizer is not configured'));
+      Reflect.set(ctx.oidc, 'params', { grant_type: GrantType.AuthorizationCode });
+      const { organization_id, ...authenticationContextClaims } = builtInClaims;
+      await expect(configuration.extraTokenClaims(ctx, token)).resolves.toEqual(
+        isDevFeaturesEnabled ? authenticationContextClaims : undefined
+      );
+      expect(runScriptLocally).toHaveBeenCalledTimes(2);
+    }
+  );
+
+  it('should preserve token exchange actor claims without adding authentication context', async () => {
+    Reflect.set(EnvSet.values, 'isDevFeaturesEnabled', true);
+    const provider = createProvider(new MockTenant());
+    const configuration = getProviderConfiguration(provider);
+    const client = createTestClient();
+    assert(client);
+    const ctx = createOidcContext({ provider, params: { grant_type: GrantType.TokenExchange } });
+    const token = new provider.AccessToken({
+      client,
+      accountId,
+      scope: 'openid',
+      grantId: 'grant-id',
+      gty: GrantType.TokenExchange,
+      extra: { act: { sub: 'actor-id' } },
+    });
+
+    await expect(configuration.extraTokenClaims(ctx, token)).resolves.toEqual({
+      act: { sub: 'actor-id' },
+    });
   });
 });
 /* eslint-enable max-lines */

--- a/packages/core/src/oidc/init.ts
+++ b/packages/core/src/oidc/init.ts
@@ -56,6 +56,7 @@ import {
   hasAppLevelAccessControlChecked,
   markAppLevelAccessControlCheckedForOidcContext,
 } from './application-access-control.js';
+import { getExtraTokenClaimsForAuthenticationContext } from './authentication-context-claims.js';
 import { buildClientIdMetadataDocumentFeature, isCimdClient } from './cimd/index.js';
 import { filterResourceScopesForTheCimdClient } from './cimd/resource-scopes.js';
 import { getOidcScopesNoLongerAllowed } from './client-scope.js';
@@ -384,6 +385,7 @@ export default function initOidc(
     },
     extraParams: Object.values(ExtraParamsKey),
     extraTokenClaims: async (ctx, token) => {
+      const authenticationContextClaims = getExtraTokenClaimsForAuthenticationContext(ctx, token);
       const [tokenExchangeClaims, organizationApiResourceClaims, jwtCustomizedClaims] =
         await Promise.all([
           getExtraTokenClaimsForTokenExchange(ctx, token),
@@ -401,13 +403,19 @@ export default function initOidc(
           ),
         ]);
 
-      if (!organizationApiResourceClaims && !jwtCustomizedClaims && !tokenExchangeClaims) {
+      if (
+        !authenticationContextClaims &&
+        !organizationApiResourceClaims &&
+        !jwtCustomizedClaims &&
+        !tokenExchangeClaims
+      ) {
         return;
       }
 
       return {
         ...tokenExchangeClaims,
         ...organizationApiResourceClaims,
+        ...authenticationContextClaims,
         ...jwtCustomizedClaims,
       };
     },

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context-access-token.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context-access-token.test.ts
@@ -1,0 +1,231 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { Prompt } from '@logto/node';
+import { GrantType, InteractionEvent, defaultTenantId, demoAppApplicationId } from '@logto/schemas';
+import { assert, assertEnv } from '@silverhand/essentials';
+import { createInterceptorsPreset, createPool, sql, type DatabasePool } from '@silverhand/slonik';
+import { decodeJwt } from 'jose';
+
+import { accessTokenJwtCustomizerPayload } from '#src/__mocks__/jwt-customizer.js';
+import { oidcApi } from '#src/api/api.js';
+import { deleteJwtCustomizer, upsertJwtCustomizer } from '#src/api/index.js';
+import { createResource, deleteResource } from '#src/api/resource.js';
+import { updateSignInExperience } from '#src/api/sign-in-experience.js';
+import { ExperienceClient } from '#src/client/experience/index.js';
+import { demoAppRedirectUri, isDevFeaturesEnabled } from '#src/constants.js';
+import { logoutClient, processSession } from '#src/helpers/client.js';
+import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
+import {
+  enableAllPasswordSignInMethods,
+  resetMfaSettings,
+} from '#src/helpers/sign-in-experience.js';
+import { generateNewUserProfile, UserApiTest } from '#src/helpers/user.js';
+
+type TokenResponse = {
+  access_token: string;
+  refresh_token: string;
+};
+
+class ResourceExperienceClient extends ExperienceClient {
+  constructor(resource?: string) {
+    super({
+      appId: demoAppApplicationId,
+      prompt: Prompt.Consent,
+      scopes: ['offline_access'],
+      resources: resource ? [resource] : [],
+    });
+
+    if (resource) {
+      // The SDK omits `resource` during code exchange. Add it to that request to cover
+      // JWT issuance from the authorization code without first using a refresh token.
+      const { requester } = this.logto.adapter;
+
+      this.logto.adapter.requester = async <T>(...args: Parameters<typeof fetch>): Promise<T> => {
+        const [url, options] = args;
+        if (typeof options?.body !== 'string') {
+          return requester<T>(...args);
+        }
+        const body = new URLSearchParams(options.body);
+        if (body.get('grant_type') !== GrantType.AuthorizationCode) {
+          return requester<T>(...args);
+        }
+
+        return requester<T>(url, {
+          ...options,
+          body: new URLSearchParams([...body, ['resource', resource]]).toString(),
+        });
+      };
+    }
+  }
+}
+
+const introspectToken = async (token: string) =>
+  oidcApi
+    .post('token/introspection', {
+      body: new URLSearchParams({
+        client_id: demoAppApplicationId,
+        token,
+        token_type_hint: 'access_token',
+      }),
+    })
+    .json<Record<string, unknown>>();
+
+const refreshTokens = async (refreshToken: string, resource?: string) =>
+  oidcApi
+    .post('token', {
+      body: new URLSearchParams({
+        grant_type: GrantType.RefreshToken,
+        client_id: demoAppApplicationId,
+        refresh_token: refreshToken,
+        ...(resource && { resource }),
+      }),
+    })
+    .json<TokenResponse>();
+
+describe('authentication context in access tokens', () => {
+  const userApi = new UserApiTest();
+  const profile = generateNewUserProfile({ username: true, password: true });
+  // eslint-disable-next-line @silverhand/fp/no-let -- The database connection is shared by the fixture and assertions.
+  let pool: DatabasePool;
+
+  beforeAll(async () => {
+    await enableAllPasswordSignInMethods();
+    await updateSignInExperience({ adaptiveMfa: { enabled: false } });
+    await userApi.create(profile);
+    // eslint-disable-next-line @silverhand/fp/no-mutation -- Initialize the connection after Jest has loaded the test environment.
+    pool = await createPool(assertEnv('DB_URL'), { interceptors: createInterceptorsPreset() });
+  });
+
+  afterAll(async () => {
+    await resetMfaSettings();
+    await userApi.cleanUp();
+    await pool.end();
+  });
+
+  const signIn = async (resource?: string) => {
+    const client = new ResourceExperienceClient(resource);
+    await client.initSession(demoAppRedirectUri);
+    await client.initInteraction({ interactionEvent: InteractionEvent.SignIn });
+    await identifyUserWithUsernamePassword(client, profile.username, profile.password);
+    const { redirectTo } = await client.submitInteraction();
+    await processSession(client, redirectTo);
+    return client;
+  };
+
+  it.each(['opaque', 'jwt'] as const)(
+    'preserves the authorization context in %s tokens through refresh rotation',
+    async (format) => {
+      const resource = format === 'jwt' ? await createResource() : undefined;
+
+      try {
+        const client = await signIn(resource?.indicator);
+        const idTokenClaims = await client.getIdTokenClaims();
+        const initialAccessToken = await client.getAccessToken();
+        const initialRefreshToken = await client.getRefreshToken();
+        assert(initialRefreshToken, new Error('Missing refresh token after code exchange'));
+
+        const readClaims = async (token: string) => {
+          if (format === 'jwt') {
+            const claims = decodeJwt(token);
+            expect(claims.aud).toBe(resource?.indicator);
+            return claims;
+          }
+
+          expect(token).not.toContain('.');
+          const claims = await introspectToken(token);
+          expect(claims.active).toBe(true);
+          // Introspection must expose the extra claims at the top level.
+          expect(claims).not.toHaveProperty('extra');
+
+          const { payload } = await pool.one<{ payload: Record<string, unknown> }>(sql`
+            select payload from oidc_model_instances
+            where tenant_id = ${defaultTenantId} and model_name = 'AccessToken' and id = ${token}
+          `);
+
+          if (isDevFeaturesEnabled) {
+            expect(payload.extra).toMatchObject({
+              acr: 'urn:logto:acr:1fa',
+              amr: ['pwd'],
+              auth_time: idTokenClaims.auth_time,
+            });
+          } else {
+            expect(payload.extra ?? {}).not.toHaveProperty('acr');
+            expect(payload.extra ?? {}).not.toHaveProperty('amr');
+            expect(payload.extra ?? {}).not.toHaveProperty('auth_time');
+          }
+
+          return claims;
+        };
+
+        const expectAuthenticationContext = (claims: Record<string, unknown>) => {
+          if (isDevFeaturesEnabled) {
+            expect(typeof idTokenClaims.auth_time).toBe('number');
+            expect(claims).toMatchObject({
+              acr: 'urn:logto:acr:1fa',
+              amr: ['pwd'],
+              auth_time: idTokenClaims.auth_time,
+            });
+          } else {
+            expect(claims).not.toHaveProperty('acr');
+            expect(claims).not.toHaveProperty('amr');
+            expect(claims).not.toHaveProperty('auth_time');
+          }
+        };
+
+        const initialClaims = await readClaims(initialAccessToken);
+        expectAuthenticationContext(initialClaims);
+
+        // A later issuance time must not replace the original authentication time.
+        await setTimeout(1100);
+        const rotated = await refreshTokens(initialRefreshToken, resource?.indicator);
+        expect(rotated.refresh_token).toBeTruthy();
+        expect(rotated.refresh_token).not.toBe(initialRefreshToken);
+        const rotatedClaims = await readClaims(rotated.access_token);
+        expectAuthenticationContext(rotatedClaims);
+        expect(rotatedClaims.iat).toBeGreaterThan(Number(initialClaims.iat));
+
+        // Use the replacement to catch a rotation that drops context from the refresh token.
+        const next = await refreshTokens(rotated.refresh_token, resource?.indicator);
+        expect(next.refresh_token).not.toBe(rotated.refresh_token);
+        expectAuthenticationContext(await readClaims(next.access_token));
+
+        await logoutClient(client);
+      } finally {
+        if (resource) {
+          await deleteResource(resource.id);
+        }
+      }
+    }
+  );
+
+  it.each(['opaque', 'jwt'] as const)(
+    'preserves customizer precedence for authentication context claims in %s tokens',
+    async (format) => {
+      const resource = format === 'jwt' ? await createResource() : undefined;
+      const customClaims = { acr: 'custom:acr', amr: ['custom'], auth_time: 123 };
+      const readClaims = async (token: string) =>
+        format === 'jwt' ? decodeJwt(token) : introspectToken(token);
+
+      try {
+        await upsertJwtCustomizer('access-token', {
+          ...accessTokenJwtCustomizerPayload,
+          script: `const getCustomJwtClaims = async () => (${JSON.stringify(customClaims)});`,
+        });
+
+        const client = await signIn(resource?.indicator);
+        expect(await readClaims(await client.getAccessToken())).toMatchObject(customClaims);
+        const refreshToken = await client.getRefreshToken();
+        assert(refreshToken, new Error('Missing refresh token after code exchange'));
+        const refreshed = await refreshTokens(refreshToken, resource?.indicator);
+        expect(await readClaims(refreshed.access_token)).toMatchObject(customClaims);
+
+        await logoutClient(client);
+      } finally {
+        await deleteJwtCustomizer('access-token');
+        if (resource) {
+          await deleteResource(resource.id);
+        }
+      }
+    }
+  );
+});

--- a/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/authentication-context.test.ts
@@ -1,5 +1,5 @@
 import { ConnectorType } from '@logto/connector-kit';
-import { decodeIdToken } from '@logto/js';
+import { decodeAccessToken, decodeIdToken } from '@logto/js';
 import { Prompt } from '@logto/node';
 import { GrantType, MfaFactor, MfaPolicy, demoAppApplicationId } from '@logto/schemas';
 import { formUrlEncodedHeaders, generateStandardId } from '@logto/shared';
@@ -12,6 +12,7 @@ import {
   deleteUser,
   updateUserLogtoConfig,
 } from '#src/api/admin-user.js';
+import { createResource, deleteResource } from '#src/api/resource.js';
 import { updateSignInExperience } from '#src/api/sign-in-experience.js';
 import { type ExperienceClient } from '#src/client/experience/index.js';
 import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
@@ -48,12 +49,13 @@ const nowInSeconds = () => Math.floor(Date.now() / 1000);
  * Start an authorization on a fresh client (so a sign-in is always required) that issues a
  * refresh token: the provider only issues one for `offline_access` under `prompt=consent`.
  */
-const initClient = async () =>
+const initClient = async (resources?: string[]) =>
   initExperienceClient({
     config: {
       appId: demoAppApplicationId,
       prompt: Prompt.Consent,
       scopes: ['offline_access'],
+      resources,
     },
     redirectUri: demoAppRedirectUri,
   });
@@ -236,8 +238,8 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
     });
 
     /** Start a sign-in on a fresh client and identify the social user without submitting. */
-    const identifySocialUser = async () => {
-      const client = await initClient();
+    const identifySocialUser = async (resources?: string[]) => {
+      const client = await initClient(resources);
       const state = 'state';
       const redirectUri = 'http://localhost:3000';
       const { verificationId } = await successfullyCreateSocialVerification(client, connectorId, {
@@ -252,16 +254,32 @@ devFeatureTest.describe('authentication context claims on sign-in', () => {
       return client;
     };
 
-    it('issues amr=[fed] and no acr', async () => {
-      const client = await identifySocialUser();
-      const claims = await finishSignIn(client);
+    it('issues amr=[fed] and no acr in ID and JWT access tokens', async () => {
+      const resource = await createResource();
 
-      expect(claims.sub).toBe(userId);
-      expect(claims.amr).toEqual(['fed']);
-      expect(claims).not.toHaveProperty('acr');
-      expect(typeof claims.auth_time).toBe('number');
+      try {
+        const client = await identifySocialUser([resource.indicator]);
+        const claims = await finishSignIn(client);
 
-      await logoutClient(client);
+        expect(claims.sub).toBe(userId);
+        expect(claims.amr).toEqual(['fed']);
+        expect(claims).not.toHaveProperty('acr');
+        expect(typeof claims.auth_time).toBe('number');
+
+        const accessTokenClaims = decodeAccessToken(
+          await client.getAccessToken(resource.indicator)
+        );
+        expect(accessTokenClaims).toMatchObject({
+          sub: userId,
+          amr: ['fed'],
+          auth_time: claims.auth_time,
+        });
+        expect(accessTokenClaims).not.toHaveProperty('acr');
+
+        await logoutClient(client);
+      } finally {
+        await deleteResource(resource.id);
+      }
     });
 
     it('keeps fed on the sign-in that links the identity to an existing account', async () => {

--- a/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
+++ b/packages/integration-tests/src/tests/api/oidc/provider-semantics.test.ts
@@ -15,7 +15,7 @@ import {
 } from '#src/api/application.js';
 import { deleteJwtCustomizer, deleteUser } from '#src/api/index.js';
 import { createResource, deleteResource } from '#src/api/resource.js';
-import { demoAppRedirectUri, logtoUrl } from '#src/constants.js';
+import { demoAppRedirectUri, isDevFeaturesEnabled, logtoUrl } from '#src/constants.js';
 import { initExperienceClient, logoutClient, processSession } from '#src/helpers/client.js';
 import { identifyUserWithUsernamePassword } from '#src/helpers/experience/index.js';
 import { createUserByAdmin } from '#src/helpers/index.js';
@@ -206,6 +206,11 @@ describe('opaque user token lifecycle', () => {
         scope: 'openid offline_access profile',
         sub: userId,
         token_type: 'Bearer',
+        ...(isDevFeaturesEnabled && {
+          acr: 'urn:logto:acr:1fa',
+          amr: ['pwd'],
+          auth_time: expect.any(Number),
+        }),
       });
       /* eslint-enable @typescript-eslint/no-unsafe-assignment */
       /**


### PR DESCRIPTION
## Summary

Propagate `acr`, `amr`, and the original `auth_time` from authorization codes and refresh tokens into JWT access tokens and opaque-token introspection responses. Preserve authentication context across refresh rotation and keep the existing JWT customizer precedence and other grant behavior.

Resolves [LOG-14102](https://linear.app/silverhand/issue/LOG-14102/propagate-acramrauth-time-into-access-tokens-and-introspection).

## Testing

Tested locally

## Checklist

- [ ] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
