### PR TITLE
fix(console): keep checking a slow subscription setup after checkout

### DIFF
--- a/packages/console/src/pages/CheckoutSuccessCallback/index.module.scss
+++ b/packages/console/src/pages/CheckoutSuccessCallback/index.module.scss
@@ -1,0 +1,18 @@
+@use '@/scss/underscore' as _;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: _.unit(6);
+  height: 100vh;
+  padding: _.unit(6);
+  color: var(--color-text);
+
+  .message {
+    max-width: 470px;
+    font: var(--font-body-2);
+    text-align: center;
+  }
+}

--- a/packages/console/src/pages/CheckoutSuccessCallback/index.test.tsx
+++ b/packages/console/src/pages/CheckoutSuccessCallback/index.test.tsx
@@ -1,0 +1,184 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import type * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import useSWR from 'swr';
+
+import { checkoutStateQueryKey } from '@/consts/subscriptions';
+import { clearLocalCheckoutSession } from '@/utils/checkout';
+
+import CheckoutSuccessCallback from '.';
+
+const mockNavigate = jest.fn();
+const mockMutateSession = jest.fn();
+const mockMutateSubscription = jest.fn();
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+
+jest.mock('swr', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('react-hot-toast', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+jest.mock('@/cloud/hooks/use-cloud-api', () => ({
+  useCloudApi: () => ({ get: jest.fn() }),
+}));
+
+jest.mock('@/hooks/use-tenant-pathname', () => ({
+  __esModule: true,
+  default: () => ({ navigate: mockNavigate }),
+}));
+
+jest.mock('@/contexts/TenantsProvider', () => {
+  const { createContext } = jest.requireActual<typeof React>('react');
+
+  return {
+    TenantsContext: createContext({
+      currentTenantId: 'tenant-1',
+      navigateTenant: jest.fn(),
+      updateTenant: jest.fn(),
+    }),
+  };
+});
+
+jest.mock('@/contexts/SubscriptionDataProvider', () => {
+  const { createContext } = jest.requireActual<typeof React>('react');
+
+  return {
+    SubscriptionDataContext: createContext({ onCurrentSubscriptionUpdated: jest.fn() }),
+  };
+});
+
+jest.mock('@/components/AppLoading', () => ({
+  __esModule: true,
+  default: () => <div>loading</div>,
+}));
+
+jest.mock('@/components/SkuName', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@/components/Conversion/utils', () => ({
+  GtagConversionId: { PurchaseProPlan: 'purchase', CreateProductionTenant: 'create' },
+  reportToGoogle: jest.fn(),
+}));
+
+jest.mock('@/utils/checkout', () => ({
+  getLocalCheckoutSession: () => ({ state: 'state-1', sessionId: 'cs_test' }),
+  clearLocalCheckoutSession: jest.fn(),
+}));
+
+const mockedUseSWR = jest.mocked(useSWR);
+const mockedClearLocalCheckoutSession = jest.mocked(clearLocalCheckoutSession);
+
+const openSession = { tenantId: 'tenant-1', skuId: 'sku-pro', status: 'open' };
+const completeSession = { ...openSession, status: 'complete' };
+const proSubscription = { planId: 'sku-pro' };
+
+const sessionKey = '/api/checkout-session/cs_test';
+const subscriptionKey = '/api/tenants/tenant-1/subscription';
+
+const stubSwr = (session: Record<string, unknown>, subscription?: Record<string, unknown>) => {
+  const responses: Record<string, { data?: unknown; mutate: jest.Mock }> = {
+    [sessionKey]: { data: session, mutate: mockMutateSession },
+    [subscriptionKey]: { data: subscription, mutate: mockMutateSubscription },
+  };
+  mockedUseSWR.mockImplementation(((key: unknown) =>
+    typeof key === 'string' ? responses[key] : undefined) as unknown as typeof useSWR);
+};
+
+/** `refreshInterval` of the last render's two polls: checkout session, then tenant subscription. */
+const swrIntervals = () =>
+  mockedUseSWR.mock.calls
+    .slice(-2)
+    .map((call) => (call[2] as { refreshInterval?: number } | undefined)?.refreshInterval);
+
+const renderPage = () => (
+  <MemoryRouter
+    future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    initialEntries={[`/checkout-success?${checkoutStateQueryKey}=state-1`]}
+  >
+    <CheckoutSuccessCallback />
+  </MemoryRouter>
+);
+
+describe('CheckoutSuccessCallback', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('completes when the session and subscription match', () => {
+    stubSwr(completeSession, proSubscription);
+
+    render(renderPage());
+
+    expect(mockedClearLocalCheckoutSession).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith('/', { replace: true });
+  });
+
+  it('keeps the local session and shows pending on timeout', () => {
+    stubSwr(openSession);
+
+    render(renderPage());
+    act(() => {
+      jest.advanceTimersByTime(60_000 - 1);
+    });
+
+    expect(screen.getByText('loading')).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(screen.getByText('admin_console.subscription.subscription_check_pending')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'admin_console.general.retry' })).toBeTruthy();
+    expect(swrIntervals()).toEqual([0, 0]);
+    expect(mockedClearLocalCheckoutSession).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('rechecks, resumes polling and restarts the timer on try again', () => {
+    stubSwr(openSession);
+
+    const { rerender } = render(renderPage());
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'admin_console.general.retry' }));
+
+    expect(screen.getByText('loading')).toBeTruthy();
+    expect(mockMutateSession).toHaveBeenCalledTimes(1);
+    expect(mockMutateSubscription).not.toHaveBeenCalled();
+    expect(swrIntervals()).toEqual([1000, 1000]);
+
+    act(() => {
+      jest.advanceTimersByTime(60_000 - 1);
+    });
+
+    expect(screen.getByText('loading')).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'admin_console.general.retry' }));
+    stubSwr(completeSession, proSubscription);
+    rerender(renderPage());
+
+    expect(mockedClearLocalCheckoutSession).toHaveBeenCalledTimes(1);
+    expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/console/src/pages/CheckoutSuccessCallback/index.tsx
+++ b/packages/console/src/pages/CheckoutSuccessCallback/index.tsx
@@ -1,6 +1,5 @@
 import { conditional, conditionalString } from '@silverhand/essentials';
-import dayjs from 'dayjs';
-import { useContext, useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { Trans, useTranslation } from 'react-i18next';
 import { Navigate, useLocation } from 'react-router-dom';
@@ -14,12 +13,17 @@ import SkuName from '@/components/SkuName';
 import { checkoutStateQueryKey } from '@/consts/subscriptions';
 import { SubscriptionDataContext } from '@/contexts/SubscriptionDataProvider';
 import { TenantsContext } from '@/contexts/TenantsProvider';
+import Button from '@/ds-components/Button';
 import useTenantPathname from '@/hooks/use-tenant-pathname';
 import { clearLocalCheckoutSession, getLocalCheckoutSession } from '@/utils/checkout';
 
+import styles from './index.module.scss';
+
 const consoleHomePage = '/';
 const subscriptionCheckingInterval = 1000;
-const subscriptionCheckingTimeout = 10 * 1000;
+const subscriptionCheckingTimeout = 60 * 1000;
+
+const getExpiryTimestamp = () => new Date(Date.now() + subscriptionCheckingTimeout);
 
 function CheckoutSuccessCallback() {
   const { t } = useTranslation(undefined, { keyPrefix: 'admin_console.subscription' });
@@ -30,22 +34,24 @@ function CheckoutSuccessCallback() {
   const { search } = useLocation();
   const checkoutState = new URLSearchParams(search).get(checkoutStateQueryKey);
   const { state, sessionId, callbackPage, isDowngrade } = getLocalCheckoutSession() ?? {};
+  const [isTimedOut, setIsTimedOut] = useState(false);
 
-  // Note: if we can't get the subscription results in 10 seconds, we will redirect to the console home page
-  useTimer({
+  // Provisioning can outlast the timer. Expiry only pauses polling and keeps the local checkout
+  // session, so a refresh or "Try again" resumes the check.
+  const { restart } = useTimer({
     autoStart: true,
-    expiryTimestamp: dayjs().add(subscriptionCheckingTimeout, 'millisecond').toDate(),
+    expiryTimestamp: getExpiryTimestamp(),
     onExpire: () => {
-      toast.error(t('subscription_check_timeout'));
-      clearLocalCheckoutSession();
-      navigate(consoleHomePage, { replace: true });
+      setIsTimedOut(true);
     },
   });
+
+  const refreshInterval = isTimedOut ? 0 : subscriptionCheckingInterval;
 
   // Note: only handle the callback comes from the stripe success callback url
   const isValidSession = state && state === checkoutState;
 
-  const { data: stripeCheckoutSession } = useSWR(
+  const { data: stripeCheckoutSession, mutate: mutateStripeCheckoutSession } = useSWR(
     isValidSession && sessionId && `/api/checkout-session/${sessionId}`,
     async () =>
       cloudApi.get('/api/checkout-session/:id', {
@@ -53,9 +59,7 @@ function CheckoutSuccessCallback() {
           id: conditionalString(sessionId),
         },
       }),
-    {
-      refreshInterval: subscriptionCheckingInterval,
-    }
+    { refreshInterval }
   );
 
   const checkoutTenantId = stripeCheckoutSession?.tenantId;
@@ -69,7 +73,7 @@ function CheckoutSuccessCallback() {
           tenantId: conditionalString(checkoutTenantId),
         },
       }),
-    { refreshInterval: subscriptionCheckingInterval }
+    { refreshInterval }
   );
 
   const isCheckoutSuccessful =
@@ -133,6 +137,23 @@ function CheckoutSuccessCallback() {
 
   if (!isValidSession) {
     return <Navigate replace to={consoleHomePage} />;
+  }
+
+  if (isTimedOut) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.message}>{t('subscription_check_pending')}</div>
+        <Button
+          title="general.retry"
+          size="large"
+          onClick={() => {
+            setIsTimedOut(false);
+            restart(getExpiryTimestamp());
+            void mutateStripeCheckoutSession();
+          }}
+        />
+      </div>
+    );
   }
 
   return <AppLoading />;

--- a/packages/phrases/src/locales/ar/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/ar/translation/admin-console/subscription/index.ts
@@ -70,7 +70,8 @@ const subscription = {
   },
   upgrade_success: 'تم الترقية بنجاح إلى <name/>',
   downgrade_success: 'تم التخفيض بنجاح إلى <name/>',
-  subscription_check_timeout: 'انتهت مهلة فحص الاشتراك. يرجى التحديث في وقت لاحق.',
+  subscription_check_pending:
+    'لقد تمت عملية الدفع الخاصة بك. إعداد اشتراكك يستغرق وقتًا أطول من المعتاد.',
   no_subscription: 'لا يوجد اشتراك',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/de/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/de/translation/admin-console/subscription/index.ts
@@ -74,7 +74,8 @@ const subscription = {
   },
   upgrade_success: 'Erfolgreich auf <name/> hochgestuft',
   downgrade_success: 'Erfolgreich auf <name/> herabgestuft',
-  subscription_check_timeout: 'Abo-Überprüfung ist abgelaufen. Bitte später aktualisieren.',
+  subscription_check_pending:
+    'Deine Zahlung wurde abgeschlossen. Das Einrichten deines Abonnements dauert länger als gewöhnlich.',
   no_subscription: 'Kein Abonnement',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/en/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/en/translation/admin-console/subscription/index.ts
@@ -73,7 +73,8 @@ const subscription = {
   },
   upgrade_success: 'Successfully upgraded to <name/>',
   downgrade_success: 'Successfully downgraded to <name/>',
-  subscription_check_timeout: 'Subscription check timed out. Please refresh later.',
+  subscription_check_pending:
+    'Your payment went through. Setting up your subscription is taking longer than usual.',
   no_subscription: 'No subscription',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/es/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/es/translation/admin-console/subscription/index.ts
@@ -74,8 +74,8 @@ const subscription = {
   },
   upgrade_success: 'Actualizado con éxito a <name/>',
   downgrade_success: 'Degradado con éxito a <name/>',
-  subscription_check_timeout:
-    'La comprobación de suscripción expiró. Por favor, actualiza más tarde.',
+  subscription_check_pending:
+    'Tu pago se ha procesado. Configurar tu suscripción está tardando más de lo habitual.',
   no_subscription: 'Sin suscripción',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/fa-ir/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/fa-ir/translation/admin-console/subscription/index.ts
@@ -73,8 +73,7 @@ const subscription = {
   },
   upgrade_success: 'با موفقیت به <name/> ارتقا یافت',
   downgrade_success: 'با موفقیت به <name/> کاهش یافت',
-  subscription_check_timeout:
-    'بررسی اشتراک با تایم‌اوت مواجه شد. لطفاً بعداً صفحه را بارگذاری کنید.',
+  subscription_check_pending: 'پرداخت شما انجام شد. تنظیم اشتراک شما بیشتر از حد معمول طول می‌کشد.',
   no_subscription: 'بدون اشتراک',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/fr/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/fr/translation/admin-console/subscription/index.ts
@@ -75,8 +75,8 @@ const subscription = {
   },
   upgrade_success: 'Passé avec succès à <name/>',
   downgrade_success: 'Rétrogradé avec succès à <name/>',
-  subscription_check_timeout:
-    "La vérification d'abonnement a expiré. Veuillez actualiser ultérieurement.",
+  subscription_check_pending:
+    "Votre paiement a été effectué. La mise en place de votre abonnement prend plus de temps que d'habitude.",
   no_subscription: 'Aucun abonnement',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/it/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/it/translation/admin-console/subscription/index.ts
@@ -74,8 +74,8 @@ const subscription = {
   },
   upgrade_success: 'Aggiornamento effettuato con successo a <name/>',
   downgrade_success: 'Degrado effettuato con successo a <name/>',
-  subscription_check_timeout:
-    "Il controllo dell'abbonamento è scaduto. Si prega di riprovare più tardi.",
+  subscription_check_pending:
+    'Il tuo pagamento è andato a buon fine. La configurazione del tuo abbonamento sta richiedendo più tempo del solito.',
   no_subscription: 'Nessuna sottoscrizione',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/ja/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/ja/translation/admin-console/subscription/index.ts
@@ -74,8 +74,8 @@ const subscription = {
   },
   upgrade_success: '正常に<name/>にアップグレードされました',
   downgrade_success: '正常に<name/>にダウングレードされました',
-  subscription_check_timeout:
-    'サブスクリプションのチェックがタイムアウトしました。後でもう一度更新してください。',
+  subscription_check_pending:
+    'お支払いは完了しました。サブスクリプションの設定に通常より時間がかかっています。',
   no_subscription: '契約なし',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/ko/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/ko/translation/admin-console/subscription/index.ts
@@ -72,7 +72,8 @@ const subscription = {
   },
   upgrade_success: '성공적으로 <name/>으로 업그레이드되었습니다.',
   downgrade_success: '성공적으로 <name/>으로 다운그레이드되었습니다.',
-  subscription_check_timeout: '구독 확인이 타임아웃되었습니다. 나중에 다시 확인해주세요.',
+  subscription_check_pending:
+    '결제가 완료되었습니다. 구독 설정에 일반적인 것보다 시간이 더 걸리고 있습니다.',
   no_subscription: '구독 없음',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/pl-pl/translation/admin-console/subscription/index.ts
@@ -74,7 +74,8 @@ const subscription = {
   },
   upgrade_success: 'Pomyślnie uaktualniono do <name/>',
   downgrade_success: 'Pomyślnie zdegradowano do <name/>',
-  subscription_check_timeout: 'Czas sprawdzenia subskrypcji wygasł. Proszę odświeżyć później.',
+  subscription_check_pending:
+    'Twoja płatność została przetworzona. Konfiguracja subskrypcji trwa dłużej niż zwykle.',
   no_subscription: 'Brak subskrypcji',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/pt-br/translation/admin-console/subscription/index.ts
@@ -74,8 +74,8 @@ const subscription = {
   },
   upgrade_success: 'Atualizado com sucesso para <name/>',
   downgrade_success: 'Downgrade realizado com sucesso para <name/>',
-  subscription_check_timeout:
-    'A verificação de assinatura expirou. Por favor, atualize mais tarde.',
+  subscription_check_pending:
+    'Seu pagamento foi processado. Configurar sua assinatura está levando mais tempo que o normal.',
   no_subscription: 'Nenhuma assinatura',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/pt-pt/translation/admin-console/subscription/index.ts
@@ -74,8 +74,8 @@ const subscription = {
   },
   upgrade_success: 'Atualizou com sucesso para <name/>',
   downgrade_success: 'Downgrade concluído com sucesso para <name/>',
-  subscription_check_timeout:
-    'A verificação de subscrição expirou. Por favor, atualize mais tarde.',
+  subscription_check_pending:
+    'O seu pagamento foi realizado. Configurar a sua subscrição está a demorar mais do que o habitual.',
   no_subscription: 'Sem subscrição',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/ru/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/ru/translation/admin-console/subscription/index.ts
@@ -73,7 +73,8 @@ const subscription = {
   },
   upgrade_success: 'Успешно повышен до <name/>',
   downgrade_success: 'Успешно понижен до <name/>',
-  subscription_check_timeout: 'Время проверки подписки истекло. Пожалуйста, обновите позже.',
+  subscription_check_pending:
+    'Ваш платеж прошел. Настройка вашей подписки занимает больше времени, чем обычно.',
   no_subscription: 'Нет подписки',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/th/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/th/translation/admin-console/subscription/index.ts
@@ -72,7 +72,8 @@ const subscription = {
   },
   upgrade_success: 'อัปเกรดเป็น <name/> สำเร็จแล้ว',
   downgrade_success: 'ลดระดับเป็น <name/> สำเร็จแล้ว',
-  subscription_check_timeout: 'การตรวจสอบการสมัครสมาชิกหมดเวลา กรุณารีเฟรชใหม่ภายหลัง',
+  subscription_check_pending:
+    'การชำระเงินของคุณผ่านเรียบร้อยแล้ว การตั้งค่าการสมัครใช้บริการของคุณใช้เวลานานกว่าปกติ',
   no_subscription: 'ไม่มีการสมัครสมาชิก',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/tr-tr/translation/admin-console/subscription/index.ts
@@ -76,8 +76,8 @@ const subscription = {
   },
   upgrade_success: "Başarıyla <name/>'e yükseltildi",
   downgrade_success: "Başarıyla <name/>'e düşürüldü",
-  subscription_check_timeout:
-    'Abonelik kontrolü zaman aşımına uğradı. Lütfen daha sonra yenileyin.',
+  subscription_check_pending:
+    'Ödemeniz alındı. Aboneliğinizi ayarlamak beklenenden daha uzun sürüyor.',
   no_subscription: 'Abonelik bulunamadı',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/zh-cn/translation/admin-console/subscription/index.ts
@@ -71,7 +71,7 @@ const subscription = {
   },
   upgrade_success: '成功升级到 <name/>',
   downgrade_success: '成功降级到 <name/>',
-  subscription_check_timeout: '订阅检查超时，请稍后刷新。',
+  subscription_check_pending: '您的付款已处理。设置您的订阅比平时需要更长时间。',
   no_subscription: '无订阅',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/zh-hk/translation/admin-console/subscription/index.ts
@@ -71,7 +71,7 @@ const subscription = {
   },
   upgrade_success: '升級成功至 <name/>',
   downgrade_success: '成功降級至 <name/>',
-  subscription_check_timeout: '訂閱檢查已逾時，請稍後重新刷新。',
+  subscription_check_pending: '你的付款已通過。設置你的訂閱比平時花費的時間要長。',
   no_subscription: '沒有訂閱',
   usage,
   token_usage_notification: {

--- a/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/index.ts
+++ b/packages/phrases/src/locales/zh-tw/translation/admin-console/subscription/index.ts
@@ -71,7 +71,7 @@ const subscription = {
   },
   upgrade_success: '已成功升級到 <name/>',
   downgrade_success: '已成功降級到 <name/>',
-  subscription_check_timeout: '訂閱檢查已逾時，請稍後重新刷新。',
+  subscription_check_pending: '你的付款已成功。設置你的訂閱比平時花費的時間更長。',
   no_subscription: '無訂閱',
   usage,
   token_usage_notification: {


### PR DESCRIPTION
## Summary
Refs LOG-14182. Console half of the checkout completion-signal fix; the cloud half is logto-io/cloud#2129.

### Context
After paying, `CheckoutSuccessCallback` polled the checkout session and the tenant subscription for 10 seconds. Provisioning regularly takes longer, so users saw "Subscription check timed out" and were sent to the home page with the local checkout session cleared, even though the subscription was set up correctly moments later.

### What changed
- `pages/CheckoutSuccessCallback/index.tsx`: the timer now runs for 60 seconds, and polling pauses while the pending state is shown. On expiry the page renders a pending message with a "Try again" button that rechecks the session immediately, resumes polling and restarts the timer, instead of the error toast and the redirect. The local checkout session is cleared only on success, so a refresh resumes the check.
- `pages/CheckoutSuccessCallback/index.module.scss`: layout for the pending state.
- Phrases: `subscription.subscription_check_pending` added to `en` and translated into the other locales with `logto-translate sync-keys` and `sync`; `subscription_check_timeout` removed everywhere as it has no consumer left.
- Tests: `pages/CheckoutSuccessCallback/index.test.tsx` covers success, the 60-second boundary keeping the session, and try again (recheck, polling resumed, timer restarted) followed by success.

### Dependency on the cloud fix
This PR does not need logto-io/cloud#2129 to merge first and can ship on its own: a slow provisioning is handled entirely here. The older-tab case (paying a Checkout tab after opening a newer one) also needs the cloud change, which keeps that session's row instead of deleting it. Until that is deployed, the pending state keeps polling a session that never completes and the user has to refresh or start over.

### Reviewer notes
- The 1-second `refreshInterval` is unchanged. SWR dedupes revalidations for 2 seconds after each response, so the page issues a request about every 2 to 3 seconds per poll in practice; over the 60-second window that is roughly 20 to 30 requests per poll, then none while the pending state is shown.
- The pending state has no exit other than "Try again" and the browser; a provisioning that never completes keeps the user on it. The previous behavior redirected home after 10 seconds.

## Testing
Unit tests

## Checklist
- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
