### PR TITLE
fix(connector-kit): reject `none` prompt combined with other prompts

### DIFF
--- a/.changeset/rude-donuts-brake.md
+++ b/.changeset/rude-donuts-brake.md
@@ -1,0 +1,11 @@
+---
+"@logto/connector-kit": patch
+---
+
+reject the OIDC `none` prompt when combined with other prompts
+
+`oidcPromptsGuard` accepted `none` alongside `consent` or `select_account`. OIDC Core 1.0 section 3.1.2.1 states that `none` requests that no authentication or consent UI be shown, and that a request containing `none` with any other value is an error.
+
+Because the combination passed validation, it could be saved from the Admin Console and was then joined into a single `prompt` parameter, so the identity provider was the first thing to reject it — Google answers `invalid_request: Invalid prompt: select_account consent none`, leaving the end user on a provider error page instead of a sign-in screen. The guard is shared by the Google and Azure AD connectors, so both were affected.
+
+The invalid combination is now rejected at config time.

--- a/packages/toolkit/connector-kit/src/types/social.test.ts
+++ b/packages/toolkit/connector-kit/src/types/social.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { OidcPrompt, oidcPromptsGuard } from './social.js';
+
+describe('oidcPromptsGuard', () => {
+  it('accepts each prompt on its own', () => {
+    for (const prompt of Object.values(OidcPrompt)) {
+      expect(oidcPromptsGuard.safeParse([prompt]).success).toBe(true);
+    }
+  });
+
+  it('accepts combinations that do not include `none`', () => {
+    expect(oidcPromptsGuard.safeParse([OidcPrompt.SelectAccount, OidcPrompt.Consent]).success).toBe(
+      true
+    );
+    expect(
+      oidcPromptsGuard.safeParse([OidcPrompt.Login, OidcPrompt.Consent, OidcPrompt.SelectAccount])
+        .success
+    ).toBe(true);
+  });
+
+  it('rejects `none` combined with any other prompt', () => {
+    // OIDC Core 1.0 section 3.1.2.1: `none` with any other value is an error.
+    expect(oidcPromptsGuard.safeParse([OidcPrompt.None, OidcPrompt.Consent]).success).toBe(false);
+    expect(oidcPromptsGuard.safeParse([OidcPrompt.SelectAccount, OidcPrompt.None]).success).toBe(
+      false
+    );
+    expect(
+      oidcPromptsGuard.safeParse([OidcPrompt.SelectAccount, OidcPrompt.Consent, OidcPrompt.None])
+        .success
+    ).toBe(false);
+  });
+
+  it('still accepts an empty array and undefined', () => {
+    expect(oidcPromptsGuard.safeParse([]).success).toBe(true);
+    expect(oidcPromptsGuard.safeParse().success).toBe(true);
+  });
+
+  it('still rejects values outside the enum', () => {
+    expect(oidcPromptsGuard.safeParse(['nope']).success).toBe(false);
+  });
+});

--- a/packages/toolkit/connector-kit/src/types/social.test.ts
+++ b/packages/toolkit/connector-kit/src/types/social.test.ts
@@ -33,7 +33,8 @@ describe('oidcPromptsGuard', () => {
 
   it('still accepts an empty array and undefined', () => {
     expect(oidcPromptsGuard.safeParse([]).success).toBe(true);
-    expect(oidcPromptsGuard.safeParse().success).toBe(true);
+    // eslint-disable-next-line unicorn/no-useless-undefined -- `safeParse` requires an argument
+    expect(oidcPromptsGuard.safeParse(undefined).success).toBe(true);
   });
 
   it('still rejects values outside the enum', () => {

--- a/packages/toolkit/connector-kit/src/types/social.ts
+++ b/packages/toolkit/connector-kit/src/types/social.ts
@@ -15,9 +15,22 @@ export enum OidcPrompt {
 
 export type OidcPrompts = OidcPrompt[];
 
+/**
+ * Per OpenID Connect Core 1.0 section 3.1.2.1, `none` requests that no
+ * authentication or consent UI be shown at all, so it cannot be combined with
+ * any other prompt: "If this parameter contains `none` with any other value, an
+ * error is returned."
+ *
+ * Without this check the invalid combination is accepted by the console and
+ * only rejected by the identity provider, at which point the end user gets a
+ * provider error page instead of a sign-in screen.
+ */
 export const oidcPromptsGuard: z.ZodType<Optional<OidcPrompts>> = z
   .nativeEnum(OidcPrompt)
   .array()
+  .refine((prompts) => !prompts.includes(OidcPrompt.None) || prompts.length === 1, {
+    message: 'The `none` prompt cannot be combined with other prompts.',
+  })
   .optional();
 
 // This type definition is for SAML connector


### PR DESCRIPTION
## Summary

Closes #9565.

`oidcPromptsGuard` accepted the OIDC `none` prompt alongside other values. Per OIDC Core 1.0 §3.1.2.1, `none` requests that no authentication or consent UI be shown, and a request containing `none` with any other value is an error.

Since the combination passed validation it could be saved from the Admin Console, and the connector then joined the values into a single `prompt` parameter. The identity provider was the first thing in the chain to reject it, so the end user landed on a provider error page instead of a sign-in screen:

```
Error 400: invalid_request
Invalid parameter value for prompt: Invalid prompt: select_account consent none
```

The guard is shared by the **Google** and **Azure AD** connectors, so fixing it in `connector-kit` covers both.

## Change

```ts
.refine(
  (prompts) => !prompts.includes(OidcPrompt.None) || prompts.length === 1,
  { message: 'The `none` prompt cannot be combined with other prompts.' }
)
```

The connector already encodes one provider rule next to this — it filters `login` out of Google's select items because Google does not support it — so invalid *values* were handled; only the mutually-exclusive *combination* was missed.

## Tests

New `packages/toolkit/connector-kit/src/types/social.test.ts` covers:

- each prompt on its own is accepted
- combinations without `none` are accepted (`select_account consent`, and with `login`)
- `none` with any other prompt is rejected, in three orderings
- an empty array and `undefined` are still accepted
- values outside the enum are still rejected

I confirmed the test fails against the guard as it stands on `master` — parsing `["select_account","consent","none"]` returns `success: true` before this change and `false` after, so the test genuinely covers the regression.

Verified against `zod@3.24.3` as pinned in the workspace root.

## Notes

- Adds a changeset for `@logto/connector-kit` (patch).
- No migration needed. An existing tenant that already stored the invalid combination keeps working exactly as before — the request was already being rejected by the provider — but the config can no longer be re-saved in that state, which is what surfaces the problem to the operator instead of to the end user.
