### PR TITLE
fix(cli): check for existing tenant roles before seeding

### DIFF
--- a/.changeset/quiet-roles-seed.md
+++ b/.changeset/quiet-roles-seed.md
@@ -1,0 +1,7 @@
+---
+"@logto/cli": patch
+---
+
+explain existing PostgreSQL tenant roles before database seeding stops
+
+The database seed command now checks for the roles it needs before creating tables. If roles from a previous Logto database remain in the PostgreSQL cluster, the command reports the conflict and explains why dropping the database did not remove them, so an administrator can clean them up safely before retrying.

--- a/packages/cli/src/commands/database/seed/index.ts
+++ b/packages/cli/src/commands/database/seed/index.ts
@@ -2,6 +2,7 @@ import type { DatabasePool } from '@silverhand/slonik';
 import type { CommandModule } from 'yargs';
 
 import { createPoolAndDatabaseIfNeeded } from '../../../database.js';
+import { assertNoExistingTenantRoles, getDatabaseName } from '../../../queries/database.js';
 import { doesConfigsTableExist } from '../../../queries/logto-config.js';
 import { consoleLog, oraPromise } from '../../../utils.js';
 import { getLatestAlterationTimestamp } from '../alteration/index.js';
@@ -26,6 +27,11 @@ export const seedByPool = async (
     disablePwnedPasswordCheck = false,
   }: SeedByPoolOptions = {}
 ) => {
+  // Roles left behind by an old installation are a cluster-level precondition, so fail here before
+  // opening the transaction.
+  const database = await getDatabaseName(pool, true);
+  await assertNoExistingTenantRoles(pool, database);
+
   await pool.transaction(async (connection) => {
     // Check alteration scripts available in order to insert correct timestamp
     const latestTimestamp = await getLatestAlterationTimestamp();

--- a/packages/cli/src/commands/database/seed/tables.ts
+++ b/packages/cli/src/commands/database/seed/tables.ts
@@ -40,7 +40,7 @@ import type { DatabaseTransactionConnection } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
 
 import { insertInto } from '../../../database.js';
-import { assertNoExistingTenantRoles, getDatabaseName } from '../../../queries/database.js';
+import { getDatabaseName } from '../../../queries/database.js';
 import { updateDatabaseTimestamp } from '../../../queries/system.js';
 import { convertToIdentifiers } from '../../../sql.js';
 import { consoleLog, getPathInModule } from '../../../utils.js';
@@ -94,9 +94,6 @@ export const createTables = async (
   connection: DatabaseTransactionConnection,
   encryptBaseRole: boolean
 ): Promise<{ password: string }> => {
-  const database = await getDatabaseName(connection, true);
-  await assertNoExistingTenantRoles(connection, database);
-
   const tableDirectory = getPathInModule('@logto/schemas', 'tables');
   const directoryFiles = await readdir(tableDirectory);
   const tableFiles = directoryFiles.filter((file) => file.endsWith('.sql'));
@@ -132,6 +129,7 @@ export const createTables = async (
     ...queries.filter(([file]) => !lifecycleNames.includes(file.slice(1, -4))),
   ];
   const sorted = allQueries.slice().sort(compareQuery);
+  const database = await getDatabaseName(connection, true);
   const password = encryptBaseRole ? generateStandardId(32) : '';
 
   await runLifecycleQuery('before_all', { database, password });

--- a/packages/cli/src/commands/database/seed/tables.ts
+++ b/packages/cli/src/commands/database/seed/tables.ts
@@ -40,7 +40,7 @@ import type { DatabaseTransactionConnection } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
 
 import { insertInto } from '../../../database.js';
-import { getDatabaseName } from '../../../queries/database.js';
+import { assertNoExistingTenantRoles, getDatabaseName } from '../../../queries/database.js';
 import { updateDatabaseTimestamp } from '../../../queries/system.js';
 import { convertToIdentifiers } from '../../../sql.js';
 import { consoleLog, getPathInModule } from '../../../utils.js';
@@ -94,6 +94,9 @@ export const createTables = async (
   connection: DatabaseTransactionConnection,
   encryptBaseRole: boolean
 ): Promise<{ password: string }> => {
+  const database = await getDatabaseName(connection, true);
+  await assertNoExistingTenantRoles(connection, database);
+
   const tableDirectory = getPathInModule('@logto/schemas', 'tables');
   const directoryFiles = await readdir(tableDirectory);
   const tableFiles = directoryFiles.filter((file) => file.endsWith('.sql'));
@@ -129,7 +132,6 @@ export const createTables = async (
     ...queries.filter(([file]) => !lifecycleNames.includes(file.slice(1, -4))),
   ];
   const sorted = allQueries.slice().sort(compareQuery);
-  const database = await getDatabaseName(connection, true);
   const password = encryptBaseRole ? generateStandardId(32) : '';
 
   await runLifecycleQuery('before_all', { database, password });

--- a/packages/cli/src/queries/database.test.ts
+++ b/packages/cli/src/queries/database.test.ts
@@ -1,0 +1,72 @@
+import { createMockPool, createMockQueryResult, sql } from '@silverhand/slonik';
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+
+import type { QueryType } from '../test-utils.js';
+import { expectSqlAssert } from '../test-utils.js';
+
+import { assertNoExistingTenantRoles, getDatabaseName } from './database.js';
+
+const mockQuery: MockedFunction<QueryType> = vi.fn();
+const pool = createMockPool({
+  query: async (query, values) => mockQuery(query, values),
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe('getDatabaseName()', () => {
+  it('returns the current database name and optionally normalizes hyphens', async () => {
+    mockQuery.mockResolvedValueOnce(createMockQueryResult([{ currentDatabase: 'logto-db' }]));
+
+    await expect(getDatabaseName(pool)).resolves.toBe('logto-db');
+
+    mockQuery.mockResolvedValueOnce(createMockQueryResult([{ currentDatabase: 'logto-db' }]));
+
+    await expect(getDatabaseName(pool, true)).resolves.toBe('logto_db');
+  });
+});
+
+describe('assertNoExistingTenantRoles()', () => {
+  const database = 'logto';
+  const roleNames = [
+    'logto_tenant_logto',
+    'logto_tenant_logto_default',
+    'logto_tenant_logto_admin',
+  ];
+  const expectedSql = sql`
+    select rolname as "roleName"
+    from pg_roles
+    where rolname in (${sql.join(
+      roleNames.map((roleName) => sql`${roleName}`),
+      sql`, `
+    )})
+    order by rolname
+  `;
+
+  it('resolves when none of the seed roles exist', async () => {
+    mockQuery.mockImplementationOnce(async (query, values) => {
+      expectSqlAssert(query, expectedSql.sql);
+      expect(values).toEqual(roleNames);
+
+      return createMockQueryResult([]);
+    });
+
+    await expect(assertNoExistingTenantRoles(pool, database)).resolves.toBeUndefined();
+  });
+
+  it('reports existing roles before the seed can create them', async () => {
+    mockQuery.mockResolvedValueOnce(createMockQueryResult([{ roleName: 'logto_tenant_logto' }]));
+
+    await expect(assertNoExistingTenantRoles(pool, database)).rejects.toThrow(
+      [
+        'Cannot seed database "logto" because these PostgreSQL roles already exist:',
+        '  - logto_tenant_logto',
+        '',
+        'PostgreSQL roles are cluster-wide and are not removed when a database is dropped.',
+        'Verify that the roles belong to an old Logto installation, remove them as a PostgreSQL administrator, and run the seed command again.',
+      ].join('\n')
+    );
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/queries/database.ts
+++ b/packages/cli/src/queries/database.ts
@@ -1,3 +1,4 @@
+import { adminTenantId, defaultTenantId } from '@logto/schemas';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
 
@@ -7,4 +8,42 @@ export const getDatabaseName = async (pool: CommonQueryMethods, normalized = fal
   `);
 
   return normalized ? currentDatabase.replaceAll('-', '_') : currentDatabase;
+};
+
+/**
+ * Check the roles that a fresh Logto database needs before creating any tables.
+ *
+ * PostgreSQL roles are shared by the whole cluster, so dropping a database does not remove the
+ * roles that were created for it. Reusing an existing role could change the permissions of another
+ * Logto installation, therefore the seed command must stop and let an administrator inspect the
+ * roles instead.
+ */
+export const assertNoExistingTenantRoles = async (pool: CommonQueryMethods, database: string) => {
+  const roleNames = [
+    `logto_tenant_${database}`,
+    `logto_tenant_${database}_${defaultTenantId}`,
+    `logto_tenant_${database}_${adminTenantId}`,
+  ];
+
+  const existingRoles = await pool.any<{ roleName: string }>(sql`
+    select rolname as "roleName"
+    from pg_roles
+    where rolname in (${sql.join(
+      roleNames.map((roleName) => sql`${roleName}`),
+      sql`, `
+    )})
+    order by rolname
+  `);
+
+  if (existingRoles.length > 0) {
+    throw new Error(
+      [
+        `Cannot seed database "${database}" because these PostgreSQL roles already exist:`,
+        ...existingRoles.map(({ roleName }) => `  - ${roleName}`),
+        '',
+        'PostgreSQL roles are cluster-wide and are not removed when a database is dropped.',
+        'Verify that the roles belong to an old Logto installation, remove them as a PostgreSQL administrator, and run the seed command again.',
+      ].join('\n')
+    );
+  }
 };

--- a/packages/cli/src/queries/database.ts
+++ b/packages/cli/src/queries/database.ts
@@ -1,3 +1,4 @@
+import { createTenantDatabaseMetadata } from '@logto/core-kit';
 import { adminTenantId, defaultTenantId } from '@logto/schemas';
 import type { CommonQueryMethods } from '@silverhand/slonik';
 import { sql } from '@silverhand/slonik';
@@ -11,7 +12,7 @@ export const getDatabaseName = async (pool: CommonQueryMethods, normalized = fal
 };
 
 /**
- * Check the roles that a fresh Logto database needs before creating any tables.
+ * Check the roles that a fresh Logto database needs before the seed opens its transaction.
  *
  * PostgreSQL roles are shared by the whole cluster, so dropping a database does not remove the
  * roles that were created for it. Reusing an existing role could change the permissions of another
@@ -19,11 +20,11 @@ export const getDatabaseName = async (pool: CommonQueryMethods, normalized = fal
  * roles instead.
  */
 export const assertNoExistingTenantRoles = async (pool: CommonQueryMethods, database: string) => {
-  const roleNames = [
-    `logto_tenant_${database}`,
-    `logto_tenant_${database}_${defaultTenantId}`,
-    `logto_tenant_${database}_${adminTenantId}`,
-  ];
+  // Derive the names from the same helper `createTenant()` uses at seed time, so this check keeps
+  // matching if the naming scheme ever changes.
+  const defaultTenant = createTenantDatabaseMetadata(database, defaultTenantId);
+  const adminTenant = createTenantDatabaseMetadata(database, adminTenantId);
+  const roleNames = [defaultTenant.parentRole, defaultTenant.role, adminTenant.role];
 
   const existingRoles = await pool.any<{ roleName: string }>(sql`
     select rolname as "roleName"


### PR DESCRIPTION
## Summary

Dropping a Logto database leaves its PostgreSQL roles in the cluster. Seeding a new database with the same name then fails with a role-already-exists error.

Check the three tenant roles needed by the seed before creating any tables. If any already exist, report their names and explain why they survived the database deletion so an administrator can inspect them before retrying. Existing roles and permissions are left unchanged.

Fixes #9555.

## Testing

- Unit tests: all 20 CLI tests passed, including the role query and conflict message.
- Integration tests: tested locally with the built CLI and an isolated PostgreSQL 17 instance. Covered a clean seed, dropping and recreating the database, and leftover default-only or admin-only roles. Conflict cases stopped before creating tables and left existing roles unchanged.
- The full monorepo integration suite was not run.

## Checklist

- [x] `.changeset`
- [x] unit tests
- [x] integration tests
- [x] necessary TSDoc comments
