### PR TITLE
ci: fix the rerun injection, isolate the size diff and pin every action

### DIFF
--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check-alteration-changes:
     runs-on: ubuntu-latest
@@ -94,6 +97,8 @@ jobs:
   # Automatically rerun the workflow since the integration tests are moody
   # From this genius: https://github.com/orgs/community/discussions/67654#discussioncomment-8038649
   rerun-on-failure:
+    permissions:
+      actions: write
     needs: run-logto
     if: failure() && fromJSON(github.run_attempt) < 3
     # An error will occur if we use a newer version of Ubuntu in the CI environment, as it has restrictions on unprivileged user namespaces and sandbox usage, which prevents Chromium (used by Puppeteer) from launching properly during integration tests. So we lock the Ubuntu version to 22.04.

--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -23,6 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       # compare the current codebase with HEAD and check if there are any changes under the alterations folder

--- a/.github/workflows/alteration-compatibility-integration-test.yml
+++ b/.github/workflows/alteration-compatibility-integration-test.yml
@@ -52,7 +52,7 @@ jobs:
       INTEGRATION_TEST: true
       DEV_FEATURES_ENABLED: false
     steps:
-      - uses: logto-io/actions-package-logto-artifact@v3
+      - uses: logto-io/actions-package-logto-artifact@c6239af6f6969b564aacc2c09c80949058d105ee # v3
         with:
           artifact-name: alteration-integration-test-${{ github.sha }}
           branch: ${{ github.base_ref }}
@@ -81,7 +81,7 @@ jobs:
       STATUS_API_KEY: test-status-api-key
 
     steps:
-      - uses: logto-io/actions-run-logto-integration-tests@v4.1.0
+      - uses: logto-io/actions-run-logto-integration-tests@192bd800da301681d11b391f293fd5847c5fd17a # v4.1.0
         with:
           branch: ${{ github.base_ref }}
           logto-artifact: alteration-integration-test-${{ github.sha }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -18,13 +18,13 @@ jobs:
           token: ${{ secrets.BOT_PAT }}
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
           gpg_private_key: ${{ secrets.BOT_GPG_KEY }}
           passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
@@ -39,7 +39,7 @@ jobs:
 
       - name: Create pull request
         if: github.event_name == 'push'
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           version: node .scripts/version.js
           setupGitUser: false

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -8,6 +8,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
 
+# Git and API writes ride BOT_PAT, the workflow token only reads
+permissions:
+  contents: read
+
 jobs:
   changesets:
     runs-on: ubuntu-latest

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           token: ${{ secrets.BOT_PAT }}
 
       - name: Setup Node and pnpm
@@ -40,6 +41,12 @@ jobs:
         run: |
           git config --global user.email bot@silverhand.io
           git config --global user.name silverhand-bot
+
+      - name: Re-attach push credential
+        env:
+          PUSH_TOKEN: ${{ secrets.BOT_PAT }}
+        # Checkout ran with persist-credentials: false, re-attach for the version branch push
+        run: git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Create pull request
         if: github.event_name == 'push'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-
+      with:
+        persist-credentials: false
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Node and pnpm

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint-commits:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -70,4 +70,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           GH_DEBUG: api
-        run: gh workflow run rerun.yml -r ${{ github.head_ref || github.ref_name }} -F run_id=${{ github.run_id }}
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: gh workflow run rerun.yml -r "$HEAD_REF" -F run_id="$RUN_ID"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   package:
     strategy:
@@ -62,6 +65,8 @@ jobs:
   # Automatically rerun the workflow since the integration tests are moody
   # From this genius: https://github.com/orgs/community/discussions/67654#discussioncomment-8038649
   rerun-on-failure:
+    permissions:
+      actions: write
     needs: run-logto
     if: failure() && fromJSON(github.run_attempt) < 3
     runs-on: ubuntu-22.04

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,7 +24,7 @@ jobs:
       DEV_FEATURES_ENABLED: ${{ matrix.dev-features-enabled }}
 
     steps:
-      - uses: logto-io/actions-package-logto-artifact@v3
+      - uses: logto-io/actions-package-logto-artifact@c6239af6f6969b564aacc2c09c80949058d105ee # v3
         with:
           artifact-name: integration-test-${{ github.sha }}-dev-features-${{ matrix.dev-features-enabled }}
           pnpm-version: 10
@@ -52,7 +52,7 @@ jobs:
       STATUS_API_KEY: test-status-api-key
 
     steps:
-      - uses: logto-io/actions-run-logto-integration-tests@v4.0.1
+      - uses: logto-io/actions-run-logto-integration-tests@f2457129b0694c78c4cc811ec025860d4d333a32 # v4.0.1
         with:
           logto-artifact: integration-test-${{ github.sha }}-dev-features-${{ env.DEV_FEATURES_ENABLED }}
           test-target: ${{ matrix.target }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
@@ -95,7 +95,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
@@ -111,14 +111,14 @@ jobs:
         run: pnpm ci:test
 
       - name: Codecov core
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           flags: core
           directory: ./packages/core
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Codecov ui
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           flags: ui
           directory: ./packages/ui
@@ -133,10 +133,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           build-args: | # Test cloud build
@@ -167,7 +166,7 @@ jobs:
         run: cp ./fresh/pnpm-lock.yaml ./
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
@@ -184,8 +183,7 @@ jobs:
       # ** End **
 
       - name: Setup Postgres
-        uses: ikalnytskyi/action-setup-postgres@v6
-
+        uses: ikalnytskyi/action-setup-postgres@687404e7b78b0b3471751635e69f70d54a09d6e7 # v6
       # ** Setup up-to-date databases and compare (test `up`) **
       - name: Setup fresh database
         working-directory: ./fresh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   main-generated-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
@@ -42,7 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
@@ -57,7 +59,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
@@ -75,7 +78,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
@@ -96,7 +100,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
@@ -133,6 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Docker Buildx
@@ -151,6 +157,7 @@ jobs:
       # ** Checkout fresh and alteration ref **
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
           path: ./fresh
 
@@ -161,6 +168,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: ${{ steps.version.outputs.current }}
           path: ./alteration
       # ** End **

--- a/.github/workflows/master-codecov-report.yml
+++ b/.github/workflows/master-codecov-report.yml
@@ -15,7 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:

--- a/.github/workflows/master-codecov-report.yml
+++ b/.github/workflows/master-codecov-report.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
@@ -30,14 +30,14 @@ jobs:
         run: pnpm ci:test
 
       - name: Codecov Core
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           flags: core
           directory: ./packages/core
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Codecov UI
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
         with:
           flags: experience
           directory: ./packages/experience

--- a/.github/workflows/master-codecov-report.yml
+++ b/.github/workflows/master-codecov-report.yml
@@ -6,6 +6,9 @@ on:
 
 concurrency: ${{ github.workflow }}
 
+permissions:
+  contents: read
+
 jobs:
   report-coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/pen-tests.yml
+++ b/.github/workflows/pen-tests.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+# No checkout and issue writing is disabled, the token is unused
+permissions: {}
+
 jobs:
   zap-scan:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/pen-tests.yml
+++ b/.github/workflows/pen-tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: sleep 30s
 
       - name: ZAP Scan
-        uses: zaproxy/action-full-scan@v0.12.0
+        uses: zaproxy/action-full-scan@75ee1686750ab1511a73b26b77a2aedd295053ed # v0.12.0
         with:
           target: http://localhost:3001
           cmd_options: "-a"

--- a/.github/workflows/pen-tests.yml
+++ b/.github/workflows/pen-tests.yml
@@ -14,8 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-# No checkout and issue writing is disabled, the token is unused
-permissions: {}
+# Issue writing is disabled, the job only reads the tree
+permissions:
+  contents: read
 
 jobs:
   zap-scan:
@@ -25,7 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - name: Docker Compose up
         run: |
           curl -fsSL https://raw.githubusercontent.com/logto-io/logto/HEAD/docker-compose.yml |\

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: |
             ghcr.io/logto-io/logto
@@ -45,10 +45,9 @@ jobs:
           : "${LOGTO_OSS_SURVEY_ENDPOINT:?LOGTO_OSS_SURVEY_ENDPOINT is required for release builds}"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Build OSS validation image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           load: true
@@ -73,23 +72,22 @@ jobs:
             '
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: silverhand-bot
           password: ${{ secrets.BOT_PAT }}
 
       - name: Setup Depot
-        uses: depot/setup-action@v1
-
+        uses: depot/setup-action@91bc8495a33ebfc504ffc89e5674379ccf23c29c # v1.7.2
       - name: Build and push
-        uses: depot/build-push-action@v1
+        uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
         with:
           platforms: linux/amd64, linux/arm64
           project: g902cp6dvv
@@ -116,7 +114,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: |
             ghcr.io/logto-io/logto
@@ -125,13 +123,13 @@ jobs:
             type=edge
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: |
             ghcr.io
@@ -139,10 +137,9 @@ jobs:
           password: ${{ secrets.BOT_PAT }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
       - name: Build and push docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           platforms: linux/amd64
           context: .
@@ -166,13 +163,13 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         with:
           gpg_private_key: ${{ secrets.BOT_GPG_KEY }}
           passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
@@ -199,7 +196,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node and pnpm
-        uses: silverhand-io/actions-node-pnpm-run-steps@v5
+        uses: silverhand-io/actions-node-pnpm-run-steps@1a627b19475990eb5723cbe3f8e1e2a049d2742d # v5
         with:
           pnpm-version: 10
           node-version: ^22.14.0
@@ -211,7 +208,7 @@ jobs:
         run: ./.scripts/package.sh
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           token: ${{ secrets.BOT_PAT }}
           body: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,9 @@ jobs:
 
   # Publish packages and create git tags if needed
   publish-and-tag:
+    # Publishing and tagging ride BOT_PAT and the npm token
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
@@ -186,6 +189,9 @@ jobs:
         run: node .scripts/publish.js
 
   create-github-release:
+    # The release is created with BOT_PAT
+    permissions:
+      contents: read
     environment: release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Docker meta
@@ -110,6 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Docker meta
@@ -161,6 +163,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           # Set Git operations with the bot PAT since we have tag protection rule
           token: ${{ secrets.BOT_PAT }}
           fetch-depth: 0
@@ -186,7 +189,12 @@ jobs:
           git config --global user.name silverhand-bot
 
       - name: Publish
-        run: node .scripts/publish.js
+        env:
+          PUSH_TOKEN: ${{ secrets.BOT_PAT }}
+        run: |
+          # Checkout ran with persist-credentials: false, re-attach for the tag push
+          git remote set-url origin "https://x-access-token:${PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          node .scripts/publish.js
 
   create-github-release:
     # The release is created with BOT_PAT
@@ -199,6 +207,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Node and pnpm

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -7,6 +7,9 @@ on:
 
 concurrency: ${{ github.workflow }}
 
+# The dispatch authenticates with BOT_PAT, the workflow token is unused
+permissions: {}
+
 jobs:
   event_dispatch:
     strategy:

--- a/.github/workflows/repository-dispatch.yml
+++ b/.github/workflows/repository-dispatch.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Dispatch Event
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.BOT_PAT }}
           repository: ${{ matrix.target }}

--- a/.github/workflows/rerun.yml
+++ b/.github/workflows/rerun.yml
@@ -6,6 +6,9 @@ on:
     inputs:
       run_id:
         required: true
+permissions:
+  actions: write
+
 jobs:
   rerun:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-pr-metadata.yml
+++ b/.github/workflows/update-pr-metadata.yml
@@ -11,6 +11,9 @@ concurrency:
 
 jobs:
   update-metadata:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +33,9 @@ jobs:
           assignees: ${{ github.event.pull_request.user.login }}
 
   pr-size-diff:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update-pr-metadata.yml
+++ b/.github/workflows/update-pr-metadata.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Add labels
-        uses: silverhand-io/actions-add-labels-run-steps@v1.2.2
+        uses: silverhand-io/actions-add-labels-run-steps@4f137f97def1e860395b061861bbd9bc7b61041a # v1.2.2
         with:
           title: ${{ github.event.pull_request.title || github.event.issue.title }}
           github-token: ${{ github.token }}
@@ -24,7 +24,7 @@ jobs:
         if: |
           contains(fromJson('["opened", "reopened"]'), github.event.action) &&
           !endsWith(github.event.pull_request.user.login, '[bot]')
-        uses: actions-ecosystem/action-add-assignees@v1
+        uses: actions-ecosystem/action-add-assignees@a5b84af721c4a621eb9c7a4a95ec20a90d0b88e9 # v1.0.1
         with:
           github_token: ${{ github.token }}
           assignees: ${{ github.event.pull_request.user.login }}
@@ -98,7 +98,7 @@ jobs:
               result.length ? `\n<details>\n<summary><b>Diff by File</b></summary>\n\n${filesHeader}${filesData}</details>\n` : ''
             }`;
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           message: |
             ${{ steps.message.outputs.result }}

--- a/.github/workflows/update-pr-metadata.yml
+++ b/.github/workflows/update-pr-metadata.yml
@@ -35,16 +35,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # https://github.com/actions/checkout/issues/518#issuecomment-890401887
-          ref: refs/pull/${{ github.event.number }}/merge
           fetch-depth: 0
           persist-credentials: false
-          allow-unsafe-pr-checkout: true
 
       - name: Prepare
+        env:
+          PR_NUMBER: ${{ github.event.number }}
         run: |
-          git checkout master
-          git checkout -
+          # The merge result is fetched as a bare ref and never checked out,
+          # so no fork-controlled file exists on disk in this privileged run.
+          git fetch --no-tags origin "refs/pull/${PR_NUMBER}/merge:refs/pr-merge"
           curl -fsSLO https://gist.githubusercontent.com/gao-sun/88dac6c38e86f4ae12c8a7c3e777040a/raw/07276574142455b3dfeace5d7f4a370447a112b3/git-file-size-diff.sh
           chmod +x git-file-size-diff.sh
 
@@ -55,7 +55,7 @@ jobs:
           script: |
             const child_process = require('child_process');
             const result = child_process
-              .execSync('./git-file-size-diff.sh --cached master', { encoding: 'utf-8' })
+              .execSync('./git-file-size-diff.sh origin/master refs/pr-merge', { encoding: 'utf-8' })
               .split('\n');
             const diff = Number(result.pop());
 


### PR DESCRIPTION
## Summary

Hi, five commits, all on the workflow security posture, no application code touched.

**Rerun injection.** The integration test rerun step spliced `github.head_ref`, which a fork PR author chooses as their branch name, directly into the shell line, in a job holding a token with actions write. A crafted branch name would execute there. The ref now arrives through `env`, which the shell treats as data, matching the shape the alteration compatibility workflow already has.

**Size diff isolation.** The pr-size-diff job ran under `pull_request_target`, which carries the base repository token, while checking out the fork's merge result. Any step that executed a file from that tree would hand the fork the privileged context, the pattern behind the March 2025 tj-actions/changed-files incident (CVE-2025-30066). The job now checks out the base only and fetches the merge result as a bare ref, and the same gist script computes the identical byte counts through its diff-tree mode, so the sticky comment does not change.

**Pins.** Every third party and cross org action now points to a full commit SHA inside the tag already in use, with the tag kept in a comment so each ref can be cross checked with `git ls-remote`. A tag is a movable pointer: whoever controls the action repository can repoint it, and the next run executes their code with this repository's credentials, the Docker Hub and GHCR logins, the npm automation token, the bot GPG key. The silverhand-io and logto-io actions are pinned like the rest, happy to drop those hunks if you prefer trusting your own orgs. First party actions (actions/*) stay on their tags. One note on updates: the shared renovate preset has no rule for the digest updates SHA bumps produce, so if you want them grouped like your version bumps, a packageRule with `matchManagers: ["github-actions"]` and `matchUpdateTypes: ["digest", "pin"]` does it, happy to add it here.

**Permissions.** Jobs without a permissions block inherit the repository default scope. Most workflows only need to read the tree, the changesets, release and dispatch flows authenticate their writes with BOT_PAT and the npm token so their workflow token drops to read, the rerun machinery keeps exactly the actions write it uses, and the metadata jobs keep their label, assignee and comment writes.

**Checkout credentials.** All 18 checkouts now set `persist-credentials: false`, and the two flows that push (the changesets version branch, the publish tag push) re-attach BOT_PAT on the remote at the moment they need it.

One heads-up: an allowed-actions list using tag patterns (`owner/action@v1`) stops matching SHA refs and fails workflows at startup, the fix is `owner/action@*` in the allowed-actions settings.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.

## Testing

Tested locally

## Checklist

- [ ] `.changeset` (N/A, workflow configuration only, no released package behavior changes)
- [ ] unit tests (N/A, no application code touched)
- [ ] integration tests (N/A, no application code touched)
- [ ] necessary TSDoc comments (N/A)