### PR TITLE
fix(core): declare 404 on the step-up routes for a deleted subject

### DIFF
--- a/packages/core/src/routes/experience/experience.openapi.json
+++ b/packages/core/src/routes/experience/experience.openapi.json
@@ -21,6 +21,9 @@
           "400": {
             "description": "A step-up interaction was requested with a non-sign-in event, or the session has no subject to pin."
           },
+          "404": {
+            "description": "The pinned subject of the step-up interaction no longer exists."
+          },
           "422": {
             "description": "The captcha verification failed."
           }
@@ -136,6 +139,9 @@
         "responses": {
           "200": {
             "description": "The public interaction data has been successfully retrieved."
+          },
+          "404": {
+            "description": "The pinned subject of the step-up interaction no longer exists."
           }
         }
       }

--- a/packages/core/src/routes/experience/index.test.ts
+++ b/packages/core/src/routes/experience/index.test.ts
@@ -28,6 +28,7 @@ import {
   mockUserWebAuthnMfaVerification,
 } from '#src/__mocks__/user.js';
 import { EnvSet } from '#src/env-set/index.js';
+import RequestError from '#src/errors/RequestError/index.js';
 import koaErrorHandler from '#src/middleware/koa-error-handler.js';
 import koaI18next from '#src/middleware/koa-i18next.js';
 import { createMockLogContext } from '#src/test-utils/koa-audit-log.js';
@@ -411,6 +412,41 @@ describe('PUT /experience', () => {
     expect(response.status).toBe(400);
     expect(response.body).toMatchObject({ code: 'session.step_up.subject_not_found' });
     expect(provider.interactionResult).not.toHaveBeenCalled();
+  });
+
+  describe('when the pinned subject no longer exists', () => {
+    // `findUserById` uses `pool.one`, whose `NotFoundError` is mapped to this error by
+    // `koaSlonikErrorHandler` when the user row has been deleted.
+    const subjectNotFound = new RequestError({ code: 'entity.not_found', status: 404 });
+
+    it('should respond 404 on creation', async () => {
+      const { requester, provider, users } = createStepUpRequester();
+      users.findUserById.mockRejectedValueOnce(subjectNotFound);
+
+      const response = await requester
+        .put('/experience')
+        .send({ interactionEvent: InteractionEvent.SignIn });
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({ code: 'entity.not_found' });
+      expect(provider.interactionResult).not.toHaveBeenCalled();
+    });
+
+    it('should respond 404 on fetching the interaction', async () => {
+      const { requester, users } = createStepUpRequester();
+
+      const created = await requester
+        .put('/experience')
+        .send({ interactionEvent: InteractionEvent.SignIn });
+      expect(created.status).toBe(204);
+
+      users.findUserById.mockRejectedValueOnce(subjectNotFound);
+
+      const response = await requester.get('/experience/interaction');
+
+      expect(response.status).toBe(404);
+      expect(response.body).toMatchObject({ code: 'entity.not_found' });
+    });
   });
 });
 

--- a/packages/core/src/routes/experience/index.ts
+++ b/packages/core/src/routes/experience/index.ts
@@ -73,8 +73,9 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
         .optional(),
       // 200 is returned when a pure step-up cannot proceed and the interaction was finished with
       // `unmet_authentication_requirements`; 400 is returned if a pure step-up cannot be created;
-      // 422 is returned if the captcha verification fails
-      status: [200, 204, 400, 422],
+      // 404 is returned if the pinned subject of a pure step-up no longer exists; 422 is returned
+      // if the captcha verification fails
+      status: [200, 204, 400, 404, 422],
     }),
     async (ctx, next) => {
       const { interactionEvent, captchaToken } = ctx.guard.body;
@@ -223,7 +224,8 @@ export default function experienceApiRoutes<T extends AnonymousRouter>(
   experienceRouter.get(
     `${experienceRoutes.interaction}`,
     koaGuard({
-      status: [200],
+      // 404 is returned if the pinned subject of a pure step-up no longer exists
+      status: [200, 404],
       response: sanitizedInteractionStorageGuard,
     }),
     async (ctx, next) => {


### PR DESCRIPTION
## Summary

Follow-up to #9567, from [this review thread](https://github.com/logto-io/logto/pull/9567#discussion_r3977727975).

`getStepUpDecision` fetches the pinned subject with `findUserById`, which uses `pool.one` and throws once the user row is gone. `koaSlonikErrorHandler` maps that to a 404 `entity.not_found`, but neither route that reads the decision declared 404:

- `PUT /experience` declared `[200, 204, 400, 422]` (via `finishUnreachableStepUp`)
- `GET /experience/interaction` declared `[200]` (via `toSanitizedJson`)

So `koaGuard` turned the 404 into a `StatusCodeError` (500) outside production, and in production let it through with a warning plus an App Insights exception. This declares 404 on both routes, documents it in the OpenAPI supplement, and adds a unit test for each path.

The window is narrow: `DELETE /users/:userId` revokes the user's sessions before deleting the row, and the provider's `interactionDetails` already rejects an interaction whose session is gone with `session.not_found`. It is reachable when the best-effort session revocation times out on deletion, or when the user row is removed outside core.

No changeset: dev feature, M8 adds it, as in #9567.

## Testing

- Unit tests: a step-up whose `findUserById` rejects with the 404 the slonik handler produces responds 404 on `PUT /experience` (without touching the provider) and on `GET /experience/interaction` (`index.test.ts`).
- Not run locally: the workspace install could not fetch the pinned `oidc-provider` fork from this session, so the suite and lint are left to CI.

## Checklist

- [ ] `.changeset` (dev feature; M8 adds the changeset)
- [x] unit tests
- [ ] integration tests (not applicable)
- [x] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PxD5RQ1MVwiHFeaxfMvkXP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PxD5RQ1MVwiHFeaxfMvkXP)_