### PR TITLE
fix(experience): opt out of browser auto-translation

### DIFF
--- a/.changeset/khaki-pumas-invite.md
+++ b/.changeset/khaki-pumas-invite.md
@@ -1,0 +1,9 @@
+---
+"@logto/experience": patch
+---
+
+opt the sign-in experience out of browser auto-translation
+
+Browser auto-translation replaces the text nodes React created (`<font><font>…</font></font>`). React's DOM bookkeeping no longer matches the document, so the next update throws `NotFoundError: Failed to execute 'removeChild' on 'Node'`; the experience app has no error boundary, so the whole tree unmounts and the user is left on a blank page in the middle of signing in or signing up — a reload is the only way out.
+
+The experience is already localized per tenant (custom phrases plus language detection), so the page now ships `translate="no"` and `<meta name="google" content="notranslate">`, which is what Chrome, Edge and Safari read before offering or applying a translation.

--- a/packages/experience/index.html
+++ b/packages/experience/index.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<!-- `translate="no"`: browser auto-translation rewrites text nodes, which breaks React's
+     DOM bookkeeping and unmounts the app mid-flow. The experience is localized per tenant. -->
+<html lang="en" translate="no">
 
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="robots" content="noindex,nofollow" />
+  <meta name="google" content="notranslate" />
   <title></title>
   <script>
     /* See {@link packages/schemas/src/types/ssr.ts} */


### PR DESCRIPTION
Fixes the crash reported in #9590 — or rather, removes its trigger.

## The problem

Browser auto-translation replaces the text nodes React created with `<font><font>…</font></font>` wrappers. React's bookkeeping no longer matches the document, so the next update throws:

```
NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
```

The experience app has no error boundary, so the whole tree unmounts: the user is left on a **blank page** in the middle of signing in or signing up, and only a reload gets them out. A one-time link is already consumed at that point, so on an invitation flow the second click lands on "token consumed" and the user is stuck.

On our self-hosted 1.41.0 tenant this cost **14 of 68 invited users over three weeks**, every one of them on Chrome (no occurrence on Edge, Firefox or Safari). The trigger there is the `/one-time-token` screen keeping `lang="en"` while rendering the tenant's French phrases (#9590) — but the attribute bug is only what *invites* the translation; the crash itself can be triggered by any user who asks their browser to translate an auth page.

## The change

Ship `translate="no"` and `<meta name="google" content="notranslate">` in `packages/experience/index.html`.

The experience app is already localized per tenant — custom phrases, language detection, `ui_locales` — so a browser translation on top of it adds little and can take the whole page down. This is what Chrome, Edge and Safari read before offering or applying a translation.

## What this PR deliberately does not do

- **It does not fix the `lang` attribute** (#9590). `document.documentElement.lang` stays at the `index.html` fallback on `/one-time-token` while `window.logtoSsr.phrases.lng` is `fr` and the UI renders in French — and `data-react-helmet` is absent from `<html>` there, so `AppMeta`'s Helmet never applied. I could not pin down the timing well enough to propose a fix I'd trust, and did not want to guess in a PR. The reproduction is in the issue.
- **It does not add an error boundary** to the experience router, which would turn any such DOM mismatch into a retry screen instead of an unmount. Happy to open a separate PR if you'd like one.

## Testing

Reproduced and verified against a self-hosted 1.41.0 tenant: with the text nodes wrapped as the translator does, confirming the terms modal unmounted the app on `/continue/password`; with `translate="no"` in place, Chrome no longer offers or applies the translation on those screens, and the flow completes.
